### PR TITLE
docs: v0.1.1 checkpoint 判断を記録する

### DIFF
--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -4,6 +4,7 @@ Use this checklist for manual `v0.x.y` releases until release automation is intr
 
 Preparation notes for the first `v0.1.0` release live in `docs/development/release-v0.1.0-prep.md`.
 Patch release criteria for `v0.1.x` live in `docs/development/release-v0.1.x-policy.md`.
+Preparation notes for the `v0.1.1` checkpoint candidate live in `docs/development/release-v0.1.1-prep.md`.
 
 ## Preconditions
 

--- a/docs/development/release-v0.1.1-prep.md
+++ b/docs/development/release-v0.1.1-prep.md
@@ -1,0 +1,95 @@
+# v0.1.1 Checkpoint Release Preparation
+
+This document records the `v0.1.1` checkpoint release decision.
+
+It does not create a tag.
+
+## Decision
+
+`v0.1.1` is a good checkpoint release candidate after the completed LLM Delivery Starter and Client Delivery Hardening increments.
+
+Reason:
+
+- the changes improve the existing `v0.1.0` foundation without broadening the public framework surface
+- the work is mostly local delivery readiness, docs, verification, and safe machine-client workflow hardening
+- the scope matches `docs/development/release-v0.1.x-policy.md`
+
+Do not tag `v0.1.1` without explicit release approval.
+
+## Candidate Scope
+
+Candidate highlights since `v0.1.0`:
+
+- local MCP server for read-only OpenAPI-aligned tools
+- API-key middleware for machine-client requests
+- endpoint scaffold workflow with the first example endpoint
+- Docker Compose MySQL verification as an opt-in real database check
+- `v0.1.x` patch release policy
+- LLM Delivery Starter milestone completion summary
+- Client Delivery Hardening milestone and README entry points
+- client project start guide
+- local MCP client configuration example
+- protected machine-client smoke workflow
+
+## Related Issues
+
+- Local MCP server: `#138`
+- API-key middleware: `#140`
+- Endpoint scaffold workflow: `#142`
+- Docker Compose real database verification: `#144`
+- `v0.1.x` patch release policy: `#146`
+- Phase close and README entry points: `#148`
+- Client project start guide: `#150`
+- Local MCP client configuration: `#152`
+- Machine-client smoke workflow: `#154`
+- This decision: `#156`
+
+## Before Tagging
+
+Before creating a `v0.1.1` tag:
+
+1. Get explicit maintainer approval to tag `v0.1.1`.
+2. Confirm `main` is up to date and clean.
+3. Confirm Backend and Frontend GitHub Actions pass on the release commit.
+4. Run the manual release checklist in `docs/development/release-checklist.md`.
+5. Draft short GitHub Release notes from the candidate scope above.
+
+Recommended local verification:
+
+```bash
+git switch main
+git pull --ff-only origin main
+docker compose run --rm app composer validate
+docker compose run --rm app composer check
+npm run check --prefix frontend
+npm run build --prefix frontend
+git diff --check
+```
+
+Optional delivery-starter smoke checks:
+
+```bash
+docker compose up -d app
+curl -i http://localhost:8080/examples/ping
+printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getHealth","arguments":{}}}' \
+  | docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
+NENE2_MACHINE_API_KEY=local-dev-key docker compose up -d app
+curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
+docker compose up -d app
+```
+
+## Non-Goals
+
+- No tag in this documentation PR.
+- No GitHub Release publication without explicit approval.
+- No Packagist publication.
+- No release automation.
+- No `1.0.0` public API stability promise.
+
+## Related Work
+
+- Patch release policy: `docs/development/release-v0.1.x-policy.md`
+- Release checklist: `docs/development/release-checklist.md`
+- Current milestone: `docs/milestones/2026-05-client-delivery-hardening.md`
+- Current TODO: `docs/todo/current.md`
+- GitHub Issue: `#156`

--- a/docs/development/release-v0.1.x-policy.md
+++ b/docs/development/release-v0.1.x-policy.md
@@ -35,6 +35,8 @@ The first post-`v0.1.0` patch release can include the completed LLM Delivery Sta
 
 These changes are useful together as a delivery-starter checkpoint, but they do not require an immediate release tag.
 
+The `v0.1.1` checkpoint decision and candidate scope are recorded in `docs/development/release-v0.1.1-prep.md`.
+
 ## Before Tagging
 
 Before tagging a `v0.1.x` release:
@@ -58,6 +60,7 @@ The tag must point to an up-to-date `main` commit and use the `vX.Y.Z` format.
 
 - Release policy: `docs/development/release-ci.md`
 - Release checklist: `docs/development/release-checklist.md`
+- `v0.1.1` checkpoint preparation: `docs/development/release-v0.1.1-prep.md`
 - LLM Delivery Starter milestone: `docs/milestones/2026-05-llm-delivery-starter.md`
 - Current TODO: `docs/todo/current.md`
 - GitHub Issue: `#146`

--- a/docs/milestones/2026-05-client-delivery-hardening.md
+++ b/docs/milestones/2026-05-client-delivery-hardening.md
@@ -35,7 +35,7 @@ The next work should make the existing foundation easier to explain, repeat, and
 - A new project start guide exists for adapting NENE2 to a small client-style API. `#150`
 - Local MCP usage can be followed from committed docs without relying on chat history. `#152`
 - Protected machine-client API smoke checks are documented with safe local credentials. `#154`
-- Any `v0.1.1` tag decision uses `docs/development/release-v0.1.x-policy.md`.
+- Any `v0.1.1` tag decision uses `docs/development/release-v0.1.x-policy.md`. `#156`
 
 ## Candidate Issues
 
@@ -43,7 +43,7 @@ The next work should make the existing foundation easier to explain, repeat, and
 - Add a client project start guide for adapting the foundation. `#150`
 - Document a local MCP client configuration example. `#152`
 - Add a protected machine-client smoke workflow. `#154`
-- Decide whether to tag `v0.1.1` as a delivery-starter checkpoint.
+- Decide whether to tag `v0.1.1` as a delivery-starter checkpoint. `#156`
 
 ## Non-Goals
 
@@ -66,4 +66,5 @@ The next work should make the existing foundation easier to explain, repeat, and
 - Machine-client smoke workflow: `docs/development/machine-client-smoke.md`
 - Database test strategy: `docs/development/test-database-strategy.md`
 - `v0.1.x` patch release policy: `docs/development/release-v0.1.x-policy.md`
+- `v0.1.1` checkpoint preparation: `docs/development/release-v0.1.1-prep.md`
 - GitHub Issue: `#148`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -108,7 +108,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add a client project start guide for adapting the foundation. `#150`
 - [x] Document a local MCP client configuration example. `#152`
 - [x] Add a protected machine-client smoke workflow. `#154`
-- [ ] Decide whether to tag `v0.1.1` as a delivery-starter checkpoint.
+- [x] Decide whether to tag `v0.1.1` as a delivery-starter checkpoint. `#156`
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Add `v0.1.1` checkpoint preparation notes without creating a tag.
- Record the decision that `v0.1.1` is a good patch release candidate after delivery-starter hardening.
- List candidate scope, related Issues, and required verification before explicit tagging approval.
- Link the decision from release docs, milestone, and TODO.

## Test plan
- [x] `docker compose run --rm app composer check`
- [x] `npm run check --prefix frontend`
- [x] `npm run build --prefix frontend`
- [x] `git diff --check`

Closes #156

Made with [Cursor](https://cursor.com)