### PR TITLE
test: OpenAPI runtime contract tests を schema validation へ拡張する

### DIFF
--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -66,7 +66,8 @@ docker compose run --rm app composer openapi
 ## Testing Direction
 
 Runtime contract tests should verify shipped JSON responses against documented examples and required schema fields.
-The first lightweight checks live in `tests/OpenApi/RuntimeContractTest.php` and should grow toward fuller JSON Schema validation only when that extra precision reduces maintenance risk.
+The first lightweight checks live in `tests/OpenApi/RuntimeContractTest.php` and verify examples plus basic schema rules for object responses: required fields, documented property types, enum values, and `additionalProperties` when present.
+Full JSON Schema validation should be added only when that extra precision reduces maintenance risk.
 
 Shared schemas for `ProblemDetails`, `ValidationProblemDetails`, and `ValidationError` live in `docs/openapi/openapi.yaml`. Stable endpoints should reference these schemas for non-2xx JSON responses where the behavior is implemented. See `docs/development/api-error-responses.md`.
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -79,10 +79,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add generated OpenAPI-to-MCP catalog direction. `#111`
 - [x] Define API-key and token boundary policy. `#113`
 - [x] Add local MCP server integration guidance. `#115`
+- [x] Expand OpenAPI runtime contract tests toward schema validation. `#117`
 
 ## Next Candidates
 
-- [ ] Expand OpenAPI runtime contract tests toward schema validation.
 - [ ] Add branch protection readiness checklist.
 - [ ] Refresh first `v0.1.0` release preparation notes.
 

--- a/tests/OpenApi/RuntimeContractTest.php
+++ b/tests/OpenApi/RuntimeContractTest.php
@@ -15,7 +15,7 @@ final class RuntimeContractTest extends TestCase
 {
     /**
      * @param array<string, mixed> $expectedPayload
-     * @param list<string> $requiredFields
+     * @param array<string, mixed> $schema
      */
     #[DataProvider('successEndpointProvider')]
     public function testRuntimeSuccessResponsesMatchOpenApiExamples(
@@ -23,7 +23,7 @@ final class RuntimeContractTest extends TestCase
         string $path,
         int $expectedStatus,
         array $expectedPayload,
-        array $requiredFields,
+        array $schema,
     ): void {
         $factory = new Psr17Factory();
         $application = (new RuntimeApplicationFactory($factory, $factory))->create();
@@ -35,13 +35,11 @@ final class RuntimeContractTest extends TestCase
         self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
         self::assertSame($expectedPayload, $payload);
 
-        foreach ($requiredFields as $requiredField) {
-            self::assertArrayHasKey($requiredField, $payload);
-        }
+        self::assertMatchesSchema($schema, $payload);
     }
 
     /**
-     * @return iterable<string, array{0: string, 1: string, 2: int, 3: array<string, mixed>, 4: list<string>}>
+     * @return iterable<string, array{0: string, 1: string, 2: int, 3: array<string, mixed>, 4: array<string, mixed>}>
      */
     public static function successEndpointProvider(): iterable
     {
@@ -81,7 +79,7 @@ final class RuntimeContractTest extends TestCase
                     $path,
                     200,
                     $example,
-                    self::requiredFieldsForSchema($openApi, $schemaRef),
+                    self::schemaForReference($openApi, $schemaRef),
                 ];
             }
         }
@@ -101,20 +99,82 @@ final class RuntimeContractTest extends TestCase
 
     /**
      * @param array<string, mixed> $openApi
-     * @return list<string>
+     * @return array<string, mixed>
      */
-    private static function requiredFieldsForSchema(array $openApi, string $schemaRef): array
+    private static function schemaForReference(array $openApi, string $schemaRef): array
     {
         $schemaName = str_replace('#/components/schemas/', '', $schemaRef);
         $schema = $openApi['components']['schemas'][$schemaName] ?? null;
 
         self::assertIsArray($schema, sprintf('Schema "%s" must exist.', $schemaName));
 
+        return $schema;
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param array<string, mixed> $payload
+     */
+    private static function assertMatchesSchema(array $schema, array $payload): void
+    {
+        self::assertSame('object', $schema['type'] ?? null, 'Runtime contract success schemas must be objects.');
+
         $required = $schema['required'] ?? [];
 
-        self::assertIsArray($required, sprintf('Schema "%s" required fields must be a list.', $schemaName));
+        self::assertIsArray($required, 'Schema required fields must be a list.');
 
-        return array_values(array_filter($required, static fn (mixed $field): bool => is_string($field)));
+        foreach ($required as $requiredField) {
+            self::assertIsString($requiredField);
+            self::assertArrayHasKey($requiredField, $payload);
+        }
+
+        $properties = $schema['properties'] ?? [];
+
+        self::assertIsArray($properties, 'Schema properties must be a map.');
+
+        foreach ($payload as $field => $value) {
+            if (!array_key_exists($field, $properties)) {
+                self::assertNotFalse(
+                    $schema['additionalProperties'] ?? true,
+                    sprintf('Unexpected response field "%s".', $field),
+                );
+
+                continue;
+            }
+
+            $property = $properties[$field];
+
+            self::assertIsArray($property, sprintf('Schema property "%s" must be a map.', $field));
+            self::assertValueMatchesPropertySchema($field, $property, $value);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $property
+     */
+    private static function assertValueMatchesPropertySchema(string $field, array $property, mixed $value): void
+    {
+        $type = $property['type'] ?? null;
+
+        if ($type === 'string') {
+            self::assertIsString($value, sprintf('Field "%s" must be a string.', $field));
+        } elseif ($type === 'integer') {
+            self::assertIsInt($value, sprintf('Field "%s" must be an integer.', $field));
+        } elseif ($type === 'number') {
+            self::assertIsNumeric($value, sprintf('Field "%s" must be numeric.', $field));
+        } elseif ($type === 'boolean') {
+            self::assertIsBool($value, sprintf('Field "%s" must be a boolean.', $field));
+        } elseif ($type === 'array') {
+            self::assertIsArray($value, sprintf('Field "%s" must be an array.', $field));
+        } elseif ($type !== null) {
+            self::fail(sprintf('Unsupported schema type "%s" for field "%s".', (string) $type, $field));
+        }
+
+        $enum = $property['enum'] ?? null;
+
+        if (is_array($enum)) {
+            self::assertContains($value, $enum, sprintf('Field "%s" must match a documented enum value.', $field));
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Extend `RuntimeContractTest` to validate shipped JSON success responses against basic OpenAPI object schema rules.
- Check required fields, documented property types, enum values, and `additionalProperties` where present.
- Update OpenAPI testing policy and current TODO state.

## Verification
- [x] `docker compose run --rm app ./vendor/bin/phpunit tests/OpenApi/RuntimeContractTest.php`
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/openapi-contract.md`

Closes #117

Made with [Cursor](https://cursor.com)