### PR TITLE
docs(frontend): npm と Node LTS 方針を定義する

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ composer check
 
 See `docs/development/php-runtime.md` and `docs/development/docker.md` for runtime and tooling details.
 
-NENE2's planned quality baseline adds PHP-CS-Fixer for backend style checks and ESLint, TypeScript, and Prettier for the React frontend starter. Framework public APIs should use PHPDoc or TSDoc where comments explain contracts or extension rules. See `docs/development/quality-tools.md` and `docs/development/documentation-comments.md`.
+NENE2's planned quality baseline adds PHP-CS-Fixer for backend style checks and npm, ESLint, TypeScript, and Prettier for the React frontend starter. The frontend starter targets active Node.js LTS, commits `package-lock.json`, and keeps dependencies modern through update automation. Framework public APIs should use PHPDoc or TSDoc where comments explain contracts or extension rules. See `docs/development/quality-tools.md`, `docs/development/frontend-integration.md`, and `docs/development/documentation-comments.md`.
 
 ## Project Workflow
 

--- a/docs/development/frontend-integration.md
+++ b/docs/development/frontend-integration.md
@@ -1,0 +1,175 @@
+# Frontend Integration Policy
+
+NENE2 provides a React + TypeScript starter direction without making the framework depend on React.
+
+## Position
+
+Frontend integration should make the first application experience smooth while keeping the PHP framework core independent.
+
+The standard direction is:
+
+- Use React + TypeScript + Vite for NENE2-maintained starter work.
+- Use npm as the official package manager for the starter.
+- Use the active Node.js LTS line as the baseline instead of chasing every current release.
+- Commit `package-lock.json` for reproducible frontend installs.
+- Adopt current major versions when adding frontend dependencies, then keep them updated through automation.
+- Keep frontend source outside `public_html/`.
+- Write built assets to `public_html/assets/` only when they are safe to serve.
+
+This Issue defines the policy only. The actual starter implementation should be added in a focused follow-up Issue.
+
+## Framework Boundary
+
+React is the official starter direction for framework-maintained examples and validation.
+
+Applications built with NENE2 may still use:
+
+- Vue
+- Nuxt
+- Next
+- plain TypeScript
+- server-rendered PHP templates only
+- another frontend stack
+
+NENE2 core must not depend on frontend packages or frontend build output.
+
+## Package Manager
+
+npm is the standard package manager for the official frontend starter.
+
+Reasons:
+
+- it ships with Node.js
+- it has the lowest setup burden
+- `package-lock.json` is widely understood
+- it keeps starter documentation simple
+- AI tools can infer commands without extra package-manager context
+
+Yarn and pnpm are acceptable for user applications, but NENE2-maintained docs, examples, and CI should use npm unless the project explicitly changes this policy.
+
+## Node.js and npm Versions
+
+NENE2 should target the active Node.js LTS line for frontend starter development.
+
+Policy:
+
+- Do not require the latest current Node.js release just because it exists.
+- Use active LTS as the minimum modern baseline.
+- Allow the next major when it is compatible and useful.
+- Define `engines` in `frontend/package.json`.
+- Define `packageManager` in `frontend/package.json`.
+
+Recommended initial shape:
+
+```json
+{
+  "engines": {
+    "node": ">=22 <25",
+    "npm": ">=10 <12"
+  },
+  "packageManager": "npm@11"
+}
+```
+
+The exact values should be checked against the current Node.js LTS and npm releases when the starter is implemented.
+
+## Dependency Versions
+
+When adding frontend dependencies:
+
+- use the latest stable major available at implementation time
+- avoid pinning old majors for convenience
+- commit the lockfile
+- document any intentional lag behind current stable releases
+
+After initial adoption, keep dependencies modern through Dependabot or Renovate instead of manually chasing every release in feature work.
+
+Recommended baseline dependency groups:
+
+- React and React DOM
+- TypeScript
+- Vite
+- ESLint with TypeScript and React support
+- Prettier
+
+## Lockfile Policy
+
+Commit `frontend/package-lock.json`.
+
+The lockfile is part of the starter's reproducibility story, like `composer.lock` is for framework development tooling.
+
+Policy:
+
+- use `npm ci` in CI once frontend CI exists
+- use `npm install` for local dependency updates
+- review lockfile changes as dependency changes
+- do not commit `node_modules/`
+
+## Build Output
+
+Frontend source belongs in `frontend/`.
+
+Build output may be written to:
+
+```text
+public_html/assets/
+```
+
+Build output should be treated as generated output unless a future release process requires committed assets for a specific distribution target.
+
+The default repository policy is:
+
+- commit source and config
+- commit lockfiles
+- ignore `node_modules/`
+- ignore generated `public_html/assets/*` except placeholder files
+
+## Commands
+
+Recommended future frontend commands:
+
+```bash
+npm install --prefix frontend
+npm run dev --prefix frontend
+npm run build --prefix frontend
+npm run check --prefix frontend
+```
+
+The future `frontend/package.json` should expose:
+
+```json
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint .",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
+    "check": "npm run type-check && npm run lint && npm run format"
+  }
+}
+```
+
+## API Client Direction
+
+Generated API clients should be considered after OpenAPI schemas are stable enough to be useful.
+
+The first starter may use a small typed fetch wrapper. Client generation should be introduced only when it reduces maintenance and keeps API contracts clearer.
+
+## SPA Shell and Server HTML
+
+React SPA shell behavior and thin server-rendered HTML should stay separate:
+
+- React owns rich interactive UI.
+- Native PHP templates remain available for thin pages and operational screens.
+- `public_html/index.php` remains the PHP front controller.
+- frontend asset serving should not bypass the HTTP runtime policy for API routes.
+
+## Non-Goals
+
+- Forcing React on applications built with NENE2.
+- Supporting multiple official starters before the first one is stable.
+- Requiring yarn or pnpm for framework development.
+- Requiring latest current Node.js releases outside the LTS line.
+- Committing `node_modules/` or generated frontend build output by default.

