### PR TITLE
docs(howto): 2 つ目のエンティティ追加 HOWTO + v0.6.0 リリース準備

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -9,7 +9,7 @@ function nav(t: {
     { text: t.explanation, link: 'explanation/why-psr',           activeMatch: 'explanation/' },
     { text: t.reference,   link: 'development/endpoint-scaffold', activeMatch: 'development/' },
     {
-      text: 'v0.4.0',
+      text: 'v0.6.0',
       items: [
         { text: 'Changelog',  link: 'https://github.com/hideyukiMORI/NENE2/blob/main/CHANGELOG.md' },
         { text: 'Releases',   link: 'https://github.com/hideyukiMORI/NENE2/releases' },
@@ -21,7 +21,7 @@ function nav(t: {
 
 function sidebar(t: {
   tutorialGroup: string; firstApi: string
-  howtoGroup: string; addRoute: string; addDb: string; deploy: string
+  howtoGroup: string; addRoute: string; addDb: string; addEntity: string; deploy: string
   explGroup: string; whyPsr: string; whyDi: string; whyPd: string; whyMcp: string
   devGroup: string; intGroup: string
 }) {
@@ -30,9 +30,10 @@ function sidebar(t: {
     '/howto/': [{
       text: t.howtoGroup,
       items: [
-        { text: t.addRoute, link: 'howto/add-custom-route' },
-        { text: t.addDb,    link: 'howto/add-database-endpoint' },
-        { text: t.deploy,   link: 'howto/deploy-production' },
+        { text: t.addRoute,  link: 'howto/add-custom-route' },
+        { text: t.addDb,     link: 'howto/add-database-endpoint' },
+        { text: t.addEntity, link: 'howto/add-second-entity' },
+        { text: t.deploy,    link: 'howto/deploy-production' },
       ],
     }],
     '/explanation/': [{
@@ -87,7 +88,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'HOWTO', explanation: 'Explanation', reference: 'Reference' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Your first API',
-          howtoGroup: 'HOWTO', addRoute: 'Add a custom route', addDb: 'Add a database-backed endpoint', deploy: 'Deploy to production',
+          howtoGroup: 'HOWTO', addRoute: 'Add a custom route', addDb: 'Add a database-backed endpoint', addEntity: 'Add a second entity', deploy: 'Deploy to production',
           explGroup: 'Explanation', whyPsr: 'Why PSR standards?', whyDi: 'Why explicit wiring?', whyPd: 'Why Problem Details?', whyMcp: 'Why MCP?',
           devGroup: 'Development', intGroup: 'Integrations',
         }),
@@ -103,7 +104,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'チュートリアル', howto: 'HOWTO', explanation: '解説', reference: 'リファレンス' }),
         sidebar: sidebar({
           tutorialGroup: 'チュートリアル', firstApi: '最初の API を動かす',
-          howtoGroup: 'HOWTO', addRoute: 'カスタムルートを追加する', addDb: 'DB 付きエンドポイントを追加する', deploy: '本番環境へデプロイする',
+          howtoGroup: 'HOWTO', addRoute: 'カスタムルートを追加する', addDb: 'DB 付きエンドポイントを追加する', addEntity: '2 つ目のエンティティを追加する', deploy: '本番環境へデプロイする',
           explGroup: '解説', whyPsr: 'なぜ PSR 標準？', whyDi: 'なぜ明示的 DI？', whyPd: 'なぜ Problem Details？', whyMcp: 'なぜ MCP？',
           devGroup: '開発ガイド', intGroup: 'インテグレーション',
         }),
@@ -124,7 +125,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutoriel', howto: 'Guides', explanation: 'Explication', reference: 'Référence' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutoriel', firstApi: 'Votre première API',
-          howtoGroup: 'Guides pratiques', addRoute: 'Ajouter une route', addDb: 'Ajouter un endpoint avec BDD', deploy: 'Déployer en production',
+          howtoGroup: 'Guides pratiques', addRoute: 'Ajouter une route', addDb: 'Ajouter un endpoint avec BDD', addEntity: 'Ajouter une deuxième entité', deploy: 'Déployer en production',
           explGroup: 'Explication', whyPsr: 'Pourquoi PSR ?', whyDi: 'Pourquoi le câblage explicite ?', whyPd: 'Pourquoi Problem Details ?', whyMcp: 'Pourquoi MCP ?',
           devGroup: 'Développement', intGroup: 'Intégrations',
         }),
@@ -143,7 +144,7 @@ export default defineConfig({
         nav: nav({ tutorial: '教程', howto: '操作指南', explanation: '说明', reference: '参考' }),
         sidebar: sidebar({
           tutorialGroup: '教程', firstApi: '创建您的第一个 API',
-          howtoGroup: '操作指南', addRoute: '添加自定义路由', addDb: '添加数据库端点', deploy: '部署到生产环境',
+          howtoGroup: '操作指南', addRoute: '添加自定义路由', addDb: '添加数据库端点', addEntity: '添加第二个实体', deploy: '部署到生产环境',
           explGroup: '说明', whyPsr: '为什么选择 PSR？', whyDi: '为什么显式依赖注入？', whyPd: '为什么使用 Problem Details？', whyMcp: '为什么选择 MCP？',
           devGroup: '开发指南', intGroup: '集成',
         }),
@@ -164,7 +165,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'Guias', explanation: 'Explicação', reference: 'Referência' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Sua primeira API',
-          howtoGroup: 'Guias práticos', addRoute: 'Adicionar uma rota', addDb: 'Adicionar endpoint com banco de dados', deploy: 'Implantar em produção',
+          howtoGroup: 'Guias práticos', addRoute: 'Adicionar uma rota', addDb: 'Adicionar endpoint com banco de dados', addEntity: 'Adicionar segunda entidade', deploy: 'Implantar em produção',
           explGroup: 'Explicação', whyPsr: 'Por que PSR?', whyDi: 'Por que injeção explícita?', whyPd: 'Por que Problem Details?', whyMcp: 'Por que MCP?',
           devGroup: 'Desenvolvimento', intGroup: 'Integrações',
         }),
@@ -183,7 +184,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'Anleitungen', explanation: 'Erklärung', reference: 'Referenz' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Ihre erste API',
-          howtoGroup: 'Anleitungen', addRoute: 'Route hinzufügen', addDb: 'Datenbankendpunkt hinzufügen', deploy: 'In Produktion deployen',
+          howtoGroup: 'Anleitungen', addRoute: 'Route hinzufügen', addDb: 'Datenbankendpunkt hinzufügen', addEntity: 'Zweite Entität hinzufügen', deploy: 'In Produktion deployen',
           explGroup: 'Erklärung', whyPsr: 'Warum PSR?', whyDi: 'Warum explizites Wiring?', whyPd: 'Warum Problem Details?', whyMcp: 'Warum MCP?',
           devGroup: 'Entwicklung', intGroup: 'Integrationen',
         }),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.6.0] — 2026-05-17
+
+### Added
+- `src/Example/Note/NoteRouteRegistrar` — registers Note routes via `__invoke(Router): void`; used by `NoteServiceProvider` and directly in tests (#299)
+- `src/Example/Tag/TagRouteRegistrar` — registers Tag routes via `__invoke(Router): void`; used by `TagServiceProvider` and directly in tests (#299)
+- `LocalMcpHttpClientInterface::hasAuthentication(): bool` — write tools are now gated: calling a `safety: write` tool without `NENE2_LOCAL_JWT_SECRET` set returns a `LocalMcpException` with a clear setup message (#301)
+- `docs/howto/add-second-entity.md` — HOWTO for adding a second domain entity using the RouteRegistrar pattern, in 6 languages (en/ja/fr/zh/pt-br/de) (#303)
+- VitePress HOWTO sidebar updated with "Add a second entity" entry in all 6 locales (#303)
+
+### Changed
+- `RuntimeApplicationFactory` constructor reduced from 16 parameters to 8 — entity-specific handler parameters removed; all entity routes are now contributed via the `$routeRegistrars` parameter (#299)
+- `NoteServiceProvider` / `TagServiceProvider` each register a `nene2.route_registrar.*` service; `RuntimeServiceProvider` references registrars by key instead of passing individual handlers (#299)
+- `NativeLocalMcpHttpClient` implements `hasAuthentication()` based on bearer token presence (#301)
+- `tools/local-mcp-server.php` token scope updated from `read:system` to `read:system write:example` (#301)
+- VitePress version badge updated to `v0.6.0` (#303)
+
+---
+
 ## [0.5.0] — 2026-05-17
 
 ### Added

--- a/docs/de/howto/add-second-entity.md
+++ b/docs/de/howto/add-second-entity.md
@@ -1,0 +1,67 @@
+# Eine zweite Domain-Entität hinzufügen
+
+Diese Anleitung zeigt, wie eine zweite Domain-Entität nach demselben Muster wie die eingebauten Beispiele `Note` und `Tag` hinzugefügt wird.
+
+**Voraussetzung**: [Datenbankendpunkt hinzufügen](./add-database-endpoint.md) abgeschlossen haben.
+
+---
+
+## Übersicht
+
+Jede Entität folgt derselben Struktur:
+
+```
+src/Example/YourEntity/
+  YourEntity.php
+  YourEntityRepositoryInterface.php
+  PdoYourEntityRepository.php
+  GetYourEntityByIdHandler.php
+  YourEntityRouteRegistrar.php   ← registriert Routen via __invoke(Router)
+  YourEntityServiceProvider.php  ← DI-Konfiguration + Routen-Registrar
+```
+
+Nur `RuntimeServiceProvider` erhält den neuen Registrar und Exception-Handler — **`RuntimeApplicationFactory` bleibt unverändert**.
+
+---
+
+## Wichtige Schritte
+
+### 1 — RouteRegistrar
+
+```php
+final readonly class ProductRouteRegistrar
+{
+    public function __construct(
+        private GetProductByIdHandler $getHandler,
+        private ListProductsHandler $listHandler,
+    ) {}
+
+    public function __invoke(Router $router): void
+    {
+        $get  = $this->getHandler;
+        $list = $this->listHandler;
+        $router->get('/examples/products', static fn ($r) => $list->handle($r));
+        $router->get('/examples/products/{id}', static fn ($r) => $get->handle($r));
+    }
+}
+```
+
+### 2 — ServiceProvider
+
+Registrar unter dem Schlüssel `nene2.route_registrar.product` in `register()` eintragen.
+
+### 3 — In RuntimeServiceProvider verdrahten
+
+```php
+$builder->addProvider(new ProductServiceProvider());
+
+return new RuntimeApplicationFactory(
+    /* ... */,
+    [$noteNotFoundHandler, $tagNotFoundHandler, $productNotFoundHandler],
+    $requestIdHolder,
+    [$noteRegistrar, $tagRegistrar, $productRegistrar],
+    $bearerMiddleware,
+);
+```
+
+Details siehe englische Version oder die Beispiele `Note`/`Tag` in `src/Example/`.

--- a/docs/fr/howto/add-second-entity.md
+++ b/docs/fr/howto/add-second-entity.md
@@ -1,0 +1,67 @@
+# Ajouter une deuxième entité de domaine
+
+Ce guide explique comment ajouter une deuxième entité de domaine en suivant le même modèle que les exemples intégrés `Note` et `Tag`.
+
+**Prérequis** : Avoir complété [Ajouter un endpoint avec BDD](./add-database-endpoint.md).
+
+---
+
+## Vue d'ensemble
+
+Chaque entité suit la même structure :
+
+```
+src/Example/YourEntity/
+  YourEntity.php
+  YourEntityRepositoryInterface.php
+  PdoYourEntityRepository.php
+  GetYourEntityByIdHandler.php
+  YourEntityRouteRegistrar.php   ← enregistre les routes via __invoke(Router)
+  YourEntityServiceProvider.php  ← câblage DI + registrar de routes
+```
+
+Seul `RuntimeServiceProvider` reçoit le nouveau registrar et le gestionnaire d'exception — **`RuntimeApplicationFactory` ne change pas**.
+
+---
+
+## Étapes clés
+
+### 1 — RouteRegistrar
+
+```php
+final readonly class ProductRouteRegistrar
+{
+    public function __construct(
+        private GetProductByIdHandler $getHandler,
+        private ListProductsHandler $listHandler,
+    ) {}
+
+    public function __invoke(Router $router): void
+    {
+        $get  = $this->getHandler;
+        $list = $this->listHandler;
+        $router->get('/examples/products', static fn ($r) => $list->handle($r));
+        $router->get('/examples/products/{id}', static fn ($r) => $get->handle($r));
+    }
+}
+```
+
+### 2 — ServiceProvider
+
+Enregistrez le registrar sous la clé `nene2.route_registrar.product` dans `register()`.
+
+### 3 — Câblage dans RuntimeServiceProvider
+
+```php
+$builder->addProvider(new ProductServiceProvider());
+
+return new RuntimeApplicationFactory(
+    /* ... */,
+    [$noteNotFoundHandler, $tagNotFoundHandler, $productNotFoundHandler],
+    $requestIdHolder,
+    [$noteRegistrar, $tagRegistrar, $productRegistrar],
+    $bearerMiddleware,
+);
+```
+
+Pour plus de détails, voir la version anglaise ou les exemples `Note` / `Tag` dans `src/Example/`.

--- a/docs/howto/add-second-entity.md
+++ b/docs/howto/add-second-entity.md
@@ -1,0 +1,207 @@
+# Add a Second Domain Entity
+
+This guide shows how to add a second domain entity alongside the built-in `Note` and `Tag` examples, following NENE2's multi-entity pattern.
+
+**Prerequisite**: You have completed [Add a database-backed endpoint](./add-database-endpoint.md) and understand the UseCase → Repository → Handler three-layer pattern.
+
+---
+
+## Overview
+
+Adding a second entity follows the same structure as the first. The key is how it plugs into the application:
+
+```
+src/Example/YourEntity/
+  YourEntity.php               ← readonly domain object
+  YourEntityRepositoryInterface.php
+  PdoYourEntityRepository.php
+  GetYourEntityByIdUseCase.php (+ interface)
+  GetYourEntityByIdHandler.php
+  YourEntityRouteRegistrar.php ← registers routes with __invoke(Router)
+  YourEntityServiceProvider.php ← wires DI + route registrar
+```
+
+`RuntimeServiceProvider` receives the new route registrar and exception handler — **no changes to `RuntimeApplicationFactory`** are needed.
+
+---
+
+## Step-by-step: a `Product` resource
+
+We will build `GET /examples/products/{id}` and `GET /examples/products` as a concrete example.
+
+### 1 — Domain entity
+
+```php
+// src/Example/Product/Product.php
+<?php
+declare(strict_types=1);
+namespace MyApp\Example\Product;
+
+final readonly class Product
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+        public readonly int $price,
+    ) {}
+}
+```
+
+### 2 — Repository interface and PDO adapter
+
+```php
+// src/Example/Product/ProductRepositoryInterface.php
+interface ProductRepositoryInterface
+{
+    public function findById(int $id): Product;
+    /** @return list<Product> */
+    public function findAll(int $limit, int $offset): array;
+}
+```
+
+```php
+// src/Example/Product/PdoProductRepository.php
+final readonly class PdoProductRepository implements ProductRepositoryInterface
+{
+    public function __construct(private DatabaseQueryExecutorInterface $query) {}
+
+    public function findById(int $id): Product
+    {
+        $rows = $this->query->select('SELECT id, name, price FROM products WHERE id = ?', [$id]);
+        if ($rows === []) {
+            throw new ProductNotFoundException($id);
+        }
+        $r = $rows[0];
+        return new Product((int) $r['id'], (string) $r['name'], (int) $r['price']);
+    }
+
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->select('SELECT id, name, price FROM products LIMIT ? OFFSET ?', [$limit, $offset]);
+        return array_map(fn ($r) => new Product((int) $r['id'], (string) $r['name'], (int) $r['price']), $rows);
+    }
+}
+```
+
+### 3 — Use cases and handlers
+
+Follow the same pattern as `GetNoteByIdUseCase` / `GetNoteByIdHandler`. Each use case is a single-method class; each handler converts the result to a JSON response.
+
+### 4 — Route registrar
+
+This is the key integration point. Instead of adding parameters to `RuntimeApplicationFactory`, create a `__invoke`-able class:
+
+```php
+// src/Example/Product/ProductRouteRegistrar.php
+<?php
+declare(strict_types=1);
+namespace MyApp\Example\Product;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ProductRouteRegistrar
+{
+    public function __construct(
+        private GetProductByIdHandler $getHandler,
+        private ListProductsHandler $listHandler,
+    ) {}
+
+    public function __invoke(Router $router): void
+    {
+        $getHandler  = $this->getHandler;
+        $listHandler = $this->listHandler;
+
+        $router->get('/examples/products', static fn (ServerRequestInterface $r) => $listHandler->handle($r));
+        $router->get('/examples/products/{id}', static fn (ServerRequestInterface $r) => $getHandler->handle($r));
+    }
+}
+```
+
+### 5 — Service provider
+
+```php
+// src/Example/Product/ProductServiceProvider.php
+<?php
+declare(strict_types=1);
+namespace MyApp\Example\Product;
+
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+// ... other imports
+
+final readonly class ProductServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(ProductRepositoryInterface::class, static function ($c) { /* ... */ })
+            ->set(GetProductByIdHandler::class, static function ($c) { /* ... */ })
+            ->set(ListProductsHandler::class, static function ($c) { /* ... */ })
+            ->set(ProductNotFoundExceptionHandler::class, static function ($c) { /* ... */ })
+            ->set('nene2.route_registrar.product', static function ($c): ProductRouteRegistrar {
+                // resolve handlers from container
+                return new ProductRouteRegistrar($get, $list);
+            });
+    }
+}
+```
+
+### 6 — Wire into RuntimeServiceProvider
+
+Open `src/Http/RuntimeServiceProvider.php` and make two small additions:
+
+```php
+// 1. Register the new provider (alongside Note and Tag):
+$builder->addProvider(new ProductServiceProvider());
+
+// 2. Pull the registrar and exception handler in the RuntimeApplicationFactory binding:
+$productRegistrar      = $container->get('nene2.route_registrar.product');
+$productNotFoundHandler = $container->get(ProductNotFoundExceptionHandler::class);
+
+// Add to the arrays:
+return new RuntimeApplicationFactory(
+    $responseFactory, $streamFactory, $logger, $config->machineApiKey,
+    [$noteNotFoundHandler, $tagNotFoundHandler, $productNotFoundHandler],  // ← add here
+    $requestIdHolder,
+    [$noteRegistrar, $tagRegistrar, $productRegistrar],                    // ← add here
+    $bearerMiddleware,
+);
+```
+
+That is all — `RuntimeApplicationFactory` itself does not change.
+
+---
+
+## Existing examples to reference
+
+| Entity | Source | Endpoints |
+|---|---|---|
+| `Note` | `src/Example/Note/` | GET/POST `/examples/notes`, GET/PUT/DELETE `/examples/notes/{id}` |
+| `Tag` | `src/Example/Tag/` | GET/POST `/examples/tags`, GET `/examples/tags/{id}` |
+
+Both follow this exact pattern. Copy the structure that fits your endpoint set.
+
+---
+
+## Testing
+
+Follow the same approach as `NoteHttpTest`:
+
+```php
+$registrar = new ProductRouteRegistrar($getHandler, $listHandler);
+
+$application = (new RuntimeApplicationFactory(
+    $factory, $factory,
+    domainExceptionHandlers: [new ProductNotFoundExceptionHandler($problemDetails)],
+    routeRegistrars: [$registrar],
+))->create();
+```
+
+Pass only the registrar you need — no other entity routes are loaded.
+
+---
+
+## Adding an MCP tool
+
+Once the endpoint is live, add an entry to `docs/mcp/tools.json` and run `composer mcp` to validate. See the [MCP tools policy](../integrations/mcp-tools.md) for the `safety` field guidance — write tools require `NENE2_LOCAL_JWT_SECRET` to be set.

--- a/docs/ja/howto/add-second-entity.md
+++ b/docs/ja/howto/add-second-entity.md
@@ -1,0 +1,154 @@
+# 2 つ目のドメインエンティティを追加する
+
+このガイドでは、組み込みの `Note`・`Tag` 例に倣い、2 つ目のドメインエンティティを追加する方法を説明します。
+
+**前提**: [DB 付きエンドポイントを追加する](./add-database-endpoint.md) を完了し、UseCase → Repository → Handler の三層パターンを理解していること。
+
+---
+
+## 全体像
+
+2 つ目のエンティティも 1 つ目と同じ構造に従います。重要なのはアプリケーションへの接続方法です：
+
+```
+src/Example/YourEntity/
+  YourEntity.php               ← readonly ドメインオブジェクト
+  YourEntityRepositoryInterface.php
+  PdoYourEntityRepository.php
+  GetYourEntityByIdUseCase.php (+ interface)
+  GetYourEntityByIdHandler.php
+  YourEntityRouteRegistrar.php ← __invoke(Router) でルートを登録
+  YourEntityServiceProvider.php ← DI + ルート登録を配線
+```
+
+`RuntimeServiceProvider` に新しいルート登録クラスと例外ハンドラーを追加するだけです — **`RuntimeApplicationFactory` は変更不要**です。
+
+---
+
+## ステップ: `Product` リソースの例
+
+`GET /examples/products/{id}` と `GET /examples/products` を構築します。
+
+### 1 — ドメインエンティティ
+
+```php
+// src/Example/Product/Product.php
+final readonly class Product
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+        public readonly int $price,
+    ) {}
+}
+```
+
+### 2 — リポジトリインターフェースと PDO アダプター
+
+```php
+interface ProductRepositoryInterface
+{
+    public function findById(int $id): Product;
+    /** @return list<Product> */
+    public function findAll(int $limit, int $offset): array;
+}
+```
+
+### 3 — ユースケースとハンドラー
+
+`GetNoteByIdUseCase` / `GetNoteByIdHandler` と同じパターン。
+
+### 4 — ルート登録クラス
+
+`RuntimeApplicationFactory` にパラメータを追加する代わりに、`__invoke` 可能なクラスを作成します：
+
+```php
+// src/Example/Product/ProductRouteRegistrar.php
+final readonly class ProductRouteRegistrar
+{
+    public function __construct(
+        private GetProductByIdHandler $getHandler,
+        private ListProductsHandler $listHandler,
+    ) {}
+
+    public function __invoke(Router $router): void
+    {
+        $getHandler  = $this->getHandler;
+        $listHandler = $this->listHandler;
+
+        $router->get('/examples/products', static fn ($r) => $listHandler->handle($r));
+        $router->get('/examples/products/{id}', static fn ($r) => $getHandler->handle($r));
+    }
+}
+```
+
+### 5 — サービスプロバイダー
+
+```php
+// src/Example/Product/ProductServiceProvider.php
+final readonly class ProductServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(ProductRepositoryInterface::class, /* ... */)
+            ->set(GetProductByIdHandler::class, /* ... */)
+            ->set(ListProductsHandler::class, /* ... */)
+            ->set(ProductNotFoundExceptionHandler::class, /* ... */)
+            ->set('nene2.route_registrar.product', static function ($c): ProductRouteRegistrar {
+                return new ProductRouteRegistrar($get, $list);
+            });
+    }
+}
+```
+
+### 6 — RuntimeServiceProvider に配線する
+
+`src/Http/RuntimeServiceProvider.php` に 2 箇所追加するだけです：
+
+```php
+// 1. プロバイダーを登録（Note・Tag と並べて）:
+$builder->addProvider(new ProductServiceProvider());
+
+// 2. registrar と例外ハンドラーを RuntimeApplicationFactory の配線に追加:
+return new RuntimeApplicationFactory(
+    $responseFactory, $streamFactory, $logger, $config->machineApiKey,
+    [$noteNotFoundHandler, $tagNotFoundHandler, $productNotFoundHandler],  // ← 追加
+    $requestIdHolder,
+    [$noteRegistrar, $tagRegistrar, $productRegistrar],                    // ← 追加
+    $bearerMiddleware,
+);
+```
+
+`RuntimeApplicationFactory` 自体は変更不要です。
+
+---
+
+## 既存の参照例
+
+| エンティティ | ソース | エンドポイント |
+|---|---|---|
+| `Note` | `src/Example/Note/` | GET/POST `/examples/notes`、GET/PUT/DELETE `/examples/notes/{id}` |
+| `Tag` | `src/Example/Tag/` | GET/POST `/examples/tags`、GET `/examples/tags/{id}` |
+
+---
+
+## テスト
+
+```php
+$registrar = new ProductRouteRegistrar($getHandler, $listHandler);
+
+$application = (new RuntimeApplicationFactory(
+    $factory, $factory,
+    domainExceptionHandlers: [new ProductNotFoundExceptionHandler($problemDetails)],
+    routeRegistrars: [$registrar],
+))->create();
+```
+
+必要な registrar だけを渡します — 他のエンティティのルートはロードされません。
+
+---
+
+## MCP ツールの追加
+
+エンドポイントが完成したら `docs/mcp/tools.json` にエントリを追加し、`composer mcp` で検証してください。write ツールは `NENE2_LOCAL_JWT_SECRET` の設定が必要です。

--- a/docs/pt-br/howto/add-second-entity.md
+++ b/docs/pt-br/howto/add-second-entity.md
@@ -1,0 +1,67 @@
+# Adicionar uma segunda entidade de domínio
+
+Este guia mostra como adicionar uma segunda entidade de domínio seguindo o mesmo padrão dos exemplos integrados `Note` e `Tag`.
+
+**Pré-requisito**: Ter concluído [Adicionar endpoint com banco de dados](./add-database-endpoint.md).
+
+---
+
+## Visão geral
+
+Cada entidade segue a mesma estrutura:
+
+```
+src/Example/YourEntity/
+  YourEntity.php
+  YourEntityRepositoryInterface.php
+  PdoYourEntityRepository.php
+  GetYourEntityByIdHandler.php
+  YourEntityRouteRegistrar.php   ← registra rotas via __invoke(Router)
+  YourEntityServiceProvider.php  ← configuração DI + registrar de rotas
+```
+
+Apenas `RuntimeServiceProvider` recebe o novo registrar e o handler de exceção — **`RuntimeApplicationFactory` não precisa ser alterado**.
+
+---
+
+## Etapas principais
+
+### 1 — RouteRegistrar
+
+```php
+final readonly class ProductRouteRegistrar
+{
+    public function __construct(
+        private GetProductByIdHandler $getHandler,
+        private ListProductsHandler $listHandler,
+    ) {}
+
+    public function __invoke(Router $router): void
+    {
+        $get  = $this->getHandler;
+        $list = $this->listHandler;
+        $router->get('/examples/products', static fn ($r) => $list->handle($r));
+        $router->get('/examples/products/{id}', static fn ($r) => $get->handle($r));
+    }
+}
+```
+
+### 2 — ServiceProvider
+
+Registre o registrar com a chave `nene2.route_registrar.product` em `register()`.
+
+### 3 — Configurar no RuntimeServiceProvider
+
+```php
+$builder->addProvider(new ProductServiceProvider());
+
+return new RuntimeApplicationFactory(
+    /* ... */,
+    [$noteNotFoundHandler, $tagNotFoundHandler, $productNotFoundHandler],
+    $requestIdHolder,
+    [$noteRegistrar, $tagRegistrar, $productRegistrar],
+    $bearerMiddleware,
+);
+```
+
+Para mais detalhes, consulte a versão em inglês ou os exemplos `Note`/`Tag` em `src/Example/`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -397,6 +397,23 @@ Goal: validate `BearerTokenMiddleware` + `LocalBearerTokenVerifier` in a realist
 - Issue a local JWT and verify the tool call succeeds
 - Record friction and open follow-up Issues
 
+## Phase 33: Architecture Quality (#298 #300)
+
+Goal: make the framework easier to extend by eliminating the growing-constructor problem and closing the MCP authentication policy gap.
+
+- `NoteRouteRegistrar` / `TagRouteRegistrar` — move entity route registration out of `RuntimeApplicationFactory` into `__invoke`-able classes
+- `RuntimeApplicationFactory` constructor reduced from 16 to 8 parameters; adding a new entity requires no change to the factory
+- `LocalMcpHttpClientInterface::hasAuthentication()` — write tools are gated behind bearer authentication; calling a write tool without `NENE2_LOCAL_JWT_SECRET` set returns a clear error
+
+## Phase 34: v0.6.0 Release
+
+Goal: consolidate Phase 33 changes and complete the multi-entity documentation started in Phase 25.
+
+- `docs/howto/add-second-entity.md` — HOWTO for adding a second domain entity using the RouteRegistrar pattern, in 6 languages
+- VitePress HOWTO sidebar updated with fourth entry
+- CHANGELOG.md v0.6.0 section
+- `v0.6.0` tag
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -253,7 +253,7 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 - [x] feat(example): `src/Example/Tag/` — 2 つ目のドメインエンティティ例を追加する. `#276`
 - [x] feat(example): `GET/POST /examples/tags` および `GET /examples/tags/{id}` エンドポイント追加. `#276`
-- [ ] docs(howto): 多エンティティパターンを HOWTO または Explanation に追記する.
+- [x] docs(howto): 多エンティティパターンを HOWTO または Explanation に追記する. `#302`
 
 ## Phase 26: 本番デプロイガイド
 
@@ -309,6 +309,14 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 - [x] refactor(http): `RuntimeApplicationFactory` コンストラクタを 16 引数から 8 引数に削減 — `NoteRouteRegistrar` / `TagRouteRegistrar` 分離. `#298`
 - [x] feat(mcp): write ツール呼び出し時の Bearer 認証ガードを `LocalMcpServer` に追加する. `#300`
+
+## Phase 34: v0.6.0 リリース
+
+- [x] docs(howto): `add-second-entity.md` — RouteRegistrar パターンを使った 2 つ目のエンティティ追加 HOWTO（6 言語）. `#302`
+- [x] docs(vitepress): HOWTO サイドバーに 4 番目のエントリ追加（6 ロケール）. `#302`
+- [x] docs(roadmap): Phase 33-34 をロードマップに追加する. `#302`
+- [x] chore(changelog): v0.6.0 セクション（Phase 33 変更を記録）. `#302`
+- [x] chore(release): `v0.6.0` タグを打つ. `#302`
 
 ## Operating Notes
 

--- a/docs/zh/howto/add-second-entity.md
+++ b/docs/zh/howto/add-second-entity.md
@@ -1,0 +1,67 @@
+# 添加第二个领域实体
+
+本指南介绍如何按照内置 `Note` 和 `Tag` 示例的模式添加第二个领域实体。
+
+**前提条件**：已完成[添加数据库端点](./add-database-endpoint.md)。
+
+---
+
+## 概述
+
+每个实体遵循相同的结构：
+
+```
+src/Example/YourEntity/
+  YourEntity.php
+  YourEntityRepositoryInterface.php
+  PdoYourEntityRepository.php
+  GetYourEntityByIdHandler.php
+  YourEntityRouteRegistrar.php   ← 通过 __invoke(Router) 注册路由
+  YourEntityServiceProvider.php  ← DI 配置 + 路由注册器
+```
+
+只需在 `RuntimeServiceProvider` 中添加新的注册器和异常处理器 — **`RuntimeApplicationFactory` 无需修改**。
+
+---
+
+## 关键步骤
+
+### 1 — RouteRegistrar
+
+```php
+final readonly class ProductRouteRegistrar
+{
+    public function __construct(
+        private GetProductByIdHandler $getHandler,
+        private ListProductsHandler $listHandler,
+    ) {}
+
+    public function __invoke(Router $router): void
+    {
+        $get  = $this->getHandler;
+        $list = $this->listHandler;
+        $router->get('/examples/products', static fn ($r) => $list->handle($r));
+        $router->get('/examples/products/{id}', static fn ($r) => $get->handle($r));
+    }
+}
+```
+
+### 2 — ServiceProvider
+
+在 `register()` 中将注册器注册为 `nene2.route_registrar.product`。
+
+### 3 — 在 RuntimeServiceProvider 中配置
+
+```php
+$builder->addProvider(new ProductServiceProvider());
+
+return new RuntimeApplicationFactory(
+    /* ... */,
+    [$noteNotFoundHandler, $tagNotFoundHandler, $productNotFoundHandler],
+    $requestIdHolder,
+    [$noteRegistrar, $tagRegistrar, $productRegistrar],
+    $bearerMiddleware,
+);
+```
+
+详细内容请参阅英文版或 `src/Example/` 中的 `Note`/`Tag` 示例。


### PR DESCRIPTION
## Summary

- Phase 25 の残りタスク: `docs/howto/add-second-entity.md` を 6 言語で追加（RouteRegistrar パターンを軸にした多エンティティ HOWTO）
- VitePress サイドバーに "Add a second entity" エントリを追加（全 6 ロケール）
- バージョンバッジを `v0.6.0` に更新
- ロードマップに Phase 33-34 を追記
- CHANGELOG v0.6.0 セクション（Phase 33 の変更: RuntimeApplicationFactory 削減 + MCP 認証ガード）
- TODO 更新

## Test plan

- [x] `composer check` — 153/153, PHPStan no errors, CS-Fixer 0 violations, OpenAPI valid, MCP catalog valid
- [x] `npm run check` — frontend 全通過
- [x] VitePress config に全 6 言語 `addEntity` キーが揃っていることを確認

Self-review: docs-policy

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)