### PR TITLE
docs(quality): 品質ツールとコメント方針を定義する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # NENE2
 
-PHP micro-framework: JSON APIs first, minimal server HTML, easy React/Vue SPA integration, structure friendly to AI tooling.
+PHP micro-framework: JSON APIs first, minimal server HTML, easy React starter integration, structure friendly to AI tooling.
 
-NENE2 is a small, modern PHP framework foundation extracted from the lessons of the original NeNe framework and the 9lick.me modernization work. It is designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add React or Vue without turning the backend into frontend build glue.
+NENE2 is a small, modern PHP framework foundation extracted from the lessons of the original NeNe framework and the 9lick.me modernization work. It is designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add a React frontend starter without turning the backend into frontend build glue.
 
 ## Theme
 
 - **API first**: define behavior through clear HTTP boundaries and OpenAPI contracts.
 - **Simple HTML**: keep server HTML minimal, predictable, and easy to replace with SPA shells.
-- **Frontend ready**: support React or Vue as optional frontend layers rather than framework lock-in.
+- **Frontend ready**: provide a React + TypeScript starter direction while keeping the frontend layer replaceable.
 - **AI readable**: prefer explicit directories, small classes, typed boundaries, and documented decisions.
 - **Modern PHP**: use strict types, PSR-oriented style, dependency injection, automated tests, and static analysis.
 
@@ -28,7 +28,7 @@ NENE2 optimizes for fast, calm development. The codebase should be easy for a so
 
 ## Repository Layout
 
-NENE2 uses a single repository with Composer at the root, PHP framework code in `src/`, tests in `tests/`, a web document root in `public_html/`, and optional frontend source in `frontend/`.
+NENE2 uses a single repository with Composer at the root, PHP framework code in `src/`, tests in `tests/`, a web document root in `public_html/`, and optional React + TypeScript frontend source in `frontend/`.
 
 ```text
 .
@@ -46,7 +46,7 @@ NENE2 uses a single repository with Composer at the root, PHP framework code in 
 ├── templates/           # native PHP templates and thin server HTML source
 ├── public_html/         # web document root
 │   └── assets/          # built frontend assets
-├── frontend/            # React/Vue/Vite source
+├── frontend/            # React/TypeScript/Vite source
 │   └── src/
 ├── docs/
 ├── LICENSE
@@ -73,7 +73,7 @@ OpenAPI and Swagger UI are available in Docker development:
 - OpenAPI: `http://localhost:8080/openapi.php`
 - Swagger UI: `http://localhost:8080/docs/`
 
-Composer lives at the repository root and provides the first verification commands:
+Composer lives at the repository root and provides the first backend verification commands:
 
 ```bash
 composer validate
@@ -83,6 +83,8 @@ composer check
 ```
 
 See `docs/development/php-runtime.md` and `docs/development/docker.md` for runtime and tooling details.
+
+NENE2's planned quality baseline adds PHP-CS-Fixer for backend style checks and ESLint, TypeScript, and Prettier for the React frontend starter. Framework public APIs should use PHPDoc or TSDoc where comments explain contracts or extension rules. See `docs/development/quality-tools.md` and `docs/development/documentation-comments.md`.
 
 ## Project Workflow
 

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -7,6 +7,7 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Target PHP `>=8.4.1 <9.0`. See `docs/development/php-runtime.md`.
 - New PHP files must use `declare(strict_types=1);`.
 - Follow PSR-12 unless a narrower project rule says otherwise.
+- Do not add large file-level copyright or project banners by default.
 - Prefer immutable value objects and readonly properties where they clarify intent.
 - Use native types, enums, and small DTOs instead of unstructured arrays at boundaries.
 - Avoid framework magic that hides control flow from tests, static analysis, or AI tools.
@@ -45,7 +46,8 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Server HTML should stay minimal and easy to replace with a SPA shell.
 - Native PHP templates are the first standard HTML path; full template engines are optional adapters.
 - Keep server HTML source in `templates/` and view abstractions in `src/View/`.
