### PR TITLE
docs: metrics and error tracking adapter policy を具体化する

### DIFF
--- a/docs/development/observability.md
+++ b/docs/development/observability.md
@@ -86,16 +86,35 @@ Error tracking tools such as Sentry should be adapters.
 
 NENE2 core should expose enough context for adapters to report errors, but should not require a specific SaaS or SDK.
 
+The first error tracking adapter boundary should accept a small, explicit report object rather than raw request or response objects.
+
 Adapters may receive:
 
 - exception
 - request id
 - route or path
 - problem type
+- HTTP method
+- HTTP status when a response exists
 - safe user or account identifier
 - environment name
 
 Adapters must not receive raw secrets or private request payloads by default.
+
+Error tracking adapters should classify expected client failures separately from server failures. Validation errors, `404`, and `405` responses should not be reported as unhandled exceptions unless an application explicitly opts in.
+
+## Error Tracking Adapter Safety
+
+Error tracking integrations must stay optional and environment-aware.
+
+Policy:
+
+- Default framework runtime must work without an error tracking package.
+- SaaS SDKs belong in adapters or application wiring, not framework core.
+- Adapter configuration must make DSNs, tokens, and environment names explicit.
+- Reports must include `request_id` when available.
+- Reports must not include `Authorization`, cookies, raw request bodies, uploaded files, database DSNs, or local file paths by default.
+- Local development should prefer disabled or test transports unless explicitly configured.
 
 ## Metrics
 
@@ -111,6 +130,38 @@ Future metrics adapters may expose:
 - rate limit events when rate limiting exists
 
 Prometheus, StatsD, OpenTelemetry, Datadog, or another backend should be optional integrations, not required core dependencies.
+
+The first metrics boundary should model framework events, not backend-specific metric names.
+
+Recommended initial events:
+
+- `http.request.completed`
+- `http.request.failed`
+- `http.validation.failed`
+- `http.request.rejected`
+
+Recommended metric context:
+
+- `request_id` when available
+- `method`
+- `path` or route pattern when available
+- `status`
+- `duration_ms`
+- `problem_type` for Problem Details responses
+- `exception_class` for server-side failures
+
+Metric labels must avoid high-cardinality or sensitive values. Do not use raw URLs with user identifiers, request bodies, authorization headers, cookies, email addresses, tokens, or database identifiers as labels.
+
+## Metrics Adapter Direction
+
+Metrics adapters should translate framework events into backend-specific counters, histograms, or spans.
+
+Policy:
+
+- Framework core may expose event context, but should not depend on Prometheus, OpenTelemetry, Datadog, StatsD, or another backend by default.
+- Adapters should decide how to bucket durations and status codes.
+- Applications should be able to disable metrics without changing HTTP behavior.
+- Metrics failures should not break request handling unless an application explicitly chooses strict behavior.
 
 ## Secret and Payload Safety
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -52,6 +52,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add the first native PHP view renderer and escaping helper. `#59`
 - [x] Add release checklist and first `v0.x.y` release preparation. `#61`
 - [x] Add Dependabot policy for PHP and GitHub Actions dependencies. `#63`
+- [x] Add metrics and error tracking adapter policy details. `#65`
 
 ## Next Candidates
 
@@ -63,7 +64,6 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Choose and wire the migration runner when the database adapter layer starts.
-- [ ] Add metrics and error tracking adapter policy details when integrations start.
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Expand error tracking adapter boundaries and safety rules.
- Add initial metrics events, context, and adapter direction.
- Update the current TODO board for Issue #65.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/middleware-security.md`

Closes #65

Made with [Cursor](https://cursor.com)