### PR TITLE
fix(i18n): 言語切り替え時の 404 を修正する (#264)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -4,9 +4,10 @@ function nav(t: {
   tutorial: string; howto: string; reference: string
 }) {
   return [
-    { text: t.tutorial,  link: 'tutorial/first-api',        activeMatch: 'tutorial/' },
-    { text: t.howto,     link: 'howto/add-custom-route',    activeMatch: 'howto/' },
-    { text: t.reference, link: 'development/endpoint-scaffold', activeMatch: 'development/' },
+    { text: t.tutorial,  link: 'tutorial/first-api',            activeMatch: 'tutorial/' },
+    { text: t.howto,     link: 'howto/add-custom-route',        activeMatch: 'howto/' },
+    // Absolute path — development pages are English-only; non-root locales must not get /ja/development/...
+    { text: t.reference, link: '/development/endpoint-scaffold', activeMatch: '/development/' },
     {
       text: 'v0.4.0',
       items: [
@@ -32,24 +33,26 @@ function sidebar(t: {
         { text: t.addDb,    link: 'howto/add-database-endpoint' },
       ],
     }],
+    // Development & Integration pages are English-only — use absolute paths so
+    // VitePress never expands them to /ja/development/... etc.
     '/development/': [
       {
         text: t.devGroup,
         items: [
-          { text: 'Setup',                  link: 'development/setup' },
-          { text: 'Endpoint scaffold',      link: 'development/endpoint-scaffold' },
-          { text: 'Domain layer',           link: 'development/domain-layer' },
-          { text: 'Authentication',         link: 'development/authentication-boundary' },
-          { text: 'Test database strategy', link: 'development/test-database-strategy' },
-          { text: 'Client project start',   link: 'development/client-project-start' },
+          { text: 'Setup',                  link: '/development/setup' },
+          { text: 'Endpoint scaffold',      link: '/development/endpoint-scaffold' },
+          { text: 'Domain layer',           link: '/development/domain-layer' },
+          { text: 'Authentication',         link: '/development/authentication-boundary' },
+          { text: 'Test database strategy', link: '/development/test-database-strategy' },
+          { text: 'Client project start',   link: '/development/client-project-start' },
         ],
       },
       {
         text: t.intGroup,
         items: [
-          { text: 'Local MCP server',       link: 'integrations/local-mcp-server' },
-          { text: 'MCP client config',      link: 'integrations/local-mcp-client-configuration' },
-          { text: 'MCP tools policy',       link: 'integrations/mcp-tools' },
+          { text: 'Local MCP server',       link: '/integrations/local-mcp-server' },
+          { text: 'MCP client config',      link: '/integrations/local-mcp-client-configuration' },
+          { text: 'MCP tools policy',       link: '/integrations/mcp-tools' },
         ],
       },
     ],
@@ -85,6 +88,9 @@ export default defineConfig({
     ja: {
       label: '日本語',
       lang: 'ja',
+      // link: always navigate to the locale home when switching — avoids 404
+      // on pages that exist only in English (development/, integrations/).
+      link: '/ja/',
       themeConfig: {
         nav: nav({ tutorial: 'チュートリアル', howto: 'HOWTO', reference: 'リファレンス' }),
         sidebar: sidebar({
@@ -105,6 +111,7 @@ export default defineConfig({
     fr: {
       label: 'Français',
       lang: 'fr',
+      link: '/fr/',
       themeConfig: {
         nav: nav({ tutorial: 'Tutoriel', howto: 'Guides', reference: 'Référence' }),
         sidebar: sidebar({
@@ -123,6 +130,7 @@ export default defineConfig({
     zh: {
       label: '中文',
       lang: 'zh-Hans',
+      link: '/zh/',
       themeConfig: {
         nav: nav({ tutorial: '教程', howto: '操作指南', reference: '参考' }),
         sidebar: sidebar({
@@ -143,6 +151,7 @@ export default defineConfig({
     'pt-br': {
       label: 'Português (Brasil)',
       lang: 'pt-BR',
+      link: '/pt-br/',
       themeConfig: {
         nav: nav({ tutorial: 'Tutorial', howto: 'Guias', reference: 'Referência' }),
         sidebar: sidebar({
@@ -161,6 +170,7 @@ export default defineConfig({
     de: {
       label: 'Deutsch',
       lang: 'de',
+      link: '/de/',
       themeConfig: {
         nav: nav({ tutorial: 'Tutorial', howto: 'Anleitungen', reference: 'Referenz' }),
         sidebar: sidebar({

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,16 @@
+---
+title: Page Not Found
+---
+
+# 404
+
+This page doesn't exist or hasn't been translated yet.
+
+**Go to the documentation home:**
+
+- [English](/)
+- [日本語](/ja/)
+- [Français](/fr/)
+- [中文](/zh/)
+- [Português (Brasil)](/pt-br/)
+- [Deutsch](/de/)

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -229,6 +229,8 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] `docs/` インデックス更新 (`docs/README.md`). `#256`
 - [x] VitePress ドキュメントサイト構築 (`npm run docs:build`). `#258`
 - [x] i18n: 日本語・フランス語・中国語・ブラジルポルトガル語・ドイツ語翻訳追加. `#260`
+- [x] theme: ダークモードをリッチなテックデザインに刷新（深い青黒背景・グロー・ドットグリッド）. `#262`
+- [x] fix(i18n): 言語切り替え時の 404 修正 — 絶対パス・locale link・404ページ. `#264`
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary

- `development/` `integrations/` の全リンクを絶対パス（`/development/...`）に変更 — VitePress がロケールプレフィックスを自動付与しなくなり 404 が消える
- 非英語ロケール全5件に `link: '/ja/'` 等を追加 — 言語スイッチャーが常にそのロケールのホームへ遷移（翻訳のないページからの切り替えも安全）
- `docs/404.md` を追加 — 404 時に全言語ホームへのリンクを表示

## Root cause

VitePress i18n はサイドバー・nav の相対リンクにロケールプレフィックスを自動付与する。
英語専用ページ（`development/setup` 等）への相対リンクが `/ja/development/setup` に展開されて 404 になっていた。

## Test plan

- [x] `npm run docs:build` — クリーンビルド

Closes #264

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)