### PR TITLE
docs: v0.1.0 final release verification を記録する

### DIFF
--- a/docs/development/release-v0.1.0-notes.md
+++ b/docs/development/release-v0.1.0-notes.md
@@ -74,7 +74,9 @@ None for existing released users.
 
 ## Verification
 
-Before publishing this release, verify:
+Release-candidate verification is recorded in `docs/development/release-v0.1.0-verification.md`.
+
+Before publishing this release, verify or reuse the recorded result:
 
 ```bash
 git switch main

--- a/docs/development/release-v0.1.0-prep.md
+++ b/docs/development/release-v0.1.0-prep.md
@@ -3,6 +3,7 @@
 This document prepares the first `v0.1.0` release. It is not a release announcement and does not tag the repository.
 
 Concrete draft release notes live in `docs/development/release-v0.1.0-notes.md`.
+Final release-candidate verification is recorded in `docs/development/release-v0.1.0-verification.md`.
 
 ## Release Intent
 

--- a/docs/development/release-v0.1.0-verification.md
+++ b/docs/development/release-v0.1.0-verification.md
@@ -1,0 +1,52 @@
+# v0.1.0 Final Verification
+
+This document records the final verification run for the `v0.1.0` release candidate.
+
+It does not create a release tag.
+
+## Verification Target
+
+- Branch: `main`
+- Commit: `a101cab`
+- Date: 2026-05-07
+- Related Issue: `#131`
+
+## Local Verification
+
+The documented release verification commands were run successfully:
+
+```bash
+docker compose run --rm app composer validate
+docker compose run --rm app composer check
+npm run check --prefix frontend
+npm run build --prefix frontend
+git diff --check
+```
+
+Results:
+
+- Composer metadata is valid.
+- PHPUnit, PHPStan, PHP-CS-Fixer, OpenAPI validation, and MCP catalog validation passed through `composer check`.
+- Frontend TypeScript, ESLint, Prettier, and Vite production build passed.
+- Whitespace diff check passed.
+
+## GitHub Actions
+
+The latest `main` push for the release candidate passed:
+
+- Backend / `Composer Check`
+- Frontend / `npm Check`
+
+Run references:
+
+- Backend: `25479856145`
+- Frontend: `25479856125`
+
+## Remaining Release Decisions
+
+Before publishing `v0.1.0`:
+
+- get explicit approval to tag `v0.1.0`
+- decide whether to enable `main` branch protection before tagging
+- create the GitHub Release from the tag using `docs/development/release-v0.1.0-notes.md`
+- keep Packagist publication deferred

--- a/docs/milestones/2026-05-v0.1.0-release-readiness.md
+++ b/docs/milestones/2026-05-v0.1.0-release-readiness.md
@@ -30,7 +30,7 @@ NENE2 should be ready to publish a first `0.x` foundation release that honestly 
 - `docs/development/release-checklist.md` can be followed without guessing.
 - `docs/development/branch-protection-readiness.md` has an explicit decision recorded for `main`. `#127`
 - Latest `main` Backend and Frontend GitHub Actions are passing.
-- Local release verification commands are documented and either run or explicitly deferred with a reason.
+- Local release verification commands are documented and recorded in `docs/development/release-v0.1.0-verification.md`. `#131`
 - Known deferred work is listed before tagging.
 - No release tag is created from an unmerged branch.
 
@@ -38,7 +38,7 @@ NENE2 should be ready to publish a first `0.x` foundation release that honestly 
 
 - Draft concrete `v0.1.0` GitHub Release notes.
 - Decide whether to enable branch protection settings for `main`.
-- Run and record final `v0.1.0` release verification.
+- Run and record final `v0.1.0` release verification. `#131`
 - Tag `v0.1.0` only after verification and explicit user approval.
 
 ## Non-Goals

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -89,6 +89,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Define the next milestone for post-foundation release readiness. `#125`
 - [x] Draft concrete `v0.1.0` GitHub Release notes after release readiness is confirmed. `#129`
 - [x] Decide whether to enable branch protection settings for `main`. `#127`
+- [x] Run and record final `v0.1.0` release verification. `#131`
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Add `docs/development/release-v0.1.0-verification.md` with the final release-candidate verification record.
- Link the verification record from release prep, release notes, milestone, and current TODO docs.
- Leave tag creation for explicit release approval.

## Verification
- [x] `docker compose run --rm app composer validate`
- [x] `docker compose run --rm app composer check`
- [x] `npm run check --prefix frontend`
- [x] `npm run build --prefix frontend`
- [x] `git diff --check`
- [x] Latest Backend and Frontend GitHub Actions on `main`

## Self-review
- `docs/review/release-ci.md`

Closes #131

Made with [Cursor](https://cursor.com)