### PR TITLE
docs: 次フェーズ導線を整備する

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,62 @@ PHP micro-framework: JSON APIs first, minimal server HTML, easy React starter in
 
 NENE2 is a small, modern PHP framework foundation extracted from the lessons of the original NeNe framework and the 9lick.me modernization work. It is designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add a React frontend starter without turning the backend into frontend build glue.
 
+The current `v0.1.x` direction is a practical starter for LLM-assisted client delivery: a maintainer can clone the repository, run a local API, share an OpenAPI contract, expose safe read-only MCP tools through the API boundary, and verify database behavior in Docker.
+
 ## Theme
 
 - **API first**: define behavior through clear HTTP boundaries and OpenAPI contracts.
 - **Simple HTML**: keep server HTML minimal, predictable, and easy to replace with SPA shells.
 - **Frontend ready**: provide a React + TypeScript starter direction while keeping the frontend layer replaceable.
 - **AI readable**: prefer explicit directories, small classes, typed boundaries, and documented decisions.
+- **LLM delivery ready**: keep API, MCP, auth, database, and handoff docs aligned for small client-style projects.
 - **Modern PHP**: use strict types, PSR-oriented style, dependency injection, automated tests, and static analysis.
+
+## Current Capabilities
+
+The foundation currently includes:
+
+- PSR-7 / PSR-15 / PSR-17 HTTP runtime with explicit routing and middleware.
+- OpenAPI contract, Swagger UI, and runtime contract tests for shipped JSON endpoints.
+- RFC 9457 Problem Details error responses.
+- Typed app and database configuration through `.env` loading boundaries.
+- PSR-11 dependency injection with explicit runtime service wiring.
+- PDO connection, query executor, transaction manager, SQLite tests, and opt-in MySQL verification through Docker Compose.
+- API-key middleware for the first protected machine-client path.
+- Local MCP server support for read-only OpenAPI-aligned tools.
+- React + TypeScript + Vite starter kept optional and decoupled from backend runtime behavior.
+
+## Quick Start
+
+Build the PHP runtime, install dependencies, and run the standard backend checks:
+
+```bash
+docker compose build
+docker compose run --rm app composer install
+docker compose run --rm app composer check
+```
+
+Start the local web runtime:
+
+```bash
+docker compose up -d app
+```
+
+The web entry point is served from `public_html/` at `http://localhost:8080/`.
+
+Useful local URLs:
+
+- API health: `http://localhost:8080/health`
+- Example endpoint: `http://localhost:8080/examples/ping`
+- OpenAPI: `http://localhost:8080/openapi.php`
+- Swagger UI: `http://localhost:8080/docs/`
+
+Run optional real MySQL verification when database adapter behavior should be checked against a service database:
+
+```bash
+docker compose up -d mysql
+docker compose run --rm app composer test:database:mysql
+```
 
 ## Development Principles
 
@@ -55,23 +104,13 @@ NENE2 uses a single repository with Composer at the root, PHP framework code in 
 
 See `docs/development/project-layout.md` for the design details and placement rules.
 
-## PHP Tooling
+## Development Commands
 
 NENE2 targets PHP `>=8.4.1 <9.0`. Docker is the standard development runtime, so the host OS does not need to provide that PHP version.
 
 ```bash
-docker compose build
-docker compose run --rm app composer install
 docker compose run --rm app composer check
-docker compose up -d app
 ```
-
-The web entry point is served from `public_html/` at `http://localhost:8080/`.
-
-OpenAPI and Swagger UI are available in Docker development:
-
-- OpenAPI: `http://localhost:8080/openapi.php`
-- Swagger UI: `http://localhost:8080/docs/`
 
 Composer lives at the repository root and provides the first backend verification commands:
 
@@ -80,11 +119,26 @@ composer validate
 composer test
 composer analyse
 composer check
