### PR TITLE
feat(example): Tag ドメインエンティティ例を追加する (Phase 25)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -92,6 +92,126 @@ paths:
           $ref: '#/components/responses/PayloadTooLarge'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /examples/tags:
+    get:
+      tags:
+        - Examples
+      summary: List example tags
+      description: Returns a paginated list of tags. Demonstrates the collection endpoint pattern for a second domain entity.
+      operationId: listExampleTags
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of tags to return (1–100).
+          required: false
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          description: Number of tags to skip before returning results.
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        '200':
+          description: List of tags.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleTagListResponse'
+              examples:
+                ok:
+                  summary: Successful list tags response
+                  value:
+                    items:
+                      - id: 1
+                        name: php
+                    limit: 20
+                    offset: 0
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Examples
+      summary: Create example tag
+      description: Creates a new tag. Demonstrates the POST write path for a second domain entity.
+      operationId: createExampleTag
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTagRequest'
+            examples:
+              valid:
+                summary: Valid create tag request
+                value:
+                  name: php
+      responses:
+        '201':
+          description: Tag created.
+          headers:
+            Location:
+              description: URI of the created tag.
+              schema:
+                type: string
+                example: /examples/tags/1
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleTagResponse'
+              examples:
+                created:
+                  summary: Successful create tag response
+                  value:
+                    id: 1
+                    name: php
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /examples/tags/{id}:
+    get:
+      tags:
+        - Examples
+      summary: Get example tag by ID
+      description: Returns a single tag by ID. Returns 404 when the tag does not exist.
+      operationId: getExampleTagById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Tag ID.
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        '200':
+          description: Tag found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleTagResponse'
+              examples:
+                ok:
+                  summary: Successful get tag response
+                  value:
+                    id: 1
+                    name: php
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /examples/notes:
     get:
       tags:
@@ -597,6 +717,46 @@ components:
         body:
           type: string
           example: This is the body of an example note.
+    CreateTagRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          example: php
+      additionalProperties: false
+    ExampleTagResponse:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: php
+    ExampleTagListResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExampleTagResponse'
+        limit:
+          type: integer
+          example: 20
+        offset:
+          type: integer
+          example: 0
     ExampleNoteListResponse:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -251,8 +251,8 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 ## Phase 25: 2 つ目のドメインエンティティ例
 
-- [ ] feat(example): `src/Example/Tag/` — 2 つ目のドメインエンティティ例を追加する.
-- [ ] feat(example): `GET/POST /examples/tags` および `GET /examples/tags/{id}` エンドポイント追加.
+- [x] feat(example): `src/Example/Tag/` — 2 つ目のドメインエンティティ例を追加する. `#276`
+- [x] feat(example): `GET/POST /examples/tags` および `GET /examples/tags/{id}` エンドポイント追加. `#276`
 - [ ] docs(howto): 多エンティティパターンを HOWTO または Explanation に追記する.
 
 ## Phase 26: 本番デプロイガイド

--- a/src/Example/Tag/CreateTagHandler.php
+++ b/src/Example/Tag/CreateTagHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateTagHandler
+{
+    public function __construct(
+        private CreateTagUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = (array) json_decode((string) $request->getBody(), associative: true);
+
+        $name = trim((string) ($body['name'] ?? ''));
+
+        if ($name === '') {
+            throw new ValidationException([new ValidationError('name', 'Name is required.', 'required')]);
+        }
+
+        $output = $this->useCase->execute(new CreateTagInput(name: $name));
+
+        return $this->response->create(
+            ['id' => $output->id, 'name' => $output->name],
+            201,
+            ['Location' => '/examples/tags/' . $output->id],
+        );
+    }
+}

--- a/src/Example/Tag/CreateTagInput.php
+++ b/src/Example/Tag/CreateTagInput.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class CreateTagInput
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/Example/Tag/CreateTagOutput.php
+++ b/src/Example/Tag/CreateTagOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class CreateTagOutput
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Example/Tag/CreateTagUseCase.php
+++ b/src/Example/Tag/CreateTagUseCase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class CreateTagUseCase implements CreateTagUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(CreateTagInput $input): CreateTagOutput
+    {
+        $id = $this->tags->save(new Tag(name: $input->name));
+
+        return new CreateTagOutput(id: $id, name: $input->name);
+    }
+}

