### PR TITLE
docs: safe local AI/MCP development commands を定義する

### DIFF
--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -111,6 +111,8 @@ Docker remains the standard backend runtime. Frontend commands may run on the ho
 
 CI should start with backend `composer check` and expand only after each tool has committed configuration and local verification commands. See `docs/development/release-ci.md`.
 
+Safe local AI and MCP command usage is documented in `docs/integrations/local-ai-commands.md`.
+
 ## Non-Goals
 
 - Forcing React on framework consumers.

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -38,5 +38,6 @@ For normal code or documentation work, an AI agent should:
 - MCP tools should interact with the application through documented APIs, not direct database access.
 - MCP tool design should follow `docs/integrations/mcp-tools.md`.
 - Machine-readable MCP tool metadata is tracked in `docs/mcp/tools.json`.
+- Safe local AI and MCP commands are documented in `docs/integrations/local-ai-commands.md`.
 - Destructive operations must require explicit user approval.
 - Production access rules must be documented before production tooling is added.

--- a/docs/integrations/local-ai-commands.md
+++ b/docs/integrations/local-ai-commands.md
@@ -1,0 +1,55 @@
+# Local AI and MCP Commands
+
+Local AI and MCP workflows may run documented verification commands when they stay inside the development boundary and do not read secrets or mutate production-like state.
+
+## Safe Defaults
+
+These commands are safe for local agents and MCP development tools:
+
+```bash
+docker compose run --rm app composer check
+docker compose run --rm app composer openapi
+docker compose run --rm app composer mcp
+docker compose run --rm app composer test:database
+npm run check --prefix frontend
+npm run build --prefix frontend
+git diff --check
+```
+
+Use `docker compose up -d app` when the local HTTP API needs to be inspected through public routes.
+
+Read-only HTTP inspection may call:
+
+```bash
+curl -fsS http://localhost:8080/
+curl -fsS http://localhost:8080/health
+curl -fsS http://localhost:8080/openapi.php
+```
+
+## Boundaries
+
+Local AI and MCP commands must:
+
+- use committed configuration and documented scripts
+- prefer public HTTP routes over direct database or filesystem shortcuts
+- keep test databases deterministic and disposable
+- avoid reading `.env`, credentials, tokens, or private user files
+- avoid destructive git commands unless the user explicitly approves them
+
+Local AI and MCP commands must not:
+
+- run production credentials or production database URLs
+- modify databases outside documented test or migration commands
+- bypass application authorization in a way that resembles production behavior
+- commit generated build output unless a release policy explicitly requires it
+- install new dependencies without a focused Issue and reviewable diff
+
+## Adding Commands
+
+Before a command becomes part of AI or MCP automation:
+
+- document the command and its purpose
+- define whether it is read-only, write, admin, or destructive
+- verify it locally
+- add it to CI only after its configuration is committed
+- update `docs/todo/current.md` or the related Issue when it changes current workflow

--- a/docs/integrations/mcp-tools.md
+++ b/docs/integrations/mcp-tools.md
@@ -59,6 +59,8 @@ The first MCP tools should be `read` tools.
 
 Local-only MCP tools may help agents inspect the development app, but they must stay clearly scoped.
 
+Safe local commands are documented in `docs/integrations/local-ai-commands.md`.
+
 Local tools may:
 
 - call local HTTP APIs

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -74,10 +74,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add an explicit database transaction boundary. `#101`
 - [x] Define MCP tool integration safety policy. `#103`
 - [x] Add a read-only MCP tool catalog aligned with OpenAPI. `#105`
+- [x] Document safe local AI/MCP development commands. `#107`
 
 ## Next Candidates
 
-- [ ] Document safe local AI/MCP development commands.
 - [ ] Add request-id based AI debugging guide.
 - [ ] Add generated OpenAPI-to-MCP catalog direction once the catalog grows.
 


### PR DESCRIPTION
## Summary
- Add `docs/integrations/local-ai-commands.md` with safe local command categories and boundaries.
- Link the policy from MCP, AI tooling, and quality tooling docs.
- Update current TODO state and keep the remaining MCP follow-up candidates visible.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/docs-policy.md`

Closes #107

Made with [Cursor](https://cursor.com)