### PR TITLE
feat: baseline middleware skeletons を追加する

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -32,6 +32,8 @@ paths:
                     name: NENE2
                     description: JSON APIs first, minimal server HTML, frontend ready, AI-readable.
                     status: ok
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:
@@ -90,6 +92,22 @@ components:
                   - field: email
                     message: Email must be a valid email address.
                     code: invalid_email
+    PayloadTooLarge:
+      description: The request body exceeds the configured size limit.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            payloadTooLarge:
+              summary: Payload too large
+              value:
+                type: https://nene2.dev/problems/payload-too-large
+                title: Payload Too Large
+                status: 413
+                detail: The request body exceeds the configured size limit.
+                instance: /upload
+                max_body_bytes: 1048576
     InternalServerError:
       description: The server encountered an unexpected condition.
       content:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -46,12 +46,12 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Implement typed config loader and `.env.example`. `#47`
 - [x] Add OpenAPI Problem Details schemas. `#49`
 - [x] Add validation error mapping and readonly DTO examples. `#51`
+- [x] Add request id, CORS, security headers, and request size middleware skeletons. `#53`
 
 ## Next Candidates
 
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
-- [ ] Add request id, CORS, security headers, and request size middleware skeletons.
 - [ ] Add PSR-3 logging adapter and request id log context.
 - [ ] Add PHP-CS-Fixer configuration and Composer scripts.
 - [ ] Add React + TypeScript frontend starter and ESLint / Prettier baseline.

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -7,7 +7,11 @@ namespace Nene2\Http;
 use Nene2\Error\ErrorHandlerMiddleware;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\FrameworkInfo;
+use Nene2\Middleware\CorsMiddleware;
 use Nene2\Middleware\MiddlewareDispatcher;
+use Nene2\Middleware\RequestIdMiddleware;
+use Nene2\Middleware\RequestSizeLimitMiddleware;
+use Nene2\Middleware\SecurityHeadersMiddleware;
 use Nene2\Routing\Router;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -39,7 +43,11 @@ final readonly class RuntimeApplicationFactory
 
         return new MiddlewareDispatcher(
             [
+                new RequestIdMiddleware(),
+                new SecurityHeadersMiddleware(),
+                new CorsMiddleware($this->responseFactory),
                 new ErrorHandlerMiddleware($problemDetails),
+                new RequestSizeLimitMiddleware($problemDetails),
             ],
             $router,
         );

--- a/src/Middleware/CorsMiddleware.php
+++ b/src/Middleware/CorsMiddleware.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Middleware;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class CorsMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param list<string> $allowedOrigins
+     * @param list<string> $allowedMethods
+     * @param list<string> $allowedHeaders
+     */
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private array $allowedOrigins = [],
+        private array $allowedMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+        private array $allowedHeaders = ['Content-Type', 'Authorization', 'X-Request-Id'],
+        private bool $allowCredentials = false,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($this->isPreflightRequest($request)) {
+            return $this->addCorsHeaders($request, $this->responseFactory->createResponse(204));
+        }
+
+        return $this->addCorsHeaders($request, $handler->handle($request));
+    }
+
+    private function isPreflightRequest(ServerRequestInterface $request): bool
+    {
+        return strtoupper($request->getMethod()) === 'OPTIONS'
+            && $request->hasHeader('Origin')
+            && $request->hasHeader('Access-Control-Request-Method');
+    }
+
+    private function addCorsHeaders(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $origin = $request->getHeaderLine('Origin');
+        $response = $response->withHeader('Vary', 'Origin');
+
+        if ($origin === '' || !in_array($origin, $this->allowedOrigins, true)) {
+            return $response;
+        }
+
+        $response = $response
+            ->withHeader('Access-Control-Allow-Origin', $origin)
+            ->withHeader('Access-Control-Allow-Methods', implode(', ', $this->allowedMethods))
+            ->withHeader('Access-Control-Allow-Headers', implode(', ', $this->allowedHeaders));
+
+        if ($this->allowCredentials) {
+            $response = $response->withHeader('Access-Control-Allow-Credentials', 'true');
+        }
+
+        return $response;
+    }
+}

