### PR TITLE
ci: frontend npm checks workflow を追加する

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,37 @@
+name: Frontend
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  npm-check:
+    name: npm Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci --prefix frontend
+
+      - name: Run frontend checks
+        run: npm run check --prefix frontend
+
+      - name: Build frontend
+        run: npm run build --prefix frontend

--- a/docs/development/release-ci.md
+++ b/docs/development/release-ci.md
@@ -97,7 +97,7 @@ As tooling is implemented, CI should expand in this order:
 4. Dependency update checks after Dependabot or Renovate is configured.
 5. Release workflow after manual release steps are stable.
 
-Recommended future frontend CI steps:
+The initial frontend workflow lives at `.github/workflows/frontend.yml` and runs:
 
 ```text
 1. set up Node.js active LTS

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -64,6 +64,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Wire the HTTP runtime through the PSR-11 container foundation. `#81`
 - [x] Add the first frontend-to-backend health API integration path. `#83`
 - [x] Add first GitHub Actions workflow for backend Composer checks. `#85`
+- [x] Add first GitHub Actions workflow for frontend npm checks. `#87`
 
 ## Next Candidates
 


### PR DESCRIPTION
## Summary
- Add a frontend GitHub Actions workflow for pull requests and `main` pushes.
- Install dependencies with `npm ci --prefix frontend`, then run frontend checks and build.
- Document the workflow location and update the current TODO board.

## Verification
- [x] `npm ci --prefix frontend`
- [x] `npm run check --prefix frontend`
- [x] `npm run build --prefix frontend`
- [x] `docker compose run --rm app php -r 'require "vendor/autoload.php"; Symfony\\Component\\Yaml\\Yaml::parseFile(".github/workflows/frontend.yml"); echo "workflow YAML parsed\n";'`
- [x] `git diff --check`

## Self-review
- `docs/review/release-ci.md`

Closes #87

Made with [Cursor](https://cursor.com)