### PR TITLE
feat(mcp): LocalMcpServer で write ツールと引数付きツールを実行できるようにする (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Local MCP server now executes write operations (`POST`, `PUT`, `DELETE`) through the documented API boundary (#228)
+  - `LocalMcpHttpClientInterface` extended with `post()`, `put()`, `delete()` methods
+  - `NativeLocalMcpHttpClient` implements the new methods with JSON body support
+  - `LocalMcpServer` routes tools to the correct HTTP method; path parameters are interpolated from arguments; GET query arguments are appended as a query string
+  - `LocalMcpToolCatalog` now exposes all tools (not only `read`); `responseSchemaRef` is nullable
+
 ---
 
 ## [0.3.0] — 2026-05-17

--- a/docs/integrations/local-mcp-server.md
+++ b/docs/integrations/local-mcp-server.md
@@ -35,13 +35,17 @@ When running the server inside Docker against the Compose `app` service, use the
 docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
 ```
 
-The first server supports:
+The server supports:
 
 - `initialize`
 - `tools/list`
 - `tools/call`
 
-Tools are loaded from `docs/mcp/tools.json`. The first supported calls are read-only OpenAPI-aligned HTTP GET tools such as `getHealth` and `getFrameworkSmoke`.
+Tools are loaded from `docs/mcp/tools.json`. Both read-only (`safety: read`) and write (`safety: write`) OpenAPI-aligned tools are exposed.
+
+Read tools (`getHealth`, `getFrameworkSmoke`, `listExampleNotes`, `getExampleNoteById`) map to HTTP GET. Arguments become path parameters or query string values.
+
+Write tools (`createExampleNote`, `updateExampleNoteById`, `deleteExampleNoteById`) map to HTTP POST, PUT, and DELETE respectively. Path parameters are interpolated from arguments; remaining arguments are sent as a JSON request body.
 
 The server communicates over newline-delimited JSON-RPC messages on stdio. It is intended for local MCP clients and development smoke checks, not direct browser use.
 
@@ -83,18 +87,18 @@ Local tools that do not need authentication should not pretend to require creden
 
 ## Tool Shape
 
-Read-only local tools should map to existing catalog or OpenAPI operations when practical.
+Local tools should map to existing catalog or OpenAPI operations when practical.
 
 Recommended metadata:
 
 - tool name
-- safety level
+- safety level (`read`, `write`, `admin`, or `destructive`)
 - source operation or command
 - required scopes, if any
 - whether the tool calls HTTP
 - whether the tool returns request id metadata
 
-Mutation, admin, and destructive tools are out of scope for the first local MCP server guidance.
+`admin` and `destructive` tools are out of scope for the current local MCP server guidance.
 
 ### Integer Path Parameters
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -189,8 +189,8 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 - [x] **Packagist 登録前準備**: `composer.json` type `"library"` + README インストール手順. `#226`
 - [x] docs(setup): RequestIdProcessor 動作確認手順. `#227`
-- [x] feat(mcp): Note write operations MCP ツール追加. `#228`
-- Packagist 登録 (`#226` 完了済み — 手動登録が残り)
+- [x] feat(mcp): Note write operations MCP ツール追加 — catalog + LocalMcpServer 実装. `#228`
+- Packagist 登録 (`#226` 完了済み — 手動登録が残り、#228 マージ後に実施)
 
 ## Operating Notes
 

--- a/src/Mcp/LocalMcpHttpClientInterface.php
+++ b/src/Mcp/LocalMcpHttpClientInterface.php
@@ -7,4 +7,12 @@ namespace Nene2\Mcp;
 interface LocalMcpHttpClientInterface
 {
     public function get(string $baseUrl, string $path): LocalMcpHttpResponse;
+
+    /** @param array<string, mixed> $body */
+    public function post(string $baseUrl, string $path, array $body): LocalMcpHttpResponse;
+
+    /** @param array<string, mixed> $body */
+    public function put(string $baseUrl, string $path, array $body): LocalMcpHttpResponse;
+
+    public function delete(string $baseUrl, string $path): LocalMcpHttpResponse;
 }

--- a/src/Mcp/LocalMcpServer.php
+++ b/src/Mcp/LocalMcpServer.php
@@ -119,34 +119,37 @@ final readonly class LocalMcpServer
             throw new LocalMcpException('tools/call params.arguments must be an object when provided.');
         }
 
-        if ($arguments !== []) {
-            throw new LocalMcpException('The first NENE2 local MCP tools do not accept arguments.');
-        }
-
         $tool = $this->catalog->find($name);
 
         if ($tool === null) {
             throw new LocalMcpException(sprintf('MCP tool "%s" was not found.', $name));
         }
 
-        if ($tool['safety'] !== 'read') {
-            throw new LocalMcpException(sprintf('MCP tool "%s" is not read-only.', $name));
+        if ($tool['source']['type'] !== 'openapi') {
+            throw new LocalMcpException(sprintf('MCP tool "%s" does not map to a local OpenAPI operation.', $name));
         }
 
-        if ($tool['source']['type'] !== 'openapi' || $tool['source']['method'] !== 'GET') {
-            throw new LocalMcpException(sprintf('MCP tool "%s" does not map to a local GET API operation.', $name));
-        }
-
-        return $this->httpToolResult($tool);
+        return $this->httpToolResult($tool, $arguments);
     }
 
     /**
      * @param McpTool $tool
+     * @param array<string, mixed> $arguments
      * @return array<string, mixed>
      */
-    private function httpToolResult(array $tool): array
+    private function httpToolResult(array $tool, array $arguments): array
     {
-        $response = $this->httpClient->get($this->apiBaseUrl, $tool['source']['path']);
+        [$path, $remainingArgs] = $this->interpolatePath($tool['source']['path'], $arguments);
+        $method = $tool['source']['method'];
+
+        $response = match ($method) {
+            'GET'    => $this->httpClient->get($this->apiBaseUrl, $this->appendQuery($path, $remainingArgs)),
+            'POST'   => $this->httpClient->post($this->apiBaseUrl, $path, $remainingArgs),
+            'PUT'    => $this->httpClient->put($this->apiBaseUrl, $path, $remainingArgs),
+            'DELETE' => $this->httpClient->delete($this->apiBaseUrl, $path),
+            default  => throw new LocalMcpException(sprintf('HTTP method "%s" is not supported.', $method)),
+        };
+
         $body = $this->decodeBody($response->body);
 
         $structuredContent = [
@@ -167,6 +170,44 @@ final readonly class LocalMcpServer
             'structuredContent' => $structuredContent,
             'isError' => !$response->isSuccessful(),
         ];
+    }
+
+    /**
+     * Splits path parameters from arguments, returning the interpolated path
+     * and the remaining arguments (for body or query string).
+     *
+     * @param array<string, mixed> $arguments
+     * @return array{string, array<string, mixed>}
+     */
+    private function interpolatePath(string $path, array $arguments): array
+    {
+        preg_match_all('/\{([^}]+)\}/', $path, $matches);
+        $pathParams = $matches[1];
+
+        $remaining = $arguments;
+
+        foreach ($pathParams as $param) {
+            if (!array_key_exists($param, $arguments)) {
+                throw new LocalMcpException(sprintf('Required path parameter "%s" was not provided.', $param));
+            }
+
+            $path = str_replace('{' . $param . '}', (string) $arguments[$param], $path);
+            unset($remaining[$param]);
+        }
+
+        return [$path, $remaining];
+    }
+
+    /**
+     * @param array<string, mixed> $queryArgs
+     */
+    private function appendQuery(string $path, array $queryArgs): string
+    {
+        if ($queryArgs === []) {
+            return $path;
+        }
+
+        return $path . '?' . http_build_query($queryArgs);
     }
 
     private function decodeBody(string $body): mixed

--- a/src/Mcp/LocalMcpToolCatalog.php
+++ b/src/Mcp/LocalMcpToolCatalog.php
@@ -6,7 +6,7 @@ namespace Nene2\Mcp;
 
 /**
  * @phpstan-type McpToolSource array{type: string, operationId: string, method: string, path: string}
- * @phpstan-type McpTool array{name: string, title: string, description: string, safety: string, source: McpToolSource, inputSchema: array<string, mixed>, responseSchemaRef: string}
+ * @phpstan-type McpTool array{name: string, title: string, description: string, safety: string, source: McpToolSource, inputSchema: array<string, mixed>, responseSchemaRef: string|null}
  */
 final readonly class LocalMcpToolCatalog
 {
@@ -38,9 +38,9 @@ final readonly class LocalMcpToolCatalog
             throw new LocalMcpException('MCP tool catalog must contain a tools array.');
         }
 
-        $readTools = array_values(array_filter($tools, static fn (mixed $t) => is_array($t) && ($t['safety'] ?? null) === 'read'));
+        $validTools = array_values(array_filter($tools, static fn (mixed $t) => is_array($t)));
 
-        return array_map($this->tool(...), $readTools);
+        return array_map($this->tool(...), $validTools);
     }
 
     /**
@@ -86,7 +86,7 @@ final readonly class LocalMcpToolCatalog
                 'path' => $this->stringValue($source, 'path'),
             ],
             'inputSchema' => $inputSchema,
-            'responseSchemaRef' => $this->stringValue($value, 'responseSchemaRef'),
+            'responseSchemaRef' => $this->nullableStringValue($value, 'responseSchemaRef'),
         ];
     }
 
@@ -99,6 +99,24 @@ final readonly class LocalMcpToolCatalog
 
         if (!is_string($value) || $value === '') {
             throw new LocalMcpException(sprintf('MCP catalog field "%s" must be a non-empty string.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function nullableStringValue(array $values, string $key): ?string
+    {
+        $value = $values[$key] ?? null;
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value) || $value === '') {
+            throw new LocalMcpException(sprintf('MCP catalog field "%s" must be a non-empty string or null.', $key));
         }
 
         return $value;

--- a/src/Mcp/NativeLocalMcpHttpClient.php
+++ b/src/Mcp/NativeLocalMcpHttpClient.php
@@ -8,30 +8,64 @@ final readonly class NativeLocalMcpHttpClient implements LocalMcpHttpClientInter
 {
     public function get(string $baseUrl, string $path): LocalMcpHttpResponse
     {
-        $headers = [
-            'Accept: application/json',
-        ];
+        return $this->request('GET', $baseUrl, $path, null);
+    }
 
-        $context = stream_context_create([
+    /** @param array<string, mixed> $body */
+    public function post(string $baseUrl, string $path, array $body): LocalMcpHttpResponse
+    {
+        return $this->request('POST', $baseUrl, $path, $body);
+    }
+
+    /** @param array<string, mixed> $body */
+    public function put(string $baseUrl, string $path, array $body): LocalMcpHttpResponse
+    {
+        return $this->request('PUT', $baseUrl, $path, $body);
+    }
+
+    public function delete(string $baseUrl, string $path): LocalMcpHttpResponse
+    {
+        return $this->request('DELETE', $baseUrl, $path, null);
+    }
+
+    /**
+     * @param array<string, mixed>|null $body
+     */
+    private function request(string $method, string $baseUrl, string $path, ?array $body): LocalMcpHttpResponse
+    {
+        $headers = ['Accept: application/json'];
+        $content = null;
+
+        if ($body !== null) {
+            $content = json_encode($body, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+            $headers[] = 'Content-Type: application/json';
+        }
+
+        $options = [
             'http' => [
-                'method' => 'GET',
+                'method' => $method,
                 'header' => implode("\r\n", $headers),
                 'ignore_errors' => true,
                 'timeout' => 10,
             ],
-        ]);
+        ];
 
+        if ($content !== null) {
+            $options['http']['content'] = $content;
+        }
+
+        $context = stream_context_create($options);
         $url = rtrim($baseUrl, '/') . $path;
-        $body = file_get_contents($url, false, $context);
+        $responseBody = file_get_contents($url, false, $context);
 
-        if ($body === false) {
+        if ($responseBody === false) {
             throw new LocalMcpException(sprintf('Local API request failed for "%s".', $url));
         }
 
         return new LocalMcpHttpResponse(
             $this->statusCode($http_response_header),
             $this->headers($http_response_header),
-            $body,
+            $responseBody,
         );
     }
 

--- a/tests/Mcp/LocalMcpServerTest.php
+++ b/tests/Mcp/LocalMcpServerTest.php
@@ -44,6 +44,26 @@ final class LocalMcpServerTest extends TestCase
         self::assertInstanceOf(\stdClass::class, $response['result']['tools'][1]['inputSchema']['properties'] ?? null);
     }
 
