### PR TITLE
docs(config): typed config と environment 方針を定義する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 composer.phar
 /vendor/
+.env
+.env.*
+!.env.example
 .phpunit.cache/
 .phpstan.cache/
 coverage/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ NENE2 optimizes for fast, calm development. The codebase should be easy for a so
 - Keep domain and use-case code decoupled from HTTP, database, template, and CLI details.
 - Use PSR-7 / PSR-15 / PSR-17 as the HTTP runtime direction.
 - Use PSR-11 as the DI boundary, with explicit wiring first.
+- Use typed config objects at runtime; keep `.env` at the loading boundary.
 - Make behavior testable before adding framework magic.
 - Treat OpenAPI as the public API contract and keep MCP integrations behind the same API boundary.
 - Keep template engines optional; server HTML should stay thin and replaceable.
@@ -33,6 +34,7 @@ NENE2 uses a single repository with Composer at the root, PHP framework code in 
 .
 ├── composer.json
 ├── src/                 # NENE2 framework core
+│   ├── Config/
 │   ├── DependencyInjection/
 │   ├── Http/
 │   ├── Routing/

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -16,6 +16,8 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Keep use cases independent from HTTP, database, templates, CLI, and frontend assets.
 - Depend on interfaces at infrastructure boundaries when it reduces coupling.
 - Prefer constructor injection for required dependencies.
+- Use typed config objects at runtime instead of passing raw arrays through the application.
+- Keep `getenv()`, `$_ENV`, and `$_SERVER` access inside the config loading boundary.
 - Use PSR-11 as the container boundary.
 - Prefer explicit factories and service providers over autowiring by default.
 - Do not use the container as a service locator inside domain or use-case code.
@@ -68,6 +70,14 @@ Testing is part of the design.
 - Store schema snapshots or generated schema docs in `database/schema/`.
 - Prefer Phinx as the first migration tool candidate, but adopt it only when the database adapter layer is introduced.
 - See `docs/development/database-migrations.md`.
+
+## Configuration
+
+- Commit only non-secret config examples and defaults.
+- Ignore local `.env` files and commit only `.env.example` when environment shape needs documentation.
+- Prefer `vlucas/phpdotenv` as the first local/test dotenv candidate, but adopt it only when the config loader is implemented.
+- Production should use real environment variables or platform secrets.
+- See `docs/development/configuration.md`.
 
 ## Static Analysis and Formatting
 

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -1,0 +1,117 @@
+# Configuration and Environment Policy
+
+NENE2 uses typed configuration objects as the runtime boundary.
+
+## Position
+
+Configuration should be explicit, typed, and safe to inspect.
+
+The standard direction is:
+
+- Use typed config objects at runtime.
+- Keep raw arrays and environment variables at the loading boundary.
+- Use `vlucas/phpdotenv` as the first local/test dotenv candidate.
+- Prefer real environment variables in production.
+- Never commit secrets.
+
+This Issue defines the policy only. Config loaders, typed config classes, and dotenv dependencies should be added in a later Issue.
+
+## Standard Directories
+
+```text
+config/                 # non-secret config examples and framework defaults
+src/Config/             # typed config objects and loaders
+.env.example            # documented non-secret environment shape
+.env                    # local secrets, ignored by Git
+```
+
+`src/Config/` and `.env.example` should be added when the first config implementation is introduced.
+
+## Runtime Boundary
+
+Application code should not call `getenv()`, `$_ENV`, or `$_SERVER` directly outside the config loading layer.
+
+The preferred flow is:
+
+```text
+environment variables
+        ↓
+config loader
+        ↓
+typed config objects
+        ↓
+application / infrastructure code
+```
+
+This keeps configuration:
+
+- easy to validate
+- easy to test
+- safe for static analysis
+- readable to AI agents
+
+## Loading Order
+
+The intended loading order is:
+
+1. framework defaults from committed non-secret config
+2. `.env` values for local and test environments
+3. real environment variables
+4. explicit test overrides
+
+Later values override earlier values.
+
+Production should rely on real environment variables or platform secrets. Production should not require a committed `.env` file.
+
+## Dotenv Policy
+
+`vlucas/phpdotenv` is the first candidate for local and test `.env` loading because it is common, small, and predictable.
+
+Dotenv loading should happen only during bootstrap. Domain, use-case, and adapter code should receive typed config values rather than reading `.env` directly.
+
+## Secret Policy
+
+Never commit:
+
+- `.env`
+- `.env.local`
+- `.env.*.local`
+- passwords
+- tokens
+- private URLs
+- production credentials
+
+Commit only non-secret examples such as `.env.example`.
+
+## Typed Config Policy
+
+Typed config objects should:
+
+- be immutable when practical
+- validate required values at construction time
+- expose narrow values, not raw config arrays
+- avoid mixing unrelated config groups
+
+Examples of future config groups:
+
+- app/runtime
+- HTTP
+- database
+- logging
+- OpenAPI
+- frontend assets
+
+## Testing
+
+Tests should use explicit config objects or test overrides. Avoid making tests depend on the developer's local `.env` unless the test is specifically about config loading.
+
+## Future Implementation Issues
+
+Follow-up work should decide:
+
+- dotenv package adoption
+- config loader interface
+- typed config object structure
+- `.env.example` contents
+- config validation error shape
+- test helper for config construction

