### PR TITLE
docs(error): Problem Details 方針を定義する

### DIFF
--- a/docs/development/api-error-responses.md
+++ b/docs/development/api-error-responses.md
@@ -1,0 +1,127 @@
+# API Error Response Policy
+
+NENE2 uses RFC 9457 Problem Details as the standard JSON API error response format.
+
+## Position
+
+API errors are public contracts. They should be stable, documented, and easy for frontend clients, MCP tools, tests, and AI agents to understand.
+
+The standard direction is:
+
+- Use RFC 9457 Problem Details for public JSON API errors.
+- Keep internal exceptions separate from public error responses.
+- Add OpenAPI shared schemas before shipping stable error behavior.
+- Use a structured `errors` array for validation details.
+- Avoid leaking secrets, stack traces, SQL, file paths, or private identifiers.
+
+This Issue defines the policy only. OpenAPI schemas and runtime implementation should be added in later Issues.
+
+## Base Shape
+
+The default error response should use `application/problem+json`.
+
+```json
+{
+  "type": "https://nene2.dev/problems/not-found",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "The requested resource was not found.",
+  "instance": "/example"
+}
+```
+
+## Required Fields
+
+For NENE2 public API errors:
+
+- `type`: stable problem identifier URI
+- `title`: short human-readable summary
+- `status`: HTTP status code
+
+Optional fields:
+
+- `detail`: safe human-readable detail
+- `instance`: request-specific URI or identifier
+- `errors`: validation error details
+
+## Problem Type Policy
+
+Problem `type` values should be stable and documented. They should not be raw exception class names.
+
+Recommended pattern:
+
+```text
+https://nene2.dev/problems/{problem-name}
+```
+
+Examples:
+
+- `https://nene2.dev/problems/not-found`
+- `https://nene2.dev/problems/method-not-allowed`
+- `https://nene2.dev/problems/validation-failed`
+- `https://nene2.dev/problems/unauthorized`
+- `https://nene2.dev/problems/forbidden`
+- `https://nene2.dev/problems/internal-server-error`
+
+## Validation Errors
+
+Validation failures should use the base Problem Details shape and include an `errors` array.
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation Failed",
+  "status": 422,
+  "detail": "The request body contains invalid values.",
+  "errors": [
+    {
+      "field": "email",
+      "message": "Email must be a valid email address.",
+      "code": "invalid_email"
+    }
+  ]
+}
+```
+
+Each validation error item should include:
+
+- `field`: field name, parameter name, or JSON pointer
+- `message`: safe human-readable message
+- `code`: stable machine-readable code
+
+The final validation rule mapping belongs to the request validation Issue.
+
+## Exception Boundary
+
+Internal exceptions are not the API contract.
+
+The error handler should map exceptions to public Problem Details responses:
+
+- known domain/application exceptions become stable public problem types
+- routing failures become `not-found` or `method-not-allowed`
+- validation failures become `validation-failed`
+- unexpected exceptions become `internal-server-error`
+
+Unexpected errors must not expose stack traces in public responses.
+
+## OpenAPI Policy
+
+OpenAPI should eventually define shared schemas for:
+
+- `ProblemDetails`
+- `ValidationProblemDetails`
+- `ValidationError`
+
+Stable endpoints should reference these schemas for non-2xx responses.
+
+## Testing
+
+Error response tests should verify:
+
+- status code
+- `Content-Type: application/problem+json`
+- problem `type`
+- safe `title` and `detail`
+- validation `errors` structure when applicable
+
+Avoid asserting full stack traces or environment-specific details.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -49,8 +49,12 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Use explicit domain or application exceptions when callers can act on them.
 - Do not swallow exceptions silently.
 - Keep user-facing error responses stable and documented.
+- Use RFC 9457 Problem Details for public JSON API errors.
+- Use `application/problem+json` for Problem Details responses.
+- Do not leak stack traces, SQL, file paths, secrets, or private identifiers in public error responses.
 - Prefer structured logs with request context once logging is introduced.
 - Do not log secrets, tokens, passwords, or private payloads.
+- See `docs/development/api-error-responses.md`.
 
 ## Testing
 

--- a/docs/development/http-runtime.md
+++ b/docs/development/http-runtime.md
@@ -92,6 +92,8 @@ The first implementation should distinguish:
 
 The public JSON error shape will be defined in the Problem Details Issue.
 
+NENE2 uses RFC 9457 Problem Details as the standard public JSON API error shape. See `docs/development/api-error-responses.md`.
+
 ## Non-Goals for the First Runtime
 
 - Full controller resolver magic.

--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -12,7 +12,7 @@ OpenAPI is the contract layer for NENE2 APIs.
 ## Principles
 
 - Public JSON APIs should have OpenAPI coverage.
-- Error responses should use shared schemas where possible.
+- Error responses should use RFC 9457 Problem Details and shared schemas where possible.
 - Examples should include at least one success and one failure case for important endpoints.
 - OpenAPI documents should describe shipped behavior, not aspirational behavior.
 - Contract changes should be reviewed as public API changes.
@@ -58,3 +58,5 @@ Then verify:
 ## Testing Direction
 
 Once runtime code exists, API tests should verify that responses match the documented contract. The first implementation can be lightweight and grow with the framework.
+
+Future OpenAPI work should add shared schemas for `ProblemDetails`, `ValidationProblemDetails`, and `ValidationError`. See `docs/development/api-error-responses.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,7 +37,7 @@ Goal: create the smallest useful runtime structure.
 - typed config loading and environment policy
 - Composer package metadata
 - PSR-11 dependency injection and explicit wiring policy
-- error handling and JSON response shape
+- RFC 9457 Problem Details error response policy
 - minimal HTML response support through native PHP templates
 - database migration layout and tool selection policy
 - first PHPUnit test suite
@@ -48,7 +48,7 @@ Goal: make API behavior explicit and client-friendly.
 
 - OpenAPI document location and generation policy
 - request and response schema conventions
-- error schema
+- shared Problem Details error schemas
 - contract tests
 - examples for success and failure responses
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -24,12 +24,14 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define PSR-first HTTP runtime and routing policy. `#15`
 - [x] Define PSR-11 DI container and explicit wiring policy. `#16`
 - [x] Define typed config and environment policy. `#17`
+- [x] Define RFC 9457 Problem Details API error response policy. `#18`
 
 ## Next Candidates
 
 - [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation.
 - [ ] Choose concrete PSR-11 container package or adapter strategy.
 - [ ] Implement typed config loader and `.env.example`.
+- [ ] Add OpenAPI Problem Details schemas.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Add the first native PHP view renderer and escaping helper.


### PR DESCRIPTION
## Summary
- JSON API error response は RFC 9457 Problem Details を標準にする方針を追加
- validation details は `errors` 配列で `field` / `message` / `code` を持つ方針に整理
- OpenAPI / HTTP runtime / coding standards / roadmap / TODO に error response 方針を反映

## Verification
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics: no issues

Closes #18

Made with [Cursor](https://cursor.com)