### PR TITLE
docs(review): Phase 31 — セルフレビューチェックリストに JWT/Auth チェックポイントを追加する (#289)

### DIFF
--- a/docs/review/middleware-security.md
+++ b/docs/review/middleware-security.md
@@ -20,3 +20,21 @@ Source policies:
 - [ ] Secrets, tokens, cookies, authorization headers, and raw request bodies are not logged by default.
 - [ ] Auth, rate limit, metrics, or error tracking integrations remain adapter-driven unless an ADR says otherwise.
 - [ ] The narrowest useful PHP verification was run, usually `composer check`.
+
+## API-Key Authentication
+
+- [ ] `ApiKeyAuthenticationMiddleware` uses `hash_equals` for constant-time comparison.
+- [ ] `protectedPaths` lists only paths that must be machine-client–gated.
+- [ ] `WWW-Authenticate: ApiKey` challenge header is present on 401 responses.
+- [ ] The API key value is never logged, committed, or returned in a response.
+
+## Bearer Token Authentication (ADR 0008)
+
+- [ ] `BearerTokenMiddleware` receives a `TokenVerifierInterface` — no concrete JWT library is imported in the middleware itself.
+- [ ] `protectedPaths` is set explicitly when only some routes require Bearer auth; empty means all routes.
+- [ ] On missing or invalid token, the response is a 401 Problem Details with `WWW-Authenticate: Bearer` (RFC 6750).
+- [ ] Bearer tokens are not logged, even partially.
+- [ ] `nene2.auth.claims` and `nene2.auth.credential_type` request attributes are set on success and consumed only where needed.
+- [ ] `LocalBearerTokenVerifier` is used only in local/test environments; production wires a library-backed verifier.
+- [ ] `NENE2_LOCAL_JWT_SECRET` is set outside the repository and not committed.
+- [ ] If the protected endpoint is new, its OpenAPI path declares `security: [{bearerAuth: []}]`.

--- a/docs/review/openapi-contract.md
+++ b/docs/review/openapi-contract.md
@@ -20,3 +20,11 @@ Source policies:
 - [ ] New `$ref` values resolve through `composer openapi`.
 - [ ] Aspirational auth, CORS, or security behavior is not documented before implementation.
 - [ ] The narrowest useful verification was run, usually `composer openapi` or `composer check`.
+
+## Security Schemes
+
+- [ ] Each `securityScheme` entry (`ApiKeyAuth`, `bearerAuth`) matches a wired middleware implementation — no scheme is declared without matching behavior.
+- [ ] Protected paths declare `security:` at the operation level with the correct scheme.
+- [ ] The `401` response (`$ref: '#/components/responses/Unauthorized'`) is listed for every operation that requires authentication.
+- [ ] Example values for API keys or tokens are clearly placeholder values, not real secrets.
+- [ ] `bearerAuth` operations that are new follow the Bearer token checklist in `docs/review/middleware-security.md`.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -288,6 +288,11 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] feat(http): `GET /examples/protected` ルートと BearerTokenMiddleware 注入を追加する. `#287`
 - [x] docs(openapi): `bearerAuth` securityScheme と `/examples/protected` パスを追加する. `#287`
 
+## Phase 31: セルフレビューチェックリスト — Auth チェックポイント
+
+- [x] docs(review): `middleware-security.md` に API キー・Bearer トークンチェック項目を追加する. `#289`
+- [x] docs(review): `openapi-contract.md` に securityScheme チェック項目を追加する. `#289`
+
 ## Operating Notes
 
 - Keep this file short.


### PR DESCRIPTION
## Summary

- `docs/review/middleware-security.md`:
  - **API-Key 認証** セクション追加（`hash_equals`・`protectedPaths`・`WWW-Authenticate`・シークレット非ログ）
  - **Bearer Token 認証（ADR 0008）** セクション追加（`TokenVerifierInterface` 注入・`protectedPaths` の使い方・RFC 6750 チャレンジヘッダー・トークン非ログ・request 属性・`LocalBearerTokenVerifier` 利用範囲・OpenAPI 連携）
- `docs/review/openapi-contract.md`:
  - **Security Schemes** セクション追加（スキームと実装の一致・operation-level `security`・`401` 明記・例示値がプレースホルダー）

## Test plan

- [x] ドキュメントのみの変更 — `composer check` は不要だが内容は実装（ADR 0008 / Phase 30）と整合済み

Closes #289

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)