### PR TITLE
test: database test strategy を定義する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "test": "phpunit",
+    "test:database": "phpunit --testsuite Database",
     "analyse": "phpstan analyse",
     "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
     "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",

--- a/docs/development/database-migrations.md
+++ b/docs/development/database-migrations.md
@@ -107,6 +107,6 @@ Repository adapters should depend on `DatabaseQueryExecutorInterface` for parame
 The database adapter milestone should continue with:
 
 - transaction policy
-- test database strategy
+- test database strategy, documented in `docs/development/test-database-strategy.md`
 
 Until that milestone, the directories are placeholders and the docs are the source of truth.

--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -37,6 +37,7 @@ Composer scripts:
 {
   "scripts": {
     "test": "phpunit",
+    "test:database": "phpunit --testsuite Database",
     "analyse": "phpstan analyse",
     "cs": "php-cs-fixer fix --dry-run --diff",
     "cs:fix": "php-cs-fixer fix",

--- a/docs/development/test-database-strategy.md
+++ b/docs/development/test-database-strategy.md
@@ -1,0 +1,52 @@
+# Test Database Strategy
+
+NENE2 database adapter tests should be deterministic by default and should not require a developer-specific database server.
+
+## Default Strategy
+
+Framework-maintained database adapter tests use SQLite in-memory databases first.
+
+Reasons:
+
+- tests run inside the existing PHP container
+- no local MySQL or PostgreSQL credentials are required
+- each test can create its own schema
+- tests stay fast enough for `composer check`
+- adapters remain easy to inspect and reason about
+
+The default command for focused database adapter checks is:
+
+```bash
+docker compose run --rm app composer test:database
+```
+
+`composer check` still runs the full PHPUnit suite, including database adapter tests.
+
+## Test Shape
+
+Database adapter tests should:
+
+- create schema inside the test
+- use tiny deterministic data
+- avoid production-like credentials
+- avoid relying on migration state unless the test is specifically about migrations
+- prefer typed config objects over raw environment variables
+- keep SQL expectations close to the adapter being tested
+
+## External Databases
+
+MySQL or PostgreSQL integration tests can be added later when they prove an adapter behavior that SQLite cannot cover.
+
+External database tests should be opt-in until CI has a documented service container and safe credentials. They should not block the default local `composer check` path before that setup exists.
+
+## Migration Tests
+
+Migration tests should be separate from repository adapter tests.
+
+When migration tests are introduced, they should define:
+
+- the database service used in CI
+- how schemas are reset between runs
+- whether seeds are allowed
+- which Composer command runs them
+- what happens when a migration is intentionally irreversible

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -70,6 +70,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Register typed config services in the runtime container. `#93`
 - [x] Add the first database connection adapter boundary. `#95`
 - [x] Add a parameterized database query boundary for repository adapters. `#97`
+- [x] Define the first database test strategy and focused test command. `#99`
 
 ## Next Candidates
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,10 @@
   <testsuites>
     <testsuite name="NENE2">
       <directory>tests</directory>
+      <exclude>tests/Database</exclude>
+    </testsuite>
+    <testsuite name="Database">
+      <directory>tests/Database</directory>
     </testsuite>
   </testsuites>
   <source>


### PR DESCRIPTION
## Summary
- Add a focused database test strategy based on SQLite in-memory adapter tests.
- Add a dedicated `Database` PHPUnit testsuite and `composer test:database` command.
- Keep `composer check` warning-free while still running database adapter tests.

## Verification
- [x] `docker compose run --rm app composer test:database`
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`

Closes #99

Made with [Cursor](https://cursor.com)