### PR TITLE
feat: Write Operations Pattern 実装 — POST/DELETE Notes end-to-end

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -92,6 +92,51 @@ paths:
           $ref: '#/components/responses/PayloadTooLarge'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /examples/notes:
+    post:
+      tags:
+        - Examples
+      summary: Create example note
+      description: Creates a new note. Demonstrates the POST → UseCase → Repository write path with body validation.
+      operationId: createExampleNote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateNoteRequest'
+            examples:
+              valid:
+                summary: Valid create note request
+                value:
+                  title: Example Note
+                  body: This is the body of an example note.
+      responses:
+        '201':
+          description: Note created.
+          headers:
+            Location:
+              description: URI of the created note.
+              schema:
+                type: string
+                example: /examples/notes/1
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleNoteResponse'
+              examples:
+                created:
+                  summary: Successful create note response
+                  value:
+                    id: 1
+                    title: Example Note
+                    body: This is the body of an example note.
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /examples/notes/{id}:
     get:
       tags:
@@ -127,6 +172,29 @@ paths:
           $ref: '#/components/responses/NotFound'
         '413':
           $ref: '#/components/responses/PayloadTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Examples
+      summary: Delete example note
+      description: Deletes a note by id. Returns 204 on success, 404 if the note does not exist.
+      operationId: deleteExampleNoteById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Note id.
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+          example: 1
+      responses:
+        '204':
+          description: Note deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /examples/ping:
@@ -402,6 +470,21 @@ components:
           enum:
             - ok
           example: ok
+    CreateNoteRequest:
+      type: object
+      required:
+        - title
+        - body
+      properties:
+        title:
+          type: string
+          minLength: 1
+          example: Example Note
+        body:
+          type: string
+          minLength: 1
+          example: This is the body of an example note.
+      additionalProperties: false
     ExampleNoteResponse:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -142,13 +142,13 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 ## Write Operations Pattern Candidates
 
 - [x] Define the Phase 10 milestone for Write Operations Pattern. `#188`
-- [ ] Add `post()` and `delete()` to `Router` and `lastInsertId()` to `DatabaseQueryExecutorInterface`.
-- [ ] Add write methods to `NoteRepositoryInterface` and `PdoNoteRepository`.
-- [ ] Add `CreateNoteUseCase` and `DeleteNoteUseCase` with readonly DTOs.
-- [ ] Add `CreateNoteHandler` (201 + Location) and `DeleteNoteHandler` (204).
-- [ ] Add body validation with `ValidationException` → 422.
-- [ ] Add OpenAPI schemas for POST and DELETE operations.
-- [ ] Add PHPUnit unit and integration tests for write paths.
+- [x] Add `post()` and `delete()` to `Router` and `lastInsertId()` to `DatabaseQueryExecutorInterface`. `#190`
+- [x] Add write methods to `NoteRepositoryInterface` and `PdoNoteRepository`. `#190`
+- [x] Add `CreateNoteUseCase` and `DeleteNoteUseCase` with readonly DTOs. `#190`
+- [x] Add `CreateNoteHandler` (201 + Location) and `DeleteNoteHandler` (204). `#190`
+- [x] Add body validation with `ValidationException` → 422. `#190`
+- [x] Add OpenAPI schemas for POST and DELETE operations. `#190`
+- [x] Add PHPUnit unit and integration tests for write paths. `#190`
 
 ## Operating Notes
 

--- a/src/Database/DatabaseQueryExecutorInterface.php
+++ b/src/Database/DatabaseQueryExecutorInterface.php
@@ -16,6 +16,8 @@ interface DatabaseQueryExecutorInterface
      */
     public function execute(string $sql, array $parameters = []): int;
 
