### PR TITLE
docs: local MCP client configuration example を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Start with these docs when adapting NENE2 for a small client-style API:
 - Client project start guide: `docs/development/client-project-start.md`
 - Endpoint workflow: `docs/development/endpoint-scaffold.md`
 - Local MCP server: `docs/integrations/local-mcp-server.md`
+- Local MCP client configuration: `docs/integrations/local-mcp-client-configuration.md`
 - MCP tool policy: `docs/integrations/mcp-tools.md`
 - Authentication boundary: `docs/development/authentication-boundary.md`
 - Database test strategy: `docs/development/test-database-strategy.md`

--- a/docs/development/client-project-start.md
+++ b/docs/development/client-project-start.md
@@ -155,6 +155,7 @@ Before handing off a client-style project, confirm:
 
 - Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
 - Local MCP server guidance: `docs/integrations/local-mcp-server.md`
+- Local MCP client configuration: `docs/integrations/local-mcp-client-configuration.md`
 - MCP tool policy: `docs/integrations/mcp-tools.md`
 - Authentication boundary: `docs/development/authentication-boundary.md`
 - Database test strategy: `docs/development/test-database-strategy.md`

--- a/docs/integrations/local-mcp-client-configuration.md
+++ b/docs/integrations/local-mcp-client-configuration.md
@@ -1,0 +1,121 @@
+# Local MCP Client Configuration
+
+This guide shows how to connect a local MCP client to the NENE2 stdio MCP server.
+
+It is for local development only. Do not reuse this configuration for production MCP deployment.
+
+## Preconditions
+
+Build the PHP image and start the local API:
+
+```bash
+docker compose build app
+docker compose up -d app
+```
+
+Confirm the API is reachable:
+
+```bash
+curl -i http://localhost:8080/health
+```
+
+The MCP server is a stdio process. It is not an HTTP server and should be launched by an MCP client.
+
+## Generic Stdio Configuration
+
+Use this shape in MCP clients that accept a command, arguments, and environment variables:
+
+```json
+{
+  "mcpServers": {
+    "nene2-local": {
+      "command": "docker",
+      "args": [
+        "compose",
+        "run",
+        "--rm",
+        "-e",
+        "NENE2_LOCAL_API_BASE_URL=http://app",
+        "app",
+        "php",
+        "tools/local-mcp-server.php"
+      ]
+    }
+  }
+}
+```
+
+Why `http://app`:
+
+- the MCP server process runs inside a Docker Compose `app` container
+- the target web service is reachable by Compose service name
+- `localhost` from inside that container would refer to the one-off MCP container, not the running web service
+
+Do not put secrets in committed MCP client configuration. If a future local tool needs a credential, pass only the environment variable name in docs and set the value outside the repository.
+
+## Local Smoke Check
+
+You can smoke test the server without a full MCP client by piping newline-delimited JSON-RPC messages.
+
+Start with `initialize`:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"local-smoke","version":"0.0.0"}}}' \
+  | docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
+```
+
+List tools:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
+```
+
+Call the health tool:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getHealth","arguments":{}}}' \
+  | docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
+```
+
+The response should include structured content from the documented local HTTP API and may include request id metadata.
+
+## Available Tools
+
+The first local server loads read-only tools from `docs/mcp/tools.json`.
+
+Current examples:
+
+- `getFrameworkSmoke`
+- `getHealth`
+
+Validate the catalog with:
+
+```bash
+docker compose run --rm app composer mcp
+```
+
+## Safety Rules
+
+Local MCP clients may:
+
+- call documented local HTTP APIs
+- read committed MCP metadata through the server
+- use read-only tools aligned with OpenAPI operations
+
+Local MCP clients must not:
+
+- read `.env` secrets
+- call production APIs
+- expose direct database or filesystem access
+- add write, admin, or destructive tools without a focused design and Issue
+- commit user-specific MCP client configuration
+
+## Related Work
+
+- Local MCP server guidance: `docs/integrations/local-mcp-server.md`
+- MCP tool policy: `docs/integrations/mcp-tools.md`
+- MCP catalog: `docs/mcp/tools.json`
+- Client project start guide: `docs/development/client-project-start.md`
+- Authentication boundary: `docs/development/authentication-boundary.md`
+- GitHub Issue: `#152`

