### PR TITLE
feat(frontend): Phase 27 — Note API ラッパーと NoteList・NoteForm コンポーネント (#280)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -264,9 +264,9 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 ## Phase 27: フロントエンドスターターコンテンツ
 
-- [ ] feat(frontend): API 接続済みコンポーネント（`NoteList` 等）を追加する.
-- [ ] feat(frontend): `frontend/src/api/` に Note エンドポイント向け型付き fetch ラッパーを追加する.
-- [ ] feat(frontend): `npm run dev` で Note データが表示される動作デモを完成させる.
+- [x] feat(frontend): API 接続済みコンポーネント（`NoteList`、`NoteForm`）を追加する. `#280`
+- [x] feat(frontend): `frontend/src/api/notes.ts` に Note エンドポイント向け型付き fetch ラッパーを追加する. `#280`
+- [x] feat(frontend): `npm run dev` で Note データが表示される動作デモを完成させる. `#280`
 
 ## Phase 28: 認証拡張
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -121,6 +121,152 @@ h1 {
   line-height: 1.6;
 }
 
+/* Notes section */
+.notes-section {
+  border: 1px solid #dce4f2;
+  border-radius: 1rem;
+  background: #ffffff;
+  margin-top: 1rem;
+  padding: 1.5rem;
+}
+
+.section-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.25rem;
+}
+
+.section-desc {
+  margin: 0 0 1.25rem;
+  color: #566174;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}
+
+.note-list {
+  list-style: none;
+  margin: 0 0 1.5rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.note-item {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  border: 1px solid #edf2fb;
+  border-radius: 0.75rem;
+  padding: 0.875rem 1rem;
+}
+
+.note-id {
+  flex-shrink: 0;
+  color: #4d63ff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding-top: 0.125rem;
+}
+
+.note-content {
+  min-width: 0;
+}
+
+.note-title {
+  display: block;
+  font-size: 0.9375rem;
+}
+
+.note-body {
+  margin: 0.25rem 0 0;
+  color: #566174;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.note-loading,
+.note-empty {
+  margin: 0 0 1.5rem;
+  color: #566174;
+  font-size: 0.9375rem;
+}
+
+.note-error {
+  margin: 0 0 1rem;
+  color: #c0392b;
+  font-size: 0.9375rem;
+}
+
+/* Note form */
+.note-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-top: 1px solid #edf2fb;
+  padding-top: 1.25rem;
+}
+
+.note-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.note-form-field label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #2d3a50;
+}
+
+.note-form-field input,
+.note-form-field textarea {
+  border: 1px solid #c8d3e8;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9375rem;
+  font-family: inherit;
+  color: #172033;
+  background: #f7f9fc;
+  resize: vertical;
+  transition: border-color 0.15s;
+}
+
+.note-form-field input:focus,
+.note-form-field textarea:focus {
+  outline: none;
+  border-color: #4d63ff;
+  background: #ffffff;
+}
+
+.note-form-field input:disabled,
+.note-form-field textarea:disabled {
+  opacity: 0.6;
+}
+
+.note-submit {
+  align-self: flex-start;
+  border: none;
+  border-radius: 0.5rem;
+  background: #4d63ff;
+  color: #ffffff;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  padding: 0.625rem 1.25rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.note-submit:hover:not(:disabled) {
+  background: #3a4fe0;
+}
+
+.note-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 @media (max-width: 720px) {
   .hero {
     padding: 2rem;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,16 +2,13 @@ import { useEffect, useState } from 'react';
 
 import './App.css';
 import { fetchHealth, type HealthResponse } from './api/health';
-
-const apiHighlights = [
-  'JSON APIs first',
-  'PSR-first PHP runtime',
-  'OpenAPI contract ready',
-] as const;
+import { NoteList } from './components/NoteList';
+import { NoteForm } from './components/NoteForm';
 
 export function App() {
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [healthError, setHealthError] = useState<string | null>(null);
+  const [noteRefresh, setNoteRefresh] = useState(0);
 
   useEffect(() => {
     let isActive = true;
@@ -36,6 +33,10 @@ export function App() {
       isActive = false;
     };
   }, []);
+
+  function handleNoteCreated() {
+    setNoteRefresh((n) => n + 1);
+  }
 
   return (
     <main className="app-shell">
@@ -66,16 +67,16 @@ export function App() {
         )}
       </section>
 
-      <section className="cards" aria-label="Starter highlights">
-        {apiHighlights.map((highlight) => (
-          <article className="card" key={highlight}>
-            <h2>{highlight}</h2>
-            <p>
-              Ready for thin integration with NENE2 without coupling application
-              code to React.
-            </p>
-          </article>
-        ))}
+      <section className="notes-section" aria-labelledby="notes-title">
+        <h2 id="notes-title" className="section-title">
+          Notes
+        </h2>
+        <p className="section-desc">
+          Live data from <code>GET /examples/notes</code>. Create a note with
+          the form below to see the list update.
+        </p>
+        <NoteList refresh={noteRefresh} />
+        <NoteForm onCreated={handleNoteCreated} />
       </section>
     </main>
   );

--- a/frontend/src/api/notes.ts
+++ b/frontend/src/api/notes.ts
@@ -1,0 +1,109 @@
+const defaultApiBaseUrl = '/api';
+
+function apiBase(): string {
+  return (
+    (import.meta.env.VITE_NENE2_API_BASE_URL as string | undefined) ??
+    defaultApiBaseUrl
+  );
+}
+
+export type Note = {
+  readonly id: number;
+  readonly title: string;
+  readonly body: string;
+};
+
+export type NoteListResponse = {
+  readonly items: readonly Note[];
+  readonly limit: number;
+  readonly offset: number;
+};
+
+export type CreateNoteRequest = {
+  readonly title: string;
+  readonly body: string;
+};
+
+function isNote(value: unknown): value is Note {
+  if (typeof value !== 'object' || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return (
+    typeof c.id === 'number' &&
+    typeof c.title === 'string' &&
+    typeof c.body === 'string'
+  );
+}
+
+function isNoteListResponse(value: unknown): value is NoteListResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return (
+    Array.isArray(c.items) &&
+    c.items.every(isNote) &&
+    typeof c.limit === 'number' &&
+    typeof c.offset === 'number'
+  );
+}
+
+export async function fetchNotes(
+  limit = 20,
+  offset = 0,
+): Promise<NoteListResponse> {
+  const url = `${apiBase()}/examples/notes?limit=${limit}&offset=${offset}`;
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch notes: HTTP ${response.status}.`);
+  }
+
+  const payload: unknown = await response.json();
+
+  if (!isNoteListResponse(payload)) {
+    throw new Error('Note list response did not match the expected shape.');
+  }
+
+  return payload;
+}
+
+export async function fetchNoteById(id: number): Promise<Note> {
+  const response = await fetch(`${apiBase()}/examples/notes/${id}`, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch note ${id}: HTTP ${response.status}.`);
+  }
+
+  const payload: unknown = await response.json();
+
+  if (!isNote(payload)) {
+    throw new Error('Note response did not match the expected shape.');
+  }
+
+  return payload;
+}
+
+export async function createNote(input: CreateNoteRequest): Promise<Note> {
+  const response = await fetch(`${apiBase()}/examples/notes`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to create note: HTTP ${response.status}.`);
+  }
+
+  const payload: unknown = await response.json();
+
+  if (!isNote(payload)) {
+    throw new Error('Create note response did not match the expected shape.');
+  }
+
+  return payload;
+}

--- a/frontend/src/components/NoteForm.tsx
+++ b/frontend/src/components/NoteForm.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { createNote } from '../api/notes';
+
+type Props = {
+  readonly onCreated: () => void;
+};
+
+export function NoteForm({ onCreated }: Props) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await createNote({ title, body });
+      setTitle('');
+      setBody('');
+      onCreated();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="note-form" onSubmit={handleSubmit} noValidate>
+      <div className="note-form-field">
+        <label htmlFor="note-title">Title</label>
+        <input
+          id="note-title"
+          type="text"
+          value={title}
+          onChange={(e) => {
+            setTitle(e.target.value);
+          }}
+          required
+          minLength={1}
+          placeholder="Note title"
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="note-form-field">
+        <label htmlFor="note-body">Body</label>
+        <textarea
+          id="note-body"
+          value={body}
+          onChange={(e) => {
+            setBody(e.target.value);
+          }}
+          required
+          minLength={1}
+          placeholder="Note body"
+          rows={3}
+          disabled={submitting}
+        />
+      </div>
+
+      {error !== null && <p className="note-error">{error}</p>}
+
+      <button
+        type="submit"
+        className="note-submit"
+        disabled={submitting || title.trim() === '' || body.trim() === ''}
+      >
+        {submitting ? 'Creating…' : 'Create note'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { fetchNotes, type Note } from '../api/notes';
+
+type LoadState =
+  | { phase: 'loading' }
+  | { phase: 'error'; message: string }
+  | { phase: 'ok'; notes: readonly Note[] };
+
+type Props = {
+  readonly refresh: number;
+};
+
+export function NoteList({ refresh }: Props) {
+  const [state, setState] = useState<LoadState>({ phase: 'loading' });
+
+  useEffect(() => {
+    let isActive = true;
+
+    fetchNotes()
+      .then((res) => {
+        if (isActive) setState({ phase: 'ok', notes: res.items });
+      })
+      .catch((err: unknown) => {
+        if (isActive) {
+          setState({
+            phase: 'error',
+            message: err instanceof Error ? err.message : 'Unknown error',
+          });
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [refresh]);
+
+  if (state.phase === 'error') {
+    return <p className="note-error">{state.message}</p>;
+  }
+
+  if (state.phase === 'loading') {
+    return <p className="note-loading">Loading notes…</p>;
+  }
+
+  if (state.notes.length === 0) {
+    return (
+      <p className="note-empty">No notes yet. Create the first one below.</p>
+    );
+  }
+
+  return (
+    <ul className="note-list">
+      {state.notes.map((note) => (
+        <li key={note.id} className="note-item">
+          <span className="note-id">#{note.id}</span>
+          <div className="note-content">
+            <strong className="note-title">{note.title}</strong>
+            <p className="note-body">{note.body}</p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary

- `frontend/src/api/notes.ts`: `fetchNotes` / `fetchNoteById` / `createNote` の型付き fetch ラッパーを追加（`health.ts` と同パターン）
- `frontend/src/components/NoteList.tsx`: `GET /examples/notes` からライブデータを取得して一覧表示。`LoadState` union 型で loading / error / ok を管理
- `frontend/src/components/NoteForm.tsx`: `POST /examples/notes` でノートを作成するフォーム。送信後に `onCreated` コールバックで親に通知
- `frontend/src/App.tsx`: Note セクションを追加し、作成後に `noteRefresh` カウンタをインクリメントして一覧を自動更新
- `frontend/src/App.css`: ノートリスト・フォーム用スタイルを追加

## Test plan

- [x] `npm run check --prefix frontend` 通過（type-check + lint + Prettier）
- [x] `npm run build --prefix frontend` 通過（195 KB JS bundle）
- [x] `react-hooks/set-state-in-effect` ESLint ルールに適合する `LoadState` union 型パターンを採用

## Related

Closes #280

Self-review: frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)