### PR TITLE
test: OpenAPI contract validation を composer check に追加する

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,6 +10,7 @@ $finder = Finder::create()
         __DIR__ . '/public_html',
         __DIR__ . '/src',
         __DIR__ . '/tests',
+        __DIR__ . '/tools',
     ])
     ->name('*.php');
 

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,12 @@
     "analyse": "phpstan analyse",
     "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
     "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
+    "openapi": "php tools/validate-openapi.php",
     "check": [
       "@test",
       "@analyse",
-      "@cs"
+      "@cs",
+      "@openapi"
     ]
   },
   "config": {
@@ -40,6 +42,7 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.95",
     "phpstan/phpstan": "^2.1",
-    "phpunit/phpunit": "^13.1"
+    "phpunit/phpunit": "^13.1",
+    "symfony/yaml": "^8.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7bb736f0c3d4e1a194799b6d18665e1",
+    "content-hash": "db5ce2917f7360569b984458612b718f",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -5087,6 +5087,81 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/string/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "54174ab48c0c0f9e21512b304be17f8150ccf8f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/54174ab48c0c0f9e21512b304be17f8150ccf8f1",
+                "reference": "54174ab48c0c0f9e21512b304be17f8150ccf8f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<7.4"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v8.0.8"
             },
             "funding": [
                 {

--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -55,6 +55,14 @@ Then verify:
 - `http://localhost:8080/openapi.php` returns the OpenAPI YAML.
 - `http://localhost:8080/docs/` loads Swagger UI.
 
+Validate the contract file locally:
+
+```bash
+docker compose run --rm app composer openapi
+```
+
+`composer check` includes this OpenAPI validation step.
+
 ## Testing Direction
 
 Once runtime code exists, API tests should verify that responses match the documented contract. The first implementation can be lightweight and grow with the framework.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -53,6 +53,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add release checklist and first `v0.x.y` release preparation. `#61`
 - [x] Add Dependabot policy for PHP and GitHub Actions dependencies. `#63`
 - [x] Add metrics and error tracking adapter policy details. `#65`
+- [x] Add OpenAPI contract validation to `composer check`. `#67`
 
 ## Next Candidates
 
@@ -62,7 +63,6 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Add npm package metadata, Node engines, package lock, and frontend check scripts.
 - [ ] Add first GitHub Actions workflow for backend Composer checks.
 - [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
-- [ ] Add OpenAPI contract validation to `composer check`.
 - [ ] Choose and wire the migration runner when the database adapter layer starts.
 
 ## Operating Notes

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,4 +3,5 @@ parameters:
   paths:
     - src
     - tests
+    - tools
   tmpDir: .phpstan.cache

--- a/tools/validate-openapi.php
+++ b/tools/validate-openapi.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$path = dirname(__DIR__) . '/docs/openapi/openapi.yaml';
+
+try {
+    $document = Yaml::parseFile($path);
+} catch (ParseException $exception) {
+    fwrite(STDERR, sprintf("OpenAPI YAML parse error: %s\n", $exception->getMessage()));
+    exit(1);
+}
+
+if (!is_array($document)) {
+    fwrite(STDERR, "OpenAPI document must parse to a mapping.\n");
+    exit(1);
+}
+
+$errors = [];
+
+foreach (['openapi', 'info', 'paths', 'components'] as $requiredKey) {
+    if (!array_key_exists($requiredKey, $document)) {
+        $errors[] = sprintf('Missing required top-level key: %s', $requiredKey);
+    }
+}
+
+if (($document['openapi'] ?? null) !== '3.1.0') {
+    $errors[] = 'OpenAPI version must be 3.1.0.';
+}
+
+validateInternalReferences($document, $document, '#', $errors);
+
+if ($errors !== []) {
+    foreach ($errors as $error) {
+        fwrite(STDERR, sprintf("OpenAPI validation error: %s\n", $error));
+    }
+
+    exit(1);
+}
+
+echo "OpenAPI contract is valid.\n";
+
+/**
+ * @param array<mixed> $node
+ * @param array<mixed> $document
+ * @param list<string> $errors
+ */
+function validateInternalReferences(array $node, array $document, string $path, array &$errors): void
+{
+    foreach ($node as $key => $value) {
+        $childPath = $path . '/' . (string) $key;
+
+        if ($key === '$ref' && is_string($value) && str_starts_with($value, '#/')) {
+            if (!hasJsonPointer($document, $value)) {
+                $errors[] = sprintf('Unresolved internal reference at %s: %s', $path, $value);
+            }
+
+            continue;
+        }
+
+        if (is_array($value)) {
+            validateInternalReferences($value, $document, $childPath, $errors);
+        }
+    }
+}
+
+/**
+ * @param array<mixed> $document
+ */
+function hasJsonPointer(array $document, string $reference): bool
+{
+    $current = $document;
+
+    foreach (explode('/', substr($reference, 2)) as $segment) {
+        $segment = str_replace(['~1', '~0'], ['/', '~'], $segment);
+
+        if (!is_array($current) || !array_key_exists($segment, $current)) {
+            return false;
+        }
+
+        $current = $current[$segment];
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Summary
- Add `tools/validate-openapi.php` to parse the OpenAPI YAML and verify internal `$ref` targets.
- Add `composer openapi` and include it in `composer check`.
- Document local OpenAPI validation and update the current TODO board.

## Verification
- [x] `docker compose run --rm app composer validate`
- [x] `docker compose run --rm app composer openapi`
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/backend-api.md`

Closes #67

Made with [Cursor](https://cursor.com)