+composer test:database
+composer test:database:mysql
 ```
 
 See `docs/development/php-runtime.md` and `docs/development/docker.md` for runtime and tooling details.
 
 NENE2's planned quality baseline adds PHP-CS-Fixer for backend style checks and npm, ESLint, TypeScript, and Prettier for the React frontend starter. The frontend starter targets active Node.js LTS, commits `package-lock.json`, and keeps dependencies modern through update automation. Framework public APIs should use PHPDoc or TSDoc where comments explain contracts or extension rules. See `docs/development/quality-tools.md`, `docs/development/frontend-integration.md`, and `docs/development/documentation-comments.md`.
+
+## Delivery Starter Docs
+
+Start with these docs when adapting NENE2 for a small client-style API:
+
+- Direction: `docs/integrations/llm-delivery-starter.md`
+- Current milestone: `docs/milestones/2026-05-client-delivery-hardening.md`
+- Endpoint workflow: `docs/development/endpoint-scaffold.md`
+- Local MCP server: `docs/integrations/local-mcp-server.md`
+- MCP tool policy: `docs/integrations/mcp-tools.md`
+- Authentication boundary: `docs/development/authentication-boundary.md`
+- Database test strategy: `docs/development/test-database-strategy.md`
+- Patch release policy: `docs/development/release-v0.1.x-policy.md`
 
 ## Project Workflow
 

--- a/docs/milestones/2026-05-client-delivery-hardening.md
+++ b/docs/milestones/2026-05-client-delivery-hardening.md
@@ -1,0 +1,66 @@
+# Client Delivery Hardening
+
+## Period
+
+May 2026 and after the LLM Delivery Starter checkpoint.
+
+## Goal
+
+Make NENE2 easier to use as a small client delivery base after the first API, MCP, auth, and database boundaries are in place.
+
+This milestone should improve the path from clone to credible handoff without broadening the framework into a large full-stack product.
+
+## Theme
+
+The next work should make the existing foundation easier to explain, repeat, and adapt:
+
+- clearer README and first-run guidance
+- practical examples for API, MCP, auth, and database workflows
+- tighter handoff docs for a maintainer or trusted collaborator
+- small hardening changes that reduce setup friction
+
+## Scope
+
+- improve README entry points for setup, verification, and delivery-starter capabilities
+- add a small guide for starting a new client-style API from the current foundation
+- document a local MCP client configuration example without adding production MCP deployment
+- add a focused machine-client smoke workflow for protected API access
+- review whether a `v0.1.1` checkpoint tag is useful after the completed delivery-starter work
+- keep Packagist publication and broad marketing deferred
+
+## Acceptance Criteria
+
+- README explains the current starter capabilities and links to the most useful docs. `#148`
+- `docs/todo/current.md` points at this milestone and lists concrete next candidates. `#148`
+- A new project start guide exists for adapting NENE2 to a small client-style API.
+- Local MCP usage can be followed from committed docs without relying on chat history.
+- Protected machine-client API smoke checks are documented with safe local credentials.
+- Any `v0.1.1` tag decision uses `docs/development/release-v0.1.x-policy.md`.
+
+## Candidate Issues
+
+- Close out the LLM Delivery Starter milestone and improve README entry points. `#148`
+- Add a client project start guide for adapting the foundation.
+- Document a local MCP client configuration example.
+- Add a protected machine-client smoke workflow.
+- Decide whether to tag `v0.1.1` as a delivery-starter checkpoint.
+
+## Non-Goals
+
+- Production MCP deployment.
+- OAuth, user login, or full authorization policy.
+- Packagist publication.
+- Release automation.
+- Broad framework marketing.
+- Replacing the explicit endpoint scaffold with code generation.
+
+## Related Work
+
+- Previous milestone: `docs/milestones/2026-05-llm-delivery-starter.md`
+- Delivery direction: `docs/integrations/llm-delivery-starter.md`
+- Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
+- Local MCP server guidance: `docs/integrations/local-mcp-server.md`
+- Authentication boundary: `docs/development/authentication-boundary.md`
+- Database test strategy: `docs/development/test-database-strategy.md`
+- `v0.1.x` patch release policy: `docs/development/release-v0.1.x-policy.md`
+- GitHub Issue: `#148`

