### PR TITLE
feat(auth): Phase 30 — LocalBearerTokenVerifier + OpenAPI bearerAuth + GET /examples/protected (#287)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -92,6 +92,34 @@ paths:
           $ref: '#/components/responses/PayloadTooLarge'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /examples/protected:
+    get:
+      tags:
+        - Examples
+      summary: Protected example endpoint
+      description: Demonstrates BearerTokenMiddleware. Returns the authenticated user's JWT claims. Requires NENE2_LOCAL_JWT_SECRET to be set in the environment.
+      operationId: getProtected
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Authenticated response with JWT claims.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProtectedResponse'
+              examples:
+                ok:
+                  summary: Successful authenticated response
+                  value:
+                    message: Welcome, authenticated user.
+                    claims:
+                      sub: user-42
+                      scope: read:system
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /examples/tags:
     get:
       tags:
@@ -443,6 +471,11 @@ components:
       in: header
       name: X-NENE2-API-Key
       description: API key for machine clients. Do not commit real key values.
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: HS256 JWT for user or service authentication. Wire a TokenVerifierInterface implementation to enable.
   responses:
     Unauthorized:
       description: A valid API key is required for this endpoint.
@@ -757,6 +790,21 @@ components:
         offset:
           type: integer
           example: 0
+    ProtectedResponse:
+      type: object
+      required:
+        - message
+        - claims
+      properties:
+        message:
+          type: string
+          example: Welcome, authenticated user.
+        claims:
+          type: object
+          additionalProperties: true
+          example:
+            sub: user-42
+            scope: read:system
     ExampleNoteListResponse:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -280,6 +280,14 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] chore(changelog): v0.5.0 セクション（Phase 23-28）を追記する. `#284`
 - [x] chore(release): `v0.5.0` タグを打つ. `#284`
 
+## Phase 30: OpenAPI bearerAuth スキームと LocalBearerTokenVerifier
+
+- [x] feat(auth): `LocalBearerTokenVerifier`（HMAC-HS256、外部ライブラリ不要）を追加する. `#287`
+- [x] feat(auth): `BearerTokenMiddleware` に `$protectedPaths` を追加する. `#287`
+- [x] feat(config): `NENE2_LOCAL_JWT_SECRET` を AppConfig / ConfigLoader に追加する. `#287`
+- [x] feat(http): `GET /examples/protected` ルートと BearerTokenMiddleware 注入を追加する. `#287`
+- [x] docs(openapi): `bearerAuth` securityScheme と `/examples/protected` パスを追加する. `#287`
+
 ## Operating Notes
 
 - Keep this file short.

--- a/src/Auth/BearerTokenMiddleware.php
+++ b/src/Auth/BearerTokenMiddleware.php
@@ -12,14 +12,22 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final readonly class BearerTokenMiddleware implements MiddlewareInterface
 {
+    /**
+     * @param list<string> $protectedPaths Restrict protection to these paths. Empty list protects all paths.
+     */
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
         private TokenVerifierInterface $verifier,
+        private array $protectedPaths = [],
     ) {
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        if (!$this->requiresAuthentication($request)) {
+            return $handler->handle($request);
+        }
+
         $authorization = $request->getHeaderLine('Authorization');
 
         if ($authorization === '') {
@@ -43,6 +51,17 @@ final readonly class BearerTokenMiddleware implements MiddlewareInterface
                 ->withAttribute('nene2.auth.credential_type', 'bearer')
                 ->withAttribute('nene2.auth.claims', $claims),
         );
+    }
+
+    private function requiresAuthentication(ServerRequestInterface $request): bool
+    {
+        if ($this->protectedPaths === []) {
+            return true;
+        }
+
+        $path = $request->getUri()->getPath() ?: '/';
+
+        return in_array($path, $this->protectedPaths, true);
     }
 
     private function unauthorized(ServerRequestInterface $request, string $error, string $description): ResponseInterface

