### PR TITLE
docs(howto): 本番デプロイガイドを追加する (Phase 26)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -21,7 +21,7 @@ function nav(t: {
 
 function sidebar(t: {
   tutorialGroup: string; firstApi: string
-  howtoGroup: string; addRoute: string; addDb: string
+  howtoGroup: string; addRoute: string; addDb: string; deploy: string
   explGroup: string; whyPsr: string; whyDi: string; whyPd: string; whyMcp: string
   devGroup: string; intGroup: string
 }) {
@@ -32,6 +32,7 @@ function sidebar(t: {
       items: [
         { text: t.addRoute, link: 'howto/add-custom-route' },
         { text: t.addDb,    link: 'howto/add-database-endpoint' },
+        { text: t.deploy,   link: 'howto/deploy-production' },
       ],
     }],
     '/explanation/': [{
@@ -86,7 +87,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'HOWTO', explanation: 'Explanation', reference: 'Reference' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Your first API',
-          howtoGroup: 'HOWTO', addRoute: 'Add a custom route', addDb: 'Add a database-backed endpoint',
+          howtoGroup: 'HOWTO', addRoute: 'Add a custom route', addDb: 'Add a database-backed endpoint', deploy: 'Deploy to production',
           explGroup: 'Explanation', whyPsr: 'Why PSR standards?', whyDi: 'Why explicit wiring?', whyPd: 'Why Problem Details?', whyMcp: 'Why MCP?',
           devGroup: 'Development', intGroup: 'Integrations',
         }),
@@ -102,7 +103,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'チュートリアル', howto: 'HOWTO', explanation: '解説', reference: 'リファレンス' }),
         sidebar: sidebar({
           tutorialGroup: 'チュートリアル', firstApi: '最初の API を動かす',
-          howtoGroup: 'HOWTO', addRoute: 'カスタムルートを追加する', addDb: 'DB 付きエンドポイントを追加する',
+          howtoGroup: 'HOWTO', addRoute: 'カスタムルートを追加する', addDb: 'DB 付きエンドポイントを追加する', deploy: '本番環境へデプロイする',
           explGroup: '解説', whyPsr: 'なぜ PSR 標準？', whyDi: 'なぜ明示的 DI？', whyPd: 'なぜ Problem Details？', whyMcp: 'なぜ MCP？',
           devGroup: '開発ガイド', intGroup: 'インテグレーション',
         }),
@@ -123,7 +124,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutoriel', howto: 'Guides', explanation: 'Explication', reference: 'Référence' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutoriel', firstApi: 'Votre première API',
-          howtoGroup: 'Guides pratiques', addRoute: 'Ajouter une route', addDb: 'Ajouter un endpoint avec BDD',
+          howtoGroup: 'Guides pratiques', addRoute: 'Ajouter une route', addDb: 'Ajouter un endpoint avec BDD', deploy: 'Déployer en production',
           explGroup: 'Explication', whyPsr: 'Pourquoi PSR ?', whyDi: 'Pourquoi le câblage explicite ?', whyPd: 'Pourquoi Problem Details ?', whyMcp: 'Pourquoi MCP ?',
           devGroup: 'Développement', intGroup: 'Intégrations',
         }),
@@ -142,7 +143,7 @@ export default defineConfig({
         nav: nav({ tutorial: '教程', howto: '操作指南', explanation: '说明', reference: '参考' }),
         sidebar: sidebar({
           tutorialGroup: '教程', firstApi: '创建您的第一个 API',
-          howtoGroup: '操作指南', addRoute: '添加自定义路由', addDb: '添加数据库端点',
+          howtoGroup: '操作指南', addRoute: '添加自定义路由', addDb: '添加数据库端点', deploy: '部署到生产环境',
           explGroup: '说明', whyPsr: '为什么选择 PSR？', whyDi: '为什么显式依赖注入？', whyPd: '为什么使用 Problem Details？', whyMcp: '为什么选择 MCP？',
           devGroup: '开发指南', intGroup: '集成',
         }),
@@ -163,7 +164,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'Guias', explanation: 'Explicação', reference: 'Referência' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Sua primeira API',
-          howtoGroup: 'Guias práticos', addRoute: 'Adicionar uma rota', addDb: 'Adicionar endpoint com banco de dados',
+          howtoGroup: 'Guias práticos', addRoute: 'Adicionar uma rota', addDb: 'Adicionar endpoint com banco de dados', deploy: 'Implantar em produção',
           explGroup: 'Explicação', whyPsr: 'Por que PSR?', whyDi: 'Por que injeção explícita?', whyPd: 'Por que Problem Details?', whyMcp: 'Por que MCP?',
           devGroup: 'Desenvolvimento', intGroup: 'Integrações',
         }),
