### PR TITLE
docs(release): versioning と CI 方針を定義する

### DIFF
--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -108,6 +108,8 @@ npm run check --prefix frontend
 
 Docker remains the standard backend runtime. Frontend commands may run on the host or in a future Node container, but the chosen approach must be documented before CI depends on it.
 
+CI should start with backend `composer check` and expand only after each tool has committed configuration and local verification commands. See `docs/development/release-ci.md`.
+
 ## Non-Goals
 
 - Forcing React on framework consumers.

--- a/docs/development/release-ci.md
+++ b/docs/development/release-ci.md
@@ -1,0 +1,164 @@
+# Release, Versioning, and CI Policy
+
+NENE2 uses SemVer, small release steps, and GitHub Actions as the standard CI direction.
+
+## Position
+
+Release and CI policy should keep the framework safe to change while the public API is still forming.
+
+The standard direction is:
+
+- Use Semantic Versioning.
+- Grow the framework through `0.x.y` releases until the public contracts are stable.
+- Use Git tags as the release source.
+- Use GitHub Releases for release notes.
+- Add CI checks incrementally as tools become part of the documented `check` commands.
+- Keep Packagist publication as a later step after Composer package contracts are more stable.
+- Start dependency update automation with Dependabot before introducing heavier automation.
+
+This Issue defines the policy only. GitHub Actions workflow files should be added in a focused follow-up Issue.
+
+## Versioning
+
+NENE2 follows Semantic Versioning.
+
+During early framework development, use `0.x.y` versions:
+
+- `0.x.y` means public contracts are still forming.
+- Minor releases may include meaningful framework surface changes.
+- Patch releases should be small fixes or documentation corrections.
+- Avoid `1.0.0` until HTTP runtime, DI, config, validation, error responses, and OpenAPI contract conventions are stable enough for users.
+
+After `1.0.0`, these changes are breaking changes and require a major version:
+
+- incompatible public PHP API changes
+- incompatible configuration changes
+- incompatible CLI behavior
+- incompatible documented middleware behavior
+- incompatible OpenAPI public contract changes
+- removal of documented extension points
+
+## Tags
+
+Release tags should use the `v` prefix:
+
+```text
+v0.1.0
+v0.2.0
+v1.0.0
+```
+
+Tags should point to commits on `main`.
+
+Do not tag unreleased local work or unmerged PR branches.
+
+## GitHub Releases
+
+GitHub Releases should be created from tags.
+
+Release notes should include:
+
+- highlights
+- breaking changes, if any
+- migration notes, if any
+- verification summary
+- related Issues or PRs
+
+Manual release notes are acceptable at first. Automated release note generation can be introduced when the release process becomes repetitive.
+
+## CI Baseline
+
+The first GitHub Actions workflow should verify backend quality.
+
+Recommended first CI steps:
+
+```text
+1. checkout
+2. set up PHP 8.4
+3. validate composer.json
+4. install Composer dependencies
+5. run composer check
+```
+
+`composer check` is the backend source of truth for the standard local verification path.
+
+Do not add frontend or OpenAPI checks to required CI before their commands and configs are committed.
+
+## Future CI Expansion
+
+As tooling is implemented, CI should expand in this order:
+
+1. PHP-CS-Fixer check after configuration is committed.
+2. OpenAPI validation after shared schemas and validation commands exist.
+3. Frontend check after `frontend/package.json` and `package-lock.json` exist.
+4. Dependency update checks after Dependabot or Renovate is configured.
+5. Release workflow after manual release steps are stable.
+
+Recommended future frontend CI steps:
+
+```text
+1. set up Node.js active LTS
+2. npm ci --prefix frontend
+3. npm run check --prefix frontend
+4. npm run build --prefix frontend
+```
+
+## Branch Protection
+
+`main` should be protected before releases become public.
+
+Recommended branch protection:
+
+- require PRs before merging
+- require CI checks before merging
+- avoid direct commits to `main`
+- keep merge commits unless the project deliberately changes history policy
+- do not force-push to `main`
+
+Merge commits are acceptable because they preserve the Issue and PR lifecycle clearly.
+
+## Packagist
+
+Packagist publication is a goal, but not required before the framework surface is useful.
+
+Before Packagist publication:
+
+- Composer metadata should be accurate.
+- Public PHP namespaces should be stable enough for early users.
+- License and README should be complete.
+- Tags should follow the versioning policy.
+- Release notes should explain support expectations.
+
+## Dependency Updates
+
+Dependabot is the preferred first dependency update tool.
+
+Initial targets:
+
+- Composer dependencies
+- GitHub Actions
+- npm dependencies once `frontend/` exists
+
+Renovate can be considered later if grouping, scheduling, or advanced dependency policies become important.
+
+Dependency update PRs should still run the same CI checks as normal PRs.
+
+## Release Checklist
+
+Before tagging a release:
+
+- `main` is up to date.
+- Required CI checks are passing.
+- Local `composer check` passes when practical.
+- Documentation for changed public behavior is updated.
+- `docs/todo/current.md` does not claim an incomplete release task is done.
+- Release notes are prepared.
+- The tag follows `vX.Y.Z`.
+
+## Non-Goals
+
+- Publishing to Packagist before the framework surface is useful.
+- Requiring frontend CI before the frontend starter exists.
+- Requiring OpenAPI validation before shared schemas and commands exist.
+- Introducing complex release automation before manual releases are understood.
+- Treating `0.x.y` as a promise of long-term public API stability.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,6 +45,7 @@ Goal: create the smallest useful runtime structure.
 - database migration layout and tool selection policy
 - first PHPUnit test suite
 - PHPDoc / TSDoc and quality tools policy
