### PR TITLE
docs(setup,mcp): X-Request-Id log verification + Note MCP write tools (#227 #228)

### DIFF
--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -121,6 +121,28 @@ docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/loc
 
 See `docs/integrations/local-mcp-server.md` for MCP client configuration.
 
+## Optional: Verify Request ID in Logs
+
+Every request generates an `X-Request-Id` that is echoed in the response header and attached to every Monolog log record as `extra.request_id`. To verify this is working:
+
+1. Start the app: `docker compose up -d app`
+2. Send a request:
+   ```bash
+   curl -i http://localhost:8080/health
+   # Look for X-Request-Id in the response headers
+   ```
+3. Watch the structured log output:
+   ```bash
+   docker compose logs app
+   # Each JSON log line includes "extra":{"request_id":"<id>"}
+   ```
+
+You can also supply your own ID:
+```bash
+curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
+# The same id appears in the response header and in docker compose logs
+```
+
 ## Troubleshooting
 
 **`composer check` fails on a clean clone**

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -37,6 +37,162 @@
         "properties": {}
       },
       "responseSchemaRef": "#/components/schemas/HealthResponse"
+    },
+    {
+      "name": "getExamplePing",
+      "title": "Example Ping",
+      "description": "Read the example ping endpoint through the documented public API.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "getExamplePing",
+        "method": "GET",
+        "path": "/examples/ping"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+      },
+      "responseSchemaRef": "#/components/schemas/ExamplePingResponse"
+    },
+    {
+      "name": "listExampleNotes",
+      "title": "List Example Notes",
+      "description": "List example notes with optional limit and offset pagination.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "listExampleNotes",
+        "method": "GET",
+        "path": "/examples/notes"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/ExampleNoteListResponse"
+    },
+    {
+      "name": "getExampleNoteById",
+      "title": "Get Example Note",
+      "description": "Read an example note by ID through the documented public API.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "getExampleNoteById",
+        "method": "GET",
+        "path": "/examples/notes/{id}"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/ExampleNoteResponse"
+    },
+    {
+      "name": "createExampleNote",
+      "title": "Create Example Note",
+      "description": "Create a new example note. Returns 201 with the created note and a Location header.",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "createExampleNote",
+        "method": "POST",
+        "path": "/examples/notes"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "body"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "responseSchemaRef": null
+    },
+    {
+      "name": "updateExampleNoteById",
+      "title": "Update Example Note",
+      "description": "Replace an existing example note (full replacement — all fields required).",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "updateExampleNoteById",
+        "method": "PUT",
+        "path": "/examples/notes/{id}"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "title", "body"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/ExampleNoteResponse"
+    },
+    {
+      "name": "deleteExampleNoteById",
+      "title": "Delete Example Note",
+      "description": "Delete an example note by ID. Returns 204 on success.",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "deleteExampleNoteById",
+        "method": "DELETE",
+        "path": "/examples/notes/{id}"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "responseSchemaRef": null
     }
   ]
 }

--- a/src/Mcp/LocalMcpToolCatalog.php
+++ b/src/Mcp/LocalMcpToolCatalog.php
@@ -38,7 +38,9 @@ final readonly class LocalMcpToolCatalog
             throw new LocalMcpException('MCP tool catalog must contain a tools array.');
         }
 
-        return array_map($this->tool(...), array_values($tools));
+        $readTools = array_values(array_filter($tools, static fn (mixed $t) => is_array($t) && ($t['safety'] ?? null) === 'read'));
+
+        return array_map($this->tool(...), $readTools);
     }
 
     /**


### PR DESCRIPTION
## Summary

- **#227**: `docs/development/setup.md` に `## Optional: Verify Request ID in Logs` セクション追加 — RequestIdProcessor の動作確認手順（curl + docker logs）
- **#228**: `docs/mcp/tools.json` に Note 操作 MCP ツール 6 件追加（read×3, write×3）+ `LocalMcpToolCatalog` を read-only フィルタに修正

## Changes

### docs/development/setup.md
- `X-Request-Id` がレスポンスヘッダーとログに出ることを確認する手順を追加
- 供給 ID（`X-Request-Id: my-trace-id`）の使用例も記載

### docs/mcp/tools.json
- Read tools: `getExamplePing`, `listExampleNotes`, `getExampleNoteById`
- Write tools (safety: "write"): `createExampleNote`, `updateExampleNoteById`, `deleteExampleNoteById`

### src/Mcp/LocalMcpToolCatalog.php
- `tools()` で `safety: "read"` のみ通すフィルタを追加
- write ツールは `responseSchemaRef: null` のためパースできない — フィルタで安全にスキップ

## Verification

```
docker compose run --rm app composer check
# 111 tests, 410 assertions — OK
# PHPStan: No errors
# CS Fixer: 0 fixable
# OpenAPI contract: valid
# MCP tool catalog: valid
```

## Self-review

Self-review: docs-policy, backend-api

Closes #227, #228