### PR TITLE
docs: self-review checklists を実装領域に合わせて更新する

### DIFF
--- a/docs/development/self-review.md
+++ b/docs/development/self-review.md
@@ -54,7 +54,9 @@ docs/review/
 ├── docs-policy.md
 ├── frontend.md
 ├── middleware-security.md
-└── release-ci.md
+├── openapi-contract.md
+├── release-ci.md
+└── view-rendering.md
 ```
 
 Add new checklist files only when a repeated work type has enough unique risk to justify one.

--- a/docs/review/openapi-contract.md
+++ b/docs/review/openapi-contract.md
@@ -1,0 +1,22 @@
+# OpenAPI Contract Self-Review
+
+Use this checklist for OpenAPI documents, examples, contract validation, and API contract tooling.
+
+Source policies:
+
+- `docs/integrations/openapi.md`
+- `docs/development/api-error-responses.md`
+- `docs/development/request-validation.md`
+- `docs/development/middleware-security.md`
+- `docs/development/language-policy.md`
+
+## Checklist
+
+- [ ] Shipped public JSON behavior is documented in `docs/openapi/openapi.yaml`.
+- [ ] OpenAPI text, operation summaries, examples, and schema descriptions are in English.
+- [ ] Stable error responses use shared Problem Details schemas where applicable.
+- [ ] Problem Details examples use `https://nene2.dev/problems/{problem-name}`.
+- [ ] Documented examples match implemented response shapes.
+- [ ] New `$ref` values resolve through `composer openapi`.
+- [ ] Aspirational auth, CORS, or security behavior is not documented before implementation.
+- [ ] The narrowest useful verification was run, usually `composer openapi` or `composer check`.

--- a/docs/review/view-rendering.md
+++ b/docs/review/view-rendering.md
@@ -1,0 +1,21 @@
+# View Rendering Self-Review
+
+Use this checklist for native PHP templates, HTML response helpers, escaping, and future template adapters.
+
+Source policies:
+
+- `docs/development/view-rendering.md`
+- `docs/development/http-runtime.md`
+- `docs/development/coding-standards.md`
+- `docs/development/documentation-comments.md`
+
+## Checklist
+
+- [ ] Server HTML remains thin and optional.
+- [ ] Template source stays under `templates/`, not `public_html/`.
+- [ ] Framework view abstractions stay under `src/View/`.
+- [ ] Template variables are escaped through an explicit helper before output.
+- [ ] Templates do not contain business logic.
+- [ ] HTML responses set `text/html; charset=utf-8`.
+- [ ] Missing or unsafe template paths fail predictably.
+- [ ] Tests cover escaping behavior and response metadata for stable rendering behavior.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -55,11 +55,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add metrics and error tracking adapter policy details. `#65`
 - [x] Add OpenAPI contract validation to `composer check`. `#67`
 - [x] Expand the HTTP runtime skeleton beyond the smoke endpoint. `#69`
+- [x] Keep self-review checklists updated as new implementation areas are introduced. `#71`
 
 ## Next Candidates
 
 - [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
-- [ ] Keep self-review checklists updated as new implementation areas are introduced.
 - [ ] Add React + TypeScript frontend starter and ESLint / Prettier baseline.
 - [ ] Add npm package metadata, Node engines, package lock, and frontend check scripts.
 - [ ] Add first GitHub Actions workflow for backend Composer checks.


### PR DESCRIPTION
## Summary
- Add an OpenAPI contract self-review checklist.
- Add a view rendering self-review checklist.
- Update the self-review checklist index and current TODO board.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/docs-policy.md`

Closes #71

Made with [Cursor](https://cursor.com)