### PR TITLE
docs(governance): 実装前のガードレールを定義する

### DIFF
--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -108,6 +108,8 @@ Good first candidates when implementation starts:
 - frontend starter implementation strategy
 - first release / Packagist publication decision
 
+Concrete package selections should create ADRs at the same time as the selection PR. Do not defer ADR creation until after implementation unless the PR is explicitly investigative only.
+
 The already documented foundation policies remain valid in `docs/development/` until a concrete decision needs ADR-level traceability.
 
 ## Non-Goals

--- a/docs/development/api-error-responses.md
+++ b/docs/development/api-error-responses.md
@@ -48,11 +48,15 @@ Optional fields:
 
 Problem `type` values should be stable and documented. They should not be raw exception class names.
 
-Recommended pattern:
+Canonical pattern:
 
 ```text
 https://nene2.dev/problems/{problem-name}
 ```
+
+`nene2.dev` is the canonical NENE2 problem type domain. Before public release, each stable problem type URI should either serve human-readable documentation or redirect to the relevant documentation page.
+
+Do not change canonical problem type URIs after clients depend on them unless the change is treated as a public API compatibility decision.
 
 Examples:
 

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -11,11 +11,13 @@ NENE2 should feel modern, small, and predictable. These rules are the source of 
 - Prefer immutable value objects and readonly properties where they clarify intent.
 - Use native types, enums, and small DTOs instead of unstructured arrays at boundaries.
 - Avoid framework magic that hides control flow from tests, static analysis, or AI tools.
+- Keep public project docs, API contracts, OpenAPI text, and public error metadata in English. See `docs/development/language-policy.md`.
 
 ## Architecture
 
 - Keep use cases independent from HTTP, database, templates, CLI, and frontend assets.
 - Depend on interfaces at infrastructure boundaries when it reduces coupling.
+- Select concrete packages using the documented package selection criteria and ADR triggers. See `docs/development/package-selection.md`.
 - Prefer constructor injection for required dependencies.
 - Use typed config objects at runtime instead of passing raw arrays through the application.
 - Use readonly DTOs or command objects for use case input boundaries.

--- a/docs/development/language-policy.md
+++ b/docs/development/language-policy.md
@@ -1,0 +1,73 @@
+# Language Policy
+
+NENE2 uses English for public-facing project contracts and allows Japanese for local operational support.
+
+## Position
+
+The repository should be easy to publish, easy to maintain, and comfortable for the current development workflow.
+
+The standard direction is:
+
+- Public project documentation is written in English.
+- Code, API contracts, OpenAPI, and public error metadata are written in English.
+- Local operational notes, Cursor rules, and AI collaboration summaries may use Japanese.
+- Mixed language is acceptable only when the boundary is intentional and documented.
+
+This policy prevents accidental language drift while keeping local development practical.
+
+## English by Default
+
+Use English for:
+
+- `README.md`
+- `docs/development/`
+- `docs/integrations/`
+- `docs/adr/`
+- `docs/review/`
+- OpenAPI documents
+- public API descriptions
+- Problem Details `title`, `type`, and validation `code`
+- code identifiers, class names, method names, and variable names
+- package metadata
+- release notes intended for public users
+
+English public docs make the framework easier to share, index, translate, and inspect with external tooling.
+
+## Japanese Allowed
+
+Japanese is allowed for:
+
+- `.cursor/rules/`
+- local TODO and handoff notes when they are primarily for the current maintainers
+- GitHub Issues and PR bodies when the audience is the current project team
+- AI collaboration notes
+- comments in chat or review discussion
+
+When a Japanese local note introduces a durable technical policy, update the English source-of-truth document as part of the same work.
+
+## Source of Truth
+
+Policy source-of-truth documents should be English.
+
+Cursor rules may summarize the policy in Japanese, but they should not become the only place where a durable technical rule exists.
+
+If a Japanese rule and an English policy conflict, update the English policy first, then adjust the local rule or note.
+
+## Public Error and API Text
+
+Public API text should be stable and English:
+
+- Problem Details `title`
+- validation `code`
+- OpenAPI operation summaries
+- schema descriptions
+- public examples
+
+Applications built with NENE2 may localize user-facing UI or application messages separately.
+
+## Non-Goals
+
+- Forcing every local project note to be English.
+- Translating all historical Issues or chat summaries.
+- Blocking Japanese discussion during design.
+- Allowing local Japanese notes to override public English policy docs.

