### PR TITLE
feat(config): typed config loader を実装する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+APP_ENV=local
+APP_DEBUG=false
+APP_NAME=NENE2

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "nyholm/psr7-server": "^1.1",
     "psr/container": "^2.0",
     "psr/http-server-handler": "^1.0",
-    "psr/http-server-middleware": "^1.0"
+    "psr/http-server-middleware": "^1.0",
+    "vlucas/phpdotenv": "^5.6"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,70 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "56191ebd18e46f40328762f52c2cdefc",
+    "content-hash": "42714b8ea9b7accec7f4de8e3f92bcfc",
     "packages": [
+        {
+            "name": "graham-campbell/result-type",
+            "version": "v1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-27T19:43:20+00:00"
+        },
         {
             "name": "nyholm/psr7",
             "version": "1.8.2",
@@ -149,6 +211,81 @@
                 }
             ],
             "time": "2023-11-08T09:30:43+00:00"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.9.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25 || ^10.5.53 || ^11.5.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-27T19:41:33+00:00"
         },
         {
             "name": "psr/container",
@@ -423,6 +560,342 @@
                 "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
             },
             "time": "2023-04-11T06:14:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v5.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "graham-campbell/result-type": "^1.1.4",
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.5",
+                "symfony/polyfill-ctype": "^1.26",
+                "symfony/polyfill-mbstring": "^1.26",
+                "symfony/polyfill-php80": "^1.26"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-filter": "*",
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
+            },
+            "suggest": {
+                "ext-filter": "Required to use the boolean validator."
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "5.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://github.com/vlucas"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-27T19:49:13+00:00"
         }
     ],
     "packages-dev": [

--- a/docs/adr/0003-use-phpdotenv-for-local-config-loading.md
+++ b/docs/adr/0003-use-phpdotenv-for-local-config-loading.md
@@ -1,0 +1,49 @@
+# ADR 0003: Use phpdotenv for Local Config Loading
+
+## Status
+
+accepted
+
+## Context
+
+NENE2 needs a typed configuration boundary so runtime code can avoid direct access to raw environment arrays, `getenv()`, `$_ENV`, and `$_SERVER`.
+
+Local and test environments also need a predictable way to load `.env` files without making production depend on committed local files.
+
+## Decision
+
+Use `vlucas/phpdotenv` as the first local and test dotenv loader.
+
+Add typed config objects in `src/Config/` and keep raw environment reads inside the config loading layer.
+
+The first implementation will load:
+
+- committed safe defaults
+- optional `.env` values through phpdotenv
+- real environment variables
+- explicit test overrides
+
+Later sources override earlier values.
+
+Do not require `.env` in production. Production should rely on real environment variables or platform secrets.
+
+Alternatives considered:
+
+- Reading `$_ENV` or `$_SERVER` directly in bootstrap code: lower dependency footprint, but it spreads raw configuration access and weakens the typed boundary.
+- Symfony Dotenv: mature and well maintained, but broader Symfony integration is not needed for the first NENE2 config step.
+- Custom `.env` parsing: avoids a dependency, but dotenv parsing is easy to get subtly wrong and is not the framework feature NENE2 should spend complexity on.
+
+## Consequences
+
+NENE2 gains a small, familiar dotenv loading path for local development while keeping runtime code dependent on typed config objects.
+
+The config loader remains replaceable because phpdotenv usage is isolated behind `src/Config/`.
+
+Future config groups can be added without passing raw arrays through the application.
+
+## Related
+
+- Issue: `#47`
+- PR: `#000`
+- Supersedes: none
+- Superseded by: none

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -69,6 +69,18 @@ Production should rely on real environment variables or platform secrets. Produc
 
 Dotenv loading should happen only during bootstrap. Domain, use-case, and adapter code should receive typed config values rather than reading `.env` directly.
 
+## Initial Implementation
+
+The first implementation uses `vlucas/phpdotenv` for optional local `.env` loading and `src/Config/` for typed config objects.
+
+The initial application config includes:
+
+- `APP_ENV`: `local`, `test`, or `production`
+- `APP_DEBUG`: boolean value
+- `APP_NAME`: non-empty application name
+
+`.env.example` documents safe local defaults. Raw environment access stays inside `ConfigLoader`; application and infrastructure code should receive `AppConfig` or future focused config objects.
+
 ## Secret Policy
 
 Never commit:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
-- Current GitHub Issue: `#47`
-- Current branch: `feat/47-typed-config-loader`
+- Current GitHub Issue: none
+- Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
 - First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
@@ -43,10 +43,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Choose concrete PSR-11 container package or adapter strategy. `#45`
 - [x] Write ADR 0002 for concrete container selections. `#45`
 - [x] Add minimal PSR-11 container foundation. `#45`
+- [x] Implement typed config loader and `.env.example`. `#47`
 
 ## Next Candidates
 
-- [ ] Implement typed config loader and `.env.example`. `#47`
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
 - [ ] Add OpenAPI Problem Details schemas.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
-- Current GitHub Issue: none
-- Current branch: `main`
+- Current GitHub Issue: `#47`
+- Current branch: `feat/47-typed-config-loader`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
 - First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
@@ -46,9 +46,9 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Next Candidates
 
+- [ ] Implement typed config loader and `.env.example`. `#47`
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
-- [ ] Implement typed config loader and `.env.example`.
 - [ ] Add OpenAPI Problem Details schemas.
 - [ ] Add validation error mapping and readonly DTO examples.
 - [ ] Add request id, CORS, security headers, and request size middleware skeletons.

--- a/src/Config/AppConfig.php
+++ b/src/Config/AppConfig.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Config;
+
+final readonly class AppConfig
+{
+    public function __construct(
+        public AppEnvironment $environment,
+        public bool $debug,
+        public string $name,
+    ) {
+        if ($this->name === '') {
+            throw new ConfigException('APP_NAME must not be empty.');
+        }
+    }
+}

--- a/src/Config/AppEnvironment.php
+++ b/src/Config/AppEnvironment.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Config;
+
+enum AppEnvironment: string
+{
+    case Local = 'local';
+    case Test = 'test';
+    case Production = 'production';
+
+    public static function fromConfigValue(string $value): self
+    {
+        return self::tryFrom($value) ?? throw new ConfigException(
+            sprintf('APP_ENV must be one of: %s.', implode(', ', self::values())),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(
+            static fn (self $environment): string => $environment->value,
+            self::cases(),
+        );
+    }
+}

--- a/src/Config/ConfigException.php
+++ b/src/Config/ConfigException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Config;
+
+use InvalidArgumentException;
+
+final class ConfigException extends InvalidArgumentException
+{
+}

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Config;
+
+use Dotenv\Dotenv;
+
+final readonly class ConfigLoader
+{
+    /**
+     * @param array<string, string> $defaults
+     */
+    public function __construct(
+        private string $projectRoot,
+        private array $defaults = [
+            'APP_ENV' => 'local',
+            'APP_DEBUG' => 'false',
+            'APP_NAME' => 'NENE2',
+        ],
+    ) {
+    }
+
+    /**
+     * @param array<string, string> $overrides
+     */
+    public function load(array $overrides = []): AppConfig
+    {
+        $this->loadDotenvIfAvailable();
+
+        $values = array_merge(
+            $this->defaults,
+            $this->readEnvironmentValues(array_keys($this->defaults)),
+            $overrides,
+        );
+
+        return new AppConfig(
+            AppEnvironment::fromConfigValue($values['APP_ENV']),
+            $this->parseBoolean('APP_DEBUG', $values['APP_DEBUG']),
+            trim($values['APP_NAME']),
+        );
+    }
+
+    private function loadDotenvIfAvailable(): void
+    {
+        if (!is_file($this->projectRoot . '/.env')) {
+            return;
+        }
+
+        Dotenv::createImmutable($this->projectRoot)->safeLoad();
+    }
+
+    /**
+     * @param list<string> $keys
+     * @return array<string, string>
+     */
+    private function readEnvironmentValues(array $keys): array
+    {
+        $values = [];
+
+        foreach ($keys as $key) {
+            $value = $_SERVER[$key] ?? $_ENV[$key] ?? null;
+
+            if (is_string($value) && $value !== '') {
+                $values[$key] = $value;
+            }
+        }
+
+        return $values;
+    }
+
+    private function parseBoolean(string $key, string $value): bool
+    {
+        return match (strtolower($value)) {
+            '1', 'true', 'yes', 'on' => true,
+            '0', 'false', 'no', 'off' => false,
+            default => throw new ConfigException(sprintf('%s must be a boolean value.', $key)),
+        };
+    }
+}

--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Config;
+
+use Nene2\Config\AppEnvironment;
+use Nene2\Config\ConfigException;
+use Nene2\Config\ConfigLoader;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigLoaderTest extends TestCase
+{
+    public function testLoadsDefaultAppConfig(): void
+    {
+        $config = (new ConfigLoader($this->emptyProjectRoot()))->load();
+
+        self::assertSame(AppEnvironment::Local, $config->environment);
+        self::assertFalse($config->debug);
+        self::assertSame('NENE2', $config->name);
+    }
+
+    public function testExplicitOverridesWinOverDefaults(): void
+    {
+        $config = (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'APP_ENV' => 'test',
+            'APP_DEBUG' => 'true',
+            'APP_NAME' => 'NENE2 Test',
+        ]);
+
+        self::assertSame(AppEnvironment::Test, $config->environment);
+        self::assertTrue($config->debug);
+        self::assertSame('NENE2 Test', $config->name);
+    }
+
+    public function testInvalidEnvironmentFailsFast(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('APP_ENV must be one of: local, test, production.');
+
+        (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'APP_ENV' => 'staging',
+        ]);
+    }
+
+    public function testInvalidBooleanFailsFast(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('APP_DEBUG must be a boolean value.');
+
+        (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'APP_DEBUG' => 'sometimes',
+        ]);
+    }
+
+    public function testEmptyApplicationNameFailsFast(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('APP_NAME must not be empty.');
+
+        (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'APP_NAME' => '   ',
+        ]);
+    }
+
+    private function emptyProjectRoot(): string
+    {
+        return sys_get_temp_dir();
+    }
+}


### PR DESCRIPTION
## Summary
- Select `vlucas/phpdotenv` for optional local/test dotenv loading and document it in ADR 0003.
- Add typed app config objects and a `ConfigLoader` boundary for defaults, `.env`, real environment values, and explicit overrides.
- Add `.env.example`, configuration policy notes, and focused PHPUnit coverage.

## Verification
- `docker compose run --rm app composer validate`
- `docker compose run --rm app composer check`
- `git diff --check`

## Self-review
- `docs/review/docs-policy.md`

Closes #47

Made with [Cursor](https://cursor.com)