### PR TITLE
feat: read-only local MCP server を追加する

### DIFF
--- a/docs/integrations/local-mcp-server.md
+++ b/docs/integrations/local-mcp-server.md
@@ -15,6 +15,36 @@ It should use:
 - `docs/mcp/tools.json`
 - documented safe local commands
 
+## First Local Server
+
+NENE2 includes a first local-only stdio MCP server:
+
+```bash
+docker compose run --rm app php tools/local-mcp-server.php
+```
+
+By default it calls the local API at `http://localhost:8080`. Override the base URL outside the repository when needed:
+
+```bash
+NENE2_LOCAL_API_BASE_URL=http://localhost:8080 docker compose run --rm app php tools/local-mcp-server.php
+```
+
+When running the server inside Docker against the Compose `app` service, use the service name as the API base URL:
+
+```bash
+NENE2_LOCAL_API_BASE_URL=http://app docker compose run --rm app php tools/local-mcp-server.php
+```
+
+The first server supports:
+
+- `initialize`
+- `tools/list`
+- `tools/call`
+
+Tools are loaded from `docs/mcp/tools.json`. The first supported calls are read-only OpenAPI-aligned HTTP GET tools such as `getHealth` and `getFrameworkSmoke`.
+
+The server communicates over newline-delimited JSON-RPC messages on stdio. It is intended for local MCP clients and development smoke checks, not direct browser use.
+
 It must not use:
 
 - direct production database access

--- a/docs/milestones/2026-05-llm-delivery-starter.md
+++ b/docs/milestones/2026-05-llm-delivery-starter.md
@@ -29,7 +29,7 @@ NENE2 should become useful first as the maintainer's own delivery base:
 
 ## Acceptance Criteria
 
-- A local MCP client can connect to a documented NENE2 MCP server and call at least one read-only tool.
+- A local MCP client can connect to a documented NENE2 MCP server and call at least one read-only tool. `#138`
 - The first protected JSON API path can require an API key and return Problem Details on authentication failure.
 - A documented endpoint creation workflow exists and is exercised by at least one small example endpoint.
 - Docker-based database verification covers at least one real service database in addition to SQLite adapter tests.
@@ -38,7 +38,7 @@ NENE2 should become useful first as the maintainer's own delivery base:
 
 ## Candidate Issues
 
-- Implement the first local MCP server for read-only OpenAPI-aligned tools.
+- Implement the first local MCP server for read-only OpenAPI-aligned tools. `#138`
 - Add API-key authentication middleware for machine-client requests.
 - Create endpoint scaffold documentation and the first example endpoint workflow.
 - Add Docker Compose real database service verification.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -96,7 +96,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## LLM Delivery Starter Candidates
 
-- [ ] Implement the first local MCP server for read-only OpenAPI-aligned tools.
+- [x] Implement the first local MCP server for read-only OpenAPI-aligned tools. `#138`
 - [ ] Add API-key authentication middleware for machine-client requests.
 - [ ] Create endpoint scaffold documentation and the first example endpoint workflow.
 - [ ] Add Docker Compose real database service verification.

--- a/src/Mcp/LocalMcpException.php
+++ b/src/Mcp/LocalMcpException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Mcp;
+
+use RuntimeException;
+
+final class LocalMcpException extends RuntimeException
+{
+}

--- a/src/Mcp/LocalMcpHttpClientInterface.php
+++ b/src/Mcp/LocalMcpHttpClientInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Mcp;
+
+interface LocalMcpHttpClientInterface
+{
+    public function get(string $baseUrl, string $path): LocalMcpHttpResponse;
+}

--- a/src/Mcp/LocalMcpHttpResponse.php
+++ b/src/Mcp/LocalMcpHttpResponse.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Mcp;
+
+final readonly class LocalMcpHttpResponse
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function __construct(
+        public int $statusCode,
+        public array $headers,
+        public string $body,
+    ) {
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->statusCode >= 200 && $this->statusCode < 300;
+    }
+
+    public function requestId(): ?string
+    {
+        return $this->headers['x-request-id'] ?? null;
+    }
+}

