### PR TITLE
refactor: HTTP runtime を DI container 経由で配線する

### DIFF
--- a/docs/development/dependency-injection.md
+++ b/docs/development/dependency-injection.md
@@ -93,7 +93,16 @@ Provider execution order must be explicit if ordering matters.
 
 The HTTP runtime should not require a container for simple route handlers.
 
-Container integration can be added at these edges:
+The default front controller builds a PSR-11 container through `RuntimeContainerFactory`.
+`RuntimeServiceProvider` registers HTTP runtime services explicitly:
+
+- PSR-17 response and stream factories
+- logger fallback
+- runtime application factory
+- PSR-15 request handler
+- response emitter
+
+Container integration can continue to grow at these edges:
 
 - route handler resolution
 - middleware construction

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -61,6 +61,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Choose and wire the migration runner when the database adapter layer starts. `#75`
 - [x] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable. `#77`
 - [x] Add route path parameters to the internal router. `#79`
+- [x] Wire the HTTP runtime through the PSR-11 container foundation. `#81`
 
 ## Next Candidates
 

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -3,13 +3,16 @@
 declare(strict_types=1);
 
 use Nene2\Http\ResponseEmitter;
-use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\RuntimeContainerFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
+use Psr\Http\Server\RequestHandlerInterface;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$psr17Factory = new Psr17Factory();
+$container = (new RuntimeContainerFactory())->create();
+$psr17Factory = $container->get(Psr17Factory::class);
+assert($psr17Factory instanceof Psr17Factory);
 $serverRequestCreator = new ServerRequestCreator(
     $psr17Factory,
     $psr17Factory,
@@ -18,7 +21,10 @@ $serverRequestCreator = new ServerRequestCreator(
 );
 
 $request = $serverRequestCreator->fromGlobals();
-$application = (new RuntimeApplicationFactory($psr17Factory, $psr17Factory))->create();
+$application = $container->get(RequestHandlerInterface::class);
+assert($application instanceof RequestHandlerInterface);
 $response = $application->handle($request);
 
-(new ResponseEmitter())->emit($response);
+$emitter = $container->get(ResponseEmitter::class);
+assert($emitter instanceof ResponseEmitter);
+$emitter->emit($response);

--- a/src/Http/RuntimeContainerFactory.php
+++ b/src/Http/RuntimeContainerFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use Nene2\DependencyInjection\ContainerBuilder;
+use Psr\Container\ContainerInterface;
+
+final readonly class RuntimeContainerFactory
+{
+    public function create(): ContainerInterface
+    {
+        return (new ContainerBuilder())
+            ->addProvider(new RuntimeServiceProvider())
+            ->build();
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+final readonly class RuntimeServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())
+            ->set(
+                ResponseFactoryInterface::class,
+                static function (ContainerInterface $container): ResponseFactoryInterface {
+                    $factory = $container->get(Psr17Factory::class);
+
+                    if (!$factory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('PSR-17 response factory service is invalid.');
+                    }
+
+                    return $factory;
+                },
+            )
+            ->set(
+                StreamFactoryInterface::class,
+                static function (ContainerInterface $container): StreamFactoryInterface {
+                    $factory = $container->get(Psr17Factory::class);
+
+                    if (!$factory instanceof StreamFactoryInterface) {
+                        throw new LogicException('PSR-17 stream factory service is invalid.');
+                    }
+
+                    return $factory;
+                },
+            )
+            ->set(LoggerInterface::class, static fn (ContainerInterface $container): LoggerInterface => new NullLogger())
+            ->set(
+                RuntimeApplicationFactory::class,
+                static function (ContainerInterface $container): RuntimeApplicationFactory {
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    $streamFactory = $container->get(StreamFactoryInterface::class);
+                    $logger = $container->get(LoggerInterface::class);
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    if (!$streamFactory instanceof StreamFactoryInterface) {
+                        throw new LogicException('Stream factory service is invalid.');
+                    }
+
+                    if (!$logger instanceof LoggerInterface) {
+                        throw new LogicException('Logger service is invalid.');
+                    }
+
+                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger);
+                },
+            )
+            ->set(
+                RequestHandlerInterface::class,
+                static function (ContainerInterface $container): RequestHandlerInterface {
+                    $factory = $container->get(RuntimeApplicationFactory::class);
+
+                    if (!$factory instanceof RuntimeApplicationFactory) {
+                        throw new LogicException('Runtime application factory service is invalid.');
+                    }
+
+                    return $factory->create();
+                },
+            )
+            ->set(ResponseEmitter::class, static fn (ContainerInterface $container): ResponseEmitter => new ResponseEmitter());
+    }
+}

--- a/tests/Http/RuntimeServiceProviderTest.php
+++ b/tests/Http/RuntimeServiceProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\ResponseEmitter;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\RuntimeContainerFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+
+final class RuntimeServiceProviderTest extends TestCase
+{
+    public function testRuntimeContainerRegistersHttpServices(): void
+    {
+        $container = (new RuntimeContainerFactory())->create();
+
+        self::assertInstanceOf(Psr17Factory::class, $container->get(Psr17Factory::class));
+        self::assertInstanceOf(ResponseFactoryInterface::class, $container->get(ResponseFactoryInterface::class));
+        self::assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));
+        self::assertInstanceOf(LoggerInterface::class, $container->get(LoggerInterface::class));
+        self::assertInstanceOf(RuntimeApplicationFactory::class, $container->get(RuntimeApplicationFactory::class));
+        self::assertInstanceOf(RequestHandlerInterface::class, $container->get(RequestHandlerInterface::class));
+        self::assertInstanceOf(ResponseEmitter::class, $container->get(ResponseEmitter::class));
+    }
+
+    public function testRuntimeRequestHandlerServesHealthEndpoint(): void
+    {
+        $container = (new RuntimeContainerFactory())->create();
+        $factory = $container->get(Psr17Factory::class);
+        $application = $container->get(RequestHandlerInterface::class);
+
+        self::assertInstanceOf(Psr17Factory::class, $factory);
+        self::assertInstanceOf(RequestHandlerInterface::class, $application);
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/health'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add explicit runtime container wiring with `RuntimeServiceProvider` and `RuntimeContainerFactory`.
- Resolve the PSR-15 request handler and response emitter from the container in the front controller.
- Add tests that verify registered runtime services and the health endpoint through container wiring.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`

Closes #81

Made with [Cursor](https://cursor.com)