### PR TITLE
docs: Problem Details type URI pages を追加する

### DIFF
--- a/docs/development/api-error-responses.md
+++ b/docs/development/api-error-responses.md
@@ -54,7 +54,7 @@ Canonical pattern:
 https://nene2.dev/problems/{problem-name}
 ```
 
-`nene2.dev` is the canonical NENE2 problem type domain. Before public release, each stable problem type URI should either serve human-readable documentation or redirect to the relevant documentation page.
+`nene2.dev` is the canonical NENE2 problem type domain. Stable problem type pages are served from `public_html/problems/{problem-name}/` and should be available at `https://nene2.dev/problems/{problem-name}` when the public domain is deployed.
 
 Do not change canonical problem type URIs after clients depend on them unless the change is treated as a public API compatibility decision.
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -59,10 +59,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add React + TypeScript frontend starter and ESLint / Prettier baseline. `#73`
 - [x] Add npm package metadata, Node engines, package lock, and frontend check scripts. `#73`
 - [x] Choose and wire the migration runner when the database adapter layer starts. `#75`
+- [x] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable. `#77`
 
 ## Next Candidates
 
-- [ ] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable.
 - [ ] Add first GitHub Actions workflow for backend Composer checks.
 
 ## Operating Notes

--- a/public_html/problems/index.html
+++ b/public_html/problems/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NENE2 Problem Types</title>
+  </head>
+  <body>
+    <main>
+      <h1>NENE2 Problem Types</h1>
+      <p>These pages document stable RFC 9457 Problem Details type URIs used by NENE2 JSON APIs.</p>
+      <ul>
+        <li><a href="/problems/not-found/">Not Found</a></li>
+        <li><a href="/problems/method-not-allowed/">Method Not Allowed</a></li>
+        <li><a href="/problems/validation-failed/">Validation Failed</a></li>
+        <li><a href="/problems/payload-too-large/">Payload Too Large</a></li>
+        <li><a href="/problems/internal-server-error/">Internal Server Error</a></li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/public_html/problems/internal-server-error/index.html
+++ b/public_html/problems/internal-server-error/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Internal Server Error - NENE2 Problem Type</title>
+  </head>
+  <body>
+    <main>
+      <h1>Internal Server Error</h1>
+      <p><strong>Type URI:</strong> <code>https://nene2.dev/problems/internal-server-error</code></p>
+      <p><strong>Status:</strong> 500</p>
+      <p>The server encountered an unexpected condition.</p>
+      <p>Public responses must not expose stack traces, SQL, file paths, secrets, or private identifiers.</p>
+    </main>
+  </body>
+</html>

--- a/public_html/problems/method-not-allowed/index.html
+++ b/public_html/problems/method-not-allowed/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Method Not Allowed - NENE2 Problem Type</title>
+  </head>
+  <body>
+    <main>
+      <h1>Method Not Allowed</h1>
+      <p><strong>Type URI:</strong> <code>https://nene2.dev/problems/method-not-allowed</code></p>
+      <p><strong>Status:</strong> 405</p>
+      <p>The requested resource does not support this HTTP method.</p>
+    </main>
+  </body>
+</html>

--- a/public_html/problems/not-found/index.html
+++ b/public_html/problems/not-found/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Not Found - NENE2 Problem Type</title>
+  </head>
+  <body>
+    <main>
+      <h1>Not Found</h1>
+      <p><strong>Type URI:</strong> <code>https://nene2.dev/problems/not-found</code></p>
+      <p><strong>Status:</strong> 404</p>
+      <p>The requested resource was not found.</p>
+    </main>
+  </body>
+</html>

--- a/public_html/problems/payload-too-large/index.html
+++ b/public_html/problems/payload-too-large/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Payload Too Large - NENE2 Problem Type</title>
+  </head>
+  <body>
+    <main>
+      <h1>Payload Too Large</h1>
+      <p><strong>Type URI:</strong> <code>https://nene2.dev/problems/payload-too-large</code></p>
+      <p><strong>Status:</strong> 413</p>
+      <p>The request body exceeds the configured size limit.</p>
+    </main>
+  </body>
+</html>

--- a/public_html/problems/validation-failed/index.html
+++ b/public_html/problems/validation-failed/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Validation Failed - NENE2 Problem Type</title>
+  </head>
+  <body>
+    <main>
+      <h1>Validation Failed</h1>
+      <p><strong>Type URI:</strong> <code>https://nene2.dev/problems/validation-failed</code></p>
+      <p><strong>Status:</strong> 422</p>
+      <p>The request body, query, or path parameters contain invalid values.</p>
+      <p>Responses include an <code>errors</code> array with field, message, and code values.</p>
+    </main>
+  </body>
+</html>

--- a/tests/OpenApi/ProblemTypePagesTest.php
+++ b/tests/OpenApi/ProblemTypePagesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\OpenApi;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProblemTypePagesTest extends TestCase
+{
+    public function testOpenApiProblemTypeExamplesHaveHumanReadablePages(): void
+    {
+        $openApi = file_get_contents(dirname(__DIR__, 2) . '/docs/openapi/openapi.yaml');
+
+        self::assertIsString($openApi);
+        preg_match_all('#https://nene2\.dev/problems/([a-z-]+)#', $openApi, $matches);
+
+        $problemNames = array_unique($matches[1]);
+        sort($problemNames);
+
+        self::assertNotSame([], $problemNames);
+
+        foreach ($problemNames as $problemName) {
+            $path = dirname(__DIR__, 2) . sprintf('/public_html/problems/%s/index.html', $problemName);
+
+            self::assertFileExists($path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add human-readable pages for implemented Problem Details type URIs under `public_html/problems/`.
- Add coverage that OpenAPI problem type examples have matching local pages.
- Update API error response docs and the current TODO board.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`
- `docs/review/openapi-contract.md`
- `docs/review/docs-policy.md`

Closes #77

Made with [Cursor](https://cursor.com)