### PR TITLE
docs(security): middleware と security baseline 方針を定義する

### DIFF
--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -31,9 +31,12 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Use PSR-15 for middleware and request handlers.
 - Use PSR-17 for factories.
 - Keep routing explicit and route tables readable.
+- Keep middleware order explicit and documented.
+- Treat CORS, security headers, request id, and request size limits as API baseline middleware concerns.
 - Keep `public_html/index.php` as the front controller.
 - Do not introduce controller resolver magic before the DI policy is settled.
 - See `docs/development/http-runtime.md`.
+- See `docs/development/middleware-security.md`.
 
 ## API and HTML
 

--- a/docs/development/http-runtime.md
+++ b/docs/development/http-runtime.md
@@ -44,6 +44,8 @@ Middleware should follow PSR-15:
 
 This keeps authentication, logging, error handling, CORS, and OpenAPI validation composable.
 
+Middleware and security baseline policy is defined in `docs/development/middleware-security.md`.
+
 ### PSR-17
 
 Response and stream creation should go through factories rather than direct implementation classes. This keeps the concrete PSR-7 implementation replaceable.

--- a/docs/development/middleware-security.md
+++ b/docs/development/middleware-security.md
@@ -1,0 +1,154 @@
+# Middleware and Security Baseline Policy
+
+NENE2 uses PSR-15 middleware as the standard HTTP cross-cutting boundary.
+
+## Position
+
+Middleware should make HTTP behavior composable without hiding application flow.
+
+The standard direction is:
+
+- Use PSR-15 for middleware and request handlers.
+- Keep middleware order explicit.
+- Include API-oriented security baseline policies early.
+- Keep authentication, authorization, rate limiting, and CSRF as clear extension points.
+- Keep local development easy while requiring explicit production configuration.
+
+This Issue defines the policy only. Middleware implementations should be added in later Issues.
+
+## Baseline Scope
+
+The initial API baseline should cover:
+
+- error handling
+- request id
+- CORS policy
+- security headers
+- request size policy
+
+Authentication, authorization, rate limiting, and CSRF are important, but should be implemented through focused follow-up Issues.
+
+## Middleware Order
+
+The default middleware order should be explicit and documented.
+
+Recommended first pipeline:
+
+```text
+1. Error handling
+2. Request id
+3. Security headers
+4. CORS
+5. Request size limit
+6. Authentication / authorization
+7. OpenAPI or request validation
+8. Routing / handler dispatch
+```
+
+Error handling should wrap the whole pipeline so every failure can be converted to a stable Problem Details response.
+
+## Request ID
+
+Every request should have a request id.
+
+Policy:
+
+- Accept a safe incoming request id header when configured.
+- Generate one when missing.
+- Add it to response headers.
+- Include it in logs once logging is implemented.
+
+Recommended header:
+
+```text
+X-Request-Id
+```
+
+## Security Headers
+
+Security headers should be added by middleware so HTML, API, and docs responses get consistent protection.
+
+Initial candidates:
+
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: no-referrer-when-downgrade`
+- `X-Frame-Options: SAMEORIGIN`
+- `Permissions-Policy` with conservative defaults
+
+Content Security Policy should be introduced carefully because Swagger UI and future frontend assets may require explicit script/style policies.
+
+## CORS
+
+Local development may be permissive. Production must use an explicit allowlist.
+
+Policy:
+
+- local: allow common localhost origins when configured
+- test: use deterministic configured origins
+- production: reject cross-origin requests unless origin is allowlisted
+- credentials must be disabled unless explicitly configured
+
+CORS should be config-driven, not hard-coded in middleware.
+
+## Request Size
+
+Request size limits should be configurable and enforced before body parsing when practical.
+
+The first policy should define:
+
+- default max body size
+- behavior for missing or invalid `Content-Length`
+- Problem Details response for payload too large
+
+The exact defaults belong to the config implementation Issue.
+
+## Authentication and Authorization
+
+Authentication and authorization are extension points, not mandatory core behavior.
+
+Planned schemes:
+
+- API key for machine clients and MCP tools
+- bearer token for user or service authentication
+- session-based auth for applications that need server sessions
+
+OpenAPI security schemes should be added when a scheme is implemented.
+
+## CSRF
+
+CSRF protection should not be globally forced for JSON APIs.
+
+Policy:
+
+- state-changing browser form routes may require CSRF
+- token or API-key based JSON APIs usually do not use CSRF
+- session-based browser routes should document CSRF expectations
+
+## Rate Limiting
+
+Rate limiting should be an adapter-driven middleware, not a hard dependency of framework core.
+
+Future implementation should decide:
+
+- in-memory local adapter
+- Redis or external store adapter
+- rate limit response shape using Problem Details
+- headers for remaining quota and reset time
+
+## OpenAPI Relationship
+
+OpenAPI should document:
+
+- security schemes
+- 401 / 403 / 413 / 429 Problem Details responses
+- CORS behavior when it becomes part of the public API contract
+
+Do not document aspirational security behavior before middleware implements it.
+
+## Non-Goals for the First Middleware Step
+
+- Built-in user system.
+- Mandatory session handling.
+- Global CSRF for all JSON APIs.
+- Production rate limiter before an adapter decision.
+- Hard-coded production CORS origins.

--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -60,3 +60,5 @@ Then verify:
 Once runtime code exists, API tests should verify that responses match the documented contract. The first implementation can be lightweight and grow with the framework.
 
 Future OpenAPI work should add shared schemas for `ProblemDetails`, `ValidationProblemDetails`, and `ValidationError`. See `docs/development/api-error-responses.md`.
+
+OpenAPI security schemes should be added only when the matching middleware or authentication adapter is implemented. See `docs/development/middleware-security.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,6 +34,7 @@ Goal: create the smallest useful runtime structure.
 - PSR-7 / PSR-15 / PSR-17 based HTTP runtime policy
 - route dispatch foundation
 - middleware pipeline foundation
+- middleware security baseline policy
 - typed config loading and environment policy
 - Composer package metadata
 - PSR-11 dependency injection and explicit wiring policy

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -25,6 +25,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define PSR-11 DI container and explicit wiring policy. `#16`
 - [x] Define typed config and environment policy. `#17`
 - [x] Define RFC 9457 Problem Details API error response policy. `#18`
+- [x] Define middleware and security baseline policy. `#19`
 
 ## Next Candidates
 
@@ -32,6 +33,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Choose concrete PSR-11 container package or adapter strategy.
 - [ ] Implement typed config loader and `.env.example`.
 - [ ] Add OpenAPI Problem Details schemas.
+- [ ] Add request id, CORS, security headers, and request size middleware skeletons.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Add the first native PHP view renderer and escaping helper.


### PR DESCRIPTION
## Summary
- PSR-15 middleware pipeline の推奨順序を定義
- request id / CORS / security headers / request size の API baseline 方針を追加
- OpenAPI security schemes と future middleware 実装の関係を整理

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for `docs/`

Closes #19

Made with [Cursor](https://cursor.com)