### PR TITLE
docs(governance): NENE2 の初期開発規約を整備する

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -1,0 +1,14 @@
+---
+description: NENE2 全作業共通の正本と安全方針
+alwaysApply: true
+---
+
+# Project Rules
+
+- 正本は `README.md`、`AGENTS.md`、`docs/CONTRIBUTING.md`、`docs/development/`、`docs/workflow.md`。
+- AI/エージェントは作業前に `AGENTS.md` と関連 docs を確認する。
+- 秘密情報、トークン、パスワード、ローカル `.env`、生成物をコミットしない。
+- 変更は依頼範囲と Issue の目的に留め、無関係な整形やリファクタを混ぜない。
+- NENE2 は API first、薄い HTML、React/Vue optional、AI-readable なモダン PHP フレームワークとして育てる。
+- 実装は疎結合、型安全、テスト容易性、OpenAPI/MCP 境界の明確さを優先する。
+- Cursor ルールと docs が食い違う場合は docs を先に更新し、このルールは短く保つ。

--- a/.cursor/rules/10-issue-driven-workflow.mdc
+++ b/.cursor/rules/10-issue-driven-workflow.mdc
@@ -1,0 +1,15 @@
+---
+description: Issue ベース開発と branch / PR / merge 運用
+alwaysApply: true
+---
+
+# Issue Driven Workflow
+
+- コード、ドキュメント、設定変更は GitHub Issue ベースで進める。
+- 作業開始時に `docs/roadmap.md`、`docs/milestones/`、`docs/todo/current.md`、関連 Issue/PR を確認する。
+- `main` へ直接コミットしない。ブランチ名は `type/issue-number-summary` を基本にする。
+- 作業完了時は通常、commit、push、PR 作成、チェック確認、merge、Issue close/update、`main` 同期まで進める。
+- PR には目的、変更点、検証結果、関連 Issue または `Closes #番号` を書く。
+- コミットは Conventional Commits。description/body は日本語、type/scope は英語。
+- ユーザーが「調査だけ」「コミットしない」「PR まで」など範囲を明示した場合は、その指示を優先する。
+- 正本は `docs/workflow.md` と `docs/development/commit-conventions.md`。

--- a/.cursor/rules/20-modern-php.mdc
+++ b/.cursor/rules/20-modern-php.mdc
@@ -1,0 +1,16 @@
+---
+description: NENE2 PHP 実装時のモダン PHP / API 契約ルール
+globs: "**/*.php"
+alwaysApply: false
+---
+
+# Modern PHP
+
+- 新規 PHP ファイルは `declare(strict_types=1);` を付け、PSR-12 を基本にする。
+- Controller は薄く保ち、入力解釈、UseCase 呼び出し、Response 生成に集中する。
+- UseCase / Domain は HTTP、DB、テンプレート、CLI、frontend build から独立させる。
+- 配列のまま境界を越えず、DTO、value object、enum、readonly property を優先する。
+- OpenAPI で表現する public API 契約と実装のズレを避ける。
+- MCP 連携は DB 直結ではなく、API または application service の明確な境界を通す。
+- テストしにくい static/global state、暗黙の命名 magic、隠れた副作用を増やさない。
+- 正本は `docs/development/coding-standards.md`。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent / AI Guide
+
+This file is the entry point for AI agents and automation working on NENE2.
+
+## Read First
+
+- Human and AI collaboration: `docs/CONTRIBUTING.md`
+- Workflow: `docs/workflow.md`
+- Coding standards: `docs/development/coding-standards.md`
+- Commit messages: `docs/development/commit-conventions.md`
+- AI tool policy: `docs/integrations/ai-tools.md`
+- Roadmap: `docs/roadmap.md`
+- Current work: `docs/todo/current.md`
+
+## Operating Rules
+
+- Work from GitHub Issues. If an implementation or documentation change has no Issue, create one before editing.
+- Do not commit directly to `main`. Use branches named like `type/issue-number-summary`.
+- Keep local milestones and `docs/todo/current.md` aligned with Issues and PRs.
+- Keep changes focused. Do not mix architecture migration, feature work, tool setup, and cosmetic cleanup in one PR.
+- Do not commit secrets, credentials, local `.env` files, or generated build outputs.
+- Prefer explicit, typed, testable code over hidden framework behavior.
+- When docs and Cursor rules conflict, update the docs first and keep `.cursor/rules/` as a concise summary.
+
+## Project Direction
+
+NENE2 should stay small, modern, and AI-readable:
+
+- JSON APIs first, with OpenAPI as the contract.
+- Minimal server HTML, with React/Vue integration kept optional and replaceable.
+- MCP and AI integrations go through documented API boundaries.
+- Test strategy is part of design, not an afterthought.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
 # NENE2
