### PR TITLE
docs: post-foundation release readiness milestone を定義する

### DIFF
--- a/docs/milestones/2026-05-v0.1.0-release-readiness.md
+++ b/docs/milestones/2026-05-v0.1.0-release-readiness.md
@@ -1,0 +1,57 @@
+# v0.1.0 Release Readiness
+
+## Period
+
+May 2026
+
+## Goal
+
+Prepare the first `v0.1.0` foundation release without expanding scope into broad application features.
+
+This milestone should turn the completed foundation into a clear, verifiable release candidate.
+
+## Theme
+
+NENE2 should be ready to publish a first `0.x` foundation release that honestly communicates what is stable, what is intentionally early, and what remains deferred.
+
+## Scope
+
+- verify `main` against the documented release checklist
+- draft concrete GitHub Release notes for `v0.1.0`
+- decide whether branch protection should be enabled before tagging
+- keep `docs/todo/current.md` aligned with release readiness
+- keep deferred work explicit rather than quietly expanding the release
+- avoid Packagist publication until Composer package contracts are stable enough for early users
+
+## Acceptance Criteria
+
+- `docs/development/release-v0.1.0-prep.md` has enough detail to produce release notes.
+- `docs/development/release-checklist.md` can be followed without guessing.
+- `docs/development/branch-protection-readiness.md` has an explicit decision recorded for `main`.
+- Latest `main` Backend and Frontend GitHub Actions are passing.
+- Local release verification commands are documented and either run or explicitly deferred with a reason.
+- Known deferred work is listed before tagging.
+- No release tag is created from an unmerged branch.
+
+## Candidate Issues
+
+- Draft concrete `v0.1.0` GitHub Release notes.
+- Decide whether to enable branch protection settings for `main`.
+- Run and record final `v0.1.0` release verification.
+- Tag `v0.1.0` only after verification and explicit user approval.
+
+## Non-Goals
+
+- Shipping Packagist publication as part of the first release.
+- Implementing production authentication or production MCP tooling.
+- Adding release automation before the manual process is exercised.
+- Claiming `1.0.0` style public API stability.
+- Broadening the framework with new application features before the foundation release is clear.
+
+## Related Work
+
+- Release preparation: `docs/development/release-v0.1.0-prep.md`
+- Release checklist: `docs/development/release-checklist.md`
+- Branch protection readiness: `docs/development/branch-protection-readiness.md`
+- Completed foundation milestone: `docs/milestones/2026-05-nene2-foundation.md`
+- GitHub Issue: `#125`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: `docs/milestones/2026-05-nene2-foundation.md`
+- Current milestone: `docs/milestones/2026-05-v0.1.0-release-readiness.md`
 - Current GitHub Issue: none
 - Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
@@ -86,7 +86,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Next Candidates
 
 - [x] Refresh the foundation milestone with completed implementation scope. `#123`
-- [ ] Define the next milestone for post-foundation release readiness.
+- [x] Define the next milestone for post-foundation release readiness. `#125`
 - [ ] Draft concrete `v0.1.0` GitHub Release notes after release readiness is confirmed.
 - [ ] Decide whether to enable branch protection settings for `main`.
 


### PR DESCRIPTION
## Summary
- Add `docs/milestones/2026-05-v0.1.0-release-readiness.md` for the next post-foundation milestone.
- Move `docs/todo/current.md` to the new current milestone and mark the milestone-definition candidate complete.
- Keep the next release-readiness candidates visible without tagging a release.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/docs-policy.md`
- `docs/review/release-ci.md`

Closes #125

Made with [Cursor](https://cursor.com)