### PR TITLE
feat(theme): ダークモードをリッチなテックデザインに刷新する (#262)

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -1,28 +1,215 @@
-/* NENE2 brand colours — overrides VitePress defaults */
+/* ============================================================
+   NENE2 VitePress Theme
+   ============================================================ */
+
+/* ── Brand colours (light mode) ─────────────────────────── */
 :root {
-  --vp-c-brand-1:        #3b82f6;  /* blue-500 */
-  --vp-c-brand-2:        #2563eb;  /* blue-600 */
-  --vp-c-brand-3:        #1d4ed8;  /* blue-700 */
-  --vp-c-brand-soft:     rgba(59, 130, 246, 0.12);
+  --vp-c-brand-1:       #3b82f6;
+  --vp-c-brand-2:       #2563eb;
+  --vp-c-brand-3:       #1d4ed8;
+  --vp-c-brand-soft:    rgba(59, 130, 246, 0.12);
 
-  --vp-home-hero-name-color:       transparent;
-  --vp-home-hero-name-background:  linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
-  --vp-home-hero-image-background-image: radial-gradient(ellipse at 50% 50%, rgba(59,130,246,0.15) 0%, transparent 70%);
+  --vp-home-hero-name-color:      transparent;
+  --vp-home-hero-name-background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+  --vp-home-hero-image-background-image:
+    radial-gradient(ellipse at 50% 50%, rgba(59,130,246,0.12) 0%, transparent 65%);
 }
 
+/* ── Dark mode — deep blue-black palette ─────────────────── */
 .dark {
-  --vp-c-brand-1:    #60a5fa;  /* blue-400 — brighter on dark */
-  --vp-c-brand-2:    #3b82f6;
-  --vp-c-brand-3:    #2563eb;
-  --vp-c-brand-soft: rgba(96, 165, 250, 0.12);
+  /* Core surfaces */
+  --vp-c-bg:         #0a0a12;
+  --vp-c-bg-alt:     #06060e;
+  --vp-c-bg-soft:    #111120;
+  --vp-c-bg-mute:    #1a1a2e;
+
+  /* Borders */
+  --vp-c-border:     rgba(96, 105, 200, 0.22);
+  --vp-c-divider:    rgba(96, 105, 200, 0.12);
+  --vp-c-gutter:     #000000;
+
+  /* Text */
+  --vp-c-text-1:     rgba(255, 255, 255, 0.93);
+  --vp-c-text-2:     rgba(200, 205, 240, 0.64);
+  --vp-c-text-3:     rgba(180, 185, 225, 0.38);
+
+  /* Brand — vivid on dark */
+  --vp-c-brand-1:    #60a5fa;
+  --vp-c-brand-2:    #818cf8;
+  --vp-c-brand-3:    #2dd4bf;
+  --vp-c-brand-soft: rgba(96, 165, 250, 0.14);
+
+  /* Hero gradient — blue → indigo → teal (infra/API positioning) */
+  --vp-home-hero-name-background:
+    linear-gradient(135deg, #60a5fa 0%, #818cf8 45%, #2dd4bf 100%);
+
+  /* Hero ambient glow — blue core → indigo → teal edge */
+  --vp-home-hero-image-background-image:
+    radial-gradient(ellipse at 50% 50%,
+      rgba(96, 165, 250, 0.22) 0%,
+      rgba(129, 140, 248, 0.12) 40%,
+      rgba(45, 212, 191, 0.06) 65%,
+      transparent 75%);
 }
 
-/* Slightly wider content area */
+/* ── Navigation ──────────────────────────────────────────── */
+.dark .VPNav {
+  background-color: rgba(6, 6, 14, 0.80) !important;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(96, 105, 200, 0.14) !important;
+}
+
+/* ── Sidebar ─────────────────────────────────────────────── */
+.dark .VPSidebar {
+  background-color: #06060e !important;
+  border-right: 1px solid rgba(96, 105, 200, 0.12) !important;
+}
+
+/* Active sidebar item accent line */
+.dark .VPSidebarItem.is-active > .item .link .text {
+  color: var(--vp-c-brand-1);
+}
+
+/* ── Home page hero ──────────────────────────────────────── */
+
+/* Dot-grid pattern behind the hero */
+.dark .VPHome .VPHero {
+  position: relative;
+  overflow: hidden;
+}
+.dark .VPHome .VPHero::before {
+  content: '';
+  position: absolute;
+  inset: -60px -120px 0;
+  background-image: radial-gradient(
+    circle,
+    rgba(148, 163, 255, 0.055) 1px,
+    transparent 1px
+  );
+  background-size: 28px 28px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Central radial glow on top of dot grid */
+.dark .VPHome .VPHero::after {
+  content: '';
+  position: absolute;
+  top: -80px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 900px;
+  height: 480px;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(59, 130, 246, 0.18) 0%,
+    rgba(139, 92, 246, 0.10) 38%,
+    transparent 68%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+.dark .VPHome .VPHero .container {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Feature cards ───────────────────────────────────────── */
+.dark .VPFeature {
+  background: rgba(16, 16, 30, 0.75);
+  border: 1px solid rgba(80, 90, 180, 0.20);
+  backdrop-filter: blur(4px);
+  transition: border-color 0.28s ease, box-shadow 0.28s ease, background 0.28s ease;
+}
+.dark .VPFeature:hover {
+  border-color: rgba(96, 165, 250, 0.42);
+  box-shadow:
+    0 0 0 1px rgba(96, 165, 250, 0.16),
+    0 0 28px rgba(96, 165, 250, 0.10),
+    0 8px 32px rgba(0, 0, 0, 0.40);
+  background: rgba(20, 20, 40, 0.90);
+}
+
+/* ── Code blocks ─────────────────────────────────────────── */
+.dark div[class*='language-'] {
+  background: #05050d !important;
+  border: 1px solid rgba(80, 90, 180, 0.20);
+}
+.dark div[class*='language-'] code {
+  background: transparent !important;
+}
+/* Language label badge */
+.dark div[class*='language-'] > span.lang {
+  color: rgba(148, 163, 255, 0.55);
+}
+/* Line numbers */
+.dark div[class*='language-'] .line-numbers-wrapper {
+  border-right: 1px solid rgba(80, 90, 180, 0.18);
+}
+
+/* Inline code */
+.dark :not(pre) > code {
+  background: rgba(80, 90, 180, 0.15);
+  border: 1px solid rgba(80, 90, 180, 0.20);
+  color: #93c5fd;
+}
+
+/* ── Tables ──────────────────────────────────────────────── */
+.dark .vp-doc table {
+  border-collapse: collapse;
+}
+.dark .vp-doc tr {
+  border-top: 1px solid rgba(80, 90, 180, 0.14);
+}
+.dark .vp-doc tr:nth-child(2n) {
+  background: rgba(16, 16, 30, 0.50);
+}
+
+/* ── Blockquotes ─────────────────────────────────────────── */
+.dark .vp-doc blockquote {
+  border-left: 3px solid rgba(96, 165, 250, 0.50);
+  background: rgba(16, 16, 30, 0.60);
+  color: var(--vp-c-text-2);
+}
+
+/* ── Custom scrollbar ────────────────────────────────────── */
+.dark ::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+.dark ::-webkit-scrollbar-track {
+  background: #06060e;
+}
+.dark ::-webkit-scrollbar-thumb {
+  background: rgba(96, 165, 250, 0.28);
+  border-radius: 3px;
+}
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: rgba(96, 165, 250, 0.50);
+}
+
+/* ── Content width ───────────────────────────────────────── */
 .VPDoc .container {
   max-width: 1152px !important;
 }
 
-/* Subtle code block styling */
+/* ── Code group tabs ─────────────────────────────────────── */
 .vp-code-group .tabs label {
   font-size: 0.8rem;
+}
+.dark .vp-code-group .tabs {
+  background: rgba(10, 10, 20, 0.80);
+  border-bottom: 1px solid rgba(80, 90, 180, 0.18);
+}
+
+/* ── Search box ──────────────────────────────────────────── */
+.dark .DocSearch-Button {
+  background: rgba(16, 16, 30, 0.80);
+  border: 1px solid rgba(80, 90, 180, 0.22);
+}
+
+/* ── Outline (on-this-page TOC) ──────────────────────────── */
+.dark .VPDocAsideOutline .outline-link.active {
+  color: var(--vp-c-brand-1);
 }


### PR DESCRIPTION
## Summary

- 背景色を `#0a0a12`（深い青黒）に変更し、明度を大幅に下げる
- ヒーローグラデーションを **blue → indigo → teal** に変更（ピンク廃止）
- ヒーローにドットグリッドパターン + 放射グローを追加
- フィーチャーカードにホバーグロー（border + box-shadow）
- ナビを半透明 + backdrop-blur に変更
- コードブロックをほぼ黒（`#05050d`）+ 微細ボーダー
- インラインコードに青白アクセント
- カスタムスクロールバー（ブランドカラー）

## Design rationale

ピンク/赤紫は欧米デベロッパーコミュニティで「デザインツール系」「スタートアップ感」と読まれやすい。
NENE2（API基盤・MCP・OpenAPI）には blue→indigo→teal の方が「インフラ・一線級ツール」として響く（Tailwind/Prisma/Cloudflare 系の訴求）。

## Test plan

- [x] `npm run docs:build` — 7.85s クリーンビルド

Closes #262

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)