### PR TITLE
docs(howto): カスタムルートと DB 付きエンドポイントの HOWTO を追加する (#253 #254)

### DIFF
--- a/docs/howto/add-custom-route.md
+++ b/docs/howto/add-custom-route.md
@@ -1,0 +1,150 @@
+# Add a Custom Route
+
+This guide shows how to add GET and POST routes with path parameters to a NENE2 application.
+
+**Prerequisite**: You have a working NENE2 application. If not, start with the [Tutorial](../tutorial/first-api.md).
+
+---
+
+## Add a simple GET route
+
+Routes are registered via `routeRegistrars` — an array of functions that each receive the router and register routes on it.
+
+```php
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['items' => [], 'count' => 0]);
+            });
+        },
+    ],
+))->create();
+```
+
+In Express this would be `app.get('/items', (req, res) => res.json(...))`. The pattern is identical — route, handler, response.
+
+---
+
+## Add a path parameter
+
+Use `{name}` syntax in the route path. Inside the handler, read all path parameters from the `Router::PARAMETERS_ATTRIBUTE` request attribute — they are stored as a named array, not as individual attributes.
+
+```php
+use Nene2\Routing\Router;
+
+$router->get('/items/{id}', static function (ServerRequestInterface $req) use ($json) {
+    // Path parameters are in a single array attribute — not individual attributes.
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+
+    return $json->create(['id' => $id]);
+});
+```
+
+> **Common mistake**: `$req->getAttribute('id')` always returns `null`.
+> Always use `$req->getAttribute(Router::PARAMETERS_ATTRIBUTE, [])['id']` instead.
+
+In Express this is `req.params.id`. In FastAPI it is a typed function argument. In NENE2 it is an explicit array read — more verbose but impossible to confuse with query string parameters.
+
+### Multiple parameters
+
+```php
+$router->get('/users/{userId}/posts/{postId}', static function (ServerRequestInterface $req) use ($json) {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $userId = (int) ($params['userId'] ?? 0);
+    $postId = (int) ($params['postId'] ?? 0);
+
+    return $json->create(['userId' => $userId, 'postId' => $postId]);
+});
+```
+
+---
+
+## Add a query string parameter
+
+Query string parameters are read from the parsed query array, not from the route pattern.
+
+```php
+$router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+    $query  = $req->getQueryParams();          // ['limit' => '20', 'offset' => '0']
+    $limit  = (int) ($query['limit']  ?? 20);
+    $offset = (int) ($query['offset'] ?? 0);
+
+    return $json->create(['limit' => $limit, 'offset' => $offset]);
+});
+```
+
+This is equivalent to `req.query.limit` in Express or `request.query_params['limit']` in FastAPI.
+
+---
+
+## Add a POST route
+
+```php
+$router->post('/items', static function (ServerRequestInterface $req) use ($json, $psr17) {
+    $body  = json_decode((string) $req->getBody(), true) ?? [];
+    $name  = (string) ($body['name'] ?? '');
+
+    if ($name === '') {
+        // Return 422 Validation Failed — see docs/development/endpoint-scaffold.md
+        // for the full validation pattern with ValidationException.
+        return $json->create(['error' => 'name is required'], 422);
+    }
+
+    // In a real endpoint you would save to a database here.
+    return $json->create(['name' => $name], 201);
+});
+```
+
+> For production endpoints, use `ValidationException` and the domain layer pattern
+> instead of inline validation. See [Add a database-backed endpoint](./add-database-endpoint.md).
+
+---
+
+## Multiple routes in one registrar
+
+You can register as many routes as you want inside a single registrar function:
+
+```php
+routeRegistrars: [
+    static function (Router $router) use ($json): void {
+        $router->get('/items',      /* handler */);
+        $router->get('/items/{id}', /* handler */);
+        $router->post('/items',     /* handler */);
+        $router->put('/items/{id}', /* handler */);
+        $router->delete('/items/{id}', /* handler */);
+    },
+],
+```
+
+Or split across multiple registrar functions for clarity when the route list grows long.
+
+---
+
+## Available HTTP methods
+
+| Method | Router method | Typical use |
+|---|---|---|
+| GET | `$router->get()` | Read a resource |
+| POST | `$router->post()` | Create a resource |
+| PUT | `$router->put()` | Replace a resource (full update) |
+| DELETE | `$router->delete()` | Remove a resource |
+
+---
+
+## Next step
+
+If your route needs to read from or write to a database, see
+[Add a database-backed endpoint](./add-database-endpoint.md).

--- a/docs/howto/add-database-endpoint.md
+++ b/docs/howto/add-database-endpoint.md
@@ -1,0 +1,249 @@
+# Add a Database-backed Endpoint
+
+This guide shows how to add an endpoint that reads from and writes to a database, following NENE2's domain layer pattern.
+
+**Prerequisite**: You have a working NENE2 application with a route registered. If not, start with [Add a custom route](./add-custom-route.md).
+
+---
+
+## The pattern
+
+NENE2 uses a three-layer pattern between the HTTP handler and the database:
+
+```
+HTTP Handler
+  ↓ calls
+UseCase          ← business logic, no HTTP or database knowledge
+  ↓ calls
+RepositoryInterface ← database operations, defined as an interface
+  ↓ implemented by
+PdoRepository    ← the actual SQL queries
+```
+
+This is the same separation you get in FastAPI with a service layer, or in Node.js with a repository pattern. The HTTP handler stays thin; the use case holds the logic; the repository handles persistence.
+
+---
+
+## Example: a `Product` resource
+
+We will build `GET /products/{id}` as a concrete example.
+
+### 1 — Define the domain entity
+
+Create `src/Product/Product.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class Product
+{
+    public function __construct(
+        public int    $id,
+        public string $name,
+        public int    $price,
+    ) {}
+}
+```
+
+`readonly` means properties are set once in the constructor and cannot change — equivalent to a frozen object in JavaScript or a dataclass with `frozen=True` in Python.
+
+### 2 — Define the repository interface
+
+Create `src/Product/ProductRepositoryInterface.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+interface ProductRepositoryInterface
+{
+    public function findById(int $id): ?Product;
+}
+```
+
+The interface declares *what* can be done, not *how*. This lets you swap a real database for an in-memory fake in tests.
+
+### 3 — Define the use case
+
+Create `src/Product/GetProductByIdUseCase.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class GetProductByIdUseCase
+{
+    public function __construct(private ProductRepositoryInterface $products) {}
+
+    public function execute(int $id): ?Product
+    {
+        return $this->products->findById($id);
+    }
+}
+```
+
+The use case knows nothing about HTTP or SQL. It receives a repository and calls it. This makes it easy to test without a database.
+
+### 4 — Implement the repository with PDO
+
+Create `src/Product/PdoProductRepository.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+use PDO;
+
+final readonly class PdoProductRepository implements ProductRepositoryInterface
+{
+    public function __construct(private PDO $pdo) {}
+
+    public function findById(int $id): ?Product
+    {
+        $stmt = $this->pdo->prepare('SELECT id, name, price FROM products WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        return new Product(
+            id:    (int) $row['id'],
+            name:  (string) $row['name'],
+            price: (int) $row['price'],
+        );
+    }
+}
+```
+
+All SQL lives here. Nothing outside this class needs to know which database or query syntax is used.
+
+### 5 — Wire it in the front controller
+
+In `public/index.php`, connect the pieces and register the route:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use MyApp\Product\GetProductByIdUseCase;
+use MyApp\Product\PdoProductRepository;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+// Wire the database and use case.
+$pdo        = new PDO('mysql:host=127.0.0.1;dbname=myapp', 'user', 'password');
+$useCase    = new GetProductByIdUseCase(new PdoProductRepository($pdo));
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json, $useCase): void {
+            $router->get('/products/{id}', static function (ServerRequestInterface $req) use ($json, $useCase) {
+                $params  = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+                $id      = (int) ($params['id'] ?? 0);
+                $product = $useCase->execute($id);
+
+                if ($product === null) {
+                    return $json->create([
+                        'type'   => 'https://nene2.dev/problems/not-found',
+                        'title'  => 'Not Found',
+                        'status' => 404,
+                    ], 404);
+                }
+
+                return $json->create([
+                    'id'    => $product->id,
+                    'name'  => $product->name,
+                    'price' => $product->price,
+                ]);
+            });
+        },
+    ],
+))->create();
+
+// ... request handling (same as tutorial)
+```
+
+> **Production note**: For larger applications, move the wiring to a service provider
+> and inject typed config objects instead of raw PDO connection strings.
+> See `src/DependencyInjection/` and `docs/development/domain-layer.md` for the full pattern.
+
+---
+
+## Test the use case without a database
+
+Because `GetProductByIdUseCase` depends on `ProductRepositoryInterface` (not `PdoProductRepository`), you can test it with a simple in-memory fake:
+
+```php
+final class InMemoryProductRepository implements ProductRepositoryInterface
+{
+    /** @param array<int, Product> $products */
+    public function __construct(private array $products = []) {}
+
+    public function findById(int $id): ?Product
+    {
+        return $this->products[$id] ?? null;
+    }
+}
+
+// In your test:
+$repo    = new InMemoryProductRepository([1 => new Product(1, 'Widget', 999)]);
+$useCase = new GetProductByIdUseCase($repo);
+$result  = $useCase->execute(1);
+
+assert($result->name === 'Widget');
+```
+
+This is the same pattern as mocking a service in Jest or using a test double in pytest.
+
+---
+
+## Directory layout
+
+Following this pattern, your project will grow into:
+
+```
+src/
+  Product/
+    Product.php                   ← domain entity
+    ProductRepositoryInterface.php ← what can be done
+    GetProductByIdUseCase.php     ← business logic
+    PdoProductRepository.php      ← SQL implementation
+public/
+  index.php                       ← wiring + routes
+```
+
+Each resource gets its own directory. Keep the handler thin and the use case focused on one operation.
+
+---
+
+## Next steps
+
+- Add OpenAPI documentation for your endpoint: see `docs/development/endpoint-scaffold.md`
+- Add database migrations: see `docs/development/test-database-strategy.md`
+- See NENE2's built-in Note example as a reference: `src/Example/Note/`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -224,9 +224,9 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 - [x] マイルストーン定義・ロードマップ追記. `#249`
 - [x] Tutorial: 最初の API を動かす (`docs/tutorial/first-api.md`). `#251`
-- [ ] HOWTO: カスタムルートを追加する (`docs/howto/add-custom-route.md`). `#251`
-- [ ] HOWTO: DB 付きエンドポイントを追加する (`docs/howto/add-database-endpoint.md`). `#252`
-- [ ] `docs/` インデックス更新. `#253`
+- [x] HOWTO: カスタムルートを追加する (`docs/howto/add-custom-route.md`). `#253`
+- [x] HOWTO: DB 付きエンドポイントを追加する (`docs/howto/add-database-endpoint.md`). `#254`
+- [ ] `docs/` インデックス更新. `#255`
 
 ## Operating Notes
 


### PR DESCRIPTION
## 目的

Diátaxis HOWTO 2本。Tutorial の次のステップとして、ルート追加とDB接続の具体的手順を提供する。

## 変更点

- `docs/howto/add-custom-route.md` — GET/POST/パスパラメーター/クエリ文字列。`Router::PARAMETERS_ATTRIBUTE` の正しい使い方を強調
- `docs/howto/add-database-endpoint.md` — UseCase → RepositoryInterface → PdoRepository 3層パターン。インメモリ fake を使ったテスト例も収録

Closes #253
Closes #254

Self-review: docs-policy