### PR TITLE
feat(log): Monolog RequestIdProcessor で X-Request-Id をログレコードに付与する

### DIFF
--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -13,6 +13,7 @@ use Nene2\Example\Note\GetNoteByIdHandler;
 use Nene2\Example\Note\ListNotesHandler;
 use Nene2\Example\Note\UpdateNoteHandler;
 use Nene2\FrameworkInfo;
+use Nene2\Log\RequestIdHolder;
 use Nene2\Middleware\ApiKeyAuthenticationMiddleware;
 use Nene2\Middleware\CorsMiddleware;
 use Nene2\Middleware\MiddlewareDispatcher;
@@ -42,6 +43,7 @@ final readonly class RuntimeApplicationFactory
         private array $domainExceptionHandlers = [],
         private ?ListNotesHandler $listNotesHandler = null,
         private ?UpdateNoteHandler $updateNoteHandler = null,
+        private ?RequestIdHolder $requestIdHolder = null,
     ) {
     }
 
@@ -127,7 +129,7 @@ final readonly class RuntimeApplicationFactory
 
         return new MiddlewareDispatcher(
             [
-                new RequestIdMiddleware(),
+                new RequestIdMiddleware('X-Request-Id', $this->requestIdHolder),
                 new RequestLoggingMiddleware($this->logger ?? new NullLogger()),
                 new SecurityHeadersMiddleware(),
                 new CorsMiddleware($this->responseFactory),

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -24,6 +24,7 @@ use Nene2\Example\Note\NoteNotFoundExceptionHandler;
 use Nene2\Example\Note\NoteServiceProvider;
 use Nene2\Example\Note\UpdateNoteHandler;
 use Nene2\Log\MonologLoggerFactory;
+use Nene2\Log\RequestIdHolder;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -159,13 +160,15 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     return $factory;
                 },
             )
+            ->set(RequestIdHolder::class, static fn (ContainerInterface $container): RequestIdHolder => new RequestIdHolder())
             ->set(
                 LoggerInterface::class,
                 static function (ContainerInterface $container): LoggerInterface {
                     $config = $container->get(AppConfig::class);
                     $debug = $config instanceof AppConfig && $config->debug;
+                    $holder = $container->get(RequestIdHolder::class);
 
-                    return (new MonologLoggerFactory())->create('nene2', $debug);
+                    return (new MonologLoggerFactory())->create('nene2', $debug, $holder instanceof RequestIdHolder ? $holder : null);
                 },
             )
             ->set(
@@ -198,6 +201,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     $listNotesHandler = $container->get(ListNotesHandler::class);
                     $updateNoteHandler = $container->get(UpdateNoteHandler::class);
                     $noteNotFoundHandler = $container->get(NoteNotFoundExceptionHandler::class);
+                    $requestIdHolder = $container->get(RequestIdHolder::class);
 
                     if (!$getNoteByIdHandler instanceof GetNoteByIdHandler) {
                         throw new LogicException('GetNoteById handler service is invalid.');
@@ -223,7 +227,11 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('NoteNotFoundException handler service is invalid.');
                     }
 
-                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger, $config->machineApiKey, $getNoteByIdHandler, $createNoteHandler, $deleteNoteHandler, [$noteNotFoundHandler], $listNotesHandler, $updateNoteHandler);
+                    if (!$requestIdHolder instanceof RequestIdHolder) {
+                        throw new LogicException('RequestIdHolder service is invalid.');
+                    }
+
+                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger, $config->machineApiKey, $getNoteByIdHandler, $createNoteHandler, $deleteNoteHandler, [$noteNotFoundHandler], $listNotesHandler, $updateNoteHandler, $requestIdHolder);
                 },
             )
             ->set(

--- a/src/Log/MonologLoggerFactory.php
+++ b/src/Log/MonologLoggerFactory.php
@@ -12,12 +12,14 @@ use Psr\Log\LoggerInterface;
 
 final readonly class MonologLoggerFactory
 {
-    public function create(string $channel, bool $debug = false): LoggerInterface
+    public function create(string $channel, bool $debug = false, ?RequestIdHolder $requestIdHolder = null): LoggerInterface
     {
         $level = $debug ? Level::Debug : Level::Warning;
         $handler = new StreamHandler('php://stderr', $level);
         $handler->setFormatter(new JsonFormatter());
 
-        return new Logger($channel, [$handler]);
+        $processors = $requestIdHolder !== null ? [new RequestIdProcessor($requestIdHolder)] : [];
+
+        return new Logger($channel, [$handler], $processors);
     }
 }

--- a/src/Log/RequestIdHolder.php
+++ b/src/Log/RequestIdHolder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Log;
+
+final class RequestIdHolder
+{
+    private string $requestId = '';
+
+    public function set(string $requestId): void
+    {
+        $this->requestId = $requestId;
+    }
+
+    public function get(): string
+    {
+        return $this->requestId;
+    }
+}

--- a/src/Log/RequestIdProcessor.php
+++ b/src/Log/RequestIdProcessor.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Log;
+
+use Monolog\LogRecord;
+
+final readonly class RequestIdProcessor
+{
+    public function __construct(
+        private RequestIdHolder $holder,
+    ) {
+    }
+
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $requestId = $this->holder->get();
+
+        if ($requestId === '') {
+            return $record;
+        }
+
+        return $record->with(extra: array_merge($record->extra, ['request_id' => $requestId]));
+    }
+}

