### PR TITLE
docs(openapi): Swagger UI の初期基盤を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ docker compose up -d app
 
 The web entry point is served from `public_html/` at `http://localhost:8080/`.
 
+OpenAPI and Swagger UI are available in Docker development:
+
+- OpenAPI: `http://localhost:8080/openapi.php`
+- Swagger UI: `http://localhost:8080/docs/`
+
 Composer lives at the repository root and provides the first verification commands:
 
 ```bash

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -40,6 +40,13 @@ Then open:
 http://localhost:8080/
 ```
 
+API documentation endpoints:
+
+```text
+http://localhost:8080/openapi.php
+http://localhost:8080/docs/
+```
+
 Stop it with:
 
 ```bash

--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -17,15 +17,43 @@ OpenAPI is the contract layer for NENE2 APIs.
 - OpenAPI documents should describe shipped behavior, not aspirational behavior.
 - Contract changes should be reviewed as public API changes.
 
-## Planned Structure
+## Structure
 
-The exact location will be decided with the runtime skeleton, but the expected shape is:
+The source of truth lives in `docs/openapi/`:
 
 ```text
 docs/openapi/
 ├── openapi.yaml
 └── examples/
 ```
+
+`public_html/openapi.php` exposes `docs/openapi/openapi.yaml` to local tools and Swagger UI without duplicating the contract file.
+
+Swagger UI is served from:
+
+```text
+http://localhost:8080/docs/
+```
+
+The raw OpenAPI contract is served from:
+
+```text
+http://localhost:8080/openapi.php
+```
+
+## Local Verification
+
+Start Docker and open Swagger UI:
+
+```bash
+docker compose up -d app
+```
+
+Then verify:
+
+- `http://localhost:8080/` returns the smoke JSON response.
+- `http://localhost:8080/openapi.php` returns the OpenAPI YAML.
+- `http://localhost:8080/docs/` loads Swagger UI.
 
 ## Testing Direction
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+info:
+  title: NENE2 API
+  version: 0.1.0
+  description: >
+    NENE2 API contract. This file is the source of truth for public JSON APIs.
+servers:
+  - url: http://localhost:8080
+    description: Local Docker development server
+tags:
+  - name: System
+    description: Framework and runtime smoke endpoints.
+paths:
+  /:
+    get:
+      tags:
+        - System
+      summary: Framework smoke endpoint
+      description: Returns a minimal JSON response that confirms the NENE2 public entry point is working.
+      operationId: getFrameworkSmoke
+      responses:
+        '200':
+          description: Framework smoke response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FrameworkSmokeResponse'
+              examples:
+                ok:
+                  summary: Successful smoke response
+                  value:
+                    name: NENE2
+                    description: JSON APIs first, minimal server HTML, frontend ready, AI-readable.
+                    status: ok
+components:
+  schemas:
+    FrameworkSmokeResponse:
+      type: object
+      required:
+        - name
+        - description
+        - status
+      properties:
+        name:
+          type: string
+          example: NENE2
+        description:
+          type: string
+          example: JSON APIs first, minimal server HTML, frontend ready, AI-readable.
+        status:
+          type: string
+          enum:
+            - ok
+          example: ok

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -18,11 +18,12 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define standard project layout and create initial directories. `#3`
 - [x] Add root Composer metadata, PHP runtime policy, PHPUnit, and PHPStan. `#5`
 - [x] Add Docker-based PHP development environment and first smoke endpoint. `#7`
+- [x] Add initial OpenAPI contract and Swagger UI. `#9`
 
 ## Next Candidates
 
-- [ ] Define initial OpenAPI file location.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
+- [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Choose the first frontend starter direction or keep both React/Vue documented as optional.
 
 ## Operating Notes

--- a/public_html/docs/index.html
+++ b/public_html/docs/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>NENE2 API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+      window.addEventListener('load', () => {
+        window.ui = SwaggerUIBundle({
+          url: '/openapi.php',
+          dom_id: '#swagger-ui',
+          presets: [
+            SwaggerUIBundle.presets.apis,
+          ],
+          layout: 'BaseLayout',
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/public_html/openapi.php
+++ b/public_html/openapi.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+$openApiPath = dirname(__DIR__) . '/docs/openapi/openapi.yaml';
+
+if (!is_file($openApiPath)) {
+    http_response_code(404);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(
+        [
+            'error' => 'OpenAPI contract not found.',
+        ],
+        JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT
+    );
+    exit;
+}
+
+header('Content-Type: application/yaml; charset=utf-8');
+header('Cache-Control: no-store');
+
+readfile($openApiPath);


### PR DESCRIPTION
## Summary
- `docs/openapi/openapi.yaml` を OpenAPI contract の正本として追加
- `public_html/openapi.php` で contract を配信し、`public_html/docs/` に Swagger UI を追加
- README / Docker docs / OpenAPI policy / TODO に確認手順と運用方針を反映

## Verification
- `docker compose run --rm app composer check`
- `docker compose up -d app`
- `curl -fsS http://localhost:8080/`
- `curl -fsS http://localhost:8080/openapi.php`
- `curl -fsS http://localhost:8080/docs/`
- `git diff --check`
- Cursor diagnostics: no issues

Closes #9

Made with [Cursor](https://cursor.com)