### PR TITLE
docs(mcp): MCP パスパラメーターの整数型要件を記録する

### DIFF
--- a/docs/integrations/local-mcp-client-configuration.md
+++ b/docs/integrations/local-mcp-client-configuration.md
@@ -95,6 +95,24 @@ Validate the catalog with:
 docker compose run --rm app composer mcp
 ```
 
+### Path Parameter Types
+
+Tools that map to OpenAPI paths with integer parameters (e.g., `{year}`, `{id}`) require JSON number values in `tools/call` arguments, not strings.
+
+Correct:
+
+```json
+{"name": "getItemsByYear", "arguments": {"year": 2026}}
+```
+
+Incorrect (will be rejected when the schema specifies `integer`):
+
+```json
+{"name": "getItemsByYear", "arguments": {"year": "2026"}}
+```
+
+Check the tool's `inputSchema` in `docs/mcp/tools.json` to confirm the expected type for each parameter.
+
 ## Safety Rules
 
 Local MCP clients may:

--- a/docs/integrations/local-mcp-server.md
+++ b/docs/integrations/local-mcp-server.md
@@ -96,6 +96,12 @@ Recommended metadata:
 
 Mutation, admin, and destructive tools are out of scope for the first local MCP server guidance.
 
+### Integer Path Parameters
+
+When a tool maps to an OpenAPI path with integer parameters such as `{year}` or `{id}`, declare them as `"type": "integer"` in the tool's `inputSchema` and pass them as JSON numbers in `tools/call` arguments.
+
+String values such as `"2026"` will be rejected by adapter validation when the schema specifies an integer type. See `docs/integrations/mcp-tools.md` for the full path parameter policy.
+
 ## HTTP Behavior
 
 When a local MCP tool calls an HTTP API:

--- a/docs/integrations/mcp-tools.md
+++ b/docs/integrations/mcp-tools.md
@@ -107,6 +107,28 @@ AI-assisted debugging guidance for request id handling lives in `docs/integratio
 
 If a tool needs a shape that does not fit the current API, update the API contract first or document why an internal service boundary is better.
 
+### Path Parameter Types
+
+When an OpenAPI path parameter is typed as `integer` (e.g., `{year}`, `{id}`), the tool's `inputSchema` must reflect that type:
+
+```json
+"inputSchema": {
+  "type": "object",
+  "properties": {
+    "year": { "type": "integer" }
+  },
+  "required": ["year"]
+}
+```
+
+LLM clients must send integer path parameters as JSON numbers, not strings:
+
+```json
+{"name": "getItemsByYear", "arguments": {"year": 2026}}
+```
+
+Sending a string (`"2026"`) will be rejected by adapter validation when the schema specifies `"type": "integer"`. This applies to any path parameter whose OpenAPI schema uses `type: integer` or `type: number`.
+
 ## Non-Goals
 
 - Direct production database tools as the first MCP milestone.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -117,6 +117,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Run the first `v0.1.1` client-style field trial. `#164`
 - [x] Link public field-trial sandbox from core docs. `#166`
 - [x] Convert field-trial friction into focused follow-up Issues. `#167` `#168`
+- [ ] Resolve friction follow-up: document MCP integer path parameters. `#167` ← **進行中**
+- [ ] Resolve friction follow-up: document Cursor GitHub MCP PAT vs `gh` CLI. `#168`
 - [ ] Decide whether any repeated field-trial step justifies a helper script or generator.
 
 _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), `#168` (Cursor GitHub MCP PAT vs `gh` CLI)._


### PR DESCRIPTION
## 目的

フィールドトライアル（sakura-exhibition-nene2-field-trial）で観測されたフリクションを docs に反映する。

OpenAPI で `integer` 型のパスパラメーター（`{year}`、`{id}` など）を持つ MCP ツールを `tools/call` で呼び出す際、LLM クライアントは値を JSON number として送る必要がある。文字列（`"2026"` など）はアダプターのスキーマ検証で拒否される。

## 変更点

- `docs/integrations/mcp-tools.md`: OpenAPI Alignment セクションに **Path Parameter Types** を追加（`inputSchema` 定義例と呼び出し例）
- `docs/integrations/local-mcp-server.md`: Tool Shape セクションに整数型パラメーターの注意事項を追加
- `docs/integrations/local-mcp-client-configuration.md`: Available Tools セクションに正しい呼び出し例と誤った例を追加
- `docs/todo/current.md`: #167 を進行中として記録

## 検証

- `composer test`: OK（68 tests, 286 assertions）
- `composer cs`: 0 errors
- `composer openapi`: valid
- `composer mcp`: valid

Self-review: docs-policy

Closes #167