### PR TITLE
chore(release): v0.4.0 CHANGELOG 確定・todo 更新 (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] — 2026-05-17
+
 ### Added
 - `RuntimeApplicationFactory` accepts `$routeRegistrars` — an optional `list<callable(Router): void>` for injecting custom routes without subclassing (#236)
 - Local MCP server now executes write operations (`POST`, `PUT`, `DELETE`) through the documented API boundary (#228)
@@ -119,7 +123,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Governance docs: workflow, coding standards, ADR policy, review checklists (#1)
 - ADR 0001–0004: HTTP runtime, DI container, phpdotenv, Phinx
 
-[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/hideyukiMORI/NENE2/compare/v0.1.2...v0.1.3

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -200,9 +200,17 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 ## Phase 20 フォローアップ
 
-- [ ] docs(scaffold): `Router::PARAMETERS_ATTRIBUTE` 取得例を追加する. `#234`
-- [ ] docs(client-start): `composer require` 起点ワイヤリング手順を追加する. `#235`
+- [x] docs(scaffold): `Router::PARAMETERS_ATTRIBUTE` 取得例を追加する. `#234`
+- [x] docs(client-start): `composer require` 起点ワイヤリング手順を追加する. `#235`
 - [x] feat: `RuntimeApplicationFactory` に `$routeRegistrars` を追加して外部ルート注入を可能にする. `#236`
+
+## Phase 21: v0.4.0 リリース
+
+- [x] chore(release): v0.4.0 CHANGELOG 確定・todo 更新. `#240`
+
+## Next Candidates
+
+- [ ] Phase 21 定義 — 次フェーズ方向を決定する
 
 ## Operating Notes
 


### PR DESCRIPTION
## 目的

v0.4.0 リリース前準備。CHANGELOG [Unreleased] → [0.4.0] 確定。

## 変更点

- CHANGELOG.md: `[Unreleased]` → `[0.4.0] — 2026-05-17` に確定。リンク追加
- docs/todo/current.md: Phase 20 フォローアップ全完了マーク + Phase 21 セクション追加

## v0.4.0 変更サマリー

### Added
- `RuntimeApplicationFactory` accepts `$routeRegistrars` (#236)
- MCP write operations: `post()` / `put()` / `delete()` (#228)

## 検証

121 tests / 444 assertions, PHPStan 0 errors, OpenAPI valid, MCP valid

Closes #240

Self-review: release-ci, docs-policy