+- release, versioning, and CI policy
 
 ## Phase 2: API Contract Foundation
 
@@ -96,6 +97,7 @@ Goal: keep the framework small while making changes safe.
 - PHP-CS-Fixer, ESLint, TypeScript, and Prettier check commands
 - dependency update automation such as Dependabot or Renovate
 - logging, metrics, and error tracking adapter policy
+- GitHub Actions, SemVer, tags, and release checklist
 - mutation or architecture tests where useful
 - semantic versioning policy
 - release checklist

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -29,6 +29,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define quality tools and documentation comments policy. `#20`
 - [x] Define request validation policy. `#21`
 - [x] Define frontend integration and toolchain policy. `#22`
+- [x] Define release, versioning, and CI policy. `#23`
 - [x] Define logging and observability policy. `#33`
 
 ## Next Candidates
@@ -44,6 +45,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Add React + TypeScript frontend starter and ESLint / Prettier baseline.
 - [ ] Add npm package metadata, Node engines, package lock, and frontend check scripts.
 - [ ] Add Dependabot or Renovate policy for PHP and frontend dependencies.
+- [ ] Add first GitHub Actions workflow for backend Composer checks.
+- [ ] Add release checklist and first `v0.x.y` release preparation when runtime surface is useful.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Add the first native PHP view renderer and escaping helper.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -15,6 +15,8 @@ NENE2 uses GitHub Issues for work tracking and local Markdown files for project 
 9. Merge after review and checks.
 10. Return local `main` to the merged, clean state.
 
+Release, versioning, and CI policy is defined in `docs/development/release-ci.md`.
+
 ## Branch Names
 
 Use Conventional Commit style as the prefix:
@@ -33,6 +35,8 @@ Every PR should include:
 - verification results
 - related Issue, preferably `Closes #number`
 - remaining risks or follow-up work
+
+Public release work should happen from `main` tags after required checks pass. Do not tag unmerged PR branches.
 
 ## Local Project Memory
 


### PR DESCRIPTION
## Summary
- SemVer / `0.x.y` / `vX.Y.Z` tag による release 方針を追加
- 最初の GitHub Actions CI は backend `composer check` から始める方針を整理
- Dependabot 先行、Packagist は package surface 安定後にする方針を明記

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for docs

Closes #23

Made with [Cursor](https://cursor.com)