--- a/docs/milestones/2026-05-llm-delivery-starter.md
+++ b/docs/milestones/2026-05-llm-delivery-starter.md
@@ -4,6 +4,10 @@
 
 May 2026 and after `v0.1.0`
 
+## Status
+
+Completed as the first post-`v0.1.0` delivery-starter checkpoint.
+
 ## Goal
 
 Turn the `v0.1.0` foundation into a practical starter kit for LLM-assisted client delivery.
@@ -45,6 +49,18 @@ NENE2 should become useful first as the maintainer's own delivery base:
 - Add Docker Compose real database service verification. `#144`
 - Review whether `v0.1.x` should include patch releases for milestone increments. `#146`
 
+## Completion Summary
+
+This milestone turned the released foundation into a practical local starter for LLM-assisted delivery:
+
+- local MCP clients can call read-only tools through documented API boundaries
+- machine clients can use the first API-key protected JSON path
+- endpoint additions have a documented PHP/OpenAPI/test workflow
+- real MySQL verification is available through Docker Compose as an opt-in check
+- `v0.1.x` checkpoint release criteria are documented before any follow-up tag is created
+
+The next milestone is `docs/milestones/2026-05-client-delivery-hardening.md`.
+
 ## Non-Goals
 
 - Production MCP deployment before local behavior is proven.
@@ -63,4 +79,5 @@ NENE2 should become useful first as the maintainer's own delivery base:
 - Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
 - Database test strategy: `docs/development/test-database-strategy.md`
 - `v0.1.x` patch release policy: `docs/development/release-v0.1.x-policy.md`
+- Next milestone: `docs/milestones/2026-05-client-delivery-hardening.md`
 - GitHub Issue: `#136`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -123,6 +123,18 @@ Goal: make the released foundation useful for real LLM-assisted client delivery.
 
 Tracked by `docs/milestones/2026-05-llm-delivery-starter.md`.
 
+## Phase 7: Client Delivery Hardening
+
+Goal: make the delivery-starter foundation easier to reuse for small client-style API projects.
+
+- README entry points for setup, verification, and current capabilities
+- new project start guidance for adapting the foundation
+- local MCP client configuration examples
+- protected machine-client API smoke workflows
+- `v0.1.x` checkpoint release decisions after useful delivery-starter increments
+
+Tracked by `docs/milestones/2026-05-client-delivery-hardening.md`.
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: `docs/milestones/2026-05-llm-delivery-starter.md`
+- Current milestone: `docs/milestones/2026-05-client-delivery-hardening.md`
 - Current GitHub Issue: none
 - Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
@@ -101,6 +101,14 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Create endpoint scaffold documentation and the first example endpoint workflow. `#142`
 - [x] Add Docker Compose real database service verification. `#144`
 - [x] Review whether `v0.1.x` should include patch releases for milestone increments. `#146`
+
+## Client Delivery Hardening Candidates
+
+- [x] Close out the LLM Delivery Starter milestone and improve README entry points. `#148`
+- [ ] Add a client project start guide for adapting the foundation.
+- [ ] Document a local MCP client configuration example.
+- [ ] Add a protected machine-client smoke workflow.
+- [ ] Decide whether to tag `v0.1.1` as a delivery-starter checkpoint.
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Close out the LLM Delivery Starter milestone with a completion summary.
- Add the next `Client Delivery Hardening` milestone and roadmap phase.
- Update `docs/todo/current.md` to point at the next milestone and list concrete candidates.
- Improve README entry points for current capabilities, quick start, and delivery-starter docs.

## Test plan
- [x] `docker compose run --rm app composer check`
- [x] `npm run check --prefix frontend`
- [x] `npm run build --prefix frontend`
- [x] `git diff --check`

Closes #148

Made with [Cursor](https://cursor.com)