### PR TITLE
feat(mcp): write ツール呼び出し時の Bearer 認証ガードを追加する

### DIFF
--- a/src/Mcp/LocalMcpHttpClientInterface.php
+++ b/src/Mcp/LocalMcpHttpClientInterface.php
@@ -15,4 +15,6 @@ interface LocalMcpHttpClientInterface
     public function put(string $baseUrl, string $path, array $body): LocalMcpHttpResponse;
 
     public function delete(string $baseUrl, string $path): LocalMcpHttpResponse;
+
+    public function hasAuthentication(): bool;
 }

--- a/src/Mcp/LocalMcpServer.php
+++ b/src/Mcp/LocalMcpServer.php
@@ -125,6 +125,15 @@ final readonly class LocalMcpServer
             throw new LocalMcpException(sprintf('MCP tool "%s" was not found.', $name));
         }
 
+        if ($tool['safety'] !== 'read' && !$this->httpClient->hasAuthentication()) {
+            throw new LocalMcpException(
+                sprintf(
+                    'Write tool "%s" requires bearer authentication. Set NENE2_LOCAL_JWT_SECRET in the MCP server environment.',
+                    $name,
+                ),
+            );
+        }
+
         if ($tool['source']['type'] !== 'openapi') {
             throw new LocalMcpException(sprintf('MCP tool "%s" does not map to a local OpenAPI operation.', $name));
         }

--- a/src/Mcp/NativeLocalMcpHttpClient.php
+++ b/src/Mcp/NativeLocalMcpHttpClient.php
@@ -32,6 +32,11 @@ final readonly class NativeLocalMcpHttpClient implements LocalMcpHttpClientInter
         return $this->request('DELETE', $baseUrl, $path, null);
     }
 
+    public function hasAuthentication(): bool
+    {
+        return $this->bearerToken !== null;
+    }
+
     /**
      * @param array<string, mixed>|null $body
      */

--- a/tests/Mcp/LocalMcpServerTest.php
+++ b/tests/Mcp/LocalMcpServerTest.php
@@ -137,6 +137,31 @@ final class LocalMcpServerTest extends TestCase
         self::assertSame('/examples/notes?limit=10&offset=5', $client->path);
     }
 
+    public function testWriteToolWithoutAuthReturnsError(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(
+            new LocalMcpHttpResponse(201, [], '{}'),
+            authenticated: false,
+        );
+        $server = $this->server($client);
+
+        $response = $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 10,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'createExampleNote',
+                'arguments' => ['title' => 'Test', 'body' => 'Body'],
+            ],
+        ]);
+
+        self::assertIsArray($response);
+        self::assertArrayHasKey('error', $response);
+        self::assertIsArray($response['error']);
+        self::assertStringContainsString('NENE2_LOCAL_JWT_SECRET', $response['error']['message']);
+        self::assertNull($client->lastMethod);
+    }
+
     public function testToolsCallPostWriteToolSendsBodyArguments(): void
     {
         $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(
@@ -239,7 +264,13 @@ final class RecordingLocalMcpHttpClient implements LocalMcpHttpClientInterface
 
     public function __construct(
         private readonly LocalMcpHttpResponse $response,
+        private readonly bool $authenticated = true,
     ) {
+    }
+
+    public function hasAuthentication(): bool
+    {
+        return $this->authenticated;
     }
 
     public function get(string $baseUrl, string $path): LocalMcpHttpResponse

--- a/tools/local-mcp-server.php
+++ b/tools/local-mcp-server.php
@@ -22,7 +22,7 @@ $jwtSecret = getenv('NENE2_LOCAL_JWT_SECRET');
 
 if (is_string($jwtSecret) && $jwtSecret !== '') {
     $v = new LocalBearerTokenVerifier($jwtSecret);
-    $bearerToken = $v->issue(['sub' => 'mcp-server', 'scope' => 'read:system', 'iat' => time(), 'exp' => time() + 86400]);
+    $bearerToken = $v->issue(['sub' => 'mcp-server', 'scope' => 'read:system write:example', 'iat' => time(), 'exp' => time() + 86400]);
 }
 
 $server = new LocalMcpServer(


### PR DESCRIPTION
## Summary

- `LocalMcpHttpClientInterface` に `hasAuthentication(): bool` を追加
- `NativeLocalMcpHttpClient` がベアラートークン設定の有無を返す実装を追加
- `LocalMcpServer::toolsCallResult()` が `safety !== 'read'` ツール実行前に認証チェックを実施 — 未認証なら `LocalMcpException` で `NENE2_LOCAL_JWT_SECRET` 設定を促す
- `tools/local-mcp-server.php` の発行トークンスコープを `read:system write:example` に更新
- `LocalMcpServerTest` に認証なし write ツール → エラーのテストを追加

## Before / After

| 状況 | Before | After |
|---|---|---|
| `NENE2_LOCAL_JWT_SECRET` 未設定で write ツール呼び出し | 実行される（ポリシー違反） | エラーレスポンス + 設定を促すメッセージ |
| `NENE2_LOCAL_JWT_SECRET` 設定済みで write ツール呼び出し | 実行される | 実行される（変更なし） |

## Test plan

- [x] `composer check` — PHPUnit 153/153, PHPStan no errors, CS-Fixer 0 violations, OpenAPI valid, MCP catalog valid
- [x] `testWriteToolWithoutAuthReturnsError` — 認証なし write ツール → error レスポンス、HTTP 呼び出しなし
- [x] 既存 write ツールテスト（POST/PUT/DELETE）— デフォルト `authenticated: true` で全通過

Self-review: middleware-security

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)