### PR TITLE
docs(release): Phase 19 v0.3.0 readiness — ADR 0007・マイルストーン・ロードマップ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Monolog `RequestIdProcessor`: attaches `X-Request-Id` as `extra.request_id` to every log record (#216)
+  - `RequestIdHolder` (mutable singleton) — middleware writes the ID, processor reads it
+  - `RequestIdMiddleware` accepts optional `RequestIdHolder` injection
+- `Router::put()` method (shipped with v0.2.0)
+- ADR 0007: PUT vs PATCH policy for resource update operations (#218)
+- v0.3.0 readiness milestone document (#222)
+
+### Changed
+- README: added Domain Layer Example section linking `src/Example/Note/` as canonical reference (#217)
+- README: Repository Layout updated with `src/Log/` and `src/Example/Note/`
+
 ---
 
 ## [0.2.0] — 2026-05-17

--- a/docs/adr/0007-put-vs-patch-policy.md
+++ b/docs/adr/0007-put-vs-patch-policy.md
@@ -1,0 +1,53 @@
+# ADR 0007 — PUT vs PATCH Policy for Resource Updates
+
+**Status:** Accepted  
+**Date:** 2026-05-17  
+**Issue:** [#218](https://github.com/hideyukiMORI/NENE2/issues/218)
+
+---
+
+## Context
+
+Phase 17 added `PUT /examples/notes/{id}`, which performs a **full replacement** of the resource
+(all fields must be supplied). Field Trial 2 flagged the absence of a documented policy on whether
+NENE2 endpoints should use PUT, PATCH, or both for update operations.
+
+Without a policy, contributors may implement partial updates inconsistently, leading to:
+- endpoints that silently ignore omitted fields (incorrect PUT semantics)
+- endpoints that require all fields for PATCH (incorrect PATCH semantics)
+- no guidance on which verb to add when a new update use case arises
+
+---
+
+## Decision
+
+**Use PUT for full replacement; add PATCH only when partial update semantics are explicitly needed.**
+
+### PUT (full replacement)
+- Client must supply all mutable fields.
+- Missing fields are treated as absent/null — they do not preserve the previous value.
+- Appropriate when the entire resource state is being set in one operation.
+- Example: `PUT /examples/notes/{id}` with `{title, body}` required.
+
+### PATCH (partial update)
+- Client supplies only the fields to change.
+- Omitted fields preserve their current value.
+- Use when the client has no reliable way to supply the full current state,
+  or when bandwidth or atomicity matters.
+- Not a default: add PATCH only when a concrete use case requires it.
+- When added, document which fields are patchable in the OpenAPI schema.
+
+### No mixed semantics
+- A PUT endpoint must not silently preserve omitted fields.
+- A PATCH endpoint must not require all fields.
+- If an endpoint has mixed behavior, it should be refactored before shipping.
+
+---
+
+## Consequences
+
+- The current `PUT /examples/notes/{id}` is compliant with this policy (all fields required).
+- Future update endpoints default to PUT unless partial semantics are explicitly justified.
+- PATCH implementations must use JSON Merge Patch (RFC 7396) or document their partial update
+  contract in the OpenAPI spec under `requestBody`.
+- OpenAPI schemas for PATCH requests should mark all properties as non-required.

--- a/docs/milestones/2026-05-v0.3.0-readiness.md
+++ b/docs/milestones/2026-05-v0.3.0-readiness.md
@@ -1,0 +1,57 @@
+# Milestone: v0.3.0 Readiness (Phase 19)
+
+## Period
+
+May–June 2026, after v0.2.0 Field Trial 2 closeout.
+
+## Goal
+
+Prepare NENE2 for a considered v0.3.0 release and, if criteria are met, Packagist publication.
+
+The v0.2.x series established the full CRUD pattern, structured logging, and error handler
+systemization. v0.3.0 should consolidate these patterns, resolve remaining Field Trial friction,
+and stabilize the public API surface before publishing to Packagist.
+
+## Packagist Publication Criteria (from ADR 0006)
+
+Before publishing to Packagist, all of the following must be true:
+
+- [ ] At least two field trial reports confirm the workflow is stable
+- [ ] No pending breaking changes in public API surface (handlers, service providers, config objects)
+- [ ] `CHANGELOG.md` covers all releases with consumer-visible changes
+- [ ] README includes Quick Start that works from a fresh clone
+- [ ] `src/Example/` position confirmed (stays in core — ADR 0006)
+
+## Status Check
+
+| Criterion | Status |
+|---|---|
+| Field trial reports | 2 complete (v0.1.1, v0.2.0) ✓ |
+| Pending breaking API changes | None known |
+| CHANGELOG.md complete | v0.1.0–v0.2.0 covered ✓ |
+| README Quick Start | Present ✓ |
+| src/Example/ position | Decided: stays in core ✓ |
+
+**Preliminary verdict:** Publication criteria are met. v0.3.0 may proceed to Packagist if no
+new breaking changes emerge during the release preparation.
+
+## Scope
+
+- ADR 0007: PUT vs PATCH policy (Field Trial 2 friction #218)
+- Phase 18: Monolog RequestIdProcessor (#216 — completed)
+- Phase 19 milestone document (this file)
+- Roadmap update
+- v0.3.0 tag after final check
+
+## Acceptance Criteria
+
+- ADR 0007 merged
+- Milestone document exists (this file)
+- Roadmap Phase 19 added
+- `docs/todo/current.md` updated
+- `CHANGELOG.md` [Unreleased] prepared for v0.3.0
+
+## Candidate Issues
+
+- v0.3.0 final check and tag (follow-up)
+- Packagist registration (after v0.3.0 tag)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -239,6 +239,31 @@ Goal: stabilize the public surface enough to make an intentional `v0.2.0` decisi
 - [x] create `CHANGELOG.md` covering v0.1.0–v0.1.3
 - [x] tag `v0.1.3` as stable checkpoint before v0.2.0 work begins
 
+## Phase 17: Full Note CRUD + v0.2.0 ✓
+
+Goal: complete the Note CRUD example and cut v0.2.0.
+
+- [x] `PUT /examples/notes/{id}` update endpoint
+- [x] `Router::put()` method
+- [x] v0.2.0 tag
+
+## Phase 18: Structured Logging with Request Correlation ✓
+
+Goal: attach `X-Request-Id` to every Monolog log record for request-level traceability.
+
+- [x] `RequestIdHolder` + `RequestIdProcessor`
+- [x] `RequestIdMiddleware` populates the holder
+- [x] `MonologLoggerFactory` wires the processor
+
+## Phase 19: v0.3.0 Readiness
+
+Goal: consolidate v0.2.x patterns, resolve Field Trial 2 friction, and prepare for Packagist publication.
+
+- ADR 0007: PUT vs PATCH policy (#218)
+- v0.3.0 milestone and Packagist criteria review
+- CHANGELOG.md [Unreleased] prepared
+- v0.3.0 tag + Packagist registration (if criteria met)
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -176,14 +176,18 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 ## Completed
 
 - [x] **Phase 17**: `PUT /examples/notes/{id}` で Note full CRUD + v0.2.0 タグ. `#212`
+- [x] **Field Trial 2**: v0.2.0 観察レポート + フリクション Issue 作成. `#215`
+- [x] **Phase 18**: Monolog RequestIdProcessor — `X-Request-Id` を全ログレコードに付与. `#216`
+- [x] **docs**: README に src/Example/Note/ を正規ドメイン層例として明記. `#217`
+
+## Current Phase
+
+- **Phase 19**: v0.3.0 readiness — ADR 0007 (PUT/PATCH)・Packagist 基準確認. `#222`
 
 ## Next Candidates
 
-- [x] Field Trial 2 session — v0.2.0 観察記録、フリクション Issue 作成. `#215`
-- Phase 18: Monolog RequestIdProcessor — `X-Request-Id` を全ログレコードに付与. `#216`
-- Phase 19: v0.3.0 readiness — Packagist 公開判断前の安定化フェーズ
-- docs: README に src/Example/Note/ を正規ドメイン層例として明記. `#217`
-- ADR: PUT vs PATCH ポリシー. `#218`
+- v0.3.0 タグ + Packagist 登録 (Phase 19 完了後)
+- ADR 0007: PUT vs PATCH ポリシー. `#218` (Phase 19 に含む)
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- `docs/adr/0007-put-vs-patch-policy.md` — PUT は全置換、PATCH は部分更新が必要な場合のみ
- `docs/milestones/2026-05-v0.3.0-readiness.md` — Packagist 公開基準を整理（2 回のフィールドトライアルで基準達成を確認）
- `docs/roadmap.md` — Phase 17-19 を追記
- `docs/todo/current.md` — Phase 18-19・Field Trial 2 完了状態に更新
- `CHANGELOG.md` — [Unreleased] に Phase 18 以降の変更を記録

## Related
Closes #218, #222

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)