+
 PHP micro-framework: JSON APIs first, minimal server HTML, easy React/Vue SPA integration, structure friendly to AI tooling.
+
+NENE2 is a small, modern PHP framework foundation extracted from the lessons of the original NeNe framework and the 9lick.me modernization work. It is designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add React or Vue without turning the backend into frontend build glue.
+
+## Theme
+
+- **API first**: define behavior through clear HTTP boundaries and OpenAPI contracts.
+- **Simple HTML**: keep server HTML minimal, predictable, and easy to replace with SPA shells.
+- **Frontend ready**: support React or Vue as optional frontend layers rather than framework lock-in.
+- **AI readable**: prefer explicit directories, small classes, typed boundaries, and documented decisions.
+- **Modern PHP**: use strict types, PSR-oriented style, dependency injection, automated tests, and static analysis.
+
+## Development Principles
+
+NENE2 optimizes for fast, calm development. The codebase should be easy for a solo developer, a team, or an AI agent to understand without hidden conventions.
+
+- Keep domain and use-case code decoupled from HTTP, database, template, and CLI details.
+- Make behavior testable before adding framework magic.
+- Treat OpenAPI as the public API contract and keep MCP integrations behind the same API boundary.
+- Prefer small, boring primitives over clever abstractions.
+- Record workflow, roadmap, and implementation decisions in `docs/` rather than only in chat.
+
+## Repository Layout
+
+The repository starts with governance documents first. Runtime code will be added in focused Issues.
+
+```text
+.
+├── docs/
+│   ├── development/     # coding, commit, and implementation standards
+│   ├── integrations/    # AI, OpenAPI, MCP, and external tool policies
+│   ├── milestones/      # local milestones linked to GitHub Issues
+│   └── todo/            # current local work board
+├── .cursor/rules/       # Cursor rules that summarize the docs
+├── AGENTS.md            # AI/agent entry point
+├── LICENSE
+└── README.md
+```
+
+## Project Workflow
+
+NENE2 uses GitHub Issues as the source of work and local Markdown files as the project memory.
+
+1. Create or reuse a focused GitHub Issue.
+2. Create an Issue-numbered branch from `main`, such as `docs/1-initial-governance`.
+3. Update code and docs together, keeping the change small.
+4. Commit with Conventional Commits and include the Issue number.
+5. Push, open a PR, merge after checks, and return local `main` to a clean state.
+
+See `docs/CONTRIBUTING.md`, `docs/workflow.md`, and `AGENTS.md` before changing the project.
+
+## License
+
+NENE2 is released under the MIT License.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+NENE2 is built through small, Issue-driven changes. This document is the shared entry point for humans and AI agents.
+
+## Required Reading
+
+| Topic | Document |
+| --- | --- |
+| Workflow | `docs/workflow.md` |
+| Coding standards | `docs/development/coding-standards.md` |
+| Commit messages | `docs/development/commit-conventions.md` |
+| AI tools | `docs/integrations/ai-tools.md` |
+| Roadmap | `docs/roadmap.md` |
+| Current work | `docs/todo/current.md` |
+
+## Collaboration Policy
+
+- Start work from a GitHub Issue.
+- Use one branch and one PR per focused work unit.
+- Keep `docs/milestones/`, `docs/roadmap.md`, and `docs/todo/current.md` updated when the direction changes.
+- Explain intent, impact, verification, and remaining risk in PRs.
+- Prefer documentation that helps the next developer or AI agent decide what to do without rereading chat history.
+
+## Secrets
+
+Do not commit passwords, tokens, private URLs, production credentials, or local `.env` files. Commit only non-secret examples such as `.env.example` when needed.
+
+## Engineering Theme
+
+NENE2 should be modern PHP without becoming heavy:
+
+- strict, typed, explicit boundaries
+- decoupled use cases and infrastructure
+- API contracts before client assumptions
+- tests that make refactoring safe
+- simple structure that remains readable to humans and AI agents

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,0 +1,64 @@
+# Coding Standards
+
+NENE2 should feel modern, small, and predictable. These rules are the source of truth for implementation style.
+
+## PHP Baseline
+
+- Target current stable PHP first and keep PHP 8.3/8.4 features in view.
+- New PHP files must use `declare(strict_types=1);`.
+- Follow PSR-12 unless a narrower project rule says otherwise.
+- Prefer immutable value objects and readonly properties where they clarify intent.
+- Use native types, enums, and small DTOs instead of unstructured arrays at boundaries.
+- Avoid framework magic that hides control flow from tests, static analysis, or AI tools.
+
+## Architecture
+
+- Keep use cases independent from HTTP, database, templates, CLI, and frontend assets.
+- Depend on interfaces at infrastructure boundaries when it reduces coupling.
+- Prefer constructor injection for required dependencies.
+- Keep controllers thin: parse input, call a use case, return a response.
+- Keep persistence details inside repositories or adapters.
+- Treat public API schemas as contracts, not incidental output.
+
+## API and HTML
+
+- JSON APIs are the primary product surface.
+- OpenAPI should describe public request, response, and error shapes.
+- Server HTML should stay minimal and easy to replace with a SPA shell.
+- React/Vue integration should be optional and isolated from backend domain logic.
+
+## Error Handling and Logging
+
+- Use explicit domain or application exceptions when callers can act on them.
+- Do not swallow exceptions silently.
+- Keep user-facing error responses stable and documented.
+- Prefer structured logs with request context once logging is introduced.
+- Do not log secrets, tokens, passwords, or private payloads.
+
+## Testing
+
+Testing is part of the design.
+
+- Unit test use cases and domain behavior without a database when practical.
+- Add integration tests around adapters and persistence only when they prove important contracts.
+- Add HTTP or contract tests for public API behavior.
+- Keep tests deterministic and small.
+- Prefer test data builders or fixtures over large hidden setup.
+
+## Static Analysis and Formatting
+
+Planned quality tools:
+
+- PHPUnit for automated tests
+- PHPStan or Psalm for static analysis
+- PHP-CS-Fixer or PHPCS for style enforcement
+- OpenAPI validation for API contracts
+
+When a tool is introduced, document its command and expected level here.
+
+## AI Readability
+
+- Name files and classes after their role.
+- Keep functions short enough to inspect without jumping through many layers.
+- Prefer explicit return types and simple data shapes.
+- Record architecture decisions in `docs/` when they affect future implementation.

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -1,0 +1,46 @@
+# Commit Message Conventions
+
+NENE2 uses Conventional Commits.
+
+## Format
+
+```text
+<type>(<optional scope>): <description> (#<issue>)
+
+[optional body]
+
+[optional footer]
+```
+
+## Language
+
+- Keep `type`, `scope`, `BREAKING CHANGE`, and other Conventional Commits keywords in English.
+- Write the description and body in Japanese.
+- Include the related GitHub Issue number in the subject when practical.
+
+Example:
+
+```text
+docs(governance): NENE2 の初期開発規約を整備する (#1)
+```
+
+## Common Types
+
+| Type | Use |
+| --- | --- |
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change without feature or bug fix |
+| `test` | Test additions or changes |
+| `build` | Dependency or build setup |
+| `ci` | CI configuration |
+| `chore` | Maintenance |
+
+## Body
+
+Use the body when the reason is not obvious from the subject. Explain why the change exists, what trade-off was chosen, and whether follow-up work remains.
+
+## Breaking Changes
+
+Use `!` or a `BREAKING CHANGE:` footer when public API, configuration, CLI, or documented behavior changes incompatibly.

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -1,0 +1,40 @@
+# AI Tooling Policy
+
+NENE2 is designed to be easy for AI agents to inspect, change, and verify without guessing.
+
+## Source of Truth
+
+- Project direction: `README.md` and `docs/roadmap.md`
+- Workflow: `docs/workflow.md`
+- Coding rules: `docs/development/coding-standards.md`
+- Current state: `docs/todo/current.md`
+- Local milestones: `docs/milestones/`
+- Agent entry point: `AGENTS.md`
+- Cursor summaries: `.cursor/rules/`
+
+## Agent Workflow
+
+For normal code or documentation work, an AI agent should:
+
+1. Confirm or create a GitHub Issue.
+2. Check the roadmap, milestone, and TODO state.
+3. Create an Issue-numbered branch from `main`.
+4. Make focused changes only.
+5. Update documentation when behavior or policy changes.
+6. Run the narrowest useful verification.
+7. Commit, push, open a PR, merge, and sync `main` unless the user narrowed the scope.
+
+## Design for AI Readability
+
+- Use predictable directory names.
+- Keep framework conventions documented.
+- Prefer typed DTOs and value objects over ambiguous arrays.
+- Keep generated files clearly separated from source files.
+- Avoid hidden reflection or naming magic unless it is documented and tested.
+
+## Safety Boundaries
+
+- AI tools must not commit secrets.
+- MCP tools should interact with the application through documented APIs, not direct database access.
+- Destructive operations must require explicit user approval.
+- Production access rules must be documented before production tooling is added.

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -1,0 +1,27 @@
+# MCP Policy
+
+MCP support should make NENE2 easy for AI tools to operate without bypassing application boundaries.
+
+## Goals
+
+- Expose safe, documented application capabilities to AI tools.
+- Reuse API contracts instead of inventing a second hidden interface.
+- Keep authentication, authorization, and audit concerns explicit.
+
+## Principles
+
+- MCP tools should call application APIs or application services through documented boundaries.
+- MCP tools should not directly manipulate databases or private filesystem state unless a specific tool is designed and documented for that purpose.
+- Tool definitions should be generated from or aligned with OpenAPI where practical.
+- Dangerous actions must be explicit and easy to review.
+- Local development MCP tools and production MCP tools must be documented separately.
+
+## Early Scope
+
+Initial MCP work should wait until the API foundation exists. The first MCP milestone should focus on read-only inspection tools before mutation tools.
+
+## Security Notes
+
+- Do not store MCP credentials in the repository.
+- Use example configuration files for non-secret setup.
+- Document required scopes for each tool before enabling it outside local development.

