### PR TITLE
docs(observability): logging と observability 方針を定義する

### DIFF
--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -21,6 +21,7 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Use readonly DTOs or command objects for use case input boundaries.
 - Keep `getenv()`, `$_ENV`, and `$_SERVER` access inside the config loading boundary.
 - Use PSR-11 as the container boundary.
+- Use PSR-3 as the logging boundary when logging is needed.
 - Prefer explicit factories and service providers over autowiring by default.
 - Do not use the container as a service locator inside domain or use-case code.
 - Keep controllers thin: parse input, call a use case, return a response.
@@ -62,9 +63,11 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Do not leak stack traces, SQL, file paths, secrets, or private identifiers in public error responses.
 - Return request validation failures as `validation-failed` Problem Details with structured `errors`.
 - Prefer structured logs with request context once logging is introduced.
+- Use request ids to correlate responses, logs, error handling, and future metrics.
 - Do not log secrets, tokens, passwords, or private payloads.
 - See `docs/development/api-error-responses.md`.
 - See `docs/development/request-validation.md`.
+- See `docs/development/observability.md`.
 
 ## Testing
 

--- a/docs/development/http-runtime.md
+++ b/docs/development/http-runtime.md
@@ -48,6 +48,8 @@ Middleware and security baseline policy is defined in `docs/development/middlewa
 
 Request validation uses a layered policy: middleware handles HTTP-wide concerns, controllers or handlers map to DTOs, and use cases protect business invariants. See `docs/development/request-validation.md`.
 
+Logging and observability should use PSR-3, request id propagation, and adapter-driven integrations. See `docs/development/observability.md`.
+
 ### PSR-17
 
 Response and stream creation should go through factories rather than direct implementation classes. This keeps the concrete PSR-7 implementation replaceable.

--- a/docs/development/middleware-security.md
+++ b/docs/development/middleware-security.md
@@ -60,6 +60,8 @@ Policy:
 - Add it to response headers.
 - Include it in logs once logging is implemented.
 
+Request id logging and observability policy is defined in `docs/development/observability.md`.
+
 Recommended header:
 
 ```text

--- a/docs/development/observability.md
+++ b/docs/development/observability.md
@@ -1,0 +1,165 @@
+# Logging and Observability Policy
+
+NENE2 keeps observability explicit and adapter-driven.
+
+## Position
+
+Framework core should make runtime behavior traceable without depending on one logging backend, metrics system, or error tracking service.
+
+The standard direction is:
+
+- Use PSR-3 as the logging boundary.
+- Depend on `Psr\Log\LoggerInterface` in framework code that needs logging.
+- Treat Monolog as the first concrete logger adapter candidate.
+- Use structured logging with request context.
+- Generate and propagate request ids through middleware.
+- Keep metrics and error tracking as adapters or integrations, not core dependencies.
+- Never log secrets, tokens, passwords, cookies, authorization headers, or private payloads.
+
+This Issue defines the policy only. Packages and implementation should be added in later Issues.
+
+## PSR-3 Boundary
+
+NENE2 should use PSR-3 for logging interoperability.
+
+Framework code may depend on:
+
+```php
+Psr\Log\LoggerInterface
+```
+
+Framework code should not depend directly on Monolog classes unless it is inside a Monolog-specific adapter or provider.
+
+## Logger Adapter Direction
+
+Monolog is the preferred first concrete logger candidate because it is widely used, PSR-3 compatible, and flexible enough for local files, stderr, JSON logs, and external handlers.
+
+The first implementation should decide:
+
+- local development output
+- production output target
+- JSON log formatter
+- log level configuration
+- whether a null logger is used as the default fallback
+
+## Structured Logging
+
+Logs should be structured enough to support debugging, operations, and AI-assisted diagnosis.
+
+Recommended request log context:
+
+- `request_id`
+- `method`
+- `path`
+- `status`
+- `duration_ms`
+- `client_ip` when safe and useful
+- `user_id` or account identifier only when it is safe and non-sensitive
+- `exception_class` for server-side diagnostics
+- `problem_type` for public Problem Details responses
+
+Message text should stay short and stable. Variable details should go into context fields.
+
+## Request ID
+
+Request id handling belongs in middleware.
+
+Policy:
+
+- Accept an incoming `X-Request-Id` only when it passes safety checks.
+- Generate a request id when missing or invalid.
+- Add the request id to the response header.
+- Include the request id in log context.
+- Make the request id available to error handling and future metrics adapters.
+
+Recommended header:
+
+```text
+X-Request-Id
+```
+
+Request ids are correlation identifiers, not authentication credentials.
+
+## Error Tracking
+
+Error tracking tools such as Sentry should be adapters.
+
+NENE2 core should expose enough context for adapters to report errors, but should not require a specific SaaS or SDK.
+
+Adapters may receive:
+
+- exception
+- request id
+- route or path
+- problem type
+- safe user or account identifier
+- environment name
+
+Adapters must not receive raw secrets or private request payloads by default.
+
+## Metrics
+
+Metrics should be adapter-driven.
+
+Future metrics adapters may expose:
+
+- request count
+- status code count
+- request duration
+- exception count
+- validation failure count
+- rate limit events when rate limiting exists
+
+Prometheus, StatsD, OpenTelemetry, Datadog, or another backend should be optional integrations, not required core dependencies.
+
+## Secret and Payload Safety
+
+NENE2 should default to safe logging.
+
+Never log these values by default:
+
+- passwords
+- tokens
+- API keys
+- session ids
+- cookies
+- `Authorization` headers
+- raw request bodies
+- uploaded files
+- private personal data
+- database connection strings
+- full SQL with bound secret values
+
+If payload logging is needed for a local debugging tool, it must be opt-in, environment-aware, and clearly documented.
+
+## Relationship to Error Responses
+
+Public error responses use Problem Details. Logs may include internal diagnostic context, but public responses must not expose stack traces, SQL, file paths, secrets, or private identifiers.
+
+When an exception becomes a public Problem Details response, logs should be able to correlate:
+
+- request id
+- HTTP status
+- problem type
+- exception class
+
+## Testing
+
+Observability tests should verify:
+
+- request id is generated when missing
+- safe incoming request id is preserved when configured
+- invalid incoming request id is replaced
+- response contains `X-Request-Id`
+- logs contain request id context
+- secrets and authorization headers are not logged
+
+The first implementation can start with request id middleware and a test logger.
+
+## Non-Goals
+
+- Requiring Monolog in framework core before the logging adapter Issue.
+- Requiring Sentry, Datadog, Prometheus, or OpenTelemetry by default.
+- Logging raw request bodies by default.
+- Making observability depend on a database.
+- Exposing stack traces or private diagnostics in public API responses.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,6 +35,7 @@ Goal: create the smallest useful runtime structure.
 - route dispatch foundation
 - middleware pipeline foundation
 - middleware security baseline policy
