### PR TITLE
feat: repository adapter query boundary を追加する

### DIFF
--- a/docs/development/database-migrations.md
+++ b/docs/development/database-migrations.md
@@ -102,6 +102,7 @@ Generated schema files should be reproducible. If a schema file is too noisy to 
 
 The first database adapter boundary is `DatabaseConnectionFactoryInterface`, with `PdoConnectionFactory` as the initial PDO implementation.
 It builds connections from `DatabaseConfig`, so application infrastructure does not read raw environment variables directly.
+Repository adapters should depend on `DatabaseQueryExecutorInterface` for parameterized SQL reads and writes instead of using raw PDO directly.
 
 The database adapter milestone should continue with:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -69,6 +69,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add typed database config and align Phinx with the config loader. `#91`
 - [x] Register typed config services in the runtime container. `#93`
 - [x] Add the first database connection adapter boundary. `#95`
+- [x] Add a parameterized database query boundary for repository adapters. `#97`
 
 ## Next Candidates
 

--- a/src/Database/DatabaseQueryExecutorInterface.php
+++ b/src/Database/DatabaseQueryExecutorInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database;
+
+/**
+ * @phpstan-type SqlParameter string|int|float|bool|null
+ * @phpstan-type SqlParameters array<string|int, SqlParameter>
+ * @phpstan-type SqlRow array<string, mixed>
+ */
+interface DatabaseQueryExecutorInterface
+{
+    /**
+     * @param SqlParameters $parameters
+     */
+    public function execute(string $sql, array $parameters = []): int;
+
+    /**
+     * @param SqlParameters $parameters
+     * @return SqlRow|null
+     */
+    public function fetchOne(string $sql, array $parameters = []): ?array;
+
+    /**
+     * @param SqlParameters $parameters
+     * @return list<SqlRow>
+     */
+    public function fetchAll(string $sql, array $parameters = []): array;
+}

--- a/src/Database/PdoDatabaseQueryExecutor.php
+++ b/src/Database/PdoDatabaseQueryExecutor.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database;
+
+use PDO;
+use PDOException;
+use PDOStatement;
+
+/**
+ * @phpstan-import-type SqlParameters from DatabaseQueryExecutorInterface
+ * @phpstan-import-type SqlRow from DatabaseQueryExecutorInterface
+ */
+final class PdoDatabaseQueryExecutor implements DatabaseQueryExecutorInterface
+{
+    private ?PDO $connection = null;
+
+    public function __construct(
+        private readonly DatabaseConnectionFactoryInterface $connectionFactory,
+    ) {
+    }
+
+    public function execute(string $sql, array $parameters = []): int
+    {
+        return $this->statement($sql, $parameters)->rowCount();
+    }
+
+    public function fetchOne(string $sql, array $parameters = []): ?array
+    {
+        $row = $this->statement($sql, $parameters)->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        /** @var SqlRow $row */
+        return $row;
+    }
+
+    public function fetchAll(string $sql, array $parameters = []): array
+    {
+        /** @var list<SqlRow> $rows */
+        $rows = $this->statement($sql, $parameters)->fetchAll(PDO::FETCH_ASSOC);
+
+        return $rows;
+    }
+
+    /**
+     * @param SqlParameters $parameters
+     */
+    private function statement(string $sql, array $parameters): PDOStatement
+    {
+        try {
+            $statement = $this->connection()->prepare($sql);
+
+            if ($statement === false) {
+                throw new DatabaseConnectionException('Database statement could not be prepared.');
+            }
+
+            $statement->execute($parameters);
+
+            return $statement;
+        } catch (PDOException $exception) {
+            throw new DatabaseConnectionException('Database query could not be executed.', previous: $exception);
+        }
+    }
+
+    private function connection(): PDO
+    {
+        return $this->connection ??= $this->connectionFactory->create();
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -8,7 +8,9 @@ use LogicException;
 use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -60,6 +62,18 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
 
                     return new PdoConnectionFactory($config->database);
+                },
+            )
+            ->set(
+                DatabaseQueryExecutorInterface::class,
+                static function (ContainerInterface $container): DatabaseQueryExecutorInterface {
+                    $connectionFactory = $container->get(DatabaseConnectionFactoryInterface::class);
+
+                    if (!$connectionFactory instanceof DatabaseConnectionFactoryInterface) {
+                        throw new LogicException('Database connection factory service is invalid.');
+                    }
+
+                    return new PdoDatabaseQueryExecutor($connectionFactory);
                 },
             )
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/tests/Database/PdoDatabaseQueryExecutorTest.php
+++ b/tests/Database/PdoDatabaseQueryExecutorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Database;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseConnectionException;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use PHPUnit\Framework\TestCase;
+
+final class PdoDatabaseQueryExecutorTest extends TestCase
+{
+    public function testExecutesParameterizedQueries(): void
+    {
+        $executor = $this->executor();
+
+        $executor->execute('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)');
+
+        self::assertSame(1, $executor->execute('INSERT INTO users (name) VALUES (:name)', ['name' => 'NENE2']));
+        self::assertSame(['id' => 1, 'name' => 'NENE2'], $executor->fetchOne(
+            'SELECT id, name FROM users WHERE name = :name',
+            ['name' => 'NENE2'],
+        ));
+        self::assertSame([
+            ['id' => 1, 'name' => 'NENE2'],
+        ], $executor->fetchAll('SELECT id, name FROM users ORDER BY id'));
+    }
+
+    public function testFetchOneReturnsNullWhenNoRowMatches(): void
+    {
+        $executor = $this->executor();
+
+        $executor->execute('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)');
+
+        self::assertNull($executor->fetchOne('SELECT id, name FROM users WHERE name = :name', ['name' => 'missing']));
+    }
+
+    public function testQueryFailureUsesDatabaseConnectionException(): void
+    {
+        $executor = $this->executor();
+
+        $this->expectException(DatabaseConnectionException::class);
+        $this->expectExceptionMessage('Database query could not be executed.');
+
+        $executor->fetchAll('SELECT * FROM missing_table');
+    }
+
+    private function executor(): PdoDatabaseQueryExecutor
+    {
+        return new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene2',
+            '',
+            'utf8',
+        )));
+    }
+}

--- a/tests/Http/RuntimeServiceProviderTest.php
+++ b/tests/Http/RuntimeServiceProviderTest.php
@@ -7,6 +7,7 @@ namespace Nene2\Tests\Http;
 use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\RuntimeContainerFactory;
@@ -31,6 +32,10 @@ final class RuntimeServiceProviderTest extends TestCase
         self::assertInstanceOf(
             DatabaseConnectionFactoryInterface::class,
             $container->get(DatabaseConnectionFactoryInterface::class),
+        );
+        self::assertInstanceOf(
+            DatabaseQueryExecutorInterface::class,
+            $container->get(DatabaseQueryExecutorInterface::class),
         );
         self::assertInstanceOf(ResponseFactoryInterface::class, $container->get(ResponseFactoryInterface::class));
         self::assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));


### PR DESCRIPTION
## Summary
- Add `DatabaseQueryExecutorInterface` for parameterized repository adapter reads and writes.
- Add `PdoDatabaseQueryExecutor` backed by the database connection factory.
- Register the query executor in runtime container wiring and cover it with SQLite-backed tests.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`

Closes #97

Made with [Cursor](https://cursor.com)