### PR TITLE
test: OpenAPI と runtime response の契約テストを追加する

### DIFF
--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -65,7 +65,8 @@ docker compose run --rm app composer openapi
 
 ## Testing Direction
 
-Once runtime code exists, API tests should verify that responses match the documented contract. The first implementation can be lightweight and grow with the framework.
+Runtime contract tests should verify shipped JSON responses against documented examples and required schema fields.
+The first lightweight checks live in `tests/OpenApi/RuntimeContractTest.php` and should grow toward fuller JSON Schema validation only when that extra precision reduces maintenance risk.
 
 Shared schemas for `ProblemDetails`, `ValidationProblemDetails`, and `ValidationError` live in `docs/openapi/openapi.yaml`. Stable endpoints should reference these schemas for non-2xx JSON responses where the behavior is implemented. See `docs/development/api-error-responses.md`.
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -65,6 +65,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add the first frontend-to-backend health API integration path. `#83`
 - [x] Add first GitHub Actions workflow for backend Composer checks. `#85`
 - [x] Add first GitHub Actions workflow for frontend npm checks. `#87`
+- [x] Add lightweight OpenAPI runtime contract tests for shipped JSON endpoints. `#89`
 
 ## Next Candidates
 

--- a/tests/OpenApi/RuntimeContractTest.php
+++ b/tests/OpenApi/RuntimeContractTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\OpenApi;
+
+use Nene2\Http\RuntimeApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Yaml\Yaml;
+
+final class RuntimeContractTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $expectedPayload
+     * @param list<string> $requiredFields
+     */
+    #[DataProvider('successEndpointProvider')]
+    public function testRuntimeSuccessResponsesMatchOpenApiExamples(
+        string $method,
+        string $path,
+        int $expectedStatus,
+        array $expectedPayload,
+        array $requiredFields,
+    ): void {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory))->create();
+
+        $response = $application->handle($factory->createServerRequest($method, 'https://example.test' . $path));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame($expectedStatus, $response->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertSame($expectedPayload, $payload);
+
+        foreach ($requiredFields as $requiredField) {
+            self::assertArrayHasKey($requiredField, $payload);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: int, 3: array<string, mixed>, 4: list<string>}>
+     */
+    public static function successEndpointProvider(): iterable
+    {
+        $openApi = self::openApi();
+
+        foreach ($openApi['paths'] as $path => $pathItem) {
+            if (!is_string($path) || !is_array($pathItem)) {
+                continue;
+            }
+
+            foreach ($pathItem as $method => $operation) {
+                if (!is_string($method) || !is_array($operation)) {
+                    continue;
+                }
+
+                $successResponse = $operation['responses']['200'] ?? null;
+
+                if (!is_array($successResponse)) {
+                    continue;
+                }
+
+                $jsonContent = $successResponse['content']['application/json'] ?? null;
+
+                if (!is_array($jsonContent)) {
+                    continue;
+                }
+
+                $example = $jsonContent['examples']['ok']['value'] ?? null;
+                $schemaRef = $jsonContent['schema']['$ref'] ?? null;
+
+                if (!is_array($example) || !is_string($schemaRef)) {
+                    continue;
+                }
+
+                yield sprintf('%s %s', strtoupper($method), $path) => [
+                    strtoupper($method),
+                    $path,
+                    200,
+                    $example,
+                    self::requiredFieldsForSchema($openApi, $schemaRef),
+                ];
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function openApi(): array
+    {
+        $openApi = Yaml::parseFile(dirname(__DIR__, 2) . '/docs/openapi/openapi.yaml');
+
+        self::assertIsArray($openApi);
+
+        return $openApi;
+    }
+
+    /**
+     * @param array<string, mixed> $openApi
+     * @return list<string>
+     */
+    private static function requiredFieldsForSchema(array $openApi, string $schemaRef): array
+    {
+        $schemaName = str_replace('#/components/schemas/', '', $schemaRef);
+        $schema = $openApi['components']['schemas'][$schemaName] ?? null;
+
+        self::assertIsArray($schema, sprintf('Schema "%s" must exist.', $schemaName));
+
+        $required = $schema['required'] ?? [];
+
+        self::assertIsArray($required, sprintf('Schema "%s" required fields must be a list.', $schemaName));
+
+        return array_values(array_filter($required, static fn (mixed $field): bool => is_string($field)));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}


### PR DESCRIPTION
## Summary
- Add lightweight runtime contract tests for documented successful JSON endpoints.
- Compare OpenAPI success examples and required schema fields against actual runtime responses.
- Document the initial contract test direction and update the current TODO board.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`
- `docs/review/openapi-contract.md`

Closes #89

Made with [Cursor](https://cursor.com)