### PR TITLE
docs(handoff): 実装フェーズ開始の引継ぎを追加する

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
-- Current GitHub Issue: none
+- Current GitHub Issue: `#41`
 - Current branch: `main`
+- Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
+- First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
 ## Foundation Completed
 
@@ -34,9 +36,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define logging and observability policy. `#33`
 - [x] Define self-review checklist policy. `#37`
 - [x] Define implementation readiness guardrails. `#39`
+- [x] Add implementation-start handoff and first task instructions. `#41`
 
 ## Next Candidates
 
+- [ ] Start HTTP runtime foundation from `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`.
 - [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation.
 - [ ] Choose concrete PSR-11 container package or adapter strategy.
 - [ ] Write ADRs for concrete HTTP runtime, router, and container package selections.

--- a/docs/todo/first-task-2026-05-04-http-runtime-foundation.md
+++ b/docs/todo/first-task-2026-05-04-http-runtime-foundation.md
@@ -1,0 +1,196 @@
+# First Task Instruction: HTTP Runtime Foundation
+
+Date: 2026-05-04
+
+Purpose: 次チャットで最初に着手する実装タスクの指示書。
+
+## Goal
+
+NENE2 を docs-only foundation から、最小 HTTP runtime skeleton が動く状態へ進める。
+
+最初の成果は、現在の smoke endpoint を PSR-first HTTP runtime 経由に移行すること。
+
+## Start Conditions
+
+作業開始前に確認すること:
+
+- `git status --short --branch` が clean であること
+- `main` が `origin/main` と同期していること
+- `docs/todo/handoff-2026-05-04-implementation-start.md` を読んでいること
+- `docs/development/package-selection.md` を読んでいること
+- `docs/development/adr.md` を読んでいること
+- `docs/review/docs-policy.md` と `docs/review/backend-api.md` を確認すること
+
+## Issue and Branch
+
+最初に GitHub Issue を作る。
+
+推奨 Issue title:
+
+```text
+feat: HTTP runtime foundation を実装する
+```
+
+Issue body に含めること:
+
+- PSR-7 / PSR-17 implementation selection
+- router strategy
+- middleware dispatcher / response emitter minimum
+- ADR 0001 creation
+- smoke endpoint migration
+- PHPUnit / PHPStan verification
+
+Branch name example:
+
+```text
+feat/{issue-number}-http-runtime-foundation
+```
+
+## Required ADR
+
+この作業では ADR を必ず作る。
+
+Suggested path:
+
+```text
+docs/adr/0001-select-http-runtime-packages.md
+```
+
+ADR must cover:
+
+- selected PSR-7 / PSR-17 package
+- selected router package or internal router strategy
+- middleware dispatcher approach
+- response emitter approach
+- alternatives considered
+- why the chosen set fits NENE2
+
+Use `docs/adr/0000-template.md`.
+
+## Package Selection
+
+Evaluate candidates using `docs/development/package-selection.md`.
+
+Recommended comparison areas:
+
+- standards compliance
+- active maintenance
+- dependency footprint
+- runtime weight
+- testability
+- static analysis friendliness
+- documentation quality
+- replacement strategy
+
+Do not choose a heavy framework runtime as the default HTTP foundation.
+
+## Likely Implementation Scope
+
+Keep the first implementation small.
+
+Expected implementation areas:
+
+```text
+src/Http/
+src/Routing/
+src/Middleware/
+src/Error/
+public_html/index.php
+tests/
+composer.json
+composer.lock
+docs/adr/
+docs/todo/current.md
+```
+
+Possible first classes or concepts:
+
+- server request factory bootstrap
+- response factory helper
+- simple route table
+- route result or matched handler
+- middleware dispatcher
+- response emitter
+- Problem Details error mapping placeholder
+
+Only add abstractions that are needed to move the smoke endpoint behind the runtime.
+
+## Smoke Endpoint Target
+
+Current behavior should remain simple:
+
+- `GET /` returns JSON smoke response
+- `public_html/openapi.php` continues serving OpenAPI YAML
+- `public_html/docs/` continues loading Swagger UI
+
+The goal is not to build a full framework in one PR. The goal is to prove the runtime path:
+
+```text
+front controller
+-> PSR-7 request
+-> middleware / error boundary
+-> router / handler
+-> PSR-7 response
+-> emitter
+```
+
+## Non-Goals
+
+Do not include in the first runtime PR unless absolutely necessary:
+
+- full controller resolver
+- attribute routing
+- autowiring
+- full DI container integration
+- runtime OpenAPI validation
+- authentication system
+- rate limiting
+- frontend starter
+- database adapter
+
+## Verification
+
+Run:
+
+```bash
+docker compose run --rm app composer check
+git diff --check
+```
+
+If new Composer dependencies are added, also run:
+
+```bash
+docker compose run --rm app composer validate
+```
+
+If Docker is unavailable, report that clearly and include the commands for hide to run.
+
+## Self-Review
+
+Before PR:
+
+- `docs/review/docs-policy.md`
+- `docs/review/backend-api.md`
+- `docs/review/middleware-security.md` if middleware behavior changes
+
+PR body should include:
+
+```text
+## Self-review
+- `docs/review/docs-policy.md`
+- `docs/review/backend-api.md`
+```
+
+## Completion Criteria
+
+The task is complete when:
+
+- Issue is created and linked
+- implementation branch is used
+- ADR 0001 is added
+- selected packages are documented
+- smoke endpoint works through the new runtime
+- tests are added or updated
+- `composer check` passes
+- PR is created, merged, and Issue is closed
+- local `main` is clean and synced

--- a/docs/todo/handoff-2026-05-04-implementation-start.md
+++ b/docs/todo/handoff-2026-05-04-implementation-start.md
@@ -1,0 +1,121 @@
+# Handoff: NENE2 Implementation Start
+
+Date: 2026-05-04
+
+Purpose: 次のチャットで NENE2 の実装フェーズを開始するための引継ぎ。
+
+## Current State
+
+NENE2 は docs-first の foundation / implementation readiness 準備を完了済み。
+
+現在の `main` は `origin/main` と同期済みで、未コミット差分なしの状態から次作業を開始できる。
+
+## Completed Foundation
+
+完了済みの主要方針:
+
+- project governance / Issue-driven workflow
+- standard project layout
+- PHP runtime / Composer / PHPUnit / PHPStan
+- Docker development runtime
+- OpenAPI / Swagger UI
+- thin HTML view policy
+- database migration layout policy
+- PSR-first HTTP runtime policy
+- PSR-11 DI policy
+- typed configuration policy
+- RFC 9457 Problem Details policy
+- middleware / security baseline policy
+- quality tools and documentation comments policy
+- request validation policy
+- frontend integration and npm / Node LTS policy
+- release / versioning / CI policy
+- ADR operation policy
+- logging / observability policy
+- self-review checklist policy
+- implementation readiness guardrails
+
+## Important Latest Decisions
+
+- `https://nene2.dev/problems/{problem-name}` is the canonical Problem Details type URI pattern.
+- `nene2.dev` has been acquired by hide and is being configured.
+- Public source-of-truth docs, API contracts, OpenAPI text, and public error metadata should be English.
+- Cursor rules, local TODO / handoff notes, and AI collaboration notes may use Japanese.
+- Concrete package selections must create ADRs in the same PR unless the work is explicitly investigative only.
+- Self-review checklists in `docs/review/` should be checked before push / PR.
+
+## Read First
+
+次チャットのリナは、作業開始前にこの順で読むこと。
+
+1. `docs/todo/current.md`
+2. `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
+3. `docs/development/package-selection.md`
+4. `docs/development/adr.md`
+5. `docs/development/http-runtime.md`
+6. `docs/development/dependency-injection.md`
+7. `docs/development/request-validation.md`
+8. `docs/development/api-error-responses.md`
+9. `docs/review/docs-policy.md`
+10. `docs/review/backend-api.md`
+
+## Next Recommended Work
+
+次は `HTTP runtime foundation` に入る。
+
+最初の作業は、実装前に以下をセットで扱うこと。
+
+- GitHub Issue を作る、または既存 Issue を再利用する
+- branch を切る
+- PSR-7 / PSR-17 implementation を選ぶ
+- router strategy / package を選ぶ
+- middleware dispatcher / response emitter の最小方針を決める
+- `docs/adr/0001-...md` を作る
+- 必要に応じて `composer.json` に dependency を追加する
+- `public_html/index.php` の smoke endpoint を HTTP runtime 経由に移行する
+- PHPUnit / PHPStan / `composer check` で検証する
+- self-review を PR body に記録する
+
+## Suggested First ADR
+
+ADR 0001 の候補:
+
+```text
+docs/adr/0001-select-http-runtime-packages.md
+```
+
+扱う判断:
+
+- PSR-7 / PSR-17 implementation
+- router strategy
+- middleware dispatcher approach
+- response emitter approach
+
+必ず `docs/development/package-selection.md` の評価基準に沿って比較する。
+
+## Watch Points
+
+- 具体パッケージ選定を ADR なしで進めない。
+- framework core を heavy framework に寄せすぎない。
+- controller resolver magic を早期導入しない。
+- use case に PSR-7 request や raw request array を渡さない。
+- public error response に stack trace / SQL / secrets / file path を出さない。
+- `docs/review/backend-api.md` と `docs/review/docs-policy.md` を確認する。
+- `.github/workflows/*` を変更する場合は、既存ルールに従い AI が push せず、ユーザーへ手動 push を依頼する。
+
+## Verification Baseline
+
+現時点で安定している検証:
+
+```bash
+docker compose run --rm app composer check
+git diff --check
+```
+
+Frontend checks are not available yet because `frontend/package.json` has not been implemented.
+
+## Conversation Context
+
+ユーザー hide は、次チャットで実装フェーズに入る意向。
+
+リナは日本語で柔らかく応答しつつ、コード・公開 docs は既存 language policy に従うこと。


### PR DESCRIPTION
## Summary
- 次チャット向けの implementation-start handoff を追加
- HTTP runtime foundation の最初の作業指示書を追加
- `docs/todo/current.md` から handoff と first task を参照できるように更新

## Self-review
- `docs/review/docs-policy.md`

## Test plan
- `docker compose run --rm app composer check`
- `git diff --check`
- Cursor diagnostics for docs/todo

Closes #41

Made with [Cursor](https://cursor.com)