### PR TITLE
feat(tag): Tag CRUD completion — PUT/DELETE + 5 MCP tools (#304)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -211,6 +211,136 @@
         }
       },
       "responseSchemaRef": null
+    },
+    {
+      "name": "listExampleTags",
+      "title": "List Example Tags",
+      "description": "List example tags with optional limit and offset pagination.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "listExampleTags",
+        "method": "GET",
+        "path": "/examples/tags"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/ExampleTagListResponse"
+    },
+    {
+      "name": "getExampleTagById",
+      "title": "Get Example Tag",
+      "description": "Read an example tag by ID through the documented public API.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "getExampleTagById",
+        "method": "GET",
+        "path": "/examples/tags/{id}"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/ExampleTagResponse"
+    },
+    {
+      "name": "createExampleTag",
+      "title": "Create Example Tag",
+      "description": "Create a new example tag. Returns 201 with the created tag and a Location header.",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "createExampleTag",
+        "method": "POST",
+        "path": "/examples/tags"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "responseSchemaRef": null
+    },
+    {
+      "name": "updateExampleTagById",
+      "title": "Update Example Tag",
+      "description": "Replace an existing example tag (full replacement — name required).",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "updateExampleTagById",
+        "method": "PUT",
+        "path": "/examples/tags/{id}"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/ExampleTagResponse"
+    },
+    {
+      "name": "deleteExampleTagById",
+      "title": "Delete Example Tag",
+      "description": "Delete an example tag by ID. Returns 204 on success.",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "deleteExampleTagById",
+        "method": "DELETE",
+        "path": "/examples/tags/{id}"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "responseSchemaRef": null
     }
   ]
 }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -240,6 +240,73 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - Examples
+      summary: Update example tag
+      description: Updates a tag by ID. Replaces the name. Returns 200 with the updated tag on success.
+      operationId: updateExampleTagById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Tag ID.
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTagRequest'
+            examples:
+              update:
+                summary: Update tag request
+                value:
+                  name: php8
+      responses:
+        '200':
+          description: Tag updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleTagResponse'
+              examples:
+                ok:
+                  summary: Successful update response
+                  value:
+                    id: 1
+                    name: php8
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Examples
+      summary: Delete example tag
+      description: Deletes a tag by ID. Returns 204 on success, 404 if the tag does not exist.
+      operationId: deleteExampleTagById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Tag ID.
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        '204':
+          description: Tag deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /examples/notes:
     get:
       tags:

--- a/src/Example/Tag/DeleteTagByIdInput.php
+++ b/src/Example/Tag/DeleteTagByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class DeleteTagByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Example/Tag/DeleteTagHandler.php
+++ b/src/Example/Tag/DeleteTagHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteTagHandler
+{
+    public function __construct(
+        private DeleteTagUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new TagNotFoundException($id);
+        }
+
+        $this->useCase->execute(new DeleteTagByIdInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/Example/Tag/DeleteTagUseCase.php
+++ b/src/Example/Tag/DeleteTagUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class DeleteTagUseCase implements DeleteTagUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(DeleteTagByIdInput $input): void
+    {
+        $tag = $this->tags->findById($input->id);
+
+        if ($tag === null) {
+            throw new TagNotFoundException($input->id);
+        }
+
+        $this->tags->delete($input->id);
+    }
+}

--- a/src/Example/Tag/DeleteTagUseCaseInterface.php
+++ b/src/Example/Tag/DeleteTagUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+interface DeleteTagUseCaseInterface
+{
+    /**
+     * @throws TagNotFoundException when no tag matches the given id.
+     */
+    public function execute(DeleteTagByIdInput $input): void;
+}

--- a/src/Example/Tag/PdoTagRepository.php
+++ b/src/Example/Tag/PdoTagRepository.php
@@ -47,4 +47,14 @@ final readonly class PdoTagRepository implements TagRepositoryInterface
 
         return $this->query->lastInsertId();
     }
+
+    public function update(Tag $tag): void
+    {
+        $this->query->execute('UPDATE tags SET name = ? WHERE id = ?', [$tag->name, $tag->id]);
+    }
+
+    public function delete(int $id): void
+    {
+        $this->query->execute('DELETE FROM tags WHERE id = ?', [$id]);
+    }
 }

--- a/src/Example/Tag/TagRepositoryInterface.php
+++ b/src/Example/Tag/TagRepositoryInterface.php
@@ -12,4 +12,8 @@ interface TagRepositoryInterface
     public function findAll(int $limit, int $offset): array;
 
     public function save(Tag $tag): int;
+
+    public function update(Tag $tag): void;
+
+    public function delete(int $id): void;
 }

--- a/src/Example/Tag/TagRouteRegistrar.php
+++ b/src/Example/Tag/TagRouteRegistrar.php
@@ -13,6 +13,8 @@ final readonly class TagRouteRegistrar
         private ListTagsHandler $listHandler,
         private GetTagByIdHandler $getHandler,
         private CreateTagHandler $createHandler,
+        private UpdateTagHandler $updateHandler,
+        private DeleteTagHandler $deleteHandler,
     ) {
     }
 