--- a/src/Example/Tag/CreateTagUseCaseInterface.php
+++ b/src/Example/Tag/CreateTagUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+interface CreateTagUseCaseInterface
+{
+    public function execute(CreateTagInput $input): CreateTagOutput;
+}

--- a/src/Example/Tag/GetTagByIdHandler.php
+++ b/src/Example/Tag/GetTagByIdHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetTagByIdHandler
+{
+    public function __construct(
+        private GetTagByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new TagNotFoundException($id);
+        }
+
+        $output = $this->useCase->execute(new GetTagByIdInput($id));
+
+        return $this->response->create(['id' => $output->id, 'name' => $output->name]);
+    }
+}

--- a/src/Example/Tag/GetTagByIdInput.php
+++ b/src/Example/Tag/GetTagByIdInput.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class GetTagByIdInput
+{
+    public function __construct(public int $id)
+    {
+    }
+}

--- a/src/Example/Tag/GetTagByIdOutput.php
+++ b/src/Example/Tag/GetTagByIdOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class GetTagByIdOutput
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Example/Tag/GetTagByIdUseCase.php
+++ b/src/Example/Tag/GetTagByIdUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class GetTagByIdUseCase implements GetTagByIdUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(GetTagByIdInput $input): GetTagByIdOutput
+    {
+        $tag = $this->tags->findById($input->id);
+
+        if ($tag === null) {
+            throw new TagNotFoundException($input->id);
+        }
+
+        return new GetTagByIdOutput(id: (int) $tag->id, name: $tag->name);
+    }
+}

--- a/src/Example/Tag/GetTagByIdUseCaseInterface.php
+++ b/src/Example/Tag/GetTagByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+interface GetTagByIdUseCaseInterface
+{
+    public function execute(GetTagByIdInput $input): GetTagByIdOutput;
+}

--- a/src/Example/Tag/ListTagItem.php
+++ b/src/Example/Tag/ListTagItem.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class ListTagItem
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Example/Tag/ListTagsHandler.php
+++ b/src/Example/Tag/ListTagsHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListTagsHandler
+{
+    private const int MAX_LIMIT = 100;
+
+    public function __construct(
+        private ListTagsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $query = $request->getQueryParams();
+        $limit = isset($query['limit']) ? (int) $query['limit'] : 20;
+        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+
+        $errors = [];
+
+        if ($limit < 1 || $limit > self::MAX_LIMIT) {
+            $errors[] = new ValidationError('limit', 'limit must be between 1 and ' . self::MAX_LIMIT . '.', 'out_of_range');
+        }
+
+        if ($offset < 0) {
+            $errors[] = new ValidationError('offset', 'offset must be 0 or greater.', 'out_of_range');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new ListTagsInput($limit, $offset));
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (ListTagItem $item) => ['id' => $item->id, 'name' => $item->name],
+                $output->items,
+            ),
+            'limit' => $output->limit,
+            'offset' => $output->offset,
+        ]);
+    }
+}

--- a/src/Example/Tag/ListTagsInput.php
+++ b/src/Example/Tag/ListTagsInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class ListTagsInput
+{
+    public function __construct(
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Example/Tag/ListTagsOutput.php
+++ b/src/Example/Tag/ListTagsOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class ListTagsOutput
+{
+    /** @param list<ListTagItem> $items */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Example/Tag/ListTagsUseCase.php
+++ b/src/Example/Tag/ListTagsUseCase.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class ListTagsUseCase implements ListTagsUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(ListTagsInput $input): ListTagsOutput
+    {
+        $tags = $this->tags->findAll($input->limit, $input->offset);
+
+        $items = array_map(
+            static fn (Tag $tag) => new ListTagItem(id: (int) $tag->id, name: $tag->name),
+            $tags,
+        );
+
+        return new ListTagsOutput(items: $items, limit: $input->limit, offset: $input->offset);
+    }
+}

--- a/src/Example/Tag/ListTagsUseCaseInterface.php
+++ b/src/Example/Tag/ListTagsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+interface ListTagsUseCaseInterface
+{
+    public function execute(ListTagsInput $input): ListTagsOutput;
+}

--- a/src/Example/Tag/PdoTagRepository.php
+++ b/src/Example/Tag/PdoTagRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoTagRepository implements TagRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Tag
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, name FROM tags WHERE id = ?',
+            [$id],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new Tag(name: (string) $row['name'], id: (int) $row['id']);
+    }
+
+    /** @return list<Tag> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, name FROM tags ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new Tag(name: (string) $row['name'], id: (int) $row['id']),
+            $rows,
+        );
+    }
+
+    public function save(Tag $tag): int
+    {
+        $this->query->execute('INSERT INTO tags (name) VALUES (?)', [$tag->name]);
+
+        return $this->query->lastInsertId();
+    }
+}

--- a/src/Example/Tag/Tag.php
+++ b/src/Example/Tag/Tag.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class Tag
+{
+    public function __construct(
+        public string $name,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Example/Tag/TagNotFoundException.php
+++ b/src/Example/Tag/TagNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use RuntimeException;
+
+final class TagNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Tag with id {$id} was not found.");
+    }
+}

--- a/src/Example/Tag/TagNotFoundExceptionHandler.php
+++ b/src/Example/Tag/TagNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class TagNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof TagNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested tag was not found.',
+        );
+    }
+}

--- a/src/Example/Tag/TagRepositoryInterface.php
+++ b/src/Example/Tag/TagRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+interface TagRepositoryInterface
+{
+    public function findById(int $id): ?Tag;
+
+    /** @return list<Tag> */
+    public function findAll(int $limit, int $offset): array;
+
+    public function save(Tag $tag): int;
+}

