### PR TITLE
feat(http): RuntimeApplicationFactory に routeRegistrars を追加して外部ルート注入を可能にする (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `RuntimeApplicationFactory` accepts `$routeRegistrars` — an optional `list<callable(Router): void>` for injecting custom routes without subclassing (#236)
 - Local MCP server now executes write operations (`POST`, `PUT`, `DELETE`) through the documented API boundary (#228)
   - `LocalMcpHttpClientInterface` extended with `post()`, `put()`, `delete()` methods
   - `NativeLocalMcpHttpClient` implements the new methods with JSON body support

--- a/docs/development/client-project-start.md
+++ b/docs/development/client-project-start.md
@@ -74,59 +74,36 @@ Serve locally with PHP's built-in server:
 php -S localhost:8080 -t public
 ```
 
-### Adding custom routes without git clone
+### Adding custom routes
 
-When custom routes are needed and you are not using the full NENE2 repository, bypass `RuntimeApplicationFactory` (which is `final`) and wire `Router` and `MiddlewareDispatcher` directly:
+Pass custom routes via `$routeRegistrars` — an optional `list<callable(Router): void>` accepted by `RuntimeApplicationFactory`:
 
 ```php
-<?php
-declare(strict_types=1);
-
-use Nene2\Config\ConfigLoader;
-use Nene2\Error\ErrorHandlerMiddleware;
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
-use Nene2\Log\MonologLoggerFactory;
-use Nene2\Log\RequestIdHolder;
-use Nene2\Middleware\CorsMiddleware;
-use Nene2\Middleware\MiddlewareDispatcher;
-use Nene2\Middleware\RequestIdMiddleware;
-use Nene2\Middleware\RequestLoggingMiddleware;
-use Nene2\Middleware\SecurityHeadersMiddleware;
+use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Routing\Router;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ServerRequestInterface;
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
 
-$root   = dirname(__DIR__);
-$psr17  = new Psr17Factory();
-$config = (new ConfigLoader($root))->load();
-$holder = new RequestIdHolder();
-$logger = (new MonologLoggerFactory())->create('app', $config->debug, $holder);
-$json   = new JsonResponseFactory($psr17, $psr17);
-
-$router = (new Router())
-    ->get('/health', static fn (ServerRequestInterface $req) => $json->create(['status' => 'ok']))
-    ->get('/items/{id}', static function (ServerRequestInterface $req) use ($json) {
-        // Path parameters are stored under Router::PARAMETERS_ATTRIBUTE, not as individual attributes.
-        $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
-        return $json->create(['id' => (int) ($params['id'] ?? 0)]);
-    });
-
-$app = new MiddlewareDispatcher(
-    [
-        new RequestIdMiddleware('X-Request-Id', $holder),
-        new RequestLoggingMiddleware($logger),
-        new SecurityHeadersMiddleware(),
-        new CorsMiddleware($psr17),
-        new ErrorHandlerMiddleware(new ProblemDetailsResponseFactory($psr17, $psr17), []),
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/items/{id}', static function (ServerRequestInterface $req) use ($json) {
+                // Path parameters are stored under Router::PARAMETERS_ATTRIBUTE, not as individual attributes.
+                $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+                return $json->create(['id' => (int) ($params['id'] ?? 0)]);
+            });
+        },
     ],
-    $router,
-);
+))->create();
 ```
 
-For path parameter access, always read from `Router::PARAMETERS_ATTRIBUTE`. See `docs/development/endpoint-scaffold.md` for details.
+Route registrars run after the built-in framework routes are registered. For path parameter access, always read from `Router::PARAMETERS_ATTRIBUTE`. See `docs/development/endpoint-scaffold.md` for details.
 
 ## First Local Setup
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -202,7 +202,7 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 - [ ] docs(scaffold): `Router::PARAMETERS_ATTRIBUTE` 取得例を追加する. `#234`
 - [ ] docs(client-start): `composer require` 起点ワイヤリング手順を追加する. `#235`
