### PR TITLE
feat: health endpoint を HTTP runtime に追加する

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -36,6 +36,30 @@ paths:
           $ref: '#/components/responses/PayloadTooLarge'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /health:
+    get:
+      tags:
+        - System
+      summary: Health endpoint
+      description: Returns a minimal JSON response for local operational health checks.
+      operationId: getHealth
+      responses:
+        '200':
+          description: Health response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+              examples:
+                ok:
+                  summary: Healthy response
+                  value:
+                    status: ok
+                    service: NENE2
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   responses:
     NotFound:
@@ -208,3 +232,17 @@ components:
           enum:
             - ok
           example: ok
+    HealthResponse:
+      type: object
+      required:
+        - status
+        - service
+      properties:
+        status:
+          type: string
+          enum:
+            - ok
+          example: ok
+        service:
+          type: string
+          example: NENE2

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -54,6 +54,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add Dependabot policy for PHP and GitHub Actions dependencies. `#63`
 - [x] Add metrics and error tracking adapter policy details. `#65`
 - [x] Add OpenAPI contract validation to `composer check`. `#67`
+- [x] Expand the HTTP runtime skeleton beyond the smoke endpoint. `#69`
 
 ## Next Candidates
 
@@ -62,7 +63,6 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [ ] Add React + TypeScript frontend starter and ESLint / Prettier baseline.
 - [ ] Add npm package metadata, Node engines, package lock, and frontend check scripts.
 - [ ] Add first GitHub Actions workflow for backend Composer checks.
-- [ ] Expand the HTTP runtime skeleton beyond the smoke endpoint.
 - [ ] Choose and wire the migration runner when the database adapter layer starts.
 
 ## Operating Notes

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -36,14 +36,22 @@ final readonly class RuntimeApplicationFactory
         $problemDetails = new ProblemDetailsResponseFactory($this->responseFactory, $this->streamFactory);
         $framework = new FrameworkInfo();
 
-        $router = (new Router())->get(
-            '/',
-            static fn (ServerRequestInterface $request) => $jsonResponses->create([
-                'name' => $framework->name(),
-                'description' => $framework->description(),
-                'status' => 'ok',
-            ]),
-        );
+        $router = (new Router())
+            ->get(
+                '/',
+                static fn (ServerRequestInterface $request) => $jsonResponses->create([
+                    'name' => $framework->name(),
+                    'description' => $framework->description(),
+                    'status' => 'ok',
+                ]),
+            )
+            ->get(
+                '/health',
+                static fn (ServerRequestInterface $request) => $jsonResponses->create([
+                    'status' => 'ok',
+                    'service' => $framework->name(),
+                ]),
+            );
 
         return new MiddlewareDispatcher(
             [

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -43,6 +43,21 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame('Not Found', $payload['title']);
     }
 
+    public function testHealthEndpointRunsThroughRuntime(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/health'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertMatchesRegularExpression('/\A[a-f0-9]{32}\z/', $response->getHeaderLine('X-Request-Id'));
+        self::assertSame('ok', $payload['status']);
+        self::assertSame('NENE2', $payload['service']);
+    }
+
     public function testUnsupportedMethodReturnsProblemDetailsWithAllowHeader(): void
     {
         $factory = new Psr17Factory();


### PR DESCRIPTION
## Summary
- Add `GET /health` through the existing HTTP runtime router.
- Document the health response in OpenAPI.
- Add runtime coverage for the endpoint and update the current TODO board.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`

Closes #69

Made with [Cursor](https://cursor.com)