--- a/docs/integrations/local-mcp-server.md
+++ b/docs/integrations/local-mcp-server.md
@@ -26,13 +26,13 @@ docker compose run --rm app php tools/local-mcp-server.php
 By default it calls the local API at `http://localhost:8080`. Override the base URL outside the repository when needed:
 
 ```bash
-NENE2_LOCAL_API_BASE_URL=http://localhost:8080 docker compose run --rm app php tools/local-mcp-server.php
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8080 app php tools/local-mcp-server.php
 ```
 
 When running the server inside Docker against the Compose `app` service, use the service name as the API base URL:
 
 ```bash
-NENE2_LOCAL_API_BASE_URL=http://app docker compose run --rm app php tools/local-mcp-server.php
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
 ```
 
 The first server supports:
@@ -44,6 +44,8 @@ The first server supports:
 Tools are loaded from `docs/mcp/tools.json`. The first supported calls are read-only OpenAPI-aligned HTTP GET tools such as `getHealth` and `getFrameworkSmoke`.
 
 The server communicates over newline-delimited JSON-RPC messages on stdio. It is intended for local MCP clients and development smoke checks, not direct browser use.
+
+Concrete local MCP client configuration examples live in `docs/integrations/local-mcp-client-configuration.md`.
 
 It must not use:
 

--- a/docs/milestones/2026-05-client-delivery-hardening.md
+++ b/docs/milestones/2026-05-client-delivery-hardening.md
@@ -33,7 +33,7 @@ The next work should make the existing foundation easier to explain, repeat, and
 - README explains the current starter capabilities and links to the most useful docs. `#148`
 - `docs/todo/current.md` points at this milestone and lists concrete next candidates. `#148`
 - A new project start guide exists for adapting NENE2 to a small client-style API. `#150`
-- Local MCP usage can be followed from committed docs without relying on chat history.
+- Local MCP usage can be followed from committed docs without relying on chat history. `#152`
 - Protected machine-client API smoke checks are documented with safe local credentials.
 - Any `v0.1.1` tag decision uses `docs/development/release-v0.1.x-policy.md`.
 
@@ -41,7 +41,7 @@ The next work should make the existing foundation easier to explain, repeat, and
 
 - Close out the LLM Delivery Starter milestone and improve README entry points. `#148`
 - Add a client project start guide for adapting the foundation. `#150`
-- Document a local MCP client configuration example.
+- Document a local MCP client configuration example. `#152`
 - Add a protected machine-client smoke workflow.
 - Decide whether to tag `v0.1.1` as a delivery-starter checkpoint.
 
@@ -61,6 +61,7 @@ The next work should make the existing foundation easier to explain, repeat, and
 - Client project start guide: `docs/development/client-project-start.md`
 - Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
 - Local MCP server guidance: `docs/integrations/local-mcp-server.md`
+- Local MCP client configuration: `docs/integrations/local-mcp-client-configuration.md`
 - Authentication boundary: `docs/development/authentication-boundary.md`
 - Database test strategy: `docs/development/test-database-strategy.md`
 - `v0.1.x` patch release policy: `docs/development/release-v0.1.x-policy.md`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -106,7 +106,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 - [x] Close out the LLM Delivery Starter milestone and improve README entry points. `#148`
 - [x] Add a client project start guide for adapting the foundation. `#150`
-- [ ] Document a local MCP client configuration example.
+- [x] Document a local MCP client configuration example. `#152`
 - [ ] Add a protected machine-client smoke workflow.
 - [ ] Decide whether to tag `v0.1.1` as a delivery-starter checkpoint.
 


### PR DESCRIPTION
## Summary
- Add a local MCP client configuration guide with a Docker Compose stdio example.
- Include JSON-RPC smoke checks for `initialize`, `tools/list`, and `getHealth`.
- Correct Docker Compose environment passing in local MCP server examples.
- Link the guide from README, client start docs, milestone, and TODO.

## Test plan
- [x] `docker compose run --rm app composer mcp`
- [x] `printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getHealth","arguments":{}}}' | docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php`
- [x] `docker compose run --rm app composer check`
- [x] `npm run check --prefix frontend`
- [x] `npm run build --prefix frontend`
- [x] `git diff --check`

Closes #152

Made with [Cursor](https://cursor.com)