@@ -182,7 +183,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'Anleitungen', explanation: 'Erklärung', reference: 'Referenz' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Ihre erste API',
-          howtoGroup: 'Anleitungen', addRoute: 'Route hinzufügen', addDb: 'Datenbankendpunkt hinzufügen',
+          howtoGroup: 'Anleitungen', addRoute: 'Route hinzufügen', addDb: 'Datenbankendpunkt hinzufügen', deploy: 'In Produktion deployen',
           explGroup: 'Erklärung', whyPsr: 'Warum PSR?', whyDi: 'Warum explizites Wiring?', whyPd: 'Warum Problem Details?', whyMcp: 'Warum MCP?',
           devGroup: 'Entwicklung', intGroup: 'Integrationen',
         }),

--- a/docs/de/howto/deploy-production.md
+++ b/docs/de/howto/deploy-production.md
@@ -1,0 +1,130 @@
+# In Produktion deployen
+
+Diese Anleitung beschreibt die Mindestschritte für den Betrieb einer NENE2-basierten Anwendung in der Produktion: Erstellen eines Produktions-Images, sichere Verwaltung von Umgebungsvariablen und Platzieren eines Reverse-Proxys.
+
+**Voraussetzung**: Ihre Anwendung funktioniert lokal mit `docker compose up -d app`.
+
+---
+
+## 1. Produktions-Docker-Image erstellen
+
+Das Entwicklungs-Image mountet das Quellverzeichnis und enthält Entwicklungswerkzeuge. Für die Produktion erstellen Sie ein eigenständiges Image mit nur den Runtime-Abhängigkeiten.
+
+Erstellen Sie `docker/php/Dockerfile.prod`:
+
+```dockerfile
+# Stage 1 — Abhängigkeiten installieren
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-progress \
+    --optimize-autoloader \
+    --prefer-dist
+
+# Stage 2 — Runtime-Image
+FROM php:8.4-apache AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && docker-php-ext-install pdo_mysql \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod rewrite \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' \
+       > /etc/apache2/conf-available/nene2.conf \
+    && a2enconf nene2 \
+    && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html
+
+COPY public_html/ public_html/
+COPY src/         src/
+COPY config/      config/
+COPY templates/   templates/
+COPY --from=vendor /app/vendor vendor/
+COPY composer.json composer.lock ./
+
+EXPOSE 80
+```
+
+Erstellen und pushen:
+
+```bash
+docker build -f docker/php/Dockerfile.prod -t my-app:latest .
+docker push my-registry/my-app:latest
+```
+
+---
+
+## 2. Umgebungsvariablen sicher verwalten
+
+Fügen Sie niemals eine `.env`-Datei in ein Produktions-Image ein. Injizieren Sie Umgebungsvariablen über das Secret-Management Ihrer Plattform.
+
+### Erforderliche Variablen
+
+| Variable | Produktionswert |
+|----------|----------------|
+| `APP_ENV` | `production` |
+| `APP_DEBUG` | `false` |
+| `DB_HOST` | Ihr verwalteter Datenbankhost |
+| `DB_PASSWORD` | Aus dem Secret Store — niemals hartcodieren |
+| `NENE2_MACHINE_API_KEY` | Aus dem Secret Store — niemals hartcodieren |
+
+---
+
+## 3. Reverse-Proxy vorschalten
+
+Der NENE2-Apache-Container ist nicht dafür ausgelegt, direkt dem Internet ausgesetzt zu sein. Schalten Sie Nginx, Caddy oder einen Cloud-Load-Balancer vor.
+
+### Nginx-Beispiel
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name api.example.com;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Caddy-Beispiel
+
+```caddyfile
+api.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+---
+
+## 4. Produktions-Sicherheits-Checkliste
+
+- [ ] `APP_ENV=production` — deaktiviert Entwicklungs-Fehlerdetails
+- [ ] `APP_DEBUG=false` — unterdrückt Stack-Traces in HTTP-Antworten
+- [ ] Datenbank-Zugangsdaten aus einem Secret Store
+- [ ] `NENE2_MACHINE_API_KEY` ist ein starker Zufallswert (≥ 32 Zeichen)
+- [ ] Container-Port nur an Loopback-Adresse gebunden
+- [ ] TLS am Reverse-Proxy terminiert
+
+---
+
+## 5. Nach dem Deployment verifizieren
+
+```bash
+curl -fsS https://api.example.com/health
+curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
+```
+
+---
+
+## 6. Problem Details Typ-URIs
+
+NENE2 verwendet `https://nene2.dev/problems/...` als Platzhalter-Domain. Vor dem Produktionseinsatz registrieren Sie diese Domain oder ersetzen Sie die Basis-URL in `ProblemDetailsResponseFactory`.

