### PR TITLE
docs(review): self-review checklist 方針を定義する

### DIFF
--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -128,3 +128,4 @@ See `docs/development/quality-tools.md`.
 - Prefer explicit return types and simple data shapes.
 - Record architecture decisions in `docs/` when they affect future implementation.
 - Use ADRs for major decisions that need long-term traceability. See `docs/development/adr.md`.
+- Use self-review checklists before push or PR when a task matches a checklist. See `docs/development/self-review.md`.

--- a/docs/development/self-review.md
+++ b/docs/development/self-review.md
@@ -1,0 +1,131 @@
+# Self-Review Checklist Policy
+
+NENE2 uses self-review checklists to make important rules hard to miss before pushing or opening a PR.
+
+## Position
+
+As the project grows, rules spread across focused policy documents. That is healthy, but it also makes it easy to miss required checks. Self-review checklists are the final, task-oriented reminder layer.
+
+The standard direction is:
+
+- Store task-specific checklists in `docs/review/`.
+- Keep checklists short and linked to the source policy docs.
+- Use checklists before pushing, opening a PR, or merging.
+- Mark non-applicable items as `N/A` in judgment, not by deleting the rule.
+- Record which checklist was used in PR descriptions when practical.
+- Use checklists as a safety net, not as a replacement for policy docs.
+
+This Issue defines the policy and first checklist set only. Checklists should evolve as implementation work reveals missing review points.
+
+## Goals
+
+Self-review checklists should:
+
+- reduce missed mandatory rules
+- make AI and human review more consistent
+- connect scattered policy documents to concrete work types
+- keep PR descriptions more honest about verification
+- help future contributors know what "done" means for each kind of change
+
+## Non-Goals
+
+Self-review checklists should not:
+
+- duplicate every rule from every policy document
+- become long compliance documents
+- replace tests, static analysis, or CI
+- block small documentation fixes with irrelevant checks
+- hide decisions that should be recorded in ADRs
+
+## Directory
+
+Checklists live in:
+
+```text
+docs/review/
+```
+
+Initial checklist files:
+
+```text
+docs/review/
+├── backend-api.md
+├── database.md
+├── docs-policy.md
+├── frontend.md
+├── middleware-security.md
+└── release-ci.md
+```
+
+Add new checklist files only when a repeated work type has enough unique risk to justify one.
+
+## How to Use
+
+Before pushing or opening a PR:
+
+1. Identify the work type.
+2. Open the matching checklist.
+3. Review every applicable item.
+4. Run the narrowest useful verification.
+5. Mention the checklist in the PR body when practical.
+
+Example PR note:
+
+```text
+Self-review: backend-api, middleware-security
+```
+
+If an item is not applicable, it can be treated as `N/A`. Do not edit the checklist just to make the current PR pass.
+
+## Checklist Design Rules
+
+Each checklist should:
+
+- focus on mistakes that would be costly if missed
+- link to source policy docs instead of copying full explanations
+- stay short enough to review quickly
+- include verification commands when they are stable
+- avoid vague items like "code is clean"
+
+Prefer:
+
+```markdown
+- [ ] Validation failures use Problem Details `validation-failed`.
+```
+
+Avoid:
+
+```markdown
+- [ ] Follow all coding standards.
+```
+
+## AI Agent Responsibilities
+
+AI agents should use the relevant checklist before finalizing code or documentation changes.
+
+For normal lifecycle work, an agent should:
+
+- pick one or more relevant checklist files
+- verify checklist-specific policy risks
+- run available checks
+- include the checklist names and verification result in the PR body
+- avoid claiming a checklist item passed when it was not checked
+
+If no checklist matches the task, use `docs/workflow.md`, `docs/development/coding-standards.md`, and the relevant policy docs directly.
+
+## Updating Checklists
+
+Update a checklist when:
+
+- a policy document adds a mandatory rule
+- review repeatedly catches the same issue
+- a new work type becomes common
+- a checklist item becomes obsolete
+
+Checklist updates should happen in the same PR as the policy change when possible.
+
+## Relationship to ADRs
+
+Checklists catch repeatable review risks. ADRs explain major one-time decisions.
+
+If a self-review item raises a major architectural choice, create or update an ADR instead of expanding the checklist into a design document.

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -1,0 +1,22 @@
+# Backend API Self-Review
+
+Use this checklist for API endpoints, controllers, handlers, request validation, responses, and HTTP-facing behavior.
+
+Source policies:
+
+- `docs/development/http-runtime.md`
+- `docs/development/request-validation.md`
+- `docs/development/api-error-responses.md`
+- `docs/integrations/openapi.md`
+- `docs/development/coding-standards.md`
+
+## Checklist
+
+- [ ] Public request or response behavior is reflected in OpenAPI when it is stable behavior.
+- [ ] Controllers or handlers map request data to readonly DTOs or command objects before calling use cases.
+- [ ] Use cases do not receive raw PSR-7 requests, superglobals, or unstructured request arrays.
+- [ ] Request validation failures use Problem Details `validation-failed` with structured `errors`.
+- [ ] Public error responses do not expose stack traces, SQL, file paths, secrets, or private identifiers.
+- [ ] HTTP behavior remains compatible with PSR-7 / PSR-15 / PSR-17 boundaries.
+- [ ] The narrowest useful PHP verification was run, usually `composer check`.
+- [ ] PR notes mention this checklist when the change is API-facing.

