### PR TITLE
docs(field-trial): Phase 20 Packagist フィールドトライアル — composer require 検証レポート (#233)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-4.md
+++ b/docs/field-trials/2026-05-field-trial-4.md
@@ -1,0 +1,108 @@
+# Field Trial 4 Report
+
+**Date:** 2026-05-17
+**NENE2 version:** v0.3.0
+**Issue:** [#233](https://github.com/hideyukiMORI/NENE2/issues/233)
+
+---
+
+## Trial context
+
+| Item | Notes |
+|---|---|
+| Sandbox | `/home/xi/docker/nene2-ft4` — fresh directory, no NENE2 source files |
+| Starting point | `composer require hideyukimori/nene2:^0.3` |
+| PHP runtime | PHP 8.4 via NENE2 Docker image (host PHP is 8.1) |
+| Goal | Validate "library consumer" experience distinct from git-clone workflow |
+
+---
+
+## Session summary
+
+### Step 1: Installation
+
+Created `composer.json` with `"hideyukimori/nene2": "^0.3"` and ran `composer install`.
+
+**Result: Installs cleanly.** 16 packages installed (Monolog, Nyholm PSR-7, phpdotenv, PSR interfaces). No errors.
+
+### Step 2: RuntimeContainerFactory path
+
+Copied `public_html/index.php` pattern from NENE2 docs and created `.env` with `DB_ADAPTER=sqlite`. Used `RuntimeContainerFactory(dirname(__DIR__))`.
+
+**Result: Works.** `GET /`, `GET /health`, `GET /examples/ping` all return 200 with correct JSON. Monolog logs appear on stderr with `request_id` in `extra`.
+
+**Friction observed:** `RuntimeServiceProvider` includes `NoteServiceProvider` — the Note CRUD routes (`/examples/notes/*`) are present in the consumer's app without being requested. These are unexpected routes in an external project.
+
+### Step 3: Adding a custom route
+
+Attempted to add a custom `/greet/{name}` route via `RuntimeApplicationFactory`. Not possible: `RuntimeApplicationFactory` is `final readonly` and takes no route-injection parameter. `RuntimeServiceProvider` is also `final`.
+
+**Workaround found:** Bypass `RuntimeApplicationFactory` and directly wire `Router` + `MiddlewareDispatcher` + middleware stack manually (6 classes, ~30 lines).
+
+**Result: Works after manual wiring.** Custom `/health` and `/greet/{name}` endpoints return 200.
+
+### Step 4: Path parameter access
+
+Using `$req->getAttribute('name')` returned empty string. Path parameters are stored under `Router::PARAMETERS_ATTRIBUTE` as an array, not as individual PSR-7 attributes.
+
+**Result: Works after correction.** `$req->getAttribute(Router::PARAMETERS_ATTRIBUTE, [])['name']` returns the correct value.
+
+**Friction observed:** `Router::PARAMETERS_ATTRIBUTE` convention is not documented in `endpoint-scaffold.md` or `client-project-start.md`. A new developer would hit this silently.
+
+---
+
+## Commands run
+
+```text
+composer install
+# 16 packages installed, including hideyukimori/nene2 v0.3.0
+
+php smoke-test.php
+# GET /          → 200  {"name":"NENE2",...}
+# GET /health    → 200  {"status":"ok",...}
+# GET /examples/ping → 200  {"message":"pong",...}
+
+php custom-route-test.php
+# GET /health       → 200  {"status":"ok","app":"ft4"}
+# GET /greet/NENE2  → 200  {"message":"Hello, NENE2!"}
+# GET /not-found    → 404  Problem Details JSON
+```
+
+---
+
+## Outcomes
+
+**What worked well:**
+
+- `composer require` installs cleanly — zero configuration friction
+- `RuntimeContainerFactory` + `.env` path works for external project roots
+- `Router` + `MiddlewareDispatcher` are independently usable as library components
+- Problem Details 404 is returned correctly for unknown routes
+- Monolog structured logging with `request_id` works out of the box
+- All PSR interfaces are properly separated and accessible
+
+**What was unclear or required discovery:**
+
+1. **Path parameters use `Router::PARAMETERS_ATTRIBUTE`, not direct PSR-7 attributes.** Not documented in `endpoint-scaffold.md` or `client-project-start.md`. A new developer will write `$req->getAttribute('name')` first.
+
+2. **No consumer-facing route extension path.** `RuntimeApplicationFactory` is `final` and not extensible. A consumer who wants custom routes must bypass it and wire `Router` + `MiddlewareDispatcher` manually. No guide exists for this pattern.
+
+3. **`RuntimeServiceProvider` bundles `NoteServiceProvider`.** An external consumer using `RuntimeContainerFactory` gets the Note CRUD endpoints unexpectedly. The `client-project-start.md` guide notes "rename the project boundary" but does not address unwanted example routes.
+
+4. **`FrameworkInfo` hardcodes NENE2 name and description.** `GET /` returns `"name": "NENE2"` in a consumer's app. No override mechanism exists.
+
+5. **No `composer require` path in docs.** `client-project-start.md` describes "start from a clean checkout" — git clone only. A developer who installs via Packagist has no guide.
+
+---
+
+## Follow-up Issues
+
+- **#234** — docs: `endpoint-scaffold.md` に `Router::PARAMETERS_ATTRIBUTE` パスパラメーター取得例を追加する
+- **#235** — docs: `client-project-start.md` に `composer require` 起点の最小ワイヤリング手順を追加する
+- **#236** — feat: `RuntimeApplicationFactory` に外部ルート注入の仕組みを検討する（Phase 21 候補）
+
+---
+
+## Packagist Field Trial Verdict
+
+`hideyukimori/nene2` は `composer require` でインストールでき、PSR コンポーネントは独立して動作する。ただし「外部消費者がカスタムアプリを素早く立ち上げる」パスはドキュメント化されておらず、発見が必要な状態。#234 と #235 のドキュメント改善で大部分の摩擦は解消できる。

--- a/docs/milestones/2026-05-phase20-packagist-field-trial.md
+++ b/docs/milestones/2026-05-phase20-packagist-field-trial.md
@@ -1,0 +1,35 @@
+# Milestone: Phase 20 — Packagist Field Trial
+
+## Period
+
+May 2026, after Packagist registration of v0.3.0.
+
+## Goal
+
+Validate `composer require hideyukimori/nene2` as a credible starting point for new projects.
+
+All prior field trials used the NENE2 repository itself as the sandbox. This trial starts from a fresh directory with no framework source files — only the installed Composer dependency. The goal is to surface friction that only appears when using the framework as a library consumer.
+
+## Acceptance Criteria
+
+- [ ] A new project directory is created outside the NENE2 repository
+- [ ] `composer require hideyukimori/nene2` installs successfully
+- [ ] A minimal working HTTP application is wired up manually (front controller, `.env`, server)
+- [ ] At least one endpoint returns a JSON response
+- [ ] The endpoint scaffold workflow is traced from the consumer perspective
+- [ ] A field trial report is recorded in `docs/field-trials/`
+- [ ] Follow-up Issues are created for any friction discovered
+- [ ] `docs/todo/current.md` is updated
+
+## Scope
+
+- No changes to framework source code during the trial (observations only)
+- The trial application is temporary and lives outside this repository
+- Friction findings become the input for Phase 21+
+
+## Candidate Follow-up Areas
+
+- Does `client-project-start.md` need a `composer require` path?
+- Is `RuntimeApplicationFactory` usable without the full repository scaffolding?
+- What minimum files does a consumer need to create?
+- Does the front controller pattern work outside the Docker image provided with the NENE2 repo?

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -264,6 +264,18 @@ Goal: consolidate v0.2.x patterns, resolve Field Trial 2 friction, and prepare f
 - CHANGELOG.md [Unreleased] prepared
 - v0.3.0 tag + Packagist registration (if criteria met)
 
+## Phase 20: Packagist Field Trial
+
+Goal: validate the `composer require hideyukimori/nene2` path as a real starting point for new projects, distinct from the git-clone-based workflow used in all prior field trials.
+
+- start a new project directory with `composer require hideyukimori/nene2`
+- build the minimum front controller, `.env`, and server setup manually
+- add a working endpoint following the documented scaffold workflow
+- record friction that only appears when using the framework as a library dependency
+- convert friction into follow-up Issues
+
+Tracked by `docs/milestones/2026-05-phase20-packagist-field-trial.md`.
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -192,6 +192,18 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] feat(mcp): Note write operations MCP ツール追加 — catalog + LocalMcpServer 実装. `#228`
 - [x] Packagist 登録: `hideyukimori/nene2` 公開済み (`composer require hideyukimori/nene2`)
 
+## Phase 20: Packagist Field Trial
+
+- [x] composer require からの新規プロジェクト構築を実施する. `#233`
+- [x] 観察レポートを `docs/field-trials/` に記録する (`docs/field-trials/2026-05-field-trial-4.md`). `#233`
+- [x] 摩擦を follow-up Issue に変換する (#234 #235 #236). `#233`
+
+## Phase 20 フォローアップ
+
+- [ ] docs(scaffold): `Router::PARAMETERS_ATTRIBUTE` 取得例を追加する. `#234`
+- [ ] docs(client-start): `composer require` 起点ワイヤリング手順を追加する. `#235`
+- [ ] feat: `RuntimeApplicationFactory` 外部ルート注入を検討する (Phase 21 候補). `#236`
+
 ## Operating Notes
 
 - Keep this file short.


### PR DESCRIPTION
## 目的

Phase 20 (#233) の完了記録。`composer require hideyukimori/nene2` を起点とした新規プロジェクト構築を実施し、外部ライブラリ消費者視点の摩擦を記録した。

## 変更点

- `docs/roadmap.md`: Phase 20 追加
- `docs/milestones/2026-05-phase20-packagist-field-trial.md`: マイルストーン作成
- `docs/field-trials/2026-05-field-trial-4.md`: 観察レポート
- `docs/todo/current.md`: Phase 20 完了・フォローアップ追記

## トライアル結果サマリー

**動いたこと:**
- `composer install` でクリーンインストール (16 packages)
- `RuntimeContainerFactory` + `.env` で外部プロジェクトルートから起動
- `Router` + `MiddlewareDispatcher` 直接ワイヤリングでカスタムルート動作
- Problem Details 404、Monolog request_id ロギング正常動作

**発見した摩擦 (→ follow-up Issues):**
- `Router::PARAMETERS_ATTRIBUTE` 未文書化 → #234
- `composer require` 起点ガイド未整備 → #235
- `RuntimeApplicationFactory` 拡張不可 → #236 (Phase 21 候補)

## Self-review

`docs-policy` チェックリスト確認。コード変更なし。

Closes #233