### PR TITLE
docs(validation): request validation 方針を定義する

### DIFF
--- a/docs/development/api-error-responses.md
+++ b/docs/development/api-error-responses.md
@@ -89,7 +89,7 @@ Each validation error item should include:
 - `message`: safe human-readable message
 - `code`: stable machine-readable code
 
-The final validation rule mapping belongs to the request validation Issue.
+The final validation rule mapping follows the layered request validation policy. See `docs/development/request-validation.md`.
 
 ## Exception Boundary
 

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -18,6 +18,7 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Depend on interfaces at infrastructure boundaries when it reduces coupling.
 - Prefer constructor injection for required dependencies.
 - Use typed config objects at runtime instead of passing raw arrays through the application.
+- Use readonly DTOs or command objects for use case input boundaries.
 - Keep `getenv()`, `$_ENV`, and `$_SERVER` access inside the config loading boundary.
 - Use PSR-11 as the container boundary.
 - Prefer explicit factories and service providers over autowiring by default.
@@ -25,6 +26,7 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Keep controllers thin: parse input, call a use case, return a response.
 - Keep persistence details inside repositories or adapters.
 - Treat public API schemas as contracts, not incidental output.
+- Keep request validation layered: middleware for HTTP-wide concerns, controllers or handlers for DTO mapping, and use cases for business invariants.
 
 ## HTTP Runtime
 
@@ -43,6 +45,7 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 
 - JSON APIs are the primary product surface.
 - OpenAPI should describe public request, response, and error shapes.
+- Request validation should use layered validation and readonly DTOs before calling use cases.
 - Server HTML should stay minimal and easy to replace with a SPA shell.
 - Native PHP templates are the first standard HTML path; full template engines are optional adapters.
 - Keep server HTML source in `templates/` and view abstractions in `src/View/`.
@@ -57,9 +60,11 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Use RFC 9457 Problem Details for public JSON API errors.
 - Use `application/problem+json` for Problem Details responses.
 - Do not leak stack traces, SQL, file paths, secrets, or private identifiers in public error responses.
+- Return request validation failures as `validation-failed` Problem Details with structured `errors`.
 - Prefer structured logs with request context once logging is introduced.
 - Do not log secrets, tokens, passwords, or private payloads.
 - See `docs/development/api-error-responses.md`.
+- See `docs/development/request-validation.md`.
 
 ## Testing
 

--- a/docs/development/http-runtime.md
+++ b/docs/development/http-runtime.md
@@ -46,6 +46,8 @@ This keeps authentication, logging, error handling, CORS, and OpenAPI validation
 
 Middleware and security baseline policy is defined in `docs/development/middleware-security.md`.
 
+Request validation uses a layered policy: middleware handles HTTP-wide concerns, controllers or handlers map to DTOs, and use cases protect business invariants. See `docs/development/request-validation.md`.
+
 ### PSR-17
 
 Response and stream creation should go through factories rather than direct implementation classes. This keeps the concrete PSR-7 implementation replaceable.

--- a/docs/development/middleware-security.md
+++ b/docs/development/middleware-security.md
@@ -47,6 +47,8 @@ Recommended first pipeline:
 
 Error handling should wrap the whole pipeline so every failure can be converted to a stable Problem Details response.
 
+Route-specific request validation should stay in controllers, handlers, DTO mappers, or use cases rather than global middleware. See `docs/development/request-validation.md`.
+
 ## Request ID
 
 Every request should have a request id.

