### PR TITLE
feat(i18n): 日本語・フランス語・中国語・ブラジルポルトガル語・ドイツ語翻訳を追加する (#260)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,5 +1,61 @@
 import { defineConfig } from 'vitepress'
 
+function nav(t: {
+  tutorial: string; howto: string; reference: string
+}) {
+  return [
+    { text: t.tutorial,  link: 'tutorial/first-api',        activeMatch: 'tutorial/' },
+    { text: t.howto,     link: 'howto/add-custom-route',    activeMatch: 'howto/' },
+    { text: t.reference, link: 'development/endpoint-scaffold', activeMatch: 'development/' },
+    {
+      text: 'v0.4.0',
+      items: [
+        { text: 'Changelog',  link: 'https://github.com/hideyukiMORI/NENE2/blob/main/CHANGELOG.md' },
+        { text: 'Releases',   link: 'https://github.com/hideyukiMORI/NENE2/releases' },
+        { text: 'Packagist',  link: 'https://packagist.org/packages/hideyukimori/nene2' },
+      ],
+    },
+  ]
+}
+
+function sidebar(t: {
+  tutorialGroup: string; firstApi: string
+  howtoGroup: string; addRoute: string; addDb: string
+  devGroup: string; intGroup: string
+}) {
+  return {
+    '/tutorial/': [{ text: t.tutorialGroup, items: [{ text: t.firstApi, link: 'tutorial/first-api' }] }],
+    '/howto/': [{
+      text: t.howtoGroup,
+      items: [
+        { text: t.addRoute, link: 'howto/add-custom-route' },
+        { text: t.addDb,    link: 'howto/add-database-endpoint' },
+      ],
+    }],
+    '/development/': [
+      {
+        text: t.devGroup,
+        items: [
+          { text: 'Setup',                  link: 'development/setup' },
+          { text: 'Endpoint scaffold',      link: 'development/endpoint-scaffold' },
+          { text: 'Domain layer',           link: 'development/domain-layer' },
+          { text: 'Authentication',         link: 'development/authentication-boundary' },
+          { text: 'Test database strategy', link: 'development/test-database-strategy' },
+          { text: 'Client project start',   link: 'development/client-project-start' },
+        ],
+      },
+      {
+        text: t.intGroup,
+        items: [
+          { text: 'Local MCP server',       link: 'integrations/local-mcp-server' },
+          { text: 'MCP client config',      link: 'integrations/local-mcp-client-configuration' },
+          { text: 'MCP tools policy',       link: 'integrations/mcp-tools' },
+        ],
+      },
+    ],
+  }
+}
+
 export default defineConfig({
   title: 'NENE2',
   description: 'Minimal PHP 8.4 JSON API Framework — with MCP and OpenAPI built in.',
@@ -8,94 +64,130 @@ export default defineConfig({
   cleanUrls: true,
   ignoreDeadLinks: true,
 
-  head: [
-    ['meta', { name: 'theme-color', content: '#3b82f6' }],
-  ],
+  head: [['meta', { name: 'theme-color', content: '#3b82f6' }]],
+
+  locales: {
+    root: {
+      label: 'English',
+      lang: 'en',
+      themeConfig: {
+        nav: nav({ tutorial: 'Tutorial', howto: 'HOWTO', reference: 'Reference' }),
+        sidebar: sidebar({
+          tutorialGroup: 'Tutorial', firstApi: 'Your first API',
+          howtoGroup: 'HOWTO', addRoute: 'Add a custom route', addDb: 'Add a database-backed endpoint',
+          devGroup: 'Development', intGroup: 'Integrations',
+        }),
+        editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'Edit this page on GitHub' },
+        footer: { message: 'Released under the MIT License.', copyright: 'Copyright © 2026 hideyukiMORI' },
+      },
+    },
+
+    ja: {
+      label: '日本語',
+      lang: 'ja',
+      themeConfig: {
+        nav: nav({ tutorial: 'チュートリアル', howto: 'HOWTO', reference: 'リファレンス' }),
+        sidebar: sidebar({
+          tutorialGroup: 'チュートリアル', firstApi: '最初の API を動かす',
+          howtoGroup: 'HOWTO', addRoute: 'カスタムルートを追加する', addDb: 'DB 付きエンドポイントを追加する',
+          devGroup: '開発ガイド', intGroup: 'インテグレーション',
+        }),
+        editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'GitHub でこのページを編集' },
+        footer: { message: 'MIT ライセンスの下で公開されています。', copyright: 'Copyright © 2026 hideyukiMORI' },
+        docFooter: { prev: '前のページ', next: '次のページ' },
+        outlineTitle: 'このページの目次',
+        returnToTopLabel: 'トップへ戻る',
+        sidebarMenuLabel: 'メニュー',
+        darkModeSwitchLabel: 'ダークモード',
+      },
+    },
+
+    fr: {
+      label: 'Français',
+      lang: 'fr',
+      themeConfig: {
+        nav: nav({ tutorial: 'Tutoriel', howto: 'Guides', reference: 'Référence' }),
+        sidebar: sidebar({
+          tutorialGroup: 'Tutoriel', firstApi: 'Votre première API',
+          howtoGroup: 'Guides pratiques', addRoute: 'Ajouter une route', addDb: 'Ajouter un endpoint avec BDD',
+          devGroup: 'Développement', intGroup: 'Intégrations',
+        }),
+        editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'Modifier cette page sur GitHub' },
+        footer: { message: 'Publié sous licence MIT.', copyright: 'Copyright © 2026 hideyukiMORI' },
+        docFooter: { prev: 'Page précédente', next: 'Page suivante' },
+        outlineTitle: 'Sur cette page',
+        returnToTopLabel: 'Retour en haut',
+      },
+    },
+
+    zh: {
+      label: '中文',
+      lang: 'zh-Hans',
+      themeConfig: {
+        nav: nav({ tutorial: '教程', howto: '操作指南', reference: '参考' }),
+        sidebar: sidebar({
+          tutorialGroup: '教程', firstApi: '创建您的第一个 API',
+          howtoGroup: '操作指南', addRoute: '添加自定义路由', addDb: '添加数据库端点',
+          devGroup: '开发指南', intGroup: '集成',
+        }),
+        editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: '在 GitHub 上编辑此页' },
+        footer: { message: '基于 MIT 许可证发布。', copyright: 'Copyright © 2026 hideyukiMORI' },
+        docFooter: { prev: '上一页', next: '下一页' },
+        outlineTitle: '本页目录',
+        returnToTopLabel: '返回顶部',
+        sidebarMenuLabel: '菜单',
+        darkModeSwitchLabel: '深色模式',
+      },
+    },
+
+    'pt-br': {
+      label: 'Português (Brasil)',
+      lang: 'pt-BR',
+      themeConfig: {
+        nav: nav({ tutorial: 'Tutorial', howto: 'Guias', reference: 'Referência' }),
+        sidebar: sidebar({
+          tutorialGroup: 'Tutorial', firstApi: 'Sua primeira API',
+          howtoGroup: 'Guias práticos', addRoute: 'Adicionar uma rota', addDb: 'Adicionar endpoint com banco de dados',
+          devGroup: 'Desenvolvimento', intGroup: 'Integrações',
+        }),
+        editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'Editar esta página no GitHub' },
+        footer: { message: 'Publicado sob a licença MIT.', copyright: 'Copyright © 2026 hideyukiMORI' },
+        docFooter: { prev: 'Página anterior', next: 'Próxima página' },
+        outlineTitle: 'Nesta página',
+        returnToTopLabel: 'Voltar ao topo',
+      },
+    },
+
+    de: {
+      label: 'Deutsch',
+      lang: 'de',
+      themeConfig: {
+        nav: nav({ tutorial: 'Tutorial', howto: 'Anleitungen', reference: 'Referenz' }),
+        sidebar: sidebar({
+          tutorialGroup: 'Tutorial', firstApi: 'Ihre erste API',
+          howtoGroup: 'Anleitungen', addRoute: 'Route hinzufügen', addDb: 'Datenbankendpunkt hinzufügen',
+          devGroup: 'Entwicklung', intGroup: 'Integrationen',
+        }),
+        editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'Diese Seite auf GitHub bearbeiten' },
+        footer: { message: 'Veröffentlicht unter der MIT-Lizenz.', copyright: 'Copyright © 2026 hideyukiMORI' },
+        docFooter: { prev: 'Vorherige Seite', next: 'Nächste Seite' },
+        outlineTitle: 'Auf dieser Seite',
+        returnToTopLabel: 'Nach oben',
+        sidebarMenuLabel: 'Menü',
+        darkModeSwitchLabel: 'Dunkelmodus',
+      },
+    },
+  },
 
   themeConfig: {
     siteTitle: 'NENE2',
-
-    nav: [
-      { text: 'Tutorial',  link: '/tutorial/first-api',        activeMatch: '/tutorial/' },
-      { text: 'HOWTO',     link: '/howto/add-custom-route',    activeMatch: '/howto/' },
-      { text: 'Reference', link: '/development/endpoint-scaffold', activeMatch: '/development/' },
-      {
-        text: 'v0.4.0',
-        items: [
-          { text: 'Changelog',  link: 'https://github.com/hideyukiMORI/NENE2/blob/main/CHANGELOG.md' },
-          { text: 'Releases',   link: 'https://github.com/hideyukiMORI/NENE2/releases' },
-          { text: 'Packagist',  link: 'https://packagist.org/packages/hideyukimori/nene2' },
-        ],
-      },
-    ],
-
-    sidebar: {
-      '/tutorial/': [
-        {
-          text: 'Tutorial',
-          items: [
-            { text: 'Your first API', link: '/tutorial/first-api' },
-          ],
-        },
-      ],
-      '/howto/': [
-        {
-          text: 'HOWTO',
-          items: [
-            { text: 'Add a custom route',            link: '/howto/add-custom-route' },
-            { text: 'Add a database-backed endpoint', link: '/howto/add-database-endpoint' },
-          ],
-        },
-      ],
-      '/development/': [
-        {
-          text: 'Development',
-          items: [
-            { text: 'Setup',                  link: '/development/setup' },
-            { text: 'Endpoint scaffold',      link: '/development/endpoint-scaffold' },
-            { text: 'Domain layer',           link: '/development/domain-layer' },
-            { text: 'Authentication',         link: '/development/authentication-boundary' },
-            { text: 'Test database strategy', link: '/development/test-database-strategy' },
-            { text: 'Client project start',   link: '/development/client-project-start' },
-          ],
-        },
-        {
-          text: 'Integrations',
-          items: [
-            { text: 'Local MCP server',       link: '/integrations/local-mcp-server' },
-            { text: 'MCP client config',      link: '/integrations/local-mcp-client-configuration' },
-            { text: 'MCP tools policy',       link: '/integrations/mcp-tools' },
-          ],
-        },
-      ],
-    },
-
-    socialLinks: [
-      { icon: 'github', link: 'https://github.com/hideyukiMORI/NENE2' },
-    ],
-
-    footer: {
-      message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2026 hideyukiMORI',
-    },
-
-    editLink: {
-      pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path',
-      text: 'Edit this page on GitHub',
-    },
-
-    search: {
-      provider: 'local',
-    },
-
+    socialLinks: [{ icon: 'github', link: 'https://github.com/hideyukiMORI/NENE2' }],
+    search: { provider: 'local' },
     outline: { level: [2, 3] },
   },
 
   markdown: {
-    theme: {
-      light: 'github-light',
-      dark:  'github-dark',
-    },
+    theme: { light: 'github-light', dark: 'github-dark' },
     lineNumbers: true,
   },
 })

--- a/docs/de/howto/add-custom-route.md
+++ b/docs/de/howto/add-custom-route.md
@@ -1,0 +1,150 @@
+# Eine Route hinzufügen
+
+Diese Anleitung zeigt, wie man GET- und POST-Routen mit Pfadparametern zu einer NENE2-Anwendung hinzufügt.
+
+**Voraussetzung**: Sie haben eine funktionierende NENE2-Anwendung. Falls nicht, beginnen Sie mit dem [Tutorial](../tutorial/first-api.md).
+
+---
+
+## Eine einfache GET-Route hinzufügen
+
+Routen werden über `routeRegistrars` registriert — ein Array von Funktionen, die jeweils den Router empfangen und Routen darauf registrieren.
+
+```php
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['items' => [], 'count' => 0]);
+            });
+        },
+    ],
+))->create();
+```
+
+In Express wäre das `app.get('/items', (req, res) => res.json(...))`. Das Muster ist identisch — Route, Handler, Response.
+
+---
+
+## Einen Pfadparameter hinzufügen
+
+Verwenden Sie die `{name}`-Syntax im Routenpfad. Im Handler lesen Sie alle Pfadparameter aus dem `Router::PARAMETERS_ATTRIBUTE`-Request-Attribut — sie werden als benanntes Array gespeichert, nicht als einzelne Attribute.
+
+```php
+use Nene2\Routing\Router;
+
+$router->get('/items/{id}', static function (ServerRequestInterface $req) use ($json) {
+    // Pfadparameter befinden sich in einem einzigen Array-Attribut — nicht in einzelnen Attributen.
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+
+    return $json->create(['id' => $id]);
+});
+```
+
+> **Häufiger Fehler**: `$req->getAttribute('id')` gibt immer `null` zurück.
+> Verwenden Sie immer `$req->getAttribute(Router::PARAMETERS_ATTRIBUTE, [])['id']`.
+
+In Express ist das `req.params.id`. In FastAPI ist es ein typisiertes Funktionsargument. In NENE2 ist es ein explizites Array-Lesen — ausführlicher, aber unmöglich mit Query-String-Parametern zu verwechseln.
+
+### Mehrere Parameter
+
+```php
+$router->get('/users/{userId}/posts/{postId}', static function (ServerRequestInterface $req) use ($json) {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $userId = (int) ($params['userId'] ?? 0);
+    $postId = (int) ($params['postId'] ?? 0);
+
+    return $json->create(['userId' => $userId, 'postId' => $postId]);
+});
+```
+
+---
+
+## Einen Query-String-Parameter hinzufügen
+
+Query-String-Parameter werden aus dem geparsten Query-Array gelesen, nicht aus dem Routenmuster.
+
+```php
+$router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+    $query  = $req->getQueryParams();          // ['limit' => '20', 'offset' => '0']
+    $limit  = (int) ($query['limit']  ?? 20);
+    $offset = (int) ($query['offset'] ?? 0);
+
+    return $json->create(['limit' => $limit, 'offset' => $offset]);
+});
+```
+
+Dies entspricht `req.query.limit` in Express oder `request.query_params['limit']` in FastAPI.
+
+---
+
+## Eine POST-Route hinzufügen
+
+```php
+$router->post('/items', static function (ServerRequestInterface $req) use ($json, $psr17) {
+    $body  = json_decode((string) $req->getBody(), true) ?? [];
+    $name  = (string) ($body['name'] ?? '');
+
+    if ($name === '') {
+        // 422 Validation Failed zurückgeben — für das vollständige Validierungsmuster mit
+        // ValidationException, siehe docs/development/endpoint-scaffold.md.
+        return $json->create(['error' => 'name is required'], 422);
+    }
+
+    // In einem echten Endpoint würden Sie hier in die Datenbank speichern.
+    return $json->create(['name' => $name], 201);
+});
+```
+
+> Für Produktions-Endpoints verwenden Sie `ValidationException` und das Domain-Layer-Pattern
+> statt Inline-Validierung. Siehe [Datenbankendpunkt hinzufügen](./add-database-endpoint.md).
+
+---
+
+## Mehrere Routen in einem Registrar
+
+Sie können beliebig viele Routen innerhalb einer einzelnen Registrar-Funktion registrieren:
+
+```php
+routeRegistrars: [
+    static function (Router $router) use ($json): void {
+        $router->get('/items',         /* handler */);
+        $router->get('/items/{id}',    /* handler */);
+        $router->post('/items',        /* handler */);
+        $router->put('/items/{id}',    /* handler */);
+        $router->delete('/items/{id}', /* handler */);
+    },
+],
+```
+
+Oder teilen Sie auf mehrere Registrar-Funktionen auf, wenn die Routenliste lang wird.
+
+---
+
+## Verfügbare HTTP-Methoden
+
+| Methode | Router-Methode | Typische Verwendung |
+|---|---|---|
+| GET | `$router->get()` | Eine Ressource lesen |
+| POST | `$router->post()` | Eine Ressource erstellen |
+| PUT | `$router->put()` | Eine Ressource ersetzen (vollständiges Update) |
+| DELETE | `$router->delete()` | Eine Ressource entfernen |
+
+---
+
+## Nächster Schritt
+
+Wenn Ihre Route aus einer Datenbank lesen oder in sie schreiben muss, siehe
+[Datenbankendpunkt hinzufügen](./add-database-endpoint.md).