-- React/Vue integration should be optional and isolated from backend domain logic.
+- React is the first framework-maintained frontend starter direction.
+- React/Vue integration should remain optional for framework consumers and isolated from backend domain logic.
 
 ## Error Handling and Logging
 
@@ -95,10 +97,21 @@ Adopted quality tools:
 
 Planned quality tools:
 
-- PHP-CS-Fixer or PHPCS for style enforcement
+- PHP-CS-Fixer for style enforcement
+- ESLint, TypeScript, and Prettier for the React frontend starter
 - OpenAPI validation for API contracts
 
 When a tool is introduced, document its command and expected level here.
+
+See `docs/development/quality-tools.md`.
+
+## Documentation Comments
+
+- Write PHPDoc for public framework APIs, interfaces, extension points, middleware, typed config objects, and behavior that users depend on.
+- Write TSDoc for exported frontend starter utilities, hooks, types, and API client helpers.
+- Do not use PHPDoc or TSDoc to repeat native types or obvious implementation details.
+- Keep licensing metadata at repository level through `LICENSE`, `composer.json`, and future frontend package metadata.
+- See `docs/development/documentation-comments.md`.
 
 ## AI Readability
 

--- a/docs/development/documentation-comments.md
+++ b/docs/development/documentation-comments.md
@@ -1,0 +1,139 @@
+# Documentation Comments Policy
+
+NENE2 treats PHPDoc and TSDoc as part of the public framework contract.
+
+## Position
+
+Types should carry the shape of the code. Documentation comments should explain public intent, extension rules, and trade-offs that types cannot express.
+
+The standard direction is:
+
+- Write PHPDoc for framework public APIs and extension points.
+- Write TSDoc for frontend starter public utilities and exported types.
+- Avoid comments that only repeat native types.
+- Keep file headers minimal.
+- Use repository-level license metadata as the source of truth.
+
+This Issue defines the policy only. Automated documentation generation can be decided later.
+
+## PHPDoc
+
+PHPDoc should be used for:
+
+- public classes that are part of the framework API
+- interfaces
+- abstract classes
+- middleware and request handlers intended for extension
+- typed config objects
+- value objects exposed to framework users
+- exceptions that map to public behavior
+- methods where parameter semantics, lifecycle, or side effects need explanation
+
+PHPDoc is not required for every private method or obvious implementation detail.
+
+Prefer this:
+
+```php
+/**
+ * Creates immutable runtime configuration from trusted environment values.
+ */
+final readonly class RuntimeConfig
+{
+}
+```
+
+Avoid this:
+
+```php
+/**
+ * Gets the name.
+ *
+ * @return string
+ */
+public function name(): string
+{
+}
+```
+
+Native PHP types should be preferred over PHPDoc-only types whenever possible.
+
+## TSDoc
+
+TSDoc should be used for:
+
+- exported frontend helper functions
+- exported React hooks
+- exported TypeScript types and interfaces
+- API client utilities
+- shared constants that affect application behavior
+
+TSDoc should explain how framework-maintained frontend code is intended to be used, not narrate every implementation step.
+
+Prefer this:
+
+```ts
+/**
+ * Fetches JSON from a NENE2 API endpoint and preserves typed error handling.
+ */
+export async function fetchJson<TResponse>(input: RequestInfo): Promise<TResponse> {
+  // ...
+}
+```
+
+## File Headers
+
+NENE2 should not require large copyright or project banners at the top of every source file.
+
+Reasons:
+
+- large banners add noise to small framework files
+- year ranges become maintenance churn
+- repository metadata already carries the license
+- generated diffs stay cleaner without repeated headers
+
+The standard PHP file shape is:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example;
+```
+
+The standard TypeScript file shape is:
+
+```ts
+import type { Example } from './example';
+```
+
+## License Metadata
+
+The repository-level `LICENSE`, `composer.json`, and future `package.json` license fields are the source of truth for licensing.
+
+SPDX file headers are allowed only when a future distribution or compliance need requires them. If adopted, they should be introduced consistently through tooling instead of manually added case by case.
+
+Example if required later:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+// SPDX-License-Identifier: MIT
+
+namespace Nene2\Example;
+```
+
+SPDX headers are not required for the current foundation phase.
+
+## AI Readability
+
+Documentation comments should help humans and AI agents understand:
+
+- why a boundary exists
+- how framework users are expected to extend it
+- whether behavior is a public contract
+- what is intentionally not handled by the component
+
+Comments should not compensate for unclear names, oversized classes, or hidden control flow.

