### PR TITLE
docs: link public field-trial sandbox (#166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Start with these docs when adapting NENE2 for a small client-style API:
 - Database test strategy: `docs/development/test-database-strategy.md`
 - Patch release policy: `docs/development/release-v0.1.x-policy.md`
 
+**Public field trial reference (optional):** [`hideyukiMORI/sakura-exhibition-nene2-field-trial`](https://github.com/hideyukiMORI/sakura-exhibition-nene2-field-trial) — client-style demo forked from **`v0.1.1`** with exhibition-shaped read-only APIs, OpenAPI, tests, local MCP, and field-trial reports. **Not affiliated with any real event;** see that repository’s `README.md`.
+
 ## Project Workflow
 
 NENE2 uses GitHub Issues as the source of work and local Markdown files as the project memory.

--- a/docs/development/client-project-start.md
+++ b/docs/development/client-project-start.md
@@ -18,6 +18,15 @@ Use this guide when a project needs:
 
 NENE2 is still a `0.x` foundation. Treat public contracts as useful but still forming.
 
+## Public field trial reference sandbox (optional)
+
+After the first local milestone, it can help to inspect a **completed public demo** that stayed on the documented scaffold path:
+
+- Repository: [`hideyukiMORI/sakura-exhibition-nene2-field-trial`](https://github.com/hideyukiMORI/sakura-exhibition-nene2-field-trial) (based on NENE2 **`v0.1.1`**).
+- Contents: read-only exhibition-shaped JSON APIs, OpenAPI, PHPUnit, local MCP tools, and Markdown field-trial notes.
+
+It is **not** an official product repository and **does not imply endorsement** of any real exhibition. **Fictional sandbox data** — read that project’s `README.md` and `SECURITY.md` before treating names or years as facts.
+
 ## First Local Setup
 
 Start from a clean checkout:

--- a/docs/integrations/llm-field-trial.md
+++ b/docs/integrations/llm-field-trial.md
@@ -93,6 +93,7 @@ Prefer claims like:
 
 ## Related Work
 
+- Public reference sandbox (`v0.1.1` fork, read-only demo): [`sakura-exhibition-nene2-field-trial`](https://github.com/hideyukiMORI/sakura-exhibition-nene2-field-trial) — see its `README.md` for affiliation and data disclaimers.
 - Field-trial report skeleton: `docs/templates/field-trial-report.md`
 - Roadmap: `docs/roadmap.md`
 - Current milestone: `docs/milestones/2026-05-field-trial.md`

--- a/docs/milestones/2026-05-field-trial.md
+++ b/docs/milestones/2026-05-field-trial.md
@@ -26,7 +26,8 @@ The next work should gather practical evidence:
 - run or document the first field trial against `v0.1.1` (`#164`)
 - record a local MCP client connection and tool call without secrets
 - record endpoint, OpenAPI, test, and handoff friction
-- create follow-up Issues from the field trial
+- link the public sandbox from core NENE2 docs (`#166`)
+- create focused follow-up Issues from friction (`#167`, `#168`)
 
 ## Acceptance Criteria
 
@@ -41,7 +42,8 @@ The next work should gather practical evidence:
 - Record the first LLM field-trial direction and next milestone. `#158`
 - Add a field-trial report template. `#160`
 - Run the first `v0.1.1` client-style field trial. `#164`
-- Convert field-trial friction into focused follow-up Issues.
+- Link the public reference sandbox from core NENE2 docs. `#166`
+- Convert field-trial friction into focused follow-up Issues (`#167`, `#168`).
 - Decide whether any repeated field-trial step justifies a helper script or generator.
 
 ## Non-Goals
@@ -55,6 +57,7 @@ The next work should gather practical evidence:
 
 ## Related Work
 
+- Public reference sandbox: [`hideyukiMORI/sakura-exhibition-nene2-field-trial`](https://github.com/hideyukiMORI/sakura-exhibition-nene2-field-trial) (`v0.1.1`-based demo; disclaimers in upstream `README.md`).
 - Field-trial direction: `docs/integrations/llm-field-trial.md`
 - Client project start guide: `docs/development/client-project-start.md`
 - Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -115,8 +115,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Record the first LLM field-trial direction and next milestone. `#158`
 - [x] Add a field-trial report template. `#160`
 - [x] Run the first `v0.1.1` client-style field trial. `#164`
-- [ ] Convert field-trial friction into focused follow-up Issues.
+- [x] Link public field-trial sandbox from core docs. `#166`
+- [x] Convert field-trial friction into focused follow-up Issues. `#167` `#168`
 - [ ] Decide whether any repeated field-trial step justifies a helper script or generator.
+
+_Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), `#168` (Cursor GitHub MCP PAT vs `gh` CLI)._
 
 ## Operating Notes
 


### PR DESCRIPTION
## Purpose
Make the first public field-trial sandbox **discoverable from NENE2** and record **friction as open docs Issues** (`#167`, `#168`).

## Changes
- **`README.md`** — Delivery Starter list + one-line link and disclaimer pointer
- **`docs/integrations/llm-field-trial.md`** — Related Work link
- **`docs/development/client-project-start.md`** — optional reference section
- **`docs/todo/current.md`** / **`docs/milestones/2026-05-field-trial.md`** — align with `#166`–`#168`

## Open follow-ups (not closed by this PR)
- **`#167`** — document strict JSON **numbers** for MCP path-parameter tools
- **`#168`** — document **Cursor GitHub MCP PAT** vs **`gh`** for private repos

Closes #166