### PR TITLE
feat(frontend): Tag CRUD 対応 — TagList / TagForm / api/tags.ts 追加 (#314)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -267,6 +267,163 @@ h1 {
   cursor: not-allowed;
 }
 
+/* Tags section */
+.tags-section {
+  border: 1px solid #dce4f2;
+  border-radius: 1rem;
+  background: #ffffff;
+  margin-top: 1rem;
+  padding: 1.5rem;
+}
+
+.tag-list {
+  list-style: none;
+  margin: 0 0 1.5rem;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 1px solid #c8d3e8;
+  border-radius: 999px;
+  background: #f0f4ff;
+  padding: 0.25rem 0.5rem 0.25rem 0.75rem;
+  font-size: 0.875rem;
+  color: #172033;
+}
+
+.tag-chip--editing {
+  border-color: #4d63ff;
+  background: #ffffff;
+  padding: 0.25rem 0.375rem;
+}
+
+.tag-name {
+  font-weight: 500;
+}
+
+.tag-edit-input {
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: #172033;
+  width: 8rem;
+  padding: 0;
+}
+
+.tag-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.875rem;
+  line-height: 1;
+  padding: 0.125rem 0.25rem;
+  color: #8898b0;
+  transition:
+    color 0.1s,
+    background 0.1s;
+}
+
+.tag-btn:hover:not(:disabled) {
+  background: #e2e8f8;
+  color: #172033;
+}
+
+.tag-btn--delete:hover:not(:disabled) {
+  background: #fde8e8;
+  color: #c0392b;
+}
+
+.tag-btn--save:hover:not(:disabled) {
+  background: #e8f8ef;
+  color: #145a32;
+}
+
+.tag-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tag-loading,
+.tag-empty {
+  margin: 0 0 1.5rem;
+  color: #566174;
+  font-size: 0.9375rem;
+}
+
+.tag-error {
+  margin: 0 0 1rem;
+  color: #c0392b;
+  font-size: 0.9375rem;
+}
+
+/* Tag form */
+.tag-form {
+  border-top: 1px solid #edf2fb;
+  padding-top: 1.25rem;
+}
+
+.tag-form-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.tag-form-row input {
+  flex: 1;
+  border: 1px solid #c8d3e8;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9375rem;
+  font-family: inherit;
+  color: #172033;
+  background: #f7f9fc;
+  transition: border-color 0.15s;
+}
+
+.tag-form-row input:focus {
+  outline: none;
+  border-color: #4d63ff;
+  background: #ffffff;
+}
+
+.tag-form-row input:disabled {
+  opacity: 0.6;
+}
+
+.tag-submit {
+  flex-shrink: 0;
+  border: none;
+  border-radius: 0.5rem;
+  background: #4d63ff;
+  color: #ffffff;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  padding: 0.625rem 1.25rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.tag-submit:hover:not(:disabled) {
+  background: #3a4fe0;
+}
+
+.tag-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 @media (max-width: 720px) {
   .hero {
     padding: 2rem;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,11 +4,14 @@ import './App.css';
 import { fetchHealth, type HealthResponse } from './api/health';
 import { NoteList } from './components/NoteList';
 import { NoteForm } from './components/NoteForm';
+import { TagList } from './components/TagList';
+import { TagForm } from './components/TagForm';
 
 export function App() {
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [healthError, setHealthError] = useState<string | null>(null);
   const [noteRefresh, setNoteRefresh] = useState(0);
+  const [tagRefresh, setTagRefresh] = useState(0);
 
   useEffect(() => {
     let isActive = true;
@@ -36,6 +39,10 @@ export function App() {
 
   function handleNoteCreated() {
     setNoteRefresh((n) => n + 1);
+  }
+
+  function handleTagChanged() {
+    setTagRefresh((n) => n + 1);
   }
 
   return (
@@ -77,6 +84,18 @@ export function App() {
         </p>
         <NoteList refresh={noteRefresh} />
         <NoteForm onCreated={handleNoteCreated} />
+      </section>
+
+      <section className="tags-section" aria-labelledby="tags-title">
+        <h2 id="tags-title" className="section-title">
+          Tags
+        </h2>
+        <p className="section-desc">
+          Live data from <code>GET /examples/tags</code>. Create, rename, or
+          delete tags. Demonstrates full CRUD from the frontend.
+        </p>
+        <TagList refresh={tagRefresh} onChanged={handleTagChanged} />
+        <TagForm onCreated={handleTagChanged} />
       </section>
     </main>
   );

--- a/frontend/src/api/tags.ts
+++ b/frontend/src/api/tags.ts
@@ -1,0 +1,117 @@
+function apiBase(): string {
+  return (
+    (import.meta.env.VITE_NENE2_API_BASE_URL as string | undefined) ?? '/api'
+  );
+}
+
+export type Tag = {
+  readonly id: number;
+  readonly name: string;
+};
+
+export type TagListResponse = {
+  readonly items: readonly Tag[];
+  readonly limit: number;
+  readonly offset: number;
+};
+
+export type CreateTagRequest = {
+  readonly name: string;
+};
+
+export type UpdateTagRequest = {
+  readonly name: string;
+};
+
+function isTag(value: unknown): value is Tag {
+  if (typeof value !== 'object' || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return typeof c.id === 'number' && typeof c.name === 'string';
+}
+
+function isTagListResponse(value: unknown): value is TagListResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return (
+    Array.isArray(c.items) &&
+    c.items.every(isTag) &&
+    typeof c.limit === 'number' &&
+    typeof c.offset === 'number'
+  );
+}
+
+export async function fetchTags(
+  limit = 20,
+  offset = 0,
+): Promise<TagListResponse> {
+  const url = `${apiBase()}/examples/tags?limit=${limit}&offset=${offset}`;
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch tags: HTTP ${response.status}.`);
+  }
+
+  const payload: unknown = await response.json();
+
+  if (!isTagListResponse(payload)) {
+    throw new Error('Tag list response did not match the expected shape.');
+  }
+
+  return payload;
+}
+
+export async function createTag(input: CreateTagRequest): Promise<Tag> {
+  const response = await fetch(`${apiBase()}/examples/tags`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to create tag: HTTP ${response.status}.`);
+  }
+
+  const payload: unknown = await response.json();
+
+  if (!isTag(payload)) {
+    throw new Error('Create tag response did not match the expected shape.');
+  }
+
+  return payload;
+}
+
+export async function updateTag(
+  id: number,
+  input: UpdateTagRequest,
+): Promise<Tag> {
+  const response = await fetch(`${apiBase()}/examples/tags/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to update tag ${id}: HTTP ${response.status}.`);
+  }
+
+  const payload: unknown = await response.json();
+
+  if (!isTag(payload)) {
+    throw new Error('Update tag response did not match the expected shape.');
+  }
+
+  return payload;
+}
+
+export async function deleteTag(id: number): Promise<void> {
+  const response = await fetch(`${apiBase()}/examples/tags/${id}`, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to delete tag ${id}: HTTP ${response.status}.`);
+  }
+}

--- a/frontend/src/components/TagForm.tsx
+++ b/frontend/src/components/TagForm.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { createTag } from '../api/tags';
+
+type Props = {
+  readonly onCreated: () => void;
+};
+
+export function TagForm({ onCreated }: Props) {
+  const [name, setName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await createTag({ name: name.trim() });
+      setName('');
+      onCreated();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="tag-form" onSubmit={handleSubmit} noValidate>
+      <div className="tag-form-row">
+        <input
+          id="tag-name"
+          type="text"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+          }}
+          required
+          minLength={1}
+          placeholder="New tag name"
+          disabled={submitting}
+          aria-label="New tag name"
+        />
+        <button
+          type="submit"
+          className="tag-submit"
+          disabled={submitting || name.trim() === ''}
+        >
+          {submitting ? 'Adding…' : 'Add tag'}
+        </button>
+      </div>
+
+      {error !== null && <p className="tag-error">{error}</p>}
+    </form>
+  );
+}

--- a/frontend/src/components/TagList.tsx
+++ b/frontend/src/components/TagList.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import { deleteTag, fetchTags, updateTag, type Tag } from '../api/tags';
+
+type LoadState =
+  | { phase: 'loading' }
+  | { phase: 'error'; message: string }
+  | { phase: 'ok'; tags: readonly Tag[] };
+
+type Props = {
+  readonly refresh: number;
+  readonly onChanged: () => void;
+};
+
+export function TagList({ refresh, onChanged }: Props) {
+  const [state, setState] = useState<LoadState>({ phase: 'loading' });
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editName, setEditName] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let isActive = true;
+
+    fetchTags()
+      .then((res) => {
+        if (isActive) setState({ phase: 'ok', tags: res.items });
+      })
+      .catch((err: unknown) => {
+        if (isActive) {
+          setState({
+            phase: 'error',
+            message: err instanceof Error ? err.message : 'Unknown error',
+          });
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [refresh]);
+
+  function startEdit(tag: Tag) {
+    setEditingId(tag.id);
+    setEditName(tag.name);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditName('');
+  }
+
+  async function handleUpdate(id: number) {
+    if (saving || editName.trim() === '') return;
+    setSaving(true);
+
+    try {
+      await updateTag(id, { name: editName.trim() });
+      setEditingId(null);
+      setEditName('');
+      onChanged();
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : 'Failed to update tag.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id: number) {
+    if (!confirm('Delete this tag?')) return;
+
+    try {
+      await deleteTag(id);
+      onChanged();
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : 'Failed to delete tag.');
+    }
+  }
+
+  if (state.phase === 'error') {
+    return <p className="tag-error">{state.message}</p>;
+  }
+
+  if (state.phase === 'loading') {
+    return <p className="tag-loading">Loading tags…</p>;
+  }
+
+  if (state.tags.length === 0) {
+    return (
+      <p className="tag-empty">No tags yet. Create the first one below.</p>
+    );
+  }
+
+  return (
+    <ul className="tag-list">
+      {state.tags.map((tag) =>
+        editingId === tag.id ? (
+          <li key={tag.id} className="tag-chip tag-chip--editing">
+            <input
+              className="tag-edit-input"
+              type="text"
+              value={editName}
+              onChange={(e) => {
+                setEditName(e.target.value);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void handleUpdate(tag.id);
+                if (e.key === 'Escape') cancelEdit();
+              }}
+              autoFocus
+              disabled={saving}
+            />
+            <button
+              className="tag-btn tag-btn--save"
+              onClick={() => void handleUpdate(tag.id)}
+              disabled={saving || editName.trim() === ''}
+              aria-label="Save"
+            >
+              ✓
+            </button>
+            <button
+              className="tag-btn tag-btn--cancel"
+              onClick={cancelEdit}
+              disabled={saving}
+              aria-label="Cancel"
+            >
+              ✕
+            </button>
+          </li>
+        ) : (
+          <li key={tag.id} className="tag-chip">
+            <span className="tag-name">{tag.name}</span>
+            <button
+              className="tag-btn tag-btn--edit"
+              onClick={() => {
+                startEdit(tag);
+              }}
+              aria-label={`Edit ${tag.name}`}
+            >
+              ✎
+            </button>
+            <button
+              className="tag-btn tag-btn--delete"
+              onClick={() => void handleDelete(tag.id)}
+              aria-label={`Delete ${tag.name}`}
+            >
+              ×
+            </button>
+          </li>
+        ),
+      )}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary

フロントエンドが Note のみ対応していた状態を解消。Tag エンティティの全 CRUD 操作をブラウザから行えるようにする。

## 追加ファイル

| ファイル | 内容 |
|---|---|
| `frontend/src/api/tags.ts` | fetchTags / createTag / updateTag / deleteTag — 型付き fetch、ランタイム型ガード付き |
| `frontend/src/components/TagList.tsx` | タグ一覧（チップ UI）、インライン編集（✎ ボタン → テキスト入力 → ✓/✕）、削除（× ボタン + confirm） |
| `frontend/src/components/TagForm.tsx` | 1 フィールド作成フォーム（name） |

## 変更ファイル

- `App.tsx`: Tags セクション追加、`tagRefresh` state で Note とは独立した再描画ループ
- `App.css`: `.tags-section` / `.tag-chip` / `.tag-btn` / `.tag-form-row` スタイル追加

## 検証

- `npm run check --prefix frontend` → TypeScript / ESLint / Prettier 全クリア
- `composer check` → 164 tests, 545 assertions — all green

Self-review: frontend

Closes #314