+    public function lastInsertId(): int;
+
     /**
      * @param SqlParameters $parameters
      * @return SqlRow|null

--- a/src/Database/PdoDatabaseQueryExecutor.php
+++ b/src/Database/PdoDatabaseQueryExecutor.php
@@ -28,6 +28,11 @@ final class PdoDatabaseQueryExecutor implements DatabaseQueryExecutorInterface
         return $this->statement($sql, $parameters)->rowCount();
     }
 
+    public function lastInsertId(): int
+    {
+        return (int) $this->connection()->lastInsertId();
+    }
+
     public function fetchOne(string $sql, array $parameters = []): ?array
     {
         $row = $this->statement($sql, $parameters)->fetch(PDO::FETCH_ASSOC);

--- a/src/Example/Note/CreateNoteHandler.php
+++ b/src/Example/Note/CreateNoteHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateNoteHandler
+{
+    public function __construct(
+        private CreateNoteUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = (array) json_decode((string) $request->getBody(), associative: true);
+
+        $errors = [];
+
+        $title = trim((string) ($body['title'] ?? ''));
+        $noteBody = trim((string) ($body['body'] ?? ''));
+
+        if ($title === '') {
+            $errors[] = new ValidationError('title', 'Title is required.', 'required');
+        }
+
+        if ($noteBody === '') {
+            $errors[] = new ValidationError('body', 'Body is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new CreateNoteInput(title: $title, body: $noteBody));
+
+        return $this->response->create(
+            ['id' => $output->id, 'title' => $output->title, 'body' => $output->body],
+            201,
+            ['Location' => '/examples/notes/' . $output->id],
+        );
+    }
+}

--- a/src/Example/Note/CreateNoteInput.php
+++ b/src/Example/Note/CreateNoteInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+final readonly class CreateNoteInput
+{
+    public function __construct(
+        public string $title,
+        public string $body,
+    ) {
+    }
+}

--- a/src/Example/Note/CreateNoteOutput.php
+++ b/src/Example/Note/CreateNoteOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+final readonly class CreateNoteOutput
+{
+    public function __construct(
+        public int $id,
+        public string $title,
+        public string $body,
+    ) {
+    }
+}

--- a/src/Example/Note/CreateNoteUseCase.php
+++ b/src/Example/Note/CreateNoteUseCase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+final readonly class CreateNoteUseCase implements CreateNoteUseCaseInterface
+{
+    public function __construct(
+        private NoteRepositoryInterface $notes,
+    ) {
+    }
+
+    public function execute(CreateNoteInput $input): CreateNoteOutput
+    {
+        $id = $this->notes->save(new Note(title: $input->title, body: $input->body));
+
+        return new CreateNoteOutput(id: $id, title: $input->title, body: $input->body);
+    }
+}

--- a/src/Example/Note/CreateNoteUseCaseInterface.php
+++ b/src/Example/Note/CreateNoteUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+interface CreateNoteUseCaseInterface
+{
+    public function execute(CreateNoteInput $input): CreateNoteOutput;
+}

--- a/src/Example/Note/DeleteNoteByIdInput.php
+++ b/src/Example/Note/DeleteNoteByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+final readonly class DeleteNoteByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Example/Note/DeleteNoteHandler.php
+++ b/src/Example/Note/DeleteNoteHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteNoteHandler
+{
+    public function __construct(
+        private DeleteNoteUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            return $this->problemDetails->create(
+                $request,
+                'not-found',
+                'Not Found',
+                404,
+                'The requested note was not found.',
+            );
+        }
+
+        try {
+            $this->useCase->execute(new DeleteNoteByIdInput($id));
+        } catch (NoteNotFoundException) {
+            return $this->problemDetails->create(
+                $request,
+                'not-found',
+                'Not Found',
+                404,
+                'The requested note was not found.',
+            );
+        }
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/Example/Note/DeleteNoteUseCase.php
+++ b/src/Example/Note/DeleteNoteUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+final readonly class DeleteNoteUseCase implements DeleteNoteUseCaseInterface
+{
+    public function __construct(
+        private NoteRepositoryInterface $notes,
+    ) {
+    }
+
+    public function execute(DeleteNoteByIdInput $input): void
+    {
+        $note = $this->notes->findById($input->id);
+
+        if ($note === null) {
+            throw new NoteNotFoundException($input->id);
+        }
+
+        $this->notes->delete($input->id);
+    }
+}

--- a/src/Example/Note/DeleteNoteUseCaseInterface.php
+++ b/src/Example/Note/DeleteNoteUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+interface DeleteNoteUseCaseInterface
+{
+    /**
+     * @throws NoteNotFoundException when no note matches the given id.
+     */
+    public function execute(DeleteNoteByIdInput $input): void;
+}

--- a/src/Example/Note/NoteRepositoryInterface.php
+++ b/src/Example/Note/NoteRepositoryInterface.php
@@ -7,4 +7,8 @@ namespace Nene2\Example\Note;
 interface NoteRepositoryInterface
 {
     public function findById(int $id): ?Note;
+
+    public function save(Note $note): int;
+
+    public function delete(int $id): void;
 }

