### PR TITLE
docs(milestone): Phase 22 — Diátaxis ドキュメント整備マイルストーン定義 (#249)

### DIFF
--- a/docs/milestones/2026-05-phase22-diataxis-docs.md
+++ b/docs/milestones/2026-05-phase22-diataxis-docs.md
@@ -1,0 +1,50 @@
+# Milestone: Phase 22 — Diátaxis Documentation
+
+## Period
+
+May 2026, after Phase 21 (Field Trial 5) completion.
+
+## Goal
+
+Make NENE2 accessible to developers who know JavaScript or Python but have not used PHP before. Produce Markdown documentation structured around the Diátaxis framework (Tutorial → HOWTO → Reference → Explanation), starting with the highest-ROI pieces.
+
+HTML generation is deferred to a later phase. This phase targets Markdown only.
+
+## Target Reader
+
+A developer who:
+- Can write JavaScript or Python
+- Has not used PHP, Composer, or Docker before (or only minimally)
+- Understands what a JSON API is
+- Wants to build a working API with minimal ceremony
+
+Key analogies that help:
+- `composer` = `npm` / `pip`
+- `docker compose up` = `npm start` / `docker run`
+- PSR-7 Request/Response = Express `req` / `res`
+- `declare(strict_types=1)` = TypeScript strict mode
+- `.env` file = same concept as Node.js dotenv
+
+## Diátaxis Structure
+
+| Type | Purpose | First document |
+|---|---|---|
+| Tutorial | Learning-oriented, step-by-step, produces a result | "Your first API in 10 minutes" |
+| HOWTO | Goal-oriented, solves a specific problem | "Add a custom route", "Add a database-backed endpoint" |
+| Reference | Information-oriented, look up while working | OpenAPI (already exists), class index |
+| Explanation | Understanding-oriented, concept depth | "Why PSR-7?", "Domain layer design" |
+
+## Acceptance Criteria
+
+- [ ] Tutorial: "Your first API" — `composer require` → running JSON endpoint (#250)
+- [ ] HOWTO: "Add a custom route" — registrar pattern, path parameters (#251)
+- [ ] HOWTO: "Add a database-backed endpoint" — UseCase → Repository → Handler (#252)
+- [ ] `docs/` index or README updated to surface the new docs
+- [ ] `docs/todo/current.md` updated
+
+## Out of Scope
+
+- HTML site generation (separate phase)
+- Full class reference generation
+- Explanation docs (lower priority)
+- Translation

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -287,6 +287,19 @@ Goal: validate that the MCP write tools added in v0.4.0 work end-to-end through 
 
 Tracked by `docs/milestones/2026-05-phase21-field-trial-5.md`.
 
+## Phase 22: Diátaxis Documentation
+
+Goal: make NENE2 accessible to developers who know JavaScript or Python but have not used PHP before, by producing Markdown documentation structured around the Diátaxis framework.
+
+- Tutorial: "Your first API in 10 minutes" — `composer require` to running JSON endpoint
+- HOWTO: "Add a custom route" — registrar pattern with path parameters
+- HOWTO: "Add a database-backed endpoint" — UseCase → Repository → Handler walkthrough
+- `docs/` index updated to surface the new entry points
+
+HTML generation is deferred to a later phase.
+
+Tracked by `docs/milestones/2026-05-phase22-diataxis-docs.md`.
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -220,6 +220,14 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] docs(mcp-smoke): write 操作の DB 前提条件を `mcp-smoke.sh` に追記する. `#245`
 - [x] docs(local-mcp): write 操作の DB 前提条件をローカル MCP サーバーガイドに追記する. `#246`
 
+## Phase 22: Diátaxis ドキュメント整備
+
+- [x] マイルストーン定義・ロードマップ追記. `#249`
+- [ ] Tutorial: 最初の API を動かす (`docs/tutorial/first-api.md`). `#250`
+- [ ] HOWTO: カスタムルートを追加する (`docs/howto/add-custom-route.md`). `#251`
+- [ ] HOWTO: DB 付きエンドポイントを追加する (`docs/howto/add-database-endpoint.md`). `#252`
+- [ ] `docs/` インデックス更新. `#253`
+
 ## Operating Notes
 
 - Keep this file short.


### PR DESCRIPTION
## 目的

JS/Python 経験者が PHP 初めてでも NENE2 を使えるように、Diátaxis 構造でドキュメントを整備するフェーズを定義する。

## 変更点

- `docs/milestones/2026-05-phase22-diataxis-docs.md` 新規作成
- `docs/roadmap.md` に Phase 22 追記
- `docs/todo/current.md` に Phase 22 タスク追加

Closes #249

Self-review: docs-policy