### PR TITLE
feat(runtime): HTTP runtime foundation を実装する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,11 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "php": ">=8.4.1 <9.0"
+    "php": ">=8.4.1 <9.0",
+    "nyholm/psr7": "^1.8",
+    "nyholm/psr7-server": "^1.1",
+    "psr/http-server-handler": "^1.0",
+    "psr/http-server-middleware": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,374 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d9103e32f122a95ced838301e5c4c7b",
-    "packages": [],
+    "content-hash": "2aa52cd7b9dc5bcd7b27315e32465cbb",
+    "packages": [
+        {
+            "name": "nyholm/psr7",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7.git",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0",
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.9",
+                "php-http/message-factory": "^1.0",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
+                "symfony/error-handler": "^4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "A fast PHP7 implementation of PSR-7",
+            "homepage": "https://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7/issues",
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-09T07:06:30+00:00"
+        },
+        {
+            "name": "nyholm/psr7-server",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7-server.git",
+                "reference": "4335801d851f554ca43fa6e7d2602141538854dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7-server/zipball/4335801d851f554ca43fa6e7d2602141538854dc",
+                "reference": "4335801d851f554ca43fa6e7d2602141538854dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "nyholm/nsa": "^1.1",
+                "nyholm/psr7": "^1.3",
+                "phpunit/phpunit": "^7.0 || ^8.5 || ^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "Helper classes to handle PSR-7 server requests",
+            "homepage": "http://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7-server/issues",
+                "source": "https://github.com/Nyholm/psr7-server/tree/1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-08T09:30:43+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/http-server-handler",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-server-handler/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:06:20+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-middleware/issues",
+                "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
+            },
+            "time": "2023-04-11T06:14:47+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "myclabs/deep-copy",
@@ -1913,12 +2279,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4.1 <9.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -4,7 +4,10 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
-RUN a2enmod rewrite \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod rewrite \
     && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
 

--- a/docs/adr/0001-select-http-runtime-packages.md
+++ b/docs/adr/0001-select-http-runtime-packages.md
@@ -1,0 +1,47 @@
+# ADR 0001: Select HTTP Runtime Packages
+
+## Status
+
+accepted
+
+## Context
+
+NENE2 needs a minimal HTTP runtime that moves the smoke endpoint behind PSR-first request handling without adopting a heavy framework runtime. The first implementation must support PSR-7 HTTP messages, PSR-17 factories, PSR-15 middleware, explicit routing, and a replaceable response emission boundary.
+
+The package selection should favor standards compliance, low dependency footprint, testability, static analysis friendliness, and clear replacement paths.
+
+## Decision
+
+Use `nyholm/psr7` as the initial PSR-7 and PSR-17 implementation.
+
+Use `nyholm/psr7-server` to create PSR-7 server requests from PHP globals in the front controller.
+
+Use `psr/http-server-middleware` and `psr/http-server-handler` for PSR-15 interfaces.
+
+Do not add a router package for the first runtime step. NENE2 will use a small internal route table that matches HTTP method and path only.
+
+Do not add a middleware dispatcher package for the first runtime step. NENE2 will use a small internal dispatcher that composes PSR-15 middleware explicitly.
+
+Do not add a response emitter package for the first runtime step. NENE2 will use a small internal emitter for status, headers, and response body output.
+
+Alternatives considered:
+
+- `laminas/laminas-diactoros`: mature PSR-7 and PSR-17 implementation, but larger than needed for the first skeleton.
+- `guzzlehttp/psr7`: widely adopted PSR-7 implementation, but `nyholm/psr7` provides the smallest fit for combined PSR-7 / PSR-17 usage in this stage.
+- `nikic/fast-route`: fast and well-known router, but path parameters and advanced dispatch are not required for the smoke endpoint.
+- A full framework runtime such as Slim or Symfony HttpKernel: useful for applications, but too much default structure for NENE2 framework-core decisions at this point.
+
+## Consequences
+
+The first runtime remains small and easy to inspect. Public HTTP boundaries use standard PSR interfaces, while concrete package usage stays near the front-controller composition boundary.
+
+NENE2 can replace the PSR-7 implementation later because handlers and middleware depend on interfaces. Routing can grow incrementally or move to a package when path parameters, route groups, or compiled dispatch become necessary.
+
+The internal emitter and dispatcher must stay intentionally small. If they gain broad behavior, a follow-up ADR should reconsider adopting focused packages.
+
+## Related
+
+- Issue: `#43`
+- PR: `#000`
+- Supersedes: none
+- Superseded by: none

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
-- Current GitHub Issue: `#41`
-- Current branch: `main`
+- Current GitHub Issue: `#43`
+- Current branch: `feat/43-http-runtime-foundation`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
 - First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
@@ -38,12 +38,16 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define implementation readiness guardrails. `#39`
 - [x] Add implementation-start handoff and first task instructions. `#41`
 
+## In Progress
+
+- [ ] Implement HTTP runtime foundation from `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`. `#43`
+- [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation. `#43`
+- [ ] Write ADR 0001 for concrete HTTP runtime and router selections. `#43`
+
 ## Next Candidates
 
-- [ ] Start HTTP runtime foundation from `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`.
-- [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation.
 - [ ] Choose concrete PSR-11 container package or adapter strategy.
-- [ ] Write ADRs for concrete HTTP runtime, router, and container package selections.
+- [ ] Write ADRs for concrete container package selections.
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
 - [ ] Implement typed config loader and `.env.example`.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
-- Current GitHub Issue: `#43`
-- Current branch: `feat/43-http-runtime-foundation`
+- Current GitHub Issue: none
+- Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
 - First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
@@ -37,12 +37,9 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define self-review checklist policy. `#37`
 - [x] Define implementation readiness guardrails. `#39`
 - [x] Add implementation-start handoff and first task instructions. `#41`
-
-## In Progress
-
-- [ ] Implement HTTP runtime foundation from `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`. `#43`
-- [ ] Choose concrete PSR-7 / PSR-17 packages and router implementation. `#43`
-- [ ] Write ADR 0001 for concrete HTTP runtime and router selections. `#43`
+- [x] Implement HTTP runtime foundation. `#43`
+- [x] Choose concrete PSR-7 / PSR-17 packages and initial router strategy. `#43`
+- [x] Write ADR 0001 for concrete HTTP runtime and router selections. `#43`
 
 ## Next Candidates
 

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -2,19 +2,23 @@
 
 declare(strict_types=1);
 
-use Nene2\FrameworkInfo;
+use Nene2\Http\ResponseEmitter;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$framework = new FrameworkInfo();
-
-header('Content-Type: application/json; charset=utf-8');
-
-echo json_encode(
-    [
-        'name' => $framework->name(),
-        'description' => $framework->description(),
-        'status' => 'ok',
-    ],
-    JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT
+$psr17Factory = new Psr17Factory();
+$serverRequestCreator = new ServerRequestCreator(
+    $psr17Factory,
+    $psr17Factory,
+    $psr17Factory,
+    $psr17Factory,
 );
+
+$request = $serverRequestCreator->fromGlobals();
+$application = (new RuntimeApplicationFactory($psr17Factory, $psr17Factory))->create();
+$response = $application->handle($request);
+
+(new ResponseEmitter())->emit($response);

--- a/src/Error/ErrorHandlerMiddleware.php
+++ b/src/Error/ErrorHandlerMiddleware.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Error;
+
+use Nene2\Routing\MethodNotAllowedException;
+use Nene2\Routing\RouteNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Throwable;
+
+final readonly class ErrorHandlerMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        try {
+            return $handler->handle($request);
+        } catch (RouteNotFoundException) {
+            return $this->problemDetails->create(
+                $request,
+                'not-found',
+                'Not Found',
+                404,
+                'The requested resource was not found.',
+            );
+        } catch (MethodNotAllowedException $exception) {
+            return $this->problemDetails
+                ->create(
+                    $request,
+                    'method-not-allowed',
+                    'Method Not Allowed',
+                    405,
+                    'The requested resource does not support this HTTP method.',
+                )
+                ->withHeader('Allow', implode(', ', $exception->allowedMethods()));
+        } catch (Throwable) {
+            return $this->problemDetails->create(
+                $request,
+                'internal-server-error',
+                'Internal Server Error',
+                500,
+                'The server encountered an unexpected condition.',
+            );
+        }
+    }
+}

--- a/src/Error/ProblemDetailsResponseFactory.php
+++ b/src/Error/ProblemDetailsResponseFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Error;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class ProblemDetailsResponseFactory
+{
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $extensions
+     */
+    public function create(
+        ServerRequestInterface $request,
+        string $type,
+        string $title,
+        int $status,
+        ?string $detail = null,
+        array $extensions = [],
+    ): ResponseInterface {
+        $payload = [
+            'type' => 'https://nene2.dev/problems/' . $type,
+            'title' => $title,
+            'status' => $status,
+            'instance' => $request->getUri()->getPath() ?: '/',
+        ];
+
+        if ($detail !== null) {
+            $payload['detail'] = $detail;
+        }
+
+        $payload = array_merge($payload, $extensions);
+
+        $body = $this->streamFactory->createStream(
+            json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)
+        );
+
+        return $this->responseFactory
+            ->createResponse($status)
+            ->withHeader('Content-Type', 'application/problem+json; charset=utf-8')
+            ->withBody($body);
+    }
+}

--- a/src/Http/JsonResponseFactory.php
+++ b/src/Http/JsonResponseFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class JsonResponseFactory
+{
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, string> $headers
+     */
+    public function create(array $data, int $status = 200, array $headers = []): ResponseInterface
+    {
+        $body = $this->streamFactory->createStream(
+            json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)
+        );
+
+        $response = $this->responseFactory
+            ->createResponse($status)
+            ->withHeader('Content-Type', 'application/json; charset=utf-8');
+
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response->withBody($body);
+    }
+}

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use Psr\Http\Message\ResponseInterface;
+
+final class ResponseEmitter
+{
+    public function emit(ResponseInterface $response): void
+    {
+        if (!headers_sent()) {
+            http_response_code($response->getStatusCode());
+
+            foreach ($response->getHeaders() as $name => $values) {
+                foreach ($values as $value) {
+                    header(sprintf('%s: %s', $name, $value), false);
+                }
+            }
+        }
+
+        echo (string) $response->getBody();
+    }
+}

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use Nene2\Error\ErrorHandlerMiddleware;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\FrameworkInfo;
+use Nene2\Middleware\MiddlewareDispatcher;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class RuntimeApplicationFactory
+{
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function create(): RequestHandlerInterface
+    {
+        $jsonResponses = new JsonResponseFactory($this->responseFactory, $this->streamFactory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->responseFactory, $this->streamFactory);
+        $framework = new FrameworkInfo();
+
+        $router = (new Router())->get(
+            '/',
+            static fn (ServerRequestInterface $request) => $jsonResponses->create([
+                'name' => $framework->name(),
+                'description' => $framework->description(),
+                'status' => 'ok',
+            ]),
+        );
+
+        return new MiddlewareDispatcher(
+            [
+                new ErrorHandlerMiddleware($problemDetails),
+            ],
+            $router,
+        );
+    }
+}

