### PR TITLE
docs(di): PSR-11 と明示 wiring 方針を定義する

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ NENE2 optimizes for fast, calm development. The codebase should be easy for a so
 
 - Keep domain and use-case code decoupled from HTTP, database, template, and CLI details.
 - Use PSR-7 / PSR-15 / PSR-17 as the HTTP runtime direction.
+- Use PSR-11 as the DI boundary, with explicit wiring first.
 - Make behavior testable before adding framework magic.
 - Treat OpenAPI as the public API contract and keep MCP integrations behind the same API boundary.
 - Keep template engines optional; server HTML should stay thin and replaceable.
@@ -32,6 +33,7 @@ NENE2 uses a single repository with Composer at the root, PHP framework code in 
 .
 ├── composer.json
 ├── src/                 # NENE2 framework core
+│   ├── DependencyInjection/
 │   ├── Http/
 │   ├── Routing/
 │   ├── Middleware/

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -16,6 +16,9 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Keep use cases independent from HTTP, database, templates, CLI, and frontend assets.
 - Depend on interfaces at infrastructure boundaries when it reduces coupling.
 - Prefer constructor injection for required dependencies.
+- Use PSR-11 as the container boundary.
+- Prefer explicit factories and service providers over autowiring by default.
+- Do not use the container as a service locator inside domain or use-case code.
 - Keep controllers thin: parse input, call a use case, return a response.
 - Keep persistence details inside repositories or adapters.
 - Treat public API schemas as contracts, not incidental output.

--- a/docs/development/dependency-injection.md
+++ b/docs/development/dependency-injection.md
@@ -1,0 +1,108 @@
+# Dependency Injection and Wiring Policy
+
+NENE2 uses PSR-11 as the container boundary and explicit wiring as the standard application style.
+
+## Position
+
+Dependency injection should make the application easier to understand, not hide how it works.
+
+The standard direction is:
+
+- Use PSR-11 for container interoperability.
+- Prefer explicit wiring through factories and service providers.
+- Keep autowiring optional and outside the initial default.
+- Keep framework core separate from application service definitions.
+- Make dependency graphs readable to humans and AI agents.
+
+This Issue defines the policy and directories only. Container packages and implementations should be added in a later Issue.
+
+## Standard Directories
+
+```text
+src/
+└── DependencyInjection/      # container contracts, providers, factories, and wiring helpers
+
+config/
+└── services.php             # future application service definitions
+```
+
+`config/services.php` is a future convention and should not be added until there is a concrete container implementation.
+
+## PSR-11 Boundary
+
+NENE2 should expose or consume containers through `Psr\Container\ContainerInterface`.
+
+Framework code should not depend on a concrete container implementation. Runtime code may accept a PSR-11 container at composition boundaries, such as:
+
+- front controller bootstrap
+- application factory
+- middleware pipeline factory
+- route handler resolver
+
+## Explicit Wiring First
+
+Explicit wiring is the default because it is:
+
+- easy to review
+- easy to test
+- friendly to static analysis
+- easy for AI agents to trace
+- predictable during refactoring
+
+Factories and service providers should show dependency construction directly. Avoid hidden class-name conventions as the primary mechanism.
+
+## Autowiring Policy
+
+Autowiring is optional and not part of the first standard runtime.
+
+If autowiring is introduced later:
+
+- make it an application opt-in
+- keep explicit wiring available
+- document how parameters and interfaces are resolved
+- test failure messages
+- avoid making controller behavior depend on invisible magic
+
+## Service Provider Policy
+
+Service providers should be small and focused.
+
+Recommended responsibilities:
+
+- register related services
+- bind interfaces to factories
+- configure framework modules
+- avoid reading request-specific state
+
+Provider execution order must be explicit if ordering matters.
+
+## HTTP Runtime Relationship
+
+The HTTP runtime should not require a container for simple route handlers.
+
+Container integration can be added at these edges:
+
+- route handler resolution
+- middleware construction
+- error handler construction
+- response factory creation
+
+Do not make the router or middleware pipeline impossible to test without a container.
+
+## Non-Goals for the First DI Step
+
+- Full autowiring.
+- Attribute-based service registration.
+- Compile-time container generation.
+- Global service locator usage inside domain or use-case code.
+- Container-dependent domain objects.
+
+## Future Implementation Issues
+
+Follow-up work should decide:
+
+- concrete PSR-11 package or minimal adapter
+- service provider interface
+- factory conventions
+- application bootstrap shape
+- test helpers for container wiring

--- a/docs/development/project-layout.md
+++ b/docs/development/project-layout.md
@@ -10,6 +10,7 @@ NENE2/
 ├── compose.yaml
 ├── docker/              # development containers
 ├── src/                 # NENE2 framework core
+│   ├── DependencyInjection/ # container contracts, providers, and wiring helpers
 │   ├── Error/           # exception to response mapping
 │   ├── Http/            # PSR HTTP helpers and response concerns
 │   ├── Middleware/      # PSR-15 middleware pipeline
@@ -57,6 +58,7 @@ Do not place the primary Composer project inside `backend/` unless NENE2 later b
 - routing and dispatch
 - middleware pipeline
 - exception to response mapping
+- dependency injection and wiring helpers
 - application/service boundaries
 - configuration loading
 - response rendering
@@ -66,6 +68,8 @@ Do not place the primary Composer project inside `backend/` unless NENE2 later b
 Application-specific examples can be added later under `examples/` if needed, but should not be mixed into the framework core.
 
 HTTP runtime follows PSR-7 / PSR-15 / PSR-17 first. See `docs/development/http-runtime.md`.
+
+Dependency injection follows PSR-11 with explicit wiring first. See `docs/development/dependency-injection.md`.
 
 ### `tests/` Mirrors Framework Behavior
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ Goal: create the smallest useful runtime structure.
 - middleware pipeline foundation
 - config loading
 - Composer package metadata
-- dependency injection container or factory policy
+- PSR-11 dependency injection and explicit wiring policy
 - error handling and JSON response shape
 - minimal HTML response support through native PHP templates
 - database migration layout and tool selection policy

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -22,10 +22,12 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define thin HTML view and optional template engine policy. `#11`
 - [x] Define database migration layout and tool selection policy. `#13`
 - [x] Define PSR-first HTTP runtime and routing policy. `#15`
+- [x] Define PSR-11 DI container and explicit wiring policy. `#16`
 
 ## Next Candidates
 
 - [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation.
+- [ ] Choose concrete PSR-11 container package or adapter strategy.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Add the first native PHP view renderer and escaping helper.


### PR DESCRIPTION
## Summary
- DI container は PSR-11 を境界にする方針を追加
- autowiring ではなく factory / service provider による明示 wiring first を標準化
- `src/DependencyInjection` の責務と標準ディレクトリを追加
- README / project layout / coding standards / roadmap / TODO に反映

## Verification
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics: no issues

Closes #16

Made with [Cursor](https://cursor.com)