### PR TITLE
test(tag): UpdateTagUseCase / DeleteTagUseCase + PdoTagRepository update/delete カバレッジ追加 (#304)

### DIFF
--- a/tests/Example/Tag/PdoTagRepositoryTest.php
+++ b/tests/Example/Tag/PdoTagRepositoryTest.php
@@ -87,4 +87,25 @@ final class PdoTagRepositoryTest extends TestCase
         self::assertSame('api', $tags[0]->name);
         self::assertSame('mcp', $tags[1]->name);
     }
+
+    public function testUpdateChangesTagName(): void
+    {
+        $repository = new PdoTagRepository($this->executor);
+        $id = $repository->save(new Tag(name: 'php'));
+
+        $repository->update(new Tag(name: 'php8', id: $id));
+        $tag = $repository->findById($id);
+
+        self::assertNotNull($tag);
+        self::assertSame('php8', $tag->name);
+    }
+
+    public function testDeleteRemovesTag(): void
+    {
+        $repository = new PdoTagRepository($this->executor);
+        $id = $repository->save(new Tag(name: 'php'));
+        $repository->delete($id);
+
+        self::assertNull($repository->findById($id));
+    }
 }

--- a/tests/Example/Tag/TagUseCaseTest.php
+++ b/tests/Example/Tag/TagUseCaseTest.php
@@ -6,12 +6,16 @@ namespace Nene2\Tests\Example\Tag;
 
 use Nene2\Example\Tag\CreateTagInput;
 use Nene2\Example\Tag\CreateTagUseCase;
+use Nene2\Example\Tag\DeleteTagByIdInput;
+use Nene2\Example\Tag\DeleteTagUseCase;
 use Nene2\Example\Tag\GetTagByIdInput;
 use Nene2\Example\Tag\GetTagByIdUseCase;
 use Nene2\Example\Tag\ListTagsInput;
 use Nene2\Example\Tag\ListTagsUseCase;
 use Nene2\Example\Tag\Tag;
 use Nene2\Example\Tag\TagNotFoundException;
+use Nene2\Example\Tag\UpdateTagInput;
+use Nene2\Example\Tag\UpdateTagUseCase;
 use PHPUnit\Framework\TestCase;
 
 final class TagUseCaseTest extends TestCase
@@ -76,5 +80,54 @@ final class TagUseCaseTest extends TestCase
 
         self::assertCount(2, $output->items);
         self::assertSame('api', $output->items[0]->name);
+    }
+
+    public function testUpdateTagChangesName(): void
+    {
+        $repository = new InMemoryTagRepository([]);
+        $createUseCase = new CreateTagUseCase($repository);
+        $updateUseCase = new UpdateTagUseCase($repository);
+
+        $created = $createUseCase->execute(new CreateTagInput(name: 'php'));
+        $output = $updateUseCase->execute(new UpdateTagInput(id: $created->id, name: 'php8'));
+
+        self::assertSame($created->id, $output->id);
+        self::assertSame('php8', $output->name);
+
+        $stored = $repository->findById($created->id);
+        self::assertNotNull($stored);
+        self::assertSame('php8', $stored->name);
+    }
+
+    public function testUpdateTagThrowsWhenAbsent(): void
+    {
+        $repository = new InMemoryTagRepository([]);
+        $updateUseCase = new UpdateTagUseCase($repository);
+
+        $this->expectException(TagNotFoundException::class);
+
+        $updateUseCase->execute(new UpdateTagInput(id: 99, name: 'php8'));
+    }
+
+    public function testDeleteTagRemovesTag(): void
+    {
+        $repository = new InMemoryTagRepository([]);
+        $createUseCase = new CreateTagUseCase($repository);
+        $deleteUseCase = new DeleteTagUseCase($repository);
+
+        $created = $createUseCase->execute(new CreateTagInput(name: 'php'));
+        $deleteUseCase->execute(new DeleteTagByIdInput($created->id));
+
+        self::assertNull($repository->findById($created->id));
+    }
+
+    public function testDeleteTagThrowsWhenAbsent(): void
+    {
+        $repository = new InMemoryTagRepository([]);
+        $deleteUseCase = new DeleteTagUseCase($repository);
+
+        $this->expectException(TagNotFoundException::class);
+
+        $deleteUseCase->execute(new DeleteTagByIdInput(99));
     }
 }


### PR DESCRIPTION
## Summary

Phase 35（#304）で実装した `UpdateTagUseCase` / `DeleteTagUseCase` / `PdoTagRepository::update()` / `PdoTagRepository::delete()` がユニットテスト・PDO アダプターテストから抜けていた。

Note 側（`UpdateNoteUseCaseTest`, `DeleteNoteUseCaseTest`, `PdoNoteRepositoryTest`）と同等のカバレッジに揃える。

## Added tests

**`TagUseCaseTest`** (+4):
- `testUpdateTagChangesName` — 更新後の name が変わることと DB 反映を確認
- `testUpdateTagThrowsWhenAbsent` — 存在しない id で `TagNotFoundException`
- `testDeleteTagRemovesTag` — 削除後 `findById` が null を返すことを確認
- `testDeleteTagThrowsWhenAbsent` — 存在しない id で `TagNotFoundException`

**`PdoTagRepositoryTest`** (+2):
- `testUpdateChangesTagName` — SQLite in-memory で UPDATE が反映されることを確認
- `testDeleteRemovesTag` — SQLite in-memory で DELETE が反映されることを確認

## Result

158 → **164 tests**, 535 → **545 assertions** — all green

Self-review: backend-api