--- a/src/Middleware/MiddlewareDispatcher.php
+++ b/src/Middleware/MiddlewareDispatcher.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class MiddlewareDispatcher implements RequestHandlerInterface
+{
+    /**
+     * @param list<MiddlewareInterface> $middleware
+     */
+    public function __construct(
+        private array $middleware,
+        private RequestHandlerInterface $handler,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $handler = array_reduce(
+            array_reverse($this->middleware),
+            static fn (RequestHandlerInterface $next, MiddlewareInterface $middleware): RequestHandlerInterface => new class ($middleware, $next) implements RequestHandlerInterface {
+                public function __construct(
+                    private readonly MiddlewareInterface $middleware,
+                    private readonly RequestHandlerInterface $next,
+                ) {
+                }
+
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->middleware->process($request, $this->next);
+                }
+            },
+            $this->handler,
+        );
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Routing/MethodNotAllowedException.php
+++ b/src/Routing/MethodNotAllowedException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Routing;
+
+use RuntimeException;
+
+final class MethodNotAllowedException extends RuntimeException
+{
+    /**
+     * @param non-empty-list<string> $allowedMethods
+     */
+    public function __construct(
+        private readonly array $allowedMethods,
+    ) {
+        parent::__construct('HTTP method is not allowed for this route.');
+    }
+
+    /**
+     * @return non-empty-list<string>
+     */
+    public function allowedMethods(): array
+    {
+        return $this->allowedMethods;
+    }
+}

--- a/src/Routing/RouteNotFoundException.php
+++ b/src/Routing/RouteNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Routing;
+
+use RuntimeException;
+
+final class RouteNotFoundException extends RuntimeException
+{
+}

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Routing;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * @phpstan-type Route array{method: non-empty-string, path: non-empty-string, handler: callable(ServerRequestInterface): ResponseInterface}
+ */
+final class Router implements RequestHandlerInterface
+{
+    /** @var list<Route> */
+    private array $routes = [];
+
+    /**
+     * @param callable(ServerRequestInterface): ResponseInterface $handler
+     */
+    public function get(string $path, callable $handler): self
+    {
+        return $this->add('GET', $path, $handler);
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $method = strtoupper($request->getMethod());
+        $path = $request->getUri()->getPath() ?: '/';
+        $allowedMethods = [];
+
+        foreach ($this->routes as $route) {
+            if ($route['path'] !== $path) {
+                continue;
+            }
+
+            if ($route['method'] === $method) {
+                return $route['handler']($request);
+            }
+
+            $allowedMethods[] = $route['method'];
+        }
+
+        if ($allowedMethods !== []) {
+            throw new MethodNotAllowedException($allowedMethods);
+        }
+
+        throw new RouteNotFoundException('No route matched the request.');
+    }
+
+    /**
+     * @param non-empty-string $method
+     * @param callable(ServerRequestInterface): ResponseInterface $handler
+     */
+    private function add(string $method, string $path, callable $handler): self
+    {
+        if ($path === '' || $path[0] !== '/') {
+            throw new InvalidArgumentException('Route path must start with /.');
+        }
+
+        $this->routes[] = [
+            'method' => $method,
+            'path' => $path,
+            'handler' => $handler,
+        ];
+
+        return $this;
+    }
+}

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests;
+
+use Nene2\Http\RuntimeApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+final class HttpRuntimeTest extends TestCase
+{
+    public function testSmokeEndpointRunsThroughRuntime(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertSame('NENE2', $payload['name']);
+        self::assertSame('ok', $payload['status']);
+    }
+
+    public function testMissingRouteReturnsProblemDetails(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/missing'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertSame('application/problem+json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertSame('https://nene2.dev/problems/not-found', $payload['type']);
+        self::assertSame('Not Found', $payload['title']);
+    }
+
+    public function testUnsupportedMethodReturnsProblemDetailsWithAllowHeader(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory))->create();
+
+        $response = $application->handle($factory->createServerRequest('POST', 'https://example.test/'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(405, $response->getStatusCode());
+        self::assertSame('GET', $response->getHeaderLine('Allow'));
+        self::assertSame('https://nene2.dev/problems/method-not-allowed', $payload['type']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}


### PR DESCRIPTION
## Summary
- Select `nyholm/psr7` and `nyholm/psr7-server` for the first PSR-7 / PSR-17 runtime boundary.
- Add ADR 0001 documenting the HTTP runtime package and internal router / dispatcher / emitter decisions.
- Move the smoke endpoint behind a minimal PSR-15 runtime with Problem Details responses for routing errors.

## Verification
- `docker compose build app`
- `docker compose run --rm app composer install`
- `docker compose run --rm app composer validate`
- `docker compose run --rm app composer check`
- `git diff --check`

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/backend-api.md`
- `docs/review/middleware-security.md`

Closes #43

Made with [Cursor](https://cursor.com)