### PR TITLE
docs: Phase 12〜16 ロードマップ追記・マイルストーン定義・todo 更新

### DIFF
--- a/docs/milestones/2026-05-error-handler-systemization.md
+++ b/docs/milestones/2026-05-error-handler-systemization.md
@@ -1,0 +1,25 @@
+# Milestone: Error Handler Systemization (Phase 11)
+
+## Goal
+
+Centralize domain exception → HTTP response mapping in the middleware layer so that
+handlers stay thin and adding new domain exceptions does not require handler changes.
+
+## Completed
+
+- `DomainExceptionHandlerInterface` added to `src/Error/`
+- `ErrorHandlerMiddleware` accepts `list<DomainExceptionHandlerInterface>`; iterates in `catch(Throwable)` block
+- `NoteNotFoundExceptionHandler` added to `src/Example/Note/`; maps `NoteNotFoundException` → 404 Problem Details
+- `GetNoteByIdHandler` and `DeleteNoteHandler` no longer inject `ProblemDetailsResponseFactory` or catch domain exceptions
+- `NoteServiceProvider` registers `NoteNotFoundExceptionHandler`
+- `RuntimeServiceProvider` wires `NoteNotFoundExceptionHandler` into `RuntimeApplicationFactory`
+- `NoteNotFoundExceptionHandlerTest` added
+
+## Outcome
+
+Handlers follow a consistent shape: parse input → call use case → return response.
+Exception → HTTP mapping is owned entirely by the middleware layer.
+New domain exception types require only a new `DomainExceptionHandlerInterface` implementation,
+registered in the relevant service provider and wired at the factory level.
+
+Merged via PR #198. Closes #197.

--- a/docs/milestones/2026-05-test-coverage-hardening.md
+++ b/docs/milestones/2026-05-test-coverage-hardening.md
@@ -1,0 +1,41 @@
+# Milestone: Test Coverage Hardening (Phase 12)
+
+## Goal
+
+Close the gap between unit-level use case tests and HTTP-level integration by adding
+end-to-end tests for the Note endpoints through the full middleware stack.
+
+Phase 9/10 added UseCase and PDO adapter tests. Phase 11 moved domain exception
+mapping to `ErrorHandlerMiddleware`. Neither phase added HTTP-level tests that verify
+the complete middleware → router → handler → middleware (error) path for Note endpoints.
+
+## Scope
+
+- Add Note endpoint HTTP-level tests in `HttpRuntimeTest` or a dedicated `NoteHttpTest`
+- Cover every meaningful response variation for the three Note endpoints
+- Ensure `DomainExceptionHandlerInterface` integration is exercised end-to-end
+
+## Deliverables
+
+### HTTP-level test cases
+
+| Endpoint | Scenario | Expected |
+|---|---|---|
+| `GET /examples/notes/{id}` | valid id, note exists | 200 + JSON body |
+| `GET /examples/notes/{id}` | valid id, note absent | 404 Problem Details |
+| `GET /examples/notes/0` | invalid id (≤ 0) | 404 Problem Details |
+| `POST /examples/notes` | valid body | 201 + Location header |
+| `POST /examples/notes` | missing title | 422 Problem Details with errors array |
+| `POST /examples/notes` | missing body field | 422 Problem Details with errors array |
+| `DELETE /examples/notes/{id}` | note exists | 204 No Content |
+| `DELETE /examples/notes/{id}` | note absent | 404 Problem Details |
+
+### Documentation
+
+- Update `docs/todo/current.md` to reflect Phase 12
+
+## Completion Record
+
+- [ ] All test cases above pass under `composer check`
+- [ ] No new PHPStan errors
+- [ ] `docs/todo/current.md` updated

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -176,6 +176,69 @@ Goal: complete the CRUD template by adding POST and DELETE endpoints to the doma
 
 Tracked by `docs/milestones/2026-05-write-operations-pattern.md`.
 
