### PR TITLE
docs(openapi): Problem Details schemas を追加する

### DIFF
--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -59,7 +59,7 @@ Then verify:
 
 Once runtime code exists, API tests should verify that responses match the documented contract. The first implementation can be lightweight and grow with the framework.
 
-Future OpenAPI work should add shared schemas for `ProblemDetails`, `ValidationProblemDetails`, and `ValidationError`. See `docs/development/api-error-responses.md`.
+Shared schemas for `ProblemDetails`, `ValidationProblemDetails`, and `ValidationError` live in `docs/openapi/openapi.yaml`. Stable endpoints should reference these schemas for non-2xx JSON responses where the behavior is implemented. See `docs/development/api-error-responses.md`.
 
 OpenAPI security schemes should be added only when the matching middleware or authentication adapter is implemented. See `docs/development/middleware-security.md`.
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -32,8 +32,146 @@ paths:
                     name: NENE2
                     description: JSON APIs first, minimal server HTML, frontend ready, AI-readable.
                     status: ok
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
+  responses:
+    NotFound:
+      description: The requested resource was not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            notFound:
+              summary: Resource not found
+              value:
+                type: https://nene2.dev/problems/not-found
+                title: Not Found
+                status: 404
+                detail: The requested resource was not found.
+                instance: /missing
+    MethodNotAllowed:
+      description: The requested resource does not support this HTTP method.
+      headers:
+        Allow:
+          description: Comma-separated list of allowed HTTP methods.
+          schema:
+            type: string
+            example: GET
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            methodNotAllowed:
+              summary: Method not allowed
+              value:
+                type: https://nene2.dev/problems/method-not-allowed
+                title: Method Not Allowed
+                status: 405
+                detail: The requested resource does not support this HTTP method.
+                instance: /
+    ValidationFailed:
+      description: The request body, query, or path parameters contain invalid values.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidationProblemDetails'
+          examples:
+            validationFailed:
+              summary: Validation failed
+              value:
+                type: https://nene2.dev/problems/validation-failed
+                title: Validation Failed
+                status: 422
+                detail: The request body contains invalid values.
+                errors:
+                  - field: email
+                    message: Email must be a valid email address.
+                    code: invalid_email
+    InternalServerError:
+      description: The server encountered an unexpected condition.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            internalServerError:
+              summary: Internal server error
+              value:
+                type: https://nene2.dev/problems/internal-server-error
+                title: Internal Server Error
+                status: 500
+                detail: The server encountered an unexpected condition.
   schemas:
+    ProblemDetails:
+      type: object
+      description: RFC 9457 Problem Details response for NENE2 JSON APIs.
+      required:
+        - type
+        - title
+        - status
+      properties:
+        type:
+          type: string
+          format: uri
+          description: Stable problem type URI.
+          example: https://nene2.dev/problems/not-found
+        title:
+          type: string
+          description: Short, human-readable summary of the problem type.
+          example: Not Found
+        status:
+          type: integer
+          format: int32
+          minimum: 400
+          maximum: 599
+          description: HTTP status code for this occurrence.
+          example: 404
+        detail:
+          type: string
+          description: Safe, human-readable detail for this occurrence.
+          example: The requested resource was not found.
+        instance:
+          type: string
+          description: Request-specific URI or identifier for this occurrence.
+          example: /missing
+      additionalProperties: true
+    ValidationProblemDetails:
+      allOf:
+        - $ref: '#/components/schemas/ProblemDetails'
+        - type: object
+          description: Problem Details response for request validation failures.
+          required:
+            - errors
+          properties:
+            errors:
+              type: array
+              minItems: 1
+              items:
+                $ref: '#/components/schemas/ValidationError'
+    ValidationError:
+      type: object
+      description: A single request validation error.
+      required:
+        - field
+        - message
+        - code
+      properties:
+        field:
+          type: string
+          description: Field name, parameter name, or JSON pointer.
+          example: email
+        message:
+          type: string
+          description: Safe, human-readable validation message.
+          example: Email must be a valid email address.
+        code:
+          type: string
+          description: Stable machine-readable validation code.
+          example: invalid_email
+      additionalProperties: false
     FrameworkSmokeResponse:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
-- Current GitHub Issue: `#49`
-- Current branch: `docs/49-openapi-problem-details-schemas`
+- Current GitHub Issue: none
+- Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
 - First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
@@ -44,10 +44,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Write ADR 0002 for concrete container selections. `#45`
 - [x] Add minimal PSR-11 container foundation. `#45`
 - [x] Implement typed config loader and `.env.example`. `#47`
+- [x] Add OpenAPI Problem Details schemas. `#49`
 
 ## Next Candidates
 
-- [ ] Add OpenAPI Problem Details schemas. `#49`
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
 - [ ] Add validation error mapping and readonly DTO examples.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
-- Current GitHub Issue: none
-- Current branch: `main`
+- Current GitHub Issue: `#49`
+- Current branch: `docs/49-openapi-problem-details-schemas`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
 - First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
@@ -47,9 +47,9 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Next Candidates
 
+- [ ] Add OpenAPI Problem Details schemas. `#49`
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
-- [ ] Add OpenAPI Problem Details schemas.
 - [ ] Add validation error mapping and readonly DTO examples.
 - [ ] Add request id, CORS, security headers, and request size middleware skeletons.
 - [ ] Add PSR-3 logging adapter and request id log context.

--- a/tests/OpenApi/OpenApiProblemDetailsTest.php
+++ b/tests/OpenApi/OpenApiProblemDetailsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\OpenApi;
+
+use PHPUnit\Framework\TestCase;
+
+final class OpenApiProblemDetailsTest extends TestCase
+{
+    public function testProblemDetailsSchemasAreDocumented(): void
+    {
+        $openApi = $this->openApi();
+
+        self::assertStringContainsString('ProblemDetails:', $openApi);
+        self::assertStringContainsString('ValidationProblemDetails:', $openApi);
+        self::assertStringContainsString('ValidationError:', $openApi);
+        self::assertStringContainsString('application/problem+json:', $openApi);
+    }
+
+    public function testCanonicalProblemTypeExamplesAreDocumented(): void
+    {
+        $openApi = $this->openApi();
+
+        foreach (
+            [
+                'https://nene2.dev/problems/not-found',
+                'https://nene2.dev/problems/method-not-allowed',
+                'https://nene2.dev/problems/validation-failed',
+                'https://nene2.dev/problems/internal-server-error',
+            ] as $problemType
+        ) {
+            self::assertStringContainsString($problemType, $openApi);
+        }
+    }
+
+    private function openApi(): string
+    {
+        $openApi = file_get_contents(dirname(__DIR__, 2) . '/docs/openapi/openapi.yaml');
+
+        self::assertIsString($openApi);
+
+        return $openApi;
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared OpenAPI schemas for `ProblemDetails`, `ValidationProblemDetails`, and `ValidationError`.
- Add reusable Problem Details responses and reference the internal server error response from the smoke endpoint.
- Add lightweight PHPUnit checks for schema names and canonical problem type examples.

## Verification
- `docker compose run --rm app composer check`
- `git diff --check`

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/backend-api.md`

Closes #49

Made with [Cursor](https://cursor.com)