-- [ ] feat: `RuntimeApplicationFactory` 外部ルート注入を検討する (Phase 21 候補). `#236`
+- [x] feat: `RuntimeApplicationFactory` に `$routeRegistrars` を追加して外部ルート注入を可能にする. `#236`
 
 ## Operating Notes
 

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -31,7 +31,10 @@ use Psr\Log\NullLogger;
 
 final readonly class RuntimeApplicationFactory
 {
-    /** @param list<DomainExceptionHandlerInterface> $domainExceptionHandlers */
+    /**
+     * @param list<DomainExceptionHandlerInterface> $domainExceptionHandlers
+     * @param list<callable(Router): void> $routeRegistrars
+     */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
@@ -44,6 +47,7 @@ final readonly class RuntimeApplicationFactory
         private ?ListNotesHandler $listNotesHandler = null,
         private ?UpdateNoteHandler $updateNoteHandler = null,
         private ?RequestIdHolder $requestIdHolder = null,
+        private array $routeRegistrars = [],
     ) {
     }
 
@@ -125,6 +129,10 @@ final readonly class RuntimeApplicationFactory
                 '/examples/notes/{id}',
                 static fn (ServerRequestInterface $request) => $deleteNoteHandler->handle($request),
             );
+        }
+
+        foreach ($this->routeRegistrars as $registrar) {
+            $registrar($router);
         }
 
         return new MiddlewareDispatcher(

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Nene2\Tests;
 
+use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 final class HttpRuntimeTest extends TestCase
 {
@@ -130,6 +133,60 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame(413, $response->getStatusCode());
         self::assertMatchesRegularExpression('/\A[a-f0-9]{32}\z/', $response->getHeaderLine('X-Request-Id'));
         self::assertSame('https://nene2.dev/problems/payload-too-large', $payload['type']);
+    }
+
+    public function testRouteRegistrarAddsCustomRoute(): void
+    {
+        $factory = new Psr17Factory();
+        $json = new JsonResponseFactory($factory, $factory);
+
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            routeRegistrars: [
+                static function (Router $router) use ($json): void {
+                    $router->get(
+                        '/custom',
+                        static fn (ServerRequestInterface $req) => $json->create(['custom' => true]),
+                    );
+                },
+            ],
+        ))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/custom'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($payload['custom']);
+    }
+
+    public function testRouteRegistrarCanAccessPathParameters(): void
+    {
+        $factory = new Psr17Factory();
+        $json = new JsonResponseFactory($factory, $factory);
+
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            routeRegistrars: [
+                static function (Router $router) use ($json): void {
+                    $router->get(
+                        '/greet/{name}',
+                        static function (ServerRequestInterface $req) use ($json): ResponseInterface {
+                            $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+
+                            return $json->create(['message' => 'Hello, ' . ($params['name'] ?? '') . '!']);
+                        },
+                    );
+                },
+            ],
+        ))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/greet/NENE2'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('Hello, NENE2!', $payload['message']);
     }
 
     /**


### PR DESCRIPTION
## 目的

`composer require` 経由でNENE2を利用するユーザーが、`RuntimeApplicationFactory` をサブクラス化せずにカスタムルートを注入できるようにする。

Field Trial 4 (`#233`) での摩擦フォローアップ Issue `#236` の対応。

## 変更点

- `RuntimeApplicationFactory` コンストラクタに `$routeRegistrars: list<callable(Router): void>` を追加（オプション、デフォルト `[]`）
- `create()` 内でフレームワーク組み込みルートの登録後にカスタムルート registrar を実行
- `docs/development/client-project-start.md` のカスタムルート例を新 API（`$routeRegistrars` 名前付き引数）に更新
- `tests/HttpRuntimeTest.php` に2テスト追加
  - `testRouteRegistrarAddsCustomRoute`: 基本的なカスタムルートの追加
  - `testRouteRegistrarCanAccessPathParameters`: `Router::PARAMETERS_ATTRIBUTE` 経由のパスパラメーター取得

## 検証

```
docker compose run --rm app composer check
# 121 tests / 444 assertions, PHPStan 0 errors, CS 0, OpenAPI valid, MCP valid
```

## 関連

Closes #236

Self-review: backend-api, docs-policy