### PR TITLE
feat: Field Trial 6 フォローアップ — JWT 発行スクリプト・MCP Bearer 対応・起動ログ (#296)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -171,6 +171,24 @@
       "responseSchemaRef": "#/components/schemas/ExampleNoteResponse"
     },
     {
+      "name": "getProtected",
+      "title": "Protected Example",
+      "description": "Call the Bearer-protected example endpoint and return JWT claims. Requires NENE2_LOCAL_JWT_SECRET to be set in the MCP server environment.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "getProtected",
+        "method": "GET",
+        "path": "/examples/protected"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+      },
+      "responseSchemaRef": "#/components/schemas/ProtectedResponse"
+    },
+    {
       "name": "deleteExampleNoteById",
       "title": "Delete Example Note",
       "description": "Delete an example note by ID. Returns 204 on success.",

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -299,11 +299,11 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] fix(config): `.env.example` に `NENE2_LOCAL_JWT_SECRET` を追加する. `#291`
 - [x] chore(issues): 摩擦から生まれたフォローアップ Issue を作成する. `#292` `#293` `#294`
 
-## フォローアップ（未着手）
+## フォローアップ（実装済み #296）
 
-- [ ] feat: `tools/issue-jwt.php` ローカル JWT 発行スクリプト. `#292`
-- [ ] feat: `NativeLocalMcpHttpClient` に Bearer トークン送信サポートを追加する. `#293`
-- [ ] feat: 起動ログにオプション機能の有効状態を出力する. `#294`
+- [x] feat: `tools/issue-jwt.php` ローカル JWT 発行スクリプト. `#292`
+- [x] feat: `NativeLocalMcpHttpClient` に Bearer トークン送信サポートを追加 + `getProtected` MCP ツール追加. `#293`
+- [x] feat: 起動ログにオプション機能の有効状態を出力する. `#294`
 
 ## Operating Notes
 

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -61,6 +61,13 @@ final readonly class RuntimeApplicationFactory
 
     public function create(): RequestHandlerInterface
     {
+        $logger = $this->logger ?? new NullLogger();
+
+        $logger->info('NENE2 runtime started.', [
+            'machine_api_key' => $this->machineApiKey !== null,
+            'bearer_middleware' => $this->bearerTokenMiddleware !== null,
+        ]);
+
         $jsonResponses = new JsonResponseFactory($this->responseFactory, $this->streamFactory);
         $problemDetails = new ProblemDetailsResponseFactory($this->responseFactory, $this->streamFactory);
         $framework = new FrameworkInfo();
@@ -179,7 +186,7 @@ final readonly class RuntimeApplicationFactory
 
         $middlewareStack = [
             new RequestIdMiddleware('X-Request-Id', $this->requestIdHolder),
-            new RequestLoggingMiddleware($this->logger ?? new NullLogger()),
+            new RequestLoggingMiddleware($logger),
             new SecurityHeadersMiddleware(),
             new CorsMiddleware($this->responseFactory),
             new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers),

--- a/src/Mcp/NativeLocalMcpHttpClient.php
+++ b/src/Mcp/NativeLocalMcpHttpClient.php
@@ -6,6 +6,10 @@ namespace Nene2\Mcp;
 
 final readonly class NativeLocalMcpHttpClient implements LocalMcpHttpClientInterface
 {
+    public function __construct(private ?string $bearerToken = null)
+    {
+    }
+
     public function get(string $baseUrl, string $path): LocalMcpHttpResponse
     {
         return $this->request('GET', $baseUrl, $path, null);
@@ -34,6 +38,11 @@ final readonly class NativeLocalMcpHttpClient implements LocalMcpHttpClientInter
     private function request(string $method, string $baseUrl, string $path, ?array $body): LocalMcpHttpResponse
     {
         $headers = ['Accept: application/json'];
+
+        if ($this->bearerToken !== null) {
+            $headers[] = 'Authorization: Bearer ' . $this->bearerToken;
+        }
+
         $content = null;
 
         if ($body !== null) {

--- a/tools/issue-jwt.php
+++ b/tools/issue-jwt.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Issue a signed HS256 JWT for local development.
+ *
+ * Requires NENE2_LOCAL_JWT_SECRET to be set in the environment.
+ *
+ * Usage:
+ *   php tools/issue-jwt.php
+ *   php tools/issue-jwt.php --sub user-1 --scope read:system --ttl 3600
+ *
+ * Options:
+ *   --sub    Subject claim (default: local-user)
+ *   --scope  Scope claim  (default: read:system)
+ *   --ttl    Token TTL in seconds (default: 3600)
+ *
+ * Output:
+ *   The signed JWT on stdout. Redirect or copy as needed.
+ *
+ * Example:
+ *   TOKEN=$(php tools/issue-jwt.php --sub ft6-user)
+ *   curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/examples/protected
+ */
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Nene2\Auth\LocalBearerTokenVerifier;
+
+$secret = getenv('NENE2_LOCAL_JWT_SECRET');
+
+if (!is_string($secret) || $secret === '') {
+    fwrite(STDERR, "Error: NENE2_LOCAL_JWT_SECRET is not set.\n");
+    fwrite(STDERR, "Set it in your .env file or export it before running this script.\n");
+    exit(1);
+}
+
+$opts = getopt('', ['sub:', 'scope:', 'ttl:']);
+
+$sub = is_string($opts['sub'] ?? null) ? $opts['sub'] : 'local-user';
+$scope = is_string($opts['scope'] ?? null) ? $opts['scope'] : 'read:system';
+$ttl = isset($opts['ttl']) && is_numeric($opts['ttl']) ? (int) $opts['ttl'] : 3600;
+
+$verifier = new LocalBearerTokenVerifier($secret);
+$token = $verifier->issue([
+    'sub' => $sub,
+    'scope' => $scope,
+    'iat' => time(),
+    'exp' => time() + $ttl,
+]);
+
+echo $token . PHP_EOL;

--- a/tools/local-mcp-server.php
+++ b/tools/local-mcp-server.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Mcp\LocalMcpException;
 use Nene2\Mcp\LocalMcpServer;
 use Nene2\Mcp\LocalMcpToolCatalog;
@@ -16,9 +17,17 @@ if (!is_string($apiBaseUrl) || $apiBaseUrl === '') {
     $apiBaseUrl = 'http://localhost:8080';
 }
 
+$bearerToken = null;
+$jwtSecret = getenv('NENE2_LOCAL_JWT_SECRET');
+
+if (is_string($jwtSecret) && $jwtSecret !== '') {
+    $v = new LocalBearerTokenVerifier($jwtSecret);
+    $bearerToken = $v->issue(['sub' => 'mcp-server', 'scope' => 'read:system', 'iat' => time(), 'exp' => time() + 86400]);
+}
+
 $server = new LocalMcpServer(
     new LocalMcpToolCatalog($root . '/docs/mcp/tools.json'),
-    new NativeLocalMcpHttpClient(),
+    new NativeLocalMcpHttpClient($bearerToken),
     $apiBaseUrl,
 );
 


### PR DESCRIPTION
## Summary

Field Trial 6 (#291) で観察した摩擦 3 件を解決する。

### #292 — `tools/issue-jwt.php`
- `NENE2_LOCAL_JWT_SECRET` から `LocalBearerTokenVerifier` を組み立て
- `--sub` / `--scope` / `--ttl` オプションで claims を指定可能
- `TOKEN=$(php tools/issue-jwt.php)` → `curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/examples/protected`

### #293 — MCP Bearer トークン送信サポート
- `NativeLocalMcpHttpClient(bearerToken: ?string)` — 全リクエストに `Authorization: Bearer` を付与
- `tools/local-mcp-server.php` — `NENE2_LOCAL_JWT_SECRET` が設定されていれば起動時に 24h トークンを自動発行して注入
- `docs/mcp/tools.json` — `getProtected` ツールを追加（`getProtected` が `tools/list` に出現）

### #294 — 起動ログ
- `RuntimeApplicationFactory::create()` 冒頭に `NENE2 runtime started.` ログ出力
- `machine_api_key: true/false` / `bearer_middleware: true/false` で設定状態を可視化

## Test plan

- [x] `composer check` 通過（152 tests, 519 assertions、PHPStan level 8、CS-Fixer、OpenAPI、MCP catalog）
- [x] `tools/issue-jwt.php` — Docker 経由でトークン発行確認
- [x] MCP `tools/list` に `getProtected` が出現することを確認

Closes #292
Closes #293
Closes #294
Closes #296

Self-review: middleware-security, backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)