### PR TITLE
refactor(http): RuntimeApplicationFactory コンストラクタを 16 引数から 8 引数に削減

### DIFF
--- a/src/Example/Note/NoteRouteRegistrar.php
+++ b/src/Example/Note/NoteRouteRegistrar.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Note;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class NoteRouteRegistrar
+{
+    public function __construct(
+        private GetNoteByIdHandler $getHandler,
+        private CreateNoteHandler $createHandler,
+        private UpdateNoteHandler $updateHandler,
+        private DeleteNoteHandler $deleteHandler,
+        private ListNotesHandler $listHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $getHandler = $this->getHandler;
+        $createHandler = $this->createHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
+        $listHandler = $this->listHandler;
+
+        $router->get('/examples/notes', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->get('/examples/notes/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
+        $router->post('/examples/notes', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->put('/examples/notes/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->delete('/examples/notes/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
+    }
+}

--- a/src/Example/Note/NoteServiceProvider.php
+++ b/src/Example/Note/NoteServiceProvider.php
@@ -186,6 +186,38 @@ final readonly class NoteServiceProvider implements ServiceProviderInterface
 
                     return new NoteNotFoundExceptionHandler($problemDetails);
                 },
+            )
+            ->set(
+                'nene2.route_registrar.note',
+                static function (ContainerInterface $c): NoteRouteRegistrar {
+                    $get = $c->get(GetNoteByIdHandler::class);
+                    $create = $c->get(CreateNoteHandler::class);
+                    $update = $c->get(UpdateNoteHandler::class);
+                    $delete = $c->get(DeleteNoteHandler::class);
+                    $list = $c->get(ListNotesHandler::class);
+
+                    if (!$get instanceof GetNoteByIdHandler) {
+                        throw new LogicException('GetNoteById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateNoteHandler) {
+                        throw new LogicException('CreateNote handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateNoteHandler) {
+                        throw new LogicException('UpdateNote handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteNoteHandler) {
+                        throw new LogicException('DeleteNote handler service is invalid.');
+                    }
+
+                    if (!$list instanceof ListNotesHandler) {
+                        throw new LogicException('ListNotes handler service is invalid.');
+                    }
+
+                    return new NoteRouteRegistrar($get, $create, $update, $delete, $list);
+                },
             );
     }
 }

--- a/src/Example/Tag/TagRouteRegistrar.php
+++ b/src/Example/Tag/TagRouteRegistrar.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class TagRouteRegistrar
+{
+    public function __construct(
+        private ListTagsHandler $listHandler,
+        private GetTagByIdHandler $getHandler,
+        private CreateTagHandler $createHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $getHandler = $this->getHandler;
+        $createHandler = $this->createHandler;
+
+        $router->get('/examples/tags', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->get('/examples/tags/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
+        $router->post('/examples/tags', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+    }
+}

--- a/src/Example/Tag/TagServiceProvider.php
+++ b/src/Example/Tag/TagServiceProvider.php
@@ -127,6 +127,28 @@ final readonly class TagServiceProvider implements ServiceProviderInterface
 
                     return new TagNotFoundExceptionHandler($problemDetails);
                 },
+            )
+            ->set(
+                'nene2.route_registrar.tag',
+                static function (ContainerInterface $c): TagRouteRegistrar {
+                    $list = $c->get(ListTagsHandler::class);
+                    $get = $c->get(GetTagByIdHandler::class);
+                    $create = $c->get(CreateTagHandler::class);
+
+                    if (!$list instanceof ListTagsHandler) {
+                        throw new LogicException('ListTags handler service is invalid.');
+                    }
+
+                    if (!$get instanceof GetTagByIdHandler) {
+                        throw new LogicException('GetTagById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateTagHandler) {
+                        throw new LogicException('CreateTag handler service is invalid.');
+                    }
+
+                    return new TagRouteRegistrar($list, $get, $create);
+                },
             );
     }
 }

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -8,14 +8,6 @@ use Nene2\Auth\BearerTokenMiddleware;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ErrorHandlerMiddleware;
 use Nene2\Error\ProblemDetailsResponseFactory;
-use Nene2\Example\Note\CreateNoteHandler;
-use Nene2\Example\Note\DeleteNoteHandler;
-use Nene2\Example\Note\GetNoteByIdHandler;
-use Nene2\Example\Note\ListNotesHandler;
-use Nene2\Example\Note\UpdateNoteHandler;
-use Nene2\Example\Tag\CreateTagHandler;
-use Nene2\Example\Tag\GetTagByIdHandler;
-use Nene2\Example\Tag\ListTagsHandler;
 use Nene2\FrameworkInfo;
 use Nene2\Log\RequestIdHolder;
 use Nene2\Middleware\ApiKeyAuthenticationMiddleware;
@@ -44,17 +36,9 @@ final readonly class RuntimeApplicationFactory
         private StreamFactoryInterface $streamFactory,
         private ?LoggerInterface $logger = null,
         private ?string $machineApiKey = null,
-        private ?GetNoteByIdHandler $getNoteByIdHandler = null,
-        private ?CreateNoteHandler $createNoteHandler = null,
-        private ?DeleteNoteHandler $deleteNoteHandler = null,
         private array $domainExceptionHandlers = [],
-        private ?ListNotesHandler $listNotesHandler = null,
-        private ?UpdateNoteHandler $updateNoteHandler = null,
         private ?RequestIdHolder $requestIdHolder = null,
         private array $routeRegistrars = [],
-        private ?ListTagsHandler $listTagsHandler = null,
-        private ?GetTagByIdHandler $getTagByIdHandler = null,
-        private ?CreateTagHandler $createTagHandler = null,
         private ?BearerTokenMiddleware $bearerTokenMiddleware = null,
     ) {
     }
@@ -71,12 +55,6 @@ final readonly class RuntimeApplicationFactory
         $jsonResponses = new JsonResponseFactory($this->responseFactory, $this->streamFactory);
         $problemDetails = new ProblemDetailsResponseFactory($this->responseFactory, $this->streamFactory);
         $framework = new FrameworkInfo();
-        $getNoteHandler = $this->getNoteByIdHandler;
-        $createNoteHandler = $this->createNoteHandler;
-        $deleteNoteHandler = $this->deleteNoteHandler;
-        $listNotesHandler = $this->listNotesHandler;
-
-        $updateNoteHandler = $this->updateNoteHandler;
 
         $router = (new Router())
             ->get(
@@ -110,65 +88,6 @@ final readonly class RuntimeApplicationFactory
                 ]),
             )
         ;
