### PR TITLE
docs: release checklist を追加する

### DIFF
--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -1,0 +1,63 @@
+# Release Checklist
+
+Use this checklist for manual `v0.x.y` releases until release automation is introduced.
+
+## Preconditions
+
+- The release is created from `main`.
+- `main` is up to date with `origin/main`.
+- The working tree is clean.
+- Relevant Issues and PRs are merged or explicitly deferred.
+- `docs/todo/current.md` reflects the actual project state.
+- Public behavior changes are documented in source-of-truth docs and OpenAPI when applicable.
+
+## Verification
+
+Run the backend verification path before tagging:
+
+```bash
+docker compose run --rm app composer validate
+docker compose run --rm app composer check
+git diff --check
+```
+
+If Docker is unavailable, run the equivalent Composer commands in a PHP `8.4` environment and record the limitation in the release notes.
+
+## Version Selection
+
+- Use `vX.Y.Z` tags.
+- Use `0.x.y` while public contracts are still forming.
+- Use a minor version for meaningful framework surface changes.
+- Use a patch version for small fixes or documentation corrections.
+- Do not describe `0.x.y` releases as long-term public API stability promises.
+
+## Tagging
+
+Create tags only from `main` after verification:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag v0.x.y
+git push origin v0.x.y
+```
+
+Do not tag unmerged PR branches or local-only commits.
+
+## GitHub Release Notes
+
+Release notes should include:
+
+- highlights
+- breaking changes, or `None`
+- migration notes, or `None`
+- verification summary
+- related Issues and PRs
+- remaining known risks or follow-up work
+
+## After Release
+
+- Confirm the GitHub Release points to the expected tag.
+- Confirm `docs/todo/current.md` does not list the release as incomplete if it is done.
+- Open follow-up Issues for deferred release work.
+- Leave Packagist publication deferred until Composer package contracts are stable enough for early users.

--- a/docs/development/release-ci.md
+++ b/docs/development/release-ci.md
@@ -6,6 +6,8 @@ NENE2 uses SemVer, small release steps, and GitHub Actions as the standard CI di
 
 Release and CI policy should keep the framework safe to change while the public API is still forming.
 
+Manual release steps are tracked in `docs/development/release-checklist.md`.
+
 The standard direction is:
 
 - Use Semantic Versioning.
@@ -145,7 +147,7 @@ Dependency update PRs should still run the same CI checks as normal PRs.
 
 ## Release Checklist
 
-Before tagging a release:
+Before tagging a release, use `docs/development/release-checklist.md`. At minimum:
 
 - `main` is up to date.
 - Required CI checks are passing.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -50,6 +50,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add PSR-3 logging adapter and request id log context. `#55`
 - [x] Add PHP-CS-Fixer configuration and Composer scripts. `#57`
 - [x] Add the first native PHP view renderer and escaping helper. `#59`
+- [x] Add release checklist and first `v0.x.y` release preparation. `#61`
 
 ## Next Candidates
 
@@ -59,7 +60,6 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Add npm package metadata, Node engines, package lock, and frontend check scripts.
 - [ ] Add Dependabot or Renovate policy for PHP and frontend dependencies.
 - [ ] Add first GitHub Actions workflow for backend Composer checks.
-- [ ] Add release checklist and first `v0.x.y` release preparation when runtime surface is useful.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Choose and wire the migration runner when the database adapter layer starts.


### PR DESCRIPTION
## Summary
- Add a manual release checklist for early `v0.x.y` releases.
- Link the checklist from the release, versioning, and CI policy.
- Update the current TODO board for Issue #61.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/release-ci.md`

Closes #61

Made with [Cursor](https://cursor.com)