### PR TITLE
docs: first LLM field trial 方向性を記録する

### DIFF
--- a/docs/integrations/llm-delivery-starter.md
+++ b/docs/integrations/llm-delivery-starter.md
@@ -66,10 +66,15 @@ This direction is working when a new client-style project can quickly produce:
 - basic machine-client authentication
 - clear handoff docs that explain what exists and what is deferred
 
+After the `v0.1.1` checkpoint, the next stronger signal is a first field trial: use NENE2 in a real or realistic client-style project and record an LLM/MCP tool call through the documented API boundary.
+
+Field-trial guidance lives in `docs/integrations/llm-field-trial.md`.
+
 ## Related Documents
 
 - Roadmap: `docs/roadmap.md`
 - Current milestone: `docs/milestones/2026-05-llm-delivery-starter.md`
+- Field-trial direction: `docs/integrations/llm-field-trial.md`
 - Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
 - AI tooling policy: `docs/integrations/ai-tools.md`
 - MCP tool policy: `docs/integrations/mcp-tools.md`

--- a/docs/integrations/llm-field-trial.md
+++ b/docs/integrations/llm-field-trial.md
@@ -1,0 +1,102 @@
+# LLM Field Trial Direction
+
+This document records the next practical step after the `v0.1.1` delivery-starter checkpoint.
+
+It is based on external review feedback, treated as a useful perspective rather than a market claim.
+
+## Position
+
+NENE2 is ready for a first field trial in a small client-style project.
+
+The goal is not to prove broad framework popularity. The goal is to prove that the existing API, OpenAPI, MCP, auth, database, and documentation boundaries help real delivery work.
+
+The most useful next evidence is:
+
+- a real or realistic client-style API started from NENE2
+- at least one endpoint added through the documented scaffold workflow
+- a local LLM client connected to the NENE2 MCP server
+- a recorded MCP tool call through the documented API boundary
+- a short handoff note showing what worked, what was confusing, and what should change
+
+## Why This Matters
+
+Until this happens, NENE2 is still mostly a well-prepared starter.
+
+After this happens, NENE2 has evidence that:
+
+- its docs are usable outside the original implementation chat
+- its MCP integration works in an actual LLM-assisted workflow
+- its API and OpenAPI boundaries are enough for a first handoff
+- its machine-client and database smoke workflows reduce setup uncertainty
+
+This is a better success signal than adding broad framework features early.
+
+## Field Trial Shape
+
+The first field trial should stay small.
+
+Recommended scenario:
+
+1. Start from the current `v0.1.1` release.
+2. Create a small client-style API project or sandbox.
+3. Add one new read-only endpoint using `docs/development/endpoint-scaffold.md`.
+4. Update OpenAPI and tests in the same change.
+5. Connect a local MCP client using `docs/integrations/local-mcp-client-configuration.md`.
+6. Call at least one MCP tool such as `getHealth` through the local server.
+7. Record the request id, command or client action, result, and any friction.
+8. Write a short field-trial report before expanding the framework.
+
+## Evidence to Record
+
+Record enough detail to make the result useful without exposing private client data.
+
+Good evidence:
+
+- repository or sandbox name when safe
+- NENE2 version or tag
+- endpoint added
+- OpenAPI operation id
+- MCP tool name called
+- request id from the API response when present
+- verification commands run
+- what the LLM did well
+- what the LLM could not infer from docs
+- follow-up Issues created from real friction
+
+Do not record:
+
+- client secrets
+- raw API keys
+- private customer data
+- production URLs
+- private prompts that include confidential business details
+
+## Conservative Claims
+
+NENE2 may become a useful differentiator for PHP projects that need LLM-assisted API delivery.
+
+Avoid documenting unsupported claims such as being the only PHP framework with MCP support unless there is a maintained comparison and clear evidence.
+
+Prefer claims like:
+
+- NENE2 has a documented local MCP path.
+- NENE2 keeps MCP tools behind API and OpenAPI boundaries.
+- NENE2 is optimized for small PHP API delivery with AI-readable docs.
+
+## Non-Goals
+
+- Production MCP deployment.
+- Marketing copy.
+- Broad framework comparisons.
+- Adding write/admin/destructive MCP tools.
+- Building generators before the first field trial exposes real repetition.
+
+## Related Work
+
+- Roadmap: `docs/roadmap.md`
+- Current milestone: `docs/milestones/2026-05-field-trial.md`
+- Client project start guide: `docs/development/client-project-start.md`
+- Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
+- Local MCP client configuration: `docs/integrations/local-mcp-client-configuration.md`
+- Machine-client smoke workflow: `docs/development/machine-client-smoke.md`
+- GitHub Issue: `#158`