-
-        if ($listNotesHandler !== null) {
-            $router->get(
-                '/examples/notes',
-                static fn (ServerRequestInterface $request) => $listNotesHandler->handle($request),
-            );
-        }
-
-        if ($getNoteHandler !== null) {
-            $router->get(
-                '/examples/notes/{id}',
-                static fn (ServerRequestInterface $request) => $getNoteHandler->handle($request),
-            );
-        }
-
-        if ($createNoteHandler !== null) {
-            $router->post(
-                '/examples/notes',
-                static fn (ServerRequestInterface $request) => $createNoteHandler->handle($request),
-            );
-        }
-
-        if ($updateNoteHandler !== null) {
-            $router->put(
-                '/examples/notes/{id}',
-                static fn (ServerRequestInterface $request) => $updateNoteHandler->handle($request),
-            );
-        }
-
-        if ($deleteNoteHandler !== null) {
-            $router->delete(
-                '/examples/notes/{id}',
-                static fn (ServerRequestInterface $request) => $deleteNoteHandler->handle($request),
-            );
-        }
-
-        if ($this->listTagsHandler !== null) {
-            $listTagsHandler = $this->listTagsHandler;
-            $router->get(
-                '/examples/tags',
-                static fn (ServerRequestInterface $request) => $listTagsHandler->handle($request),
-            );
-        }
-
-        if ($this->getTagByIdHandler !== null) {
-            $getTagByIdHandler = $this->getTagByIdHandler;
-            $router->get(
-                '/examples/tags/{id}',
-                static fn (ServerRequestInterface $request) => $getTagByIdHandler->handle($request),
-            );
-        }
-
-        if ($this->createTagHandler !== null) {
-            $createTagHandler = $this->createTagHandler;
-            $router->post(
-                '/examples/tags',
-                static fn (ServerRequestInterface $request) => $createTagHandler->handle($request),
-            );
-        }
 
         if ($this->bearerTokenMiddleware !== null) {
             $router->get(

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -18,17 +18,11 @@ use Nene2\Database\PdoDatabaseTransactionManager;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
-use Nene2\Example\Note\CreateNoteHandler;
-use Nene2\Example\Note\DeleteNoteHandler;
-use Nene2\Example\Note\GetNoteByIdHandler;
-use Nene2\Example\Note\ListNotesHandler;
 use Nene2\Example\Note\NoteNotFoundExceptionHandler;
+use Nene2\Example\Note\NoteRouteRegistrar;
 use Nene2\Example\Note\NoteServiceProvider;
-use Nene2\Example\Note\UpdateNoteHandler;
-use Nene2\Example\Tag\CreateTagHandler;
-use Nene2\Example\Tag\GetTagByIdHandler;
-use Nene2\Example\Tag\ListTagsHandler;
 use Nene2\Example\Tag\TagNotFoundExceptionHandler;
+use Nene2\Example\Tag\TagRouteRegistrar;
 use Nene2\Example\Tag\TagServiceProvider;
 use Nene2\Log\MonologLoggerFactory;
 use Nene2\Log\RequestIdHolder;
@@ -186,6 +180,11 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     $streamFactory = $container->get(StreamFactoryInterface::class);
                     $logger = $container->get(LoggerInterface::class);
                     $config = $container->get(AppConfig::class);
+                    $noteNotFoundHandler = $container->get(NoteNotFoundExceptionHandler::class);
+                    $tagNotFoundHandler = $container->get(TagNotFoundExceptionHandler::class);
+                    $noteRegistrar = $container->get('nene2.route_registrar.note');
+                    $tagRegistrar = $container->get('nene2.route_registrar.tag');
+                    $requestIdHolder = $container->get(RequestIdHolder::class);
 
                     if (!$responseFactory instanceof ResponseFactoryInterface) {
                         throw new LogicException('Response factory service is invalid.');
@@ -203,56 +202,20 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Application config service is invalid.');
                     }
 
-                    $getNoteByIdHandler = $container->get(GetNoteByIdHandler::class);
-                    $createNoteHandler = $container->get(CreateNoteHandler::class);
-                    $deleteNoteHandler = $container->get(DeleteNoteHandler::class);
-                    $listNotesHandler = $container->get(ListNotesHandler::class);
-                    $updateNoteHandler = $container->get(UpdateNoteHandler::class);
-                    $noteNotFoundHandler = $container->get(NoteNotFoundExceptionHandler::class);
-                    $listTagsHandler = $container->get(ListTagsHandler::class);
-                    $getTagByIdHandler = $container->get(GetTagByIdHandler::class);
-                    $createTagHandler = $container->get(CreateTagHandler::class);
-                    $tagNotFoundHandler = $container->get(TagNotFoundExceptionHandler::class);
-                    $requestIdHolder = $container->get(RequestIdHolder::class);
-
-                    if (!$getNoteByIdHandler instanceof GetNoteByIdHandler) {
-                        throw new LogicException('GetNoteById handler service is invalid.');
-                    }
-
-                    if (!$createNoteHandler instanceof CreateNoteHandler) {
-                        throw new LogicException('CreateNote handler service is invalid.');
-                    }
-
-                    if (!$deleteNoteHandler instanceof DeleteNoteHandler) {
-                        throw new LogicException('DeleteNote handler service is invalid.');
-                    }
-
-                    if (!$listNotesHandler instanceof ListNotesHandler) {
-                        throw new LogicException('ListNotes handler service is invalid.');
-                    }
-
-                    if (!$updateNoteHandler instanceof UpdateNoteHandler) {
-                        throw new LogicException('UpdateNote handler service is invalid.');
-                    }
-
                     if (!$noteNotFoundHandler instanceof NoteNotFoundExceptionHandler) {
                         throw new LogicException('NoteNotFoundException handler service is invalid.');
                     }
 
-                    if (!$listTagsHandler instanceof ListTagsHandler) {
-                        throw new LogicException('ListTags handler service is invalid.');
-                    }
-
-                    if (!$getTagByIdHandler instanceof GetTagByIdHandler) {
-                        throw new LogicException('GetTagById handler service is invalid.');
-                    }
-
-                    if (!$createTagHandler instanceof CreateTagHandler) {
-                        throw new LogicException('CreateTag handler service is invalid.');
-                    }
-
                     if (!$tagNotFoundHandler instanceof TagNotFoundExceptionHandler) {
                         throw new LogicException('TagNotFoundException handler service is invalid.');
+                    }
+
+                    if (!$noteRegistrar instanceof NoteRouteRegistrar) {
+                        throw new LogicException('Note route registrar service is invalid.');
+                    }
+
+                    if (!$tagRegistrar instanceof TagRouteRegistrar) {
+                        throw new LogicException('Tag route registrar service is invalid.');
                     }
 
                     if (!$requestIdHolder instanceof RequestIdHolder) {
@@ -275,7 +238,16 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         );
                     }
 
-                    return new RuntimeApplicationFactory($responseFactory, $streamFactory, $logger, $config->machineApiKey, $getNoteByIdHandler, $createNoteHandler, $deleteNoteHandler, [$noteNotFoundHandler, $tagNotFoundHandler], $listNotesHandler, $updateNoteHandler, $requestIdHolder, [], $listTagsHandler, $getTagByIdHandler, $createTagHandler, $bearerMiddleware);
+                    return new RuntimeApplicationFactory(
+                        $responseFactory,
+                        $streamFactory,
+                        $logger,
+                        $config->machineApiKey,
+                        [$noteNotFoundHandler, $tagNotFoundHandler],
+                        $requestIdHolder,
+                        [$noteRegistrar, $tagRegistrar],
+                        $bearerMiddleware,
+                    );
                 },
             )
             ->set(

--- a/tests/Example/Note/NoteHttpTest.php
+++ b/tests/Example/Note/NoteHttpTest.php
@@ -15,6 +15,7 @@ use Nene2\Example\Note\ListNotesHandler;
 use Nene2\Example\Note\ListNotesUseCase;
 use Nene2\Example\Note\Note;
 use Nene2\Example\Note\NoteNotFoundExceptionHandler;
+use Nene2\Example\Note\NoteRouteRegistrar;
 use Nene2\Example\Note\UpdateNoteHandler;
 use Nene2\Example\Note\UpdateNoteUseCase;
 use Nene2\Http\JsonResponseFactory;
@@ -38,30 +39,19 @@ final class NoteHttpTest extends TestCase
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
+        $registrar = new NoteRouteRegistrar(
+            new GetNoteByIdHandler(new GetNoteByIdUseCase($this->repository), $jsonResponse),
+            new CreateNoteHandler(new CreateNoteUseCase($this->repository), $jsonResponse),
+            new UpdateNoteHandler(new UpdateNoteUseCase($this->repository), $jsonResponse),
+            new DeleteNoteHandler(new DeleteNoteUseCase($this->repository), $this->factory),
+            new ListNotesHandler(new ListNotesUseCase($this->repository), $jsonResponse),
+        );
+
         $this->application = (new RuntimeApplicationFactory(
             $this->factory,
             $this->factory,
-            getNoteByIdHandler: new GetNoteByIdHandler(
-                new GetNoteByIdUseCase($this->repository),
-                $jsonResponse,
-            ),
-            createNoteHandler: new CreateNoteHandler(
-                new CreateNoteUseCase($this->repository),
-                $jsonResponse,
-            ),
-            deleteNoteHandler: new DeleteNoteHandler(
-                new DeleteNoteUseCase($this->repository),
-                $this->factory,
-            ),
             domainExceptionHandlers: [new NoteNotFoundExceptionHandler($problemDetails)],
-            listNotesHandler: new ListNotesHandler(
-                new ListNotesUseCase($this->repository),
-                $jsonResponse,
-            ),
-            updateNoteHandler: new UpdateNoteHandler(
-                new UpdateNoteUseCase($this->repository),
-                $jsonResponse,
-            ),
+            routeRegistrars: [$registrar],
         ))->create();
     }
 