+- logging and observability policy
 - typed config loading and environment policy
 - Composer package metadata
 - PSR-11 dependency injection and explicit wiring policy
@@ -84,6 +85,7 @@ Goal: let AI tools inspect and operate the app through safe, documented contract
 - API-key or token boundary policy
 - tool definitions derived from OpenAPI where practical
 - safe local development commands
+- request id and structured log context for AI-assisted debugging
 
 ## Phase 5: Quality and Release
 
@@ -93,6 +95,7 @@ Goal: keep the framework small while making changes safe.
 - formatter and linter configuration
 - PHP-CS-Fixer, ESLint, TypeScript, and Prettier check commands
 - dependency update automation such as Dependabot or Renovate
+- logging, metrics, and error tracking adapter policy
 - mutation or architecture tests where useful
 - semantic versioning policy
 - release checklist

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -29,6 +29,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define quality tools and documentation comments policy. `#20`
 - [x] Define request validation policy. `#21`
 - [x] Define frontend integration and toolchain policy. `#22`
+- [x] Define logging and observability policy. `#33`
 
 ## Next Candidates
 
@@ -38,6 +39,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Add OpenAPI Problem Details schemas.
 - [ ] Add validation error mapping and readonly DTO examples.
 - [ ] Add request id, CORS, security headers, and request size middleware skeletons.
+- [ ] Add PSR-3 logging adapter and request id log context.
 - [ ] Add PHP-CS-Fixer configuration and Composer scripts.
 - [ ] Add React + TypeScript frontend starter and ESLint / Prettier baseline.
 - [ ] Add npm package metadata, Node engines, package lock, and frontend check scripts.
@@ -46,7 +48,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Add the first native PHP view renderer and escaping helper.
 - [ ] Choose and wire the migration runner when the database adapter layer starts.
-- [ ] Define logging and observability policy.
+- [ ] Add metrics and error tracking adapter policy details when integrations start.
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- PSR-3 を logging boundary とする observability 方針を追加
- request id、structured logging、secret / payload logging 禁止方針を整理
- Monolog、error tracking、metrics を adapter / integration として扱う方針を明記

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for docs

Closes #33

Made with [Cursor](https://cursor.com)