### PR TITLE
feat(tools): ローカル MCP スモークヘルパースクリプトを追加する

### DIFF
--- a/docs/integrations/local-ai-commands.md
+++ b/docs/integrations/local-ai-commands.md
@@ -26,6 +26,15 @@ curl -fsS http://localhost:8080/health
 curl -fsS http://localhost:8080/openapi.php
 ```
 
+MCP smoke checks may use the helper script (requires `docker compose up -d app` first):
+
+```bash
+bash tools/mcp-smoke.sh
+bash tools/mcp-smoke.sh getHealth '{}'
+```
+
+The script runs `initialize` and `tools/list` (plus an optional `tools/call`) against the running `app` service. See `docs/integrations/local-mcp-client-configuration.md` for details.
+
 ## Boundaries
 
 Local AI and MCP commands must:

--- a/docs/integrations/local-mcp-client-configuration.md
+++ b/docs/integrations/local-mcp-client-configuration.md
@@ -55,26 +55,40 @@ Do not put secrets in committed MCP client configuration. If a future local tool
 
 ## Local Smoke Check
 
-You can smoke test the server without a full MCP client by piping newline-delimited JSON-RPC messages.
+Use the smoke helper script to run a full JSON-RPC sequence without boilerplate.
 
-Start with `initialize`:
+The app service must be running first:
 
 ```bash
-printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"local-smoke","version":"0.0.0"}}}' \
-  | docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
+docker compose up -d app
 ```
 
-List tools:
+Then run the helper:
 
 ```bash
-printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
-  | docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
+# initialize + tools/list only
+bash tools/mcp-smoke.sh
+
+# call a specific tool
+bash tools/mcp-smoke.sh getHealth '{}'
+
+# call a tool with path parameters (use JSON numbers for integer fields)
+bash tools/mcp-smoke.sh getExhibitionWorkByYearAndId '{"year":2026,"workId":20260101}'
 ```
 
-Call the health tool:
+The script pipes the messages to the stdio MCP server, which calls the running `app` service at `http://app` on the Compose network. Override the API base URL when needed:
 
 ```bash
-printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getHealth","arguments":{}}}' \
+NENE2_LOCAL_API_BASE_URL=http://my-api bash tools/mcp-smoke.sh getHealth '{}'
+```
+
+**Manual alternative** — pipe raw JSON-RPC lines when finer control is needed:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"local-smoke","version":"0.0.0"}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getHealth","arguments":{}}}' \
   | docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
 ```
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -119,7 +119,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Convert field-trial friction into focused follow-up Issues. `#167` `#168`
 - [x] Resolve friction follow-up: document MCP integer path parameters. `#167`
 - [x] Resolve friction follow-up: document Cursor GitHub MCP PAT vs `gh` CLI. `#168`
-- [ ] Decide whether any repeated field-trial step justifies a helper script or generator.
+- [x] Decide whether any repeated field-trial step justifies a helper script or generator. → MCP スモークコマンドをスクリプト化する（`tools/mcp-smoke.sh`）。
+- [ ] Add local MCP smoke helper script (`tools/mcp-smoke.sh`). ← **進行中**
 
 _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), `#168` (Cursor GitHub MCP PAT vs `gh` CLI)._
 

--- a/tools/mcp-smoke.sh
+++ b/tools/mcp-smoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Local MCP smoke helper.
+# Pipes JSON-RPC messages to the stdio MCP server against the running app service.
+#
+# Precondition: docker compose up -d app
+#
+# Usage:
+#   bash tools/mcp-smoke.sh
+#   bash tools/mcp-smoke.sh getHealth '{}'
+#   bash tools/mcp-smoke.sh getExhibitionWorkByYearAndId '{"year":2026,"workId":20260101}'
+#
+# Environment:
+#   NENE2_LOCAL_API_BASE_URL  override API base URL (default: http://app)
+
+set -euo pipefail
+
+API_BASE="${NENE2_LOCAL_API_BASE_URL:-http://app}"
+TOOL="${1:-}"
+ARGS="${2:-}"
+[[ -z "${ARGS}" ]] && ARGS="{}"
+
+MESSAGES=(
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mcp-smoke","version":"0.0.0"}}}'
+    '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+)
+
+if [[ -n "${TOOL}" ]]; then
+    MESSAGES+=("{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"${TOOL}\",\"arguments\":${ARGS}}}")
+fi
+
+printf '%s\n' "${MESSAGES[@]}" \
+    | docker compose run --rm -T \
+        -e "NENE2_LOCAL_API_BASE_URL=${API_BASE}" \
+        app php tools/local-mcp-server.php


### PR DESCRIPTION
## 目的

フィールドトライアルで MCP スモークコマンドが 3 回繰り返された（artists / works / work-detail）。毎回 9 行のボイラープレートを手でコピーしていたため、`tools/mcp-smoke.sh` に切り出す。

## 変更点

- **`tools/mcp-smoke.sh`** 新規追加
  - `docker compose up -d app` 済みの状態を前提に動作
  - 引数なし: `initialize` + `tools/list` のみ
  - 引数あり: `tools/call` も追加
  - `NENE2_LOCAL_API_BASE_URL` で API ベース URL を上書き可能
  - bash の `${:-{}}` バグ（`{}` 内の `}` が `${}` の閉じとみなされ `{}}` になる）を `ARGS="${2:-}"` + `[[ -z ]]` パターンで回避
- **`docs/integrations/local-mcp-client-configuration.md`**: Local Smoke Check セクションをヘルパー優先に更新、手動 printf コマンドは代替として残す
- **`docs/integrations/local-ai-commands.md`**: ヘルパーを safe コマンドとして追記
- **`docs/todo/current.md`**: 決定と実装を記録

## 検証

```bash
# 引数なし (initialize + tools/list)
bash tools/mcp-smoke.sh
# → id:1, id:2 が返る ✓

# tools/call
bash tools/mcp-smoke.sh getHealth '{}'
# → id:1, id:2, id:3 (status:"ok") ✓
```

- `composer test`: OK (68 tests, 286 assertions)
- `composer cs`: 0 errors
- `composer openapi`: valid
- `composer mcp`: valid

Self-review: docs-policy

Closes #178