### PR TITLE
docs: first v0.1.0 release preparation notes を更新する

### DIFF
--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -2,6 +2,8 @@
 
 Use this checklist for manual `v0.x.y` releases until release automation is introduced.
 
+Preparation notes for the first `v0.1.0` release live in `docs/development/release-v0.1.0-prep.md`.
+
 ## Preconditions
 
 - The release is created from `main`.

--- a/docs/development/release-ci.md
+++ b/docs/development/release-ci.md
@@ -7,6 +7,7 @@ NENE2 uses SemVer, small release steps, and GitHub Actions as the standard CI di
 Release and CI policy should keep the framework safe to change while the public API is still forming.
 
 Manual release steps are tracked in `docs/development/release-checklist.md`.
+The first release preparation notes live in `docs/development/release-v0.1.0-prep.md`.
 
 The standard direction is:
 

--- a/docs/development/release-v0.1.0-prep.md
+++ b/docs/development/release-v0.1.0-prep.md
@@ -1,0 +1,101 @@
+# v0.1.0 Release Preparation
+
+This document prepares the first `v0.1.0` release. It is not a release announcement and does not tag the repository.
+
+## Release Intent
+
+`v0.1.0` should represent the first coherent NENE2 foundation release:
+
+- PSR-first HTTP runtime skeleton
+- explicit dependency injection wiring
+- typed configuration boundary
+- Problem Details error shape
+- OpenAPI contract and lightweight contract tests
+- React + TypeScript starter baseline
+- database adapter boundaries
+- MCP and AI tooling policies
+- backend and frontend CI checks
+
+The release should still be described as early `0.x` framework foundation work. It must not promise long-term public API stability.
+
+## Candidate Highlights
+
+Potential release highlights:
+
+- JSON API first runtime with `/` and `/health` endpoints.
+- Internal router with full-segment path parameters.
+- PSR-15 middleware pipeline foundation with request id, security, CORS, and request size policies.
+- RFC 9457 Problem Details response policy and shared OpenAPI schemas.
+- Runtime contract tests aligned with OpenAPI examples and basic response schemas.
+- Typed app and database configuration.
+- PDO connection, query executor, and transaction manager boundaries.
+- React + TypeScript + Vite starter with frontend-to-backend health integration.
+- GitHub Actions for backend Composer checks and frontend npm checks.
+- MCP read-only catalog, safe local command guidance, local server guidance, and authentication boundary policies.
+
+## Verification Before Tagging
+
+Before tagging `v0.1.0`, run:
+
+```bash
+git switch main
+git pull --ff-only origin main
+docker compose run --rm app composer validate
+docker compose run --rm app composer check
+npm run check --prefix frontend
+npm run build --prefix frontend
+git diff --check
+```
+
+Confirm the latest `main` push has passing Backend and Frontend GitHub Actions.
+
+## Draft Release Notes Shape
+
+```markdown
+## Highlights
+
+- <short foundation summary>
+
+## Breaking Changes
+
+None. This is the first `0.x` foundation release.
+
+## Migration Notes
+
+None for existing released users.
+
+## Verification
+
+- `composer validate`
+- `composer check`
+- `npm run check --prefix frontend`
+- `npm run build --prefix frontend`
+- Backend and Frontend GitHub Actions on `main`
+
+## Known Follow-up Work
+
+- <deferred items>
+```
+
+## Deferred Work
+
+Do not block `v0.1.0` on:
+
+- Packagist publication
+- production MCP tooling
+- full authentication middleware
+- full JSON Schema runtime validation
+- release automation
+- branch protection being enabled in repository settings
+- `1.0.0` stability guarantees
+
+## Tagging Reminder
+
+Only tag from an up-to-date, clean `main` after verification:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Create the GitHub Release from that tag and include related Issues and PRs in the notes.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -81,10 +81,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add local MCP server integration guidance. `#115`
 - [x] Expand OpenAPI runtime contract tests toward schema validation. `#117`
 - [x] Add branch protection readiness checklist. `#119`
+- [x] Refresh first `v0.1.0` release preparation notes. `#121`
 
 ## Next Candidates
 
-- [ ] Refresh first `v0.1.0` release preparation notes.
+No active candidates. Choose the next Issue from `docs/roadmap.md` and current project direction.
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Add `docs/development/release-v0.1.0-prep.md` with first release intent, candidate highlights, verification, draft notes shape, and deferred work.
- Link the prep notes from release checklist and release/CI policy.
- Mark the current TODO candidate complete and return the board to roadmap selection.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/release-ci.md`

Closes #121

Made with [Cursor](https://cursor.com)