--- a/docs/review/database.md
+++ b/docs/review/database.md
@@ -1,0 +1,21 @@
+# Database Self-Review
+
+Use this checklist for database adapter work, migrations, seeds, schema snapshots, repositories, and persistence boundaries.
+
+Source policies:
+
+- `docs/development/database-migrations.md`
+- `docs/development/configuration.md`
+- `docs/development/coding-standards.md`
+
+## Checklist
+
+- [ ] Framework core remains database-independent unless an ADR changes that boundary.
+- [ ] Migrations are placed under `database/migrations/`.
+- [ ] Seeds are placed under `database/seeds/` and do not contain production secrets or private data.
+- [ ] Schema snapshots or docs are placed under `database/schema/` when introduced.
+- [ ] Database credentials come from typed config or environment boundaries, not hard-coded values.
+- [ ] Use cases remain independent from concrete database tools.
+- [ ] Repository or adapter boundaries hide persistence details from domain and use-case code.
+- [ ] Database tool adoption, such as Phinx, is documented before becoming required.
+- [ ] The narrowest useful PHP verification was run, usually `composer check`.

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -1,0 +1,23 @@
+# Documentation and Policy Self-Review
+
+Use this checklist for policy docs, workflow docs, ADRs, roadmap updates, TODO updates, and Cursor-facing rules.
+
+Source policies:
+
+- `docs/workflow.md`
+- `docs/development/adr.md`
+- `docs/development/coding-standards.md`
+- `docs/development/self-review.md`
+- `docs/todo/current.md`
+- `docs/roadmap.md`
+
+## Checklist
+
+- [ ] The source-of-truth policy doc was updated instead of only adding a summary elsewhere.
+- [ ] Related `docs/roadmap.md` or `docs/todo/current.md` state was updated when project state changed.
+- [ ] New major architecture, dependency, public contract, or release decisions considered whether an ADR is needed.
+- [ ] The change avoids duplicating full policy text across multiple files.
+- [ ] New checklist items link to source policy docs instead of becoming a second source of truth.
+- [ ] Issue and PR references are included where useful.
+- [ ] The wording is concrete enough for both humans and AI agents to follow.
+- [ ] Docs diagnostics and whitespace checks were reviewed.

--- a/docs/review/frontend.md
+++ b/docs/review/frontend.md
@@ -1,0 +1,22 @@
+# Frontend Self-Review
+
+Use this checklist for the React + TypeScript starter, frontend tooling, API client helpers, and built asset integration.
+
+Source policies:
+
+- `docs/development/frontend-integration.md`
+- `docs/development/quality-tools.md`
+- `docs/development/documentation-comments.md`
+- `docs/development/project-layout.md`
+
+## Checklist
+
+- [ ] Framework core does not depend on frontend packages or build output.
+- [ ] Frontend source stays under `frontend/`, not `public_html/`.
+- [ ] Built assets are generated into `public_html/assets/` only when safe to serve.
+- [ ] npm remains the official starter package manager unless policy changes.
+- [ ] `package-lock.json` is committed when frontend dependencies exist.
+- [ ] `node_modules/` and generated assets are not committed by default.
+- [ ] Exported frontend utilities, hooks, and shared types use TSDoc when they expose public semantics.
+- [ ] Frontend checks were run when available, usually `npm run check --prefix frontend`.
+- [ ] PHP checks were still considered when backend integration behavior changed.

--- a/docs/review/middleware-security.md
+++ b/docs/review/middleware-security.md
@@ -1,0 +1,22 @@
+# Middleware and Security Self-Review
+
+Use this checklist for middleware, request id, CORS, security headers, auth boundaries, logging context, and request-size behavior.
+
+Source policies:
+
+- `docs/development/middleware-security.md`
+- `docs/development/observability.md`
+- `docs/development/request-validation.md`
+- `docs/development/api-error-responses.md`
+
+## Checklist
+
+- [ ] Middleware order remains explicit and easy to trace.
+- [ ] Error handling still wraps failures that should become Problem Details responses.
+- [ ] Request id behavior preserves safe incoming values, generates missing values, and returns `X-Request-Id`.
+- [ ] CORS behavior is config-driven and production does not allow wildcard origins by accident.
+- [ ] Security headers do not break documented local docs or frontend behavior without explanation.
+- [ ] Route-specific business validation is not placed in global middleware.
+- [ ] Secrets, tokens, cookies, authorization headers, and raw request bodies are not logged by default.
+- [ ] Auth, rate limit, metrics, or error tracking integrations remain adapter-driven unless an ADR says otherwise.
+- [ ] The narrowest useful PHP verification was run, usually `composer check`.