--- a/src/Example/Note/NoteServiceProvider.php
+++ b/src/Example/Note/NoteServiceProvider.php
@@ -11,6 +11,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 
 final readonly class NoteServiceProvider implements ServiceProviderInterface
 {
@@ -61,6 +62,69 @@ final readonly class NoteServiceProvider implements ServiceProviderInterface
                     }
 
                     return new GetNoteByIdHandler($useCase, $response, $problemDetails);
+                },
+            )
+            ->set(
+                CreateNoteUseCaseInterface::class,
+                static function (ContainerInterface $c): CreateNoteUseCaseInterface {
+                    $repository = $c->get(NoteRepositoryInterface::class);
+
+                    if (!$repository instanceof NoteRepositoryInterface) {
+                        throw new LogicException('Note repository service is invalid.');
+                    }
+
+                    return new CreateNoteUseCase($repository);
+                },
+            )
+            ->set(
+                CreateNoteHandler::class,
+                static function (ContainerInterface $c): CreateNoteHandler {
+                    $useCase = $c->get(CreateNoteUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateNoteUseCaseInterface) {
+                        throw new LogicException('CreateNote use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateNoteHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteNoteUseCaseInterface::class,
+                static function (ContainerInterface $c): DeleteNoteUseCaseInterface {
+                    $repository = $c->get(NoteRepositoryInterface::class);
+
+                    if (!$repository instanceof NoteRepositoryInterface) {
+                        throw new LogicException('Note repository service is invalid.');
+                    }
+
+                    return new DeleteNoteUseCase($repository);
+                },
+            )
+            ->set(
+                DeleteNoteHandler::class,
+                static function (ContainerInterface $c): DeleteNoteHandler {
+                    $useCase = $c->get(DeleteNoteUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$useCase instanceof DeleteNoteUseCaseInterface) {
+                        throw new LogicException('DeleteNote use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new DeleteNoteHandler($useCase, $responseFactory, $problemDetails);
                 },
             );
     }

--- a/src/Example/Note/PdoNoteRepository.php
+++ b/src/Example/Note/PdoNoteRepository.php
@@ -30,4 +30,19 @@ final readonly class PdoNoteRepository implements NoteRepositoryInterface
             id: (int) $row['id'],
         );
     }
+
+    public function save(Note $note): int
+    {
+        $this->query->execute(
+            'INSERT INTO notes (title, body) VALUES (?, ?)',
+            [$note->title, $note->body],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function delete(int $id): void
+    {
+        $this->query->execute('DELETE FROM notes WHERE id = ?', [$id]);
+    }
 }

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -6,6 +6,8 @@ namespace Nene2\Http;
 
 use Nene2\Error\ErrorHandlerMiddleware;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Example\Note\CreateNoteHandler;
+use Nene2\Example\Note\DeleteNoteHandler;
 use Nene2\Example\Note\GetNoteByIdHandler;
 use Nene2\FrameworkInfo;
 use Nene2\Middleware\ApiKeyAuthenticationMiddleware;
@@ -31,6 +33,8 @@ final readonly class RuntimeApplicationFactory
         private ?LoggerInterface $logger = null,
         private ?string $machineApiKey = null,
         private ?GetNoteByIdHandler $getNoteByIdHandler = null,
+        private ?CreateNoteHandler $createNoteHandler = null,
+        private ?DeleteNoteHandler $deleteNoteHandler = null,
     ) {
     }
 
@@ -40,6 +44,8 @@ final readonly class RuntimeApplicationFactory
         $problemDetails = new ProblemDetailsResponseFactory($this->responseFactory, $this->streamFactory);
         $framework = new FrameworkInfo();
         $getNoteHandler = $this->getNoteByIdHandler;
+        $createNoteHandler = $this->createNoteHandler;
+        $deleteNoteHandler = $this->deleteNoteHandler;
 
         $router = (new Router())
             ->get(
@@ -78,6 +84,20 @@ final readonly class RuntimeApplicationFactory
             $router->get(
                 '/examples/notes/{id}',
                 static fn (ServerRequestInterface $request) => $getNoteHandler->handle($request),
+            );
+        }
+
+        if ($createNoteHandler !== null) {
+            $router->post(
+                '/examples/notes',
+                static fn (ServerRequestInterface $request) => $createNoteHandler->handle($request),
+            );
+        }
+
+        if ($deleteNoteHandler !== null) {
+            $router->delete(
+                '/examples/notes/{id}',
+                static fn (ServerRequestInterface $request) => $deleteNoteHandler->handle($request),
             );
         }
 

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -16,6 +16,8 @@ use Nene2\Database\PdoDatabaseTransactionManager;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Example\Note\CreateNoteHandler;
+use Nene2\Example\Note\DeleteNoteHandler;
 use Nene2\Example\Note\GetNoteByIdHandler;
 use Nene2\Example\Note\NoteServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -180,12 +182,22 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
 
                     $getNoteByIdHandler = $container->get(GetNoteByIdHandler::class);
+                    $createNoteHandler = $container->get(CreateNoteHandler::class);
+                    $deleteNoteHandler = $container->get(DeleteNoteHandler::class);
 
                     if (!$getNoteByIdHandler instanceof GetNoteByIdHandler) {
                         throw new LogicException('GetNoteById handler service is invalid.');
                     }
 
-                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger, $config->machineApiKey, $getNoteByIdHandler);
+                    if (!$createNoteHandler instanceof CreateNoteHandler) {
+                        throw new LogicException('CreateNote handler service is invalid.');
+                    }
+
+                    if (!$deleteNoteHandler instanceof DeleteNoteHandler) {
+                        throw new LogicException('DeleteNote handler service is invalid.');
+                    }
+
+                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger, $config->machineApiKey, $getNoteByIdHandler, $createNoteHandler, $deleteNoteHandler);
                 },
             )
             ->set(

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -27,6 +27,22 @@ final class Router implements RequestHandlerInterface
         return $this->add('GET', $path, $handler);
     }
 