--- a/src/Mcp/LocalMcpServer.php
+++ b/src/Mcp/LocalMcpServer.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Mcp;
+
+/**
+ * @phpstan-import-type McpTool from LocalMcpToolCatalog
+ */
+final readonly class LocalMcpServer
+{
+    public function __construct(
+        private LocalMcpToolCatalog $catalog,
+        private LocalMcpHttpClientInterface $httpClient,
+        private string $apiBaseUrl,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     * @return array<string, mixed>|null
+     */
+    public function handle(array $message): ?array
+    {
+        $method = $message['method'] ?? null;
+        $id = $message['id'] ?? null;
+
+        if (!is_string($method)) {
+            return $this->error($id, -32600, 'JSON-RPC request must include a method.');
+        }
+
+        if (!array_key_exists('id', $message)) {
+            return null;
+        }
+
+        try {
+            return match ($method) {
+                'initialize' => $this->success($id, $this->initializeResult()),
+                'tools/list' => $this->success($id, $this->toolsListResult()),
+                'tools/call' => $this->success($id, $this->toolsCallResult($message['params'] ?? null)),
+                default => $this->error($id, -32601, sprintf('Method "%s" is not supported.', $method)),
+            };
+        } catch (LocalMcpException $exception) {
+            return $this->error($id, -32603, $exception->getMessage());
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function initializeResult(): array
+    {
+        return [
+            'protocolVersion' => '2024-11-05',
+            'capabilities' => [
+                'tools' => [
+                    'listChanged' => false,
+                ],
+            ],
+            'serverInfo' => [
+                'name' => 'nene2-local-mcp',
+                'version' => '0.1.0',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toolsListResult(): array
+    {
+        return [
+            'tools' => array_map(
+                fn (array $tool): array => [
+                    'name' => $tool['name'],
+                    'title' => $tool['title'],
+                    'description' => $tool['description'],
+                    'inputSchema' => $this->mcpInputSchema($tool['inputSchema']),
+                    'annotations' => [
+                        'readOnlyHint' => $tool['safety'] === 'read',
+                    ],
+                ],
+                $this->catalog->tools(),
+            ),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @return array<string, mixed>
+     */
+    private function mcpInputSchema(array $schema): array
+    {
+        if (($schema['properties'] ?? null) === []) {
+            $schema['properties'] = new \stdClass();
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @param mixed $params
+     * @return array<string, mixed>
+     */
+    private function toolsCallResult(mixed $params): array
+    {
+        if (!is_array($params)) {
+            throw new LocalMcpException('tools/call params must be an object.');
+        }
+
+        $name = $params['name'] ?? null;
+        $arguments = $params['arguments'] ?? [];
+
+        if (!is_string($name) || $name === '') {
+            throw new LocalMcpException('tools/call params.name must be a non-empty string.');
+        }
+
+        if (!is_array($arguments)) {
+            throw new LocalMcpException('tools/call params.arguments must be an object when provided.');
+        }
+
+        if ($arguments !== []) {
+            throw new LocalMcpException('The first NENE2 local MCP tools do not accept arguments.');
+        }
+
+        $tool = $this->catalog->find($name);
+
+        if ($tool === null) {
+            throw new LocalMcpException(sprintf('MCP tool "%s" was not found.', $name));
+        }
+
+        if ($tool['safety'] !== 'read') {
+            throw new LocalMcpException(sprintf('MCP tool "%s" is not read-only.', $name));
+        }
+
+        if ($tool['source']['type'] !== 'openapi' || $tool['source']['method'] !== 'GET') {
+            throw new LocalMcpException(sprintf('MCP tool "%s" does not map to a local GET API operation.', $name));
+        }
+
+        return $this->httpToolResult($tool);
+    }
+
+    /**
+     * @param McpTool $tool
+     * @return array<string, mixed>
+     */
+    private function httpToolResult(array $tool): array
+    {
+        $response = $this->httpClient->get($this->apiBaseUrl, $tool['source']['path']);
+        $body = $this->decodeBody($response->body);
+
+        $structuredContent = [
+            'tool' => $tool['name'],
+            'operationId' => $tool['source']['operationId'],
+            'statusCode' => $response->statusCode,
+            'requestId' => $response->requestId(),
+            'body' => $body,
+        ];
+
+        return [
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => json_encode($structuredContent, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+                ],
+            ],
+            'structuredContent' => $structuredContent,
+            'isError' => !$response->isSuccessful(),
+        ];
+    }
+
+    private function decodeBody(string $body): mixed
+    {
+        try {
+            return json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return $body;
+        }
+    }
+
+    /**
+     * @param mixed $id
+     * @param array<string, mixed> $result
+     * @return array<string, mixed>
+     */
+    private function success(mixed $id, array $result): array
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'id' => $id,
+            'result' => $result,
+        ];
+    }
+
+    /**
+     * @param mixed $id
+     * @return array<string, mixed>
+     */
+    private function error(mixed $id, int $code, string $message): array
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'id' => $id,
+            'error' => [
+                'code' => $code,
+                'message' => $message,
+            ],
+        ];
+    }
+}

--- a/src/Mcp/LocalMcpToolCatalog.php
+++ b/src/Mcp/LocalMcpToolCatalog.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Mcp;
+
+/**
+ * @phpstan-type McpToolSource array{type: string, operationId: string, method: string, path: string}
+ * @phpstan-type McpTool array{name: string, title: string, description: string, safety: string, source: McpToolSource, inputSchema: array<string, mixed>, responseSchemaRef: string}
+ */
+final readonly class LocalMcpToolCatalog
+{
+    public function __construct(
+        private string $catalogPath,
+    ) {
+    }
+
+    /**
+     * @return list<McpTool>
+     */
+    public function tools(): array
+    {
+        $contents = file_get_contents($this->catalogPath);
+
+        if ($contents === false) {
+            throw new LocalMcpException(sprintf('MCP tool catalog could not be read from "%s".', $this->catalogPath));
+        }
+
+        $catalog = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($catalog)) {
+            throw new LocalMcpException('MCP tool catalog must parse to an object.');
+        }
+
+        $tools = $catalog['tools'] ?? null;
+
+        if (!is_array($tools)) {
+            throw new LocalMcpException('MCP tool catalog must contain a tools array.');
+        }
+
+        return array_map($this->tool(...), array_values($tools));
+    }
+
+    /**
+     * @return McpTool|null
+     */
+    public function find(string $name): ?array
+    {
+        foreach ($this->tools() as $tool) {
+            if ($tool['name'] === $name) {
+                return $tool;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed $value
+     * @return McpTool
+     */
+    private function tool(mixed $value): array
+    {
+        if (!is_array($value)) {
+            throw new LocalMcpException('Each MCP catalog tool must be an object.');
+        }
+
+        $source = $value['source'] ?? null;
+        $inputSchema = $value['inputSchema'] ?? null;
+
+        if (!is_array($source) || !is_array($inputSchema)) {
+            throw new LocalMcpException('Each MCP catalog tool must define source and inputSchema objects.');
+        }
+
+        return [
+            'name' => $this->stringValue($value, 'name'),
+            'title' => $this->stringValue($value, 'title'),
+            'description' => $this->stringValue($value, 'description'),
+            'safety' => $this->stringValue($value, 'safety'),
+            'source' => [
+                'type' => $this->stringValue($source, 'type'),
+                'operationId' => $this->stringValue($source, 'operationId'),
+                'method' => strtoupper($this->stringValue($source, 'method')),
+                'path' => $this->stringValue($source, 'path'),
+            ],
+            'inputSchema' => $inputSchema,
+            'responseSchemaRef' => $this->stringValue($value, 'responseSchemaRef'),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function stringValue(array $values, string $key): string
+    {
+        $value = $values[$key] ?? null;
+
+        if (!is_string($value) || $value === '') {
+            throw new LocalMcpException(sprintf('MCP catalog field "%s" must be a non-empty string.', $key));
+        }
+
+        return $value;
+    }
+}

--- a/src/Mcp/NativeLocalMcpHttpClient.php
+++ b/src/Mcp/NativeLocalMcpHttpClient.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Mcp;
+
+final readonly class NativeLocalMcpHttpClient implements LocalMcpHttpClientInterface
+{
+    public function get(string $baseUrl, string $path): LocalMcpHttpResponse
+    {
+        $headers = [
+            'Accept: application/json',
+        ];
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'header' => implode("\r\n", $headers),
+                'ignore_errors' => true,
+                'timeout' => 10,
+            ],
+        ]);
+
+        $url = rtrim($baseUrl, '/') . $path;
+        $body = file_get_contents($url, false, $context);
+
+        if ($body === false) {
+            throw new LocalMcpException(sprintf('Local API request failed for "%s".', $url));
+        }
+
+        return new LocalMcpHttpResponse(
+            $this->statusCode($http_response_header),
+            $this->headers($http_response_header),
+            $body,
+        );
+    }
+
+    /**
+     * @param list<string> $responseHeaders
+     */
+    private function statusCode(array $responseHeaders): int
+    {
+        $statusLine = $responseHeaders[0] ?? '';
+
+        if (preg_match('/\AHTTP\/\S+\s+(\d{3})\b/', $statusLine, $matches) !== 1) {
+            throw new LocalMcpException('Local API response did not include an HTTP status line.');
+        }
+
+        return (int) $matches[1];
+    }
+
+    /**
+     * @param list<string> $responseHeaders
+     * @return array<string, string>
+     */
+    private function headers(array $responseHeaders): array
+    {
+        $headers = [];
+
+        foreach ($responseHeaders as $header) {
+            if (!str_contains($header, ':')) {
+                continue;
+            }
+
+            [$name, $value] = explode(':', $header, 2);
+            $headers[strtolower(trim($name))] = trim($value);
+        }
+
+        return $headers;
+    }
+}

--- a/tests/Mcp/LocalMcpServerTest.php
+++ b/tests/Mcp/LocalMcpServerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Mcp;
+
+use Nene2\Mcp\LocalMcpHttpClientInterface;
+use Nene2\Mcp\LocalMcpHttpResponse;
+use Nene2\Mcp\LocalMcpServer;
+use Nene2\Mcp\LocalMcpToolCatalog;
+use PHPUnit\Framework\TestCase;
+
+final class LocalMcpServerTest extends TestCase
+{
+    public function testInitializeReturnsServerCapabilities(): void
+    {
+        $server = $this->server();
+
+        $response = $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+            'params' => [],
+        ]);
+
+        self::assertSame('2.0', $response['jsonrpc'] ?? null);
+        self::assertSame(1, $response['id'] ?? null);
+        self::assertSame('nene2-local-mcp', $response['result']['serverInfo']['name'] ?? null);
+        self::assertSame(false, $response['result']['capabilities']['tools']['listChanged'] ?? null);
+    }
+
+    public function testToolsListReturnsCatalogTools(): void
+    {
+        $server = $this->server();
+
+        $response = $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'method' => 'tools/list',
+        ]);
+
+        self::assertSame('getHealth', $response['result']['tools'][1]['name'] ?? null);
+        self::assertSame(true, $response['result']['tools'][1]['annotations']['readOnlyHint'] ?? null);
+        self::assertInstanceOf(\stdClass::class, $response['result']['tools'][1]['inputSchema']['properties'] ?? null);
+    }
+
+    public function testToolsCallInvokesLocalHttpApiAndReturnsRequestId(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(
+            200,
+            ['x-request-id' => 'request-123'],
+            '{"status":"ok","service":"NENE2"}',
+        ));
+        $server = $this->server($client);
+
+        $response = $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 3,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'getHealth',
+                'arguments' => [],
+            ],
+        ]);
+
+        self::assertSame('http://localhost:8080', $client->baseUrl);
+        self::assertSame('/health', $client->path);
+        self::assertSame(false, $response['result']['isError'] ?? null);
+        self::assertSame('request-123', $response['result']['structuredContent']['requestId'] ?? null);
+        self::assertSame('ok', $response['result']['structuredContent']['body']['status'] ?? null);
+    }
+
+    public function testNotificationsDoNotReturnResponses(): void
+    {
+        $server = $this->server();
+
+        self::assertNull($server->handle([
+            'jsonrpc' => '2.0',
+            'method' => 'notifications/initialized',
+        ]));
+    }
+
+    private function server(?RecordingLocalMcpHttpClient $client = null): LocalMcpServer
+    {
+        return new LocalMcpServer(
+            new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json'),
+            $client ?? new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(200, [], '{}')),
+            'http://localhost:8080',
+        );
+    }
+}
+
+final class RecordingLocalMcpHttpClient implements LocalMcpHttpClientInterface
+{
+    public ?string $baseUrl = null;
+
+    public ?string $path = null;
+
+    public function __construct(
+        private readonly LocalMcpHttpResponse $response,
+    ) {
+    }
+
+    public function get(string $baseUrl, string $path): LocalMcpHttpResponse
+    {
+        $this->baseUrl = $baseUrl;
+        $this->path = $path;
+
+        return $this->response;
+    }
+}