--- a/src/Example/Tag/TagServiceProvider.php
+++ b/src/Example/Tag/TagServiceProvider.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+final readonly class TagServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                TagRepositoryInterface::class,
+                static function (ContainerInterface $c): TagRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoTagRepository($query);
+                },
+            )
+            ->set(
+                ListTagsUseCaseInterface::class,
+                static function (ContainerInterface $c): ListTagsUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new ListTagsUseCase($repository);
+                },
+            )
+            ->set(
+                ListTagsHandler::class,
+                static function (ContainerInterface $c): ListTagsHandler {
+                    $useCase = $c->get(ListTagsUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListTagsUseCaseInterface) {
+                        throw new LogicException('ListTags use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListTagsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                GetTagByIdUseCaseInterface::class,
+                static function (ContainerInterface $c): GetTagByIdUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new GetTagByIdUseCase($repository);
+                },
+            )
+            ->set(
+                GetTagByIdHandler::class,
+                static function (ContainerInterface $c): GetTagByIdHandler {
+                    $useCase = $c->get(GetTagByIdUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetTagByIdUseCaseInterface) {
+                        throw new LogicException('GetTagById use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetTagByIdHandler($useCase, $response);
+                },
+            )
+            ->set(
+                CreateTagUseCaseInterface::class,
+                static function (ContainerInterface $c): CreateTagUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new CreateTagUseCase($repository);
+                },
+            )
+            ->set(
+                CreateTagHandler::class,
+                static function (ContainerInterface $c): CreateTagHandler {
+                    $useCase = $c->get(CreateTagUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateTagUseCaseInterface) {
+                        throw new LogicException('CreateTag use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateTagHandler($useCase, $response);
+                },
+            )
+            ->set(
+                TagNotFoundExceptionHandler::class,
+                static function (ContainerInterface $c): TagNotFoundExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new TagNotFoundExceptionHandler($problemDetails);
+                },
+            );
+    }
+}

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -12,6 +12,9 @@ use Nene2\Example\Note\DeleteNoteHandler;
 use Nene2\Example\Note\GetNoteByIdHandler;
 use Nene2\Example\Note\ListNotesHandler;
 use Nene2\Example\Note\UpdateNoteHandler;
+use Nene2\Example\Tag\CreateTagHandler;
+use Nene2\Example\Tag\GetTagByIdHandler;
+use Nene2\Example\Tag\ListTagsHandler;
 use Nene2\FrameworkInfo;
 use Nene2\Log\RequestIdHolder;
 use Nene2\Middleware\ApiKeyAuthenticationMiddleware;
@@ -48,6 +51,9 @@ final readonly class RuntimeApplicationFactory
         private ?UpdateNoteHandler $updateNoteHandler = null,
         private ?RequestIdHolder $requestIdHolder = null,
         private array $routeRegistrars = [],
+        private ?ListTagsHandler $listTagsHandler = null,
+        private ?GetTagByIdHandler $getTagByIdHandler = null,
+        private ?CreateTagHandler $createTagHandler = null,
     ) {
     }
 
@@ -128,6 +134,30 @@ final readonly class RuntimeApplicationFactory
             $router->delete(
                 '/examples/notes/{id}',
                 static fn (ServerRequestInterface $request) => $deleteNoteHandler->handle($request),
+            );
+        }
+
+        if ($this->listTagsHandler !== null) {
+            $listTagsHandler = $this->listTagsHandler;
+            $router->get(
+                '/examples/tags',
+                static fn (ServerRequestInterface $request) => $listTagsHandler->handle($request),
+            );
+        }
+
+        if ($this->getTagByIdHandler !== null) {
+            $getTagByIdHandler = $this->getTagByIdHandler;
+            $router->get(
+                '/examples/tags/{id}',
+                static fn (ServerRequestInterface $request) => $getTagByIdHandler->handle($request),
+            );
+        }
+
+        if ($this->createTagHandler !== null) {
+            $createTagHandler = $this->createTagHandler;
+            $router->post(
+                '/examples/tags',
+                static fn (ServerRequestInterface $request) => $createTagHandler->handle($request),
             );
         }
 

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -23,6 +23,11 @@ use Nene2\Example\Note\ListNotesHandler;
 use Nene2\Example\Note\NoteNotFoundExceptionHandler;
 use Nene2\Example\Note\NoteServiceProvider;
 use Nene2\Example\Note\UpdateNoteHandler;