--- a/docs/development/package-selection.md
+++ b/docs/development/package-selection.md
@@ -1,0 +1,104 @@
+# Package Selection Policy
+
+NENE2 chooses dependencies conservatively and records major package choices before implementation.
+
+## Position
+
+Dependencies shape the framework as much as code does. Package selection should favor interoperability, replaceability, and long-term maintainability over novelty alone.
+
+The standard direction is:
+
+- Prefer PHP-FIG, W3C, OpenAPI, and ecosystem standards where they exist.
+- Prefer small, focused packages over broad frameworks.
+- Choose packages that are actively maintained.
+- Keep concrete packages behind NENE2 adapters when they are infrastructure choices.
+- Avoid dependencies that hide control flow from tests, static analysis, or AI tools.
+- Record major package selections in ADRs.
+
+This policy applies before selecting concrete PSR-7 / PSR-17, router, container, dotenv, logger, migration, OpenAPI, and frontend tooling packages.
+
+## Evaluation Criteria
+
+Evaluate candidate packages against:
+
+- standards compliance
+- maintenance activity
+- release history
+- license compatibility with MIT
+- dependency footprint
+- runtime weight
+- testability
+- static analysis friendliness
+- documentation quality
+- framework lock-in risk
+- adapter or replacement strategy
+- security history
+- community adoption
+
+No package needs to be perfect, but trade-offs should be explicit for major choices.
+
+## Preferred Shape
+
+Prefer packages that:
+
+- implement standard interfaces such as PSR-7, PSR-11, PSR-15, PSR-17, or PSR-3
+- work without global state
+- can be configured explicitly
+- are easy to test with fake implementations
+- can be replaced without rewriting domain or use-case code
+- are understandable from small examples
+
+Avoid packages that:
+
+- require hidden global containers
+- depend on heavy framework runtime assumptions
+- force unrelated conventions into NENE2 core
+- require broad magic or code generation before the project needs it
+- make public API behavior hard to trace
+
+## ADR Requirement
+
+Create an ADR when selecting a package that affects:
+
+- HTTP runtime
+- routing
+- dependency injection
+- configuration loading
+- logging or observability
+- database migrations
+- OpenAPI validation or generation
+- frontend starter architecture
+- release or dependency automation
+
+The ADR should compare the selected package with at least one reasonable alternative unless there is an obvious standard choice.
+
+## Implementation Boundary
+
+Use adapters or explicit providers for concrete infrastructure packages.
+
+Framework domain and use-case code should not depend directly on package-specific implementations when a standard interface or local boundary is available.
+
+Examples:
+
+- depend on PSR-11 instead of a concrete container inside use cases
+- depend on PSR-3 instead of Monolog outside logging adapters
+- depend on PSR-7 interfaces at HTTP boundaries
+- keep dotenv access inside configuration loading
+
+## Version Policy
+
+When adding a package:
+
+- use the latest stable compatible major by default
+- document intentional lag behind current stable releases
+- avoid unstable pre-release packages unless the feature explicitly requires them
+- commit lockfile updates when the package manager uses a lockfile
+
+Dependency update automation should keep packages current after initial adoption.
+
+## Non-Goals
+
+- Rejecting every dependency in favor of custom code.
+- Choosing packages only because they are new.
+- Wrapping stable standard interfaces with unnecessary abstractions.
+- Recording an ADR for every small development-only tool.

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -9,6 +9,7 @@ Source policies:
 - `docs/development/api-error-responses.md`
 - `docs/integrations/openapi.md`
 - `docs/development/coding-standards.md`
+- `docs/development/language-policy.md`
 
 ## Checklist
 
@@ -16,6 +17,8 @@ Source policies:
 - [ ] Controllers or handlers map request data to readonly DTOs or command objects before calling use cases.
 - [ ] Use cases do not receive raw PSR-7 requests, superglobals, or unstructured request arrays.
 - [ ] Request validation failures use Problem Details `validation-failed` with structured `errors`.
+- [ ] Problem Details `type` values use the canonical `https://nene2.dev/problems/{problem-name}` pattern for stable NENE2 errors.
+- [ ] Public API text, Problem Details titles, and validation codes are in English.
 - [ ] Public error responses do not expose stack traces, SQL, file paths, secrets, or private identifiers.
 - [ ] HTTP behavior remains compatible with PSR-7 / PSR-15 / PSR-17 boundaries.
 - [ ] The narrowest useful PHP verification was run, usually `composer check`.

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -7,6 +7,8 @@ Source policies:
 - `docs/workflow.md`
 - `docs/development/adr.md`
 - `docs/development/coding-standards.md`
+- `docs/development/language-policy.md`
+- `docs/development/package-selection.md`
 - `docs/development/self-review.md`
 - `docs/todo/current.md`
 - `docs/roadmap.md`
@@ -16,6 +18,8 @@ Source policies:
 - [ ] The source-of-truth policy doc was updated instead of only adding a summary elsewhere.
 - [ ] Related `docs/roadmap.md` or `docs/todo/current.md` state was updated when project state changed.
 - [ ] New major architecture, dependency, public contract, or release decisions considered whether an ADR is needed.
+- [ ] Concrete package selections were recorded in an ADR when applicable.
+- [ ] Public source-of-truth docs, API contracts, and OpenAPI text are in English unless policy allows otherwise.
 - [ ] The change avoids duplicating full policy text across multiple files.
 - [ ] New checklist items link to source policy docs instead of becoming a second source of truth.
 - [ ] Issue and PR references are included where useful.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,6 +21,7 @@ Goal: make contribution, AI operation, and technical direction unambiguous befor
 - local roadmap, milestone, and TODO board
 - coding standards
 - self-review checklist policy
+- language and package selection guardrails
 - Cursor rules
 - OpenAPI / MCP direction documents
 - standard repository layout

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -33,12 +33,14 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define ADR operation policy. `#24`
 - [x] Define logging and observability policy. `#33`
 - [x] Define self-review checklist policy. `#37`
+- [x] Define implementation readiness guardrails. `#39`
 
 ## Next Candidates
 
 - [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation.
 - [ ] Choose concrete PSR-11 container package or adapter strategy.
 - [ ] Write ADRs for concrete HTTP runtime, router, and container package selections.
+- [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
 - [ ] Implement typed config loader and `.env.example`.
 - [ ] Add OpenAPI Problem Details schemas.


### PR DESCRIPTION
## Summary
- public docs / API / OpenAPI は英語、local / Cursor 補足は日本語可とする language policy を追加
- dependency / package selection criteria と ADR trigger を追加
- `https://nene2.dev/problems/{problem-name}` を canonical Problem Type URI として明記
- self-review checklist に Problem Type URI、language、package selection ADR の確認を追加

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/backend-api.md`

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for docs

Closes #39

Made with [Cursor](https://cursor.com)