### PR TITLE
docs: request-id based AI debugging guide を追加する

### DIFF
--- a/docs/development/observability.md
+++ b/docs/development/observability.md
@@ -80,6 +80,8 @@ X-Request-Id
 
 Request ids are correlation identifiers, not authentication credentials.
 
+AI-assisted debugging should use request ids as the first HTTP correlation value. See `docs/integrations/ai-debugging.md`.
+
 ## Error Tracking
 
 Error tracking tools such as Sentry should be adapters.

--- a/docs/integrations/ai-debugging.md
+++ b/docs/integrations/ai-debugging.md
@@ -1,0 +1,71 @@
+# AI-Assisted Debugging
+
+AI-assisted debugging should start from stable runtime evidence, not guesses.
+
+For HTTP behavior, the first correlation value is the request id.
+
+## Request ID Workflow
+
+When debugging a local API response:
+
+1. Call the public HTTP route.
+2. Capture the `X-Request-Id` response header.
+3. Use the request id to correlate logs, Problem Details responses, and future metrics or error tracking events.
+4. Share only the minimal safe context needed to diagnose the issue.
+
+Example:
+
+```bash
+curl -i http://localhost:8080/health
+```
+
+The response should include:
+
+```text
+X-Request-Id: <request-id>
+```
+
+If the request fails with Problem Details, keep these fields together:
+
+- `X-Request-Id` response header
+- HTTP status
+- Problem Details `type`
+- Problem Details `title`
+- request method and path
+
+## Safe Context
+
+Good AI debugging context includes:
+
+- request id
+- HTTP method
+- route path or route pattern
+- status code
+- Problem Details `type`
+- exception class when it is already in safe server logs
+- short reproduction steps
+- relevant command output from documented local checks
+
+Do not include:
+
+- `.env` values
+- tokens, API keys, session ids, cookies, or `Authorization` headers
+- raw request bodies that may contain private data
+- database DSNs or credentials
+- private filesystem paths unless they are already part of committed repository paths
+
+## MCP Tooling Direction
+
+Read-only MCP tools should return request id metadata when they call HTTP APIs and the response includes `X-Request-Id`.
+
+Mutation, admin, and destructive MCP tools must define audit behavior before implementation. The audit record should include request id when the tool maps to HTTP behavior.
+
+## Logging Relationship
+
+NENE2 request logs should include `request_id`, `method`, `path`, `status`, and `duration_ms` when request logging is enabled.
+
+AI debugging should use those structured fields as correlation points. It should not require raw request payload logging by default.
+
+## Local Commands
+
+Use the safe command policy in `docs/integrations/local-ai-commands.md` before running local checks during debugging.

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -39,5 +39,6 @@ For normal code or documentation work, an AI agent should:
 - MCP tool design should follow `docs/integrations/mcp-tools.md`.
 - Machine-readable MCP tool metadata is tracked in `docs/mcp/tools.json`.
 - Safe local AI and MCP commands are documented in `docs/integrations/local-ai-commands.md`.
+- AI-assisted debugging should follow `docs/integrations/ai-debugging.md`.
 - Destructive operations must require explicit user approval.
 - Production access rules must be documented before production tooling is added.

--- a/docs/integrations/mcp-tools.md
+++ b/docs/integrations/mcp-tools.md
@@ -96,6 +96,8 @@ When a tool maps to an HTTP API operation:
 - preserve Problem Details error behavior
 - include request id in logs and returned metadata where useful
 
+AI-assisted debugging guidance for request id handling lives in `docs/integrations/ai-debugging.md`.
+
 If a tool needs a shape that does not fit the current API, update the API contract first or document why an internal service boundary is better.
 
 ## Non-Goals

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -75,10 +75,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define MCP tool integration safety policy. `#103`
 - [x] Add a read-only MCP tool catalog aligned with OpenAPI. `#105`
 - [x] Document safe local AI/MCP development commands. `#107`
+- [x] Add request-id based AI debugging guide. `#109`
 
 ## Next Candidates
 
-- [ ] Add request-id based AI debugging guide.
 - [ ] Add generated OpenAPI-to-MCP catalog direction once the catalog grows.
 
 ## Operating Notes


### PR DESCRIPTION
## Summary
- Add `docs/integrations/ai-debugging.md` with request-id-first HTTP debugging workflow.
- Link the guide from observability, AI tooling, and MCP tool policy docs.
- Update current TODO state and leave the generated OpenAPI-to-MCP follow-up visible.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/docs-policy.md`

Closes #109

Made with [Cursor](https://cursor.com)