### PR TITLE
feat: read-only MCP tool catalog を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
     "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
     "openapi": "php tools/validate-openapi.php",
+    "mcp": "php tools/validate-mcp-tools.php",
     "migrations:status": "phinx status -c phinx.php",
     "migrations:migrate": "phinx migrate -c phinx.php",
     "migrations:rollback": "phinx rollback -c phinx.php",
@@ -38,7 +39,8 @@
       "@test",
       "@analyse",
       "@cs",
-      "@openapi"
+      "@openapi",
+      "@mcp"
     ]
   },
   "config": {

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -37,5 +37,6 @@ For normal code or documentation work, an AI agent should:
 - AI tools must not commit secrets.
 - MCP tools should interact with the application through documented APIs, not direct database access.
 - MCP tool design should follow `docs/integrations/mcp-tools.md`.
+- Machine-readable MCP tool metadata is tracked in `docs/mcp/tools.json`.
 - Destructive operations must require explicit user approval.
 - Production access rules must be documented before production tooling is added.

--- a/docs/integrations/mcp-tools.md
+++ b/docs/integrations/mcp-tools.md
@@ -24,6 +24,18 @@ Preferred sources for tool definitions:
 
 Avoid creating MCP-only behavior that cannot be exercised or verified through normal application boundaries.
 
+## Catalog
+
+The first machine-readable MCP tool catalog lives at `docs/mcp/tools.json`.
+
+It contains read-only tool metadata aligned with shipped OpenAPI operations. The catalog is validated by:
+
+```bash
+docker compose run --rm app composer mcp
+```
+
+`composer check` includes this validation.
+
 ## Safety Levels
 
 Each MCP tool should be classified before implementation:

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "source": "docs/openapi/openapi.yaml",
+  "tools": [
+    {
+      "name": "getFrameworkSmoke",
+      "title": "Framework Smoke",
+      "description": "Read the framework smoke endpoint through the documented public API.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "getFrameworkSmoke",
+        "method": "GET",
+        "path": "/"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+      },
+      "responseSchemaRef": "#/components/schemas/FrameworkSmokeResponse"
+    },
+    {
+      "name": "getHealth",
+      "title": "Health",
+      "description": "Read the health endpoint through the documented public API.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "getHealth",
+        "method": "GET",
+        "path": "/health"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+      },
+      "responseSchemaRef": "#/components/schemas/HealthResponse"
+    }
+  ]
+}

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -73,10 +73,13 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define the first database test strategy and focused test command. `#99`
 - [x] Add an explicit database transaction boundary. `#101`
 - [x] Define MCP tool integration safety policy. `#103`
+- [x] Add a read-only MCP tool catalog aligned with OpenAPI. `#105`
 
 ## Next Candidates
 
-No active candidates. Choose the next Issue from `docs/roadmap.md` and current project direction.
+- [ ] Document safe local AI/MCP development commands.
+- [ ] Add request-id based AI debugging guide.
+- [ ] Add generated OpenAPI-to-MCP catalog direction once the catalog grows.
 
 ## Operating Notes
 