+    public function testToolsListIncludesWriteToolsWithReadOnlyHintFalse(): void
+    {
+        $server = $this->server();
+
+        $response = $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'method' => 'tools/list',
+        ]);
+
+        $tools = $response['result']['tools'] ?? [];
+        $writeTools = array_values(array_filter($tools, static fn (array $t) => $t['annotations']['readOnlyHint'] === false));
+
+        self::assertNotEmpty($writeTools);
+        $names = array_column($writeTools, 'name');
+        self::assertContains('createExampleNote', $names);
+        self::assertContains('updateExampleNoteById', $names);
+        self::assertContains('deleteExampleNoteById', $names);
+    }
+
     public function testToolsCallInvokesLocalHttpApiAndReturnsRequestId(): void
     {
         $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(
@@ -65,9 +85,125 @@ final class LocalMcpServerTest extends TestCase
 
         self::assertSame('http://localhost:8080', $client->baseUrl);
         self::assertSame('/health', $client->path);
+        self::assertSame('get', $client->lastMethod);
         self::assertSame(false, $response['result']['isError'] ?? null);
         self::assertSame('request-123', $response['result']['structuredContent']['requestId'] ?? null);
         self::assertSame('ok', $response['result']['structuredContent']['body']['status'] ?? null);
+    }
+
+    public function testToolsCallWithIdArgumentInterpolatesPath(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(
+            200,
+            ['x-request-id' => 'req-456'],
+            '{"id":5,"title":"Test","body":"Body content"}',
+        ));
+        $server = $this->server($client);
+
+        $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 4,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'getExampleNoteById',
+                'arguments' => ['id' => 5],
+            ],
+        ]);
+
+        self::assertSame('get', $client->lastMethod);
+        self::assertSame('/examples/notes/5', $client->path);
+    }
+
+    public function testToolsCallGetWithQueryArguments(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(
+            200,
+            [],
+            '{"items":[],"limit":10,"offset":5}',
+        ));
+        $server = $this->server($client);
+
+        $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 5,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'listExampleNotes',
+                'arguments' => ['limit' => 10, 'offset' => 5],
+            ],
+        ]);
+
+        self::assertSame('get', $client->lastMethod);
+        self::assertSame('/examples/notes?limit=10&offset=5', $client->path);
+    }
+
+    public function testToolsCallPostWriteToolSendsBodyArguments(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(
+            201,
+            ['x-request-id' => 'req-789'],
+            '{"id":1,"title":"New note","body":"Some content"}',
+        ));
+        $server = $this->server($client);
+
+        $response = $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 6,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'createExampleNote',
+                'arguments' => ['title' => 'New note', 'body' => 'Some content'],
+            ],
+        ]);
+
+        self::assertSame('post', $client->lastMethod);
+        self::assertSame('/examples/notes', $client->path);
+        self::assertSame(['title' => 'New note', 'body' => 'Some content'], $client->body);
+        self::assertSame(false, $response['result']['isError'] ?? null);
+    }
+
+    public function testToolsCallPutInterpolatesPathAndSendsBody(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(
+            200,
+            [],
+            '{"id":3,"title":"Updated","body":"New body"}',
+        ));
+        $server = $this->server($client);
+
+        $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 7,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'updateExampleNoteById',
+                'arguments' => ['id' => 3, 'title' => 'Updated', 'body' => 'New body'],
+            ],
+        ]);
+
+        self::assertSame('put', $client->lastMethod);
+        self::assertSame('/examples/notes/3', $client->path);
+        self::assertSame(['title' => 'Updated', 'body' => 'New body'], $client->body);
+    }
+
+    public function testToolsCallDeleteInterpolatesPath(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(204, [], ''));
+        $server = $this->server($client);
+
+        $response = $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 8,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'deleteExampleNoteById',
+                'arguments' => ['id' => 7],
+            ],
+        ]);
+
+        self::assertSame('delete', $client->lastMethod);
+        self::assertSame('/examples/notes/7', $client->path);
+        self::assertSame(false, $response['result']['isError'] ?? null);
     }
 
     public function testNotificationsDoNotReturnResponses(): void
