### PR TITLE
docs: Phase 9 マイルストーンを定義する — Domain Layer Starter

### DIFF
--- a/docs/milestones/2026-05-domain-layer-starter.md
+++ b/docs/milestones/2026-05-domain-layer-starter.md
@@ -1,0 +1,85 @@
+# Domain Layer Starter
+
+## Period
+
+May 2026 and after the First LLM Field Trial milestone.
+
+## Goal
+
+Add a minimal, conventional domain layer pattern to NENE2 so that application code has a clear, documented path from HTTP handler to use case to repository adapter.
+
+This milestone should turn "the infrastructure is in place" into "there is a working pattern for building real features on top of it."
+
+## Theme
+
+The field trial exposed the central gap: NENE2's infrastructure layer (routing, DI, config, database, MCP) is in place, but a client project that clones the repository has no example of how a real endpoint should delegate to a use case and repository. The only examples are `getHealth` and `getFrameworkSmoke`, which test infrastructure rather than application logic.
+
+The next work should add a domain layer convention without making NENE2 a full-stack framework:
+
+- a documented UseCase interface and invocation pattern
+- a documented RepositoryInterface convention for database-backed adapters
+- at least one working example endpoint that uses these patterns end to end
+- updated workflow docs so endpoint scaffold and self-review checklists cover domain concerns
+- unit tests for use cases and integration tests for repository adapters
+
+## Scope
+
+- write a domain layer policy doc (`docs/development/domain-layer.md`) covering:
+  - UseCase interface and single-responsibility invocation
+  - RepositoryInterface convention and adapter naming
+  - readonly input and output DTOs for cross-layer data passing
+  - where application code lives relative to `src/` framework primitives
+  - how to register use cases and repositories in the PSR-11 container
+- add at least one example use case, repository interface, and PDO adapter in `src/`
+- add at least one example handler that delegates to the use case (replacing or augmenting a smoke-only endpoint)
+- add OpenAPI schema entries for the example endpoint
+- add PHPUnit tests: unit tests for the use case, integration tests for the PDO adapter
+- update `docs/development/endpoint-scaffold.md` to reference domain layer patterns
+- update `docs/development/client-project-start.md` to point at the domain layer doc
+- update self-review checklists to cover domain layer concerns (no business logic in handlers, no raw SQL outside adapters)
+
+## Acceptance Criteria
+
+- `docs/development/domain-layer.md` exists and defines the UseCase/RepositoryInterface/DTO conventions.
+- At least one working example endpoint demonstrates the full UseCase → Repository → Handler path.
+- The example endpoint has PHPUnit coverage: use case unit tests and repository adapter integration tests.
+- OpenAPI schema for the example endpoint is present and passes `composer openapi`.
+- `docs/development/endpoint-scaffold.md` references the domain layer policy.
+- `docs/development/client-project-start.md` references the domain layer policy.
+- Self-review checklists include domain layer checkpoints.
+- `docs/todo/current.md` points at this milestone and lists concrete next candidates.
+
+## Candidate Issues
+
+- Define the Phase 9 milestone for Domain Layer Starter. `#180`
+- Write the domain layer policy doc (`docs/development/domain-layer.md`).
+- Add a minimal UseCase interface and example use case in `src/`.
+- Add a RepositoryInterface convention and example PDO adapter.
+- Add an example handler that delegates to the use case.
+- Add OpenAPI schema entries for the example domain endpoint.
+- Add PHPUnit unit tests for the example use case.
+- Add PHPUnit integration tests for the example PDO adapter.
+- Update `docs/development/endpoint-scaffold.md` to reference domain layer patterns.
+- Update `docs/development/client-project-start.md` to reference the domain layer doc.
+- Update self-review checklists with domain layer checkpoints.
+- Decide whether Phase 9 warrants a `v0.1.2` patch release.
+
+## Non-Goals
+
+- Laravel-style Eloquent models or active record patterns.
+- Automatic code generation or scaffolding commands.
+- Event sourcing or CQRS patterns in the first pass.
+- Multiple example domains or complex aggregate roots.
+- Production deployment patterns.
+- Full test coverage of all infrastructure boundaries (only the example domain path).
+
+## Related Work
+
+- Previous milestone: `docs/milestones/2026-05-field-trial.md`
+- Database adapter boundaries: `src/Database/`
+- PSR-11 container and wiring: `src/DependencyInjection/`
+- Endpoint scaffold workflow: `docs/development/endpoint-scaffold.md`
+- Client project start guide: `docs/development/client-project-start.md`
+- Database test strategy: `docs/development/test-database-strategy.md`
+- Coding standards: `docs/development/coding-standards.md`
+- GitHub Issue: `#180`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -147,6 +147,20 @@ Goal: prove the delivery-starter workflow in a real or realistic client-style pr
 
 Tracked by `docs/milestones/2026-05-field-trial.md`.
 
