### PR TITLE
docs: LLM delivery starter direction を記録する

### DIFF
--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -5,6 +5,7 @@ NENE2 is designed to be easy for AI agents to inspect, change, and verify withou
 ## Source of Truth
 
 - Project direction: `README.md` and `docs/roadmap.md`
+- LLM-assisted delivery direction: `docs/integrations/llm-delivery-starter.md`
 - Workflow: `docs/workflow.md`
 - Coding rules: `docs/development/coding-standards.md`
 - Current state: `docs/todo/current.md`

--- a/docs/integrations/llm-delivery-starter.md
+++ b/docs/integrations/llm-delivery-starter.md
@@ -1,0 +1,75 @@
+# LLM Delivery Starter Direction
+
+This document records useful planning notes for NENE2 after the first `v0.1.0` foundation release.
+
+These notes are not a broad product pivot. They clarify how NENE2 should be useful to its primary maintainer when delivering LLM-assisted client work quickly and safely.
+
+## Position
+
+NENE2 is most useful when treated as a small starter kit for client delivery that needs:
+
+- a working JSON API foundation
+- an OpenAPI contract that can be shared early
+- MCP tool metadata or server integration that can be derived from the API boundary
+- predictable PHP deployment on common hosting or VPS environments
+- code structure that stays readable to humans and AI agents
+
+The first audience is the maintainer and trusted project collaborators, not a broad public framework market.
+
+## Why This Matters
+
+For LLM-assisted delivery work, the valuable outcome is not framework popularity. The valuable outcome is reducing the time between project start and a credible technical handoff:
+
+- API behavior is documented before it spreads across implementation details.
+- AI agents can inspect the project through committed docs and stable commands.
+- MCP integrations can be built from application boundaries instead of direct database or filesystem access.
+- Small client projects can start from a known runtime, CI, test, and documentation baseline.
+
+This direction fits the current NENE2 foundation better than trying to compete directly with full-stack frameworks.
+
+## Prioritization Notes
+
+The next work should favor capabilities that help a maintainer deliver a small API or AI-enabled system quickly.
+
+High-value next candidates:
+
+- implement a local MCP server that clients can actually connect to
+- add an API-key authentication middleware path suitable for machine clients
+- add a documented way to create new API endpoints with OpenAPI and tests together
+- add real service database checks, starting with MySQL or PostgreSQL in Docker Compose
+
+Lower-priority work for now:
+
+- Packagist publication
+- broad public marketing
+- release automation beyond the first manual release path
+- framework convenience layers that make code less explicit
+
+## Boundaries
+
+NENE2 should keep these constraints:
+
+- Do not expose MCP tools that bypass the documented API or service boundary.
+- Do not treat direct production database access as a first-class AI integration.
+- Do not make frontend tooling part of the backend runtime contract.
+- Do not promise `1.0.0` style public API stability while the framework is still proving its shape.
+- Do not add broad framework features unless they help real delivery workflows.
+
+## Success Signals
+
+This direction is working when a new client-style project can quickly produce:
+
+- a running local API
+- OpenAPI documentation
+- a small set of tested endpoints
+- a safe read-only MCP integration path
+- basic machine-client authentication
+- clear handoff docs that explain what exists and what is deferred
+
+## Related Documents
+
+- Roadmap: `docs/roadmap.md`
+- AI tooling policy: `docs/integrations/ai-tools.md`
+- MCP tool policy: `docs/integrations/mcp-tools.md`
+- Local MCP server guidance: `docs/integrations/local-mcp-server.md`
+- Authentication boundary: `docs/development/authentication-boundary.md`

--- a/docs/integrations/mcp-tools.md
+++ b/docs/integrations/mcp-tools.md
@@ -6,6 +6,8 @@ NENE2 MCP tools should expose application capabilities through documented bounda
 
 MCP integration is an API-facing integration layer.
 
+NENE2's LLM-assisted delivery direction is documented in `docs/integrations/llm-delivery-starter.md`.
+
 The default direction is:
 
 - derive tool shape from OpenAPI where practical

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,8 @@ NENE2 should let a developer clone one repository and quickly build:
 - testable use cases and adapters
 - OpenAPI and MCP integrations through documented boundaries
 
+The first practical delivery target is documented in `docs/integrations/llm-delivery-starter.md`: NENE2 should help its maintainer start LLM-assisted client work with a working API, clear OpenAPI handoff, and safe MCP integration path.
+
 ## Phase 0: Project Foundation
 
 Goal: make contribution, AI operation, and technical direction unambiguous before runtime code grows.
@@ -85,6 +87,7 @@ Goal: make the React + TypeScript starter easy to adopt without making NENE2 a f
 
 Goal: let AI tools inspect and operate the app through safe, documented contracts.
 
+- LLM-assisted delivery starter direction
 - MCP server integration guidance
 - API-key or token boundary policy
 - tool definitions derived from OpenAPI where practical

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: `docs/milestones/2026-05-v0.1.0-release-readiness.md`
+- Current milestone: choose next milestone after `v0.1.0`
 - Current GitHub Issue: none
 - Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
@@ -90,6 +90,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Draft concrete `v0.1.0` GitHub Release notes after release readiness is confirmed. `#129`
 - [x] Decide whether to enable branch protection settings for `main`. `#127`
 - [x] Run and record final `v0.1.0` release verification. `#131`
+- [x] Publish the first `v0.1.0` foundation release. `#133`
+- [x] Record LLM-assisted delivery starter direction from review notes. `#134`
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Add `docs/integrations/llm-delivery-starter.md` to capture useful review notes as planning input.
- Link the direction from the roadmap, AI tooling policy, MCP tool policy, and current TODO.
- Keep the direction scoped to NENE2 as a maintainer-first delivery starter, not a broad framework-market pivot.

## Test plan
- [x] Documentation review
- [x] `git diff --check`

Closes #134

Made with [Cursor](https://cursor.com)