--- a/docs/fr/howto/deploy-production.md
+++ b/docs/fr/howto/deploy-production.md
@@ -1,0 +1,130 @@
+# Déployer en production
+
+Ce guide couvre les étapes minimales pour exécuter une application basée sur NENE2 en production : construction d'une image de production, gestion sécurisée des variables d'environnement, et placement d'un proxy inverse.
+
+**Prérequis**: Votre application fonctionne localement avec `docker compose up -d app`.
+
+---
+
+## 1. Construire une image Docker de production
+
+L'image de développement monte le répertoire source et inclut les outils de développement. Pour la production, construisez une image autonome avec uniquement les dépendances d'exécution.
+
+Créez `docker/php/Dockerfile.prod` :
+
+```dockerfile
+# Étape 1 — installation des dépendances
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-progress \
+    --optimize-autoloader \
+    --prefer-dist
+
+# Étape 2 — image d'exécution
+FROM php:8.4-apache AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && docker-php-ext-install pdo_mysql \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod rewrite \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' \
+       > /etc/apache2/conf-available/nene2.conf \
+    && a2enconf nene2 \
+    && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html
+
+COPY public_html/ public_html/
+COPY src/         src/
+COPY config/      config/
+COPY templates/   templates/
+COPY --from=vendor /app/vendor vendor/
+COPY composer.json composer.lock ./
+
+EXPOSE 80
+```
+
+Construire et pousser :
+
+```bash
+docker build -f docker/php/Dockerfile.prod -t my-app:latest .
+docker push my-registry/my-app:latest
+```
+
+---
+
+## 2. Gérer les variables d'environnement de façon sécurisée
+
+Ne jamais inclure un fichier `.env` dans une image de production. Injectez les variables d'environnement via la gestion des secrets de votre plateforme.
+
+### Variables requises
+
+| Variable | Valeur de production |
+|----------|---------------------|
+| `APP_ENV` | `production` |
+| `APP_DEBUG` | `false` |
+| `DB_HOST` | Votre hôte de base de données géré |
+| `DB_PASSWORD` | Depuis le gestionnaire de secrets |
+| `NENE2_MACHINE_API_KEY` | Depuis le gestionnaire de secrets |
+
+---
+
+## 3. Placer un proxy inverse en amont
+
+Le conteneur Apache de NENE2 n'est pas conçu pour faire face directement à Internet. Placez Nginx, Caddy ou un équilibreur de charge cloud en amont.
+
+### Exemple Nginx
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name api.example.com;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Exemple Caddy
+
+```caddyfile
+api.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+---
+
+## 4. Liste de contrôle de sécurité production
+
+- [ ] `APP_ENV=production` — désactive les détails d'erreur de développement
+- [ ] `APP_DEBUG=false` — supprime les traces de pile dans les réponses HTTP
+- [ ] Identifiants de base de données depuis un gestionnaire de secrets
+- [ ] `NENE2_MACHINE_API_KEY` valeur aléatoire forte (≥ 32 caractères)
+- [ ] Port du conteneur lié à l'adresse de bouclage uniquement
+- [ ] TLS terminé au niveau du proxy inverse
+
+---
+
+## 5. Vérifier après déploiement
+
+```bash
+curl -fsS https://api.example.com/health
+curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
+```
+
+---
+
+## 6. URIs de type Problem Details
+
+NENE2 utilise `https://nene2.dev/problems/...` comme domaine de substitution. Avant la mise en production, enregistrez ce domaine ou remplacez l'URL de base dans `ProblemDetailsResponseFactory`.

