### PR TITLE
docs: main branch protection decision を記録する

### DIFF
--- a/docs/development/branch-protection-readiness.md
+++ b/docs/development/branch-protection-readiness.md
@@ -39,6 +39,24 @@ Before enabling or tightening branch protection:
 - [ ] `docs/todo/current.md` does not list an incomplete CI setup task as complete.
 - [ ] The team agrees whether merge commits remain the default.
 
+## Current Decision
+
+As of the `v0.1.0` release readiness milestone, `main` is not protected in GitHub repository settings.
+
+Decision:
+
+- Do not enable branch protection as an incidental documentation change.
+- Treat `main` as ready for the smallest recommended protection once the release owner explicitly approves the repository setting change.
+- Keep merge commits as the default history policy.
+- Use `Composer Check` and `npm Check` as the initial required status checks when protection is enabled.
+- Reconfirm the exact required check names from a fresh `main` run immediately before changing repository settings.
+
+Reason:
+
+- The workflows are passing on pull requests and `main` pushes.
+- Enabling repository protection is an operational setting change, not a source-code change.
+- The first `v0.1.0` release can still be prepared while this remains a documented pre-tag decision.
+
 ## Rollout Notes
 
 Start with the smallest effective protection:

--- a/docs/milestones/2026-05-v0.1.0-release-readiness.md
+++ b/docs/milestones/2026-05-v0.1.0-release-readiness.md
@@ -27,7 +27,7 @@ NENE2 should be ready to publish a first `0.x` foundation release that honestly 
 
 - `docs/development/release-v0.1.0-prep.md` has enough detail to produce release notes.
 - `docs/development/release-checklist.md` can be followed without guessing.
-- `docs/development/branch-protection-readiness.md` has an explicit decision recorded for `main`.
+- `docs/development/branch-protection-readiness.md` has an explicit decision recorded for `main`. `#127`
 - Latest `main` Backend and Frontend GitHub Actions are passing.
 - Local release verification commands are documented and either run or explicitly deferred with a reason.
 - Known deferred work is listed before tagging.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -88,7 +88,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Refresh the foundation milestone with completed implementation scope. `#123`
 - [x] Define the next milestone for post-foundation release readiness. `#125`
 - [ ] Draft concrete `v0.1.0` GitHub Release notes after release readiness is confirmed.
-- [ ] Decide whether to enable branch protection settings for `main`.
+- [x] Decide whether to enable branch protection settings for `main`. `#127`
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Record that `main` is currently unprotected and ready for minimal protection when explicitly approved.
- Keep merge commits as the default policy and identify `Composer Check` / `npm Check` as initial required checks.
- Mark the branch protection decision TODO complete.

## Verification
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`

## Self-review
- `docs/review/release-ci.md`

Closes #127

Made with [Cursor](https://cursor.com)