### PR TITLE
docs: endpoint scaffold workflow を追加する

### DIFF
--- a/docs/development/endpoint-scaffold.md
+++ b/docs/development/endpoint-scaffold.md
@@ -1,0 +1,103 @@
+# Endpoint Scaffold Workflow
+
+This workflow keeps new NENE2 JSON endpoints aligned across runtime code, OpenAPI, tests, and optional MCP metadata.
+
+It is intentionally manual for now. The goal is to make the steps clear before adding code generation.
+
+## Position
+
+An endpoint is complete only when its behavior is visible in all relevant places:
+
+- runtime route and handler
+- OpenAPI path, response schema, and examples
+- runtime or handler tests
+- contract tests through `docs/openapi/openapi.yaml`
+- MCP catalog updates when the endpoint should become a tool
+- documentation updates when the endpoint changes project policy or workflow
+
+## Standard Steps
+
+1. Create or reuse a focused GitHub Issue.
+2. Add or update the runtime route in the smallest appropriate handler boundary.
+3. Add the OpenAPI path with `operationId`, examples, success schema, and Problem Details responses.
+4. Add or update tests close to the behavior.
+5. Run the focused tests first, then `docker compose run --rm app composer check`.
+6. Run a local HTTP smoke check when the endpoint is reachable through Docker.
+7. Update `docs/todo/current.md`, milestone docs, or MCP catalog only when the endpoint affects current work.
+
+## Runtime Route
+
+For the current small runtime, example routes live in `RuntimeApplicationFactory`.
+
+The scaffold example is:
+
+```text
+GET /examples/ping
+```
+
+It returns:
+
+```json
+{
+  "message": "pong",
+  "status": "ok"
+}
+```
+
+This endpoint exists to exercise the workflow. Application endpoints should move toward thin handlers or use cases as behavior grows.
+
+## OpenAPI Requirements
+
+Each shipped JSON endpoint should include:
+
+- stable `operationId`
+- short summary and safe description
+- `200` response schema and `ok` example
+- appropriate Problem Details responses such as `401`, `413`, and `500`
+- security requirements only when matching middleware exists
+
+Runtime contract tests automatically read `docs/openapi/openapi.yaml` and verify documented `200` examples for JSON endpoints.
+
+## Testing Requirements
+
+Use the narrowest useful checks first:
+
+```bash
+docker compose run --rm app vendor/bin/phpunit tests/HttpRuntimeTest.php tests/OpenApi/RuntimeContractTest.php
+```
+
+Then run the full backend check:
+
+```bash
+docker compose run --rm app composer check
+```
+
+For endpoints served by Docker, run a local smoke check:
+
+```bash
+curl -i http://localhost:8080/examples/ping
+```
+
+## MCP Relationship
+
+If a new endpoint should become an MCP tool:
+
+1. Add the OpenAPI operation first.
+2. Add a read-only entry to `docs/mcp/tools.json` only when the tool can safely call the public API boundary.
+3. Run `docker compose run --rm app composer mcp`.
+4. Keep mutation, admin, and destructive tools out of scope until authentication, authorization, and audit behavior are documented and implemented.
+
+## Non-Goals
+
+- Generating endpoint files automatically before the manual workflow proves useful.
+- Hiding route behavior behind magic controller discovery.
+- Updating MCP catalog for every endpoint by default.
+- Requiring runtime OpenAPI validation before the route and schema patterns stabilize.
+
+## Related Work
+
+- Runtime: `src/Http/RuntimeApplicationFactory.php`
+- OpenAPI: `docs/openapi/openapi.yaml`
+- Runtime contract tests: `tests/OpenApi/RuntimeContractTest.php`
+- Request validation policy: `docs/development/request-validation.md`
+- MCP tool policy: `docs/integrations/mcp-tools.md`

--- a/docs/integrations/llm-delivery-starter.md
+++ b/docs/integrations/llm-delivery-starter.md
@@ -70,6 +70,7 @@ This direction is working when a new client-style project can quickly produce:
 
 - Roadmap: `docs/roadmap.md`
 - Current milestone: `docs/milestones/2026-05-llm-delivery-starter.md`
+- Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
 - AI tooling policy: `docs/integrations/ai-tools.md`
 - MCP tool policy: `docs/integrations/mcp-tools.md`
 - Local MCP server guidance: `docs/integrations/local-mcp-server.md`

--- a/docs/milestones/2026-05-llm-delivery-starter.md
+++ b/docs/milestones/2026-05-llm-delivery-starter.md
@@ -31,7 +31,7 @@ NENE2 should become useful first as the maintainer's own delivery base:
 
 - A local MCP client can connect to a documented NENE2 MCP server and call at least one read-only tool. `#138`
 - The first protected JSON API path can require an API key and return Problem Details on authentication failure. `#140`
