### PR TITLE
feat: route path parameters を追加する

### DIFF
--- a/docs/development/http-runtime.md
+++ b/docs/development/http-runtime.md
@@ -60,7 +60,8 @@ Routing should be explicit and small:
 
 - method and path matching are the first required features
 - route handlers should be callables, invokable classes, or request handlers
-- route groups, path parameters, and middleware attachment can be added incrementally
+- path parameters use `{name}` full path segments and are exposed as request attributes
+- route groups and middleware attachment can be added incrementally
 - attribute routing is not a default requirement
 
 NENE2 may adopt a small router implementation later, but the framework should keep the route table readable.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -60,6 +60,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add npm package metadata, Node engines, package lock, and frontend check scripts. `#73`
 - [x] Choose and wire the migration runner when the database adapter layer starts. `#75`
 - [x] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable. `#77`
+- [x] Add route path parameters to the internal router. `#79`
 
 ## Next Candidates
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -10,10 +10,12 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * @phpstan-type Route array{method: non-empty-string, path: non-empty-string, handler: callable(ServerRequestInterface): ResponseInterface}
+ * @phpstan-type Route array{method: non-empty-string, path: non-empty-string, pattern: string, parameterNames: list<non-empty-string>, handler: callable(ServerRequestInterface): ResponseInterface}
  */
 final class Router implements RequestHandlerInterface
 {
+    public const PARAMETERS_ATTRIBUTE = 'nene2.route.parameters';
+
     /** @var list<Route> */
     private array $routes = [];
 
@@ -32,12 +34,16 @@ final class Router implements RequestHandlerInterface
         $allowedMethods = [];
 
         foreach ($this->routes as $route) {
-            if ($route['path'] !== $path) {
+            $parameters = $this->match($route, $path);
+
+            if ($parameters === null) {
                 continue;
             }
 
             if ($route['method'] === $method) {
-                return $route['handler']($request);
+                return $route['handler'](
+                    $request->withAttribute(self::PARAMETERS_ATTRIBUTE, $parameters)
+                );
             }
 
             $allowedMethods[] = $route['method'];
@@ -60,12 +66,61 @@ final class Router implements RequestHandlerInterface
             throw new InvalidArgumentException('Route path must start with /.');
         }
 
+        [$pattern, $parameterNames] = $this->compilePath($path);
+
         $this->routes[] = [
             'method' => $method,
             'path' => $path,
+            'pattern' => $pattern,
+            'parameterNames' => $parameterNames,
             'handler' => $handler,
         ];
 
         return $this;
+    }
+
+    /**
+     * @return array{0: string, 1: list<non-empty-string>}
+     */
+    private function compilePath(string $path): array
+    {
+        $parameterNames = [];
+        $segments = explode('/', $path);
+        $patternSegments = [];
+
+        foreach ($segments as $segment) {
+            if (preg_match('/^\{([A-Za-z_][A-Za-z0-9_]*)\}$/', $segment, $matches) === 1) {
+                $parameterNames[] = $matches[1];
+                $patternSegments[] = '([^/]+)';
+                continue;
+            }
+
+            if (str_contains($segment, '{') || str_contains($segment, '}')) {
+                throw new InvalidArgumentException('Route path parameters must occupy a full path segment.');
+            }
+
+            $patternSegments[] = preg_quote($segment, '#');
+        }
+
+        return ['#^' . implode('/', $patternSegments) . '$#', $parameterNames];
+    }
+
+    /**
+     * @param Route $route
+     * @return array<string, string>|null
+     */
+    private function match(array $route, string $path): ?array
+    {
+        if (preg_match($route['pattern'], $path, $matches) !== 1) {
+            return null;
+        }
+
+        $parameters = [];
+
+        foreach ($route['parameterNames'] as $index => $name) {
+            $parameters[$name] = rawurldecode($matches[$index + 1]);
+        }
+
+        return $parameters;
     }
 }

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Routing;
+
+use InvalidArgumentException;
+use Nene2\Routing\MethodNotAllowedException;
+use Nene2\Routing\RouteNotFoundException;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class RouterTest extends TestCase
+{
+    public function testMatchesFixedRoute(): void
+    {
+        $factory = new Psr17Factory();
+        $router = (new Router())->get(
+            '/health',
+            static fn (ServerRequestInterface $request): ResponseInterface => $factory->createResponse(204),
+        );
+
+        $response = $router->handle($factory->createServerRequest('GET', 'https://example.test/health'));
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testMatchesPathParametersAsRequestAttribute(): void
+    {
+        $factory = new Psr17Factory();
+        $router = (new Router())->get(
+            '/users/{userId}/posts/{postId}',
+            static function (ServerRequestInterface $request) use ($factory): ResponseInterface {
+                $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+
+                self::assertSame(
+                    [
+                        'userId' => 'alice',
+                        'postId' => 'hello world',
+                    ],
+                    $parameters,
+                );
+
+                return $factory->createResponse(200);
+            },
+        );
+
+        $response = $router->handle(
+            $factory->createServerRequest('GET', 'https://example.test/users/alice/posts/hello%20world'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testMethodNotAllowedStillUsesPathMatch(): void
+    {
+        $factory = new Psr17Factory();
+        $router = (new Router())->get(
+            '/users/{userId}',
+            static fn (ServerRequestInterface $request): ResponseInterface => $factory->createResponse(200),
+        );
+
+        $this->expectException(MethodNotAllowedException::class);
+
+        $router->handle($factory->createServerRequest('POST', 'https://example.test/users/alice'));
+    }
+
+    public function testMissingRouteStillThrowsRouteNotFound(): void
+    {
+        $factory = new Psr17Factory();
+        $router = (new Router())->get(
+            '/users/{userId}',
+            static fn (ServerRequestInterface $request): ResponseInterface => $factory->createResponse(200),
+        );
+
+        $this->expectException(RouteNotFoundException::class);
+
+        $router->handle($factory->createServerRequest('GET', 'https://example.test/projects/alice'));
+    }
+
+    public function testRejectsPartialPathParameterSegment(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Router())->get(
+            '/users/{userId}.json',
+            static fn (ServerRequestInterface $request): ResponseInterface => (new Psr17Factory())->createResponse(200),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `{name}` full-segment route path parameters to the internal router.
- Pass matched parameters through `Router::PARAMETERS_ATTRIBUTE` on the PSR-7 request.
- Add router tests for fixed paths, path parameters, 404, 405, and invalid partial parameters.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`

Closes #79

Made with [Cursor](https://cursor.com)