--- a/tools/validate-mcp-tools.php
+++ b/tools/validate-mcp-tools.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$root = dirname(__DIR__);
+$catalogPath = $root . '/docs/mcp/tools.json';
+$openApiPath = $root . '/docs/openapi/openapi.yaml';
+
+$catalog = json_decode((string) file_get_contents($catalogPath), true, 512, JSON_THROW_ON_ERROR);
+$openApi = Yaml::parseFile($openApiPath);
+
+if (!is_array($catalog)) {
+    fwrite(STDERR, "MCP tool catalog must parse to an object.\n");
+    exit(1);
+}
+
+if (!is_array($openApi)) {
+    fwrite(STDERR, "OpenAPI document must parse to an object.\n");
+    exit(1);
+}
+
+$errors = [];
+$allowedSafetyLevels = ['read', 'write', 'admin', 'destructive'];
+$tools = $catalog['tools'] ?? null;
+
+if (!is_array($tools) || $tools === []) {
+    $errors[] = 'MCP tool catalog must contain at least one tool.';
+} else {
+    foreach ($tools as $index => $tool) {
+        if (!is_array($tool)) {
+            $errors[] = sprintf('Tool at index %d must be an object.', $index);
+            continue;
+        }
+
+        validateTool($tool, $index, $openApi, $allowedSafetyLevels, $errors);
+    }
+}
+
+if ($errors !== []) {
+    foreach ($errors as $error) {
+        fwrite(STDERR, sprintf("MCP tool catalog validation error: %s\n", $error));
+    }
+
+    exit(1);
+}
+
+echo "MCP tool catalog is valid.\n";
+
+/**
+ * @param array<string, mixed> $tool
+ * @param array<string, mixed> $openApi
+ * @param list<string> $allowedSafetyLevels
+ * @param list<string> $errors
+ */
+function validateTool(array $tool, int $index, array $openApi, array $allowedSafetyLevels, array &$errors): void
+{
+    $name = $tool['name'] ?? null;
+    $safety = $tool['safety'] ?? null;
+    $source = $tool['source'] ?? null;
+    $responseSchemaRef = $tool['responseSchemaRef'] ?? null;
+
+    if (!is_string($name) || $name === '') {
+        $errors[] = sprintf('Tool at index %d must have a non-empty name.', $index);
+    }
+
+    if (!is_string($safety) || !in_array($safety, $allowedSafetyLevels, true)) {
+        $errors[] = sprintf('Tool "%s" has an unsupported safety level.', displayName($name, $index));
+    }
+
+    if (!is_array($source)) {
+        $errors[] = sprintf('Tool "%s" must define a source object.', displayName($name, $index));
+        return;
+    }
+
+    $operation = openApiOperation($openApi, $source);
+
+    if ($operation === null) {
+        $errors[] = sprintf('Tool "%s" source does not match an OpenAPI operation.', displayName($name, $index));
+        return;
+    }
+
+    $operationId = $source['operationId'] ?? null;
+
+    if (($operation['operationId'] ?? null) !== $operationId) {
+        $errors[] = sprintf('Tool "%s" operationId does not match OpenAPI.', displayName($name, $index));
+    }
+
+    if ($responseSchemaRef !== successResponseSchemaRef($operation)) {
+        $errors[] = sprintf('Tool "%s" responseSchemaRef does not match the OpenAPI 200 response schema.', displayName($name, $index));
+    }
+}
+
+/**
+ * @param array<string, mixed> $openApi
+ * @param array<string, mixed> $source
+ * @return array<string, mixed>|null
+ */
+function openApiOperation(array $openApi, array $source): ?array
+{
+    $method = $source['method'] ?? null;
+    $path = $source['path'] ?? null;
+
+    if (!is_string($method) || !is_string($path)) {
+        return null;
+    }
+
+    $operation = $openApi['paths'][$path][strtolower($method)] ?? null;
+
+    return is_array($operation) ? $operation : null;
+}
+
+/**
+ * @param array<string, mixed> $operation
+ */
+function successResponseSchemaRef(array $operation): ?string
+{
+    $schemaRef = $operation['responses']['200']['content']['application/json']['schema']['$ref'] ?? null;
+
+    return is_string($schemaRef) ? $schemaRef : null;
+}
+
+function displayName(mixed $name, int $index): string
+{
+    return is_string($name) && $name !== '' ? $name : sprintf('#%d', $index);
+}


### PR DESCRIPTION
## Summary
- Add the first read-only MCP tool catalog at `docs/mcp/tools.json` for shipped OpenAPI operations.
- Add `tools/validate-mcp-tools.php` and `composer mcp`, then include catalog validation in `composer check`.
- Restore next TODO candidates for safe AI/MCP follow-up work.

## Verification
- [x] `docker compose run --rm app composer mcp`
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/openapi-contract.md`

Closes #105

Made with [Cursor](https://cursor.com)