--- a/docs/review/release-ci.md
+++ b/docs/review/release-ci.md
@@ -1,0 +1,21 @@
+# Release and CI Self-Review
+
+Use this checklist for GitHub Actions, release policy, versioning, dependency update automation, tags, and Packagist-related work.
+
+Source policies:
+
+- `docs/development/release-ci.md`
+- `docs/development/quality-tools.md`
+- `docs/development/frontend-integration.md`
+- `docs/workflow.md`
+
+## Checklist
+
+- [ ] CI starts from documented local commands before becoming required.
+- [ ] Backend CI includes Composer validation, install, and `composer check` when appropriate.
+- [ ] Frontend CI uses `npm ci --prefix frontend` only after `frontend/package-lock.json` exists.
+- [ ] OpenAPI validation is not made required before schemas and commands exist.
+- [ ] Release tags use `vX.Y.Z` and point to commits on `main`.
+- [ ] `0.x.y` releases are not described as long-term public API stability promises.
+- [ ] Dependency update automation targets are explicit, with Dependabot preferred first.
+- [ ] Workflow changes are documented with verification and any manual push limitations.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,6 +20,7 @@ Goal: make contribution, AI operation, and technical direction unambiguous befor
 - Issue-driven workflow
 - local roadmap, milestone, and TODO board
 - coding standards
+- self-review checklist policy
 - Cursor rules
 - OpenAPI / MCP direction documents
 - standard repository layout

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -32,12 +32,14 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define release, versioning, and CI policy. `#23`
 - [x] Define ADR operation policy. `#24`
 - [x] Define logging and observability policy. `#33`
+- [x] Define self-review checklist policy. `#37`
 
 ## Next Candidates
 
 - [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation.
 - [ ] Choose concrete PSR-11 container package or adapter strategy.
 - [ ] Write ADRs for concrete HTTP runtime, router, and container package selections.
+- [ ] Keep self-review checklists updated as new implementation areas are introduced.
 - [ ] Implement typed config loader and `.env.example`.
 - [ ] Add OpenAPI Problem Details schemas.
 - [ ] Add validation error mapping and readonly DTO examples.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -9,11 +9,12 @@ NENE2 uses GitHub Issues for work tracking and local Markdown files for project 
 3. Create a branch from `main` named like `type/issue-number-summary`.
 4. Implement the smallest useful change.
 5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
-6. Run the narrowest meaningful verification available.
-7. Commit with Conventional Commits and include the Issue number.
-8. Push the branch and create a PR linked to the Issue.
-9. Merge after review and checks.
-10. Return local `main` to the merged, clean state.
+6. Review the relevant self-review checklist in `docs/review/`.
+7. Run the narrowest meaningful verification available.
+8. Commit with Conventional Commits and include the Issue number.
+9. Push the branch and create a PR linked to the Issue.
+10. Merge after review and checks.
+11. Return local `main` to the merged, clean state.
 
 Release, versioning, and CI policy is defined in `docs/development/release-ci.md`.
 
@@ -33,6 +34,7 @@ Every PR should include:
 - purpose
 - change summary
 - verification results
+- self-review checklist used, when applicable
 - related Issue, preferably `Closes #number`
 - remaining risks or follow-up work
 
@@ -49,6 +51,8 @@ Do not leave important decisions only in chat. If it changes how the project sho
 
 Use ADRs only for decisions that affect architecture, public contracts, dependency choices, release policy, or long-term maintenance. See `docs/development/adr.md`.
 
+Use self-review checklists as task-specific reminders before push or PR. See `docs/development/self-review.md`.
+
 ## AI Agent Responsibilities
 
 AI agents should manage the normal lifecycle when asked to complete work:
@@ -56,6 +60,7 @@ AI agents should manage the normal lifecycle when asked to complete work:
 - create or reuse the Issue
 - create the Issue branch
 - edit only relevant files
+- review relevant self-review checklists
 - verify the change
 - commit, push, open PR, merge, and sync `main`
 - update local docs that describe project state


### PR DESCRIPTION
## Summary
- self-review checklist policy を追加
- `docs/review/` に作業タイプ別 checklist を追加
- workflow に push / PR 前の checklist 確認を組み込み

## Self-review
- `docs/review/docs-policy.md`

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for docs

Closes #37

Made with [Cursor](https://cursor.com)