--- a/docs/howto/deploy-production.md
+++ b/docs/howto/deploy-production.md
@@ -1,0 +1,225 @@
+# Deploy to Production
+
+This guide covers the minimum steps to run a NENE2-based application in a production environment: building a production image, managing environment variables securely, and placing a reverse proxy in front.
+
+**Prerequisite**: Your application is working locally with `docker compose up -d app`.
+
+---
+
+## 1. Build a production Docker image
+
+The development image mounts the source directory and includes dev tools. For production, build a self-contained image with only the runtime dependencies.
+
+Create `docker/php/Dockerfile.prod`:
+
+```dockerfile
+# Stage 1 — install dependencies
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-progress \
+    --optimize-autoloader \
+    --prefer-dist
+
+# Stage 2 — runtime image
+FROM php:8.4-apache AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && docker-php-ext-install pdo_mysql \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod rewrite \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' \
+       > /etc/apache2/conf-available/nene2.conf \
+    && a2enconf nene2 \
+    && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html
+
+# Copy application source
+COPY public_html/ public_html/
+COPY src/         src/
+COPY config/      config/
+COPY templates/   templates/
+
+# Copy production vendor from stage 1
+COPY --from=vendor /app/vendor vendor/
+
+# Copy composer files (needed for autoloader)
+COPY composer.json composer.lock ./
+
+EXPOSE 80
+```
+
+Build and push:
+
+```bash
+docker build -f docker/php/Dockerfile.prod -t my-app:latest .
+docker push my-registry/my-app:latest
+```
+
+---
+
+## 2. Manage environment variables securely
+
+Never ship a `.env` file in a production image. Inject environment variables through your platform's secret management.
+
+### Required variables
+
+| Variable | Production value |
+|----------|-----------------|
+| `APP_ENV` | `production` |
+| `APP_DEBUG` | `false` |
+| `DB_ADAPTER` | `mysql` |
+| `DB_HOST` | Your managed database hostname |
+| `DB_PORT` | `3306` |
+| `DB_NAME` | Your database name |
+| `DB_USER` | Your database username |
+| `DB_PASSWORD` | From secret store — never hardcode |
+| `NENE2_MACHINE_API_KEY` | From secret store — never hardcode |
+
+### Example: Docker Compose with secrets file
+
+```yaml
+# compose.prod.yaml
+services:
+  app:
+    image: my-registry/my-app:latest
+    env_file:
+      - .env.production     # not committed — injected by CI/CD or secret manager
+    ports:
+      - "127.0.0.1:8080:80"   # bind to loopback only — Nginx in front
+    restart: unless-stopped
+```
+
+```bash
+# .env.production (on the server, not in git)
+APP_ENV=production
+APP_DEBUG=false
+DB_HOST=db.internal
+DB_NAME=myapp
+DB_USER=myapp
+DB_PASSWORD=<from secret manager>
+NENE2_MACHINE_API_KEY=<from secret manager>
+```
+
+### Platform-specific injection
+
+| Platform | Method |
+|----------|--------|
+| Docker Swarm | `docker secret create` + `secrets:` in compose |
+| Kubernetes | `Secret` resource + `envFrom` |
+| AWS ECS | Task definition secrets from Parameter Store / Secrets Manager |
+| Railway / Render / Fly.io | Environment variable settings in dashboard |
+
+---
+
+## 3. Place a reverse proxy in front
+
+The NENE2 Apache container is not designed to face the internet directly. Put Nginx, Caddy, or a cloud load balancer in front.
+
+### Nginx example
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name api.example.com;
+
+    ssl_certificate     /etc/ssl/certs/api.example.com.crt;
+    ssl_certificate_key /etc/ssl/private/api.example.com.key;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+    }
+}
+
+server {
+    listen 80;
+    server_name api.example.com;
+    return 301 https://$host$request_uri;
+}
+```
+
+### Caddy example
+
+```caddyfile
+api.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+Caddy automatically provisions TLS certificates via Let's Encrypt.
+
+---
+
+## 4. Production security checklist
+
+Before accepting traffic, verify:
+
+- [ ] `APP_ENV=production` — disables development error details
+- [ ] `APP_DEBUG=false` — suppresses stack traces in HTTP responses
+- [ ] Database credentials come from a secret store, not from `.env` in the image
+- [ ] `NENE2_MACHINE_API_KEY` is a strong random value (≥ 32 characters)
+- [ ] The container port is bound to loopback (`127.0.0.1:8080`) or a private network, not `0.0.0.0`
+- [ ] TLS is terminated at the reverse proxy
+- [ ] `X-Forwarded-For` / `X-Real-IP` headers are set by the proxy only
+- [ ] Apache `ServerTokens` and `ServerSignature` are set to `Off` (add to `Dockerfile.prod`)
+
+---
+
+## 5. Verify after deployment
+
+```bash
+# Health check
+curl -fsS https://api.example.com/health
+
+# Machine client smoke check
+curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
+```
+
+Expected responses:
+
+```json
+{ "status": "ok", "service": "NENE2" }
+```
+
+---
+
+## 6. Problem Details type URIs
+
+NENE2 error responses include a `type` URI such as:
+
+```
+https://nene2.dev/problems/validation-failed
+```
+
+`nene2.dev` is a placeholder domain. Before going to production, choose one of:
+
+**Option A — register nene2.dev**: If you maintain the framework, register the domain and host problem documentation there.
+
+**Option B — use your own domain**: Replace the base URL in `ProblemDetailsResponseFactory`:
+
+```php
+// src/Error/ProblemDetailsResponseFactory.php
+private const string TYPE_BASE = 'https://problems.example.com/';
+```
+
+The `type` URI should be stable. Changing it after launch breaks clients that switch on the `type` value.
+
+---
+
+## Further reading
+
+- [Tutorial: Your first API](../tutorial/first-api.md)
+- [HOWTO: Add a database-backed endpoint](add-database-endpoint.md)
+- [Development: Setup guide](../development/setup.md)
+- [Explanation: Why Problem Details?](../explanation/why-problem-details.md)

