### PR TITLE
feat: database connection adapter boundary を追加する

### DIFF
--- a/docs/development/database-migrations.md
+++ b/docs/development/database-migrations.md
@@ -100,7 +100,10 @@ Generated schema files should be reproducible. If a schema file is too noisy to 
 
 ## Future Implementation
 
-The database adapter milestone should decide:
+The first database adapter boundary is `DatabaseConnectionFactoryInterface`, with `PdoConnectionFactory` as the initial PDO implementation.
+It builds connections from `DatabaseConfig`, so application infrastructure does not read raw environment variables directly.
+
+The database adapter milestone should continue with:
 
 - transaction policy
 - test database strategy

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -68,6 +68,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add lightweight OpenAPI runtime contract tests for shipped JSON endpoints. `#89`
 - [x] Add typed database config and align Phinx with the config loader. `#91`
 - [x] Register typed config services in the runtime container. `#93`
+- [x] Add the first database connection adapter boundary. `#95`
 
 ## Next Candidates
 

--- a/src/Database/DatabaseConnectionException.php
+++ b/src/Database/DatabaseConnectionException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database;
+
+use RuntimeException;
+
+final class DatabaseConnectionException extends RuntimeException
+{
+}

--- a/src/Database/DatabaseConnectionFactoryInterface.php
+++ b/src/Database/DatabaseConnectionFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database;
+
+use PDO;
+
+interface DatabaseConnectionFactoryInterface
+{
+    public function create(): PDO;
+}

--- a/src/Database/PdoConnectionFactory.php
+++ b/src/Database/PdoConnectionFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database;
+
+use Nene2\Config\DatabaseConfig;
+use PDO;
+use PDOException;
+
+final readonly class PdoConnectionFactory implements DatabaseConnectionFactoryInterface
+{
+    public function __construct(
+        private DatabaseConfig $config,
+    ) {
+    }
+
+    public function create(): PDO
+    {
+        try {
+            return new PDO(
+                $this->dsn(),
+                $this->config->user,
+                $this->config->password,
+                [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                    PDO::ATTR_EMULATE_PREPARES => false,
+                ],
+            );
+        } catch (PDOException $exception) {
+            throw new DatabaseConnectionException('Database connection could not be created.', previous: $exception);
+        }
+    }
+
+    private function dsn(): string
+    {
+        if ($this->config->usesUrl()) {
+            return $this->config->url ?? throw new DatabaseConnectionException('DATABASE_URL is missing.');
+        }
+
+        return match ($this->config->adapter) {
+            'sqlite' => $this->sqliteDsn(),
+            'mysql' => sprintf(
+                'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+                $this->config->host,
+                $this->config->port,
+                $this->config->name,
+                $this->config->charset,
+            ),
+            default => throw new DatabaseConnectionException(sprintf(
+                'Database adapter "%s" is not supported by the PDO factory.',
+                $this->config->adapter,
+            )),
+        };
+    }
+
+    private function sqliteDsn(): string
+    {
+        if ($this->config->name === ':memory:') {
+            return 'sqlite::memory:';
+        }
+
+        return 'sqlite:' . $this->config->name;
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -7,6 +7,8 @@ namespace Nene2\Http;
 use LogicException;
 use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\PdoConnectionFactory;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -46,6 +48,18 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
 
                     return $loader->load();
+                },
+            )
+            ->set(
+                DatabaseConnectionFactoryInterface::class,
+                static function (ContainerInterface $container): DatabaseConnectionFactoryInterface {
+                    $config = $container->get(AppConfig::class);
+
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    return new PdoConnectionFactory($config->database);
                 },
             )
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/tests/Database/PdoConnectionFactoryTest.php
+++ b/tests/Database/PdoConnectionFactoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Database;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseConnectionException;
+use Nene2\Database\PdoConnectionFactory;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class PdoConnectionFactoryTest extends TestCase
+{
+    public function testCreatesSqliteConnectionWithSafeDefaults(): void
+    {
+        $connection = (new PdoConnectionFactory($this->sqliteConfig()))->create();
+
+        self::assertSame(PDO::ERRMODE_EXCEPTION, $connection->getAttribute(PDO::ATTR_ERRMODE));
+        self::assertSame(PDO::FETCH_ASSOC, $connection->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE));
+
+        $connection->exec('CREATE TABLE health_checks (name TEXT NOT NULL)');
+        $connection->exec("INSERT INTO health_checks (name) VALUES ('NENE2')");
+
+        $statement = $connection->query('SELECT name FROM health_checks');
+
+        self::assertNotFalse($statement);
+        self::assertSame(['name' => 'NENE2'], $statement->fetch());
+    }
+
+    public function testUnsupportedAdapterFailsFast(): void
+    {
+        $factory = new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'unknown',
+            'localhost',
+            1,
+            'nene2',
+            'nene2',
+            '',
+            'utf8',
+        ));
+
+        $this->expectException(DatabaseConnectionException::class);
+        $this->expectExceptionMessage('Database adapter "unknown" is not supported by the PDO factory.');
+
+        $factory->create();
+    }
+
+    private function sqliteConfig(): DatabaseConfig
+    {
+        return new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene2',
+            '',
+            'utf8',
+        );
+    }
+}

--- a/tests/Http/RuntimeServiceProviderTest.php
+++ b/tests/Http/RuntimeServiceProviderTest.php
@@ -6,6 +6,7 @@ namespace Nene2\Tests\Http;
 
 use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
 use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\RuntimeContainerFactory;
@@ -27,6 +28,10 @@ final class RuntimeServiceProviderTest extends TestCase
         self::assertSame(dirname(__DIR__, 2), $container->get(RuntimeServiceProvider::PROJECT_ROOT));
         self::assertInstanceOf(ConfigLoader::class, $container->get(ConfigLoader::class));
         self::assertInstanceOf(AppConfig::class, $container->get(AppConfig::class));
+        self::assertInstanceOf(
+            DatabaseConnectionFactoryInterface::class,
+            $container->get(DatabaseConnectionFactoryInterface::class),
+        );
         self::assertInstanceOf(ResponseFactoryInterface::class, $container->get(ResponseFactoryInterface::class));
         self::assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));
         self::assertInstanceOf(LoggerInterface::class, $container->get(LoggerInterface::class));


### PR DESCRIPTION
## Summary
- Add `DatabaseConnectionFactoryInterface` and a first `PdoConnectionFactory` implementation.
- Register the database connection factory in runtime container wiring from typed `DatabaseConfig`.
- Add SQLite in-memory tests for deterministic connection behavior and unsupported adapter failures.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`

Closes #95

Made with [Cursor](https://cursor.com)