--- a/src/Auth/LocalBearerTokenVerifier.php
+++ b/src/Auth/LocalBearerTokenVerifier.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+/**
+ * HMAC-HS256 JWT verifier for local development.
+ * Uses no external library — suitable only for controlled local environments.
+ * Production deployments should inject a library-backed TokenVerifierInterface.
+ */
+final readonly class LocalBearerTokenVerifier implements TokenVerifierInterface
+{
+    public function __construct(private string $secret)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws TokenVerificationException
+     */
+    public function verify(string $token): array
+    {
+        $parts = explode('.', $token);
+
+        if (count($parts) !== 3) {
+            throw new TokenVerificationException('Token format is invalid: expected three dot-separated segments.');
+        }
+
+        [$headerB64, $payloadB64, $sigB64] = $parts;
+
+        $header = $this->decodeJsonSegment($headerB64);
+
+        if (($header['alg'] ?? null) !== 'HS256') {
+            throw new TokenVerificationException('Token algorithm must be HS256.');
+        }
+
+        $expected = $this->base64UrlEncode(
+            hash_hmac('sha256', $headerB64 . '.' . $payloadB64, $this->secret, true)
+        );
+
+        if (!hash_equals($expected, $sigB64)) {
+            throw new TokenVerificationException('Token signature is invalid.');
+        }
+
+        $claims = $this->decodeJsonSegment($payloadB64);
+
+        if (isset($claims['exp']) && is_int($claims['exp']) && $claims['exp'] < time()) {
+            throw new TokenVerificationException('Token has expired.');
+        }
+
+        return $claims;
+    }
+
+    /**
+     * Issue a signed HS256 JWT for local testing.
+     *
+     * @param array<string, mixed> $claims
+     */
+    public function issue(array $claims): string
+    {
+        $headerB64 = $this->base64UrlEncode((string) json_encode(['typ' => 'JWT', 'alg' => 'HS256'], JSON_THROW_ON_ERROR));
+        $payloadB64 = $this->base64UrlEncode((string) json_encode($claims, JSON_THROW_ON_ERROR));
+        $sigB64 = $this->base64UrlEncode(hash_hmac('sha256', $headerB64 . '.' . $payloadB64, $this->secret, true));
+
+        return $headerB64 . '.' . $payloadB64 . '.' . $sigB64;
+    }
+
+    private function base64UrlEncode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws TokenVerificationException
+     */
+    private function decodeJsonSegment(string $b64): array
+    {
+        $json = base64_decode(strtr($b64, '-_', '+/'), strict: true);
+
+        if ($json === false) {
+            throw new TokenVerificationException('Token segment has invalid base64url encoding.');
+        }
+
+        try {
+            $decoded = json_decode($json, associative: true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            throw new TokenVerificationException('Token segment has invalid JSON.');
+        }
+
+        if (!is_array($decoded)) {
+            throw new TokenVerificationException('Token segment must be a JSON object.');
+        }
+
+        return $decoded;
+    }
+}

--- a/src/Config/AppConfig.php
+++ b/src/Config/AppConfig.php
@@ -12,6 +12,7 @@ final readonly class AppConfig
         public string $name,
         public DatabaseConfig $database,
         public ?string $machineApiKey,
+        public ?string $localJwtSecret = null,
     ) {
         if ($this->name === '') {
             throw new ConfigException('APP_NAME must not be empty.');

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -18,6 +18,7 @@ final readonly class ConfigLoader
             'APP_DEBUG' => 'false',
             'APP_NAME' => 'NENE2',
             'NENE2_MACHINE_API_KEY' => '',
+            'NENE2_LOCAL_JWT_SECRET' => '',
             'DATABASE_URL' => '',
             'DB_ENV' => 'local',
             'DB_ADAPTER' => 'mysql',
@@ -60,6 +61,7 @@ final readonly class ConfigLoader
                 trim($values['DB_CHARSET']),
             ),
             $this->optionalString($values['NENE2_MACHINE_API_KEY']),
+            $this->optionalString($values['NENE2_LOCAL_JWT_SECRET']),
         );
     }
 

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Http;
 
+use Nene2\Auth\BearerTokenMiddleware;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ErrorHandlerMiddleware;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -54,6 +55,7 @@ final readonly class RuntimeApplicationFactory
         private ?ListTagsHandler $listTagsHandler = null,
         private ?GetTagByIdHandler $getTagByIdHandler = null,
         private ?CreateTagHandler $createTagHandler = null,
+        private ?BearerTokenMiddleware $bearerTokenMiddleware = null,
     ) {
     }
 
@@ -161,21 +163,34 @@ final readonly class RuntimeApplicationFactory
             );
         }
 
+        if ($this->bearerTokenMiddleware !== null) {
+            $router->get(
+                '/examples/protected',
+                static fn (ServerRequestInterface $request) => $jsonResponses->create([
+                    'message' => 'Welcome, authenticated user.',
+                    'claims' => $request->getAttribute('nene2.auth.claims') ?? [],
+                ]),
+            );
+        }
+
         foreach ($this->routeRegistrars as $registrar) {
             $registrar($router);
         }
 
