### PR TITLE
docs(integrations): Cursor GitHub MCP の認証方式を記録する

### DIFF
--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -46,3 +46,27 @@ For normal code or documentation work, an AI agent should:
 - AI-assisted debugging should follow `docs/integrations/ai-debugging.md`.
 - Destructive operations must require explicit user approval.
 - Production access rules must be documented before production tooling is added.
+
+## Cursor GitHub MCP Authentication
+
+Cursor's GitHub MCP integration uses its own configured Personal Access Token (PAT), not the `gh` CLI session established by `gh auth login`.
+
+If you encounter a `403` error on GitHub MCP operations such as `create_pull_request` for a private repository, fix the PAT in Cursor's MCP settings — not the `gh` CLI session.
+
+**`gh auth login` does not affect Cursor's GitHub MCP credentials.**
+
+### Required PAT scopes for private repositories
+
+Use one of these token types:
+
+- **Classic PAT**: `repo` scope. If the repository belongs to an organization with SSO, also authorize the token for that organization after creation.
+- **Fine-grained PAT**: grant `Contents` (read) and `Pull requests` (read and write) permissions on the target repository, plus any other scopes the MCP operations require.
+
+### Where to update the token
+
+The token location depends on your Cursor MCP configuration. Common locations:
+
+- Cursor settings → MCP → GitHub integration → token field
+- Your local MCP client configuration file (if you maintain one outside the repository)
+
+Do not commit PAT values to the repository. Store them only in your local Cursor or MCP client settings.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -118,7 +118,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Link public field-trial sandbox from core docs. `#166`
 - [x] Convert field-trial friction into focused follow-up Issues. `#167` `#168`
 - [x] Resolve friction follow-up: document MCP integer path parameters. `#167`
-- [ ] Resolve friction follow-up: document Cursor GitHub MCP PAT vs `gh` CLI. `#168`
+- [ ] Resolve friction follow-up: document Cursor GitHub MCP PAT vs `gh` CLI. `#168` ← **進行中**
 - [ ] Decide whether any repeated field-trial step justifies a helper script or generator.
 
 _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), `#168` (Cursor GitHub MCP PAT vs `gh` CLI)._


### PR DESCRIPTION
## 目的

フィールドトライアルで観測されたフリクションを docs に反映する。

Cursor の GitHub MCP は `gh auth login` で確立した CLI セッションではなく、
MCP 設定に登録した PAT を使用する。プライベートリポジトリで `403` が出た際に
`gh auth login` を試みても解決しないため、正しい対処法を記録する。

## 変更点

- `docs/integrations/ai-tools.md`: **Cursor GitHub MCP Authentication** セクションを新設
  - `gh` CLI と Cursor GitHub MCP の認証が独立していることを明記
  - 必要な PAT スコープ（classic `repo` / fine-grained `Contents` + `Pull requests`）を記載
  - Organization SSO 認可が必要なケースを明記
  - PAT をリポジトリにコミットしない旨を注意として追加
- `docs/todo/current.md`: #168 を進行中として記録

## 検証

- `composer test`: OK（68 tests, 286 assertions）
- `composer cs`: 0 errors
- `composer openapi`: valid
- `composer mcp`: valid

Self-review: docs-policy

Closes #168