### PR TITLE
docs: machine-client smoke workflow を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Start with these docs when adapting NENE2 for a small client-style API:
 - Local MCP client configuration: `docs/integrations/local-mcp-client-configuration.md`
 - MCP tool policy: `docs/integrations/mcp-tools.md`
 - Authentication boundary: `docs/development/authentication-boundary.md`
+- Machine-client smoke workflow: `docs/development/machine-client-smoke.md`
 - Database test strategy: `docs/development/test-database-strategy.md`
 - Patch release policy: `docs/development/release-v0.1.x-policy.md`
 

--- a/docs/development/authentication-boundary.md
+++ b/docs/development/authentication-boundary.md
@@ -24,6 +24,8 @@ X-NENE2-API-Key
 
 The key value is loaded from `NENE2_MACHINE_API_KEY` when configured. Leave it unset for public-only local development, and set it outside the repository when testing protected routes.
 
+Local smoke workflow for the first protected path is documented in `docs/development/machine-client-smoke.md`.
+
 ## API Keys
 
 API keys are long-lived credentials for non-human clients.

--- a/docs/development/client-project-start.md
+++ b/docs/development/client-project-start.md
@@ -123,6 +123,7 @@ curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
 Do not commit real API keys, generated secrets, or local `.env` files.
 
 Authentication policy lives in `docs/development/authentication-boundary.md`.
+The local protected route smoke workflow lives in `docs/development/machine-client-smoke.md`.
 
 ## Verify Database Behavior
 
@@ -158,6 +159,7 @@ Before handing off a client-style project, confirm:
 - Local MCP client configuration: `docs/integrations/local-mcp-client-configuration.md`
 - MCP tool policy: `docs/integrations/mcp-tools.md`
 - Authentication boundary: `docs/development/authentication-boundary.md`
+- Machine-client smoke workflow: `docs/development/machine-client-smoke.md`
 - Database test strategy: `docs/development/test-database-strategy.md`
 - Release policy: `docs/development/release-v0.1.x-policy.md`
 - Current milestone: `docs/milestones/2026-05-client-delivery-hardening.md`

--- a/docs/development/machine-client-smoke.md
+++ b/docs/development/machine-client-smoke.md
@@ -1,0 +1,99 @@
+# Machine-Client Smoke Workflow
+
+This workflow verifies the first protected machine-client API path in local Docker development.
+
+It uses a local-only placeholder key. Do not commit real API keys or local `.env` files.
+
+## Target
+
+The protected smoke endpoint is:
+
+```text
+GET /machine/health
+```
+
+It requires:
+
+```text
+X-NENE2-API-Key
+```
+
+The expected success response includes:
+
+```json
+{
+  "status": "ok",
+  "service": "NENE2",
+  "credential_type": "api_key"
+}
+```
+
+## Start With a Local Key
+
+Start or recreate the local app service with a disposable key:
+
+```bash
+NENE2_MACHINE_API_KEY=local-dev-key docker compose up -d app
+```
+
+This passes the key through `compose.yaml` into the app container for local testing only.
+
+## Verify Missing Credentials
+
+Call the protected path without a key:
+
+```bash
+curl -i http://localhost:8080/machine/health
+```
+
+Expected result:
+
+- HTTP status: `401 Unauthorized`
+- `Content-Type`: `application/problem+json; charset=utf-8`
+- Problem Details `type`: `https://nene2.dev/problems/unauthorized`
+- no secret value in the response
+
+## Verify Valid Credentials
+
+Call the same path with the configured key:
+
+```bash
+curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
+```
+
+Expected result:
+
+- HTTP status: `200 OK`
+- `Content-Type`: `application/json; charset=utf-8`
+- JSON body includes `"credential_type": "api_key"`
+- response includes `X-Request-Id`
+
+## Cleanup
+
+Unset the shell variable when the smoke check is done:
+
+```bash
+unset NENE2_MACHINE_API_KEY
+```
+
+If you want to return the running app service to public-only local development, recreate it without the key:
+
+```bash
+docker compose up -d app
+```
+
+## Safety Notes
+
+- Use placeholder values such as `local-dev-key` only for local smoke checks.
+- Do not add real credentials to `.env.example`, committed docs, screenshots, logs, or MCP metadata.
+- Do not reuse the local smoke key in production.
+- Production machine-client authentication needs explicit owner, scope, rotation, storage, and audit policy before use.
+
+## Related Work
+
+- Authentication boundary: `docs/development/authentication-boundary.md`
+- Middleware security: `docs/development/middleware-security.md`
+- Client project start guide: `docs/development/client-project-start.md`
+- OpenAPI contract: `docs/openapi/openapi.yaml`
+- Runtime tests: `tests/HttpRuntimeTest.php`
+- GitHub Issue: `#154`

