### PR TITLE
docs(mcp): write ツールの DB 前提条件を mcp-smoke.sh とローカル MCP ガイドに追記する (#245 #246)

### DIFF
--- a/docs/integrations/local-mcp-server.md
+++ b/docs/integrations/local-mcp-server.md
@@ -35,6 +35,19 @@ When running the server inside Docker against the Compose `app` service, use the
 docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
 ```
 
+### Database precondition for write tools
+
+Read tools (`getHealth`, `listExampleNotes`, `getExampleNoteById`, etc.) require only the `app` container.
+
+Write tools (`createExampleNote`, `updateExampleNoteById`, `deleteExampleNoteById`) call endpoints that persist to the database. Before calling write tools, start MySQL and apply migrations:
+
+```bash
+docker compose up -d mysql
+docker compose run --rm app composer migrations:migrate
+```
+
+Without this step, write tool calls return HTTP 500 with no further detail. If a write tool returns 500, confirm that MySQL is running and migrations are applied before investigating further.
+
 The server supports:
 
 - `initialize`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -217,8 +217,8 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 ## Phase 21 フォローアップ
 
-- [ ] docs(mcp-smoke): write 操作の DB 前提条件を `mcp-smoke.sh` に追記する. `#245`
-- [ ] docs(local-mcp): write 操作の DB 前提条件をローカル MCP サーバーガイドに追記する. `#246`
+- [x] docs(mcp-smoke): write 操作の DB 前提条件を `mcp-smoke.sh` に追記する. `#245`
+- [x] docs(local-mcp): write 操作の DB 前提条件をローカル MCP サーバーガイドに追記する. `#246`
 
 ## Operating Notes
 

--- a/tools/mcp-smoke.sh
+++ b/tools/mcp-smoke.sh
@@ -2,12 +2,20 @@
 # Local MCP smoke helper.
 # Pipes JSON-RPC messages to the stdio MCP server against the running app service.
 #
-# Precondition: docker compose up -d app
+# Preconditions:
+#   Read tools (getHealth, listExampleNotes, getExampleNoteById, ...):
+#     docker compose up -d app
+#
+#   Write tools (createExampleNote, updateExampleNoteById, deleteExampleNoteById):
+#     docker compose up -d app mysql
+#     docker compose run --rm app composer migrations:migrate
 #
 # Usage:
 #   bash tools/mcp-smoke.sh
 #   bash tools/mcp-smoke.sh getHealth '{}'
-#   bash tools/mcp-smoke.sh getExhibitionWorkByYearAndId '{"year":2026,"workId":20260101}'
+#   bash tools/mcp-smoke.sh createExampleNote '{"title":"hello","body":"world"}'
+#   bash tools/mcp-smoke.sh updateExampleNoteById '{"id":1,"title":"updated","body":"body"}'
+#   bash tools/mcp-smoke.sh deleteExampleNoteById '{"id":1}'
 #
 # Environment:
 #   NENE2_LOCAL_API_BASE_URL  override API base URL (default: http://app)


### PR DESCRIPTION
## 目的

Field Trial 5 (#244) で観察した摩擦 F-1 / F-2 の対応。

write ツール使用前に MySQL + マイグレーションが必要なことが未記載だったため、最初の write ツール呼び出しで原因不明の 500 が返る問題を解消する。

## 変更点

### `tools/mcp-smoke.sh` (#245)
- `Precondition:` を read / write で分けて記載
- write ツール向けに `docker compose up -d mysql` + `composer migrations:migrate` を追記
- Usage 例に write ツールの具体例を追加

### `docs/integrations/local-mcp-server.md` (#246)
- "Database precondition for write tools" セクションを新設
- 500 が返った場合のデバッグ起点（MySQL + migrations 確認）を明記

Closes #245
Closes #246

Self-review: docs-policy