--- a/docs/development/project-layout.md
+++ b/docs/development/project-layout.md
@@ -10,6 +10,7 @@ NENE2/
 ├── compose.yaml
 ├── docker/              # development containers
 ├── src/                 # NENE2 framework core
+│   ├── Config/          # typed config objects and loaders
 │   ├── DependencyInjection/ # container contracts, providers, and wiring helpers
 │   ├── Error/           # exception to response mapping
 │   ├── Http/            # PSR HTTP helpers and response concerns
@@ -61,6 +62,7 @@ Do not place the primary Composer project inside `backend/` unless NENE2 later b
 - dependency injection and wiring helpers
 - application/service boundaries
 - configuration loading
+- typed configuration objects
 - response rendering
 - view rendering interfaces and adapters
 - integration interfaces
@@ -70,6 +72,8 @@ Application-specific examples can be added later under `examples/` if needed, bu
 HTTP runtime follows PSR-7 / PSR-15 / PSR-17 first. See `docs/development/http-runtime.md`.
 
 Dependency injection follows PSR-11 with explicit wiring first. See `docs/development/dependency-injection.md`.
+
+Configuration uses typed config objects at runtime and keeps raw `.env` access at the loading boundary. See `docs/development/configuration.md`.
 
 ### `tests/` Mirrors Framework Behavior
 
@@ -85,6 +89,8 @@ Test files should make framework behavior safe to refactor. They should not depe
 ### `config/` Is Non-Secret Configuration
 
 `config/` contains default configuration, examples, or framework-level config definitions. Secrets belong in environment variables or ignored local files, never in committed config.
+
+Future typed config objects and loaders belong in `src/Config/`.
 
 ### `database/` Contains Application Schema Work
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@ Goal: create the smallest useful runtime structure.
 - PSR-7 / PSR-15 / PSR-17 based HTTP runtime policy
 - route dispatch foundation
 - middleware pipeline foundation
-- config loading
+- typed config loading and environment policy
 - Composer package metadata
 - PSR-11 dependency injection and explicit wiring policy
 - error handling and JSON response shape

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -23,11 +23,13 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define database migration layout and tool selection policy. `#13`
 - [x] Define PSR-first HTTP runtime and routing policy. `#15`
 - [x] Define PSR-11 DI container and explicit wiring policy. `#16`
+- [x] Define typed config and environment policy. `#17`
 
 ## Next Candidates
 
 - [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation.
 - [ ] Choose concrete PSR-11 container package or adapter strategy.
+- [ ] Implement typed config loader and `.env.example`.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Add the first native PHP view renderer and escaping helper.


### PR DESCRIPTION
## Summary
- runtime では typed config object を使い、raw env access は config loading boundary に閉じる方針を追加
- `vlucas/phpdotenv` を local / test の標準候補、production は実環境変数優先として整理
- `.env` 系 ignore、`src/Config`、README / layout / coding standards / roadmap / TODO を更新

## Verification
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics: no issues

Closes #17

Made with [Cursor](https://cursor.com)