### PR TITLE
feat: native PHP view renderer を追加する

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -49,6 +49,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add request id, CORS, security headers, and request size middleware skeletons. `#53`
 - [x] Add PSR-3 logging adapter and request id log context. `#55`
 - [x] Add PHP-CS-Fixer configuration and Composer scripts. `#57`
+- [x] Add the first native PHP view renderer and escaping helper. `#59`
 
 ## Next Candidates
 
@@ -61,7 +62,6 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Add release checklist and first `v0.x.y` release preparation when runtime surface is useful.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
-- [ ] Add the first native PHP view renderer and escaping helper.
 - [ ] Choose and wire the migration runner when the database adapter layer starts.
 - [ ] Add metrics and error tracking adapter policy details when integrations start.
 

--- a/src/View/HtmlEscaper.php
+++ b/src/View/HtmlEscaper.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\View;
+
+final readonly class HtmlEscaper
+{
+    public function escape(mixed $value): string
+    {
+        return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+    }
+}

--- a/src/View/HtmlResponseFactory.php
+++ b/src/View/HtmlResponseFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\View;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class HtmlResponseFactory
+{
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+        private NativePhpViewRenderer $renderer,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, string> $headers
+     */
+    public function create(string $template, array $data = [], int $status = 200, array $headers = []): ResponseInterface
+    {
+        $response = $this->responseFactory
+            ->createResponse($status)
+            ->withHeader('Content-Type', 'text/html; charset=utf-8');
+
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response->withBody(
+            $this->streamFactory->createStream($this->renderer->render($template, $data))
+        );
+    }
+}

--- a/src/View/NativePhpViewRenderer.php
+++ b/src/View/NativePhpViewRenderer.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\View;
+
+use Throwable;
+
+final readonly class NativePhpViewRenderer
+{
+    public function __construct(
+        private string $templateRoot,
+        private HtmlEscaper $escaper = new HtmlEscaper(),
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function render(string $template, array $data = []): string
+    {
+        $path = $this->resolveTemplate($template);
+        $escape = fn (mixed $value): string => $this->escaper->escape($value);
+
+        ob_start();
+
+        try {
+            $this->includeTemplate($path, $data, $escape);
+
+            return (string) ob_get_clean();
+        } catch (Throwable $exception) {
+            ob_end_clean();
+
+            throw $exception;
+        }
+    }
+
+    private function resolveTemplate(string $template): string
+    {
+        $normalized = ltrim($template, '/');
+
+        if ($normalized === '' || str_contains($normalized, '..')) {
+            throw new TemplateNotFoundException(sprintf('Template "%s" was not found.', $template));
+        }
+
+        $path = rtrim($this->templateRoot, '/') . '/' . $normalized;
+
+        if (!is_file($path)) {
+            throw new TemplateNotFoundException(sprintf('Template "%s" was not found.', $template));
+        }
+
+        return $path;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param callable(mixed): string $escape
+     */
+    private function includeTemplate(string $path, array $data, callable $escape): void
+    {
+        (static function () use ($path, $data, $escape): void {
+            extract($data, EXTR_SKIP);
+            $e = $escape;
+
+            require $path;
+        })();
+    }
+}

--- a/src/View/TemplateNotFoundException.php
+++ b/src/View/TemplateNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\View;
+
+use RuntimeException;
+
+final class TemplateNotFoundException extends RuntimeException
+{
+}

--- a/tests/View/NativePhpViewRendererTest.php
+++ b/tests/View/NativePhpViewRendererTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\View;
+
+use Nene2\View\HtmlEscaper;
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use Nene2\View\TemplateNotFoundException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class NativePhpViewRendererTest extends TestCase
+{
+    private string $templateRoot;
+
+    protected function setUp(): void
+    {
+        $this->templateRoot = sys_get_temp_dir() . '/nene2-view-test-' . bin2hex(random_bytes(6));
+        mkdir($this->templateRoot);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->templateRoot . '/*.php') ?: [] as $file) {
+            unlink($file);
+        }
+
+        rmdir($this->templateRoot);
+    }
+
+    public function testEscaperEscapesHtmlSpecialCharacters(): void
+    {
+        $escaper = new HtmlEscaper();
+
+        self::assertSame('&lt;script&gt;&quot;x&quot; &amp; &apos;y&apos;&lt;/script&gt;', $escaper->escape('<script>"x" & \'y\'</script>'));
+    }
+
+    public function testRendererPassesVariablesAndEscapingHelperToTemplate(): void
+    {
+        file_put_contents(
+            $this->templateRoot . '/hello.php',
+            '<h1><?= $e($title) ?></h1><p><?= $e($message) ?></p>',
+        );
+
+        $renderer = new NativePhpViewRenderer($this->templateRoot);
+
+        self::assertSame(
+            '<h1>Hello</h1><p>&lt;strong&gt;NENE2&lt;/strong&gt;</p>',
+            $renderer->render('hello.php', [
+                'title' => 'Hello',
+                'message' => '<strong>NENE2</strong>',
+            ]),
+        );
+    }
+
+    public function testRendererRejectsMissingTemplate(): void
+    {
+        $renderer = new NativePhpViewRenderer($this->templateRoot);
+
+        $this->expectException(TemplateNotFoundException::class);
+
+        $renderer->render('missing.php');
+    }
+
+    public function testRendererRejectsParentDirectoryTraversal(): void
+    {
+        $renderer = new NativePhpViewRenderer($this->templateRoot);
+
+        $this->expectException(TemplateNotFoundException::class);
+
+        $renderer->render('../secret.php');
+    }
+
+    public function testHtmlResponseFactoryCreatesHtmlResponse(): void
+    {
+        file_put_contents($this->templateRoot . '/page.php', '<main><?= $e($content) ?></main>');
+
+        $psr17Factory = new Psr17Factory();
+        $responseFactory = new HtmlResponseFactory(
+            $psr17Factory,
+            $psr17Factory,
+            new NativePhpViewRenderer($this->templateRoot),
+        );
+
+        $response = $responseFactory->create('page.php', ['content' => 'OK'], 201, ['X-View' => 'native']);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('text/html; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertSame('native', $response->getHeaderLine('X-View'));
+        self::assertSame('<main>OK</main>', (string) $response->getBody());
+    }
+}


### PR DESCRIPTION
## Summary
- Add a native PHP view renderer with an explicit HTML escaping helper.
- Add an HTML response factory backed by PSR-17 factories.
- Add focused tests for escaping, rendering, missing templates, path traversal rejection, and HTML response metadata.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/backend-api.md`

Closes #59

Made with [Cursor](https://cursor.com)