+    /**
+     * @param callable(ServerRequestInterface): ResponseInterface $handler
+     */
+    public function post(string $path, callable $handler): self
+    {
+        return $this->add('POST', $path, $handler);
+    }
+
+    /**
+     * @param callable(ServerRequestInterface): ResponseInterface $handler
+     */
+    public function delete(string $path, callable $handler): self
+    {
+        return $this->add('DELETE', $path, $handler);
+    }
+
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $method = strtoupper($request->getMethod());

--- a/tests/Example/Note/CreateNoteUseCaseTest.php
+++ b/tests/Example/Note/CreateNoteUseCaseTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Example\Note;
+
+use Nene2\Example\Note\CreateNoteInput;
+use Nene2\Example\Note\CreateNoteUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class CreateNoteUseCaseTest extends TestCase
+{
+    public function testReturnsOutputWithNewId(): void
+    {
+        $repository = new InMemoryNoteRepository([]);
+        $useCase = new CreateNoteUseCase($repository);
+
+        $output = $useCase->execute(new CreateNoteInput(title: 'Hello', body: 'World'));
+
+        self::assertSame(1, $output->id);
+        self::assertSame('Hello', $output->title);
+        self::assertSame('World', $output->body);
+    }
+
+    public function testAssignsSequentialIds(): void
+    {
+        $repository = new InMemoryNoteRepository([]);
+        $useCase = new CreateNoteUseCase($repository);
+
+        $first = $useCase->execute(new CreateNoteInput(title: 'First', body: 'Body'));
+        $second = $useCase->execute(new CreateNoteInput(title: 'Second', body: 'Body'));
+
+        self::assertSame(1, $first->id);
+        self::assertSame(2, $second->id);
+    }
+}

--- a/tests/Example/Note/DeleteNoteUseCaseTest.php
+++ b/tests/Example/Note/DeleteNoteUseCaseTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Example\Note;
+
+use Nene2\Example\Note\CreateNoteInput;
+use Nene2\Example\Note\CreateNoteUseCase;
+use Nene2\Example\Note\DeleteNoteByIdInput;
+use Nene2\Example\Note\DeleteNoteUseCase;
+use Nene2\Example\Note\NoteNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteNoteUseCaseTest extends TestCase
+{
+    public function testDeletesExistingNote(): void
+    {
+        $repository = new InMemoryNoteRepository([]);
+        $createUseCase = new CreateNoteUseCase($repository);
+        $deleteUseCase = new DeleteNoteUseCase($repository);
+
+        $created = $createUseCase->execute(new CreateNoteInput(title: 'Hello', body: 'World'));
+        $deleteUseCase->execute(new DeleteNoteByIdInput($created->id));
+
+        self::assertNull($repository->findById($created->id));
+    }
+
+    public function testThrowsNoteNotFoundExceptionWhenNoteIsAbsent(): void
+    {
+        $repository = new InMemoryNoteRepository([]);
+        $deleteUseCase = new DeleteNoteUseCase($repository);
+
+        $this->expectException(NoteNotFoundException::class);
+
+        $deleteUseCase->execute(new DeleteNoteByIdInput(99));
+    }
+}