--- a/docs/development/project-layout.md
+++ b/docs/development/project-layout.md
@@ -27,7 +27,7 @@ NENE2/
 ├── public_html/         # web document root
 │   ├── index.php        # front controller
 │   └── assets/          # built frontend assets
-├── frontend/            # React/Vue/Vite source
+├── frontend/            # React/TypeScript/Vite source for the first starter
 │   ├── package.json
 │   └── src/
 ├── docs/
@@ -127,9 +127,9 @@ The name `public_html` is intentionally compatible with common hosting terminolo
 
 ### `frontend/` Contains Source, Not Public Files
 
-`frontend/` is for optional React, Vue, TypeScript, and Vite source code. Its build output may be written to `public_html/assets/`, but source files and `node_modules/` must stay outside the document root.
+`frontend/` is for optional frontend source code. NENE2's first framework-maintained starter should use React, TypeScript, and Vite. Its build output may be written to `public_html/assets/`, but source files and `node_modules/` must stay outside the document root.
 
-NENE2 should not force React or Vue at the framework level. The first starter may choose one, but this layout keeps the frontend replaceable.
+NENE2 should not force React at the framework consumer level. This layout keeps Vue, Nuxt, Next, plain TypeScript, and other frontend stacks replaceable for applications built with NENE2.
 
 ## Future Extension Points
 

--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -1,0 +1,113 @@
+# Quality Tools Policy
+
+NENE2 keeps quality checks explicit, fast, and easy to run in Docker.
+
+## Position
+
+Quality tools are part of the framework design. They should make changes safer without forcing application users into one frontend or deployment stack.
+
+The standard direction is:
+
+- Backend framework development uses PHP, Composer, PHPUnit, PHPStan, and PHP-CS-Fixer.
+- Frontend starter development uses React, TypeScript, Vite, ESLint, and Prettier.
+- OpenAPI validation should be added as the API contract grows.
+- Commands should be predictable and documented before they become required in CI.
+- Framework users may replace the frontend stack, but NENE2's own starter and examples should use the documented baseline.
+
+This Issue defines the policy only. Tool installation and configuration should be added in focused follow-up Issues.
+
+## Backend PHP Baseline
+
+Adopted tools:
+
+- PHPUnit for automated tests.
+- PHPStan for static analysis.
+
+Planned tools:
+
+- `friendsofphp/php-cs-fixer` for PSR-12 oriented formatting and style checks.
+- OpenAPI validation for public API contracts.
+- Rector for modernization only when a focused migration need exists.
+
+PHP-CS-Fixer is the preferred first formatter because it gives a simple check/fix workflow and fits the project's "easy to repair" development style.
+
+Recommended future Composer scripts:
+
+```json
+{
+  "scripts": {
+    "test": "phpunit",
+    "analyse": "phpstan analyse",
+    "cs": "php-cs-fixer fix --dry-run --diff",
+    "cs:fix": "php-cs-fixer fix",
+    "check": [
+      "@test",
+      "@analyse",
+      "@cs"
+    ]
+  }
+}
+```
+
+Do not add a tool to `composer check` until its config is committed and local Docker execution is verified.
+
+## Frontend TypeScript Baseline
+
+NENE2's own frontend starter direction is React + TypeScript.
+
+The framework should not force React on applications built with NENE2. Users may choose Vue, Nuxt, Next, plain TypeScript, or another frontend stack. However, framework-maintained examples, starter files, and internal validation should use one default stack to avoid fragmented maintenance.
+
+Planned frontend baseline:
+
+- React for the first official starter.
+- TypeScript for frontend source.
+- Vite for local development and production builds.
+- ESLint with TypeScript support for linting.
+- Prettier for formatting.
+- `tsc --noEmit` for type checking unless the starter adopts a tool that provides an equivalent check.
+
+Recommended future frontend scripts:
+
+```json
+{
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "lint": "eslint .",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
+    "check": "npm run type-check && npm run lint && npm run format"
+  }
+}
+```
+
+The exact package manager should be decided when the frontend starter is implemented.
+
+## OpenAPI Validation
+
+OpenAPI validation should become part of the standard check path after shared schemas and stable endpoints exist.
+
+The first validation should verify:
+
+- the OpenAPI document parses successfully
+- shared schemas are valid
+- documented examples are structurally valid
+
+Runtime response validation belongs to later contract test work.
+
+## Command Shape
+
+The intended split is:
+
+```bash
+composer check
+npm run check --prefix frontend
+```
+
+Docker remains the standard backend runtime. Frontend commands may run on the host or in a future Node container, but the chosen approach must be documented before CI depends on it.
+
+## Non-Goals
+
+- Forcing React on framework consumers.
+- Adding every quality tool before there is code for it to check.
+- Introducing Rector as a general-purpose automatic refactoring step.
+- Making frontend checks required before `frontend/` exists.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ NENE2 should let a developer clone one repository and quickly build:
 
 - JSON APIs with clear contracts
 - thin server HTML when needed
