### PR TITLE
docs(milestone): Phase 21 — Field Trial 5 (MCP Write Tools) マイルストーン定義 (#242)

### DIFF
--- a/docs/milestones/2026-05-phase21-field-trial-5.md
+++ b/docs/milestones/2026-05-phase21-field-trial-5.md
@@ -1,0 +1,36 @@
+# Milestone: Phase 21 — Field Trial 5 (MCP Write Tools)
+
+## Period
+
+May 2026, after v0.4.0 release.
+
+## Goal
+
+Validate that the MCP write tools added in v0.4.0 (#228) work end-to-end through the local MCP server — covering `POST`, `PUT`, and `DELETE` operations against the Note endpoints.
+
+All prior field trials focused on HTTP endpoints or the `composer require` consumer path. This trial focuses specifically on the MCP tool layer and write operations.
+
+## Acceptance Criteria
+
+- [ ] Local MCP server is started against a running NENE2 app
+- [ ] `create_note` tool (`POST /examples/notes`) is called and returns the created note id
+- [ ] `update_note` tool (`PUT /examples/notes/{id}`) is called and verifies the update
+- [ ] `delete_note` tool (`DELETE /examples/notes/{id}`) is called and verifies deletion
+- [ ] Path parameter interpolation is confirmed working (`{id}` → actual id)
+- [ ] A field trial report is recorded in `docs/field-trials/`
+- [ ] Follow-up Issues are created for any friction discovered
+- [ ] `docs/todo/current.md` is updated
+
+## Scope
+
+- Framework source code changes are out of scope during the trial (observations only)
+- The trial uses the NENE2 repository directly (no separate consumer project needed)
+- Friction findings become the input for Phase 22+
+
+## Candidate Follow-up Areas
+
+- Does path parameter interpolation (`{id}`) behave as documented?
+- Does the MCP client (Claude / Cursor) correctly pass integer vs string arguments?
+- Is the tool catalog clear enough for an LLM to call write tools without guidance?
+- Is there friction in starting the local MCP server alongside the app container?
+- Are write tool error responses (422, 404) surfaced usefully through MCP?

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -276,6 +276,17 @@ Goal: validate the `composer require hideyukimori/nene2` path as a real starting
 
 Tracked by `docs/milestones/2026-05-phase20-packagist-field-trial.md`.
 
+## Phase 21: Field Trial 5 — MCP Write Tools
+
+Goal: validate that the MCP write tools added in v0.4.0 work end-to-end through the local MCP server, covering `POST`, `PUT`, and `DELETE` operations against the Note endpoints.
+
+- start the local MCP server against a running NENE2 app container
+- call `create_note`, `update_note`, and `delete_note` tools through an MCP client
+- confirm path parameter interpolation (`{id}` → actual id) works correctly
+- record friction and open follow-up Issues
+
+Tracked by `docs/milestones/2026-05-phase21-field-trial-5.md`.
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -208,9 +208,12 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 - [x] chore(release): v0.4.0 CHANGELOG 確定・todo 更新. `#240`
 
-## Next Candidates
+## Phase 21: Field Trial 5 — MCP Write Tools
 
-- [ ] Phase 21 定義 — 次フェーズ方向を決定する
+- [x] マイルストーン定義・ロードマップ追記. `#242`
+- [ ] ローカル MCP サーバーを起動し write tools を操作する
+- [ ] 観察レポートを `docs/field-trials/2026-05-field-trial-5.md` に記録する
+- [ ] 摩擦を follow-up Issue に変換する
 
 ## Operating Notes
 


### PR DESCRIPTION
## 目的

v0.4.0 で追加した MCP write tools の動作観察フィールドトライアル (Field Trial 5) のマイルストーンを定義する。

## 変更点

- `docs/milestones/2026-05-phase21-field-trial-5.md` 新規作成
- `docs/roadmap.md` に Phase 21 追記
- `docs/todo/current.md` に Phase 21 セクション追加

Closes #242

Self-review: docs-policy