+use Nene2\Example\Tag\CreateTagHandler;
+use Nene2\Example\Tag\GetTagByIdHandler;
+use Nene2\Example\Tag\ListTagsHandler;
+use Nene2\Example\Tag\TagNotFoundExceptionHandler;
+use Nene2\Example\Tag\TagServiceProvider;
 use Nene2\Log\MonologLoggerFactory;
 use Nene2\Log\RequestIdHolder;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -39,6 +44,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
     public function register(ContainerBuilder $builder): void
     {
         $builder->addProvider(new NoteServiceProvider());
+        $builder->addProvider(new TagServiceProvider());
 
         $builder
             ->set(
@@ -201,6 +207,10 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     $listNotesHandler = $container->get(ListNotesHandler::class);
                     $updateNoteHandler = $container->get(UpdateNoteHandler::class);
                     $noteNotFoundHandler = $container->get(NoteNotFoundExceptionHandler::class);
+                    $listTagsHandler = $container->get(ListTagsHandler::class);
+                    $getTagByIdHandler = $container->get(GetTagByIdHandler::class);
+                    $createTagHandler = $container->get(CreateTagHandler::class);
+                    $tagNotFoundHandler = $container->get(TagNotFoundExceptionHandler::class);
                     $requestIdHolder = $container->get(RequestIdHolder::class);
 
                     if (!$getNoteByIdHandler instanceof GetNoteByIdHandler) {
@@ -227,11 +237,27 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('NoteNotFoundException handler service is invalid.');
                     }
 
+                    if (!$listTagsHandler instanceof ListTagsHandler) {
+                        throw new LogicException('ListTags handler service is invalid.');
+                    }
+
+                    if (!$getTagByIdHandler instanceof GetTagByIdHandler) {
+                        throw new LogicException('GetTagById handler service is invalid.');
+                    }
+
+                    if (!$createTagHandler instanceof CreateTagHandler) {
+                        throw new LogicException('CreateTag handler service is invalid.');
+                    }
+
+                    if (!$tagNotFoundHandler instanceof TagNotFoundExceptionHandler) {
+                        throw new LogicException('TagNotFoundException handler service is invalid.');
+                    }
+
                     if (!$requestIdHolder instanceof RequestIdHolder) {
                         throw new LogicException('RequestIdHolder service is invalid.');
                     }
 
-                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger, $config->machineApiKey, $getNoteByIdHandler, $createNoteHandler, $deleteNoteHandler, [$noteNotFoundHandler], $listNotesHandler, $updateNoteHandler, $requestIdHolder);
+                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger, $config->machineApiKey, $getNoteByIdHandler, $createNoteHandler, $deleteNoteHandler, [$noteNotFoundHandler, $tagNotFoundHandler], $listNotesHandler, $updateNoteHandler, $requestIdHolder, [], $listTagsHandler, $getTagByIdHandler, $createTagHandler);
                 },
             )
             ->set(

--- a/tests/Example/Tag/InMemoryTagRepository.php
+++ b/tests/Example/Tag/InMemoryTagRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Example\Tag;
+
+use Nene2\Example\Tag\Tag;
+use Nene2\Example\Tag\TagRepositoryInterface;
+
+final class InMemoryTagRepository implements TagRepositoryInterface
+{
+    /** @var array<int, Tag> */
+    private array $tags;
+
+    private int $nextId;
+
+    /** @param list<Tag> $tags */
+    public function __construct(array $tags = [])
+    {
+        $this->tags = [];
+        $this->nextId = 1;
+
+        foreach ($tags as $tag) {
+            if ($tag->id !== null) {
+                $this->tags[$tag->id] = $tag;
+                $this->nextId = max($this->nextId, $tag->id + 1);
+            }
+        }
+    }
+
+    public function findById(int $id): ?Tag
+    {
+        return $this->tags[$id] ?? null;
+    }
+
+    /** @return list<Tag> */
+    public function findAll(int $limit, int $offset): array
+    {
+        return array_slice(array_values($this->tags), $offset, $limit);
+    }
+
+    public function save(Tag $tag): int
+    {
+        $id = $this->nextId++;
+        $this->tags[$id] = new Tag(name: $tag->name, id: $id);
+
+        return $id;
+    }
+}

--- a/tests/Example/Tag/PdoTagRepositoryTest.php
+++ b/tests/Example/Tag/PdoTagRepositoryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Example\Tag;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Example\Tag\PdoTagRepository;
+use Nene2\Example\Tag\Tag;
+use PHPUnit\Framework\TestCase;
+
+final class PdoTagRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene2',
+            '',
+            'utf8',
+        )));
+
+        $this->executor->execute(
+            'CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)',
+        );
+    }
+
+    public function testFindByIdReturnsTag(): void
+    {
+        $this->executor->execute("INSERT INTO tags (name) VALUES ('php')");
+
+        $repository = new PdoTagRepository($this->executor);
+        $tag = $repository->findById(1);
+
+        self::assertNotNull($tag);
+        self::assertSame(1, $tag->id);
+        self::assertSame('php', $tag->name);
+    }
+
+    public function testFindByIdReturnsNullWhenAbsent(): void
+    {
+        $repository = new PdoTagRepository($this->executor);
+
+        self::assertNull($repository->findById(99));
+    }
+
+    public function testSaveReturnsNewId(): void
+    {
+        $repository = new PdoTagRepository($this->executor);
+        $id = $repository->save(new Tag(name: 'api'));
+
+        self::assertSame(1, $id);
+    }
+
+    public function testFindAllReturnsTags(): void
+    {
+        $this->executor->execute("INSERT INTO tags (name) VALUES ('php')");
+        $this->executor->execute("INSERT INTO tags (name) VALUES ('api')");
+
+        $repository = new PdoTagRepository($this->executor);
+        $tags = $repository->findAll(10, 0);
+
+        self::assertCount(2, $tags);
+        self::assertSame('php', $tags[0]->name);
+        self::assertSame('api', $tags[1]->name);
+    }
+
+    public function testFindAllRespectsLimitAndOffset(): void
+    {
+        $this->executor->execute("INSERT INTO tags (name) VALUES ('php')");
+        $this->executor->execute("INSERT INTO tags (name) VALUES ('api')");
+        $this->executor->execute("INSERT INTO tags (name) VALUES ('mcp')");
+
+        $repository = new PdoTagRepository($this->executor);
+        $tags = $repository->findAll(2, 1);
+
+        self::assertCount(2, $tags);
+        self::assertSame('api', $tags[0]->name);
+        self::assertSame('mcp', $tags[1]->name);
+    }
+}

