### PR TITLE
chore(docs): Phase 9 を完了する — milestone 記録と v0.1.2 リリース判断

### DIFF
--- a/docs/development/release-v0.1.2-prep.md
+++ b/docs/development/release-v0.1.2-prep.md
@@ -1,0 +1,95 @@
+# v0.1.2 Checkpoint Release Preparation
+
+This document records the `v0.1.2` checkpoint release decision.
+
+It does not create a tag.
+
+## Decision
+
+`v0.1.2` is a good checkpoint release candidate after the completed Domain Layer Starter milestone and First LLM Field Trial friction fixes.
+
+Reason:
+
+- the changes improve the existing `v0.1.1` foundation without broadening the public framework surface
+- the domain layer example, policy doc, and tests make NENE2 meaningfully more useful as a client project starter
+- the friction fixes and smoke helper reduce MCP setup effort observed in the field trial
+- the scope matches `docs/development/release-v0.1.x-policy.md`
+
+Do not tag `v0.1.2` without explicit release approval.
+
+## Candidate Scope
+
+Candidate highlights since `v0.1.1`:
+
+- domain layer policy doc (`docs/development/domain-layer.md`): UseCase/RepositoryInterface/DTO conventions
+- example end-to-end domain endpoint `GET /examples/notes/{id}` with UseCase, PDO adapter, and handler
+- PHPUnit unit tests for the use case (in-memory repository, no DB) and integration tests for the PDO adapter (SQLite in-memory)
+- Phinx migration for the `notes` table
+- OpenAPI schema for the example domain endpoint
+- field-trial friction fix: document MCP integer path parameter type requirement
+- field-trial friction fix: document Cursor GitHub MCP PAT independence from `gh` CLI
+- local MCP smoke helper script (`tools/mcp-smoke.sh`) with stdin piping fix
+
+## Related Issues
+
+- Domain layer policy doc: `#182`
+- Domain layer example implementation: `#184`
+- MCP integer path parameters: `#167`
+- Cursor GitHub MCP PAT guidance: `#168`
+- MCP smoke helper script: `#178`
+- Phase 9 milestone definition: `#180`
+- This decision: `#186`
+
+## Before Tagging
+
+Before creating a `v0.1.2` tag:
+
+1. Get explicit maintainer approval to tag `v0.1.2`.
+2. Confirm `main` is up to date and clean.
+3. Confirm Backend and Frontend GitHub Actions pass on the release commit.
+4. Run the manual release checklist in `docs/development/release-checklist.md`.
+5. Draft short GitHub Release notes from the candidate scope above.
+
+Recommended local verification:
+
+```bash
+git switch main
+git pull --ff-only origin main
+docker compose run --rm app composer validate
+docker compose run --rm app composer check
+npm run check --prefix frontend
+npm run build --prefix frontend
+git diff --check
+```
+
+Recommended domain layer smoke checks:
+
+```bash
+docker compose up -d app
+docker compose run --rm app composer migrations:migrate
+curl -i http://localhost:8080/examples/notes/1
+```
+
+Note: `GET /examples/notes/1` returns `404` until a seed row is inserted. The 404 Problem Details response itself confirms the full UseCase → Handler path is wired correctly through the container.
+
+Optional MCP smoke check:
+
+```bash
+bash tools/mcp-smoke.sh getHealth '{}'
+```
+
+## Non-Goals
+
+- No tag in this documentation PR.
+- No GitHub Release publication without explicit approval.
+- No Packagist publication.
+- No release automation.
+- No `1.0.0` public API stability promise.
+
+## Related Work
+
+- Patch release policy: `docs/development/release-v0.1.x-policy.md`
+- Release checklist: `docs/development/release-checklist.md`
+- Domain Layer Starter milestone: `docs/milestones/2026-05-domain-layer-starter.md`
+- Current TODO: `docs/todo/current.md`
+- GitHub Issue: `#186`

--- a/docs/milestones/2026-05-domain-layer-starter.md
+++ b/docs/milestones/2026-05-domain-layer-starter.md
@@ -73,6 +73,22 @@ The next work should add a domain layer convention without making NENE2 a full-s
 - Production deployment patterns.
 - Full test coverage of all infrastructure boundaries (only the example domain path).
 
+## Completion Record
+
+All acceptance criteria were met by the end of May 2026.
+
+- `docs/development/domain-layer.md` defines the UseCase/RepositoryInterface/DTO conventions. `#182`
+- `GET /examples/notes/{id}` demonstrates the full UseCase → Repository → Handler path. `#184`
+- `GetNoteByIdUseCaseTest` covers the use case with an in-memory repository. `#184`
+- `PdoNoteRepositoryTest` covers the PDO adapter with SQLite in-memory. `#184`
+- OpenAPI schema for the example endpoint is present and passes `composer openapi`. `#184`
+- `docs/development/endpoint-scaffold.md` references domain layer patterns. `#182`
+- `docs/development/client-project-start.md` references the domain layer policy. `#182`
+- Self-review checklists include domain layer checkpoints. `#182`
+- `docs/todo/current.md` is up to date. `#186`
+
+`v0.1.2` patch release preparation is recorded in `docs/development/release-v0.1.2-prep.md`.
+
 ## Related Work
 
 - Previous milestone: `docs/milestones/2026-05-field-trial.md`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -134,10 +134,10 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] Add OpenAPI schema entries for the example domain endpoint. `#184`
 - [x] Add PHPUnit unit tests for the example use case. `#184`
 - [x] Add PHPUnit integration tests for the example PDO adapter. `#184`
-- [ ] Update `docs/development/endpoint-scaffold.md` to reference domain layer patterns.
-- [ ] Update `docs/development/client-project-start.md` to reference the domain layer doc.
-- [ ] Update self-review checklists with domain layer checkpoints.
-- [ ] Decide whether Phase 9 warrants a `v0.1.2` patch release.
+- [x] Update `docs/development/endpoint-scaffold.md` to reference domain layer patterns. `#182`
+- [x] Update `docs/development/client-project-start.md` to reference the domain layer doc. `#182`
+- [x] Update self-review checklists with domain layer checkpoints. `#182`
+- [x] Decide whether Phase 9 warrants a `v0.1.2` patch release. `#186` → yes, see `docs/development/release-v0.1.2-prep.md`
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary

- `docs/milestones/2026-05-domain-layer-starter.md` に Completion Record を追加
- `docs/development/release-v0.1.2-prep.md` を新規作成（v0.1.2 リリース判断・スコープ・検証手順）
- `docs/todo/current.md` の残り 4 項目を完了としてマーク

## v0.1.2 decision

Phase 9 の完了スコープ（since v0.1.1）が `v0.1.x-policy.md` の基準に合致するため `v0.1.2` を推奨。
**タグ作成は明示的な承認後に行う。**

## Test plan

- [ ] `docs/development/release-v0.1.2-prep.md` が作成されている
- [ ] `docs/milestones/2026-05-domain-layer-starter.md` に Completion Record が追加されている
- [ ] `docs/todo/current.md` の Domain Layer Starter Candidates がすべて `[x]` になっている

Self-review: docs-policy

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)