### PR TITLE
docs(readme): Quick Start に .env セットアップ手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The foundation currently includes:
 Build the PHP runtime, install dependencies, and run the standard backend checks:
 
 ```bash
+cp .env.example .env
 docker compose build
 docker compose run --rm app composer install
 docker compose run --rm app composer check


### PR DESCRIPTION
## Summary
- `cp .env.example .env` を Quick Start の先頭に追加

## Test plan
- [ ] README を読んで手順通りに初回セットアップできることを確認

Closes #192

Self-review: docs-policy