--- a/docs/development/request-validation.md
+++ b/docs/development/request-validation.md
@@ -1,0 +1,192 @@
+# Request Validation Policy
+
+NENE2 uses layered request validation with OpenAPI as the public contract and readonly DTOs as the application input boundary.
+
+## Position
+
+Validation should make request handling predictable without turning middleware into hidden controller logic.
+
+The standard direction is:
+
+- Use layered validation.
+- Keep OpenAPI as the API contract source of truth.
+- Start with contract and schema validation in tests.
+- Add runtime OpenAPI validation later when schemas and routes are stable.
+- Convert HTTP input into readonly DTOs or command objects before calling use cases.
+- Keep business invariants inside use cases and domain services.
+- Return validation failures as RFC 9457 Problem Details.
+
+This Issue defines the policy only. Validation packages and implementation should be added in later Issues.
+
+## Layered Validation
+
+Validation responsibilities are split by layer.
+
+```text
+Middleware:
+  request size / content-type / JSON parse / auth / CORS / request id
+
+Controller or handler:
+  path / query / body mapping
+  readonly DTO creation
+  format validation
+  API input semantic validation
+
+Use case:
+  business invariants
+  authorization-sensitive application rules
+  state-dependent rules
+```
+
+This keeps each rule close to the layer that understands it.
+
+## Middleware Boundary
+
+Middleware should handle request concerns that apply across routes.
+
+Good middleware validation candidates:
+
+- request size
+- content type
+- malformed JSON
+- authentication and authorization boundary checks
+- request id propagation
+- CORS
+- future runtime OpenAPI validation
+
+Middleware should not contain route-specific business input rules such as "email must be unique" or "campaign must still be editable".
+
+## Controller and Handler Boundary
+
+Controllers and handlers should be thin input mappers.
+
+They should:
+
+- read path parameters, query parameters, headers, and body data from the PSR-7 request
+- validate request-local format and semantic rules
+- create readonly DTOs or command objects
+- call a use case with explicit input
+- return a response
+
+They should not pass raw unstructured request arrays deep into use cases.
+
+## DTO and Command Object Policy
+
+Readonly DTOs are the standard use case input boundary.
+
+Recommended shape:
+
+```php
+final readonly class CreateUserInput
+{
+    public function __construct(
+        public string $email,
+        public string $name,
+    ) {
+    }
+}
+```
+
+DTOs should:
+
+- be small and named after the use case or operation
+- use native PHP types
+- avoid depending on PSR-7 or superglobals
+- represent already parsed request values
+- include PHPDoc only when it explains public semantics that types cannot express
+
+DTO construction may happen in controllers, handlers, or focused mapper/factory classes when mapping becomes non-trivial.
+
+## Use Case Boundary
+
+Use cases validate business invariants.
+
+Examples:
+
+- a user cannot register with an email that already exists
+- an expired campaign cannot be edited
+- an account cannot access another account's private resource
+- a state transition is not allowed from the current state
+
+These rules should not be expressed only as HTTP request validation because they must remain true outside HTTP, including CLI, workers, tests, and future MCP-driven workflows.
+
+## OpenAPI Relationship
+
+OpenAPI is the public API contract.
+
+Initial policy:
+
+- document public request shapes in OpenAPI before clients depend on them
+- validate OpenAPI documents and examples in tests first
+- use shared Problem Details schemas for validation errors
+- do not require runtime OpenAPI validation in the first HTTP skeleton
+
+Future runtime OpenAPI validation can be added as PSR-15 middleware after:
+
+- route definitions are stable enough
+- OpenAPI schemas are shared and maintained
+- error mapping to Problem Details is implemented
+- performance and developer experience are understood
+
+## Error Response
+
+Validation failures should use:
+
+```text
+422 Unprocessable Content
+Content-Type: application/problem+json
+```
+
+Problem type:
+
+```text
+https://nene2.dev/problems/validation-failed
+```
+
+The response should include an `errors` array.
+
+Each item should include:
+
+- `field`: field name, parameter name, or JSON pointer
+- `message`: safe human-readable message
+- `code`: stable machine-readable code
+
+Example:
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation Failed",
+  "status": 422,
+  "detail": "The request body contains invalid values.",
+  "errors": [
+    {
+      "field": "email",
+      "message": "Email must be a valid email address.",
+      "code": "invalid_email"
+    }
+  ]
+}
+```
+
+## Testing
+
+Request validation tests should cover:
+
+- successful DTO creation from valid request data
+- missing required fields
+- invalid field format
+- invalid query or path parameters
+- malformed JSON at the middleware boundary
+- Problem Details response shape for validation failures
+- use case invariant failures separately from request format failures
+
+Contract tests should verify that stable API behavior matches OpenAPI.
+
+## Non-Goals
+
+- Passing raw request arrays throughout the application.
+- Putting route-specific business validation into global middleware.
+- Requiring runtime OpenAPI validation before the HTTP runtime is stable.
+- Generating all DTOs from OpenAPI as the first implementation path.
+- Hiding validation behind magic controller resolvers.

--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -62,3 +62,5 @@ Once runtime code exists, API tests should verify that responses match the docum
 Future OpenAPI work should add shared schemas for `ProblemDetails`, `ValidationProblemDetails`, and `ValidationError`. See `docs/development/api-error-responses.md`.
 
 OpenAPI security schemes should be added only when the matching middleware or authentication adapter is implemented. See `docs/development/middleware-security.md`.
+
+Runtime OpenAPI request validation should be added after the HTTP runtime and schemas are stable. The first validation step should be contract and schema validation in tests. See `docs/development/request-validation.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,6 +39,7 @@ Goal: create the smallest useful runtime structure.
 - Composer package metadata
 - PSR-11 dependency injection and explicit wiring policy
 - RFC 9457 Problem Details error response policy
+- layered request validation and readonly DTO policy
 - minimal HTML response support through native PHP templates
 - database migration layout and tool selection policy
 - first PHPUnit test suite
@@ -50,6 +51,7 @@ Goal: make API behavior explicit and client-friendly.
 
 - OpenAPI document location and generation policy
 - request and response schema conventions
+- contract-first request validation tests
 - shared Problem Details error schemas
 - contract tests
 - examples for success and failure responses

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -27,6 +27,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define RFC 9457 Problem Details API error response policy. `#18`
 - [x] Define middleware and security baseline policy. `#19`
 - [x] Define quality tools and documentation comments policy. `#20`
+- [x] Define request validation policy. `#21`
 - [x] Define frontend integration and toolchain policy. `#22`
 
 ## Next Candidates
@@ -35,6 +36,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Choose concrete PSR-11 container package or adapter strategy.
 - [ ] Implement typed config loader and `.env.example`.
 - [ ] Add OpenAPI Problem Details schemas.
+- [ ] Add validation error mapping and readonly DTO examples.
 - [ ] Add request id, CORS, security headers, and request size middleware skeletons.
 - [ ] Add PHP-CS-Fixer configuration and Composer scripts.
 - [ ] Add React + TypeScript frontend starter and ESLint / Prettier baseline.


### PR DESCRIPTION
## Summary
- layered validation / OpenAPI contract-first / readonly DTO 方針を追加
- middleware、controller / handler、use case の validation 責務を整理
- Problem Details、OpenAPI、HTTP runtime との接続を反映

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for docs

Closes #21

Made with [Cursor](https://cursor.com)