--- a/tests/Example/Note/InMemoryNoteRepository.php
+++ b/tests/Example/Note/InMemoryNoteRepository.php
@@ -12,14 +12,18 @@ final class InMemoryNoteRepository implements NoteRepositoryInterface
     /** @var array<int, Note> */
     private array $notes;
 
+    private int $nextId;
+
     /** @param list<Note> $notes */
     public function __construct(array $notes = [])
     {
         $this->notes = [];
+        $this->nextId = 1;
 
         foreach ($notes as $note) {
             if ($note->id !== null) {
                 $this->notes[$note->id] = $note;
+                $this->nextId = max($this->nextId, $note->id + 1);
             }
         }
     }
@@ -27,5 +31,18 @@ final class InMemoryNoteRepository implements NoteRepositoryInterface
     public function findById(int $id): ?Note
     {
         return $this->notes[$id] ?? null;
+    }
+
+    public function save(Note $note): int
+    {
+        $id = $this->nextId++;
+        $this->notes[$id] = new Note(title: $note->title, body: $note->body, id: $id);
+
+        return $id;
+    }
+
+    public function delete(int $id): void
+    {
+        unset($this->notes[$id]);
     }
 }

--- a/tests/Example/Note/PdoNoteRepositoryTest.php
+++ b/tests/Example/Note/PdoNoteRepositoryTest.php
@@ -7,6 +7,7 @@ namespace Nene2\Tests\Example\Note;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Example\Note\Note;
 use Nene2\Example\Note\PdoNoteRepository;
 use PHPUnit\Framework\TestCase;
 
@@ -52,5 +53,33 @@ final class PdoNoteRepositoryTest extends TestCase
         $note = $repository->findById(99);
 
         self::assertNull($note);
+    }
+
+    public function testSaveReturnsNewId(): void
+    {
+        $repository = new PdoNoteRepository($this->executor);
+        $id = $repository->save(new Note(title: 'Hello', body: 'World'));
+
+        self::assertSame(1, $id);
+    }
+
+    public function testSavedNoteIsRetrievableById(): void
+    {
+        $repository = new PdoNoteRepository($this->executor);
+        $id = $repository->save(new Note(title: 'Hello', body: 'World'));
+        $note = $repository->findById($id);
+
+        self::assertNotNull($note);
+        self::assertSame('Hello', $note->title);
+        self::assertSame('World', $note->body);
+    }
+
+    public function testDeleteRemovesNote(): void
+    {
+        $repository = new PdoNoteRepository($this->executor);
+        $id = $repository->save(new Note(title: 'To delete', body: 'Body'));
+        $repository->delete($id);
+
+        self::assertNull($repository->findById($id));
     }
 }


### PR DESCRIPTION
## Summary

`POST /examples/notes` と `DELETE /examples/notes/{id}` を実装して CRUD テンプレートを完成させる。

**インフラ拡張**
- `Router`: `post()` / `delete()` メソッド追加
- `DatabaseQueryExecutorInterface` / `PdoDatabaseQueryExecutor`: `lastInsertId()` 追加

**ドメイン層**
- `NoteRepositoryInterface`: `save()` / `delete()` 追加
- `PdoNoteRepository`: `save()` / `delete()` 実装
- `CreateNoteInput` / `CreateNoteOutput` readonly DTO
- `CreateNoteUseCaseInterface` / `CreateNoteUseCase`
- `DeleteNoteByIdInput` / `DeleteNoteUseCaseInterface` / `DeleteNoteUseCase`
- `CreateNoteHandler`: body バリデーション → 201 Created + Location ヘッダ / 422
- `DeleteNoteHandler`: 204 No Content / 404 Not Found

**OpenAPI**
- `POST /examples/notes`: `CreateNoteRequest` スキーマ、201/422 レスポンス
- `DELETE /examples/notes/{id}`: 204/404 レスポンス

**テスト**
- `CreateNoteUseCaseTest` / `DeleteNoteUseCaseTest`: in-memory、DB 不要
- `PdoNoteRepositoryTest`: save/delete を SQLite in-memory で検証

## Architecture note

DB 接続は遅延生成のまま。`docker compose up -d app` のみで起動可能で、MySQL コンテナは不要。
Write 系エンドポイントも `composer migrations:migrate` 後に SQLite で動作する。

## Verification

```
composer check: OK (79 tests, 307 assertions, 0 PHPStan errors, 0 CS issues, OpenAPI valid, MCP valid)
```

Self-review: backend-api, openapi-contract, database

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)