--- a/docs/milestones/2026-05-client-delivery-hardening.md
+++ b/docs/milestones/2026-05-client-delivery-hardening.md
@@ -34,7 +34,7 @@ The next work should make the existing foundation easier to explain, repeat, and
 - `docs/todo/current.md` points at this milestone and lists concrete next candidates. `#148`
 - A new project start guide exists for adapting NENE2 to a small client-style API. `#150`
 - Local MCP usage can be followed from committed docs without relying on chat history. `#152`
-- Protected machine-client API smoke checks are documented with safe local credentials.
+- Protected machine-client API smoke checks are documented with safe local credentials. `#154`
 - Any `v0.1.1` tag decision uses `docs/development/release-v0.1.x-policy.md`.
 
 ## Candidate Issues
@@ -42,7 +42,7 @@ The next work should make the existing foundation easier to explain, repeat, and
 - Close out the LLM Delivery Starter milestone and improve README entry points. `#148`
 - Add a client project start guide for adapting the foundation. `#150`
 - Document a local MCP client configuration example. `#152`
-- Add a protected machine-client smoke workflow.
+- Add a protected machine-client smoke workflow. `#154`
 - Decide whether to tag `v0.1.1` as a delivery-starter checkpoint.
 
 ## Non-Goals
@@ -63,6 +63,7 @@ The next work should make the existing foundation easier to explain, repeat, and
 - Local MCP server guidance: `docs/integrations/local-mcp-server.md`
 - Local MCP client configuration: `docs/integrations/local-mcp-client-configuration.md`
 - Authentication boundary: `docs/development/authentication-boundary.md`
+- Machine-client smoke workflow: `docs/development/machine-client-smoke.md`
 - Database test strategy: `docs/development/test-database-strategy.md`
 - `v0.1.x` patch release policy: `docs/development/release-v0.1.x-policy.md`
 - GitHub Issue: `#148`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -107,7 +107,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Close out the LLM Delivery Starter milestone and improve README entry points. `#148`
 - [x] Add a client project start guide for adapting the foundation. `#150`
 - [x] Document a local MCP client configuration example. `#152`
-- [ ] Add a protected machine-client smoke workflow.
+- [x] Add a protected machine-client smoke workflow. `#154`
 - [ ] Decide whether to tag `v0.1.1` as a delivery-starter checkpoint.
 
 ## Operating Notes


### PR DESCRIPTION
## Summary
- Add a local smoke workflow for the protected `/machine/health` endpoint.
- Document expected missing-key `401` Problem Details and valid-key `200` JSON behavior.
- Link the smoke workflow from README, auth docs, client start guide, milestone, and TODO.

## Test plan
- [x] `NENE2_MACHINE_API_KEY=local-dev-key docker compose up -d app`
- [x] `curl -i http://localhost:8080/machine/health`
- [x] `curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health`
- [x] `docker compose up -d app`
- [x] `docker compose run --rm app composer check`
- [x] `npm run check --prefix frontend`
- [x] `npm run build --prefix frontend`
- [x] `git diff --check`

Closes #154

Made with [Cursor](https://cursor.com)