### PR TITLE
refactor: runtime container に typed config を登録する

### DIFF
--- a/docs/development/dependency-injection.md
+++ b/docs/development/dependency-injection.md
@@ -96,6 +96,7 @@ The HTTP runtime should not require a container for simple route handlers.
 The default front controller builds a PSR-11 container through `RuntimeContainerFactory`.
 `RuntimeServiceProvider` registers HTTP runtime services explicitly:
 
+- project root and typed application config
 - PSR-17 response and stream factories
 - logger fallback
 - runtime application factory

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -67,6 +67,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add first GitHub Actions workflow for frontend npm checks. `#87`
 - [x] Add lightweight OpenAPI runtime contract tests for shipped JSON endpoints. `#89`
 - [x] Add typed database config and align Phinx with the config loader. `#91`
+- [x] Register typed config services in the runtime container. `#93`
 
 ## Next Candidates
 

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -10,7 +10,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$container = (new RuntimeContainerFactory())->create();
+$container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
 $psr17Factory = $container->get(Psr17Factory::class);
 assert($psr17Factory instanceof Psr17Factory);
 $serverRequestCreator = new ServerRequestCreator(

--- a/src/Http/RuntimeContainerFactory.php
+++ b/src/Http/RuntimeContainerFactory.php
@@ -9,9 +9,17 @@ use Psr\Container\ContainerInterface;
 
 final readonly class RuntimeContainerFactory
 {
+    public function __construct(
+        private ?string $projectRoot = null,
+    ) {
+    }
+
     public function create(): ContainerInterface
     {
+        $projectRoot = $this->projectRoot ?? dirname(__DIR__, 2);
+
         return (new ContainerBuilder())
+            ->value(RuntimeServiceProvider::PROJECT_ROOT, $projectRoot)
             ->addProvider(new RuntimeServiceProvider())
             ->build();
     }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Nene2\Http;
 
 use LogicException;
+use Nene2\Config\AppConfig;
+use Nene2\Config\ConfigLoader;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -17,9 +19,35 @@ use Psr\Log\NullLogger;
 
 final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 {
+    public const PROJECT_ROOT = 'nene2.project_root';
+
     public function register(ContainerBuilder $builder): void
     {
         $builder
+            ->set(
+                ConfigLoader::class,
+                static function (ContainerInterface $container): ConfigLoader {
+                    $projectRoot = $container->get(self::PROJECT_ROOT);
+
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root service is invalid.');
+                    }
+
+                    return new ConfigLoader($projectRoot);
+                },
+            )
+            ->set(
+                AppConfig::class,
+                static function (ContainerInterface $container): AppConfig {
+                    $loader = $container->get(ConfigLoader::class);
+
+                    if (!$loader instanceof ConfigLoader) {
+                        throw new LogicException('Config loader service is invalid.');
+                    }
+
+                    return $loader->load();
+                },
+            )
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())
             ->set(
                 ResponseFactoryInterface::class,

--- a/tests/Http/RuntimeServiceProviderTest.php
+++ b/tests/Http/RuntimeServiceProviderTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Nene2\Tests\Http;
 
+use Nene2\Config\AppConfig;
+use Nene2\Config\ConfigLoader;
 use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\RuntimeContainerFactory;
+use Nene2\Http\RuntimeServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -21,6 +24,9 @@ final class RuntimeServiceProviderTest extends TestCase
         $container = (new RuntimeContainerFactory())->create();
 
         self::assertInstanceOf(Psr17Factory::class, $container->get(Psr17Factory::class));
+        self::assertSame(dirname(__DIR__, 2), $container->get(RuntimeServiceProvider::PROJECT_ROOT));
+        self::assertInstanceOf(ConfigLoader::class, $container->get(ConfigLoader::class));
+        self::assertInstanceOf(AppConfig::class, $container->get(AppConfig::class));
         self::assertInstanceOf(ResponseFactoryInterface::class, $container->get(ResponseFactoryInterface::class));
         self::assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));
         self::assertInstanceOf(LoggerInterface::class, $container->get(LoggerInterface::class));
@@ -42,5 +48,20 @@ final class RuntimeServiceProviderTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function testRuntimeContainerUsesExplicitProjectRootForConfig(): void
+    {
+        $container = (new RuntimeContainerFactory($this->emptyProjectRoot()))->create();
+        $config = $container->get(AppConfig::class);
+
+        self::assertInstanceOf(AppConfig::class, $config);
+        self::assertSame('NENE2', $config->name);
+        self::assertSame('nene2', $config->database->name);
+    }
+
+    private function emptyProjectRoot(): string
+    {
+        return sys_get_temp_dir();
     }
 }


### PR DESCRIPTION
## Summary
- Register project root, `ConfigLoader`, and `AppConfig` in the runtime container.
- Let `RuntimeContainerFactory` accept an explicit project root and pass it from the front controller.
- Extend runtime container tests to verify config services and explicit project root wiring.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`

Closes #93

Made with [Cursor](https://cursor.com)