### PR TITLE
feat: frontend から backend health API を読む導線を追加する

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \
     && rm -rf /var/lib/apt/lists/* \
     && a2enmod rewrite \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene2.conf \
+    && a2enconf nene2 \
     && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
 

--- a/docs/development/frontend-integration.md
+++ b/docs/development/frontend-integration.md
@@ -155,7 +155,10 @@ npm run check --prefix frontend
 
 Generated API clients should be considered after OpenAPI schemas are stable enough to be useful.
 
-The first starter may use a small typed fetch wrapper. Client generation should be introduced only when it reduces maintenance and keeps API contracts clearer.
+The first starter uses a small typed fetch wrapper for the `/health` API under `frontend/src/api/`.
+Vite proxies `/api/*` to the local Docker backend during development, while applications can set `VITE_NENE2_API_BASE_URL` when they need a different API base URL.
+
+Client generation should be introduced only when it reduces maintenance and keeps API contracts clearer.
 
 ## SPA Shell and Server HTML
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -62,6 +62,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Publish or redirect `https://nene2.dev/problems/*` before public error contracts are stable. `#77`
 - [x] Add route path parameters to the internal router. `#79`
 - [x] Wire the HTTP runtime through the PSR-11 container foundation. `#81`
+- [x] Add the first frontend-to-backend health API integration path. `#83`
 
 ## Next Candidates
 

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,3 +14,10 @@ npm run check --prefix frontend
 ```
 
 `npm run check --prefix frontend` runs TypeScript, ESLint, and Prettier checks.
+
+## Backend API
+
+The starter calls the NENE2 `/health` endpoint through `src/api/health.ts`.
+
+During local development, Vite proxies `/api/*` to the Docker backend at `http://localhost:8080`.
+Set `VITE_NENE2_API_BASE_URL` when an application needs a different API base URL.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -66,6 +66,36 @@ h1 {
   line-height: 1.7;
 }
 
+.status-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid #dce4f2;
+  border-radius: 1rem;
+  background: #ffffff;
+  margin-top: 1rem;
+  padding: 1.25rem;
+}
+
+.status-panel h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.status-message {
+  border-radius: 999px;
+  background: #edf2fb;
+  margin: 0;
+  padding: 0.75rem 1rem;
+  color: #566174;
+}
+
+.status-message.is-ok {
+  background: #e8f8ef;
+  color: #145a32;
+}
+
 .cards {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -98,5 +128,10 @@ h1 {
 
   .cards {
     grid-template-columns: 1fr;
+  }
+
+  .status-panel {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,7 @@
+import { useEffect, useState } from 'react';
+
 import './App.css';
+import { fetchHealth, type HealthResponse } from './api/health';
 
 const apiHighlights = [
   'JSON APIs first',
@@ -7,6 +10,33 @@ const apiHighlights = [
 ] as const;
 
 export function App() {
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [healthError, setHealthError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isActive = true;
+
+    fetchHealth()
+      .then((response) => {
+        if (isActive) {
+          setHealth(response);
+          setHealthError(null);
+        }
+      })
+      .catch((error: unknown) => {
+        if (isActive) {
+          setHealth(null);
+          setHealthError(
+            error instanceof Error ? error.message : 'Unknown error',
+          );
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
   return (
     <main className="app-shell">
       <section className="hero">
@@ -16,6 +46,24 @@ export function App() {
           This starter stays isolated under <code>frontend/</code> so the PHP
           framework core remains independent from frontend tooling.
         </p>
+      </section>
+
+      <section className="status-panel" aria-labelledby="backend-status-title">
+        <div>
+          <p className="eyebrow">Backend Integration</p>
+          <h2 id="backend-status-title">Health API status</h2>
+        </div>
+
+        {health !== null ? (
+          <p className="status-message is-ok">
+            {health.service} responded with <strong>{health.status}</strong>.
+          </p>
+        ) : (
+          <p className="status-message">
+            {healthError ??
+              'Waiting for the NENE2 backend health endpoint to respond.'}
+          </p>
+        )}
       </section>
 
       <section className="cards" aria-label="Starter highlights">

--- a/frontend/src/api/health.ts
+++ b/frontend/src/api/health.ts
@@ -1,0 +1,42 @@
+export type HealthResponse = {
+  readonly status: string;
+  readonly service: string;
+};
+
+const defaultApiBaseUrl = '/api';
+
+export async function fetchHealth(
+  apiBaseUrl: string = import.meta.env.VITE_NENE2_API_BASE_URL ??
+    defaultApiBaseUrl,
+): Promise<HealthResponse> {
+  const response = await fetch(`${apiBaseUrl}/health`, {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Health check failed with HTTP ${response.status}.`);
+  }
+
+  const payload: unknown = await response.json();
+
+  if (!isHealthResponse(payload)) {
+    throw new Error('Health check response did not match the expected shape.');
+  }
+
+  return payload;
+}
+
+function isHealthResponse(value: unknown): value is HealthResponse {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  return (
+    typeof candidate.status === 'string' &&
+    typeof candidate.service === 'string'
+  );
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_NENE2_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,4 +3,13 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 });

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,0 +1,5 @@
+RewriteEngine On
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.php [QSA,L]


### PR DESCRIPTION
## Summary
- Add a typed `fetchHealth()` frontend API wrapper and show backend health status in the React starter.
- Configure Vite `/api/*` proxying to the local Docker backend and document `VITE_NENE2_API_BASE_URL`.
- Enable Apache rewrite/front-controller clean URLs so `/health` works in the Docker container.

## Verification
- [x] `npm run check --prefix frontend`
- [x] `npm run build --prefix frontend`
- [x] `docker compose run --rm app composer check`
- [x] `curl -fsS http://localhost:8080/health`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`
- `docs/review/openapi-contract.md`

Closes #83

Made with [Cursor](https://cursor.com)