### PR TITLE
chore(release): Phase 29 — v0.5.0 CHANGELOG 確定・ロードマップ拡張 (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.0] — 2026-05-17
+
+### Added
+- Diátaxis Explanation pages in 6 languages (English, Japanese, French, Chinese, Portuguese, German): `why-psr`, `why-explicit-wiring`, `why-problem-details`, `why-mcp` (#275)
+- Second domain entity example: `src/Example/Tag/` with full CRUD (#277)
+  - `GET /examples/tags`, `POST /examples/tags`, `GET /examples/tags/{id}`
+  - `ListTagsUseCase`, `GetTagByIdUseCase`, `CreateTagUseCase` with readonly DTOs
+  - `PdoTagRepository`, `InMemoryTagRepository`, `TagServiceProvider`
+  - OpenAPI schemas and 8 HTTP-level tests
+- Production deployment guide (`docs/howto/deploy-production.md`) with multi-stage `Dockerfile.prod`, env management, Nginx/Caddy reverse proxy examples, security checklist, and post-deploy verification in 6 languages (#279)
+- Frontend starter content: `NoteList` and `NoteForm` React components with live API integration (#281)
+  - Typed fetch wrapper `frontend/src/api/notes.ts` for all Note endpoints
+  - `LoadState` union type pattern for loading / error / ok states
+  - `App.tsx` wired to refresh the list on note creation
+- `src/Auth/BearerTokenMiddleware` — PSR-15 middleware for `Authorization: Bearer` tokens; returns RFC 6750-compliant 401 Problem Details on failure (#283)
+- `src/Auth/TokenVerifierInterface` — pluggable token verifier; framework ships no concrete JWT library dependency (#283)
+- `src/Auth/TokenVerificationException` — thrown by verifier implementations on any failure (#283)
+- ADR 0008: JWT authentication direction — library-agnostic design, `firebase/php-jwt` as recommended starting point (#283)
+- VitePress 1.6.4 multilingual documentation site with 6 locales, Explanation nav/sidebar, and production deployment sidebar entry (#275)
+
+### Changed
+- CI `backend.yml`: explicit PHP extensions (`pdo`, `pdo_sqlite`, `pdo_mysql`) and Composer dependency cache (#273)
+- CI `docs.yml`: `cache-dependency-path: package-lock.json` added to setup-node step (#273)
+- `docs/development/authentication-boundary.md`: JWT section with `firebase/php-jwt` wiring example, request attribute table, and failure response specification (#283)
+- `docs/adr/index.md`: ADR 0008 entry added (#283)
+
+---
+
 ## [0.4.0] — 2026-05-17
 
 ### Added

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -363,6 +363,40 @@ Goal: document the JWT and OAuth2 direction so client projects adopting NENE2 ha
 - Decision on whether `nene2.dev` domain will be registered or replaced in Problem Details type URIs
 - Update self-review checklist with JWT/OAuth2 checkpoints
 
+## Phase 29: v0.5.0 Readiness
+
+Goal: consolidate Phase 23–28 additions into a versioned release so adopters get a stable checkpoint covering documentation, second domain entity, frontend starter, production guide, and JWT auth stub.
+
+- CHANGELOG.md v0.5.0 section (Phases 23–28)
+- `v0.5.0` tag on main
+- Roadmap and TODO updated
+
+## Phase 30: OpenAPI Bearer Security Scheme
+
+Goal: make the `BearerTokenMiddleware` fully integrated into the OpenAPI contract with a concrete local demo.
+
+- Add `bearerAuth` `securitySchemes` entry to OpenAPI document
+- Add `LocalBearerTokenVerifier` (HMAC-HS256) for local development wiring
+- Wire `BearerTokenMiddleware` + `LocalBearerTokenVerifier` to a new `GET /examples/protected` endpoint
+- Add `security: [bearerAuth]` to the protected endpoint's OpenAPI path
+- Add HTTP-level tests for 200 (valid token) and 401 (missing/invalid) cases
+
+## Phase 31: Self-Review Checklist — Auth Checkpoints
+
+Goal: add JWT/OAuth2 checkpoints to `docs/review/middleware-security.md` so PRs that touch authentication are reviewed consistently.
+
+- Add Bearer token checklist items: interface injection, WWW-Authenticate header, no secret logging
+- Add OpenAPI security scheme checklist: `bearerAuth` present, 401 response documented
+- Add ADR 0008 compliance reminder
+
+## Phase 32: Field Trial 6 — JWT End-to-End
+
+Goal: validate `BearerTokenMiddleware` + `LocalBearerTokenVerifier` in a realistic project scenario.
+
+- Start MCP client against NENE2 with a protected endpoint
+- Issue a local JWT and verify the tool call succeeds
+- Record friction and open follow-up Issues
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -274,6 +274,12 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] feat(auth): `BearerTokenMiddleware` スタブと `TokenVerifierInterface` を追加する. `#282`
 - [x] docs(auth): `authentication-boundary.md` を JWT セクションで拡張する. `#282`
 
+## Phase 29: v0.5.0 リリース準備
+
+- [x] docs(roadmap): Phase 29-32 をロードマップに追加する. `#284`
+- [x] chore(changelog): v0.5.0 セクション（Phase 23-28）を追記する. `#284`
+- [ ] chore(release): `v0.5.0` タグを打つ. `#284`
+
 ## Operating Notes
 
 - Keep this file short.


### PR DESCRIPTION
## Summary

- `CHANGELOG.md`: v0.5.0 セクションを追記（Phase 23-28 の全変更点）
- `docs/roadmap.md`: Phase 29-32 を追加（v0.5.0 リリース / OpenAPI bearerAuth / セルフレビューチェックリスト更新 / Field Trial 6）
- `docs/todo/current.md`: Phase 29 タスクリストを追加

## Covered in v0.5.0

- Phase 23: CI Hardening（backend.yml 拡張・docs.yml cache-dependency-path）
- Phase 24: Diátaxis Explanation ページ × 6 言語
- Phase 25: Tag ドメインエンティティ（GET/POST/GET-by-id・テスト 8 本）
- Phase 26: 本番デプロイガイド × 6 言語
- Phase 27: フロントエンドスターターコンテンツ（NoteList・NoteForm）
- Phase 28: BearerTokenMiddleware + TokenVerifierInterface + ADR 0008

## Test plan

- [x] `composer check` 通過済み（142 tests, 500 assertions）

Closes #284

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)