--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -1,0 +1,32 @@
+# OpenAPI Policy
+
+OpenAPI is the contract layer for NENE2 APIs.
+
+## Goals
+
+- Make API behavior explicit before frontend or MCP clients depend on it.
+- Keep request, response, pagination, and error shapes stable.
+- Enable tests and client generation where useful.
+- Make the API understandable to humans and AI agents.
+
+## Principles
+
+- Public JSON APIs should have OpenAPI coverage.
+- Error responses should use shared schemas where possible.
+- Examples should include at least one success and one failure case for important endpoints.
+- OpenAPI documents should describe shipped behavior, not aspirational behavior.
+- Contract changes should be reviewed as public API changes.
+
+## Planned Structure
+
+The exact location will be decided with the runtime skeleton, but the expected shape is:
+
+```text
+docs/openapi/
+├── openapi.yaml
+└── examples/
+```
+
+## Testing Direction
+
+Once runtime code exists, API tests should verify that responses match the documented contract. The first implementation can be lightweight and grow with the framework.

--- a/docs/milestones/2026-05-nene2-foundation.md
+++ b/docs/milestones/2026-05-nene2-foundation.md
@@ -1,0 +1,36 @@
+# NENE2 Foundation
+
+## Period
+
+May 2026
+
+## Goal
+
+Create the project foundation for NENE2 before adding runtime framework code. The foundation should make the project easy to understand, easy to contribute to, and easy for AI agents to navigate.
+
+## Theme
+
+NENE2 should be a compact modern PHP framework for fast API development, minimal HTML output, optional React/Vue integration, and AI-readable architecture.
+
+## Scope
+
+- README direction
+- contribution guide
+- Issue-driven workflow
+- local roadmap / milestone / TODO board
+- coding standards
+- OpenAPI and MCP integration policy
+- Cursor rules
+
+## Acceptance Criteria
+
+- A new contributor can understand the project direction from `README.md`.
+- A human or AI agent can find the correct workflow from `AGENTS.md` and `docs/CONTRIBUTING.md`.
+- Branch, commit, PR, and merge rules are documented in `docs/workflow.md`.
+- Coding rules favor modern PHP, decoupling, testability, and API contracts.
+- Local project memory exists in `docs/roadmap.md`, `docs/milestones/`, and `docs/todo/current.md`.
+- Cursor rules summarize the docs without becoming the source of truth.
+
+## Related Work
+
+- GitHub Issue: `#1`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,83 @@
+# Roadmap
+
+This roadmap keeps NENE2 focused on a small, modern, AI-readable PHP framework foundation.
+
+## North Star
+
+NENE2 should let a developer clone one repository and quickly build:
+
+- JSON APIs with clear contracts
+- thin server HTML when needed
+- React or Vue frontends without backend lock-in
+- testable use cases and adapters
+- OpenAPI and MCP integrations through documented boundaries
+
+## Phase 0: Project Foundation
+
+Goal: make contribution, AI operation, and technical direction unambiguous before runtime code grows.
+
+- README and contribution guide
+- Issue-driven workflow
+- local roadmap, milestone, and TODO board
+- coding standards
+- Cursor rules
+- OpenAPI / MCP direction documents
+
+Tracked by `docs/milestones/2026-05-nene2-foundation.md`.
+
+## Phase 1: Framework Skeleton
+
+Goal: create the smallest useful runtime structure.
+
+- HTTP request/response abstraction
+- route dispatch foundation
+- config loading
+- dependency injection container or factory policy
+- error handling and JSON response shape
+- minimal HTML response support
+- first PHPUnit test suite
+
+## Phase 2: API Contract Foundation
+
+Goal: make API behavior explicit and client-friendly.
+
+- OpenAPI document location and generation policy
+- request and response schema conventions
+- error schema
+- contract tests
+- examples for success and failure responses
+
+## Phase 3: Frontend Integration
+
+Goal: make React or Vue easy to adopt without making NENE2 a frontend framework.
+
+- `frontend/` starter policy
+- Vite-oriented integration notes
+- API client generation or typed fetch wrapper policy
+- SPA shell and static asset serving guidance
+
+## Phase 4: MCP and AI Tooling
+
+Goal: let AI tools inspect and operate the app through safe, documented contracts.
+
+- MCP server integration guidance
+- API-key or token boundary policy
+- tool definitions derived from OpenAPI where practical
+- safe local development commands
+
+## Phase 5: Quality and Release
+
+Goal: keep the framework small while making changes safe.
+
+- static analysis
+- formatter and linter configuration
+- mutation or architecture tests where useful
+- semantic versioning policy
+- release checklist
+
+## Non-Goals
+
+- Recreating Laravel or Symfony.
+- Hiding application behavior behind magic conventions.
+- Coupling the framework to one frontend library.
+- Treating AI integration as direct database or filesystem access.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,0 +1,31 @@
+# Current TODO
+
+Purpose: keep the current work visible across chats, agents, and local sessions.
+
+## Status
+
+- Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
+- Current GitHub Issue: none
+- Current branch: `main`
+
+## Foundation Completed
+
+- [x] Create GitHub Issue for initial governance docs. `#1`
+- [x] Create Issue branch for initial governance docs. `docs/1-initial-governance`
+- [x] Add README, AGENTS, workflow, roadmap, milestone, TODO, coding standards, and integration policy docs. `#1`
+- [x] Add Cursor rules that summarize the docs. `#1`
+- [x] Merge the initial governance PR. `#1`
+
+## Next Candidates
+
+- [ ] Create the first runtime skeleton Issue.
+- [ ] Decide PHP runtime target and package metadata.
+- [ ] Add Composer configuration and development dependencies.
+- [ ] Define initial OpenAPI file location.
+- [ ] Choose the first frontend starter direction or keep both React/Vue documented as optional.
+
+## Operating Notes
+
+- Keep this file short.
+- Move completed historical detail to milestone files when it becomes noisy.
+- If a task needs review, create or link a GitHub Issue.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,56 @@
+# Workflow
+
+NENE2 uses GitHub Issues for work tracking and local Markdown files for project memory.
+
+## Standard Flow
+
+1. Create or reuse a focused GitHub Issue.
+2. Confirm related local context in `docs/roadmap.md`, `docs/milestones/`, and `docs/todo/current.md`.
+3. Create a branch from `main` named like `type/issue-number-summary`.
+4. Implement the smallest useful change.
+5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
+6. Run the narrowest meaningful verification available.
+7. Commit with Conventional Commits and include the Issue number.
+8. Push the branch and create a PR linked to the Issue.
+9. Merge after review and checks.
+10. Return local `main` to the merged, clean state.
+
+## Branch Names
+
+Use Conventional Commit style as the prefix:
+
+- `docs/1-initial-governance`
+- `feat/12-openapi-router-contract`
+- `refactor/24-container-boundaries`
+- `test/31-http-contract-tests`
+
+## PR Requirements
+
+Every PR should include:
+
+- purpose
+- change summary
+- verification results
+- related Issue, preferably `Closes #number`
+- remaining risks or follow-up work
+
+## Local Project Memory
+
+- `docs/roadmap.md`: long-lived direction and phases
+- `docs/milestones/`: medium-sized goals and acceptance criteria
+- `docs/todo/current.md`: current task board and handoff notes
+
+Do not leave important decisions only in chat. If it changes how the project should be built, record it in `docs/`.
+
+## AI Agent Responsibilities
+
+AI agents should manage the normal lifecycle when asked to complete work:
+
+- create or reuse the Issue
+- create the Issue branch
+- edit only relevant files
+- verify the change
+- commit, push, open PR, merge, and sync `main`
+- update local docs that describe project state
+
+If a user explicitly says investigation only, no commit, no PR, or another narrower scope, follow that instruction.


### PR DESCRIPTION
## Summary
- README / AGENTS / contributing docs に NENE2 の API first・AI-readable 方針を整理
- Issue ベースの workflow、local roadmap / milestone / TODO、commit conventions を追加
- OpenAPI / MCP 方針と Cursor rules を追加

## Verification
- git diff --check
- Cursor lints: no diagnostics for edited docs/rules

Closes #1

Made with [Cursor](https://cursor.com)