### PR TITLE
docs: add field-trial report template

### DIFF
--- a/docs/integrations/llm-field-trial.md
+++ b/docs/integrations/llm-field-trial.md
@@ -93,6 +93,7 @@ Prefer claims like:
 
 ## Related Work
 
+- Field-trial report skeleton: `docs/templates/field-trial-report.md`
 - Roadmap: `docs/roadmap.md`
 - Current milestone: `docs/milestones/2026-05-field-trial.md`
 - Client project start guide: `docs/development/client-project-start.md`

--- a/docs/milestones/2026-05-field-trial.md
+++ b/docs/milestones/2026-05-field-trial.md
@@ -22,7 +22,7 @@ The next work should gather practical evidence:
 
 ## Scope
 
-- create a field-trial report template
+- create a field-trial report template (`#160`)
 - run or document the first field trial against `v0.1.1`
 - record a local MCP client connection and tool call without secrets
 - record endpoint, OpenAPI, test, and handoff friction
@@ -39,7 +39,7 @@ The next work should gather practical evidence:
 ## Candidate Issues
 
 - Record the first LLM field-trial direction and next milestone. `#158`
-- Add a field-trial report template.
+- Add a field-trial report template. `#160`
 - Run the first `v0.1.1` client-style field trial.
 - Convert field-trial friction into focused follow-up Issues.
 - Decide whether any repeated field-trial step justifies a helper script or generator.

--- a/docs/templates/field-trial-report.md
+++ b/docs/templates/field-trial-report.md
@@ -1,0 +1,52 @@
+# Field trial report
+
+Copy this skeleton into a sandbox or client project when you record a trial. Keep it short. Do **not** include secrets, raw API keys, private customer data, production URLs, or confidential prompt text.
+
+Direction and evidence expectations: `docs/integrations/llm-field-trial.md`.
+
+## Trial context
+
+| Item | Notes |
+| Sandbox or repository name (if safe to name) | |
+| NENE2 version or tag | |
+| Read-only endpoint(s) added or exercised | |
+| OpenAPI `operationId`(s) involved | |
+
+## MCP and API boundary
+
+| Item | Notes |
+| MCP tool name(s) called | |
+| `X-Request-Id` or equivalent from the API (if present) | |
+| Command, UI action, or high-level client step you record | |
+
+## Commands run
+
+Paste exact verification commands (strip env files and keys).
+
+```text
+
+```
+
+## Outcomes
+
+What worked well:
+
+-
+
+What the LLM inferred easily:
+
+-
+
+What docs or boundaries were unclear:
+
+-
+
+## Follow-up Issues
+
+List GitHub Issue numbers and one line each (friction-driven, not speculative features).
+
+-
+
+## Reminder (do not fill)
+
+Confirm this report omits client secrets, raw keys, production endpoints, and confidential business-only prompts.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -113,7 +113,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## First LLM Field Trial Candidates
 
 - [x] Record the first LLM field-trial direction and next milestone. `#158`
-- [ ] Add a field-trial report template.
+- [ ] Add a field-trial report template. `#160`
 - [ ] Run the first `v0.1.1` client-style field trial.
 - [ ] Convert field-trial friction into focused follow-up Issues.
 - [ ] Decide whether any repeated field-trial step justifies a helper script or generator.


### PR DESCRIPTION
## Purpose
Fulfill the First LLM Field Trial milestone item by adding a **short, copy-ready** Markdown skeleton for capturing trial evidence aligned with `docs/integrations/llm-field-trial.md`.

## Changes
- New `docs/templates/field-trial-report.md`
- Link from Related Work in `docs/integrations/llm-field-trial.md`
- Reference `#160` in `docs/milestones/2026-05-field-trial.md` (scope + candidate bullets) and `docs/todo/current.md`

## Verification
- Documentation-only PR; prose reviewed for omission of secrets and parity with 「Evidence to Record」in llm-field-trial.

Closes #160