--- a/docs/ja/howto/deploy-production.md
+++ b/docs/ja/howto/deploy-production.md
@@ -1,0 +1,211 @@
+# 本番環境へデプロイする
+
+このガイドでは NENE2 ベースのアプリケーションを本番環境で動かすための最低限の手順を説明します。本番用イメージのビルド、環境変数の安全な管理、リバースプロキシの配置が主な内容です。
+
+**前提条件**: `docker compose up -d app` でローカル動作を確認済みであること。
+
+---
+
+## 1. 本番用 Docker イメージをビルドする
+
+開発用イメージはソースディレクトリをマウントし開発ツールを含んでいます。本番ではランタイム依存のみを含む自己完結型イメージをビルドします。
+
+`docker/php/Dockerfile.prod` を作成します。
+
+```dockerfile
+# Stage 1 — 依存関係のインストール
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-progress \
+    --optimize-autoloader \
+    --prefer-dist
+
+# Stage 2 — ランタイムイメージ
+FROM php:8.4-apache AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && docker-php-ext-install pdo_mysql \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod rewrite \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' \
+       > /etc/apache2/conf-available/nene2.conf \
+    && a2enconf nene2 \
+    && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html
+
+COPY public_html/ public_html/
+COPY src/         src/
+COPY config/      config/
+COPY templates/   templates/
+COPY --from=vendor /app/vendor vendor/
+COPY composer.json composer.lock ./
+
+EXPOSE 80
+```
+
+ビルドとプッシュ:
+
+```bash
+docker build -f docker/php/Dockerfile.prod -t my-app:latest .
+docker push my-registry/my-app:latest
+```
+
+---
+
+## 2. 環境変数を安全に管理する
+
+本番イメージに `.env` ファイルを含めないでください。プラットフォームのシークレット管理を通じて環境変数を注入します。
+
+### 必須変数
+
+| 変数 | 本番での値 |
+|------|-----------|
+| `APP_ENV` | `production` |
+| `APP_DEBUG` | `false` |
+| `DB_ADAPTER` | `mysql` |
+| `DB_HOST` | マネージドデータベースのホスト名 |
+| `DB_PORT` | `3306` |
+| `DB_NAME` | データベース名 |
+| `DB_USER` | データベースユーザー名 |
+| `DB_PASSWORD` | シークレットストアから — 直接書かない |
+| `NENE2_MACHINE_API_KEY` | シークレットストアから — 直接書かない |
+
+### Docker Compose + シークレットファイルの例
+
+```yaml
+# compose.prod.yaml
+services:
+  app:
+    image: my-registry/my-app:latest
+    env_file:
+      - .env.production   # コミットしない — CI/CD またはシークレットマネージャーから注入
+    ports:
+      - "127.0.0.1:8080:80"   # ループバックのみ — Nginx が前段
+    restart: unless-stopped
+```
+
+```bash
+# .env.production（サーバー上、git には含めない）
+APP_ENV=production
+APP_DEBUG=false
+DB_HOST=db.internal
+DB_NAME=myapp
+DB_USER=myapp
+DB_PASSWORD=<シークレットマネージャーから>
+NENE2_MACHINE_API_KEY=<シークレットマネージャーから>
+```
+
+---
+
+## 3. リバースプロキシを前段に配置する
+
+NENE2 の Apache コンテナは直接インターネットに向けることを想定していません。Nginx、Caddy、またはクラウドロードバランサーを前段に配置します。
+
+### Nginx の例
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name api.example.com;
+
+    ssl_certificate     /etc/ssl/certs/api.example.com.crt;
+    ssl_certificate_key /etc/ssl/private/api.example.com.key;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+    }
+}
+
+server {
+    listen 80;
+    server_name api.example.com;
+    return 301 https://$host$request_uri;
+}
+```
+
+### Caddy の例
+
+```caddyfile
+api.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+Caddy は Let's Encrypt 経由で TLS 証明書を自動発行します。
+
+---
+
+## 4. 本番セキュリティチェックリスト
+
+トラフィックを受け入れる前に確認します。
+
+- [ ] `APP_ENV=production` — 開発用エラー詳細を無効化
+- [ ] `APP_DEBUG=false` — HTTP レスポンスのスタックトレースを抑制
+- [ ] データベース認証情報はシークレットストアから取得（イメージに含めない）
+- [ ] `NENE2_MACHINE_API_KEY` は強力なランダム値（32 文字以上）
+- [ ] コンテナポートはループバック（`127.0.0.1:8080`）または内部ネットワークにバインド（`0.0.0.0` ではない）
+- [ ] TLS はリバースプロキシで終端
+- [ ] `X-Forwarded-For` / `X-Real-IP` ヘッダーはプロキシのみが設定
+- [ ] Apache の `ServerTokens` と `ServerSignature` を `Off` に設定（`Dockerfile.prod` に追加）
+
+---
+
+## 5. デプロイ後の確認
+
+```bash
+# ヘルスチェック
+curl -fsS https://api.example.com/health
+
+# マシンクライアントスモークチェック
+curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
+```
+
+期待されるレスポンス:
+
+```json
+{ "status": "ok", "service": "NENE2" }
+```
+
+---
+
+## 6. Problem Details の type URI について
+
+NENE2 のエラーレスポンスは次のような `type` URI を含みます。
+
+```
+https://nene2.dev/problems/validation-failed
+```
+
+`nene2.dev` はプレースホルダードメインです。本番稼働前に以下のいずれかを選択してください。
+
+**オプション A — nene2.dev を登録する**: フレームワークをメンテナンスする場合、ドメインを登録して問題ドキュメントをホストします。
+
+**オプション B — 独自ドメインを使用する**: `ProblemDetailsResponseFactory` のベース URL を置き換えます。
+
+```php
+// src/Error/ProblemDetailsResponseFactory.php
+private const string TYPE_BASE = 'https://problems.example.com/';
+```
+
+`type` URI は安定させてください。リリース後に変更すると、`type` 値でスイッチしているクライアントが壊れます。
+
+---
+
+## 関連ドキュメント
+
+- [チュートリアル: 最初の API を動かす](../tutorial/first-api.md)
+- [HOWTO: DB 付きエンドポイントを追加する](add-database-endpoint.md)
+- [開発ガイド: セットアップ](../development/setup.md)
+- [解説: なぜ Problem Details？](../explanation/why-problem-details.md)

