### PR TITLE
feat(auth): Phase 28 — BearerTokenMiddleware スタブと JWT 認証 ADR 0008 (#282)

### DIFF
--- a/docs/adr/0008-jwt-authentication.md
+++ b/docs/adr/0008-jwt-authentication.md
@@ -1,0 +1,71 @@
+# ADR 0008: JWT Authentication Direction
+
+## Status
+
+accepted
+
+## Context
+
+NENE2 already ships an API-key middleware path (`ApiKeyAuthenticationMiddleware`) for machine clients.
+Applications that serve human users — or service-to-service flows that need short-lived, scoped tokens — need a Bearer token path.
+
+The options evaluated:
+
+| Option | Coupling | Flexibility | Notes |
+|--------|----------|-------------|-------|
+| Hard-code `firebase/php-jwt` into the middleware | High | Low | Locks the framework to one library |
+| Expose a `TokenVerifierInterface`, ship no concrete implementation | None | High | Applications plug in any JWT library or identity provider |
+| Build a full OAuth 2.0 server | Very high | N/A | Far beyond framework scope |
+
+**Recommended concrete library** (for applications that adopt JWT): `firebase/php-jwt` — actively maintained, minimal API surface, supports RS256 / ES256 / HS256.
+
+## Decision
+
+1. Define `Nene2\Auth\TokenVerifierInterface` with a single `verify(string $token): array<string, mixed>` method that either returns claims or throws `TokenVerificationException`.
+2. Implement `Nene2\Auth\BearerTokenMiddleware` as a PSR-15 middleware that:
+   - Reads the `Authorization: Bearer <token>` header.
+   - Delegates verification to `TokenVerifierInterface`.
+   - On success: forwards the request with `nene2.auth.claims` and `nene2.auth.credential_type = bearer` request attributes set.
+   - On failure: returns a 401 Problem Details response with a `WWW-Authenticate: Bearer` challenge header (RFC 6750).
+3. Ship **no concrete JWT verifier** in the framework core. Applications wire their preferred library through the interface.
+4. Add a `firebase/php-jwt` integration note to `authentication-boundary.md` as the recommended starting point.
+
+### Middleware placement (pipeline position 6)
+
+```
+1. Error handling
+2. Request id
+3. Security headers
+4. CORS
+5. Request size limit
+6. Authentication / authorization  ← BearerTokenMiddleware or ApiKeyAuthenticationMiddleware
+7. OpenAPI or request validation
+8. Routing / handler dispatch
+```
+
+### Request attributes set on success
+
+| Attribute | Type | Value |
+|-----------|------|-------|
+| `nene2.auth.credential_type` | `string` | `"bearer"` |
+| `nene2.auth.claims` | `array<string, mixed>` | Verified JWT payload |
+
+## Consequences
+
+**Benefits**
+- The framework core stays library-agnostic; the interface is the only coupling.
+- Applications can use any JWT library, JWKS endpoint adapter, or opaque token verifier.
+- The middleware is testable in isolation: pass a stub `TokenVerifierInterface`.
+
+**Costs / follow-up work**
+- Applications must wire a concrete `TokenVerifierInterface` implementation before using the middleware.
+- OpenAPI security scheme (`bearerAuth`) should be added when the middleware is wired to real routes.
+- Scope enforcement is not in scope for this ADR; it belongs in a future `AuthorizationMiddleware` or handler-level guard.
+
+## Related
+
+- Issue: `#282`
+- PR: `#283`
+- Supersedes: none
+- Superseded by: none
+- See also: `docs/development/authentication-boundary.md`

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -13,6 +13,7 @@ Architecture decisions are recorded here as lightweight ADRs. Each record captur
 | [0005](0005-use-monolog-for-structured-logging.md) | Use Monolog for structured logging |
 | [0006](0006-v0.2.0-scope-and-packagist-policy.md) | v0.2.0 scope and Packagist policy |
 | [0007](0007-put-vs-patch-policy.md) | PUT vs PATCH policy |
+| [0008](0008-jwt-authentication.md) | JWT authentication direction |
 
 ## Template
 

--- a/docs/development/authentication-boundary.md
+++ b/docs/development/authentication-boundary.md
@@ -61,6 +61,56 @@ Bearer tokens should be treated as secrets even when they are short-lived.
 
 The framework should not prescribe one token format before an authentication adapter exists. JWT, opaque tokens, or external identity provider tokens can be supported by adapters later.
 
+## JWT Authentication (ADR 0008)
+
+NENE2 provides `BearerTokenMiddleware` as a PSR-15 middleware that reads `Authorization: Bearer <token>` and delegates verification to a `TokenVerifierInterface`.
+
+The framework ships **no concrete JWT verifier**. Applications wire their preferred library through the interface. The recommended starting point is `firebase/php-jwt`:
+
+```bash
+composer require firebase/php-jwt
+```
+
+### Wiring example
+
+```php
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+
+$verifier = new class ($secret) implements TokenVerifierInterface {
+    public function __construct(private readonly string $secret) {}
+
+    public function verify(string $token): array
+    {
+        try {
+            $decoded = JWT::decode($token, new Key($this->secret, 'HS256'));
+            return (array) $decoded;
+        } catch (\Exception $e) {
+            throw new TokenVerificationException($e->getMessage(), previous: $e);
+        }
+    }
+};
+
+// Pipeline position 6 — after CORS, before routing
+$pipeline->pipe(new BearerTokenMiddleware($problemDetails, $verifier));
+```
+
+### Request attributes set on success
+
+| Attribute | Value |
+|-----------|-------|
+| `nene2.auth.credential_type` | `"bearer"` |
+| `nene2.auth.claims` | `array<string, mixed>` — decoded JWT payload |
+
+### Failure responses
+
+Missing or invalid tokens return HTTP 401 with `application/problem+json` and a `WWW-Authenticate: Bearer` challenge header (RFC 6750).
+
+See `docs/adr/0008-jwt-authentication.md` for the full decision record.
+
 ## Scopes
 
 Scopes describe allowed capabilities.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -270,9 +270,9 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 ## Phase 28: 認証拡張
 
-- [ ] docs(adr): ADR 0008 — JWT 認証方向（ライブラリ選定・トークン検証境界・PSR-15 ミドルウェア配置）.
-- [ ] feat(auth): `BearerTokenMiddleware` スタブと検証用インターフェースを追加する.
-- [ ] docs(auth): `authentication-boundary.md` を JWT/OAuth2 セクションで拡張する.
+- [x] docs(adr): ADR 0008 — JWT 認証方向（ライブラリ選定・トークン検証境界・PSR-15 ミドルウェア配置）. `#282`
+- [x] feat(auth): `BearerTokenMiddleware` スタブと `TokenVerifierInterface` を追加する. `#282`
+- [x] docs(auth): `authentication-boundary.md` を JWT セクションで拡張する. `#282`
 
 ## Operating Notes
 

--- a/src/Auth/BearerTokenMiddleware.php
+++ b/src/Auth/BearerTokenMiddleware.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class BearerTokenMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+        private TokenVerifierInterface $verifier,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $authorization = $request->getHeaderLine('Authorization');
+
+        if ($authorization === '') {
+            return $this->unauthorized($request, 'missing_token', 'No Bearer token was provided.');
+        }
+
+        if (!str_starts_with($authorization, 'Bearer ')) {
+            return $this->unauthorized($request, 'invalid_token', 'Authorization header must use the Bearer scheme.');
+        }
+
+        $token = substr($authorization, 7);
+
+        try {
+            $claims = $this->verifier->verify($token);
+        } catch (TokenVerificationException $e) {
+            return $this->unauthorized($request, 'invalid_token', $e->getMessage());
+        }
+
+        return $handler->handle(
+            $request
+                ->withAttribute('nene2.auth.credential_type', 'bearer')
+                ->withAttribute('nene2.auth.claims', $claims),
+        );
+    }
+
+    private function unauthorized(ServerRequestInterface $request, string $error, string $description): ResponseInterface
+    {
+        return $this->problemDetails
+            ->create($request, 'unauthorized', 'Unauthorized', 401, $description)
+            ->withHeader(
+                'WWW-Authenticate',
+                sprintf('Bearer realm="NENE2", error="%s", error_description="%s"', $error, $description),
+            );
+    }
+}

