### PR TITLE
docs: v0.1.x patch release 方針を整理する

### DIFF
--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -3,6 +3,7 @@
 Use this checklist for manual `v0.x.y` releases until release automation is introduced.
 
 Preparation notes for the first `v0.1.0` release live in `docs/development/release-v0.1.0-prep.md`.
+Patch release criteria for `v0.1.x` live in `docs/development/release-v0.1.x-policy.md`.
 
 ## Preconditions
 
@@ -31,6 +32,7 @@ If Docker is unavailable, run the equivalent Composer commands in a PHP `8.4` en
 - Use `0.x.y` while public contracts are still forming.
 - Use a minor version for meaningful framework surface changes.
 - Use a patch version for small fixes or documentation corrections.
+- Use a `v0.1.x` patch version for small completed delivery-starter increments only when they do not broaden the public framework surface.
 - Do not describe `0.x.y` releases as long-term public API stability promises.
 
 ## Tagging

--- a/docs/development/release-ci.md
+++ b/docs/development/release-ci.md
@@ -8,6 +8,7 @@ Release and CI policy should keep the framework safe to change while the public 
 
 Manual release steps are tracked in `docs/development/release-checklist.md`.
 The first release preparation notes live in `docs/development/release-v0.1.0-prep.md`.
+Post-`v0.1.0` patch release criteria live in `docs/development/release-v0.1.x-policy.md`.
 
 The standard direction is:
 
@@ -30,6 +31,7 @@ During early framework development, use `0.x.y` versions:
 - `0.x.y` means public contracts are still forming.
 - Minor releases may include meaningful framework surface changes.
 - Patch releases should be small fixes or documentation corrections.
+- `v0.1.x` patch releases can also bundle small completed LLM Delivery Starter increments when they improve the existing foundation without broadening the public framework surface.
 - Avoid `1.0.0` until HTTP runtime, DI, config, validation, error responses, and OpenAPI contract conventions are stable enough for users.
 
 After `1.0.0`, these changes are breaking changes and require a major version:

--- a/docs/development/release-v0.1.x-policy.md
+++ b/docs/development/release-v0.1.x-policy.md
@@ -1,0 +1,63 @@
+# v0.1.x Patch Release Policy
+
+This document records how NENE2 should handle small `v0.1.x` releases after the first `v0.1.0` foundation release.
+
+It does not create a tag.
+
+## Position
+
+`v0.1.x` patch releases are useful when a completed increment makes the existing `v0.1.0` foundation easier to use without changing its overall product shape.
+
+Use a patch release for small, self-contained improvements such as:
+
+- bug fixes in shipped runtime, configuration, tests, or tooling
+- documentation corrections that materially improve setup or handoff
+- local verification improvements that do not change public contracts
+- LLM Delivery Starter increments that complete an already-scoped milestone candidate
+
+Use a later minor release such as `v0.2.0` for changes that broaden the framework surface:
+
+- new public extension points
+- substantial runtime behavior changes
+- authentication or authorization policy beyond the current machine API-key path
+- production MCP deployment behavior
+- generated endpoint or MCP tooling that changes the development workflow
+- Packagist publication or support expectations for external users
+
+## Candidate `v0.1.x` Baseline
+
+The first post-`v0.1.0` patch release can include the completed LLM Delivery Starter foundation increments if the maintainer wants a checkpoint tag:
+
+- local MCP server for read-only OpenAPI-aligned tools
+- API-key middleware for machine-client requests
+- endpoint scaffold workflow with the first example endpoint
+- Docker Compose MySQL verification as an opt-in real database check
+
+These changes are useful together as a delivery-starter checkpoint, but they do not require an immediate release tag.
+
+## Before Tagging
+
+Before tagging a `v0.1.x` release:
+
+1. Confirm all included Issues and PRs are merged to `main`.
+2. Confirm Backend and Frontend GitHub Actions pass on the release commit.
+3. Run the manual release checklist in `docs/development/release-checklist.md`.
+4. Draft short GitHub Release notes with highlights, verification, related Issues, and known follow-up work.
+5. Get explicit release approval before creating and pushing the tag.
+
+The tag must point to an up-to-date `main` commit and use the `vX.Y.Z` format.
+
+## Non-Goals
+
+- No automatic patch release after every merged PR.
+- No release tag without explicit approval.
+- No Packagist publication as part of `v0.1.x` by default.
+- No promise of `1.0.0` public API stability.
+
+## Related Work
+
+- Release policy: `docs/development/release-ci.md`
+- Release checklist: `docs/development/release-checklist.md`
+- LLM Delivery Starter milestone: `docs/milestones/2026-05-llm-delivery-starter.md`
+- Current TODO: `docs/todo/current.md`
+- GitHub Issue: `#146`

--- a/docs/milestones/2026-05-llm-delivery-starter.md
+++ b/docs/milestones/2026-05-llm-delivery-starter.md
@@ -33,6 +33,7 @@ NENE2 should become useful first as the maintainer's own delivery base:
 - The first protected JSON API path can require an API key and return Problem Details on authentication failure. `#140`
 - A documented endpoint creation workflow exists and is exercised by at least one small example endpoint. `#142`
 - Docker-based database verification covers at least one real service database in addition to SQLite adapter tests. `#144`
+- `v0.1.x` patch release criteria are reviewed and documented before tagging any delivery-starter checkpoint. `#146`
 - `docs/todo/current.md` points at this milestone and lists concrete next candidates.
 - Follow-up work remains split into small GitHub Issues and PRs.
 
@@ -42,7 +43,7 @@ NENE2 should become useful first as the maintainer's own delivery base:
 - Add API-key authentication middleware for machine-client requests. `#140`
 - Create endpoint scaffold documentation and the first example endpoint workflow. `#142`
 - Add Docker Compose real database service verification. `#144`
-- Review whether `v0.1.x` should include patch releases for milestone increments.
+- Review whether `v0.1.x` should include patch releases for milestone increments. `#146`
 
 ## Non-Goals
 
@@ -61,4 +62,5 @@ NENE2 should become useful first as the maintainer's own delivery base:
 - Authentication boundary: `docs/development/authentication-boundary.md`
 - Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
 - Database test strategy: `docs/development/test-database-strategy.md`
+- `v0.1.x` patch release policy: `docs/development/release-v0.1.x-policy.md`
 - GitHub Issue: `#136`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -100,7 +100,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add API-key authentication middleware for machine-client requests. `#140`
 - [x] Create endpoint scaffold documentation and the first example endpoint workflow. `#142`
 - [x] Add Docker Compose real database service verification. `#144`
-- [ ] Review whether `v0.1.x` should include patch releases for milestone increments.
+- [x] Review whether `v0.1.x` should include patch releases for milestone increments. `#146`
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Add a dedicated `v0.1.x` patch release policy for post-`v0.1.0` delivery-starter checkpoints.
- Clarify when small completed LLM Delivery Starter increments fit a patch release versus a later minor release.
- Link the decision from release policy, release checklist, milestone, and current TODO.

## Test plan
- [x] `docker compose run --rm app composer check`
- [x] `npm run check --prefix frontend`
- [x] `npm run build --prefix frontend`
- [x] `git diff --check`

Closes #146

Made with [Cursor](https://cursor.com)