--- a/tests/Example/Tag/TagHttpTest.php
+++ b/tests/Example/Tag/TagHttpTest.php
@@ -13,6 +13,7 @@ use Nene2\Example\Tag\ListTagsHandler;
 use Nene2\Example\Tag\ListTagsUseCase;
 use Nene2\Example\Tag\Tag;
 use Nene2\Example\Tag\TagNotFoundExceptionHandler;
+use Nene2\Example\Tag\TagRouteRegistrar;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -34,22 +35,17 @@ final class TagHttpTest extends TestCase
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
+        $registrar = new TagRouteRegistrar(
+            new ListTagsHandler(new ListTagsUseCase($this->repository), $jsonResponse),
+            new GetTagByIdHandler(new GetTagByIdUseCase($this->repository), $jsonResponse),
+            new CreateTagHandler(new CreateTagUseCase($this->repository), $jsonResponse),
+        );
+
         $this->application = (new RuntimeApplicationFactory(
             $this->factory,
             $this->factory,
             domainExceptionHandlers: [new TagNotFoundExceptionHandler($problemDetails)],
-            listTagsHandler: new ListTagsHandler(
-                new ListTagsUseCase($this->repository),
-                $jsonResponse,
-            ),
-            getTagByIdHandler: new GetTagByIdHandler(
-                new GetTagByIdUseCase($this->repository),
-                $jsonResponse,
-            ),
-            createTagHandler: new CreateTagHandler(
-                new CreateTagUseCase($this->repository),
-                $jsonResponse,
-            ),
+            routeRegistrars: [$registrar],
         ))->create();
     }
 