@@ -21,9 +23,13 @@ final readonly class TagRouteRegistrar
         $listHandler = $this->listHandler;
         $getHandler = $this->getHandler;
         $createHandler = $this->createHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
 
         $router->get('/examples/tags', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
         $router->get('/examples/tags/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
         $router->post('/examples/tags', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->put('/examples/tags/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->delete('/examples/tags/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
     }
 }

--- a/src/Example/Tag/TagServiceProvider.php
+++ b/src/Example/Tag/TagServiceProvider.php
@@ -11,6 +11,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 
 final readonly class TagServiceProvider implements ServiceProviderInterface
 {
@@ -117,6 +118,64 @@ final readonly class TagServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                UpdateTagUseCaseInterface::class,
+                static function (ContainerInterface $c): UpdateTagUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new UpdateTagUseCase($repository);
+                },
+            )
+            ->set(
+                UpdateTagHandler::class,
+                static function (ContainerInterface $c): UpdateTagHandler {
+                    $useCase = $c->get(UpdateTagUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateTagUseCaseInterface) {
+                        throw new LogicException('UpdateTag use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateTagHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteTagUseCaseInterface::class,
+                static function (ContainerInterface $c): DeleteTagUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new DeleteTagUseCase($repository);
+                },
+            )
+            ->set(
+                DeleteTagHandler::class,
+                static function (ContainerInterface $c): DeleteTagHandler {
+                    $useCase = $c->get(DeleteTagUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteTagUseCaseInterface) {
+                        throw new LogicException('DeleteTag use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteTagHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
                 TagNotFoundExceptionHandler::class,
                 static function (ContainerInterface $c): TagNotFoundExceptionHandler {
                     $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
@@ -134,6 +193,8 @@ final readonly class TagServiceProvider implements ServiceProviderInterface
                     $list = $c->get(ListTagsHandler::class);
                     $get = $c->get(GetTagByIdHandler::class);
                     $create = $c->get(CreateTagHandler::class);
+                    $update = $c->get(UpdateTagHandler::class);
+                    $delete = $c->get(DeleteTagHandler::class);
 
                     if (!$list instanceof ListTagsHandler) {
                         throw new LogicException('ListTags handler service is invalid.');
@@ -147,7 +208,15 @@ final readonly class TagServiceProvider implements ServiceProviderInterface
                         throw new LogicException('CreateTag handler service is invalid.');
                     }
 
-                    return new TagRouteRegistrar($list, $get, $create);
+                    if (!$update instanceof UpdateTagHandler) {
+                        throw new LogicException('UpdateTag handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteTagHandler) {
+                        throw new LogicException('DeleteTag handler service is invalid.');
+                    }
+
+                    return new TagRouteRegistrar($list, $get, $create, $update, $delete);
                 },
             );
     }

--- a/src/Example/Tag/UpdateTagHandler.php
+++ b/src/Example/Tag/UpdateTagHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateTagHandler
+{
+    public function __construct(
+        private UpdateTagUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new TagNotFoundException($id);
+        }
+
+        $body = (array) json_decode((string) $request->getBody(), associative: true);
+
+        $name = trim((string) ($body['name'] ?? ''));
+
+        if ($name === '') {
+            throw new ValidationException([new ValidationError('name', 'Name is required.', 'required')]);
+        }
+
+        $output = $this->useCase->execute(new UpdateTagInput(id: $id, name: $name));
+
+        return $this->response->create(['id' => $output->id, 'name' => $output->name]);
+    }
+}

--- a/src/Example/Tag/UpdateTagInput.php
+++ b/src/Example/Tag/UpdateTagInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class UpdateTagInput
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Example/Tag/UpdateTagOutput.php
+++ b/src/Example/Tag/UpdateTagOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class UpdateTagOutput
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Example/Tag/UpdateTagUseCase.php
+++ b/src/Example/Tag/UpdateTagUseCase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+final readonly class UpdateTagUseCase implements UpdateTagUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(UpdateTagInput $input): UpdateTagOutput
+    {
+        $tag = $this->tags->findById($input->id);
+
+        if ($tag === null) {
+            throw new TagNotFoundException($input->id);
+        }
+
+        $updated = new Tag(name: $input->name, id: $input->id);
+        $this->tags->update($updated);
+
+        return new UpdateTagOutput(id: $input->id, name: $input->name);
+    }
+}

--- a/src/Example/Tag/UpdateTagUseCaseInterface.php
+++ b/src/Example/Tag/UpdateTagUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Tag;
+
+interface UpdateTagUseCaseInterface
+{
+    public function execute(UpdateTagInput $input): UpdateTagOutput;
+}

--- a/tests/Example/Tag/InMemoryTagRepository.php
+++ b/tests/Example/Tag/InMemoryTagRepository.php
@@ -46,4 +46,16 @@ final class InMemoryTagRepository implements TagRepositoryInterface
 
         return $id;
     }
+
+    public function update(Tag $tag): void
+    {
+        if ($tag->id !== null) {
+            $this->tags[$tag->id] = $tag;
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        unset($this->tags[$id]);
+    }
 }

--- a/tests/Example/Tag/TagHttpTest.php
+++ b/tests/Example/Tag/TagHttpTest.php
@@ -7,6 +7,8 @@ namespace Nene2\Tests\Example\Tag;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Example\Tag\CreateTagHandler;
 use Nene2\Example\Tag\CreateTagUseCase;
+use Nene2\Example\Tag\DeleteTagHandler;
+use Nene2\Example\Tag\DeleteTagUseCase;
 use Nene2\Example\Tag\GetTagByIdHandler;
 use Nene2\Example\Tag\GetTagByIdUseCase;
 use Nene2\Example\Tag\ListTagsHandler;
@@ -14,6 +16,8 @@ use Nene2\Example\Tag\ListTagsUseCase;
 use Nene2\Example\Tag\Tag;
 use Nene2\Example\Tag\TagNotFoundExceptionHandler;
 use Nene2\Example\Tag\TagRouteRegistrar;
+use Nene2\Example\Tag\UpdateTagHandler;
+use Nene2\Example\Tag\UpdateTagUseCase;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -39,6 +43,8 @@ final class TagHttpTest extends TestCase
             new ListTagsHandler(new ListTagsUseCase($this->repository), $jsonResponse),
             new GetTagByIdHandler(new GetTagByIdUseCase($this->repository), $jsonResponse),
             new CreateTagHandler(new CreateTagUseCase($this->repository), $jsonResponse),
+            new UpdateTagHandler(new UpdateTagUseCase($this->repository), $jsonResponse),
+            new DeleteTagHandler(new DeleteTagUseCase($this->repository), $this->factory),
         );
 
         $this->application = (new RuntimeApplicationFactory(
@@ -120,6 +126,57 @@ final class TagHttpTest extends TestCase
         self::assertSame(422, $response->getStatusCode());
         self::assertStringContainsString('application/problem+json', $response->getHeaderLine('Content-Type'));
         self::assertNotEmpty($payload['errors']);
+    }
+
+    public function testUpdateTagReturns200(): void
+    {
+        $id = $this->repository->save(new Tag(name: 'php'));
+
+        $response = $this->request('PUT', "/examples/tags/{$id}", ['name' => 'php8']);
+        $payload = $this->decode($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($id, $payload['id']);
+        self::assertSame('php8', $payload['name']);
+    }
+
+    public function testUpdateTagReturns404WhenAbsent(): void
+    {
+        $response = $this->request('PUT', '/examples/tags/99', ['name' => 'php8']);
+        $payload = $this->decode($response);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('application/problem+json', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function testUpdateTagReturns422WhenNameMissing(): void
+    {
+        $id = $this->repository->save(new Tag(name: 'php'));
+
+        $response = $this->request('PUT', "/examples/tags/{$id}", ['name' => '']);
+        $payload = $this->decode($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertNotEmpty($payload['errors']);
+    }
+
+    public function testDeleteTagReturns204(): void
+    {
+        $id = $this->repository->save(new Tag(name: 'php'));
+
+        $response = $this->request('DELETE', "/examples/tags/{$id}");
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertNull($this->repository->findById($id));
+    }
+
+    public function testDeleteTagReturns404WhenAbsent(): void
+    {
+        $response = $this->request('DELETE', '/examples/tags/99');
+        $payload = $this->decode($response);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('application/problem+json', $response->getHeaderLine('Content-Type'));
     }
 
     /** @param array<string, mixed>|null $body */


### PR DESCRIPTION
## Summary

- `PUT /examples/tags/{id}` — tag update endpoint (full replacement of `name`)
- `DELETE /examples/tags/{id}` — tag delete endpoint
- Tag MCP tool catalog completed: list / get / create / update / delete (5 tools)
- Note/Tag symmetry restored — both entities now have full CRUD coverage

## Changes

**Domain layer**
- `TagRepositoryInterface`: added `update(Tag): void` and `delete(int): void`
- `PdoTagRepository` / `InMemoryTagRepository`: implemented both methods
- `UpdateTagInput/Output`, `UpdateTagUseCaseInterface`, `UpdateTagUseCase`, `UpdateTagHandler`
- `DeleteTagByIdInput`, `DeleteTagUseCaseInterface`, `DeleteTagUseCase`, `DeleteTagHandler`

**Route wiring**
- `TagRouteRegistrar`: added PUT/DELETE routes (now 5 routes, 5 constructor params)
- `TagServiceProvider`: registers 4 new services + updated registrar closure

**API contract**
- OpenAPI: `PUT /examples/tags/{id}` and `DELETE /examples/tags/{id}` paths added
- `docs/mcp/tools.json`: 5 Tag tools added (previously 0)

**Tests**
- `TagHttpTest`: +5 tests for PUT/DELETE (200, 404, 422, 204, 404)
- Total: 158 tests, 535 assertions — all green

## Verification

```
composer check   → OK (158 tests, PHPStan clean, CS clean, OpenAPI valid, MCP valid)
```

Self-review: backend-api, openapi-contract

Closes #304