### PR TITLE
docs(roadmap): Phase 23–28 マイルストーン追加・中短期ロードマップ更新

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -300,6 +300,69 @@ HTML generation is deferred to a later phase.
 
 Tracked by `docs/milestones/2026-05-phase22-diataxis-docs.md`.
 
+## Phase 23: CI Hardening + Node.js Upgrade
+
+Goal: close the Node.js 20 deprecation gap in CI before June 2026 EOL, and strengthen automated checks so regressions surface earlier.
+
+- Upgrade `actions/setup-node` to Node.js 22 LTS in `docs.yml`
+- Add a dedicated `backend.yml` CI workflow running `composer check` (PHPUnit + PHPStan + CS + OpenAPI + MCP)
+- Add a `frontend.yml` CI workflow running `npm run check`
+- Confirm all workflows pass on clean `main` push
+
+## Phase 24: Diátaxis Explanation Pages
+
+Goal: add the missing fourth Diátaxis pillar — Explanation — so developers understand *why* NENE2 makes the choices it does, not just *how* to use it.
+
+- `docs/explanation/why-psr.md` — why PSR-7/15/17 instead of custom HTTP abstractions
+- `docs/explanation/why-explicit-wiring.md` — why explicit DI over autowiring or Laravel-style magic
+- `docs/explanation/why-problem-details.md` — why RFC 9457 for API errors
+- `docs/explanation/why-mcp.md` — why MCP as the AI integration boundary
+- Update `docs/README.md` index to surface Explanation section
+- Add Explanation nav/sidebar entry to VitePress config
+
+## Phase 25: Second Domain Entity Example
+
+Goal: prove that the UseCase → Repository → Handler pattern scales beyond a single Note entity by introducing a second, minimally related domain object.
+
+- Choose a lightweight second entity (e.g. `Tag`) that can relate to `Note`
+- Add `src/Example/Tag/` mirroring the Note domain layer structure
+- Add `GET/POST /examples/tags` and `GET /examples/tags/{id}` endpoints
+- Add OpenAPI schemas for the new entity
+- Add PHPUnit unit and integration tests for the Tag use cases
+- Update endpoint scaffold docs to reference the two-entity example
+- Document the multi-entity pattern in `docs/explanation/` or a new HOWTO
+
+## Phase 26: Production Deployment Guide
+
+Goal: document a minimal, secure path from development Docker Compose to a production-grade deployment so that client projects adopting NENE2 have a reference starting point.
+
+- `docs/howto/deploy-production.md` — Docker production image, env file management, secret injection
+- Nginx / Caddy reverse proxy configuration example
+- Security checklist: disable debug mode, set `APP_ENV=production`, remove dev endpoints
+- Health endpoint verification in production context
+- Note on `nene2.dev` Problem Details type URIs — confirm or replace placeholder domain before production use
+
+## Phase 27: Frontend Starter Content
+
+Goal: move the React + TypeScript starter beyond a skeleton so adopters have a working, styled example to reference or delete.
+
+- At least one real API-connected component (`NoteList`, `NoteForm`, or equivalent)
+- Typed fetch wrapper in `frontend/src/api/` for Note endpoints
+- Basic CSS or Tailwind baseline (adopter can replace)
+- `npm run dev` demo that renders live Note data from the backend
+- Update frontend HOWTO or Tutorial section to reference the working example
+- Score target: frontend evaluation ≥ 70/100
+
+## Phase 28: Authentication Expansion
+
+Goal: document the JWT and OAuth2 direction so client projects adopting NENE2 have a clear path beyond the current API-key-only machine client.
+
+- ADR 0008: JWT authentication direction (library selection, token validation boundary, PSR-15 middleware placement)
+- `docs/development/authentication-boundary.md` extended with JWT and OAuth2 sections
+- Example `BearerTokenMiddleware` stub with interface for pluggable validation
+- Decision on whether `nene2.dev` domain will be registered or replaced in Problem Details type URIs
+- Update self-review checklist with JWT/OAuth2 checkpoints
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -234,6 +234,46 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] feat(i18n): 全 9 リファレンスページを 5 言語（ja/fr/zh/pt-br/de）に翻訳する. `#266`
 - [x] ci: GitHub Pages に VitePress ドキュメントを自動デプロイする. `#268`
 
