### PR TITLE
docs: post-v0.1.0 LLM delivery starter milestone を定義する

### DIFF
--- a/docs/integrations/llm-delivery-starter.md
+++ b/docs/integrations/llm-delivery-starter.md
@@ -69,6 +69,7 @@ This direction is working when a new client-style project can quickly produce:
 ## Related Documents
 
 - Roadmap: `docs/roadmap.md`
+- Current milestone: `docs/milestones/2026-05-llm-delivery-starter.md`
 - AI tooling policy: `docs/integrations/ai-tools.md`
 - MCP tool policy: `docs/integrations/mcp-tools.md`
 - Local MCP server guidance: `docs/integrations/local-mcp-server.md`

--- a/docs/milestones/2026-05-llm-delivery-starter.md
+++ b/docs/milestones/2026-05-llm-delivery-starter.md
@@ -1,0 +1,63 @@
+# LLM Delivery Starter
+
+## Period
+
+May 2026 and after `v0.1.0`
+
+## Goal
+
+Turn the `v0.1.0` foundation into a practical starter kit for LLM-assisted client delivery.
+
+This milestone should make it realistic to start a small client-style API project and quickly produce a running API, OpenAPI handoff, and safe MCP integration path.
+
+## Theme
+
+NENE2 should become useful first as the maintainer's own delivery base:
+
+- small enough to understand quickly
+- explicit enough for AI agents to change safely
+- complete enough to demonstrate API, MCP, auth, and database boundaries in one local environment
+
+## Scope
+
+- implement a local MCP server that exposes read-only tools through documented API boundaries
+- add a basic API-key authentication middleware path for machine clients
+- define and document an endpoint scaffold workflow that keeps PHP code, OpenAPI, and tests aligned
+- add real service database verification through Docker Compose, starting with MySQL or PostgreSQL
+- keep the existing React starter optional and decoupled from backend runtime behavior
+- keep Packagist publication deferred until the starter proves its project shape
+
+## Acceptance Criteria
+
+- A local MCP client can connect to a documented NENE2 MCP server and call at least one read-only tool.
+- The first protected JSON API path can require an API key and return Problem Details on authentication failure.
+- A documented endpoint creation workflow exists and is exercised by at least one small example endpoint.
+- Docker-based database verification covers at least one real service database in addition to SQLite adapter tests.
+- `docs/todo/current.md` points at this milestone and lists concrete next candidates.
+- Follow-up work remains split into small GitHub Issues and PRs.
+
+## Candidate Issues
+
+- Implement the first local MCP server for read-only OpenAPI-aligned tools.
+- Add API-key authentication middleware for machine-client requests.
+- Create endpoint scaffold documentation and the first example endpoint workflow.
+- Add Docker Compose real database service verification.
+- Review whether `v0.1.x` should include patch releases for milestone increments.
+
+## Non-Goals
+
+- Production MCP deployment before local behavior is proven.
+- OAuth, user login, or full authorization policy.
+- Direct production database access through MCP tools.
+- Packagist publication.
+- Broad framework marketing.
+- Release automation before the manual release path has been exercised a little more.
+
+## Related Work
+
+- Delivery direction: `docs/integrations/llm-delivery-starter.md`
+- MCP tool policy: `docs/integrations/mcp-tools.md`
+- Local MCP server guidance: `docs/integrations/local-mcp-server.md`
+- Authentication boundary: `docs/development/authentication-boundary.md`
+- Database test strategy: `docs/development/test-database-strategy.md`
+- GitHub Issue: `#136`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-This roadmap keeps NENE2 focused on a small, modern, AI-readable PHP framework foundation.
+This roadmap keeps NENE2 focused on a small, modern, AI-readable PHP framework foundation and delivery starter.
 
 ## North Star
 
@@ -107,6 +107,21 @@ Goal: keep the framework small while making changes safe.
 - mutation or architecture tests where useful
 - semantic versioning policy
 - release checklist
+
+Tracked by `docs/milestones/2026-05-v0.1.0-release-readiness.md` for the first foundation release.
+
+## Phase 6: LLM Delivery Starter
+
+Goal: make the released foundation useful for real LLM-assisted client delivery.
+
+- local MCP server that clients can connect to
+- read-only MCP tools aligned with OpenAPI and Problem Details behavior
+- API-key authentication middleware for machine clients
+- endpoint scaffold workflow that keeps PHP code, OpenAPI, and tests aligned
+- real service database verification through Docker Compose
+- small `v0.1.x` patch releases when delivery-starter increments are worth tagging
+
+Tracked by `docs/milestones/2026-05-llm-delivery-starter.md`.
 
 ## Non-Goals
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: choose next milestone after `v0.1.0`
+- Current milestone: `docs/milestones/2026-05-llm-delivery-starter.md`
 - Current GitHub Issue: none
 - Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
@@ -92,6 +92,15 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Run and record final `v0.1.0` release verification. `#131`
 - [x] Publish the first `v0.1.0` foundation release. `#133`
 - [x] Record LLM-assisted delivery starter direction from review notes. `#134`
+- [x] Define the post-`v0.1.0` LLM delivery starter milestone. `#136`
+
+## LLM Delivery Starter Candidates
+
+- [ ] Implement the first local MCP server for read-only OpenAPI-aligned tools.
+- [ ] Add API-key authentication middleware for machine-client requests.
+- [ ] Create endpoint scaffold documentation and the first example endpoint workflow.
+- [ ] Add Docker Compose real database service verification.
+- [ ] Review whether `v0.1.x` should include patch releases for milestone increments.
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Add `docs/milestones/2026-05-llm-delivery-starter.md` for the next stage after `v0.1.0`.
- Extend the roadmap with Phase 6 focused on local MCP, API-key auth, endpoint scaffolding, and real database verification.
- Update `docs/todo/current.md` with the new current milestone and concrete next candidates.

## Test plan
- [x] Documentation review
- [x] `git diff --check`
- [x] Linter diagnostics for edited docs

Closes #136

Made with [Cursor](https://cursor.com)