-        return new MiddlewareDispatcher(
-            [
-                new RequestIdMiddleware('X-Request-Id', $this->requestIdHolder),
-                new RequestLoggingMiddleware($this->logger ?? new NullLogger()),
-                new SecurityHeadersMiddleware(),
-                new CorsMiddleware($this->responseFactory),
-                new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers),
-                new RequestSizeLimitMiddleware($problemDetails),
-                new ApiKeyAuthenticationMiddleware($problemDetails, $this->machineApiKey, ['/machine/health']),
-            ],
-            $router,
-        );
+        $middlewareStack = [
+            new RequestIdMiddleware('X-Request-Id', $this->requestIdHolder),
+            new RequestLoggingMiddleware($this->logger ?? new NullLogger()),
+            new SecurityHeadersMiddleware(),
+            new CorsMiddleware($this->responseFactory),
+            new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers),
+            new RequestSizeLimitMiddleware($problemDetails),
+            new ApiKeyAuthenticationMiddleware($problemDetails, $this->machineApiKey, ['/machine/health']),
+        ];
+
+        if ($this->bearerTokenMiddleware !== null) {
+            $middlewareStack[] = $this->bearerTokenMiddleware;
+        }
+
+        return new MiddlewareDispatcher($middlewareStack, $router);
     }
 }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Nene2\Http;
 
 use LogicException;
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
@@ -257,7 +259,23 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('RequestIdHolder service is invalid.');
                     }
 