+## Phase 9: Domain Layer Starter
+
+Goal: add a minimal, conventional domain layer pattern so that application code has a clear, documented path from HTTP handler to use case to repository adapter.
+
+- UseCase interface and single-responsibility invocation convention
+- RepositoryInterface convention for database-backed adapters
+- readonly input and output DTOs for cross-layer data passing
+- at least one working example endpoint demonstrating the full UseCase → Repository → Handler path
+- PHPUnit unit tests for the use case and integration tests for the PDO adapter
+- updated endpoint scaffold workflow and client project start guide referencing domain patterns
+- self-review checklist entries for domain layer concerns
+
+Tracked by `docs/milestones/2026-05-domain-layer-starter.md`.
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,8 +4,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: `docs/milestones/2026-05-field-trial.md`
-- Current GitHub Issue: none
+- Current milestone: `docs/milestones/2026-05-domain-layer-starter.md`
+- Current GitHub Issue: `#180`
 - Current branch: `main`
 - Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
 - First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
@@ -123,6 +123,21 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - [x] Add local MCP smoke helper script (`tools/mcp-smoke.sh`). `#178`
 
 _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), `#168` (Cursor GitHub MCP PAT vs `gh` CLI)._
+
+## Domain Layer Starter Candidates
+
+- [x] Define the Phase 9 milestone for Domain Layer Starter. `#180`
+- [ ] Write the domain layer policy doc (`docs/development/domain-layer.md`).
+- [ ] Add a minimal UseCase interface and example use case in `src/`.
+- [ ] Add a RepositoryInterface convention and example PDO adapter.
+- [ ] Add an example handler that delegates to the use case.
+- [ ] Add OpenAPI schema entries for the example domain endpoint.
+- [ ] Add PHPUnit unit tests for the example use case.
+- [ ] Add PHPUnit integration tests for the example PDO adapter.
+- [ ] Update `docs/development/endpoint-scaffold.md` to reference domain layer patterns.
+- [ ] Update `docs/development/client-project-start.md` to reference the domain layer doc.
+- [ ] Update self-review checklists with domain layer checkpoints.
+- [ ] Decide whether Phase 9 warrants a `v0.1.2` patch release.
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary

- `docs/milestones/2026-05-domain-layer-starter.md` を新規追加
- `docs/roadmap.md` に Phase 9 を追加
- `docs/todo/current.md` を Phase 9 に更新（マイルストーン・候補 Issue リスト）

## Context

Phase 8（First LLM Field Trial）完了後、フィールドトライアルの観察から最大のギャップが判明した:

- フレームワークのインフラ（ルーティング・DI・設定・DB・MCP）は揃っている
- しかし UseCase → Repository → Handler の実際のパターンを示すコードが本体にない
- `getHealth` と `getFrameworkSmoke` しかなく、クライアントプロジェクト開始時の参考にならない

Phase 9 ではこのギャップを埋める方針・スコープ・受け入れ条件を定める。実装は別 Issue で管理する。

## Test plan

- [ ] `docs/milestones/2026-05-domain-layer-starter.md` が存在し、UseCase/Repository/DTO 規約を記述している
- [ ] `docs/roadmap.md` に Phase 9 セクションが追加されている
- [ ] `docs/todo/current.md` のマイルストーン pointer が Phase 9 を指している
- [ ] `docs/todo/current.md` に Domain Layer Starter Candidates セクションが追加されている

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)