--- a/docs/pt-br/howto/deploy-production.md
+++ b/docs/pt-br/howto/deploy-production.md
@@ -1,0 +1,130 @@
+# Implantar em produção
+
+Este guia cobre as etapas mínimas para executar uma aplicação baseada em NENE2 em produção: construção de uma imagem de produção, gerenciamento seguro de variáveis de ambiente e colocação de um proxy reverso na frente.
+
+**Pré-requisito**: Sua aplicação está funcionando localmente com `docker compose up -d app`.
+
+---
+
+## 1. Construir uma imagem Docker de produção
+
+A imagem de desenvolvimento monta o diretório de origem e inclui ferramentas de desenvolvimento. Para produção, construa uma imagem autossuficiente com apenas as dependências de runtime.
+
+Crie `docker/php/Dockerfile.prod`:
+
+```dockerfile
+# Etapa 1 — instalar dependências
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-progress \
+    --optimize-autoloader \
+    --prefer-dist
+
+# Etapa 2 — imagem de runtime
+FROM php:8.4-apache AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && docker-php-ext-install pdo_mysql \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod rewrite \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' \
+       > /etc/apache2/conf-available/nene2.conf \
+    && a2enconf nene2 \
+    && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html
+
+COPY public_html/ public_html/
+COPY src/         src/
+COPY config/      config/
+COPY templates/   templates/
+COPY --from=vendor /app/vendor vendor/
+COPY composer.json composer.lock ./
+
+EXPOSE 80
+```
+
+Construir e enviar:
+
+```bash
+docker build -f docker/php/Dockerfile.prod -t my-app:latest .
+docker push my-registry/my-app:latest
+```
+
+---
+
+## 2. Gerenciar variáveis de ambiente com segurança
+
+Nunca inclua um arquivo `.env` em uma imagem de produção. Injete variáveis de ambiente através do gerenciamento de segredos da sua plataforma.
+
+### Variáveis obrigatórias
+
+| Variável | Valor de produção |
+|----------|------------------|
+| `APP_ENV` | `production` |
+| `APP_DEBUG` | `false` |
+| `DB_HOST` | Seu host de banco de dados gerenciado |
+| `DB_PASSWORD` | Do gerenciador de segredos — nunca codifique diretamente |
+| `NENE2_MACHINE_API_KEY` | Do gerenciador de segredos — nunca codifique diretamente |
+
+---
+
+## 3. Colocar um proxy reverso na frente
+
+O contêiner Apache do NENE2 não é projetado para enfrentar a internet diretamente. Coloque Nginx, Caddy ou um balanceador de carga em nuvem na frente.
+
+### Exemplo Nginx
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name api.example.com;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Exemplo Caddy
+
+```caddyfile
+api.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+---
+
+## 4. Lista de verificação de segurança de produção
+
+- [ ] `APP_ENV=production` — desabilita detalhes de erro de desenvolvimento
+- [ ] `APP_DEBUG=false` — suprime rastreamentos de pilha nas respostas HTTP
+- [ ] Credenciais do banco de dados vêm de um gerenciador de segredos
+- [ ] `NENE2_MACHINE_API_KEY` é um valor aleatório forte (≥ 32 caracteres)
+- [ ] Porta do contêiner vinculada apenas ao endereço de loopback
+- [ ] TLS terminado no proxy reverso
+
+---
+
+## 5. Verificar após implantação
+
+```bash
+curl -fsS https://api.example.com/health
+curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
+```
+
+---
+
+## 6. URIs de tipo Problem Details
+
+NENE2 usa `https://nene2.dev/problems/...` como domínio de espaço reservado. Antes de ir para produção, registre esse domínio ou substitua a URL base em `ProblemDetailsResponseFactory`.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -257,10 +257,10 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 ## Phase 26: 本番デプロイガイド
 
