### PR TITLE
docs(milestone): Phase 15 フィールドトライアル2 マイルストーン・todo 更新

### DIFF
--- a/docs/milestones/2026-05-field-trial-2.md
+++ b/docs/milestones/2026-05-field-trial-2.md
@@ -1,0 +1,40 @@
+# Milestone: Field Trial 2 (Phase 15)
+
+## Period
+
+May 2026, after the `v0.1.3` checkpoint.
+
+## Goal
+
+Run a second field trial with the enhanced NENE2 stack:
+- Structured JSON logging via Monolog (Phase 14)
+- Complete Note CRUD + collection endpoint (Phases 8–13)
+- Error handler systemization (Phase 11)
+- HTTP-level test coverage (Phase 12)
+
+Verify that the improvements from Field Trial 1 friction have been addressed and that the
+framework is ready for a v0.2.0 readiness decision.
+
+## Theme
+
+- Confirm that structured logging makes request tracing observable
+- Validate that collection endpoint pagination works in a real-use scenario
+- Record any remaining friction for Phase 16 (v0.2.0 readiness)
+
+## Scope
+
+- Tag `v0.1.3` as a stable checkpoint on `main`
+- Run at least one sandbox session against `v0.1.3`
+- Record observations in `docs/field-trials/`
+- Create follow-up Issues from new friction
+
+## Acceptance Criteria
+
+- `v0.1.3` tag exists on `main`
+- `docs/todo/current.md` updated to Phase 15
+- Milestone document exists (this file)
+- Field trial session recorded (can be brief)
+
+## Candidate Issues
+
+- After trial: Phase 16 v0.2.0 readiness decisions (#209, TBD)

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,8 +4,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: `docs/milestones/2026-05-test-coverage-hardening.md` (Phase 12)
-- Current GitHub Issue: `#201`
+- Current milestone: `docs/milestones/2026-05-field-trial-2.md` (Phase 15)
+- Current GitHub Issue: `#208`
 - Current branch: `main`
 
 ## Foundation Completed
@@ -163,12 +163,18 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] Define Phase 12 milestone and update roadmap. `#200`
 - [x] Add HTTP-level tests for Note endpoints (GET/POST/DELETE × success + error paths). `#201`
 
-## Planned Phases (rough)
+## Completed Phases
 
-- **Phase 13**: Collection endpoint — `GET /examples/notes` with list use case and OpenAPI schema
-- **Phase 14**: Logger integration decision — Monolog 統合 or 明示的な PSR-3 open policy を ADR に記録
-- **Phase 15**: Field Trial 2 — 最新 v0.1.x から新クライアントプロジェクト、CRUD フル活用
-- **Phase 16**: v0.2.0 readiness — `src/Example/` の位置付け、Packagist 公開判断、SemVer 方針
+- [x] **Phase 13**: Collection endpoint — `GET /examples/notes` with list use case and OpenAPI schema. `#204`
+- [x] **Phase 14**: Monolog structured logging (stderr JSON, debug/warning level via APP_DEBUG). `#206`
+
+## Current Phase
+
+- **Phase 15**: Field Trial 2 — v0.1.3 tag + field trial session. `#208`
+
+## Planned Phases
+
+- **Phase 16**: v0.2.0 readiness — `src/Example/` の位置付け、Packagist 公開判断、SemVer 方針、CHANGELOG.md
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- `docs/milestones/2026-05-field-trial-2.md` を新規作成（Phase 15 Field Trial 2 マイルストーン）
- `docs/todo/current.md` を更新: Phase 13-14 完了記録、Phase 15 を現在フェーズとして設定

## Test plan
- [x] ドキュメント変更のみ、コード変更なし

## Related
Closes #208

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)