### PR TITLE
chore(docs): mark first v0.1.1 client-style field trial complete

### DIFF
--- a/docs/milestones/2026-05-field-trial.md
+++ b/docs/milestones/2026-05-field-trial.md
@@ -23,7 +23,7 @@ The next work should gather practical evidence:
 ## Scope
 
 - create a field-trial report template (`#160`)
-- run or document the first field trial against `v0.1.1`
+- run or document the first field trial against `v0.1.1` (`#164`)
 - record a local MCP client connection and tool call without secrets
 - record endpoint, OpenAPI, test, and handoff friction
 - create follow-up Issues from the field trial
@@ -40,7 +40,7 @@ The next work should gather practical evidence:
 
 - Record the first LLM field-trial direction and next milestone. `#158`
 - Add a field-trial report template. `#160`
-- Run the first `v0.1.1` client-style field trial.
+- Run the first `v0.1.1` client-style field trial. `#164`
 - Convert field-trial friction into focused follow-up Issues.
 - Decide whether any repeated field-trial step justifies a helper script or generator.
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -114,7 +114,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 - [x] Record the first LLM field-trial direction and next milestone. `#158`
 - [x] Add a field-trial report template. `#160`
-- [ ] Run the first `v0.1.1` client-style field trial.
+- [x] Run the first `v0.1.1` client-style field trial. `#164`
 - [ ] Convert field-trial friction into focused follow-up Issues.
 - [ ] Decide whether any repeated field-trial step justifies a helper script or generator.
 


### PR DESCRIPTION
## Purpose
Marks the **`v0.1.1` client-style field trial** as executed using evidence in **`hideyukiMORI/sakura-exhibition-nene2-field-trial`** (`docs/field-trial/reports/`, MCP notes).

## Changes
- `docs/todo/current.md`
- `docs/milestones/2026-05-field-trial.md`

Closes #164