### PR TITLE
feat(log): Monolog 構造化ロギングを導入する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "require": {
     "php": ">=8.4.1 <9.0",
+    "monolog/monolog": "^3.0",
     "nyholm/psr7": "^1.8",
     "nyholm/psr7-server": "^1.1",
     "psr/container": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f701c0a590bc130636253ec573d76af7",
+    "content-hash": "f38073b9b80120aecd6b4418c446dbb5",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -67,6 +67,109 @@
                 }
             ],
             "time": "2025-12-27T19:43:20+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8 || ^2.0",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/docs/adr/0005-use-monolog-for-structured-logging.md
+++ b/docs/adr/0005-use-monolog-for-structured-logging.md
@@ -1,0 +1,43 @@
+# ADR 0005 — Use Monolog for Structured Logging
+
+**Status:** Accepted  
+**Date:** 2026-05-17  
+**Issue:** [#206](https://github.com/hideyukiMORI/NENE2/issues/206)
+
+---
+
+## Context
+
+NENE2 has a PSR-3 `LoggerInterface` binding in the DI container, but it was wired to `Psr\Log\NullLogger` — discarding all log output.
+Structured, machine-readable logs are needed before the second field trial to diagnose request failures and observe behaviour in production-like environments.
+
+Requirements:
+- PSR-3 compatible (no leakage of `monolog/monolog` into domain or use-case code)
+- JSON output to stderr (compatible with Docker / container log aggregators)
+- Log level configurable via `APP_DEBUG`
+- Minimal dependencies; no config files
+
+## Decision
+
+Use **Monolog 3.x** as the concrete PSR-3 implementation.
+
+- `MonologLoggerFactory` (in `src/Log/`) creates a `Logger` with a single `StreamHandler` writing JSON to `php://stderr`.
+- Channel name: `nene2`.
+- Log level: `debug` when `APP_DEBUG=true`, `warning` otherwise.
+- `RuntimeServiceProvider` replaces the `NullLogger` binding with a `MonologLoggerFactory` call.
+
+## Alternatives Considered
+
+| Option | Reason not chosen |
+|---|---|
+| Keep `NullLogger` | No observability; can't diagnose field trial issues |
+| Custom PSR-3 JSON logger | Unnecessary maintenance burden; Monolog is the PHP standard |
+| File handler | Requires volume management; stderr is the 12-factor standard |
+| Log level via env variable | Extra env var complexity; `APP_DEBUG` is already available |
+
+## Consequences
+
+- Adds `monolog/monolog ^3.0` as a runtime dependency.
+- Errors and warnings are visible in `docker compose logs app` with structured JSON fields.
+- Domain, use-case, and middleware code stays decoupled — they only see `LoggerInterface`.
+- Future: add `RequestIdProcessor` to attach `request_id` to every log record (out of scope here).

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -22,13 +22,13 @@ use Nene2\Example\Note\GetNoteByIdHandler;
 use Nene2\Example\Note\ListNotesHandler;
 use Nene2\Example\Note\NoteNotFoundExceptionHandler;
 use Nene2\Example\Note\NoteServiceProvider;
+use Nene2\Log\MonologLoggerFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 {
@@ -158,7 +158,15 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     return $factory;
                 },
             )
-            ->set(LoggerInterface::class, static fn (ContainerInterface $container): LoggerInterface => new NullLogger())
+            ->set(
+                LoggerInterface::class,
+                static function (ContainerInterface $container): LoggerInterface {
+                    $config = $container->get(AppConfig::class);
+                    $debug = $config instanceof AppConfig && $config->debug;
+
+                    return (new MonologLoggerFactory())->create('nene2', $debug);
+                },
+            )
             ->set(
                 RuntimeApplicationFactory::class,
                 static function (ContainerInterface $container): RuntimeApplicationFactory {

--- a/src/Log/MonologLoggerFactory.php
+++ b/src/Log/MonologLoggerFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Log;
+
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+final readonly class MonologLoggerFactory
+{
+    public function create(string $channel, bool $debug = false): LoggerInterface
+    {
+        $level = $debug ? Level::Debug : Level::Warning;
+        $handler = new StreamHandler('php://stderr', $level);
+        $handler->setFormatter(new JsonFormatter());
+
+        return new Logger($channel, [$handler]);
+    }
+}


### PR DESCRIPTION
## Summary
- `NullLogger` を Monolog 3.x JSON ロガーで置き換え
- `APP_DEBUG=true` のとき `debug`、それ以外は `warning` レベル
- stderr への JSON 出力で Docker ログアグリゲーターに対応
- `MonologLoggerFactory` を `src/Log/` に新設、DI バインディングを `RuntimeServiceProvider` で更新
- ADR 0005 で選定理由と代替案を記録

## Test plan
- [x] `composer check` 全グリーン (100 tests, 0 PHPStan errors, 0 CS issues)
- [x] 既存テストは HTTP / ユニット / DB 全レイヤー通過

## Related
Closes #206

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)