--- a/tests/Example/Tag/TagHttpTest.php
+++ b/tests/Example/Tag/TagHttpTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Example\Tag;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Example\Tag\CreateTagHandler;
+use Nene2\Example\Tag\CreateTagUseCase;
+use Nene2\Example\Tag\GetTagByIdHandler;
+use Nene2\Example\Tag\GetTagByIdUseCase;
+use Nene2\Example\Tag\ListTagsHandler;
+use Nene2\Example\Tag\ListTagsUseCase;
+use Nene2\Example\Tag\Tag;
+use Nene2\Example\Tag\TagNotFoundExceptionHandler;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class TagHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryTagRepository $repository;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        $this->factory = new Psr17Factory();
+        $this->repository = new InMemoryTagRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [new TagNotFoundExceptionHandler($problemDetails)],
+            listTagsHandler: new ListTagsHandler(
+                new ListTagsUseCase($this->repository),
+                $jsonResponse,
+            ),
+            getTagByIdHandler: new GetTagByIdHandler(
+                new GetTagByIdUseCase($this->repository),
+                $jsonResponse,
+            ),
+            createTagHandler: new CreateTagHandler(
+                new CreateTagUseCase($this->repository),
+                $jsonResponse,
+            ),
+        ))->create();
+    }
+
+    public function testListTagsReturnsEmptyList(): void
+    {
+        $response = $this->request('GET', '/examples/tags');
+        $payload = $this->decode($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame([], $payload['items']);
+        self::assertSame(20, $payload['limit']);
+        self::assertSame(0, $payload['offset']);
+    }
+
+    public function testListTagsReturnsTags(): void
+    {
+        $this->repository->save(new Tag(name: 'php'));
+        $this->repository->save(new Tag(name: 'api'));
+
+        $response = $this->request('GET', '/examples/tags');
+        $payload = $this->decode($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(2, $payload['items']);
+        self::assertSame('php', $payload['items'][0]['name']);
+    }
+
+    public function testGetTagByIdReturnsTag(): void
+    {
+        $id = $this->repository->save(new Tag(name: 'php'));
+
+        $response = $this->request('GET', "/examples/tags/{$id}");
+        $payload = $this->decode($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($id, $payload['id']);
+        self::assertSame('php', $payload['name']);
+    }
+
+    public function testGetTagByIdReturns404WhenAbsent(): void
+    {
+        $response = $this->request('GET', '/examples/tags/99');
+        $payload = $this->decode($response);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('application/problem+json', $response->getHeaderLine('Content-Type'));
+        self::assertSame('Not Found', $payload['title']);
+    }
+
+    public function testGetTagByIdReturns404ForInvalidId(): void
+    {
+        $response = $this->request('GET', '/examples/tags/0');
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testCreateTagReturns201(): void
+    {
+        $response = $this->request('POST', '/examples/tags', ['name' => 'php']);
+        $payload = $this->decode($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('php', $payload['name']);
+        self::assertStringEndsWith('/examples/tags/' . $payload['id'], $response->getHeaderLine('Location'));
+    }
+
+    public function testCreateTagReturns422WhenNameMissing(): void
+    {
+        $response = $this->request('POST', '/examples/tags', ['name' => '']);
+        $payload = $this->decode($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('application/problem+json', $response->getHeaderLine('Content-Type'));
+        self::assertNotEmpty($payload['errors']);
+    }
+
+    /** @param array<string, mixed>|null $body */
+    private function request(string $method, string $path, ?array $body = null): ResponseInterface
+    {
+        $request = $this->factory->createServerRequest($method, "https://example.test{$path}");
+
+        if ($body !== null) {
+            $stream = $this->factory->createStream((string) json_encode($body));
+            $request = $request->withBody($stream);
+        }
+
+        return $this->application->handle($request);
+    }
+
+    /** @return array<string, mixed> */
+    private function decode(ResponseInterface $response): array
+    {
+        return (array) json_decode((string) $response->getBody(), associative: true);
+    }
+}

--- a/tests/Example/Tag/TagUseCaseTest.php
+++ b/tests/Example/Tag/TagUseCaseTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Example\Tag;
+
+use Nene2\Example\Tag\CreateTagInput;
+use Nene2\Example\Tag\CreateTagUseCase;
+use Nene2\Example\Tag\GetTagByIdInput;
+use Nene2\Example\Tag\GetTagByIdUseCase;
+use Nene2\Example\Tag\ListTagsInput;
+use Nene2\Example\Tag\ListTagsUseCase;
+use Nene2\Example\Tag\Tag;
+use Nene2\Example\Tag\TagNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class TagUseCaseTest extends TestCase
+{
+    public function testCreateTagReturnsOutputWithNewId(): void
+    {
+        $repository = new InMemoryTagRepository([]);
+        $useCase = new CreateTagUseCase($repository);
+
+        $output = $useCase->execute(new CreateTagInput(name: 'php'));
+
+        self::assertSame(1, $output->id);
+        self::assertSame('php', $output->name);
+    }
+
+    public function testGetTagByIdReturnsTag(): void
+    {
+        $repository = new InMemoryTagRepository([new Tag(name: 'php', id: 1)]);
+        $useCase = new GetTagByIdUseCase($repository);
+
+        $output = $useCase->execute(new GetTagByIdInput(1));
+
+        self::assertSame(1, $output->id);
+        self::assertSame('php', $output->name);
+    }
+
+    public function testGetTagByIdThrowsWhenAbsent(): void
+    {
+        $repository = new InMemoryTagRepository([]);
+        $useCase = new GetTagByIdUseCase($repository);
+
+        $this->expectException(TagNotFoundException::class);
+
+        $useCase->execute(new GetTagByIdInput(99));
+    }
+
+    public function testListTagsReturnsItems(): void
+    {
+        $repository = new InMemoryTagRepository([
+            new Tag(name: 'php', id: 1),
+            new Tag(name: 'api', id: 2),
+        ]);
+        $useCase = new ListTagsUseCase($repository);
+
+        $output = $useCase->execute(new ListTagsInput(limit: 10, offset: 0));
+
+        self::assertCount(2, $output->items);
+        self::assertSame('php', $output->items[0]->name);
+        self::assertSame('api', $output->items[1]->name);
+    }
+
+    public function testListTagsRespectsOffset(): void
+    {
+        $repository = new InMemoryTagRepository([
+            new Tag(name: 'php', id: 1),
+            new Tag(name: 'api', id: 2),
+            new Tag(name: 'mcp', id: 3),
+        ]);
+        $useCase = new ListTagsUseCase($repository);
+
+        $output = $useCase->execute(new ListTagsInput(limit: 10, offset: 1));
+
+        self::assertCount(2, $output->items);
+        self::assertSame('api', $output->items[0]->name);
+    }
+}

--- a/tests/OpenApi/RuntimeContractTest.php
+++ b/tests/OpenApi/RuntimeContractTest.php
@@ -67,9 +67,9 @@ final class RuntimeContractTest extends TestCase
                     continue;
                 }
 
-                // Skip Note domain paths: they require optional domain handlers (ListNotesHandler etc.)
-                // and are covered by NoteHttpTest with InMemoryNoteRepository.
-                if (str_starts_with($path, '/examples/notes')) {
+                // Skip domain example paths: they require optional domain handlers and are covered
+                // by NoteHttpTest / TagHttpTest with in-memory repositories.
+                if (str_starts_with($path, '/examples/notes') || str_starts_with($path, '/examples/tags')) {
                     continue;
                 }
 


### PR DESCRIPTION
## 概要

Phase 25 — Note に続く 2 つ目のドメインエンティティとして `Tag` を追加。多エンティティパターンを実証する。

## 変更内容

### ドメイン層（`src/Example/Tag/`）22 ファイル
- `Tag` readonly DTO / `TagRepositoryInterface`
- `PdoTagRepository`（SQLite in-memory 互換）
- `ListTagsUseCase` / `GetTagByIdUseCase` / `CreateTagUseCase`（各 Interface 付き）
- `ListTagsHandler` / `GetTagByIdHandler` / `CreateTagHandler`
- `TagNotFoundException` / `TagNotFoundExceptionHandler`
- `TagServiceProvider`

### HTTP ルート（`RuntimeApplicationFactory`）
- `GET  /examples/tags` — 一覧（limit/offset バリデーション付き）
- `GET  /examples/tags/{id}` — 詳細（404 対応）
- `POST /examples/tags` — 作成（201 + Location / 422）

### OpenAPI（`docs/openapi/openapi.yaml`）
- `/examples/tags` / `/examples/tags/{id}` パス追加
- `CreateTagRequest` / `ExampleTagResponse` / `ExampleTagListResponse` スキーマ追加

### テスト（`tests/Example/Tag/`）
- `InMemoryTagRepository` — テスト用インメモリ実装
- `TagUseCaseTest` — ユニットテスト（5 件）
- `PdoTagRepositoryTest` — PDO 結合テスト（SQLite in-memory、5 件）
- `TagHttpTest` — HTTP テスト（8 件、全パス × 成功/エラー）

## 検証

```
docker compose run --rm app composer check
```

✅ 全テスト通過 / PHPStan level 8 / CS / OpenAPI / MCP catalog

Closes #276

Self-review: backend-api, openapi-contract, database