-- React or Vue frontends without backend lock-in
+- React frontend starters without backend lock-in, while allowing applications to choose another frontend stack
 - testable use cases and adapters
 - OpenAPI and MCP integrations through documented boundaries
 
@@ -42,6 +42,7 @@ Goal: create the smallest useful runtime structure.
 - minimal HTML response support through native PHP templates
 - database migration layout and tool selection policy
 - first PHPUnit test suite
+- PHPDoc / TSDoc and quality tools policy
 
 ## Phase 2: API Contract Foundation
 
@@ -65,9 +66,9 @@ Goal: support database-backed applications without making framework core databas
 
 ## Phase 3: Frontend Integration
 
-Goal: make React or Vue easy to adopt without making NENE2 a frontend framework.
+Goal: make the React + TypeScript starter easy to adopt without making NENE2 a frontend framework or blocking other frontend stacks.
 
-- `frontend/` starter policy
+- React + TypeScript `frontend/` starter policy
 - Vite-oriented integration notes
 - API client generation or typed fetch wrapper policy
 - SPA shell and static asset serving guidance
@@ -87,6 +88,7 @@ Goal: keep the framework small while making changes safe.
 
 - static analysis
 - formatter and linter configuration
+- PHP-CS-Fixer, ESLint, TypeScript, and Prettier check commands
 - mutation or architecture tests where useful
 - semantic versioning policy
 - release checklist

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -26,6 +26,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define typed config and environment policy. `#17`
 - [x] Define RFC 9457 Problem Details API error response policy. `#18`
 - [x] Define middleware and security baseline policy. `#19`
+- [x] Define quality tools and documentation comments policy. `#20`
 
 ## Next Candidates
 
@@ -34,11 +35,13 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Implement typed config loader and `.env.example`.
 - [ ] Add OpenAPI Problem Details schemas.
 - [ ] Add request id, CORS, security headers, and request size middleware skeletons.
+- [ ] Add PHP-CS-Fixer configuration and Composer scripts.
+- [ ] Add React + TypeScript frontend starter and ESLint / Prettier baseline.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Add the first native PHP view renderer and escaping helper.
 - [ ] Choose and wire the migration runner when the database adapter layer starts.
-- [ ] Choose the first frontend starter direction or keep both React/Vue documented as optional.
+- [ ] Define logging and observability policy.
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- PHP-CS-Fixer を backend style baseline の第一候補として整理
- React + TypeScript を framework-maintained frontend starter の標準方針として定義
- PHPDoc / TSDoc の対象範囲と file header / license metadata 方針を追加

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for docs and README

Closes #20

Made with [Cursor](https://cursor.com)