### PR TITLE
ci: Phase 23 CI Hardening — Composer キャッシュ・PHP 拡張明示・npm キャッシュパス追加

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,8 +24,20 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
+          extensions: pdo, pdo_sqlite, pdo_mysql
           coverage: none
           tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
 
       - name: Validate Composer metadata
         run: composer validate --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: '22'
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -237,9 +237,9 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 ## Phase 23: CI Hardening + Node.js Upgrade
 
 - [x] docs(roadmap): Phase 23+ マイルストーン追加・ロードマップ更新. `#270`
-- [ ] ci: `actions/setup-node` を Node.js 22 LTS に更新し Node.js 20 deprecation を解消する.
-- [ ] ci: バックエンド `composer check` を実行する `backend.yml` ワークフローを追加する.
-- [ ] ci: フロントエンド `npm run check` を実行する `frontend.yml` ワークフローを追加する.
+- [x] ci: `actions/setup-node` を Node.js 22 LTS に更新し Node.js 20 deprecation を解消する.
+- [x] ci: バックエンド `composer check` を実行する `backend.yml` ワークフローを追加する.
+- [x] ci: フロントエンド `npm run check` を実行する `frontend.yml` ワークフローを追加する.
 
 ## Phase 24: Diátaxis Explanation Pages
 


### PR DESCRIPTION
## 概要

Phase 23 — CI Hardening。既存の3ワークフロー（backend / frontend / docs）の品質を改善する。

## 変更内容

### `.github/workflows/backend.yml`
- `shivammathur/setup-php@v2` に `extensions: pdo, pdo_sqlite, pdo_mysql` を追加（テストで必要な PDO 拡張を明示）
- `actions/cache@v4` で Composer 依存キャッシュを追加（CI 時間短縮）

### `.github/workflows/docs.yml`
- `actions/setup-node@v4` に `cache-dependency-path: package-lock.json` を追加（キャッシュキーを正確に）

## 確認

- 全ワークフロー（Backend / Frontend / Docs）が `main` push で success ✅
- Node.js 22 LTS 設定済み ✅
- `composer check` が GitHub runner で直接実行可能であることを確認済み ✅

Closes #272

Self-review: release-ci