### PR TITLE
feat: PSR-3 request logging を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "psr/container": "^2.0",
     "psr/http-server-handler": "^1.0",
     "psr/http-server-middleware": "^1.0",
+    "psr/log": "^3.0",
     "vlucas/phpdotenv": "^5.6"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42714b8ea9b7accec7f4de8e3f92bcfc",
+    "content-hash": "0baf4328e54148c30ac38dfdd851c84c",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -560,6 +560,56 @@
                 "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
             },
             "time": "2023-04-11T06:14:47+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -47,12 +47,12 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add OpenAPI Problem Details schemas. `#49`
 - [x] Add validation error mapping and readonly DTO examples. `#51`
 - [x] Add request id, CORS, security headers, and request size middleware skeletons. `#53`
+- [x] Add PSR-3 logging adapter and request id log context. `#55`
 
 ## Next Candidates
 
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Keep self-review checklists updated as new implementation areas are introduced.
-- [ ] Add PSR-3 logging adapter and request id log context.
 - [ ] Add PHP-CS-Fixer configuration and Composer scripts.
 - [ ] Add React + TypeScript frontend starter and ESLint / Prettier baseline.
 - [ ] Add npm package metadata, Node engines, package lock, and frontend check scripts.

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -10,6 +10,7 @@ use Nene2\FrameworkInfo;
 use Nene2\Middleware\CorsMiddleware;
 use Nene2\Middleware\MiddlewareDispatcher;
 use Nene2\Middleware\RequestIdMiddleware;
+use Nene2\Middleware\RequestLoggingMiddleware;
 use Nene2\Middleware\RequestSizeLimitMiddleware;
 use Nene2\Middleware\SecurityHeadersMiddleware;
 use Nene2\Routing\Router;
@@ -17,12 +18,15 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 final readonly class RuntimeApplicationFactory
 {
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        private ?LoggerInterface $logger = null,
     ) {
     }
 
@@ -44,6 +48,7 @@ final readonly class RuntimeApplicationFactory
         return new MiddlewareDispatcher(
             [
                 new RequestIdMiddleware(),
+                new RequestLoggingMiddleware($this->logger ?? new NullLogger()),
                 new SecurityHeadersMiddleware(),
                 new CorsMiddleware($this->responseFactory),
                 new ErrorHandlerMiddleware($problemDetails),

--- a/src/Middleware/RequestLoggingMiddleware.php
+++ b/src/Middleware/RequestLoggingMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+
+final readonly class RequestLoggingMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $startedAt = hrtime(true);
+        $response = $handler->handle($request);
+
+        $this->logger->info('HTTP request handled.', [
+            'request_id' => $this->requestId($request),
+            'method' => $request->getMethod(),
+            'path' => $request->getUri()->getPath() ?: '/',
+            'status' => $response->getStatusCode(),
+            'duration_ms' => $this->durationMilliseconds($startedAt),
+        ]);
+
+        return $response;
+    }
+
+    private function requestId(ServerRequestInterface $request): ?string
+    {
+        $requestId = $request->getAttribute(RequestIdMiddleware::ATTRIBUTE);
+
+        return is_string($requestId) && $requestId !== '' ? $requestId : null;
+    }
+
+    private function durationMilliseconds(int $startedAt): float
+    {
+        return round((hrtime(true) - $startedAt) / 1_000_000, 3);
+    }
+}

--- a/tests/Middleware/BaselineMiddlewareTest.php
+++ b/tests/Middleware/BaselineMiddlewareTest.php
@@ -7,6 +7,7 @@ namespace Nene2\Tests\Middleware;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Middleware\CorsMiddleware;
 use Nene2\Middleware\RequestIdMiddleware;
+use Nene2\Middleware\RequestLoggingMiddleware;
 use Nene2\Middleware\RequestSizeLimitMiddleware;
 use Nene2\Middleware\SecurityHeadersMiddleware;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -14,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\AbstractLogger;
+use Stringable;
 
 final class BaselineMiddlewareTest extends TestCase
 {
@@ -131,6 +134,44 @@ final class BaselineMiddlewareTest extends TestCase
         self::assertSame(413, $response->getStatusCode());
         self::assertSame('https://nene2.dev/problems/payload-too-large', $payload['type']);
         self::assertSame(10, $payload['max_body_bytes']);
+    }
+
+    public function testRequestLoggingIncludesSafeRequestContext(): void
+    {
+        $factory = new Psr17Factory();
+        $logger = new class () extends AbstractLogger {
+            /** @var list<array{level: mixed, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            /**
+             * @param array<string, mixed> $context
+             */
+            public function log($level, Stringable|string $message, array $context = []): void
+            {
+                $this->records[] = [
+                    'level' => $level,
+                    'message' => (string) $message,
+                    'context' => $context,
+                ];
+            }
+        };
+        $middleware = new RequestLoggingMiddleware($logger);
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/health')
+            ->withHeader('Authorization', 'Bearer secret')
+            ->withAttribute(RequestIdMiddleware::ATTRIBUTE, 'request-123');
+
+        $middleware->process($request, $this->okHandler($factory));
+
+        self::assertCount(1, $logger->records);
+        self::assertSame('info', $logger->records[0]['level']);
+        self::assertSame('HTTP request handled.', $logger->records[0]['message']);
+        self::assertSame('request-123', $logger->records[0]['context']['request_id']);
+        self::assertSame('GET', $logger->records[0]['context']['method']);
+        self::assertSame('/health', $logger->records[0]['context']['path']);
+        self::assertSame(200, $logger->records[0]['context']['status']);
+        self::assertArrayHasKey('duration_ms', $logger->records[0]['context']);
+        self::assertArrayNotHasKey('Authorization', $logger->records[0]['context']);
     }
 
     private function okHandler(Psr17Factory $factory): RequestHandlerInterface


### PR DESCRIPTION
## Summary
- Add `psr/log` as the PSR-3 logging boundary package.
- Add request logging middleware with request id, method, path, status, and duration context.
- Wire a `NullLogger` fallback into the runtime factory and update the current TODO board.

## Verification
- [x] `docker compose run --rm app composer validate`
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`
- `docs/review/middleware-security.md`

Closes #55

Made with [Cursor](https://cursor.com)