### PR TITLE
feat(validation): validation error mapping を追加する

### DIFF
--- a/docs/development/request-validation.md
+++ b/docs/development/request-validation.md
@@ -97,6 +97,34 @@ DTOs should:
 
 DTO construction may happen in controllers, handlers, or focused mapper/factory classes when mapping becomes non-trivial.
 
+Example mapper shape:
+
+```php
+final readonly class CreateUserInputMapper
+{
+    public function fromArray(array $data): CreateUserInput
+    {
+        $errors = [];
+
+        if (($data['email'] ?? '') === '') {
+            $errors[] = new ValidationError('email', 'Email is required.', 'required');
+        }
+
+        if (($data['name'] ?? '') === '') {
+            $errors[] = new ValidationError('name', 'Name is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        return new CreateUserInput((string) $data['email'], (string) $data['name']);
+    }
+}
+```
+
+`ValidationException` maps to `validation-failed` Problem Details at the HTTP error boundary. Use cases may still throw domain-specific exceptions for business invariants.
+
 ## Use Case Boundary
 
 Use cases validate business invariants.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
-- Current GitHub Issue: `#51`
-- Current branch: `feat/51-validation-error-mapping`
+- Current GitHub Issue: none
+- Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
 - First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
@@ -45,10 +45,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add minimal PSR-11 container foundation. `#45`
 - [x] Implement typed config loader and `.env.example`. `#47`
 - [x] Add OpenAPI Problem Details schemas. `#49`
+- [x] Add validation error mapping and readonly DTO examples. `#51`
 
 ## Next Candidates
 
-- [ ] Add validation error mapping and readonly DTO examples. `#51`
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
 - [ ] Add request id, CORS, security headers, and request size middleware skeletons.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
-- Current GitHub Issue: none
-- Current branch: `main`
+- Current GitHub Issue: `#51`
+- Current branch: `feat/51-validation-error-mapping`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
 - First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
@@ -48,9 +48,9 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Next Candidates
 
+- [ ] Add validation error mapping and readonly DTO examples. `#51`
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
-- [ ] Add validation error mapping and readonly DTO examples.
 - [ ] Add request id, CORS, security headers, and request size middleware skeletons.
 - [ ] Add PSR-3 logging adapter and request id log context.
 - [ ] Add PHP-CS-Fixer configuration and Composer scripts.

--- a/src/Error/ErrorHandlerMiddleware.php
+++ b/src/Error/ErrorHandlerMiddleware.php
@@ -6,6 +6,7 @@ namespace Nene2\Error;
 
 use Nene2\Routing\MethodNotAllowedException;
 use Nene2\Routing\RouteNotFoundException;
+use Nene2\Validation\ValidationException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -41,6 +42,17 @@ final readonly class ErrorHandlerMiddleware implements MiddlewareInterface
                     'The requested resource does not support this HTTP method.',
                 )
                 ->withHeader('Allow', implode(', ', $exception->allowedMethods()));
+        } catch (ValidationException $exception) {
+            return $this->problemDetails->create(
+                $request,
+                'validation-failed',
+                'Validation Failed',
+                422,
+                'The request contains invalid values.',
+                [
+                    'errors' => $exception->errorsForResponse(),
+                ],
+            );
         } catch (Throwable) {
             return $this->problemDetails->create(
                 $request,

--- a/src/Validation/ValidationError.php
+++ b/src/Validation/ValidationError.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Validation;
+
+use InvalidArgumentException;
+
+final readonly class ValidationError
+{
+    public function __construct(
+        public string $field,
+        public string $message,
+        public string $code,
+    ) {
+        if ($this->field === '') {
+            throw new InvalidArgumentException('Validation error field must not be empty.');
+        }
+
+        if ($this->message === '') {
+            throw new InvalidArgumentException('Validation error message must not be empty.');
+        }
+
+        if ($this->code === '') {
+            throw new InvalidArgumentException('Validation error code must not be empty.');
+        }
+    }
+
+    /**
+     * @return array{field: string, message: string, code: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'field' => $this->field,
+            'message' => $this->message,
+            'code' => $this->code,
+        ];
+    }
+}

--- a/src/Validation/ValidationException.php
+++ b/src/Validation/ValidationException.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Validation;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+final class ValidationException extends RuntimeException
+{
+    /** @var non-empty-list<ValidationError> */
+    private readonly array $errors;
+
+    /**
+     * @param list<ValidationError> $errors
+     */
+    public function __construct(
+        array $errors,
+        string $message = 'The request contains invalid values.',
+    ) {
+        if ($errors === []) {
+            throw new InvalidArgumentException('ValidationException requires at least one error.');
+        }
+
+        parent::__construct($message);
+
+        $this->errors = $errors;
+    }
+
+    /**
+     * @return non-empty-list<ValidationError>
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return non-empty-list<array{field: string, message: string, code: string}>
+     */
+    public function errorsForResponse(): array
+    {
+        return array_map(
+            static fn (ValidationError $error): array => $error->toArray(),
+            $this->errors,
+        );
+    }
+}

--- a/tests/Error/ErrorHandlerMiddlewareTest.php
+++ b/tests/Error/ErrorHandlerMiddlewareTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Error;
+
+use Nene2\Error\ErrorHandlerMiddleware;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ErrorHandlerMiddlewareTest extends TestCase
+{
+    public function testValidationExceptionMapsToProblemDetails(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new ErrorHandlerMiddleware(new ProblemDetailsResponseFactory($factory, $factory));
+        $request = $factory->createServerRequest('POST', 'https://example.test/users');
+
+        $response = $middleware->process(
+            $request,
+            new class () implements RequestHandlerInterface {
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    throw new ValidationException([
+                        new ValidationError('email', 'Email must be a valid email address.', 'invalid_email'),
+                    ]);
+                }
+            },
+        );
+
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+        self::assertSame(422, $response->getStatusCode());
+        self::assertSame('application/problem+json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertSame('https://nene2.dev/problems/validation-failed', $payload['type']);
+        self::assertSame('Validation Failed', $payload['title']);
+        self::assertSame('/users', $payload['instance']);
+        self::assertSame(
+            [
+                [
+                    'field' => 'email',
+                    'message' => 'Email must be a valid email address.',
+                    'code' => 'invalid_email',
+                ],
+            ],
+            $payload['errors'],
+        );
+    }
+}

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Validation;
+
+use InvalidArgumentException;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+final class ValidationExceptionTest extends TestCase
+{
+    public function testValidationErrorExportsPublicShape(): void
+    {
+        $error = new ValidationError('email', 'Email is required.', 'required');
+
+        self::assertSame(
+            [
+                'field' => 'email',
+                'message' => 'Email is required.',
+                'code' => 'required',
+            ],
+            $error->toArray(),
+        );
+    }
+
+    public function testValidationExceptionRequiresErrors(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ValidationException([]);
+    }
+
+    public function testValidationExceptionExportsErrorsForResponse(): void
+    {
+        $exception = new ValidationException([
+            new ValidationError('name', 'Name is required.', 'required'),
+        ]);
+
+        self::assertSame(
+            [
+                [
+                    'field' => 'name',
+                    'message' => 'Name is required.',
+                    'code' => 'required',
+                ],
+            ],
+            $exception->errorsForResponse(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ValidationError` and `ValidationException` for structured request validation failures.
- Map validation failures to `validation-failed` Problem Details with a safe `errors` array.
- Document a readonly DTO mapper example and add focused PHPUnit coverage.

## Verification
- `docker compose run --rm app composer check`
- `git diff --check`

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/backend-api.md`

Closes #51

Made with [Cursor](https://cursor.com)