### PR TITLE
chore(release): v0.7.0 CHANGELOG 確定 + HOWTO Tag テーブル修正 + バッジ更新

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -9,7 +9,7 @@ function nav(t: {
     { text: t.explanation, link: 'explanation/why-psr',           activeMatch: 'explanation/' },
     { text: t.reference,   link: 'development/endpoint-scaffold', activeMatch: 'development/' },
     {
-      text: 'v0.6.0',
+      text: 'v0.7.0',
       items: [
         { text: 'Changelog',  link: 'https://github.com/hideyukiMORI/NENE2/blob/main/CHANGELOG.md' },
         { text: 'Releases',   link: 'https://github.com/hideyukiMORI/NENE2/releases' },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.7.0] — 2026-05-18
+
 ### Added
 - `PUT /examples/tags/{id}` — full tag update endpoint; replaces `name` field (#304)
 - `DELETE /examples/tags/{id}` — tag delete endpoint; returns 204 (#304)
@@ -18,10 +22,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `DeleteTagUseCase`, `DeleteTagHandler`, `DeleteTagByIdInput`, `DeleteTagUseCaseInterface` (#304)
 - `TagRepositoryInterface::update(Tag): void` and `delete(int): void` implemented in `PdoTagRepository` and `InMemoryTagRepository` (#304)
 - 5 Tag MCP tools in `docs/mcp/tools.json`: `listExampleTags`, `getExampleTagById`, `createExampleTag`, `updateExampleTagById`, `deleteExampleTagById` — Tag/Note MCP parity restored (#304)
+- `database/migrations/20260516000001_create_tags_table.php` — Phinx migration for the `tags` table (#306)
+- `database/schema/tags.sql` — schema snapshot for the `tags` table (#306)
+- Endpoint scaffold checklist: added "create migration" step for new entity tables (#307)
 
 ### Changed
 - `TagRouteRegistrar` extended from 3 to 5 routes and constructor params (#304)
 - `TagServiceProvider` registers `UpdateTagHandler`, `DeleteTagHandler`, and their use cases; registrar closure updated (#304)
+- `docs/howto/add-second-entity.md` — Tag endpoint table corrected to reflect full CRUD
 
 ---
 
@@ -181,7 +189,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Governance docs: workflow, coding standards, ADR policy, review checklists (#1)
 - ADR 0001–0004: HTTP runtime, DI container, phpdotenv, Phinx
 
-[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.1.3...v0.2.0

--- a/docs/howto/add-second-entity.md
+++ b/docs/howto/add-second-entity.md
@@ -178,7 +178,7 @@ That is all — `RuntimeApplicationFactory` itself does not change.
 | Entity | Source | Endpoints |
 |---|---|---|
 | `Note` | `src/Example/Note/` | GET/POST `/examples/notes`, GET/PUT/DELETE `/examples/notes/{id}` |
-| `Tag` | `src/Example/Tag/` | GET/POST `/examples/tags`, GET `/examples/tags/{id}` |
+| `Tag` | `src/Example/Tag/` | GET/POST `/examples/tags`, GET/PUT/DELETE `/examples/tags/{id}` |
 
 Both follow this exact pattern. Copy the structure that fits your endpoint set.
 

--- a/docs/ja/howto/add-second-entity.md
+++ b/docs/ja/howto/add-second-entity.md
@@ -129,7 +129,7 @@ return new RuntimeApplicationFactory(
 | エンティティ | ソース | エンドポイント |
 |---|---|---|
 | `Note` | `src/Example/Note/` | GET/POST `/examples/notes`、GET/PUT/DELETE `/examples/notes/{id}` |
-| `Tag` | `src/Example/Tag/` | GET/POST `/examples/tags`、GET `/examples/tags/{id}` |
+| `Tag` | `src/Example/Tag/` | GET/POST `/examples/tags`、GET/PUT/DELETE `/examples/tags/{id}` |
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -424,6 +424,26 @@ Goal: restore Note/Tag symmetry by completing Tag full CRUD and closing the MCP 
 - 5 Tag MCP tools added to `docs/mcp/tools.json` (list / get / create / update / delete)
 - TagHttpTest expanded with PUT/DELETE coverage (158 tests total)
 
+## Phase 36: Field Trial 7 (#306)
+
+Goal: validate Tag CRUD and MCP write auth guard end-to-end, record friction.
+
+- All Tag CRUD HTTP endpoints verified against MySQL
+- MCP write auth guard confirmed (blocks writes without JWT secret)
+- All 5 Tag MCP tools validated
+- Missing migration discovered and fixed (`CreateTagsTable`)
+- Scaffold checklist updated with migration step
+
+## Phase 37: v0.7.0 Release
+
+Goal: consolidate Phase 35–36 changes into a tagged release.
+
+- CHANGELOG v0.7.0 section (Tag CRUD, migrations, scaffold fix)
+- CHANGELOG footer links corrected for v0.5.0 / v0.6.0 (previously missing)
+- `add-second-entity.md` Tag endpoint table corrected to full CRUD (en/ja)
+- VitePress version badge updated to v0.7.0
+- `v0.7.0` tag
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -331,6 +331,13 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] chore(db): `database/schema/tags.sql` スキーマスナップショット追加. `#308`
 - [x] docs(scaffold): エンドポイントスキャフォールドチェックリストにマイグレーション作成ステップ追加. `#307`
 
+## Phase 37: v0.7.0 リリース
+
+- [x] chore(changelog): v0.7.0 セクション確定・リンク修正（v0.5.0/v0.6.0 欠落を補完）.
+- [x] docs(howto): `add-second-entity.md` Tag エンドポイントテーブルを full CRUD に更新（en/ja）.
+- [x] chore(vitepress): バージョンバッジ v0.6.0 → v0.7.0.
+- [x] chore(release): `v0.7.0` タグを打つ.
+
 ## Operating Notes
 
 - Keep this file short.


### PR DESCRIPTION
## Summary

- CHANGELOG `[Unreleased]` → `[0.7.0] — 2026-05-18` 確定
- CHANGELOG footer links: v0.5.0 / v0.6.0 の比較リンクが欠落していたため補完
- `docs/howto/add-second-entity.md` (en/ja): Tag 参照テーブルの Endpoints 列が古かった (`GET /examples/tags/{id}` のみ) → `GET/PUT/DELETE /examples/tags/{id}` に修正
- `.vitepress/config.mts`: バージョンバッジ `v0.6.0` → `v0.7.0`
- `docs/roadmap.md`: Phase 36 / 37 追加
- `docs/todo/current.md`: Phase 37 完了マーク

## Pre-merge checklist

- `composer check` → 158 tests OK, PHPStan clean, CS clean, OpenAPI valid, MCP valid

Self-review: docs-policy, release-ci

Closes (no new issue — housekeeping cleanup)