-- [ ] docs(howto): `docs/howto/deploy-production.md` — Docker 本番イメージ・env 管理・シークレット注入.
-- [ ] docs(howto): Nginx / Caddy リバースプロキシ設定例.
-- [ ] docs(howto): 本番セキュリティチェックリスト（デバッグ無効・`APP_ENV=production`・dev エンドポイント削除）.
-- [ ] chore: `nene2.dev` Problem Details type URI プレースホルダーの方針を決定する.
+- [x] docs(howto): `docs/howto/deploy-production.md` — Docker 本番イメージ・env 管理・シークレット注入. `#278`
+- [x] docs(howto): Nginx / Caddy リバースプロキシ設定例. `#278`
+- [x] docs(howto): 本番セキュリティチェックリスト（デバッグ無効・`APP_ENV=production`・dev エンドポイント削除）. `#278`
+- [x] chore: `nene2.dev` Problem Details type URI プレースホルダーの方針を決定する（Option A/B をガイドに明記）. `#278`
 
 ## Phase 27: フロントエンドスターターコンテンツ
 

--- a/docs/zh/howto/deploy-production.md
+++ b/docs/zh/howto/deploy-production.md
@@ -1,0 +1,130 @@
+# 部署到生产环境
+
+本指南涵盖在生产环境中运行基于 NENE2 的应用程序的最低步骤：构建生产镜像、安全管理环境变量以及在前端放置反向代理。
+
+**前提条件**：您的应用程序可通过 `docker compose up -d app` 在本地正常运行。
+
+---
+
+## 1. 构建生产 Docker 镜像
+
+开发镜像挂载源目录并包含开发工具。对于生产环境，请构建仅包含运行时依赖项的独立镜像。
+
+创建 `docker/php/Dockerfile.prod`：
+
+```dockerfile
+# 阶段 1 — 安装依赖
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-progress \
+    --optimize-autoloader \
+    --prefer-dist
+
+# 阶段 2 — 运行时镜像
+FROM php:8.4-apache AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && docker-php-ext-install pdo_mysql \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod rewrite \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' \
+       > /etc/apache2/conf-available/nene2.conf \
+    && a2enconf nene2 \
+    && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html
+
+COPY public_html/ public_html/
+COPY src/         src/
+COPY config/      config/
+COPY templates/   templates/
+COPY --from=vendor /app/vendor vendor/
+COPY composer.json composer.lock ./
+
+EXPOSE 80
+```
+
+构建并推送：
+
+```bash
+docker build -f docker/php/Dockerfile.prod -t my-app:latest .
+docker push my-registry/my-app:latest
+```
+
+---
+
+## 2. 安全管理环境变量
+
+切勿在生产镜像中包含 `.env` 文件。通过平台的密钥管理注入环境变量。
+
+### 必需变量
+
+| 变量 | 生产值 |
+|------|--------|
+| `APP_ENV` | `production` |
+| `APP_DEBUG` | `false` |
+| `DB_HOST` | 托管数据库主机名 |
+| `DB_PASSWORD` | 来自密钥存储 — 切勿硬编码 |
+| `NENE2_MACHINE_API_KEY` | 来自密钥存储 — 切勿硬编码 |
+
+---
+
+## 3. 在前端放置反向代理
+
+NENE2 的 Apache 容器不适合直接面对互联网。请在前端放置 Nginx、Caddy 或云负载均衡器。
+
+### Nginx 示例
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name api.example.com;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Caddy 示例
+
+```caddyfile
+api.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+---
+
+## 4. 生产安全检查清单
+
+- [ ] `APP_ENV=production` — 禁用开发错误详情
+- [ ] `APP_DEBUG=false` — 抑制 HTTP 响应中的堆栈跟踪
+- [ ] 数据库凭据来自密钥存储
+- [ ] `NENE2_MACHINE_API_KEY` 为强随机值（≥ 32 字符）
+- [ ] 容器端口仅绑定到回环地址
+- [ ] TLS 在反向代理处终止
+
+---
+
+## 5. 部署后验证
+
+```bash
+curl -fsS https://api.example.com/health
+curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
+```
+
+---
+
+## 6. Problem Details 类型 URI
+
+NENE2 使用 `https://nene2.dev/problems/...` 作为占位域名。在投产前，请注册该域名或在 `ProblemDetailsResponseFactory` 中替换基础 URL。


### PR DESCRIPTION
## 概要

Phase 26 — 本番環境へのデプロイ手順を HOWTO として整備した。

## 追加ファイル

### `docs/howto/deploy-production.md`（英語版）
1. **マルチステージ Dockerfile.prod** — dev 依存なし・オートローダー最適化済みの本番イメージ
2. **環境変数の安全な管理** — `.env` を含めない、プラットフォーム別シークレット注入パターン
3. **リバースプロキシ設定** — Nginx と Caddy の最小設定例
4. **本番セキュリティチェックリスト** — APP_DEBUG・ポートバインド・TLS・Apache ヘッダー等
5. **デプロイ後確認手順** — `/health` と `/machine/health` の curl 検証
6. **`nene2.dev` URI 方針** — Option A（ドメイン登録）/ Option B（独自ドメイン置換）を明示

### 翻訳（5 言語）
`docs/ja/`, `docs/fr/`, `docs/zh/`, `docs/pt-br/`, `docs/de/`

### VitePress config
全 6 言語の sidebar に `deploy-production` を追加

## 検証

- `npm run docs:build` — ✅ build complete in 12.09s

Closes #278

Self-review: docs-policy