@@ -92,9 +228,14 @@ final class LocalMcpServerTest extends TestCase
 
 final class RecordingLocalMcpHttpClient implements LocalMcpHttpClientInterface
 {
+    public ?string $lastMethod = null;
+
     public ?string $baseUrl = null;
 
     public ?string $path = null;
+
+    /** @var array<string, mixed>|null */
+    public ?array $body = null;
 
     public function __construct(
         private readonly LocalMcpHttpResponse $response,
@@ -103,6 +244,38 @@ final class RecordingLocalMcpHttpClient implements LocalMcpHttpClientInterface
 
     public function get(string $baseUrl, string $path): LocalMcpHttpResponse
     {
+        $this->lastMethod = 'get';
+        $this->baseUrl = $baseUrl;
+        $this->path = $path;
+
+        return $this->response;
+    }
+
+    /** @param array<string, mixed> $body */
+    public function post(string $baseUrl, string $path, array $body): LocalMcpHttpResponse
+    {
+        $this->lastMethod = 'post';
+        $this->baseUrl = $baseUrl;
+        $this->path = $path;
+        $this->body = $body;
+
+        return $this->response;
+    }
+
+    /** @param array<string, mixed> $body */
+    public function put(string $baseUrl, string $path, array $body): LocalMcpHttpResponse
+    {
+        $this->lastMethod = 'put';
+        $this->baseUrl = $baseUrl;
+        $this->path = $path;
+        $this->body = $body;
+
+        return $this->response;
+    }
+
+    public function delete(string $baseUrl, string $path): LocalMcpHttpResponse
+    {
+        $this->lastMethod = 'delete';
         $this->baseUrl = $baseUrl;
         $this->path = $path;
 

--- a/tests/Mcp/LocalMcpToolCatalogTest.php
+++ b/tests/Mcp/LocalMcpToolCatalogTest.php
@@ -21,4 +21,29 @@ final class LocalMcpToolCatalogTest extends TestCase
         self::assertSame('/health', $tool['source']['path']);
         self::assertSame('getHealth', $tool['source']['operationId']);
     }
+
+    public function testLoadsWriteToolsFromCommittedCatalog(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+
+        $tool = $catalog->find('createExampleNote');
+
+        self::assertNotNull($tool);
+        self::assertSame('write', $tool['safety']);
+        self::assertSame('POST', $tool['source']['method']);
+        self::assertSame('/examples/notes', $tool['source']['path']);
+        self::assertNull($tool['responseSchemaRef']);
+    }
+
+    public function testAllToolsArePresentInToolsList(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+
+        $names = array_column($catalog->tools(), 'name');
+
+        self::assertContains('getHealth', $names);
+        self::assertContains('createExampleNote', $names);
+        self::assertContains('updateExampleNoteById', $names);
+        self::assertContains('deleteExampleNoteById', $names);
+    }
 }


### PR DESCRIPTION
## 目的

Issue #228 の完全実装。`docs/mcp/tools.json` に write ツールが追加されていたが、`LocalMcpServer` は `safety !== 'read'` と `arguments !== []` を即エラーにしていたため、write ツールも引数付き read ツールも実際には呼べなかった。

## 変更点

| ファイル | 変更内容 |
|---|---|
| `src/Mcp/LocalMcpToolCatalog` | `read` フィルターを廃止、全ツールを返す。`responseSchemaRef` を nullable 型に変更 |
| `src/Mcp/LocalMcpHttpClientInterface` | `post()` / `put()` / `delete()` を追加 |
| `src/Mcp/NativeLocalMcpHttpClient` | 共通リクエストロジックを抽出し write メソッドを実装（JSON ボディ、Content-Type 付与） |
| `src/Mcp/LocalMcpServer` | `interpolatePath()` でパス補間、`appendQuery()` でクエリ付与、ツールの HTTP メソッドに応じてルーティング |
| `tests/Mcp/LocalMcpServerTest` | `RecordingLocalMcpHttpClient` に write メソッド追加、引数付きテスト 5 件追加 |
| `tests/Mcp/LocalMcpToolCatalogTest` | write ツール・全ツール一覧のテスト追加 |
| `docs/integrations/local-mcp-server.md` | write ツール対応の説明に更新 |
| `CHANGELOG.md` | [Unreleased] に追記 |

## 動作概要

- `getExampleNoteById` に `id: 5` → `/examples/notes/5` に GET
- `listExampleNotes` に `limit: 10, offset: 5` → `/examples/notes?limit=10&offset=5` に GET
- `createExampleNote` に `title`, `body` → `/examples/notes` に POST (JSON ボディ)
- `updateExampleNoteById` に `id: 3`, `title`, `body` → `/examples/notes/3` に PUT (JSON ボディ)
- `deleteExampleNoteById` に `id: 7` → `/examples/notes/7` に DELETE

## 検証結果

```
OK (119 tests, 438 assertions)
PHPStan: 0 errors
PHP-CS-Fixer: 0 fixable files
OpenAPI contract: valid
MCP catalog: valid
```

## Self-review

`backend-api` チェックリスト — MCP ツールは OpenAPI 境界を経由しており、直接 DB アクセスなし。シークレット非含有。

Closes #228