--- a/src/Auth/TokenVerificationException.php
+++ b/src/Auth/TokenVerificationException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+use RuntimeException;
+
+final class TokenVerificationException extends RuntimeException
+{
+}

--- a/src/Auth/TokenVerifierInterface.php
+++ b/src/Auth/TokenVerifierInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+/**
+ * Verifies a raw bearer token string and returns the decoded claims.
+ *
+ * Throw TokenVerificationException for any failure: expired, bad signature, malformed, etc.
+ */
+interface TokenVerifierInterface
+{
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws TokenVerificationException
+     */
+    public function verify(string $token): array;
+}

--- a/tests/Auth/BearerTokenMiddlewareTest.php
+++ b/tests/Auth/BearerTokenMiddlewareTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Auth;
+
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class BearerTokenMiddlewareTest extends TestCase
+{
+    public function testMissingAuthorizationHeaderReturns401(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = $this->makeMiddleware($factory, $this->acceptingVerifier());
+        $request = $factory->createServerRequest('GET', 'https://example.test/protected');
+
+        $response = $middleware->process($request, $this->failHandler());
+        $payload = $this->decodeBody($response);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertStringContainsString('application/problem+json', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('Bearer', $response->getHeaderLine('WWW-Authenticate'));
+        self::assertStringContainsString('missing_token', $response->getHeaderLine('WWW-Authenticate'));
+        self::assertSame('https://nene2.dev/problems/unauthorized', $payload['type']);
+    }
+
+    public function testNonBearerSchemeReturns401(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = $this->makeMiddleware($factory, $this->acceptingVerifier());
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/protected')
+            ->withHeader('Authorization', 'Basic dXNlcjpwYXNz');
+
+        $response = $middleware->process($request, $this->failHandler());
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertStringContainsString('invalid_token', $response->getHeaderLine('WWW-Authenticate'));
+    }
+
+    public function testInvalidTokenReturns401(): void
+    {
+        $factory = new Psr17Factory();
+        $verifier = new class () implements TokenVerifierInterface {
+            public function verify(string $token): array
+            {
+                throw new TokenVerificationException('Token has expired.');
+            }
+        };
+        $middleware = $this->makeMiddleware($factory, $verifier);
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/protected')
+            ->withHeader('Authorization', 'Bearer expired.token.here');
+
+        $response = $middleware->process($request, $this->failHandler());
+        $payload = $this->decodeBody($response);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('Token has expired.', $payload['detail']);
+    }
+
+    public function testValidTokenForwardsRequestWithClaims(): void
+    {
+        $factory = new Psr17Factory();
+        $claims = ['sub' => 'user-42', 'scope' => 'read:system'];
+        $middleware = $this->makeMiddleware($factory, $this->acceptingVerifier($claims));
+
+        $capture = new \stdClass();
+        $capture->request = null;
+
+        $handler = new class ($factory, $capture) implements RequestHandlerInterface {
+            public function __construct(
+                private readonly Psr17Factory $factory,
+                private readonly \stdClass $capture,
+            ) {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->capture->request = $request;
+
+                return $this->factory->createResponse(200);
+            }
+        };
+
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/protected')
+            ->withHeader('Authorization', 'Bearer valid.token.here');
+
+        $response = $middleware->process($request, $handler);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertInstanceOf(ServerRequestInterface::class, $capture->request);
+        self::assertSame('bearer', $capture->request->getAttribute('nene2.auth.credential_type'));
+        self::assertSame($claims, $capture->request->getAttribute('nene2.auth.claims'));
+    }
+
+    private function makeMiddleware(Psr17Factory $factory, TokenVerifierInterface $verifier): BearerTokenMiddleware
+    {
+        return new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $verifier,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $claims
+     */
+    private function acceptingVerifier(array $claims = []): TokenVerifierInterface
+    {
+        return new class ($claims) implements TokenVerifierInterface {
+            /** @param array<string, mixed> $claims */
+            public function __construct(private readonly array $claims)
+            {
+            }
+
+            public function verify(string $token): array
+            {
+                return $this->claims;
+            }
+        };
+    }
+
+    private function failHandler(): RequestHandlerInterface
+    {
+        return new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                throw new \LogicException('Handler should not be reached.');
+            }
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeBody(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Summary

- `src/Auth/TokenVerifierInterface` — `verify(string $token): array<string, mixed>` 単一メソッドのインターフェース。フレームワークは具体的な JWT ライブラリに依存しない
- `src/Auth/TokenVerificationException` — 検証失敗時にスローする例外
- `src/Auth/BearerTokenMiddleware` — PSR-15 ミドルウェア（位置: pipeline step 6）
  - `Authorization: Bearer <token>` を解析
  - `TokenVerifierInterface` に検証を委譲
  - 成功時: `nene2.auth.credential_type = bearer` と `nene2.auth.claims` を request 属性に設定
  - 失敗時: 401 Problem Details + `WWW-Authenticate: Bearer` チャレンジヘッダー（RFC 6750）
- `docs/adr/0008-jwt-authentication.md` — ライブラリ非依存設計の決定記録。`firebase/php-jwt` を推奨具体実装として記録
- `docs/development/authentication-boundary.md` — JWT セクションを追加（配線例、成功時 request 属性、失敗レスポンス仕様）

## Test plan

- [x] `tests/Auth/BearerTokenMiddlewareTest.php` — 4 テスト（missing / wrong scheme / invalid / valid token）すべて通過
- [x] `composer check` 通過（142 tests, 500 assertions、PHPStan level 8、CS-Fixer、OpenAPI、MCP）

## Related

Closes #282

Self-review: backend-api, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)