--- a/src/Middleware/RequestIdMiddleware.php
+++ b/src/Middleware/RequestIdMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Middleware;
 
+use Nene2\Log\RequestIdHolder;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -15,12 +16,14 @@ final readonly class RequestIdMiddleware implements MiddlewareInterface
 
     public function __construct(
         private string $headerName = 'X-Request-Id',
+        private ?RequestIdHolder $requestIdHolder = null,
     ) {
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $requestId = $this->safeRequestId($request->getHeaderLine($this->headerName)) ?? $this->generateRequestId();
+        $this->requestIdHolder?->set($requestId);
         $response = $handler->handle($request->withAttribute(self::ATTRIBUTE, $requestId));
 
         return $response->withHeader($this->headerName, $requestId);

--- a/tests/Log/RequestIdMiddlewareHolderTest.php
+++ b/tests/Log/RequestIdMiddlewareHolderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Log;
+
+use Nene2\Log\RequestIdHolder;
+use Nene2\Middleware\RequestIdMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class RequestIdMiddlewareHolderTest extends TestCase
+{
+    public function testPopulatesHolderWithRequestId(): void
+    {
+        $factory = new Psr17Factory();
+        $holder = new RequestIdHolder();
+        $middleware = new RequestIdMiddleware('X-Request-Id', $holder);
+
+        $request = $factory->createServerRequest('GET', 'https://example.test/')
+            ->withHeader('X-Request-Id', 'test-id-123');
+
+        $handler = new class ($factory) implements RequestHandlerInterface {
+            public function __construct(private readonly Psr17Factory $factory)
+            {
+            }
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse(200);
+            }
+        };
+
+        $middleware->process($request, $handler);
+
+        self::assertSame('test-id-123', $holder->get());
+    }
+
+    public function testGeneratesAndPopulatesHolderWhenHeaderAbsent(): void
+    {
+        $factory = new Psr17Factory();
+        $holder = new RequestIdHolder();
+        $middleware = new RequestIdMiddleware('X-Request-Id', $holder);
+
+        $request = $factory->createServerRequest('GET', 'https://example.test/');
+
+        $handler = new class ($factory) implements RequestHandlerInterface {
+            public function __construct(private readonly Psr17Factory $factory)
+            {
+            }
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse(200);
+            }
+        };
+
+        $middleware->process($request, $handler);
+
+        self::assertNotEmpty($holder->get());
+    }
+}

--- a/tests/Log/RequestIdProcessorTest.php
+++ b/tests/Log/RequestIdProcessorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Log;
+
+use DateTimeImmutable;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Nene2\Log\RequestIdHolder;
+use Nene2\Log\RequestIdProcessor;
+use PHPUnit\Framework\TestCase;
+
+final class RequestIdProcessorTest extends TestCase
+{
+    public function testAddsRequestIdToExtra(): void
+    {
+        $holder = new RequestIdHolder();
+        $holder->set('abc123');
+
+        $processor = new RequestIdProcessor($holder);
+        $record = new LogRecord(new DateTimeImmutable(), 'test', Level::Info, 'msg');
+        $result = $processor($record);
+
+        self::assertSame('abc123', $result->extra['request_id']);
+    }
+
+    public function testSkipsExtraWhenHolderIsEmpty(): void
+    {
+        $holder = new RequestIdHolder();
+        $processor = new RequestIdProcessor($holder);
+        $record = new LogRecord(new DateTimeImmutable(), 'test', Level::Info, 'msg');
+        $result = $processor($record);
+
+        self::assertArrayNotHasKey('request_id', $result->extra);
+    }
+
+    public function testPreservesExistingExtraFields(): void
+    {
+        $holder = new RequestIdHolder();
+        $holder->set('req-1');
+
+        $processor = new RequestIdProcessor($holder);
+        $record = new LogRecord(new DateTimeImmutable(), 'test', Level::Info, 'msg', extra: ['foo' => 'bar']);
+        $result = $processor($record);
+
+        self::assertSame('bar', $result->extra['foo']);
+        self::assertSame('req-1', $result->extra['request_id']);
+    }
+}


### PR DESCRIPTION
## Summary
- `RequestIdHolder` — mutable singleton、`RequestIdMiddleware` がリクエスト ID を書き込む
- `RequestIdProcessor` — Monolog Processor、ホルダーから ID を読み `extra.request_id` に付与
- `MonologLoggerFactory::create()` — `?RequestIdHolder` を受け取りプロセッサーを追加
- `RequestIdMiddleware` — `?RequestIdHolder` 注入で ID をホルダーへ書き込む（既存挙動を変えない）
- `RuntimeServiceProvider` / `RuntimeApplicationFactory` でホルダーを DI スレッド
- テスト 5 件追加（processor unit × 3、middleware-holder integration × 2）

## Test plan
- [x] `composer check` 全グリーン (111 tests, 0 PHPStan errors, 0 CS issues)
- [x] `RequestIdProcessorTest` — extra.request_id 付与、空 ID スキップ、既存フィールド保持
- [x] `RequestIdMiddlewareHolderTest` — ヘッダーあり/なし両方でホルダーが更新される

## Related
Closes #216

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)