### PR TITLE
docs(adr): ADR 運用方針を定義する

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,24 @@
+# ADR 0000: Title
+
+## Status
+
+proposed
+
+## Context
+
+Describe the problem, constraints, and trade-offs that make this decision necessary.
+
+## Decision
+
+Describe the decision in clear, direct language.
+
+## Consequences
+
+Describe the expected benefits, costs, and follow-up work.
+
+## Related
+
+- Issue: `#000`
+- PR: `#000`
+- Supersedes: none
+- Superseded by: none

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -1,0 +1,118 @@
+# ADR Policy
+
+NENE2 uses lightweight Architecture Decision Records for decisions that future maintainers should be able to understand without reading old chats.
+
+## Position
+
+ADRs are not meeting minutes. They are a small set of decision records that preserve architectural intent.
+
+The standard direction is:
+
+- Store ADRs in `docs/adr/`.
+- Use numbered Markdown files.
+- Keep ADRs short and decision-focused.
+- Record only decisions that affect architecture, public contracts, dependencies, releases, or long-term maintenance.
+- Keep day-to-day task detail in Issues, PRs, roadmap, and TODO files.
+- Supersede old ADRs instead of editing history to hide previous context.
+
+This Issue defines the policy and template only. Existing foundation decisions do not need to be backfilled immediately.
+
+## Directory
+
+ADRs live in:
+
+```text
+docs/adr/
+```
+
+File names should use a four-digit sequence and short kebab-case title:
+
+```text
+0001-use-psr-http-runtime.md
+0002-use-react-typescript-starter.md
+```
+
+The number is stable after creation. Do not renumber ADRs.
+
+## Status
+
+Use one of these statuses:
+
+- `proposed`: under discussion
+- `accepted`: active decision
+- `superseded`: replaced by a later ADR
+
+If an ADR is superseded, link to the newer ADR. Do not delete the old ADR unless it was created by mistake and never used.
+
+## When to Write an ADR
+
+Write an ADR when a decision affects:
+
+- public PHP APIs
+- HTTP runtime architecture
+- dependency or package selection
+- frontend starter architecture
+- OpenAPI contract strategy
+- release, versioning, or compatibility policy
+- database or migration strategy
+- observability or security architecture
+- AI / MCP integration boundaries
+- a trade-off that future contributors are likely to question
+
+Do not write an ADR for:
+
+- simple bug fixes
+- routine documentation edits
+- small internal refactors
+- obvious tool configuration changes
+- work already fully explained by a narrow Issue and PR
+
+## Relationship to Other Docs
+
+ADRs explain why a major decision was made.
+
+Other documents explain how the project currently works:
+
+- `docs/development/`: current policies and implementation guidance
+- `docs/roadmap.md`: phase direction
+- `docs/todo/current.md`: current task board
+- GitHub Issues: work units and discussion
+- PRs: concrete changes and verification
+
+If an ADR changes current policy, update the relevant `docs/development/` file in the same PR.
+
+## Template
+
+Use `docs/adr/0000-template.md` as the starting point.
+
+Required sections:
+
+- Title
+- Status
+- Context
+- Decision
+- Consequences
+- Related
+
+Keep ADRs concise. A good ADR should usually fit on one screen or two.
+
+## First ADR Candidates
+
+Do not backfill every existing decision.
+
+Good first candidates when implementation starts:
+
+- concrete PSR-7 / PSR-17 package and router selection
+- concrete PSR-11 container strategy
+- logging adapter selection
+- frontend starter implementation strategy
+- first release / Packagist publication decision
+
+The already documented foundation policies remain valid in `docs/development/` until a concrete decision needs ADR-level traceability.
+
+## Non-Goals
+
+- Turning every Issue into an ADR.
+- Duplicating all development documentation in ADR files.
+- Rewriting old decisions just to create a complete historical archive.
+- Using ADRs to avoid updating the actual policy docs.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -127,3 +127,4 @@ See `docs/development/quality-tools.md`.
 - Keep functions short enough to inspect without jumping through many layers.
 - Prefer explicit return types and simple data shapes.
 - Record architecture decisions in `docs/` when they affect future implementation.
+- Use ADRs for major decisions that need long-term traceability. See `docs/development/adr.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,6 +23,7 @@ Goal: make contribution, AI operation, and technical direction unambiguous befor
 - Cursor rules
 - OpenAPI / MCP direction documents
 - standard repository layout
+- ADR operation policy
 
 Tracked by `docs/milestones/2026-05-nene2-foundation.md`.
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -30,12 +30,14 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define request validation policy. `#21`
 - [x] Define frontend integration and toolchain policy. `#22`
 - [x] Define release, versioning, and CI policy. `#23`
+- [x] Define ADR operation policy. `#24`
 - [x] Define logging and observability policy. `#33`
 
 ## Next Candidates
 
 - [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation.
 - [ ] Choose concrete PSR-11 container package or adapter strategy.
+- [ ] Write ADRs for concrete HTTP runtime, router, and container package selections.
 - [ ] Implement typed config loader and `.env.example`.
 - [ ] Add OpenAPI Problem Details schemas.
 - [ ] Add validation error mapping and readonly DTO examples.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -43,8 +43,11 @@ Public release work should happen from `main` tags after required checks pass. D
 - `docs/roadmap.md`: long-lived direction and phases
 - `docs/milestones/`: medium-sized goals and acceptance criteria
 - `docs/todo/current.md`: current task board and handoff notes
+- `docs/adr/`: major architecture decisions that should remain traceable
 
 Do not leave important decisions only in chat. If it changes how the project should be built, record it in `docs/`.
+
+Use ADRs only for decisions that affect architecture, public contracts, dependency choices, release policy, or long-term maintenance. See `docs/development/adr.md`.
 
 ## AI Agent Responsibilities
 


### PR DESCRIPTION
## Summary
- lightweight ADR policy を追加
- `docs/adr/0000-template.md` を追加
- ADR 対象を architecture / public contract / dependency / release policy など重要判断に限定

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for docs

Closes #24

Made with [Cursor](https://cursor.com)