### PR DESCRIPTION
## Summary

- `RuntimeApplicationFactory` のコンストラクタからエンティティ固有ハンドラー引数 8 個を削除し、8 引数のフレームワーク基盤のみに集約
- `NoteRouteRegistrar` / `TagRouteRegistrar` を新設し、各エンティティのルート登録ロジックを `__invoke(Router): void` に移動
- `NoteServiceProvider` / `TagServiceProvider` に `nene2.route_registrar.*` サービスを追加し、`RuntimeServiceProvider` が registrar を参照する形に変更
- テスト (`NoteHttpTest`, `TagHttpTest`) を `routeRegistrars` named param 形式に移行

## Before / After

| 指標 | Before | After |
|---|---|---|
| `RuntimeApplicationFactory` コンストラクタ引数数 | 16 | 8 |
| `create()` 内の条件分岐ブロック | 8 | 0 |
| `RuntimeServiceProvider` の配線行数 | ~95 行 | ~60 行 |
| 次エンティティ追加コスト | ハンドラー引数 3+ + 条件分岐 3+ + ServiceProvider 配線 | registrar 1 + RuntimeServiceProvider 2 行 |

## Test plan

- [x] `composer check` — PHPUnit 152/152, PHPStan no errors, CS-Fixer 0 violations, OpenAPI valid, MCP catalog valid
- [x] `NoteHttpTest` (15 tests) / `TagHttpTest` (8 tests) 全通過
- [x] `ProtectedEndpointHttpTest` (4 tests) 変更なし・全通過
- [x] `RuntimeServiceProviderTest` (3 tests) 変更なし・全通過

Self-review: backend-api

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)