--- a/src/Middleware/RequestIdMiddleware.php
+++ b/src/Middleware/RequestIdMiddleware.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class RequestIdMiddleware implements MiddlewareInterface
+{
+    public const ATTRIBUTE = 'nene2.request_id';
+
+    public function __construct(
+        private string $headerName = 'X-Request-Id',
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $requestId = $this->safeRequestId($request->getHeaderLine($this->headerName)) ?? $this->generateRequestId();
+        $response = $handler->handle($request->withAttribute(self::ATTRIBUTE, $requestId));
+
+        return $response->withHeader($this->headerName, $requestId);
+    }
+
+    private function safeRequestId(string $requestId): ?string
+    {
+        if ($requestId === '' || strlen($requestId) > 128) {
+            return null;
+        }
+
+        if (preg_match('/\A[A-Za-z0-9._:-]+\z/', $requestId) !== 1) {
+            return null;
+        }
+
+        return $requestId;
+    }
+
+    private function generateRequestId(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+}

--- a/src/Middleware/RequestSizeLimitMiddleware.php
+++ b/src/Middleware/RequestSizeLimitMiddleware.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Middleware;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class RequestSizeLimitMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+        private int $maxBodyBytes = 1_048_576,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $contentLength = $request->getHeaderLine('Content-Length');
+
+        if ($contentLength !== '' && $this->isOversized($contentLength)) {
+            return $this->problemDetails->create(
+                $request,
+                'payload-too-large',
+                'Payload Too Large',
+                413,
+                'The request body exceeds the configured size limit.',
+                [
+                    'max_body_bytes' => $this->maxBodyBytes,
+                ],
+            );
+        }
+
+        return $handler->handle($request);
+    }
+
+    private function isOversized(string $contentLength): bool
+    {
+        if (preg_match('/\A\d+\z/', $contentLength) !== 1) {
+            return false;
+        }
+
+        return (int) $contentLength > $this->maxBodyBytes;
+    }
+}

--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class SecurityHeadersMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function __construct(
+        private array $headers = [
+            'X-Content-Type-Options' => 'nosniff',
+            'Referrer-Policy' => 'no-referrer-when-downgrade',
+            'X-Frame-Options' => 'SAMEORIGIN',
+            'Permissions-Policy' => 'camera=(), geolocation=(), microphone=()',
+        ],
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        foreach ($this->headers as $name => $value) {
+            if (!$response->hasHeader($name)) {
+                $response = $response->withHeader($name, $value);
+            }
+        }
+
+        return $response;
+    }
+}

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -21,6 +21,8 @@ final class HttpRuntimeTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertMatchesRegularExpression('/\A[a-f0-9]{32}\z/', $response->getHeaderLine('X-Request-Id'));
+        self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
         self::assertSame('NENE2', $payload['name']);
         self::assertSame('ok', $payload['status']);
     }
@@ -35,6 +37,8 @@ final class HttpRuntimeTest extends TestCase
 
         self::assertSame(404, $response->getStatusCode());
         self::assertSame('application/problem+json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertMatchesRegularExpression('/\A[a-f0-9]{32}\z/', $response->getHeaderLine('X-Request-Id'));
+        self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
         self::assertSame('https://nene2.dev/problems/not-found', $payload['type']);
         self::assertSame('Not Found', $payload['title']);
     }
@@ -50,6 +54,23 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame(405, $response->getStatusCode());
         self::assertSame('GET', $response->getHeaderLine('Allow'));
         self::assertSame('https://nene2.dev/problems/method-not-allowed', $payload['type']);
