### PR TITLE
docs: branch protection readiness checklist を追加する

### DIFF
--- a/docs/development/branch-protection-readiness.md
+++ b/docs/development/branch-protection-readiness.md
@@ -1,0 +1,62 @@
+# Branch Protection Readiness
+
+`main` should be protected before NENE2 releases become public.
+
+This checklist documents the expected protection shape. It does not change GitHub repository settings by itself.
+
+## Required Checks
+
+The current required check candidates are:
+
+- `Composer Check` from `.github/workflows/backend.yml`
+- `npm Check` from `.github/workflows/frontend.yml`
+
+Do not require a check before the workflow has run successfully on both pull requests and `main` pushes.
+
+## Recommended Protection
+
+Recommended `main` protection:
+
+- require pull requests before merging
+- require the latest `Composer Check`
+- require the latest `npm Check`
+- require branches to be up to date before merging when GitHub reports stale checks clearly
+- block force pushes
+- block branch deletion
+- keep merge commits unless the project deliberately changes history policy
+- avoid allowing bypasses except for repository administrators during documented emergencies
+
+## Readiness Checklist
+
+Before enabling or tightening branch protection:
+
+- [ ] `docs/workflow.md` describes the PR-first workflow.
+- [ ] `.github/workflows/backend.yml` runs on pull requests and pushes to `main`.
+- [ ] `.github/workflows/frontend.yml` runs on pull requests and pushes to `main`.
+- [ ] The latest `main` push has passing Backend and Frontend workflow runs.
+- [ ] `composer check` passes locally or in CI.
+- [ ] `npm run check --prefix frontend` and `npm run build --prefix frontend` pass in CI.
+- [ ] `docs/todo/current.md` does not list an incomplete CI setup task as complete.
+- [ ] The team agrees whether merge commits remain the default.
+
+## Rollout Notes
+
+Start with the smallest effective protection:
+
+1. Require pull requests.
+2. Require `Composer Check` and `npm Check`.
+3. Disable force pushes and branch deletion.
+4. Add stricter review or stale-branch rules only after the workflow is stable.
+
+If a required check is renamed, update this document and `docs/development/release-ci.md` in the same PR.
+
+## Emergency Changes
+
+Emergency bypasses should be rare and documented after the fact.
+
+If an emergency change bypasses the normal PR path:
+
+- record the reason in an Issue
+- run the normal verification after the change
+- open a follow-up PR if docs, tests, or workflow files need cleanup
+- confirm `main` returns to passing CI

--- a/docs/development/release-ci.md
+++ b/docs/development/release-ci.md
@@ -110,6 +110,8 @@ The initial frontend workflow lives at `.github/workflows/frontend.yml` and runs
 
 `main` should be protected before releases become public.
 
+Readiness details and the current required check candidates live in `docs/development/branch-protection-readiness.md`.
+
 Recommended branch protection:
 
 - require PRs before merging

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -80,10 +80,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define API-key and token boundary policy. `#113`
 - [x] Add local MCP server integration guidance. `#115`
 - [x] Expand OpenAPI runtime contract tests toward schema validation. `#117`
+- [x] Add branch protection readiness checklist. `#119`
 
 ## Next Candidates
 
-- [ ] Add branch protection readiness checklist.
 - [ ] Refresh first `v0.1.0` release preparation notes.
 
 ## Operating Notes

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -17,6 +17,7 @@ NENE2 uses GitHub Issues for work tracking and local Markdown files for project 
 11. Return local `main` to the merged, clean state.
 
 Release, versioning, and CI policy is defined in `docs/development/release-ci.md`.
+Branch protection readiness is tracked in `docs/development/branch-protection-readiness.md`.
 
 ## Branch Names
 


### PR DESCRIPTION
## Summary
- Add `docs/development/branch-protection-readiness.md` with required check candidates and rollout checklist for protecting `main`.
- Link the readiness checklist from release/CI policy and workflow docs.
- Update current TODO state and leave the first release preparation candidate visible.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/release-ci.md`

Closes #119

Made with [Cursor](https://cursor.com)