-- A documented endpoint creation workflow exists and is exercised by at least one small example endpoint.
+- A documented endpoint creation workflow exists and is exercised by at least one small example endpoint. `#142`
 - Docker-based database verification covers at least one real service database in addition to SQLite adapter tests.
 - `docs/todo/current.md` points at this milestone and lists concrete next candidates.
 - Follow-up work remains split into small GitHub Issues and PRs.
@@ -40,7 +40,7 @@ NENE2 should become useful first as the maintainer's own delivery base:
 
 - Implement the first local MCP server for read-only OpenAPI-aligned tools. `#138`
 - Add API-key authentication middleware for machine-client requests. `#140`
-- Create endpoint scaffold documentation and the first example endpoint workflow.
+- Create endpoint scaffold documentation and the first example endpoint workflow. `#142`
 - Add Docker Compose real database service verification.
 - Review whether `v0.1.x` should include patch releases for milestone increments.
 
@@ -59,5 +59,6 @@ NENE2 should become useful first as the maintainer's own delivery base:
 - MCP tool policy: `docs/integrations/mcp-tools.md`
 - Local MCP server guidance: `docs/integrations/local-mcp-server.md`
 - Authentication boundary: `docs/development/authentication-boundary.md`
+- Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
 - Database test strategy: `docs/development/test-database-strategy.md`
 - GitHub Issue: `#136`

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -90,6 +90,30 @@ paths:
           $ref: '#/components/responses/PayloadTooLarge'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /examples/ping:
+    get:
+      tags:
+        - System
+      summary: Example ping endpoint
+      description: Returns a minimal response used to exercise the endpoint scaffold workflow.
+      operationId: getExamplePing
+      responses:
+        '200':
+          description: Example ping response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExamplePingResponse'
+              examples:
+                ok:
+                  summary: Successful example ping response
+                  value:
+                    message: pong
+                    status: ok
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -323,3 +347,19 @@ components:
           enum:
             - api_key
           example: api_key
+    ExamplePingResponse:
+      type: object
+      required:
+        - message
+        - status
+      properties:
+        message:
+          type: string
+          enum:
+            - pong
+          example: pong
+        status:
+          type: string
+          enum:
+            - ok
+          example: ok

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -98,7 +98,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 - [x] Implement the first local MCP server for read-only OpenAPI-aligned tools. `#138`
 - [x] Add API-key authentication middleware for machine-client requests. `#140`
-- [ ] Create endpoint scaffold documentation and the first example endpoint workflow.
+- [x] Create endpoint scaffold documentation and the first example endpoint workflow. `#142`
 - [ ] Add Docker Compose real database service verification.
 - [ ] Review whether `v0.1.x` should include patch releases for milestone increments.
 

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -61,6 +61,13 @@ final readonly class RuntimeApplicationFactory
                     'service' => $framework->name(),
                     'credential_type' => $request->getAttribute('nene2.auth.credential_type'),
                 ]),
+            )
+            ->get(
+                '/examples/ping',
+                static fn (ServerRequestInterface $request) => $jsonResponses->create([
+                    'message' => 'pong',
+                    'status' => 'ok',
+                ]),
             );
 
         return new MiddlewareDispatcher(

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -89,6 +89,19 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame('api_key', $payload['credential_type']);
     }
 
+    public function testExamplePingEndpointRunsThroughRuntime(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/examples/ping'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('pong', $payload['message']);
+        self::assertSame('ok', $payload['status']);
+    }
+
     public function testUnsupportedMethodReturnsProblemDetailsWithAllowHeader(): void
     {
         $factory = new Psr17Factory();


### PR DESCRIPTION
## Summary
- Add `docs/development/endpoint-scaffold.md` with the repeatable endpoint creation workflow.
- Add `GET /examples/ping` as the first small endpoint that exercises the workflow.
- Document the endpoint in OpenAPI and cover it through runtime and contract tests.
- Update the LLM Delivery Starter milestone, direction doc, and TODO state.

## Test plan
- [x] `docker compose run --rm app vendor/bin/phpunit tests/HttpRuntimeTest.php tests/OpenApi/RuntimeContractTest.php`
- [x] `docker compose run --rm app composer check`
- [x] `git diff --check`
- [x] `curl -i http://localhost:8080/examples/ping`
- [x] `curl -i http://localhost:8080/health`

Closes #142

Made with [Cursor](https://cursor.com)