-                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger, $config->machineApiKey, $getNoteByIdHandler, $createNoteHandler, $deleteNoteHandler, [$noteNotFoundHandler, $tagNotFoundHandler], $listNotesHandler, $updateNoteHandler, $requestIdHolder, [], $listTagsHandler, $getTagByIdHandler, $createTagHandler);
+                    $bearerMiddleware = null;
+
+                    if ($config->localJwtSecret !== null) {
+                        $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                        if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                            throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                        }
+
+                        $bearerMiddleware = new BearerTokenMiddleware(
+                            $problemDetails,
+                            new LocalBearerTokenVerifier($config->localJwtSecret),
+                            ['/examples/protected'],
+                        );
+                    }
+
+                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger, $config->machineApiKey, $getNoteByIdHandler, $createNoteHandler, $deleteNoteHandler, [$noteNotFoundHandler, $tagNotFoundHandler], $listNotesHandler, $updateNoteHandler, $requestIdHolder, [], $listTagsHandler, $getTagByIdHandler, $createTagHandler, $bearerMiddleware);
                 },
             )
             ->set(

--- a/tests/Auth/LocalBearerTokenVerifierTest.php
+++ b/tests/Auth/LocalBearerTokenVerifierTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Auth;
+
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Auth\TokenVerificationException;
+use PHPUnit\Framework\TestCase;
+
+final class LocalBearerTokenVerifierTest extends TestCase
+{
+    private const string SECRET = 'test-secret-key-at-least-32-chars!!';
+
+    public function testIssueAndVerifyRoundTrip(): void
+    {
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+        $claims = ['sub' => 'user-1', 'scope' => 'read:system'];
+
+        $token = $verifier->issue($claims);
+        $decoded = $verifier->verify($token);
+
+        self::assertSame('user-1', $decoded['sub']);
+        self::assertSame('read:system', $decoded['scope']);
+    }
+
+    public function testVerifyRejectsWrongSecret(): void
+    {
+        $issuer = new LocalBearerTokenVerifier(self::SECRET);
+        $verifier = new LocalBearerTokenVerifier('different-secret-that-is-also-long!!');
+
+        $token = $issuer->issue(['sub' => 'user-1']);
+
+        $this->expectException(TokenVerificationException::class);
+        $verifier->verify($token);
+    }
+
+    public function testVerifyRejectsMalformedToken(): void
+    {
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+
+        $this->expectException(TokenVerificationException::class);
+        $verifier->verify('not.a.valid.jwt.format.here');
+    }
+
+    public function testVerifyRejectsExpiredToken(): void
+    {
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+        $token = $verifier->issue(['sub' => 'user-1', 'exp' => time() - 60]);
+
+        $this->expectException(TokenVerificationException::class);
+        $verifier->verify($token);
+    }
+
+    public function testVerifyAcceptsTokenWithFutureExpiry(): void
+    {
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+        $token = $verifier->issue(['sub' => 'user-1', 'exp' => time() + 3600]);
+
+        $claims = $verifier->verify($token);
+
+        self::assertSame('user-1', $claims['sub']);
+    }
+
+    public function testVerifyRejectsWrongAlgorithm(): void
+    {
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+
+        $headerB64 = rtrim(strtr(base64_encode((string) json_encode(['typ' => 'JWT', 'alg' => 'RS256'])), '+/', '-_'), '=');
+        $payloadB64 = rtrim(strtr(base64_encode((string) json_encode(['sub' => 'x'])), '+/', '-_'), '=');
+        $sigB64 = rtrim(strtr(base64_encode(hash_hmac('sha256', $headerB64 . '.' . $payloadB64, self::SECRET, true)), '+/', '-_'), '=');
+        $token = $headerB64 . '.' . $payloadB64 . '.' . $sigB64;
+
+        $this->expectException(TokenVerificationException::class);
+        $verifier->verify($token);
+    }
+}

--- a/tests/Auth/ProtectedEndpointHttpTest.php
+++ b/tests/Auth/ProtectedEndpointHttpTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Auth;
+
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ProtectedEndpointHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-key-for-protected-endpoint!!';
+
+    private Psr17Factory $factory;
+    private LocalBearerTokenVerifier $verifier;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        $this->factory = new Psr17Factory();
+        $this->verifier = new LocalBearerTokenVerifier(self::SECRET);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $bearerMiddleware = new BearerTokenMiddleware(
+            $problemDetails,
+            $this->verifier,
+            ['/examples/protected'],
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            bearerTokenMiddleware: $bearerMiddleware,
+        ))->create();
+    }
+
+    public function testMissingTokenReturns401(): void
+    {
+        $response = $this->request('GET', '/examples/protected');
+
+        $payload = $this->decodeBody($response);
+        self::assertSame(401, $response->getStatusCode());
+        self::assertStringContainsString('application/problem+json', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('Bearer', $response->getHeaderLine('WWW-Authenticate'));
+        self::assertSame('https://nene2.dev/problems/unauthorized', $payload['type']);
+    }
+
+    public function testInvalidTokenReturns401(): void
+    {
+        $response = $this->request('GET', '/examples/protected', ['Authorization' => 'Bearer tampered.invalid.token']);
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function testValidTokenReturns200WithClaims(): void
+    {
+        $token = $this->verifier->issue(['sub' => 'user-42', 'scope' => 'read:system']);
+        $response = $this->request('GET', '/examples/protected', ['Authorization' => 'Bearer ' . $token]);
+
+        $payload = $this->decodeBody($response);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('Welcome, authenticated user.', $payload['message']);
+        self::assertSame('user-42', $payload['claims']['sub']);
+        self::assertSame('read:system', $payload['claims']['scope']);
+    }
+
+    public function testPublicRouteIsUnaffectedByBearerMiddleware(): void
+    {
+        $response = $this->request('GET', '/health');
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    private function request(string $method, string $path, array $headers = []): ResponseInterface
+    {
+        $request = $this->factory->createServerRequest($method, 'http://localhost' . $path);
+
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        return $this->application->handle($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeBody(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/OpenApi/RuntimeContractTest.php
+++ b/tests/OpenApi/RuntimeContractTest.php
@@ -68,8 +68,8 @@ final class RuntimeContractTest extends TestCase
                 }
 
                 // Skip domain example paths: they require optional domain handlers and are covered
-                // by NoteHttpTest / TagHttpTest with in-memory repositories.
-                if (str_starts_with($path, '/examples/notes') || str_starts_with($path, '/examples/tags')) {
+                // by NoteHttpTest / TagHttpTest / ProtectedEndpointHttpTest with in-memory repositories.
+                if (str_starts_with($path, '/examples/notes') || str_starts_with($path, '/examples/tags') || $path === '/examples/protected') {
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

- `src/Auth/LocalBearerTokenVerifier` — HMAC-HS256 JWT 検証（外部ライブラリ不要）。`issue()` メソッドでローカルテスト用トークンも発行可能
- `src/Auth/BearerTokenMiddleware` — `$protectedPaths` パラメータを追加（空 = 全パス保護 / 非空 = 指定パスのみ。既存テスト互換）
- `NENE2_LOCAL_JWT_SECRET` — `AppConfig` / `ConfigLoader` に追加
- `GET /examples/protected` — Bearer トークン認証が必要なデモエンドポイント。JWT claims を JSON で返す
- `RuntimeServiceProvider` — `localJwtSecret` が設定されていれば `LocalBearerTokenVerifier` + `BearerTokenMiddleware(['/examples/protected'])` を自動組み立て
- OpenAPI — `bearerAuth` securityScheme + `/examples/protected` パス + `ProtectedResponse` スキーマ

## Test plan

- [x] `tests/Auth/LocalBearerTokenVerifierTest.php` — 6 テスト（round-trip / wrong secret / malformed / expired / future exp / wrong alg）
- [x] `tests/Auth/ProtectedEndpointHttpTest.php` — 4 テスト（401 missing / 401 invalid / 200 valid / 公開ルート不影響）
- [x] `composer check` 通過（152 tests, 519 assertions、PHPStan level 8、CS-Fixer、OpenAPI validation）

## Usage

```bash
# .env に追記
NENE2_LOCAL_JWT_SECRET=your-32-char-or-longer-secret!!

# トークン発行（PHP で）
$verifier = new LocalBearerTokenVerifier($_ENV['NENE2_LOCAL_JWT_SECRET']);
$token = $verifier->issue(['sub' => 'user-1', 'exp' => time() + 3600]);

# エンドポイントにアクセス
curl -H "Authorization: Bearer $token" http://localhost:8080/examples/protected
```

Closes #287

Self-review: backend-api, middleware-security, openapi-contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)