+    }
+
+    public function testOversizedRequestReturnsProblemDetails(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory))->create();
+
+        $response = $application->handle(
+            $factory
+                ->createServerRequest('POST', 'https://example.test/')
+                ->withHeader('Content-Length', '1048577'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(413, $response->getStatusCode());
+        self::assertMatchesRegularExpression('/\A[a-f0-9]{32}\z/', $response->getHeaderLine('X-Request-Id'));
+        self::assertSame('https://nene2.dev/problems/payload-too-large', $payload['type']);
     }
 
     /**

--- a/tests/Middleware/BaselineMiddlewareTest.php
+++ b/tests/Middleware/BaselineMiddlewareTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Middleware;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Middleware\CorsMiddleware;
+use Nene2\Middleware\RequestIdMiddleware;
+use Nene2\Middleware\RequestSizeLimitMiddleware;
+use Nene2\Middleware\SecurityHeadersMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class BaselineMiddlewareTest extends TestCase
+{
+    public function testRequestIdPreservesSafeIncomingHeader(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestIdMiddleware();
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/')
+            ->withHeader('X-Request-Id', 'client-request-123');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame('client-request-123', $response->getHeaderLine('X-Request-Id'));
+    }
+
+    public function testRequestIdReplacesUnsafeIncomingHeader(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestIdMiddleware();
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/')
+            ->withHeader('X-Request-Id', 'unsafe value');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertMatchesRegularExpression('/\A[a-f0-9]{32}\z/', $response->getHeaderLine('X-Request-Id'));
+    }
+
+    public function testSecurityHeadersAreAddedWithoutOverwritingExistingHeaders(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new SecurityHeadersMiddleware();
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://example.test/'),
+            new class ($factory) implements RequestHandlerInterface {
+                public function __construct(
+                    private readonly Psr17Factory $factory,
+                ) {
+                }
+
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->factory
+                        ->createResponse(200)
+                        ->withHeader('X-Frame-Options', 'DENY');
+                }
+            },
+        );
+
+        self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
+        self::assertSame('DENY', $response->getHeaderLine('X-Frame-Options'));
+    }
+
+    public function testCorsAddsHeadersForAllowedOrigin(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new CorsMiddleware($factory, ['https://app.example.test']);
+        $request = $factory
+            ->createServerRequest('GET', 'https://api.example.test/')
+            ->withHeader('Origin', 'https://app.example.test');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame('https://app.example.test', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        self::assertSame('Origin', $response->getHeaderLine('Vary'));
+    }
+
+    public function testCorsDoesNotAllowUnconfiguredOrigin(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new CorsMiddleware($factory);
+        $request = $factory
+            ->createServerRequest('GET', 'https://api.example.test/')
+            ->withHeader('Origin', 'https://app.example.test');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame('', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        self::assertSame('Origin', $response->getHeaderLine('Vary'));
+    }
+
+    public function testCorsPreflightReturnsNoContentForAllowedOrigin(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new CorsMiddleware($factory, ['https://app.example.test']);
+        $request = $factory
+            ->createServerRequest('OPTIONS', 'https://api.example.test/')
+            ->withHeader('Origin', 'https://app.example.test')
+            ->withHeader('Access-Control-Request-Method', 'POST');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertSame('https://app.example.test', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        self::assertSame('GET, POST, PUT, PATCH, DELETE, OPTIONS', $response->getHeaderLine('Access-Control-Allow-Methods'));
+    }
+
+    public function testRequestSizeLimitReturnsProblemDetailsForOversizedPayload(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestSizeLimitMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            10,
+        );
+        $request = $factory
+            ->createServerRequest('POST', 'https://example.test/upload')
+            ->withHeader('Content-Length', '11');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+        self::assertSame(413, $response->getStatusCode());
+        self::assertSame('https://nene2.dev/problems/payload-too-large', $payload['type']);
+        self::assertSame(10, $payload['max_body_bytes']);
+    }
+
+    private function okHandler(Psr17Factory $factory): RequestHandlerInterface
+    {
+        return new class ($factory) implements RequestHandlerInterface {
+            public function __construct(
+                private readonly Psr17Factory $factory,
+            ) {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse(200);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Add PSR-15 baseline middleware for request ids, security headers, CORS, and request size limits.
- Wire the middleware into the HTTP runtime and document the new 413 Problem Details response in OpenAPI.
- Update the current TODO board for Issue #53.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`
- `docs/review/middleware-security.md`

Closes #53

Made with [Cursor](https://cursor.com)