+## Phase 11: Error Handler Systemization
+
+Goal: centralize domain exception → HTTP response mapping in the middleware layer so handlers stay thin and new domain exceptions do not require handler changes.
+
+- `DomainExceptionHandlerInterface` with `supports()` and `handle()`
+- `ErrorHandlerMiddleware` accepts `list<DomainExceptionHandlerInterface>`
+- `NoteNotFoundExceptionHandler` as the first registered domain mapper
+- handlers (`GetNoteByIdHandler`, `DeleteNoteHandler`) no longer catch domain exceptions
+- `RuntimeServiceProvider` wires domain handlers explicitly
+
+Tracked by `docs/milestones/2026-05-error-handler-systemization.md`.
+
+## Phase 12: Test Coverage Hardening
+
+Goal: close the gap between unit-level use case tests and HTTP-level integration by adding end-to-end tests for the Note endpoints through the middleware stack.
+
+- `HttpRuntimeTest` (or dedicated `NoteHttpTest`) covers all Note endpoint behaviors
+- GET with valid id → 200
+- GET with missing note → 404 via `DomainExceptionHandlerInterface`
+- GET with invalid id (≤ 0) → 404 via `DomainExceptionHandlerInterface`
+- POST with valid body → 201 + Location header
+- POST with invalid body → 422 Problem Details
+- DELETE with valid id → 204
+- DELETE with missing note → 404 via `DomainExceptionHandlerInterface`
+
+Tracked by `docs/milestones/2026-05-test-coverage-hardening.md`.
+
+## Phase 13: Collection Endpoint Pattern
+
+Goal: complete the CRUD example set by adding a list endpoint that demonstrates collection response shape and introduces a basic pagination design decision.
+
+- `GET /examples/notes` returning an array of notes
+- `ListNotesUseCase` with optional limit/offset or cursor parameters
+- `findAll()` on `NoteRepositoryInterface` and `PdoNoteRepository`
+- OpenAPI schema for collection response
+- PHPUnit unit and integration tests for the list path
+
+## Phase 14: Logger Integration Decision
+
+Goal: resolve the `NullLogger` placeholder by either wiring a real structured logger or explicitly documenting that the logger is the application owner's responsibility.
+
+- ADR recording the decision: embed Monolog vs leave PSR-3 open for the caller
+- if embedded: `RequestLoggingMiddleware` emits structured fields (`request_id`, `method`, `path`, `status`, `duration_ms`)
+- if caller-provided: update setup guide and service provider examples
+
+## Phase 15: Field Trial 2
+
+Goal: validate the full CRUD domain layer pattern in a second client-style project, exercising GET/POST/DELETE and the collection endpoint in a realistic scenario.
+
+- start from the latest `v0.1.x` checkpoint
+- scaffold at least one new domain entity using documented patterns
+- connect local MCP client and verify tool calls against new endpoints
+- record friction and open follow-up Issues
+
+## Phase 16: v0.2.0 Readiness
+
+Goal: stabilize the public surface enough to make an intentional `v0.2.0` decision, covering API stability, Packagist publication readiness, and the boundary between framework core and example code.
+
+- decide whether `src/Example/` stays in core or ships as a separate repository
+- review `DatabaseQueryExecutorInterface` and `DatabaseTransactionManagerInterface` for public API stability
+- decide Packagist publication timeline
+- update `CHANGELOG.md` and SemVer policy for `v0.2.x`
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,11 +4,9 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: `docs/milestones/2026-05-write-operations-pattern.md`
-- Current GitHub Issue: `#188`
+- Current milestone: `docs/milestones/2026-05-test-coverage-hardening.md` (Phase 12)
+- Current GitHub Issue: `#201`
 - Current branch: `main`
-- Handoff for next chat: `docs/todo/handoff-2026-05-04-implementation-start.md`
-- First implementation task: `docs/todo/first-task-2026-05-04-http-runtime-foundation.md`
 
 ## Foundation Completed
 
@@ -149,6 +147,28 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] Add body validation with `ValidationException` → 422. `#190`
 - [x] Add OpenAPI schemas for POST and DELETE operations. `#190`
 - [x] Add PHPUnit unit and integration tests for write paths. `#190`
+
+## Error Handler Systemization Candidates
+
+- [x] Add `DomainExceptionHandlerInterface` to `src/Error/`. `#197`
+- [x] Add `list<DomainExceptionHandlerInterface>` to `ErrorHandlerMiddleware`. `#197`
+- [x] Add `NoteNotFoundExceptionHandler` and wire it in `RuntimeServiceProvider`. `#197`
+- [x] Remove `ProblemDetailsResponseFactory` from `GetNoteByIdHandler` and `DeleteNoteHandler`. `#197`
+- [x] Add MySQL write operations verification and `compose.yaml` DB env defaults. `#194`
+- [x] Add `docs/development/setup.md` getting-started guide. `#196`
+- [x] Update `docs/development/docker.md` with MySQL service section. `#196`
+
+## Test Coverage Hardening Candidates (Phase 12)
+
+- [x] Define Phase 12 milestone and update roadmap. `#200`
+- [ ] Add HTTP-level tests for Note endpoints (GET/POST/DELETE × success + error paths). `#201`
+
+## Planned Phases (rough)
+
+- **Phase 13**: Collection endpoint — `GET /examples/notes` with list use case and OpenAPI schema
+- **Phase 14**: Logger integration decision — Monolog 統合 or 明示的な PSR-3 open policy を ADR に記録
+- **Phase 15**: Field Trial 2 — 最新 v0.1.x から新クライアントプロジェクト、CRUD フル活用
+- **Phase 16**: v0.2.0 readiness — `src/Example/` の位置付け、Packagist 公開判断、SemVer 方針
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- `docs/roadmap.md` に Phase 11〜16 を追記
- `docs/milestones/2026-05-error-handler-systemization.md` 作成（Phase 11 完了記録）
- `docs/milestones/2026-05-test-coverage-hardening.md` 作成（Phase 12 定義）
- `docs/todo/current.md` を Phase 12 基準に更新、Phase 13〜16 の方向を記録

Closes #200

Self-review: docs-policy