### PR TITLE
build(docker): PHP 開発コンテナを追加する

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.cursor
+vendor
+.phpunit.cache
+.phpstan.cache
+coverage
+frontend/node_modules
+public_html/assets

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ composer.phar
 .phpstan.cache/
 coverage/
 clover.xml
+/frontend/node_modules/
+/frontend/dist/
+/public_html/assets/*
+!/public_html/assets/.gitkeep
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/README.md
+++ b/README.md
@@ -45,7 +45,18 @@ See `docs/development/project-layout.md` for the design details and placement ru
 
 ## PHP Tooling
 
-NENE2 targets PHP `>=8.4.1 <9.0`. Composer lives at the repository root and provides the first verification commands:
+NENE2 targets PHP `>=8.4.1 <9.0`. Docker is the standard development runtime, so the host OS does not need to provide that PHP version.
+
+```bash
+docker compose build
+docker compose run --rm app composer install
+docker compose run --rm app composer check
+docker compose up -d app
+```
+
+The web entry point is served from `public_html/` at `http://localhost:8080/`.
+
+Composer lives at the repository root and provides the first verification commands:
 
 ```bash
 composer validate
@@ -54,7 +65,7 @@ composer analyse
 composer check
 ```
 
-See `docs/development/php-runtime.md` for runtime and tooling details.
+See `docs/development/php-runtime.md` and `docs/development/docker.md` for runtime and tooling details.
 
 ## Project Workflow
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: docker/php/Dockerfile
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+      - composer-cache:/tmp/composer-cache
+    environment:
+      COMPOSER_CACHE_DIR: /tmp/composer-cache
+
+volumes:
+  composer-cache:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:8.4-apache
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+RUN a2enmod rewrite \
+    && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -1,0 +1,51 @@
+# Docker Development
+
+NENE2 uses Docker as the standard development runtime so contributors do not need to install the required PHP version on the host OS.
+
+## Services
+
+`compose.yaml` defines one service:
+
+- `app`: PHP 8.4 Apache container with Composer installed
+
+Apache serves `public_html/` as the document root.
+
+## First Setup
+
+```bash
+docker compose build
+docker compose run --rm app composer install
+```
+
+## Verification
+
+```bash
+docker compose run --rm app composer validate --strict
+docker compose run --rm app composer test
+docker compose run --rm app composer analyse
+docker compose run --rm app composer check
+```
+
+Use these Docker commands as the default verification path when the host PHP version is older than NENE2's runtime requirement.
+
+## Web Server
+
+```bash
+docker compose up -d app
+```
+
+Then open:
+
+```text
+http://localhost:8080/
+```
+
+Stop it with:
+
+```bash
+docker compose down
+```
+
+## Runtime Boundary
+
+Only `public_html/` is exposed by Apache. Source code, `vendor/`, tests, config, and frontend source stay outside the document root.

--- a/docs/development/php-runtime.md
+++ b/docs/development/php-runtime.md
@@ -50,3 +50,5 @@ composer check
 ## Local Environment
 
 Use PHP 8.4.1 or newer for local development. Older PHP versions are unsupported even if some non-runtime commands still execute.
+
+Docker is the recommended path when the host OS cannot provide PHP 8.4.1 or newer. See `docs/development/docker.md`.

--- a/docs/development/project-layout.md
+++ b/docs/development/project-layout.md
@@ -7,6 +7,8 @@ This document defines the standard NENE2 repository layout. It is the source of 
 ```text
 NENE2/
 ├── composer.json
+├── compose.yaml
+├── docker/              # development containers
 ├── src/                 # NENE2 framework core
 ├── tests/               # PHPUnit / architecture / contract tests
 ├── config/              # framework default config or examples
@@ -103,3 +105,9 @@ These directories may be added later when the need is concrete:
 - `packages/` only if NENE2 becomes a true multi-package repository
 
 Add them through Issues and document why they exist before broad use.
+
+## Docker
+
+`docker/` contains development container definitions. Docker is the standard way to run NENE2 with the required PHP version without changing the host OS.
+
+The first container serves `public_html/` through Apache and runs Composer, PHPUnit, and PHPStan in the same PHP runtime.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -17,12 +17,12 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Merge the initial governance PR. `#1`
 - [x] Define standard project layout and create initial directories. `#3`
 - [x] Add root Composer metadata, PHP runtime policy, PHPUnit, and PHPStan. `#5`
+- [x] Add Docker-based PHP development environment and first smoke endpoint. `#7`
 
 ## Next Candidates
 
-- [ ] Create the first runtime skeleton Issue.
 - [ ] Define initial OpenAPI file location.
-- [ ] Add the first PHP runtime skeleton and smoke test.
+- [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Choose the first frontend starter direction or keep both React/Vue documented as optional.
 
 ## Operating Notes

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Nene2\FrameworkInfo;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$framework = new FrameworkInfo();
+
+header('Content-Type: application/json; charset=utf-8');
+
+echo json_encode(
+    [
+        'name' => $framework->name(),
+        'description' => $framework->description(),
+        'status' => 'ok',
+    ],
+    JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT
+);

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2;
+
+final readonly class FrameworkInfo
+{
+    public function name(): string
+    {
+        return 'NENE2';
+    }
+
+    public function description(): string
+    {
+        return 'JSON APIs first, minimal server HTML, frontend ready, AI-readable.';
+    }
+}

--- a/tests/FrameworkInfoTest.php
+++ b/tests/FrameworkInfoTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests;
+
+use Nene2\FrameworkInfo;
+use PHPUnit\Framework\TestCase;
+
+final class FrameworkInfoTest extends TestCase
+{
+    public function testNameReturnsFrameworkName(): void
+    {
+        self::assertSame('NENE2', (new FrameworkInfo())->name());
+    }
+}


### PR DESCRIPTION
## Summary
- Docker Compose と PHP 8.4 Apache + Composer の開発コンテナを追加
- `public_html/` を document root にした smoke endpoint と最小 PHPUnit smoke test を追加
- Docker 経由の composer install / test / analyse / check / web 起動手順を docs と README に追加

## Verification
- `composer validate --strict` passed on host
- `git diff --check` passed
- Cursor diagnostics: no issues
- Docker build / composer install / composer check / web container startup could not be executed because this WSL distro does not have the `docker` command available. Docker Desktop WSL integration needs to be enabled before running `docker compose build` and `docker compose up -d app`.

Closes #7

Made with [Cursor](https://cursor.com)