--- a/tests/Mcp/LocalMcpToolCatalogTest.php
+++ b/tests/Mcp/LocalMcpToolCatalogTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Mcp;
+
+use Nene2\Mcp\LocalMcpToolCatalog;
+use PHPUnit\Framework\TestCase;
+
+final class LocalMcpToolCatalogTest extends TestCase
+{
+    public function testLoadsReadOnlyToolsFromCommittedCatalog(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+
+        $tool = $catalog->find('getHealth');
+
+        self::assertNotNull($tool);
+        self::assertSame('read', $tool['safety']);
+        self::assertSame('GET', $tool['source']['method']);
+        self::assertSame('/health', $tool['source']['path']);
+        self::assertSame('getHealth', $tool['source']['operationId']);
+    }
+}

--- a/tools/local-mcp-server.php
+++ b/tools/local-mcp-server.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Nene2\Mcp\LocalMcpException;
+use Nene2\Mcp\LocalMcpServer;
+use Nene2\Mcp\LocalMcpToolCatalog;
+use Nene2\Mcp\NativeLocalMcpHttpClient;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$root = dirname(__DIR__);
+$apiBaseUrl = getenv('NENE2_LOCAL_API_BASE_URL');
+
+if (!is_string($apiBaseUrl) || $apiBaseUrl === '') {
+    $apiBaseUrl = 'http://localhost:8080';
+}
+
+$server = new LocalMcpServer(
+    new LocalMcpToolCatalog($root . '/docs/mcp/tools.json'),
+    new NativeLocalMcpHttpClient(),
+    $apiBaseUrl,
+);
+
+while (($line = fgets(STDIN)) !== false) {
+    $line = trim($line);
+
+    if ($line === '') {
+        continue;
+    }
+
+    try {
+        $message = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($message)) {
+            throw new LocalMcpException('JSON-RPC message must be an object.');
+        }
+
+        $response = $server->handle($message);
+
+        if ($response === null) {
+            continue;
+        }
+    } catch (Throwable $exception) {
+        $response = [
+            'jsonrpc' => '2.0',
+            'id' => null,
+            'error' => [
+                'code' => -32700,
+                'message' => $exception->getMessage(),
+            ],
+        ];
+    }
+
+    fwrite(STDOUT, json_encode($response, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+}


### PR DESCRIPTION
## Summary
- Add a local-only stdio JSON-RPC MCP server entry point at `tools/local-mcp-server.php`.
- Load read-only OpenAPI-aligned tools from `docs/mcp/tools.json` and call the local API through a configured base URL.
- Return structured response content with HTTP status and request-id metadata, plus focused PHPUnit coverage.
- Document local usage and mark the first LLM Delivery Starter candidate complete.

## Test plan
- [x] `docker compose run --rm app vendor/bin/phpunit tests/Mcp`
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`
- [x] Local stdio smoke against `getHealth` using `NENE2_LOCAL_API_BASE_URL=http://app`

Closes #138

Made with [Cursor](https://cursor.com)