--- a/docs/development/project-layout.md
+++ b/docs/development/project-layout.md
@@ -131,6 +131,8 @@ The name `public_html` is intentionally compatible with common hosting terminolo
 
 NENE2 should not force React at the framework consumer level. This layout keeps Vue, Nuxt, Next, plain TypeScript, and other frontend stacks replaceable for applications built with NENE2.
 
+The official starter uses npm, active Node.js LTS, and committed `package-lock.json` for reproducible frontend development. See `docs/development/frontend-integration.md`.
+
 ## Future Extension Points
 
 These directories may be added later when the need is concrete:

--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -9,7 +9,7 @@ Quality tools are part of the framework design. They should make changes safer w
 The standard direction is:
 
 - Backend framework development uses PHP, Composer, PHPUnit, PHPStan, and PHP-CS-Fixer.
-- Frontend starter development uses React, TypeScript, Vite, ESLint, and Prettier.
+- Frontend starter development uses React, TypeScript, Vite, npm, ESLint, and Prettier.
 - OpenAPI validation should be added as the API contract grows.
 - Commands should be predictable and documented before they become required in CI.
 - Framework users may replace the frontend stack, but NENE2's own starter and examples should use the documented baseline.
@@ -62,9 +62,12 @@ Planned frontend baseline:
 - React for the first official starter.
 - TypeScript for frontend source.
 - Vite for local development and production builds.
+- npm as the official package manager.
+- Active Node.js LTS as the version baseline.
 - ESLint with TypeScript support for linting.
 - Prettier for formatting.
 - `tsc --noEmit` for type checking unless the starter adopts a tool that provides an equivalent check.
+- `package-lock.json` committed for reproducible installs.
 
 Recommended future frontend scripts:
 
@@ -80,7 +83,7 @@ Recommended future frontend scripts:
 }
 ```
 
-The exact package manager should be decided when the frontend starter is implemented.
+See `docs/development/frontend-integration.md` for npm, Node.js, lockfile, build output, and dependency update policy.
 
 ## OpenAPI Validation
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,6 +69,7 @@ Goal: support database-backed applications without making framework core databas
 Goal: make the React + TypeScript starter easy to adopt without making NENE2 a frontend framework or blocking other frontend stacks.
 
 - React + TypeScript `frontend/` starter policy
+- npm, active Node.js LTS, and lockfile policy
 - Vite-oriented integration notes
 - API client generation or typed fetch wrapper policy
 - SPA shell and static asset serving guidance
@@ -89,6 +90,7 @@ Goal: keep the framework small while making changes safe.
 - static analysis
 - formatter and linter configuration
 - PHP-CS-Fixer, ESLint, TypeScript, and Prettier check commands
+- dependency update automation such as Dependabot or Renovate
 - mutation or architecture tests where useful
 - semantic versioning policy
 - release checklist

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -27,6 +27,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define RFC 9457 Problem Details API error response policy. `#18`
 - [x] Define middleware and security baseline policy. `#19`
 - [x] Define quality tools and documentation comments policy. `#20`
+- [x] Define frontend integration and toolchain policy. `#22`
 
 ## Next Candidates
 
@@ -37,6 +38,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Add request id, CORS, security headers, and request size middleware skeletons.
 - [ ] Add PHP-CS-Fixer configuration and Composer scripts.
 - [ ] Add React + TypeScript frontend starter and ESLint / Prettier baseline.
+- [ ] Add npm package metadata, Node engines, package lock, and frontend check scripts.
+- [ ] Add Dependabot or Renovate policy for PHP and frontend dependencies.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Add the first native PHP view renderer and escaping helper.


### PR DESCRIPTION
## Summary
- React + TypeScript + Vite starter の frontend integration 方針を追加
- npm 標準、active Node.js LTS、`package-lock.json` commit 方針を整理
- dependencies は導入時 latest major を使い、Dependabot / Renovate で更新する方針を明記

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for docs and README

Closes #22

Made with [Cursor](https://cursor.com)