### PR TITLE
feat: database transaction boundary を追加する

### DIFF
--- a/docs/development/database-migrations.md
+++ b/docs/development/database-migrations.md
@@ -103,10 +103,10 @@ Generated schema files should be reproducible. If a schema file is too noisy to 
 The first database adapter boundary is `DatabaseConnectionFactoryInterface`, with `PdoConnectionFactory` as the initial PDO implementation.
 It builds connections from `DatabaseConfig`, so application infrastructure does not read raw environment variables directly.
 Repository adapters should depend on `DatabaseQueryExecutorInterface` for parameterized SQL reads and writes instead of using raw PDO directly.
+Use `DatabaseTransactionManagerInterface` when a use case or adapter operation needs commit/rollback behavior across multiple queries.
 
 The database adapter milestone should continue with:
 
-- transaction policy
 - test database strategy, documented in `docs/development/test-database-strategy.md`
 
 Until that milestone, the directories are placeholders and the docs are the source of truth.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -71,6 +71,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add the first database connection adapter boundary. `#95`
 - [x] Add a parameterized database query boundary for repository adapters. `#97`
 - [x] Define the first database test strategy and focused test command. `#99`
+- [x] Add an explicit database transaction boundary. `#101`
 
 ## Next Candidates
 

--- a/src/Database/DatabaseTransactionManagerInterface.php
+++ b/src/Database/DatabaseTransactionManagerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database;
+
+interface DatabaseTransactionManagerInterface
+{
+    /**
+     * @template T
+     * @param callable(DatabaseQueryExecutorInterface): T $callback
+     * @return T
+     */
+    public function transactional(callable $callback): mixed;
+}

--- a/src/Database/PdoDatabaseQueryExecutor.php
+++ b/src/Database/PdoDatabaseQueryExecutor.php
@@ -18,7 +18,9 @@ final class PdoDatabaseQueryExecutor implements DatabaseQueryExecutorInterface
 
     public function __construct(
         private readonly DatabaseConnectionFactoryInterface $connectionFactory,
+        ?PDO $connection = null,
     ) {
+        $this->connection = $connection;
     }
 
     public function execute(string $sql, array $parameters = []): int

--- a/src/Database/PdoDatabaseTransactionManager.php
+++ b/src/Database/PdoDatabaseTransactionManager.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database;
+
+use PDOException;
+use Throwable;
+
+final readonly class PdoDatabaseTransactionManager implements DatabaseTransactionManagerInterface
+{
+    public function __construct(
+        private DatabaseConnectionFactoryInterface $connectionFactory,
+    ) {
+    }
+
+    public function transactional(callable $callback): mixed
+    {
+        try {
+            $connection = $this->connectionFactory->create();
+            $connection->beginTransaction();
+
+            try {
+                $result = $callback(new PdoDatabaseQueryExecutor($this->connectionFactory, $connection));
+                $connection->commit();
+
+                return $result;
+            } catch (Throwable $exception) {
+                if ($connection->inTransaction()) {
+                    $connection->rollBack();
+                }
+
+                throw $exception;
+            }
+        } catch (PDOException $exception) {
+            throw new DatabaseConnectionException('Database transaction could not be completed.', previous: $exception);
+        }
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -9,8 +9,10 @@ use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\PdoDatabaseTransactionManager;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -74,6 +76,18 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
 
                     return new PdoDatabaseQueryExecutor($connectionFactory);
+                },
+            )
+            ->set(
+                DatabaseTransactionManagerInterface::class,
+                static function (ContainerInterface $container): DatabaseTransactionManagerInterface {
+                    $connectionFactory = $container->get(DatabaseConnectionFactoryInterface::class);
+
+                    if (!$connectionFactory instanceof DatabaseConnectionFactoryInterface) {
+                        throw new LogicException('Database connection factory service is invalid.');
+                    }
+
+                    return new PdoDatabaseTransactionManager($connectionFactory);
                 },
             )
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/tests/Database/PdoDatabaseTransactionManagerTest.php
+++ b/tests/Database/PdoDatabaseTransactionManagerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Database;
+
+use LogicException;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseTransactionManager;
+use PHPUnit\Framework\TestCase;
+
+final class PdoDatabaseTransactionManagerTest extends TestCase
+{
+    /** @var list<string> */
+    private array $databaseFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->databaseFiles as $databaseFile) {
+            if (is_file($databaseFile)) {
+                unlink($databaseFile);
+            }
+        }
+
+        $this->databaseFiles = [];
+    }
+
+    public function testCommitsSuccessfulTransaction(): void
+    {
+        $manager = $this->manager();
+
+        $result = $manager->transactional(function (DatabaseQueryExecutorInterface $database): string {
+            $database->execute('CREATE TABLE events (name TEXT NOT NULL)');
+            $database->execute('INSERT INTO events (name) VALUES (:name)', ['name' => 'committed']);
+
+            return 'done';
+        });
+
+        self::assertSame('done', $result);
+
+        $manager->transactional(function (DatabaseQueryExecutorInterface $database): void {
+            self::assertSame(['name' => 'committed'], $database->fetchOne('SELECT name FROM events'));
+        });
+    }
+
+    public function testRollsBackFailedTransaction(): void
+    {
+        $manager = $this->manager();
+
+        $manager->transactional(static function (DatabaseQueryExecutorInterface $database): void {
+            $database->execute('CREATE TABLE events (name TEXT NOT NULL)');
+        });
+
+        try {
+            $manager->transactional(static function (DatabaseQueryExecutorInterface $database): void {
+                $database->execute('INSERT INTO events (name) VALUES (:name)', ['name' => 'rolled back']);
+
+                throw new LogicException('Stop transaction.');
+            });
+        } catch (LogicException) {
+            // Expected failure path.
+        }
+
+        $manager->transactional(function (DatabaseQueryExecutorInterface $database): void {
+            self::assertSame([], $database->fetchAll('SELECT name FROM events'));
+        });
+    }
+
+    private function manager(): PdoDatabaseTransactionManager
+    {
+        $databaseFile = sys_get_temp_dir() . '/nene2-test-' . bin2hex(random_bytes(8)) . '.sqlite';
+        $this->databaseFiles[] = $databaseFile;
+
+        return new PdoDatabaseTransactionManager(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            $databaseFile,
+            'nene2',
+            '',
+            'utf8',
+        )));
+    }
+}

--- a/tests/Http/RuntimeServiceProviderTest.php
+++ b/tests/Http/RuntimeServiceProviderTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\RuntimeContainerFactory;
@@ -36,6 +37,10 @@ final class RuntimeServiceProviderTest extends TestCase
         self::assertInstanceOf(
             DatabaseQueryExecutorInterface::class,
             $container->get(DatabaseQueryExecutorInterface::class),
+        );
+        self::assertInstanceOf(
+            DatabaseTransactionManagerInterface::class,
+            $container->get(DatabaseTransactionManagerInterface::class),
         );
         self::assertInstanceOf(ResponseFactoryInterface::class, $container->get(ResponseFactoryInterface::class));
         self::assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));


### PR DESCRIPTION
## Summary
- Add `DatabaseTransactionManagerInterface` and a PDO-backed transaction manager.
- Pass a same-connection query executor into transaction callbacks, committing on success and rolling back on failure.
- Register transaction management in runtime container wiring and cover commit/rollback behavior with SQLite tests.

## Verification
- [x] `docker compose run --rm app composer test:database`
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/backend-api.md`

Closes #101

Made with [Cursor](https://cursor.com)