--- a/docs/milestones/2026-05-field-trial.md
+++ b/docs/milestones/2026-05-field-trial.md
@@ -1,0 +1,64 @@
+# First LLM Field Trial
+
+## Period
+
+May 2026 and after the `v0.1.1` checkpoint release.
+
+## Goal
+
+Use NENE2 in a first real or realistic client-style project and record whether the LLM/MCP delivery workflow actually helps.
+
+This milestone should turn "the starter is ready" into "the starter has been used and observed."
+
+## Theme
+
+The next work should gather practical evidence:
+
+- one small project or sandbox starts from NENE2
+- one endpoint is added through the documented workflow
+- one local MCP client connects successfully
+- one MCP tool call is recorded through the API boundary
+- friction becomes follow-up Issues instead of guesswork
+
+## Scope
+
+- create a field-trial report template
+- run or document the first field trial against `v0.1.1`
+- record a local MCP client connection and tool call without secrets
+- record endpoint, OpenAPI, test, and handoff friction
+- create follow-up Issues from the field trial
+
+## Acceptance Criteria
+
+- Field-trial direction is documented. `#158`
+- `docs/todo/current.md` points at this milestone and lists concrete next candidates. `#158`
+- A field-trial report template exists.
+- A first field-trial report records at least one MCP tool call through the documented API boundary.
+- Follow-up Issues are created from observed friction rather than speculative feature ideas.
+
+## Candidate Issues
+
+- Record the first LLM field-trial direction and next milestone. `#158`
+- Add a field-trial report template.
+- Run the first `v0.1.1` client-style field trial.
+- Convert field-trial friction into focused follow-up Issues.
+- Decide whether any repeated field-trial step justifies a helper script or generator.
+
+## Non-Goals
+
+- Production MCP deployment.
+- Broad marketing claims.
+- Packagist publication.
+- Release automation.
+- Write/admin/destructive MCP tools.
+- Large framework features before field-trial evidence exists.
+
+## Related Work
+
+- Field-trial direction: `docs/integrations/llm-field-trial.md`
+- Client project start guide: `docs/development/client-project-start.md`
+- Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
+- Local MCP client configuration: `docs/integrations/local-mcp-client-configuration.md`
+- Machine-client smoke workflow: `docs/development/machine-client-smoke.md`
+- `v0.1.1` release prep: `docs/development/release-v0.1.1-prep.md`
+- GitHub Issue: `#158`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,6 +135,18 @@ Goal: make the delivery-starter foundation easier to reuse for small client-styl
 
 Tracked by `docs/milestones/2026-05-client-delivery-hardening.md`.
 
+## Phase 8: First LLM Field Trial
+
+Goal: prove the delivery-starter workflow in a real or realistic client-style project.
+
+- start from the `v0.1.1` checkpoint release
+- add a small endpoint using the documented scaffold workflow
+- connect a local LLM/MCP client through the documented stdio configuration
+- record at least one MCP tool call through the API boundary
+- turn observed friction into focused follow-up Issues
+
+Tracked by `docs/milestones/2026-05-field-trial.md`.
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: `docs/milestones/2026-05-client-delivery-hardening.md`
+- Current milestone: `docs/milestones/2026-05-field-trial.md`
 - Current GitHub Issue: none
 - Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
@@ -109,6 +109,14 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Document a local MCP client configuration example. `#152`
 - [x] Add a protected machine-client smoke workflow. `#154`
 - [x] Decide whether to tag `v0.1.1` as a delivery-starter checkpoint. `#156`
+
+## First LLM Field Trial Candidates
+
+- [x] Record the first LLM field-trial direction and next milestone. `#158`
+- [ ] Add a field-trial report template.
+- [ ] Run the first `v0.1.1` client-style field trial.
+- [ ] Convert field-trial friction into focused follow-up Issues.
+- [ ] Decide whether any repeated field-trial step justifies a helper script or generator.
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- Add a field-trial direction document for proving NENE2 in a real or realistic client-style project.
- Add the next `First LLM Field Trial` milestone.
- Update the roadmap and current TODO to point at the field-trial phase.
- Link the new direction from the LLM Delivery Starter notes while keeping claims conservative.

## Test plan
- [x] `docker compose run --rm app composer check`
- [x] `npm run check --prefix frontend`
- [x] `npm run build --prefix frontend`
- [x] `git diff --check`

Closes #158

Made with [Cursor](https://cursor.com)