--- a/docs/de/howto/add-database-endpoint.md
+++ b/docs/de/howto/add-database-endpoint.md
@@ -1,0 +1,249 @@
+# Datenbankendpunkt hinzufügen
+
+Diese Anleitung zeigt, wie man einen Endpoint hinzufügt, der eine Datenbank liest und beschreibt, und dabei dem Domain-Layer-Pattern von NENE2 folgt.
+
+**Voraussetzung**: Sie haben eine funktionierende NENE2-Anwendung mit einer registrierten Route. Falls nicht, beginnen Sie mit [Eine Route hinzufügen](./add-custom-route.md).
+
+---
+
+## Das Pattern
+
+NENE2 verwendet ein Drei-Schichten-Pattern zwischen dem HTTP-Handler und der Datenbank:
+
+```
+HTTP Handler
+  ↓ ruft auf
+UseCase          ← Geschäftslogik, ohne HTTP- oder Datenbankkenntnis
+  ↓ ruft auf
+RepositoryInterface ← Datenbankoperationen, als Interface definiert
+  ↓ implementiert durch
+PdoRepository    ← die eigentlichen SQL-Queries
+```
+
+Das ist die gleiche Trennung wie in FastAPI mit einer Service-Schicht oder in Node.js mit einem Repository-Pattern. Der HTTP-Handler bleibt schlank; der Use Case enthält die Logik; das Repository verwaltet die Persistenz.
+
+---
+
+## Beispiel: eine `Product`-Ressource
+
+Wir werden `GET /products/{id}` als konkretes Beispiel aufbauen.
+
+### 1 — Die Domain-Entität definieren
+
+Erstellen Sie `src/Product/Product.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class Product
+{
+    public function __construct(
+        public int    $id,
+        public string $name,
+        public int    $price,
+    ) {}
+}
+```
+
+`readonly` bedeutet, dass Eigenschaften einmal im Konstruktor gesetzt werden und sich nicht ändern können — äquivalent zu einem gefrorenen Objekt in JavaScript oder einer Dataclass mit `frozen=True` in Python.
+
+### 2 — Das Repository-Interface definieren
+
+Erstellen Sie `src/Product/ProductRepositoryInterface.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+interface ProductRepositoryInterface
+{
+    public function findById(int $id): ?Product;
+}
+```
+
+Das Interface deklariert *was getan werden kann*, nicht *wie*. Das ermöglicht es, eine echte Datenbank in Tests durch einen In-Memory-Fake zu ersetzen.
+
+### 3 — Den Use Case definieren
+
+Erstellen Sie `src/Product/GetProductByIdUseCase.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class GetProductByIdUseCase
+{
+    public function __construct(private ProductRepositoryInterface $products) {}
+
+    public function execute(int $id): ?Product
+    {
+        return $this->products->findById($id);
+    }
+}
+```
+
+Der Use Case weiß nichts über HTTP oder SQL. Er empfängt ein Repository und ruft es auf. Das macht es einfach, ohne Datenbank zu testen.
+
+### 4 — Das Repository mit PDO implementieren
+
+Erstellen Sie `src/Product/PdoProductRepository.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+use PDO;
+
+final readonly class PdoProductRepository implements ProductRepositoryInterface
+{
+    public function __construct(private PDO $pdo) {}
+
+    public function findById(int $id): ?Product
+    {
+        $stmt = $this->pdo->prepare('SELECT id, name, price FROM products WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        return new Product(
+            id:    (int) $row['id'],
+            name:  (string) $row['name'],
+            price: (int) $row['price'],
+        );
+    }
+}
+```
+
+Alle SQL-Statements befinden sich hier. Nichts außerhalb dieser Klasse muss wissen, welche Datenbank oder Abfragesyntax verwendet wird.
+
+### 5 — Im Front Controller verdrahten
+
+In `public/index.php` verbinden Sie die Teile und registrieren die Route:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use MyApp\Product\GetProductByIdUseCase;
+use MyApp\Product\PdoProductRepository;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+// Datenbank und Use Case verdrahten.
+$pdo     = new PDO('mysql:host=127.0.0.1;dbname=myapp', 'user', 'password');
+$useCase = new GetProductByIdUseCase(new PdoProductRepository($pdo));
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json, $useCase): void {
+            $router->get('/products/{id}', static function (ServerRequestInterface $req) use ($json, $useCase) {
+                $params  = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+                $id      = (int) ($params['id'] ?? 0);
+                $product = $useCase->execute($id);
+
+                if ($product === null) {
+                    return $json->create([
+                        'type'   => 'https://nene2.dev/problems/not-found',
+                        'title'  => 'Not Found',
+                        'status' => 404,
+                    ], 404);
+                }
+
+                return $json->create([
+                    'id'    => $product->id,
+                    'name'  => $product->name,
+                    'price' => $product->price,
+                ]);
+            });
+        },
+    ],
+))->create();
+
+// ... Request-Handling (wie im Tutorial)
+```
+
+> **Produktionshinweis**: Für größere Anwendungen verschieben Sie die Verdrahtung in einen Service Provider
+> und injizieren Sie typisierte Config-Objekte statt roher PDO-Verbindungsstrings.
+> Siehe `src/DependencyInjection/` und `docs/development/domain-layer.md` für das vollständige Pattern.
+
+---
+
+## Den Use Case ohne Datenbank testen
+
+Da `GetProductByIdUseCase` von `ProductRepositoryInterface` abhängt (nicht von `PdoProductRepository`), können Sie ihn mit einem einfachen In-Memory-Fake testen:
+
+```php
+final class InMemoryProductRepository implements ProductRepositoryInterface
+{
+    /** @param array<int, Product> $products */
+    public function __construct(private array $products = []) {}
+
+    public function findById(int $id): ?Product
+    {
+        return $this->products[$id] ?? null;
+    }
+}
+
+// In Ihrem Test:
+$repo    = new InMemoryProductRepository([1 => new Product(1, 'Widget', 999)]);
+$useCase = new GetProductByIdUseCase($repo);
+$result  = $useCase->execute(1);
+
+assert($result->name === 'Widget');
+```
+
+Das ist das gleiche Pattern wie das Mocken eines Services in Jest oder die Verwendung eines Test-Doubles in pytest.
+
+---
+
+## Verzeichnisstruktur
+
+Diesem Pattern folgend, wird Ihr Projekt zu:
+
+```
+src/
+  Product/
+    Product.php                    ← Domain-Entität
+    ProductRepositoryInterface.php ← was getan werden kann
+    GetProductByIdUseCase.php      ← Geschäftslogik
+    PdoProductRepository.php       ← SQL-Implementierung
+public/
+  index.php                        ← Verdrahtung + Routen
+```
+
+Jede Ressource bekommt ihr eigenes Verzeichnis. Halten Sie den Handler schlank und den Use Case auf eine Operation fokussiert.
+
+---
+
+## Nächste Schritte
+
+- OpenAPI-Dokumentation für Ihren Endpoint hinzufügen: siehe `docs/development/endpoint-scaffold.md`
+- Datenbankmigrationen hinzufügen: siehe `docs/development/test-database-strategy.md`
+- NENE2's eingebautes Note-Beispiel als Referenz ansehen: `src/Example/Note/`

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -1,0 +1,43 @@
+---
+layout: home
+
+hero:
+  name: "NENE2"
+  text: "Minimales PHP API Framework"
+  tagline: JSON APIs schnell bauen. OpenAPI und MCP eingebaut. Vom ersten Tag an KI-bereit.
+  actions:
+    - theme: brand
+      text: Loslegen →
+      link: /de/tutorial/first-api
+    - theme: alt
+      text: Auf GitHub ansehen
+      link: https://github.com/hideyukiMORI/NENE2
+    - theme: alt
+      text: Packagist
+      link: https://packagist.org/packages/hideyukimori/nene2
+
+features:
+  - icon: 🚀
+    title: In Minuten einsatzbereit
+    details: Ein einfaches composer require hideyukimori/nene2 und Sie haben eine laufende JSON API mit Health Checks, Request IDs und Problem Details Fehlern — bevor Sie eine einzige Route schreiben.
+
+  - icon: 📄
+    title: OpenAPI zuerst
+    details: Jeder Endpoint, den Sie erstellen, kommt mit einem OpenAPI-Vertrag. Swagger UI ist inklusive. Der Vertrag ist das, was Sie Ihrem Kunden übergeben, kein nachträglicher Gedanke.
+
+  - icon: 🤖
+    title: MCP-bereit
+    details: Ein lokaler MCP-Server stellt Ihre API als Werkzeuge bereit, die KI-Agenten (Claude, Cursor) direkt aufrufen können. Keine spezielle Integration — er liest aus Ihrem OpenAPI-Katalog.
+
+  - icon: 🛡️
+    title: RFC 9457 Fehler
+    details: Jede Fehlerantwort ist ein Problem Details Objekt — eine maschinenlesbare JSON-Struktur mit type, title, status und detail. Keine rohen Ausnahmen in der Produktion.
+
+  - icon: 🧱
+    title: Saubere Architektur
+    details: UseCase → RepositoryInterface → PDO-Adapter. Jede Schicht isoliert testbar. Kein Magic, keine versteckte Verdrahtung, kein Framework, das in Ihre Domäne eindringt.
+
+  - icon: 🔬
+    title: PHPStan Level 8
+    details: Statische Analyse auf höchster Stufe. Wenn es PHPStan besteht, überrascht es Sie nicht zur Laufzeit. Funktioniert sofort mit PHPUnit und PHP-CS-Fixer.
+---

--- a/docs/de/tutorial/first-api.md
+++ b/docs/de/tutorial/first-api.md
@@ -1,0 +1,263 @@
+# Ihre erste API in 10 Minuten
+
+Dieses Tutorial führt Sie von null bis zu einer laufenden JSON API mit NENE2.
+
+Am Ende werden Sie haben:
+- eine lokale API, die auf HTTP-Anfragen antwortet
+- einen `/hello`-Endpoint, der JSON zurückgibt
+- ein Verständnis dafür, wie Anfragen durch das Framework fließen
+
+**Für wen**: Entwickler, die JavaScript oder Python kennen, aber PHP noch nicht verwendet haben. Wenn Sie Express oder FastAPI genutzt haben, lassen sich die Konzepte direkt übertragen.
+
+**Zeit**: etwa 10 Minuten.
+
+---
+
+## Was Sie benötigen
+
+| Werkzeug | Warum | Überprüfung |
+|---|---|---|
+| PHP 8.4 | führt die Anwendung aus | `php --version` |
+| Composer | PHP-Paketmanager (wie npm) | `composer --version` |
+| Ein Terminal | alle Befehle werden hier ausgeführt | — |
+
+> **Docker-Alternative**: Wenn Sie PHP lieber nicht lokal installieren möchten, funktioniert Docker ebenfalls.
+> Siehe [Docker-basiertes Setup](#docker-basiertes-setup) am Ende dieser Seite.
+
+---
+
+## Schritt 1 — Projektverzeichnis erstellen
+
+```bash
+mkdir my-api && cd my-api
+```
+
+Dies entspricht `mkdir my-app && cd my-app` in einem Node.js-Projekt.
+
+---
+
+## Schritt 2 — NENE2 installieren
+
+```bash
+composer init --name="yourname/my-api" --no-interaction
+composer require hideyukimori/nene2:^0.4
+```
+
+`composer require` ist das PHP-Äquivalent von `npm install`. Es lädt NENE2 und seine Abhängigkeiten in `vendor/` herunter.
+
+Danach sieht Ihr Verzeichnis so aus:
+
+```
+my-api/
+  vendor/        ← installierte Pakete (wie node_modules/)
+  composer.json  ← Paket-Metadaten (wie package.json)
+  composer.lock  ← fixierte Versionen (wie package-lock.json)
+```
+
+---
+
+## Schritt 3 — Eine `.env`-Datei erstellen
+
+```bash
+cat > .env << 'EOF'
+APP_ENV=local
+APP_DEBUG=true
+APP_NAME="My API"
+DB_ADAPTER=sqlite
+EOF
+```
+
+`.env` funktioniert genauso wie in Node.js. Das Framework liest sie beim Start automatisch.
+
+---
+
+## Schritt 4 — Den Front Controller erstellen
+
+Erstellen Sie `public/index.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/hello', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['message' => 'Hello, world!', 'status' => 'ok']);
+            });
+        },
+    ],
+))->create();
+
+$request  = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGlobals();
+$response = $app->handle($request);
+
+foreach ($response->getHeaders() as $name => $values) {
+    foreach ($values as $value) {
+        header(sprintf('%s: %s', $name, $value), false);
+    }
+}
+http_response_code($response->getStatusCode());
+echo $response->getBody();
+```
+
+**Was das bewirkt** (Zeile für Zeile):
+
+- `require .../vendor/autoload.php` — lädt alle installierten Pakete, wie `import` in JS
+- `$psr17 = new Psr17Factory()` — erstellt HTTP-Objekt-Factories (denken Sie: Request/Response-Builder)
+- `RuntimeApplicationFactory` — verdrahtet die komplette Middleware-Pipeline
+- `routeRegistrars` — hier fügen Sie Ihre eigenen Routen hinzu (mehr dazu in den HOWTO-Docs)
+- `$router->get('/hello', ...)` — registriert eine GET-Route, wie `app.get('/hello', ...)` in Express
+- `$json->create([...])` — erstellt eine JSON-Antwort aus einem PHP-Array
+
+---
+
+## Schritt 5 — Den Server starten
+
+```bash
+php -S localhost:8080 -t public
+```
+
+Dies ist PHPs eingebauter Entwicklungsserver. Er entspricht `npm run dev` — nicht für Produktion, aber gut für lokale Entwicklung.
+
+Sie sollten sehen:
+
+```
+PHP 8.4.x Development Server (http://localhost:8080) started
+```
+
+---
+
+## Schritt 6 — Die API aufrufen
+
+Öffnen Sie ein neues Terminal und führen Sie aus:
+
+```bash
+curl http://localhost:8080/hello
+```
+
+Sie sollten sehen:
+
+```json
+{
+    "message": "Hello, world!",
+    "status": "ok"
+}
+```
+
+Probieren Sie auch den eingebauten Health-Endpoint:
+
+```bash
+curl http://localhost:8080/health
+```
+
+```json
+{
+    "status": "ok",
+    "service": "My API"
+}
+```
+
+Das ist Ihre erste laufende API. Schauen wir, was sonst noch enthalten ist.
+
+---
+
+## Schritt 7 — Fehlerbehandlung in Aktion
+
+NENE2 gibt [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) für alle Fehler zurück. Rufen Sie eine Route auf, die nicht existiert:
+
+```bash
+curl http://localhost:8080/missing
+```
+
+```json
+{
+    "type": "https://nene2.dev/problems/not-found",
+    "title": "Not Found",
+    "status": 404,
+    "instance": "/missing"
+}
+```
+
+Jede Fehlerantwort hat einen `type`-URI, einen `title` und einen HTTP-`status`. Dies ist das Standardformat, das in allen NENE2-Fehlerantworten verwendet wird.
+
+---
+
+## Was gerade passiert ist
+
+Hier ist der Request-Flow für `GET /hello`:
+
+```
+HTTP-Anfrage
+  → RequestIdMiddleware      fügt X-Request-Id-Header hinzu
+  → SecurityHeadersMiddleware fügt X-Content-Type-Options usw. hinzu
+  → CorsMiddleware           behandelt CORS-Preflight
+  → ErrorHandlerMiddleware   fängt unbehandelte Ausnahmen
+  → RequestSizeLimitMiddleware weist zu große Payloads ab
+  → Router                   matched /hello → Ihr Handler
+  → Ihr Handler              gibt {"message": "Hello, world!"} zurück
+HTTP-Antwort
+```
+
+All das passiert automatisch. Ihr Handler muss nur eine Antwort zurückgeben — das Framework kümmert sich um Header, Fehlerformatierung und Request-Korrelation.
+
+---
+
+## Nächste Schritte
+
+- **Einen Pfadparameter hinzufügen** (wie `/hello/{name}`): siehe [Eine Route hinzufügen](../howto/add-custom-route.md)
+- **Eine Datenbank verbinden**: siehe [Datenbankendpunkt hinzufügen](../howto/add-database-endpoint.md)
+- **Die vollständige API-Dokumentation sehen**: starten Sie den Server und öffnen Sie `http://localhost:8080/openapi.php`
+
+---
+
+## Docker-basiertes Setup
+
+Wenn Sie Docker einer lokalen PHP-Installation vorziehen:
+
+```bash
+mkdir my-api && cd my-api
+```
+
+Erstellen Sie eine minimale `compose.yaml`:
+
+```yaml
+services:
+  app:
+    image: php:8.4-apache
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+    working_dir: /var/www/html
+```
+
+Installieren Sie dann Composer innerhalb des Containers:
+
+```bash
+docker compose run --rm app bash -c "curl -sS https://getcomposer.org/installer | php && php composer.phar require hideyukimori/nene2:^0.4"
+```
+
+Folgen Sie den Schritten 3–4 oben, um `.env` und `public/index.php` zu erstellen, dann:
+
+```bash
+docker compose up -d
+curl http://localhost:8080/hello
+```
+
+Für ein vollständigeres Docker-Setup mit MySQL-Unterstützung, siehe den [NENE2-Repository-Setup-Guide](../development/setup.md).

--- a/docs/fr/howto/add-custom-route.md
+++ b/docs/fr/howto/add-custom-route.md
@@ -1,0 +1,150 @@
+# Ajouter une route personnalisée
+
+Ce guide montre comment ajouter des routes GET et POST avec des paramètres de chemin à une application NENE2.
+
+**Prérequis** : Vous avez une application NENE2 fonctionnelle. Sinon, commencez par le [Tutoriel](../tutorial/first-api.md).
+
+---
+
+## Ajouter une route GET simple
+
+Les routes sont enregistrées via `routeRegistrars` — un tableau de fonctions qui reçoivent chacune le routeur et y enregistrent des routes.
+
+```php
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['items' => [], 'count' => 0]);
+            });
+        },
+    ],
+))->create();
+```
+
+Dans Express ce serait `app.get('/items', (req, res) => res.json(...))`. Le modèle est identique — route, handler, réponse.
+
+---
+
+## Ajouter un paramètre de chemin
+
+Utilisez la syntaxe `{name}` dans le chemin de route. Dans le handler, lisez tous les paramètres de chemin depuis l'attribut de requête `Router::PARAMETERS_ATTRIBUTE` — ils sont stockés dans un tableau nommé, pas en tant qu'attributs individuels.
+
+```php
+use Nene2\Routing\Router;
+
+$router->get('/items/{id}', static function (ServerRequestInterface $req) use ($json) {
+    // Les paramètres de chemin sont dans un seul attribut tableau — pas des attributs individuels.
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+
+    return $json->create(['id' => $id]);
+});
+```
+
+> **Erreur fréquente** : `$req->getAttribute('id')` retourne toujours `null`.
+> Utilisez toujours `$req->getAttribute(Router::PARAMETERS_ATTRIBUTE, [])['id']` à la place.
+
+Dans Express c'est `req.params.id`. Dans FastAPI c'est un argument de fonction typé. Dans NENE2 c'est une lecture explicite de tableau — plus verbeux mais impossible de confondre avec les paramètres de query string.
+
+### Paramètres multiples
+
+```php
+$router->get('/users/{userId}/posts/{postId}', static function (ServerRequestInterface $req) use ($json) {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $userId = (int) ($params['userId'] ?? 0);
+    $postId = (int) ($params['postId'] ?? 0);
+
+    return $json->create(['userId' => $userId, 'postId' => $postId]);
+});
+```
+
+---
+
+## Ajouter un paramètre de query string
+
+Les paramètres de query string sont lus depuis le tableau de query parsé, pas depuis le pattern de route.
+
+```php
+$router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+    $query  = $req->getQueryParams();          // ['limit' => '20', 'offset' => '0']
+    $limit  = (int) ($query['limit']  ?? 20);
+    $offset = (int) ($query['offset'] ?? 0);
+
+    return $json->create(['limit' => $limit, 'offset' => $offset]);
+});
+```
+
+C'est équivalent à `req.query.limit` dans Express ou `request.query_params['limit']` dans FastAPI.
+
+---
+
+## Ajouter une route POST
+
+```php
+$router->post('/items', static function (ServerRequestInterface $req) use ($json, $psr17) {
+    $body  = json_decode((string) $req->getBody(), true) ?? [];
+    $name  = (string) ($body['name'] ?? '');
+
+    if ($name === '') {
+        // Retourner 422 Validation Failed — voir docs/development/endpoint-scaffold.md
+        // pour le pattern de validation complet avec ValidationException.
+        return $json->create(['error' => 'name is required'], 422);
+    }
+
+    // Dans un vrai endpoint, vous sauvegarderiez en base de données ici.
+    return $json->create(['name' => $name], 201);
+});
+```
+
+> Pour les endpoints de production, utilisez `ValidationException` et le pattern de couche domaine
+> plutôt que la validation inline. Voir [Ajouter un endpoint avec base de données](./add-database-endpoint.md).
+
+---
+
+## Plusieurs routes dans un seul registrar
+
+Vous pouvez enregistrer autant de routes que vous voulez dans une seule fonction registrar :
+
+```php
+routeRegistrars: [
+    static function (Router $router) use ($json): void {
+        $router->get('/items',         /* handler */);
+        $router->get('/items/{id}',    /* handler */);
+        $router->post('/items',        /* handler */);
+        $router->put('/items/{id}',    /* handler */);
+        $router->delete('/items/{id}', /* handler */);
+    },
+],
+```
+
+Ou répartissez sur plusieurs fonctions registrar pour plus de clarté quand la liste de routes devient longue.
+
+---
+
+## Méthodes HTTP disponibles
+
+| Méthode | Méthode Router | Usage typique |
+|---|---|---|
+| GET | `$router->get()` | Lire une ressource |
+| POST | `$router->post()` | Créer une ressource |
+| PUT | `$router->put()` | Remplacer une ressource (mise à jour complète) |
+| DELETE | `$router->delete()` | Supprimer une ressource |
+
+---
+
+## Étape suivante
+
+Si votre route doit lire depuis ou écrire dans une base de données, voir
+[Ajouter un endpoint avec base de données](./add-database-endpoint.md).

--- a/docs/fr/howto/add-database-endpoint.md
+++ b/docs/fr/howto/add-database-endpoint.md
@@ -1,0 +1,249 @@
+# Ajouter un endpoint avec base de données
+
+Ce guide montre comment ajouter un endpoint qui lit et écrit dans une base de données, en suivant le pattern de couche domaine de NENE2.
+
+**Prérequis** : Vous avez une application NENE2 fonctionnelle avec une route enregistrée. Sinon, commencez par [Ajouter une route personnalisée](./add-custom-route.md).
+
+---
+
+## Le pattern
+
+NENE2 utilise un pattern à trois couches entre le handler HTTP et la base de données :
+
+```
+HTTP Handler
+  ↓ appelle
+UseCase          ← logique métier, sans connaissance HTTP ou base de données
+  ↓ appelle
+RepositoryInterface ← opérations base de données, définies comme interface
+  ↓ implémentée par
+PdoRepository    ← les vraies requêtes SQL
+```
+
+C'est la même séparation que dans FastAPI avec une couche service, ou dans Node.js avec un pattern repository. Le handler HTTP reste mince ; le use case contient la logique ; le repository gère la persistance.
+
+---
+
+## Exemple : une ressource `Product`
+
+Nous allons construire `GET /products/{id}` comme exemple concret.
+
+### 1 — Définir l'entité domaine
+
+Créez `src/Product/Product.php` :
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class Product
+{
+    public function __construct(
+        public int    $id,
+        public string $name,
+        public int    $price,
+    ) {}
+}
+```
+
+`readonly` signifie que les propriétés sont définies une fois dans le constructeur et ne peuvent pas changer — équivalent à un objet gelé en JavaScript ou une dataclass avec `frozen=True` en Python.
+
+### 2 — Définir l'interface repository
+
+Créez `src/Product/ProductRepositoryInterface.php` :
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+interface ProductRepositoryInterface
+{
+    public function findById(int $id): ?Product;
+}
+```
+
+L'interface déclare *ce qui peut être fait*, pas *comment*. Cela vous permet de remplacer une vraie base de données par un faux en mémoire dans les tests.
+
+### 3 — Définir le use case
+
+Créez `src/Product/GetProductByIdUseCase.php` :
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class GetProductByIdUseCase
+{
+    public function __construct(private ProductRepositoryInterface $products) {}
+
+    public function execute(int $id): ?Product
+    {
+        return $this->products->findById($id);
+    }
+}
+```
+
+Le use case ne sait rien sur HTTP ou SQL. Il reçoit un repository et l'appelle. Cela facilite les tests sans base de données.
+
+### 4 — Implémenter le repository avec PDO
+
+Créez `src/Product/PdoProductRepository.php` :
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+use PDO;
+
+final readonly class PdoProductRepository implements ProductRepositoryInterface
+{
+    public function __construct(private PDO $pdo) {}
+
+    public function findById(int $id): ?Product
+    {
+        $stmt = $this->pdo->prepare('SELECT id, name, price FROM products WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        return new Product(
+            id:    (int) $row['id'],
+            name:  (string) $row['name'],
+            price: (int) $row['price'],
+        );
+    }
+}
+```
+
+Tout le SQL se trouve ici. Rien à l'extérieur de cette classe n'a besoin de savoir quelle base de données ou syntaxe de requête est utilisée.
+
+### 5 — Câbler dans le contrôleur frontal
+
+Dans `public/index.php`, connectez les pièces et enregistrez la route :
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use MyApp\Product\GetProductByIdUseCase;
+use MyApp\Product\PdoProductRepository;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+// Câbler la base de données et le use case.
+$pdo     = new PDO('mysql:host=127.0.0.1;dbname=myapp', 'user', 'password');
+$useCase = new GetProductByIdUseCase(new PdoProductRepository($pdo));
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json, $useCase): void {
+            $router->get('/products/{id}', static function (ServerRequestInterface $req) use ($json, $useCase) {
+                $params  = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+                $id      = (int) ($params['id'] ?? 0);
+                $product = $useCase->execute($id);
+
+                if ($product === null) {
+                    return $json->create([
+                        'type'   => 'https://nene2.dev/problems/not-found',
+                        'title'  => 'Not Found',
+                        'status' => 404,
+                    ], 404);
+                }
+
+                return $json->create([
+                    'id'    => $product->id,
+                    'name'  => $product->name,
+                    'price' => $product->price,
+                ]);
+            });
+        },
+    ],
+))->create();
+
+// ... gestion des requêtes (comme dans le tutoriel)
+```
+
+> **Note pour la production** : Pour les applications plus grandes, déplacez le câblage dans un service provider
+> et injectez des objets de config typés plutôt que des chaînes de connexion PDO brutes.
+> Voir `src/DependencyInjection/` et `docs/development/domain-layer.md` pour le pattern complet.
+
+---
+
+## Tester le use case sans base de données
+
+Comme `GetProductByIdUseCase` dépend de `ProductRepositoryInterface` (pas de `PdoProductRepository`), vous pouvez le tester avec un simple faux en mémoire :
+
+```php
+final class InMemoryProductRepository implements ProductRepositoryInterface
+{
+    /** @param array<int, Product> $products */
+    public function __construct(private array $products = []) {}
+
+    public function findById(int $id): ?Product
+    {
+        return $this->products[$id] ?? null;
+    }
+}
+
+// Dans votre test :
+$repo    = new InMemoryProductRepository([1 => new Product(1, 'Widget', 999)]);
+$useCase = new GetProductByIdUseCase($repo);
+$result  = $useCase->execute(1);
+
+assert($result->name === 'Widget');
+```
+
+C'est le même pattern que de mocker un service dans Jest ou d'utiliser un test double dans pytest.
+
+---
+
+## Structure des répertoires
+
+En suivant ce pattern, votre projet évoluera vers :
+
+```
+src/
+  Product/
+    Product.php                    ← entité domaine
+    ProductRepositoryInterface.php ← ce qui peut être fait
+    GetProductByIdUseCase.php      ← logique métier
+    PdoProductRepository.php       ← implémentation SQL
+public/
+  index.php                        ← câblage + routes
+```
+
+Chaque ressource obtient son propre répertoire. Gardez le handler mince et le use case centré sur une opération.
+
+---
+
+## Étapes suivantes
+
+- Ajouter la documentation OpenAPI pour votre endpoint : voir `docs/development/endpoint-scaffold.md`
+- Ajouter des migrations de base de données : voir `docs/development/test-database-strategy.md`
+- Voir l'exemple Note intégré de NENE2 comme référence : `src/Example/Note/`

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -1,0 +1,43 @@
+---
+layout: home
+
+hero:
+  name: "NENE2"
+  text: "Framework PHP API Minimaliste"
+  tagline: Construisez des API JSON rapidement. OpenAPI et MCP intégrés. Prêt pour l'IA dès le premier jour.
+  actions:
+    - theme: brand
+      text: Commencer →
+      link: /fr/tutorial/first-api
+    - theme: alt
+      text: Voir sur GitHub
+      link: https://github.com/hideyukiMORI/NENE2
+    - theme: alt
+      text: Packagist
+      link: https://packagist.org/packages/hideyukimori/nene2
+
+features:
+  - icon: 🚀
+    title: Opérationnel en minutes
+    details: Un simple composer require hideyukimori/nene2 et vous avez une API JSON fonctionnelle avec health checks, request IDs et erreurs Problem Details — avant même d'écrire une seule route.
+
+  - icon: 📄
+    title: OpenAPI en premier
+    details: Chaque endpoint que vous créez est accompagné d'un contrat OpenAPI. Swagger UI est inclus. Le contrat est ce que vous remettez à votre client, pas une réflexion après coup.
+
+  - icon: 🤖
+    title: Prêt pour MCP
+    details: Un serveur MCP local expose votre API en tant qu'outils que les agents IA (Claude, Cursor) peuvent appeler directement. Aucune intégration spéciale — il lit depuis votre catalogue OpenAPI.
+
+  - icon: 🛡️
+    title: Erreurs RFC 9457
+    details: Chaque réponse d'erreur est un objet Problem Details — une structure JSON lisible par les machines avec type, title, status et detail. Pas d'exceptions brutes en production.
+
+  - icon: 🧱
+    title: Architecture propre
+    details: UseCase → RepositoryInterface → adaptateur PDO. Chaque couche est testable isolément. Pas de magie, pas de câblage caché, pas de framework qui s'infiltre dans votre domaine.
+
+  - icon: 🔬
+    title: PHPStan niveau 8
+    details: Analyse statique au niveau le plus strict. Si ça passe PHPStan, ça ne vous surprendra pas en production. Fonctionne avec PHPUnit et PHP-CS-Fixer dès l'installation.
+---

--- a/docs/fr/tutorial/first-api.md
+++ b/docs/fr/tutorial/first-api.md
@@ -1,0 +1,263 @@
+# Votre première API en 10 minutes
+
+Ce tutoriel vous guide de zéro à une API JSON fonctionnelle avec NENE2.
+
+À la fin vous aurez :
+- une API locale qui répond aux requêtes HTTP
+- un endpoint `/hello` qui retourne du JSON
+- une compréhension du flux des requêtes à travers le framework
+
+**Pour qui** : Les développeurs qui connaissent JavaScript ou Python mais n'ont jamais utilisé PHP. Si vous avez utilisé Express ou FastAPI, les concepts s'y mappent directement.
+
+**Durée** : environ 10 minutes.
+
+---
+
+## Ce dont vous avez besoin
+
+| Outil | Pourquoi | Vérification |
+|---|---|---|
+| PHP 8.4 | exécute l'application | `php --version` |
+| Composer | gestionnaire de paquets PHP (comme npm) | `composer --version` |
+| Un terminal | toutes les commandes s'y exécutent | — |
+
+> **Alternative Docker** : si vous préférez ne pas installer PHP localement, Docker fonctionne aussi.
+> Voir [Configuration avec Docker](#configuration-avec-docker) en bas de cette page.
+
+---
+
+## Étape 1 — Créer un répertoire de projet
+
+```bash
+mkdir my-api && cd my-api
+```
+
+C'est comme `mkdir my-app && cd my-app` dans un projet Node.js.
+
+---
+
+## Étape 2 — Installer NENE2
+
+```bash
+composer init --name="yourname/my-api" --no-interaction
+composer require hideyukimori/nene2:^0.4
+```
+
+`composer require` est l'équivalent PHP de `npm install`. Il télécharge NENE2 et ses dépendances dans `vendor/`.
+
+Après cela, votre répertoire ressemble à :
+
+```
+my-api/
+  vendor/        ← paquets installés (comme node_modules/)
+  composer.json  ← métadonnées du paquet (comme package.json)
+  composer.lock  ← versions verrouillées (comme package-lock.json)
+```
+
+---
+
+## Étape 3 — Créer un fichier `.env`
+
+```bash
+cat > .env << 'EOF'
+APP_ENV=local
+APP_DEBUG=true
+APP_NAME="My API"
+DB_ADAPTER=sqlite
+EOF
+```
+
+`.env` fonctionne comme dans Node.js. Le framework le lit automatiquement au démarrage.
+
+---
+
+## Étape 4 — Créer le contrôleur frontal
+
+Créez `public/index.php` :
+
+```php
+<?php
+declare(strict_types=1);
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/hello', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['message' => 'Hello, world!', 'status' => 'ok']);
+            });
+        },
+    ],
+))->create();
+
+$request  = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGlobals();
+$response = $app->handle($request);
+
+foreach ($response->getHeaders() as $name => $values) {
+    foreach ($values as $value) {
+        header(sprintf('%s: %s', $name, $value), false);
+    }
+}
+http_response_code($response->getStatusCode());
+echo $response->getBody();
+```
+
+**Ce que ça fait** (ligne par ligne) :
+
+- `require .../vendor/autoload.php` — charge tous les paquets installés, comme `import` en JS
+- `$psr17 = new Psr17Factory()` — crée des factories d'objets HTTP (pensez : constructeurs de requêtes/réponses)
+- `RuntimeApplicationFactory` — assemble le pipeline middleware complet
+- `routeRegistrars` — là où vous ajoutez vos propres routes (voir les docs HOWTO)
+- `$router->get('/hello', ...)` — enregistre une route GET, comme `app.get('/hello', ...)` dans Express
+- `$json->create([...])` — construit une réponse JSON depuis un tableau PHP
+
+---
+
+## Étape 5 — Démarrer le serveur
+
+```bash
+php -S localhost:8080 -t public
+```
+
+C'est le serveur de développement intégré de PHP. C'est l'équivalent de `npm run dev` — pas pour la production, mais parfait pour le développement local.
+
+Vous devriez voir :
+
+```
+PHP 8.4.x Development Server (http://localhost:8080) started
+```
+
+---
+
+## Étape 6 — Appeler l'API
+
+Ouvrez un nouveau terminal et exécutez :
+
+```bash
+curl http://localhost:8080/hello
+```
+
+Vous devriez voir :
+
+```json
+{
+    "message": "Hello, world!",
+    "status": "ok"
+}
+```
+
+Essayez aussi l'endpoint de santé intégré :
+
+```bash
+curl http://localhost:8080/health
+```
+
+```json
+{
+    "status": "ok",
+    "service": "My API"
+}
+```
+
+C'est votre première API en fonctionnement. Voyons ce qui est inclus d'autre.
+
+---
+
+## Étape 7 — Voir la gestion des erreurs en action
+
+NENE2 retourne [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) pour toutes les erreurs. Appelez une route qui n'existe pas :
+
+```bash
+curl http://localhost:8080/missing
+```
+
+```json
+{
+    "type": "https://nene2.dev/problems/not-found",
+    "title": "Not Found",
+    "status": 404,
+    "instance": "/missing"
+}
+```
+
+Chaque réponse d'erreur a un URI `type`, un `title` et un `status` HTTP. C'est le format standard utilisé dans toutes les réponses d'erreur NENE2.
+
+---
+
+## Ce qui vient de se passer
+
+Voici le flux de requête pour `GET /hello` :
+
+```
+Requête HTTP
+  → RequestIdMiddleware      ajoute l'en-tête X-Request-Id
+  → SecurityHeadersMiddleware ajoute X-Content-Type-Options etc.
+  → CorsMiddleware           gère le preflight CORS
+  → ErrorHandlerMiddleware   capture les exceptions non gérées
+  → RequestSizeLimitMiddleware rejette les charges trop importantes
+  → Router                   correspond /hello → votre handler
+  → votre handler            retourne {"message": "Hello, world!"}
+Réponse HTTP
+```
+
+Tout cela se passe automatiquement. Votre handler a seulement besoin de retourner une réponse — le framework gère les en-têtes, le formatage des erreurs et la corrélation des requêtes.
+
+---
+
+## Étapes suivantes
+
+- **Ajouter un paramètre de chemin** (comme `/hello/{name}`) : voir [Ajouter une route personnalisée](../howto/add-custom-route.md)
+- **Connecter une base de données** : voir [Ajouter un endpoint avec base de données](../howto/add-database-endpoint.md)
+- **Voir la documentation API complète** : démarrez le serveur et ouvrez `http://localhost:8080/openapi.php`
+
+---
+
+## Configuration avec Docker
+
+Si vous préférez Docker à une installation PHP locale :
+
+```bash
+mkdir my-api && cd my-api
+```
+
+Créez un `compose.yaml` minimal :
+
+```yaml
+services:
+  app:
+    image: php:8.4-apache
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+    working_dir: /var/www/html
+```
+
+Puis installez Composer à l'intérieur du conteneur :
+
+```bash
+docker compose run --rm app bash -c "curl -sS https://getcomposer.org/installer | php && php composer.phar require hideyukimori/nene2:^0.4"
+```
+
+Suivez les étapes 3 à 4 ci-dessus pour créer `.env` et `public/index.php`, puis :
+
+```bash
+docker compose up -d
+curl http://localhost:8080/hello
+```
+
+Pour une configuration Docker plus complète avec support MySQL, consultez le [guide de configuration du dépôt NENE2](../development/setup.md).

--- a/docs/ja/howto/add-custom-route.md
+++ b/docs/ja/howto/add-custom-route.md
@@ -1,0 +1,151 @@
+# カスタムルートを追加する
+
+このガイドでは、NENE2 アプリケーションにパスパラメーター付きの GET・POST ルートを追加する方法を説明します。
+
+**前提条件**: 動作する NENE2 アプリケーションがあること。まだの場合は [チュートリアル](../tutorial/first-api.md) から始めてください。
+
+---
+
+## シンプルな GET ルートを追加する
+
+ルートは `routeRegistrars` で登録します。各関数がルーターを受け取り、ルートを登録します。
+
+```php
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['items' => [], 'count' => 0]);
+            });
+        },
+    ],
+))->create();
+```
+
+Express では `app.get('/items', (req, res) => res.json(...))` になります。パターンは同じです — ルート、ハンドラー、レスポンス。
+
+---
+
+## パスパラメーターを追加する
+
+ルートパスに `{name}` 構文を使います。ハンドラー内では `Router::PARAMETERS_ATTRIBUTE` リクエスト属性からすべてのパスパラメーターを取得します。個別の属性ではなく名前付き配列として格納されています。
+
+```php
+use Nene2\Routing\Router;
+
+$router->get('/items/{id}', static function (ServerRequestInterface $req) use ($json) {
+    // パスパラメーターは単一の配列属性に入っています — 個別の属性ではありません。
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+
+    return $json->create(['id' => $id]);
+});
+```
+
+> **よくある間違い**: `$req->getAttribute('id')` は常に `null` を返します。
+> 必ず `$req->getAttribute(Router::PARAMETERS_ATTRIBUTE, [])['id']` を使ってください。
+
+Express では `req.params.id`、FastAPI では型付き関数引数です。NENE2 では明示的な配列読み取りです — より冗長ですが、クエリ文字列パラメーターと混同することはありません。
+
+### 複数のパラメーター
+
+```php
+$router->get('/users/{userId}/posts/{postId}', static function (ServerRequestInterface $req) use ($json) {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $userId = (int) ($params['userId'] ?? 0);
+    $postId = (int) ($params['postId'] ?? 0);
+
+    return $json->create(['userId' => $userId, 'postId' => $postId]);
+});
+```
+
+---
+
+## クエリ文字列パラメーターを追加する
+
+クエリ文字列パラメーターはルートパターンではなく、パース済みのクエリ配列から読み取ります。
+
+```php
+$router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+    $query  = $req->getQueryParams();          // ['limit' => '20', 'offset' => '0']
+    $limit  = (int) ($query['limit']  ?? 20);
+    $offset = (int) ($query['offset'] ?? 0);
+
+    return $json->create(['limit' => $limit, 'offset' => $offset]);
+});
+```
+
+Express の `req.query.limit`、FastAPI の `request.query_params['limit']` に相当します。
+
+---
+
+## POST ルートを追加する
+
+```php
+$router->post('/items', static function (ServerRequestInterface $req) use ($json, $psr17) {
+    $body  = json_decode((string) $req->getBody(), true) ?? [];
+    $name  = (string) ($body['name'] ?? '');
+
+    if ($name === '') {
+        // 422 Validation Failed を返す — 完全なバリデーションパターンは
+        // docs/development/endpoint-scaffold.md を参照。
+        return $json->create(['error' => 'name is required'], 422);
+    }
+
+    // 実際のエンドポイントではここでデータベースに保存します。
+    return $json->create(['name' => $name], 201);
+});
+```
+
+> 本番エンドポイントでは、インラインバリデーションの代わりに
+> `ValidationException` とドメインレイヤーパターンを使ってください。
+> [DB 付きエンドポイントを追加する](./add-database-endpoint.md) を参照。
+
+---
+
+## 1 つの registrar に複数のルートを登録する
+
+1 つの registrar 関数内に好きなだけルートを登録できます:
+
+```php
+routeRegistrars: [
+    static function (Router $router) use ($json): void {
+        $router->get('/items',         /* handler */);
+        $router->get('/items/{id}',    /* handler */);
+        $router->post('/items',        /* handler */);
+        $router->put('/items/{id}',    /* handler */);
+        $router->delete('/items/{id}', /* handler */);
+    },
+],
+```
+
+ルートリストが長くなったら、複数の registrar 関数に分割してください。
+
+---
+
+## 使用可能な HTTP メソッド
+
+| メソッド | Router メソッド | 典型的な用途 |
+|---|---|---|
+| GET | `$router->get()` | リソースを読み取る |
+| POST | `$router->post()` | リソースを作成する |
+| PUT | `$router->put()` | リソースを置き換える（完全更新） |
+| DELETE | `$router->delete()` | リソースを削除する |
+
+---
+
+## 次のステップ
+
+ルートがデータベースの読み書きを必要とする場合は
+[DB 付きエンドポイントを追加する](./add-database-endpoint.md) を参照してください。

--- a/docs/ja/howto/add-database-endpoint.md
+++ b/docs/ja/howto/add-database-endpoint.md
@@ -1,0 +1,249 @@
+# DB 付きエンドポイントを追加する
+
+このガイドでは、NENE2 のドメインレイヤーパターンに従って、データベースを読み書きするエンドポイントを追加する方法を説明します。
+
+**前提条件**: ルートが登録された動作する NENE2 アプリケーションがあること。まだの場合は [カスタムルートを追加する](./add-custom-route.md) から始めてください。
+
+---
+
+## パターン
+
+HTTP ハンドラーとデータベースの間には 3 層のパターンがあります:
+
+```
+HTTP Handler
+  ↓ 呼び出し
+UseCase          ← ビジネスロジック。HTTP も DB も知らない
+  ↓ 呼び出し
+RepositoryInterface ← データベース操作。インターフェースとして定義
+  ↓ 実装
+PdoRepository    ← 実際の SQL クエリ
+```
+
+FastAPI のサービス層や Node.js のリポジトリパターンと同じ分離です。HTTP ハンドラーは薄く保ち、ユースケースにロジックを置き、リポジトリが永続化を担当します。
+
+---
+
+## 例: `Product` リソース
+
+`GET /products/{id}` を具体的な例として構築します。
+
+### 1 — ドメインエンティティを定義する
+
+`src/Product/Product.php` を作成します:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class Product
+{
+    public function __construct(
+        public int    $id,
+        public string $name,
+        public int    $price,
+    ) {}
+}
+```
+
+`readonly` はコンストラクターでプロパティを一度だけセットし、変更できないことを意味します。JavaScript のフリーズされたオブジェクトや Python の `frozen=True` の dataclass に相当します。
+
+### 2 — リポジトリインターフェースを定義する
+
+`src/Product/ProductRepositoryInterface.php` を作成します:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+interface ProductRepositoryInterface
+{
+    public function findById(int $id): ?Product;
+}
+```
+
+インターフェースは *何ができるか* を宣言し、*どうやるか* は宣言しません。これにより、テストで実際のデータベースをインメモリのフェイクに差し替えられます。
+
+### 3 — ユースケースを定義する
+
+`src/Product/GetProductByIdUseCase.php` を作成します:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class GetProductByIdUseCase
+{
+    public function __construct(private ProductRepositoryInterface $products) {}
+
+    public function execute(int $id): ?Product
+    {
+        return $this->products->findById($id);
+    }
+}
+```
+
+ユースケースは HTTP も SQL も知りません。リポジトリを受け取り、それを呼び出すだけです。データベースなしでテストするのが簡単です。
+
+### 4 — PDO でリポジトリを実装する
+
+`src/Product/PdoProductRepository.php` を作成します:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+use PDO;
+
+final readonly class PdoProductRepository implements ProductRepositoryInterface
+{
+    public function __construct(private PDO $pdo) {}
+
+    public function findById(int $id): ?Product
+    {
+        $stmt = $this->pdo->prepare('SELECT id, name, price FROM products WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        return new Product(
+            id:    (int) $row['id'],
+            name:  (string) $row['name'],
+            price: (int) $row['price'],
+        );
+    }
+}
+```
+
+すべての SQL はここに集まります。このクラスの外では、どのデータベースやクエリ構文が使われているかを知る必要はありません。
+
+### 5 — フロントコントローラーで接続する
+
+`public/index.php` で各部品を接続してルートを登録します:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use MyApp\Product\GetProductByIdUseCase;
+use MyApp\Product\PdoProductRepository;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+// DB とユースケースを接続する。
+$pdo     = new PDO('mysql:host=127.0.0.1;dbname=myapp', 'user', 'password');
+$useCase = new GetProductByIdUseCase(new PdoProductRepository($pdo));
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json, $useCase): void {
+            $router->get('/products/{id}', static function (ServerRequestInterface $req) use ($json, $useCase) {
+                $params  = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+                $id      = (int) ($params['id'] ?? 0);
+                $product = $useCase->execute($id);
+
+                if ($product === null) {
+                    return $json->create([
+                        'type'   => 'https://nene2.dev/problems/not-found',
+                        'title'  => 'Not Found',
+                        'status' => 404,
+                    ], 404);
+                }
+
+                return $json->create([
+                    'id'    => $product->id,
+                    'name'  => $product->name,
+                    'price' => $product->price,
+                ]);
+            });
+        },
+    ],
+))->create();
+
+// ... リクエスト処理（チュートリアルと同じ）
+```
+
+> **本番向け注記**: 大きなアプリケーションでは、ワイヤリングをサービスプロバイダーに移し、
+> 生の PDO 接続文字列の代わりに型付き設定オブジェクトを注入してください。
+> フルパターンは `src/DependencyInjection/` と `docs/development/domain-layer.md` を参照。
+
+---
+
+## データベースなしでユースケースをテストする
+
+`GetProductByIdUseCase` は `PdoProductRepository` ではなく `ProductRepositoryInterface` に依存しているため、シンプルなインメモリフェイクでテストできます:
+
+```php
+final class InMemoryProductRepository implements ProductRepositoryInterface
+{
+    /** @param array<int, Product> $products */
+    public function __construct(private array $products = []) {}
+
+    public function findById(int $id): ?Product
+    {
+        return $this->products[$id] ?? null;
+    }
+}
+
+// テストで:
+$repo    = new InMemoryProductRepository([1 => new Product(1, 'Widget', 999)]);
+$useCase = new GetProductByIdUseCase($repo);
+$result  = $useCase->execute(1);
+
+assert($result->name === 'Widget');
+```
+
+Jest でサービスをモックしたり、pytest でテストダブルを使うのと同じパターンです。
+
+---
+
+## ディレクトリ構成
+
+このパターンに従うと、プロジェクトは次のように成長します:
+
+```
+src/
+  Product/
+    Product.php                    ← ドメインエンティティ
+    ProductRepositoryInterface.php ← できることの定義
+    GetProductByIdUseCase.php      ← ビジネスロジック
+    PdoProductRepository.php       ← SQL 実装
+public/
+  index.php                        ← ワイヤリング + ルート
+```
+
+各リソースには専用のディレクトリを作ります。ハンドラーは薄く、ユースケースは 1 つの操作に集中させます。
+
+---
+
+## 次のステップ
+
+- エンドポイントの OpenAPI ドキュメントを追加する: `docs/development/endpoint-scaffold.md` を参照
+- データベースマイグレーションを追加する: `docs/development/test-database-strategy.md` を参照
+- NENE2 の組み込み Note サンプルを参照する: `src/Example/Note/`

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,0 +1,43 @@
+---
+layout: home
+
+hero:
+  name: "NENE2"
+  text: "ミニマル PHP API フレームワーク"
+  tagline: JSON API を素早く構築。OpenAPI と MCP を標準搭載。最初から AI 対応。
+  actions:
+    - theme: brand
+      text: はじめる →
+      link: /ja/tutorial/first-api
+    - theme: alt
+      text: GitHub で見る
+      link: https://github.com/hideyukiMORI/NENE2
+    - theme: alt
+      text: Packagist
+      link: https://packagist.org/packages/hideyukimori/nene2
+
+features:
+  - icon: 🚀
+    title: 数分で起動
+    details: composer require hideyukimori/nene2 を実行するだけで、ヘルスチェック・リクエスト ID・Problem Details エラーを備えた JSON API がすぐに動きます。ルートを一行も書く前から。
+
+  - icon: 📄
+    title: OpenAPI ファースト
+    details: 作成したエンドポイントはすべて OpenAPI コントラクトを持ちます。Swagger UI を同梱。コントラクトはクライアントに渡すものであり、後付けではありません。
+
+  - icon: 🤖
+    title: MCP 対応
+    details: ローカル MCP サーバーが API をツールとして公開し、AI エージェント（Claude・Cursor）が直接呼び出せます。OpenAPI カタログを読み取るだけで、特別な統合作業は不要です。
+
+  - icon: 🛡️
+    title: RFC 9457 エラー
+    details: すべてのエラーレスポンスは Problem Details オブジェクトです。type・title・status・detail を含む機械可読な JSON 構造体。本番環境で生の例外は返しません。
+
+  - icon: 🧱
+    title: クリーンアーキテクチャ
+    details: UseCase → RepositoryInterface → PDO アダプター。各レイヤーを独立してテスト可能。マジックなし、隠しワイヤリングなし、ドメインへのフレームワーク侵食なし。
+
+  - icon: 🔬
+    title: PHPStan レベル 8
+    details: 最高レベルの静的解析。PHPStan を通れば、実行時に驚かされません。PHPUnit・PHP-CS-Fixer とすぐに連携して動きます。
+---

--- a/docs/ja/tutorial/first-api.md
+++ b/docs/ja/tutorial/first-api.md
@@ -1,0 +1,263 @@
+# 最初の API を 10 分で動かす
+
+このチュートリアルでは、NENE2 を使って JSON API をゼロから動かすまでの手順を解説します。
+
+最終的に次のことができるようになります:
+- ローカルで HTTP リクエストに応答する API を起動する
+- JSON を返す `/hello` エンドポイントを作成する
+- リクエストがフレームワーク内をどう流れるかを理解する
+
+**対象読者**: JavaScript や Python を知っているが PHP を使ったことのない開発者。Express や FastAPI を使ったことがあれば、概念はそのまま対応しています。
+
+**所要時間**: 約 10 分。
+
+---
+
+## 必要なもの
+
+| ツール | 用途 | 確認コマンド |
+|---|---|---|
+| PHP 8.4 | アプリを実行する | `php --version` |
+| Composer | PHP パッケージマネージャー（npm 相当） | `composer --version` |
+| ターミナル | すべてのコマンドはここで実行する | — |
+
+> **Docker を使う場合**: PHP をローカルにインストールしたくない場合は Docker でも構いません。
+> このページ下部の [Docker を使ったセットアップ](#docker-を使ったセットアップ) を参照してください。
+
+---
+
+## ステップ 1 — プロジェクトディレクトリを作成する
+
+```bash
+mkdir my-api && cd my-api
+```
+
+Node.js プロジェクトでの `mkdir my-app && cd my-app` と同じです。
+
+---
+
+## ステップ 2 — NENE2 をインストールする
+
+```bash
+composer init --name="yourname/my-api" --no-interaction
+composer require hideyukimori/nene2:^0.4
+```
+
+`composer require` は `npm install` の PHP 版です。NENE2 とその依存パッケージを `vendor/` にダウンロードします。
+
+実行後、ディレクトリ構成は次のようになります:
+
+```
+my-api/
+  vendor/        ← インストール済みパッケージ（node_modules/ 相当）
+  composer.json  ← パッケージメタデータ（package.json 相当）
+  composer.lock  ← バージョン固定（package-lock.json 相当）
+```
+
+---
+
+## ステップ 3 — `.env` ファイルを作成する
+
+```bash
+cat > .env << 'EOF'
+APP_ENV=local
+APP_DEBUG=true
+APP_NAME="My API"
+DB_ADAPTER=sqlite
+EOF
+```
+
+`.env` は Node.js と同じように動作します。フレームワークが起動時に自動的に読み込みます。
+
+---
+
+## ステップ 4 — フロントコントローラーを作成する
+
+`public/index.php` を作成します:
+
+```php
+<?php
+declare(strict_types=1);
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/hello', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['message' => 'Hello, world!', 'status' => 'ok']);
+            });
+        },
+    ],
+))->create();
+
+$request  = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGlobals();
+$response = $app->handle($request);
+
+foreach ($response->getHeaders() as $name => $values) {
+    foreach ($values as $value) {
+        header(sprintf('%s: %s', $name, $value), false);
+    }
+}
+http_response_code($response->getStatusCode());
+echo $response->getBody();
+```
+
+**各行の説明**:
+
+- `require .../vendor/autoload.php` — インストール済みパッケージを読み込む（JS の `import` 相当）
+- `$psr17 = new Psr17Factory()` — HTTP オブジェクトファクトリを生成する（リクエスト・レスポンスビルダー）
+- `RuntimeApplicationFactory` — ミドルウェアパイプライン全体を組み立てる
+- `routeRegistrars` — 独自のルートを追加する場所（詳しくは HOWTO ドキュメントを参照）
+- `$router->get('/hello', ...)` — GET ルートを登録する（Express の `app.get('/hello', ...)` 相当）
+- `$json->create([...])` — PHP 配列から JSON レスポンスを生成する
+
+---
+
+## ステップ 5 — サーバーを起動する
+
+```bash
+php -S localhost:8080 -t public
+```
+
+PHP 組み込みの開発サーバーです。`npm run dev` 相当です。本番環境向けではありませんが、ローカル開発には十分です。
+
+次のような出力が表示されるはずです:
+
+```
+PHP 8.4.x Development Server (http://localhost:8080) started
+```
+
+---
+
+## ステップ 6 — API を呼び出す
+
+別のターミナルを開いて実行します:
+
+```bash
+curl http://localhost:8080/hello
+```
+
+次のレスポンスが返るはずです:
+
+```json
+{
+    "message": "Hello, world!",
+    "status": "ok"
+}
+```
+
+組み込みのヘルスエンドポイントも試してみましょう:
+
+```bash
+curl http://localhost:8080/health
+```
+
+```json
+{
+    "status": "ok",
+    "service": "My API"
+}
+```
+
+最初の API が動いています。他に何が含まれているか見てみましょう。
+
+---
+
+## ステップ 7 — エラーハンドリングを確認する
+
+NENE2 はすべてのエラーに対して [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) を返します。存在しないルートを呼び出してみましょう:
+
+```bash
+curl http://localhost:8080/missing
+```
+
+```json
+{
+    "type": "https://nene2.dev/problems/not-found",
+    "title": "Not Found",
+    "status": 404,
+    "instance": "/missing"
+}
+```
+
+すべてのエラーレスポンスには `type` URI・`title`・HTTP `status` が含まれます。これが NENE2 全体で使われる標準フォーマットです。
+
+---
+
+## 何が起きていたか
+
+`GET /hello` のリクエストフローは次の通りです:
+
+```
+HTTP リクエスト
+  → RequestIdMiddleware      X-Request-Id ヘッダーを付与
+  → SecurityHeadersMiddleware X-Content-Type-Options 等を付与
+  → CorsMiddleware           CORS プリフライトを処理
+  → ErrorHandlerMiddleware   未処理例外をキャッチ
+  → RequestSizeLimitMiddleware 過大なペイロードを拒否
+  → Router                   /hello → ハンドラーにマッチ
+  → your handler             {"message": "Hello, world!"} を返す
+HTTP レスポンス
+```
+
+これらはすべて自動的に行われます。ハンドラーはレスポンスを返すだけで、フレームワークがヘッダー・エラーフォーマット・リクエスト相関を処理します。
+
+---
+
+## 次のステップ
+
+- **パスパラメーターを追加する**（`/hello/{name}` など）: [カスタムルートを追加する](../howto/add-custom-route.md) を参照
+- **データベースに接続する**: [DB 付きエンドポイントを追加する](../howto/add-database-endpoint.md) を参照
+- **完全な API ドキュメントを見る**: サーバーを起動して `http://localhost:8080/openapi.php` を開く
+
+---
+
+## Docker を使ったセットアップ
+
+PHP をローカルにインストールせず Docker を使いたい場合:
+
+```bash
+mkdir my-api && cd my-api
+```
+
+最小限の `compose.yaml` を作成します:
+
+```yaml
+services:
+  app:
+    image: php:8.4-apache
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+    working_dir: /var/www/html
+```
+
+コンテナ内で Composer をインストールします:
+
+```bash
+docker compose run --rm app bash -c "curl -sS https://getcomposer.org/installer | php && php composer.phar require hideyukimori/nene2:^0.4"
+```
+
+上記のステップ 3〜4 に従って `.env` と `public/index.php` を作成してから:
+
+```bash
+docker compose up -d
+curl http://localhost:8080/hello
+```
+
+MySQL サポートを含むより完全な Docker セットアップについては、[NENE2 リポジトリのセットアップガイド](../development/setup.md) を参照してください。

--- a/docs/pt-br/howto/add-custom-route.md
+++ b/docs/pt-br/howto/add-custom-route.md
@@ -1,0 +1,150 @@
+# Adicionar uma rota personalizada
+
+Este guia mostra como adicionar rotas GET e POST com parâmetros de rota a uma aplicação NENE2.
+
+**Pré-requisito**: Você tem uma aplicação NENE2 funcionando. Se não, comece com o [Tutorial](../tutorial/first-api.md).
+
+---
+
+## Adicionar uma rota GET simples
+
+As rotas são registradas via `routeRegistrars` — um array de funções que cada uma recebe o roteador e registra rotas nele.
+
+```php
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['items' => [], 'count' => 0]);
+            });
+        },
+    ],
+))->create();
+```
+
+No Express seria `app.get('/items', (req, res) => res.json(...))`. O padrão é idêntico — rota, handler, resposta.
+
+---
+
+## Adicionar um parâmetro de rota
+
+Use a sintaxe `{name}` no caminho da rota. Dentro do handler, leia todos os parâmetros de rota do atributo de requisição `Router::PARAMETERS_ATTRIBUTE` — eles são armazenados como um array nomeado, não como atributos individuais.
+
+```php
+use Nene2\Routing\Router;
+
+$router->get('/items/{id}', static function (ServerRequestInterface $req) use ($json) {
+    // Parâmetros de rota ficam em um único atributo array — não atributos individuais.
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+
+    return $json->create(['id' => $id]);
+});
+```
+
+> **Erro comum**: `$req->getAttribute('id')` sempre retorna `null`.
+> Sempre use `$req->getAttribute(Router::PARAMETERS_ATTRIBUTE, [])['id']`.
+
+No Express é `req.params.id`. No FastAPI é um argumento de função tipado. No NENE2 é uma leitura explícita de array — mais verboso mas impossível de confundir com parâmetros de query string.
+
+### Múltiplos parâmetros
+
+```php
+$router->get('/users/{userId}/posts/{postId}', static function (ServerRequestInterface $req) use ($json) {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $userId = (int) ($params['userId'] ?? 0);
+    $postId = (int) ($params['postId'] ?? 0);
+
+    return $json->create(['userId' => $userId, 'postId' => $postId]);
+});
+```
+
+---
+
+## Adicionar um parâmetro de query string
+
+Parâmetros de query string são lidos do array de query parseado, não do padrão da rota.
+
+```php
+$router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+    $query  = $req->getQueryParams();          // ['limit' => '20', 'offset' => '0']
+    $limit  = (int) ($query['limit']  ?? 20);
+    $offset = (int) ($query['offset'] ?? 0);
+
+    return $json->create(['limit' => $limit, 'offset' => $offset]);
+});
+```
+
+Isso é equivalente a `req.query.limit` no Express ou `request.query_params['limit']` no FastAPI.
+
+---
+
+## Adicionar uma rota POST
+
+```php
+$router->post('/items', static function (ServerRequestInterface $req) use ($json, $psr17) {
+    $body  = json_decode((string) $req->getBody(), true) ?? [];
+    $name  = (string) ($body['name'] ?? '');
+
+    if ($name === '') {
+        // Retornar 422 Validation Failed — veja docs/development/endpoint-scaffold.md
+        // para o padrão de validação completo com ValidationException.
+        return $json->create(['error' => 'name is required'], 422);
+    }
+
+    // Em um endpoint real, você salvaria no banco de dados aqui.
+    return $json->create(['name' => $name], 201);
+});
+```
+
+> Para endpoints de produção, use `ValidationException` e o padrão de camada de domínio
+> em vez de validação inline. Veja [Adicionar um endpoint com banco de dados](./add-database-endpoint.md).
+
+---
+
+## Múltiplas rotas em um único registrar
+
+Você pode registrar quantas rotas quiser dentro de uma única função registrar:
+
+```php
+routeRegistrars: [
+    static function (Router $router) use ($json): void {
+        $router->get('/items',         /* handler */);
+        $router->get('/items/{id}',    /* handler */);
+        $router->post('/items',        /* handler */);
+        $router->put('/items/{id}',    /* handler */);
+        $router->delete('/items/{id}', /* handler */);
+    },
+],
+```
+
+Ou divida em múltiplas funções registrar para clareza quando a lista de rotas crescer.
+
+---
+
+## Métodos HTTP disponíveis
+
+| Método | Método do Router | Uso típico |
+|---|---|---|
+| GET | `$router->get()` | Ler um recurso |
+| POST | `$router->post()` | Criar um recurso |
+| PUT | `$router->put()` | Substituir um recurso (atualização completa) |
+| DELETE | `$router->delete()` | Remover um recurso |
+
+---
+
+## Próximo passo
+
+Se sua rota precisar ler ou escrever em um banco de dados, veja
+[Adicionar um endpoint com banco de dados](./add-database-endpoint.md).

--- a/docs/pt-br/howto/add-database-endpoint.md
+++ b/docs/pt-br/howto/add-database-endpoint.md
@@ -1,0 +1,249 @@
+# Adicionar um endpoint com banco de dados
+
+Este guia mostra como adicionar um endpoint que lê e escreve em um banco de dados, seguindo o padrão de camada de domínio do NENE2.
+
+**Pré-requisito**: Você tem uma aplicação NENE2 funcionando com uma rota registrada. Se não, comece com [Adicionar uma rota personalizada](./add-custom-route.md).
+
+---
+
+## O padrão
+
+NENE2 usa um padrão de três camadas entre o handler HTTP e o banco de dados:
+
+```
+HTTP Handler
+  ↓ chama
+UseCase          ← lógica de negócio, sem conhecimento de HTTP ou banco de dados
+  ↓ chama
+RepositoryInterface ← operações de banco de dados, definidas como interface
+  ↓ implementada por
+PdoRepository    ← as queries SQL reais
+```
+
+Esta é a mesma separação que você tem no FastAPI com uma camada de serviço, ou no Node.js com um padrão repository. O handler HTTP fica fino; o use case contém a lógica; o repository gerencia a persistência.
+
+---
+
+## Exemplo: um recurso `Product`
+
+Vamos construir `GET /products/{id}` como exemplo concreto.
+
+### 1 — Definir a entidade de domínio
+
+Crie `src/Product/Product.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class Product
+{
+    public function __construct(
+        public int    $id,
+        public string $name,
+        public int    $price,
+    ) {}
+}
+```
+
+`readonly` significa que as propriedades são definidas uma vez no construtor e não podem mudar — equivalente a um objeto congelado em JavaScript ou uma dataclass com `frozen=True` em Python.
+
+### 2 — Definir a interface repository
+
+Crie `src/Product/ProductRepositoryInterface.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+interface ProductRepositoryInterface
+{
+    public function findById(int $id): ?Product;
+}
+```
+
+A interface declara *o que pode ser feito*, não *como*. Isso permite trocar um banco de dados real por um fake em memória nos testes.
+
+### 3 — Definir o use case
+
+Crie `src/Product/GetProductByIdUseCase.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class GetProductByIdUseCase
+{
+    public function __construct(private ProductRepositoryInterface $products) {}
+
+    public function execute(int $id): ?Product
+    {
+        return $this->products->findById($id);
+    }
+}
+```
+
+O use case não sabe nada sobre HTTP ou SQL. Ele recebe um repository e o chama. Isso torna fácil testar sem um banco de dados.
+
+### 4 — Implementar o repository com PDO
+
+Crie `src/Product/PdoProductRepository.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+use PDO;
+
+final readonly class PdoProductRepository implements ProductRepositoryInterface
+{
+    public function __construct(private PDO $pdo) {}
+
+    public function findById(int $id): ?Product
+    {
+        $stmt = $this->pdo->prepare('SELECT id, name, price FROM products WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        return new Product(
+            id:    (int) $row['id'],
+            name:  (string) $row['name'],
+            price: (int) $row['price'],
+        );
+    }
+}
+```
+
+Todo o SQL fica aqui. Nada fora desta classe precisa saber qual banco de dados ou sintaxe de query é usada.
+
+### 5 — Conectar no front controller
+
+Em `public/index.php`, conecte as peças e registre a rota:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use MyApp\Product\GetProductByIdUseCase;
+use MyApp\Product\PdoProductRepository;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+// Conectar o banco de dados e o use case.
+$pdo     = new PDO('mysql:host=127.0.0.1;dbname=myapp', 'user', 'password');
+$useCase = new GetProductByIdUseCase(new PdoProductRepository($pdo));
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json, $useCase): void {
+            $router->get('/products/{id}', static function (ServerRequestInterface $req) use ($json, $useCase) {
+                $params  = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+                $id      = (int) ($params['id'] ?? 0);
+                $product = $useCase->execute($id);
+
+                if ($product === null) {
+                    return $json->create([
+                        'type'   => 'https://nene2.dev/problems/not-found',
+                        'title'  => 'Not Found',
+                        'status' => 404,
+                    ], 404);
+                }
+
+                return $json->create([
+                    'id'    => $product->id,
+                    'name'  => $product->name,
+                    'price' => $product->price,
+                ]);
+            });
+        },
+    ],
+))->create();
+
+// ... tratamento de requisição (igual ao tutorial)
+```
+
+> **Nota de produção**: Para aplicações maiores, mova a fiação para um service provider
+> e injete objetos de configuração tipados em vez de strings de conexão PDO brutas.
+> Veja `src/DependencyInjection/` e `docs/development/domain-layer.md` para o padrão completo.
+
+---
+
+## Testando o use case sem banco de dados
+
+Como `GetProductByIdUseCase` depende de `ProductRepositoryInterface` (não de `PdoProductRepository`), você pode testá-lo com um fake simples em memória:
+
+```php
+final class InMemoryProductRepository implements ProductRepositoryInterface
+{
+    /** @param array<int, Product> $products */
+    public function __construct(private array $products = []) {}
+
+    public function findById(int $id): ?Product
+    {
+        return $this->products[$id] ?? null;
+    }
+}
+
+// No seu teste:
+$repo    = new InMemoryProductRepository([1 => new Product(1, 'Widget', 999)]);
+$useCase = new GetProductByIdUseCase($repo);
+$result  = $useCase->execute(1);
+
+assert($result->name === 'Widget');
+```
+
+Este é o mesmo padrão que mockar um serviço no Jest ou usar um test double no pytest.
+
+---
+
+## Estrutura de diretórios
+
+Seguindo este padrão, seu projeto crescerá para:
+
+```
+src/
+  Product/
+    Product.php                    ← entidade de domínio
+    ProductRepositoryInterface.php ← o que pode ser feito
+    GetProductByIdUseCase.php      ← lógica de negócio
+    PdoProductRepository.php       ← implementação SQL
+public/
+  index.php                        ← fiação + rotas
+```
+
+Cada recurso tem seu próprio diretório. Mantenha o handler fino e o use case focado em uma operação.
+
+---
+
+## Próximos passos
+
+- Adicionar documentação OpenAPI para seu endpoint: veja `docs/development/endpoint-scaffold.md`
+- Adicionar migrações de banco de dados: veja `docs/development/test-database-strategy.md`
+- Ver o exemplo Note embutido do NENE2 como referência: `src/Example/Note/`

--- a/docs/pt-br/index.md
+++ b/docs/pt-br/index.md
@@ -1,0 +1,43 @@
+---
+layout: home
+
+hero:
+  name: "NENE2"
+  text: "Framework PHP API Minimalista"
+  tagline: Construa APIs JSON rapidamente. OpenAPI e MCP embutidos. Pronto para IA desde o primeiro dia.
+  actions:
+    - theme: brand
+      text: Começar →
+      link: /pt-br/tutorial/first-api
+    - theme: alt
+      text: Ver no GitHub
+      link: https://github.com/hideyukiMORI/NENE2
+    - theme: alt
+      text: Packagist
+      link: https://packagist.org/packages/hideyukimori/nene2
+
+features:
+  - icon: 🚀
+    title: Em funcionamento em minutos
+    details: Um simples composer require hideyukimori/nene2 e você tem uma API JSON funcionando com health checks, request IDs e erros Problem Details — antes de escrever uma única rota.
+
+  - icon: 📄
+    title: OpenAPI em primeiro lugar
+    details: Cada endpoint que você cria vem com um contrato OpenAPI. Swagger UI está incluído. O contrato é o que você entrega ao seu cliente, não uma reflexão posterior.
+
+  - icon: 🤖
+    title: Pronto para MCP
+    details: Um servidor MCP local expõe sua API como ferramentas que agentes de IA (Claude, Cursor) podem chamar diretamente. Sem integração especial — lê do seu catálogo OpenAPI.
+
+  - icon: 🛡️
+    title: Erros RFC 9457
+    details: Cada resposta de erro é um objeto Problem Details — uma estrutura JSON legível por máquinas com type, title, status e detail. Sem exceções brutas em produção.
+
+  - icon: 🧱
+    title: Arquitetura limpa
+    details: UseCase → RepositoryInterface → adaptador PDO. Cada camada testável isoladamente. Sem mágica, sem fiação oculta, sem framework invadindo seu domínio.
+
+  - icon: 🔬
+    title: PHPStan nível 8
+    details: Análise estática no nível mais estrito. Se passar no PHPStan, não vai te surpreender em produção. Funciona com PHPUnit e PHP-CS-Fixer logo na instalação.
+---

--- a/docs/pt-br/tutorial/first-api.md
+++ b/docs/pt-br/tutorial/first-api.md
@@ -1,0 +1,263 @@
+# Sua primeira API em 10 minutos
+
+Este tutorial leva você do zero a uma API JSON funcionando com NENE2.
+
+Ao final você terá:
+- uma API local que responde a requisições HTTP
+- um endpoint `/hello` que retorna JSON
+- um entendimento de como as requisições fluem pelo framework
+
+**Para quem é**: Desenvolvedores que conhecem JavaScript ou Python mas não usaram PHP antes. Se você já usou Express ou FastAPI, os conceitos se mapeiam diretamente.
+
+**Tempo**: cerca de 10 minutos.
+
+---
+
+## O que você precisa
+
+| Ferramenta | Por quê | Verificação |
+|---|---|---|
+| PHP 8.4 | executa a aplicação | `php --version` |
+| Composer | gerenciador de pacotes PHP (como npm) | `composer --version` |
+| Um terminal | todos os comandos rodam aqui | — |
+
+> **Alternativa com Docker**: se você preferir não instalar PHP localmente, o Docker também funciona.
+> Veja [Configuração com Docker](#configuração-com-docker) no final desta página.
+
+---
+
+## Passo 1 — Criar um diretório de projeto
+
+```bash
+mkdir my-api && cd my-api
+```
+
+É o equivalente a `mkdir my-app && cd my-app` em um projeto Node.js.
+
+---
+
+## Passo 2 — Instalar o NENE2
+
+```bash
+composer init --name="yourname/my-api" --no-interaction
+composer require hideyukimori/nene2:^0.4
+```
+
+`composer require` é o equivalente PHP do `npm install`. Ele baixa o NENE2 e suas dependências para `vendor/`.
+
+Após isso, seu diretório ficará assim:
+
+```
+my-api/
+  vendor/        ← pacotes instalados (como node_modules/)
+  composer.json  ← metadados do pacote (como package.json)
+  composer.lock  ← versões fixadas (como package-lock.json)
+```
+
+---
+
+## Passo 3 — Criar um arquivo `.env`
+
+```bash
+cat > .env << 'EOF'
+APP_ENV=local
+APP_DEBUG=true
+APP_NAME="My API"
+DB_ADAPTER=sqlite
+EOF
+```
+
+`.env` funciona da mesma forma que no Node.js. O framework o lê automaticamente na inicialização.
+
+---
+
+## Passo 4 — Criar o front controller
+
+Crie `public/index.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/hello', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['message' => 'Hello, world!', 'status' => 'ok']);
+            });
+        },
+    ],
+))->create();
+
+$request  = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGlobals();
+$response = $app->handle($request);
+
+foreach ($response->getHeaders() as $name => $values) {
+    foreach ($values as $value) {
+        header(sprintf('%s: %s', $name, $value), false);
+    }
+}
+http_response_code($response->getStatusCode());
+echo $response->getBody();
+```
+
+**O que isso faz** (linha por linha):
+
+- `require .../vendor/autoload.php` — carrega todos os pacotes instalados, como `import` em JS
+- `$psr17 = new Psr17Factory()` — cria factories de objetos HTTP (pense: construtores de request/response)
+- `RuntimeApplicationFactory` — monta o pipeline de middleware completo
+- `routeRegistrars` — onde você adiciona suas próprias rotas (veja os docs HOWTO)
+- `$router->get('/hello', ...)` — registra uma rota GET, como `app.get('/hello', ...)` no Express
+- `$json->create([...])` — constrói uma resposta JSON a partir de um array PHP
+
+---
+
+## Passo 5 — Iniciar o servidor
+
+```bash
+php -S localhost:8080 -t public
+```
+
+Este é o servidor de desenvolvimento embutido do PHP. É o equivalente de `npm run dev` — não para produção, mas ótimo para desenvolvimento local.
+
+Você deve ver:
+
+```
+PHP 8.4.x Development Server (http://localhost:8080) started
+```
+
+---
+
+## Passo 6 — Chamar a API
+
+Abra um novo terminal e execute:
+
+```bash
+curl http://localhost:8080/hello
+```
+
+Você deve ver:
+
+```json
+{
+    "message": "Hello, world!",
+    "status": "ok"
+}
+```
+
+Experimente também o endpoint de health check embutido:
+
+```bash
+curl http://localhost:8080/health
+```
+
+```json
+{
+    "status": "ok",
+    "service": "My API"
+}
+```
+
+Essa é sua primeira API funcionando. Vamos ver o que mais está incluído.
+
+---
+
+## Passo 7 — Ver o tratamento de erros em ação
+
+NENE2 retorna [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) para todos os erros. Chame uma rota que não existe:
+
+```bash
+curl http://localhost:8080/missing
+```
+
+```json
+{
+    "type": "https://nene2.dev/problems/not-found",
+    "title": "Not Found",
+    "status": 404,
+    "instance": "/missing"
+}
+```
+
+Cada resposta de erro tem um URI `type`, um `title` e um `status` HTTP. Este é o formato padrão usado em todas as respostas de erro do NENE2.
+
+---
+
+## O que acabou de acontecer
+
+Aqui está o fluxo de requisição para `GET /hello`:
+
+```
+Requisição HTTP
+  → RequestIdMiddleware      adiciona o cabeçalho X-Request-Id
+  → SecurityHeadersMiddleware adiciona X-Content-Type-Options etc.
+  → CorsMiddleware           trata o preflight CORS
+  → ErrorHandlerMiddleware   captura exceções não tratadas
+  → RequestSizeLimitMiddleware rejeita payloads muito grandes
+  → Router                   corresponde /hello → seu handler
+  → seu handler              retorna {"message": "Hello, world!"}
+Resposta HTTP
+```
+
+Tudo isso acontece automaticamente. Seu handler só precisa retornar uma resposta — o framework cuida dos cabeçalhos, formatação de erros e correlação de requisições.
+
+---
+
+## Próximos passos
+
+- **Adicionar um parâmetro de rota** (como `/hello/{name}`): veja [Adicionar uma rota personalizada](../howto/add-custom-route.md)
+- **Conectar um banco de dados**: veja [Adicionar um endpoint com banco de dados](../howto/add-database-endpoint.md)
+- **Ver a documentação completa da API**: inicie o servidor e abra `http://localhost:8080/openapi.php`
+
+---
+
+## Configuração com Docker
+
+Se você preferir Docker a uma instalação local de PHP:
+
+```bash
+mkdir my-api && cd my-api
+```
+
+Crie um `compose.yaml` mínimo:
+
+```yaml
+services:
+  app:
+    image: php:8.4-apache
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+    working_dir: /var/www/html
+```
+
+Então instale o Composer dentro do container:
+
+```bash
+docker compose run --rm app bash -c "curl -sS https://getcomposer.org/installer | php && php composer.phar require hideyukimori/nene2:^0.4"
+```
+
+Siga os Passos 3–4 acima para criar `.env` e `public/index.php`, depois:
+
+```bash
+docker compose up -d
+curl http://localhost:8080/hello
+```
+
+Para uma configuração Docker mais completa com suporte a MySQL, veja o [guia de configuração do repositório NENE2](../development/setup.md).

--- a/docs/zh/howto/add-custom-route.md
+++ b/docs/zh/howto/add-custom-route.md
@@ -1,0 +1,150 @@
+# 添加自定义路由
+
+本指南展示如何在 NENE2 应用程序中添加带路径参数的 GET 和 POST 路由。
+
+**前提条件**：您已有一个可运行的 NENE2 应用程序。如果没有，请从[教程](../tutorial/first-api.md)开始。
+
+---
+
+## 添加简单的 GET 路由
+
+路由通过 `routeRegistrars` 注册——这是一个函数数组，每个函数接收路由器并在其上注册路由。
+
+```php
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['items' => [], 'count' => 0]);
+            });
+        },
+    ],
+))->create();
+```
+
+在 Express 中这是 `app.get('/items', (req, res) => res.json(...))`。模式完全相同——路由、处理器、响应。
+
+---
+
+## 添加路径参数
+
+在路由路径中使用 `{name}` 语法。在处理器中，从 `Router::PARAMETERS_ATTRIBUTE` 请求属性读取所有路径参数——它们存储为命名数组，而非单独的属性。
+
+```php
+use Nene2\Routing\Router;
+
+$router->get('/items/{id}', static function (ServerRequestInterface $req) use ($json) {
+    // 路径参数在单个数组属性中——不是单独的属性。
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+
+    return $json->create(['id' => $id]);
+});
+```
+
+> **常见错误**：`$req->getAttribute('id')` 总是返回 `null`。
+> 请始终使用 `$req->getAttribute(Router::PARAMETERS_ATTRIBUTE, [])['id']`。
+
+在 Express 中是 `req.params.id`，在 FastAPI 中是类型化函数参数。在 NENE2 中是显式数组读取——更冗长但不可能与查询字符串参数混淆。
+
+### 多个参数
+
+```php
+$router->get('/users/{userId}/posts/{postId}', static function (ServerRequestInterface $req) use ($json) {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $userId = (int) ($params['userId'] ?? 0);
+    $postId = (int) ($params['postId'] ?? 0);
+
+    return $json->create(['userId' => $userId, 'postId' => $postId]);
+});
+```
+
+---
+
+## 添加查询字符串参数
+
+查询字符串参数从解析后的查询数组中读取，而非从路由模式中读取。
+
+```php
+$router->get('/items', static function (ServerRequestInterface $req) use ($json) {
+    $query  = $req->getQueryParams();          // ['limit' => '20', 'offset' => '0']
+    $limit  = (int) ($query['limit']  ?? 20);
+    $offset = (int) ($query['offset'] ?? 0);
+
+    return $json->create(['limit' => $limit, 'offset' => $offset]);
+});
+```
+
+这等同于 Express 中的 `req.query.limit` 或 FastAPI 中的 `request.query_params['limit']`。
+
+---
+
+## 添加 POST 路由
+
+```php
+$router->post('/items', static function (ServerRequestInterface $req) use ($json, $psr17) {
+    $body  = json_decode((string) $req->getBody(), true) ?? [];
+    $name  = (string) ($body['name'] ?? '');
+
+    if ($name === '') {
+        // 返回 422 Validation Failed——完整的验证模式请参见
+        // docs/development/endpoint-scaffold.md
+        return $json->create(['error' => 'name is required'], 422);
+    }
+
+    // 在真实端点中，您会在这里保存到数据库。
+    return $json->create(['name' => $name], 201);
+});
+```
+
+> 对于生产端点，请使用 `ValidationException` 和领域层模式
+> 而非内联验证。参见[添加数据库端点](./add-database-endpoint.md)。
+
+---
+
+## 在一个 registrar 中注册多个路由
+
+您可以在单个 registrar 函数中注册任意数量的路由：
+
+```php
+routeRegistrars: [
+    static function (Router $router) use ($json): void {
+        $router->get('/items',         /* handler */);
+        $router->get('/items/{id}',    /* handler */);
+        $router->post('/items',        /* handler */);
+        $router->put('/items/{id}',    /* handler */);
+        $router->delete('/items/{id}', /* handler */);
+    },
+],
+```
+
+当路由列表变长时，也可以拆分到多个 registrar 函数中以提高可读性。
+
+---
+
+## 可用的 HTTP 方法
+
+| 方法 | Router 方法 | 典型用途 |
+|---|---|---|
+| GET | `$router->get()` | 读取资源 |
+| POST | `$router->post()` | 创建资源 |
+| PUT | `$router->put()` | 替换资源（完整更新） |
+| DELETE | `$router->delete()` | 删除资源 |
+
+---
+
+## 下一步
+
+如果您的路由需要从数据库读取或写入，请参见
+[添加数据库端点](./add-database-endpoint.md)。

--- a/docs/zh/howto/add-database-endpoint.md
+++ b/docs/zh/howto/add-database-endpoint.md
@@ -1,0 +1,249 @@
+# 添加数据库端点
+
+本指南展示如何按照 NENE2 的领域层模式添加一个读写数据库的端点。
+
+**前提条件**：您已有一个注册了路由的可运行 NENE2 应用程序。如果没有，请从[添加自定义路由](./add-custom-route.md)开始。
+
+---
+
+## 模式
+
+HTTP 处理器与数据库之间有三层模式：
+
+```
+HTTP Handler
+  ↓ 调用
+UseCase          ← 业务逻辑，不了解 HTTP 或数据库
+  ↓ 调用
+RepositoryInterface ← 数据库操作，定义为接口
+  ↓ 由...实现
+PdoRepository    ← 实际的 SQL 查询
+```
+
+这与 FastAPI 中的服务层或 Node.js 中的仓库模式是相同的分离。HTTP 处理器保持精简；用例持有逻辑；仓库负责持久化。
+
+---
+
+## 示例：`Product` 资源
+
+我们将以 `GET /products/{id}` 为具体示例进行构建。
+
+### 1 — 定义领域实体
+
+创建 `src/Product/Product.php`：
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class Product
+{
+    public function __construct(
+        public int    $id,
+        public string $name,
+        public int    $price,
+    ) {}
+}
+```
+
+`readonly` 意味着属性在构造函数中设置一次后不可更改——相当于 JavaScript 中的冻结对象或 Python 中 `frozen=True` 的 dataclass。
+
+### 2 — 定义仓库接口
+
+创建 `src/Product/ProductRepositoryInterface.php`：
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+interface ProductRepositoryInterface
+{
+    public function findById(int $id): ?Product;
+}
+```
+
+接口声明*可以做什么*，而非*如何做*。这使您可以在测试中用内存中的假对象替换真实数据库。
+
+### 3 — 定义用例
+
+创建 `src/Product/GetProductByIdUseCase.php`：
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+final readonly class GetProductByIdUseCase
+{
+    public function __construct(private ProductRepositoryInterface $products) {}
+
+    public function execute(int $id): ?Product
+    {
+        return $this->products->findById($id);
+    }
+}
+```
+
+用例对 HTTP 或 SQL 一无所知。它接收仓库并调用它。这使得在没有数据库的情况下测试变得容易。
+
+### 4 — 用 PDO 实现仓库
+
+创建 `src/Product/PdoProductRepository.php`：
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Product;
+
+use PDO;
+
+final readonly class PdoProductRepository implements ProductRepositoryInterface
+{
+    public function __construct(private PDO $pdo) {}
+
+    public function findById(int $id): ?Product
+    {
+        $stmt = $this->pdo->prepare('SELECT id, name, price FROM products WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        return new Product(
+            id:    (int) $row['id'],
+            name:  (string) $row['name'],
+            price: (int) $row['price'],
+        );
+    }
+}
+```
+
+所有 SQL 都在这里。这个类之外的任何地方都不需要知道使用了哪个数据库或查询语法。
+
+### 5 — 在前端控制器中装配
+
+在 `public/index.php` 中连接各部分并注册路由：
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use MyApp\Product\GetProductByIdUseCase;
+use MyApp\Product\PdoProductRepository;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+// 装配数据库和用例。
+$pdo     = new PDO('mysql:host=127.0.0.1;dbname=myapp', 'user', 'password');
+$useCase = new GetProductByIdUseCase(new PdoProductRepository($pdo));
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json, $useCase): void {
+            $router->get('/products/{id}', static function (ServerRequestInterface $req) use ($json, $useCase) {
+                $params  = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+                $id      = (int) ($params['id'] ?? 0);
+                $product = $useCase->execute($id);
+
+                if ($product === null) {
+                    return $json->create([
+                        'type'   => 'https://nene2.dev/problems/not-found',
+                        'title'  => 'Not Found',
+                        'status' => 404,
+                    ], 404);
+                }
+
+                return $json->create([
+                    'id'    => $product->id,
+                    'name'  => $product->name,
+                    'price' => $product->price,
+                ]);
+            });
+        },
+    ],
+))->create();
+
+// ... 请求处理（与教程相同）
+```
+
+> **生产注意事项**：对于更大的应用程序，将装配移到服务提供者中
+> 并注入类型化配置对象而非原始 PDO 连接字符串。
+> 完整模式请参见 `src/DependencyInjection/` 和 `docs/development/domain-layer.md`。
+
+---
+
+## 不使用数据库测试用例
+
+由于 `GetProductByIdUseCase` 依赖 `ProductRepositoryInterface`（而非 `PdoProductRepository`），您可以用简单的内存假对象测试它：
+
+```php
+final class InMemoryProductRepository implements ProductRepositoryInterface
+{
+    /** @param array<int, Product> $products */
+    public function __construct(private array $products = []) {}
+
+    public function findById(int $id): ?Product
+    {
+        return $this->products[$id] ?? null;
+    }
+}
+
+// 在您的测试中：
+$repo    = new InMemoryProductRepository([1 => new Product(1, 'Widget', 999)]);
+$useCase = new GetProductByIdUseCase($repo);
+$result  = $useCase->execute(1);
+
+assert($result->name === 'Widget');
+```
+
+这与在 Jest 中模拟服务或在 pytest 中使用测试替身是相同的模式。
+
+---
+
+## 目录结构
+
+遵循此模式，您的项目将成长为：
+
+```
+src/
+  Product/
+    Product.php                    ← 领域实体
+    ProductRepositoryInterface.php ← 可以做什么
+    GetProductByIdUseCase.php      ← 业务逻辑
+    PdoProductRepository.php       ← SQL 实现
+public/
+  index.php                        ← 装配 + 路由
+```
+
+每个资源有自己的目录。保持处理器精简，用例专注于单一操作。
+
+---
+
+## 下一步
+
+- 为您的端点添加 OpenAPI 文档：参见 `docs/development/endpoint-scaffold.md`
+- 添加数据库迁移：参见 `docs/development/test-database-strategy.md`
+- 参考 NENE2 内置的 Note 示例：`src/Example/Note/`

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -1,0 +1,43 @@
+---
+layout: home
+
+hero:
+  name: "NENE2"
+  text: "极简 PHP API 框架"
+  tagline: 快速构建 JSON API。内置 OpenAPI 与 MCP。从第一天起就为 AI 准备好。
+  actions:
+    - theme: brand
+      text: 快速开始 →
+      link: /zh/tutorial/first-api
+    - theme: alt
+      text: 在 GitHub 上查看
+      link: https://github.com/hideyukiMORI/NENE2
+    - theme: alt
+      text: Packagist
+      link: https://packagist.org/packages/hideyukimori/nene2
+
+features:
+  - icon: 🚀
+    title: 分钟内启动
+    details: 只需 composer require hideyukimori/nene2，您就拥有了一个带有健康检查、请求 ID 和 Problem Details 错误的 JSON API——无需编写任何路由。
+
+  - icon: 📄
+    title: OpenAPI 优先
+    details: 您发布的每个端点都附带 OpenAPI 契约。内置 Swagger UI。契约是交给客户端的内容，而非事后的补充。
+
+  - icon: 🤖
+    title: MCP 就绪
+    details: 本地 MCP 服务器将您的 API 作为工具暴露出来，AI 代理（Claude、Cursor）可以直接调用。无需特殊集成——它从您的 OpenAPI 目录中读取。
+
+  - icon: 🛡️
+    title: RFC 9457 错误
+    details: 每个错误响应都是 Problem Details 对象——包含 type、title、status 和 detail 的机器可读 JSON 结构。生产环境不会返回原始异常。
+
+  - icon: 🧱
+    title: 整洁架构
+    details: UseCase → RepositoryInterface → PDO 适配器。每层可独立测试。无魔法、无隐式装配、框架不侵入您的领域。
+
+  - icon: 🔬
+    title: PHPStan 8 级
+    details: 最严格级别的静态分析。通过 PHPStan 就不会在运行时出现意外。与 PHPUnit 和 PHP-CS-Fixer 开箱即用。
+---

--- a/docs/zh/tutorial/first-api.md
+++ b/docs/zh/tutorial/first-api.md
@@ -1,0 +1,263 @@
+# 10 分钟创建您的第一个 API
+
+本教程将带您从零开始，使用 NENE2 运行一个 JSON API。
+
+完成后，您将拥有：
+- 一个响应 HTTP 请求的本地 API
+- 一个返回 JSON 的 `/hello` 端点
+- 对请求如何流经框架的理解
+
+**适用对象**：熟悉 JavaScript 或 Python 但未接触过 PHP 的开发者。如果您用过 Express 或 FastAPI，这里的概念可以直接对应。
+
+**所需时间**：约 10 分钟。
+
+---
+
+## 所需工具
+
+| 工具 | 用途 | 检查命令 |
+|---|---|---|
+| PHP 8.4 | 运行应用程序 | `php --version` |
+| Composer | PHP 包管理器（类似 npm） | `composer --version` |
+| 终端 | 所有命令在此运行 | — |
+
+> **Docker 替代方案**：如果您不想在本地安装 PHP，也可以使用 Docker。
+> 请参阅本页底部的 [基于 Docker 的配置](#基于-docker-的配置)。
+
+---
+
+## 第 1 步 — 创建项目目录
+
+```bash
+mkdir my-api && cd my-api
+```
+
+这等同于 Node.js 项目中的 `mkdir my-app && cd my-app`。
+
+---
+
+## 第 2 步 — 安装 NENE2
+
+```bash
+composer init --name="yourname/my-api" --no-interaction
+composer require hideyukimori/nene2:^0.4
+```
+
+`composer require` 是 `npm install` 的 PHP 等价物。它将 NENE2 及其依赖下载到 `vendor/`。
+
+完成后目录结构如下：
+
+```
+my-api/
+  vendor/        ← 已安装的包（类似 node_modules/）
+  composer.json  ← 包元数据（类似 package.json）
+  composer.lock  ← 版本锁定（类似 package-lock.json）
+```
+
+---
+
+## 第 3 步 — 创建 `.env` 文件
+
+```bash
+cat > .env << 'EOF'
+APP_ENV=local
+APP_DEBUG=true
+APP_NAME="My API"
+DB_ADAPTER=sqlite
+EOF
+```
+
+`.env` 的工作方式与 Node.js 相同。框架在启动时自动读取它。
+
+---
+
+## 第 4 步 — 创建前端控制器
+
+创建 `public/index.php`：
+
+```php
+<?php
+declare(strict_types=1);
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Routing\Router;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$psr17 = new Psr17Factory();
+$json  = new JsonResponseFactory($psr17, $psr17);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [
+        static function (Router $router) use ($json): void {
+            $router->get('/hello', static function (ServerRequestInterface $req) use ($json) {
+                return $json->create(['message' => 'Hello, world!', 'status' => 'ok']);
+            });
+        },
+    ],
+))->create();
+
+$request  = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGlobals();
+$response = $app->handle($request);
+
+foreach ($response->getHeaders() as $name => $values) {
+    foreach ($values as $value) {
+        header(sprintf('%s: %s', $name, $value), false);
+    }
+}
+http_response_code($response->getStatusCode());
+echo $response->getBody();
+```
+
+**代码解释**（逐行）：
+
+- `require .../vendor/autoload.php` — 加载所有已安装的包，相当于 JS 中的 `import`
+- `$psr17 = new Psr17Factory()` — 创建 HTTP 对象工厂（类似请求/响应构建器）
+- `RuntimeApplicationFactory` — 组装完整的中间件管道
+- `routeRegistrars` — 在此添加您自己的路由（详见 HOWTO 文档）
+- `$router->get('/hello', ...)` — 注册 GET 路由，类似 Express 中的 `app.get('/hello', ...)`
+- `$json->create([...])` — 从 PHP 数组构建 JSON 响应
+
+---
+
+## 第 5 步 — 启动服务器
+
+```bash
+php -S localhost:8080 -t public
+```
+
+这是 PHP 内置的开发服务器，相当于 `npm run dev`——不适用于生产环境，但适合本地开发。
+
+您应该看到：
+
+```
+PHP 8.4.x Development Server (http://localhost:8080) started
+```
+
+---
+
+## 第 6 步 — 调用 API
+
+打开新终端并运行：
+
+```bash
+curl http://localhost:8080/hello
+```
+
+您应该看到：
+
+```json
+{
+    "message": "Hello, world!",
+    "status": "ok"
+}
+```
+
+也试试内置的健康检查端点：
+
+```bash
+curl http://localhost:8080/health
+```
+
+```json
+{
+    "status": "ok",
+    "service": "My API"
+}
+```
+
+这就是您的第一个 API 在运行。让我们看看还包含了什么。
+
+---
+
+## 第 7 步 — 查看错误处理的实际效果
+
+NENE2 为所有错误返回 [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457)。访问一个不存在的路由：
+
+```bash
+curl http://localhost:8080/missing
+```
+
+```json
+{
+    "type": "https://nene2.dev/problems/not-found",
+    "title": "Not Found",
+    "status": 404,
+    "instance": "/missing"
+}
+```
+
+每个错误响应都有 `type` URI、`title` 和 HTTP `status`。这是 NENE2 所有错误响应使用的标准格式。
+
+---
+
+## 刚才发生了什么
+
+以下是 `GET /hello` 的请求流：
+
+```
+HTTP 请求
+  → RequestIdMiddleware      添加 X-Request-Id 头
+  → SecurityHeadersMiddleware 添加 X-Content-Type-Options 等
+  → CorsMiddleware           处理 CORS 预检
+  → ErrorHandlerMiddleware   捕获未处理的异常
+  → RequestSizeLimitMiddleware 拒绝过大的载荷
+  → Router                   匹配 /hello → 您的处理器
+  → 您的处理器               返回 {"message": "Hello, world!"}
+HTTP 响应
+```
+
+这些都是自动发生的。您的处理器只需要返回响应——框架处理头部、错误格式化和请求关联。
+
+---
+
+## 下一步
+
+- **添加路径参数**（如 `/hello/{name}`）：参见 [添加自定义路由](../howto/add-custom-route.md)
+- **连接数据库**：参见 [添加数据库端点](../howto/add-database-endpoint.md)
+- **查看完整 API 文档**：启动服务器并打开 `http://localhost:8080/openapi.php`
+
+---
+
+## 基于 Docker 的配置
+
+如果您偏好 Docker 而非本地 PHP 安装：
+
+```bash
+mkdir my-api && cd my-api
+```
+
+创建一个最小的 `compose.yaml`：
+
+```yaml
+services:
+  app:
+    image: php:8.4-apache
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+    working_dir: /var/www/html
+```
+
+在容器内安装 Composer：
+
+```bash
+docker compose run --rm app bash -c "curl -sS https://getcomposer.org/installer | php && php composer.phar require hideyukimori/nene2:^0.4"
+```
+
+按照上述第 3-4 步创建 `.env` 和 `public/index.php`，然后：
+
+```bash
+docker compose up -d
+curl http://localhost:8080/hello
+```
+
+要获取包含 MySQL 支持的更完整 Docker 配置，请参阅 [NENE2 仓库配置指南](../development/setup.md)。


### PR DESCRIPTION
## Summary

- VitePress config を `locales` ベースの i18n 構成にリファクタリング（nav/sidebar を DRY ヘルパー関数化）
- 5 言語 × 4 ファイル = 計 20 の翻訳コンテンツファイルを追加
  - `docs/ja/` — 日本語
  - `docs/fr/` — フランス語
  - `docs/zh/` — 中国語（簡体字）
  - `docs/pt-br/` — ブラジルポルトガル語
  - `docs/de/` — ドイツ語
- 各言語: `index.md`（ホーム）+ `tutorial/first-api.md` + `howto/add-custom-route.md` + `howto/add-database-endpoint.md`

## Test plan

- [x] `npm run docs:build` — 8.20s でクリーンビルド完了
- [x] `vitepress build` がロケールごとにページを正常にレンダリング

Closes #260

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)