### PR TITLE
ci: GitHub Pages に VitePress ドキュメントを自動デプロイする (#268)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build VitePress site
+        run: npm run docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .vitepress/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -59,6 +59,7 @@ function sidebar(t: {
 export default defineConfig({
   title: 'NENE2',
   description: 'Minimal PHP 8.4 JSON API Framework — with MCP and OpenAPI built in.',
+  base: process.env.GITHUB_ACTIONS ? '/NENE2/' : '/',
   srcDir: './docs',
   outDir: './.vitepress/dist',
   cleanUrls: true,

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -232,6 +232,7 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] theme: ダークモードをリッチなテックデザインに刷新（深い青黒背景・グロー・ドットグリッド）. `#262`
 - [x] fix(i18n): 言語切り替え時の 404 修正 — 絶対パス・locale link・404ページ. `#264`
 - [x] feat(i18n): 全 9 リファレンスページを 5 言語（ja/fr/zh/pt-br/de）に翻訳する. `#266`
+- [x] ci: GitHub Pages に VitePress ドキュメントを自動デプロイする. `#268`
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary

- `.github/workflows/docs.yml` を追加：`main` push 時に `npm run docs:build` → GitHub Pages デプロイ
- `.vitepress/config.mts` に `base` を追加：GitHub Actions 環境では `/NENE2/`、ローカルは `/`
- ローカル `docs:dev` / `docs:build` は変更なしで動作する

## Test plan

- [x] `GITHUB_ACTIONS=true npm run docs:build` 成功、出力に `/NENE2/` アセットパス確認
- [x] ローカル `npm run docs:build`（base なし）も成功
- [x] `docs/todo/current.md` 更新

## マージ後の手動手順

PR マージ後、リポジトリの **Settings → Pages → Source → GitHub Actions** を選択すること。
設定後、`docs.yml` ワークフローが自動実行されてデプロイされる。
デプロイ URL: `https://hideyukimori.github.io/NENE2/`

Closes #268

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)