+## Phase 23: CI Hardening + Node.js Upgrade
+
+- [ ] docs(roadmap): Phase 23+ マイルストーン追加・ロードマップ更新. `#270`
+- [ ] ci: `actions/setup-node` を Node.js 22 LTS に更新し Node.js 20 deprecation を解消する.
+- [ ] ci: バックエンド `composer check` を実行する `backend.yml` ワークフローを追加する.
+- [ ] ci: フロントエンド `npm run check` を実行する `frontend.yml` ワークフローを追加する.
+
+## Phase 24: Diátaxis Explanation Pages
+
+- [ ] docs(explanation): `docs/explanation/why-psr.md` — PSR 選択理由.
+- [ ] docs(explanation): `docs/explanation/why-explicit-wiring.md` — 明示的 DI の理由.
+- [ ] docs(explanation): `docs/explanation/why-problem-details.md` — RFC 9457 選択理由.
+- [ ] docs(explanation): `docs/explanation/why-mcp.md` — MCP 境界の理由.
+- [ ] docs(vitepress): Explanation セクションを nav/sidebar に追加する.
+
+## Phase 25: 2 つ目のドメインエンティティ例
+
+- [ ] feat(example): `src/Example/Tag/` — 2 つ目のドメインエンティティ例を追加する.
+- [ ] feat(example): `GET/POST /examples/tags` および `GET /examples/tags/{id}` エンドポイント追加.
+- [ ] docs(howto): 多エンティティパターンを HOWTO または Explanation に追記する.
+
+## Phase 26: 本番デプロイガイド
+
+- [ ] docs(howto): `docs/howto/deploy-production.md` — Docker 本番イメージ・env 管理・シークレット注入.
+- [ ] docs(howto): Nginx / Caddy リバースプロキシ設定例.
+- [ ] docs(howto): 本番セキュリティチェックリスト（デバッグ無効・`APP_ENV=production`・dev エンドポイント削除）.
+- [ ] chore: `nene2.dev` Problem Details type URI プレースホルダーの方針を決定する.
+
+## Phase 27: フロントエンドスターターコンテンツ
+
+- [ ] feat(frontend): API 接続済みコンポーネント（`NoteList` 等）を追加する.
+- [ ] feat(frontend): `frontend/src/api/` に Note エンドポイント向け型付き fetch ラッパーを追加する.
+- [ ] feat(frontend): `npm run dev` で Note データが表示される動作デモを完成させる.
+
+## Phase 28: 認証拡張
+
+- [ ] docs(adr): ADR 0008 — JWT 認証方向（ライブラリ選定・トークン検証境界・PSR-15 ミドルウェア配置）.
+- [ ] feat(auth): `BearerTokenMiddleware` スタブと検証用インターフェースを追加する.
+- [ ] docs(auth): `authentication-boundary.md` を JWT/OAuth2 セクションで拡張する.
+
 ## Operating Notes
 
 - Keep this file short.


### PR DESCRIPTION
## 概要

評価で明らかになった課題を踏まえ、Phase 23〜28 のマイルストーンを `docs/roadmap.md` に追加し、`docs/todo/current.md` に対応するタスク候補を追記した。

## 追加フェーズ

| フェーズ | テーマ | 主な課題対応 |
|---------|--------|-------------|
| Phase 23 | CI Hardening + Node.js 22 LTS | Node.js 20 deprecation（June 2026 EOL）、backend/frontend CI 不在 |
| Phase 24 | Diátaxis Explanation ページ | Explanation 欠如（Diátaxis 第 4 の柱） |
| Phase 25 | 2 つ目のドメインエンティティ例 | Note のみ、多エンティティパターン未実証 |
| Phase 26 | 本番デプロイガイド | 本番デプロイ手順ゼロ、`nene2.dev` URI 方針未定 |
| Phase 27 | フロントエンドスターターコンテンツ | React が骨格のみ（評価 45/100） |
| Phase 28 | 認証拡張 | JWT/OAuth2 方向未定（API キーのみ） |

## 検証

- `npm run docs:build` — ✅ build complete in 10.81s

## 関連

Closes #270

Self-review: docs-policy