### PR TITLE
chore(release): v0.3.0 CHANGELOG 確定・todo 更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.3.0] — 2026-05-17
+
 ### Added
 - Monolog `RequestIdProcessor`: attaches `X-Request-Id` as `extra.request_id` to every log record (#216)
   - `RequestIdHolder` (mutable singleton) — middleware writes the ID, processor reads it
   - `RequestIdMiddleware` accepts optional `RequestIdHolder` injection
-- `Router::put()` method (shipped with v0.2.0)
 - ADR 0007: PUT vs PATCH policy for resource update operations (#218)
-- v0.3.0 readiness milestone document (#222)
+- v0.3.0 readiness milestone with Packagist publication criteria review (#222)
 
 ### Changed
 - README: added Domain Layer Example section linking `src/Example/Note/` as canonical reference (#217)
@@ -108,7 +111,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Governance docs: workflow, coding standards, ADR policy, review checklists (#1)
 - ADR 0001–0004: HTTP runtime, DI container, phpdotenv, Phinx
 
-[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/hideyukiMORI/NENE2/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/hideyukiMORI/NENE2/compare/v0.1.1...v0.1.2

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -182,12 +182,12 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 ## Current Phase
 
-- **Phase 19**: v0.3.0 readiness — ADR 0007 (PUT/PATCH)・Packagist 基準確認. `#222`
+- [x] **Phase 19**: v0.3.0 readiness — ADR 0007・Packagist 基準確認・v0.3.0 タグ. `#222`
 
 ## Next Candidates
 
-- v0.3.0 タグ + Packagist 登録 (Phase 19 完了後)
-- ADR 0007: PUT vs PATCH ポリシー. `#218` (Phase 19 に含む)
+- Packagist 登録 — v0.3.0 タグ打ち後、公開基準を満たしていることを確認して実施
+- Phase 20: 次のフィールドトライアルまたは機能追加フェーズ
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary
- CHANGELOG.md [Unreleased] → [0.3.0] — 2026-05-17 に確定
- `[Unreleased]` リンクを v0.3.0 ベースに更新
- `docs/todo/current.md` を Phase 19 完了・次候補 (Packagist) に更新

## Related
Part of #222

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)