### PR TITLE
docs(adr): ADR 0009 — v1.0 公開 API スコープと安定性保証

### DIFF
--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -1,0 +1,99 @@
+# ADR 0009: v1.0 Public API Scope and Stability Guarantee
+
+## Status
+
+accepted
+
+## Context
+
+NENE2 reached v0.7.0 with full CRUD example endpoints, MCP integration, JWT auth, and Packagist publication.
+The `CHANGELOG.md` carries the notice "breaking changes may occur between minor versions until `v1.0.0`."
+
+Before cutting v1.0, the project needs to answer two questions:
+
+1. **What is the "public API"?** — which classes, interfaces, and constants does NENE2 commit to not breaking between major versions?
+2. **What is `src/Example/`?** — framework core or reference implementation? The ADR 0006 decision deferred this to post-v0.2.x.
+
+### Options evaluated for `src/Example/`
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Separate into its own repository | Clean library boundary | Two repos to maintain; MySQL integration tests depend on Note/Tag repositories; significantly higher solo-dev overhead |
+| Keep in core, mark stable | No split cost | Pollutes the version signal — changes to example code would require major-version bumps |
+| **Keep in core, mark as reference implementation (unstable)** | No split cost; tests stay intact; AI tools can read usage patterns from vendor | Requires explicit documentation that `src/Example/` is not covered by the stability promise |
+
+### Scope of "public API"
+
+The project uses semantic versioning. For v1.0+, a breaking change is any modification that:
+
+- Removes or renames a public class, interface, method, or constant that application code is expected to reference.
+- Changes a method signature in a way that breaks existing call sites.
+- Changes the behavior of a method in a way that violates its documented contract.
+
+## Decision
+
+### 1. `src/Example/` stays in the core repository
+
+`src/Example/Note/` and `src/Example/Tag/` remain part of the `hideyukimori/nene2` package through v1.0 and beyond. Separating them into a standalone repository is deferred indefinitely unless team size or adoption patterns make it necessary.
+
+**Rationale:** The MySQL integration tests in `tests/Database/MySql/` use the Note/Tag repositories as their fixture layer. Splitting the repository would either duplicate the test infrastructure or create a cross-repository test dependency — both are worse than the namespace cost.
+
+### 2. `src/Example/` is explicitly outside the stability guarantee
+
+`src/Example/` is a **reference implementation** — code that demonstrates how to use the framework, not code that applications are expected to depend on directly.
+
+- Changes to `src/Example/` classes, method signatures, or DTOs **do not** trigger a major version bump, even after v1.0.
+- Application code should **copy and adapt** the example patterns, not import the example classes as library dependencies.
+- This policy is analogous to a framework's scaffold generator: the generated code belongs to the application, not to the framework.
+
+### 3. The stable public API surface
+
+The following namespaces and their public members are covered by the v1.0 stability guarantee (no breaking changes without a major version bump):
+
+| Namespace | Key public surfaces |
+|-----------|---------------------|
+| `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `delete`, `handle`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
+| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `HtmlResponseFactory` |
+| `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
+| `Nene2\Config` | `AppConfig`, `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
+| `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException` |
+| `Nene2\Error` | `DomainExceptionHandlerInterface`, `ProblemDetailsResponseFactory` |
+| `Nene2\Auth` | `TokenVerifierInterface`, `TokenVerificationException`, `BearerTokenMiddleware` |
+| `Nene2\Middleware` | All shipped middleware classes |
+| `Nene2\Validation` | `ValidationException`, `ValidationError` |
+| `Nene2\View` | `NativePhpViewRenderer`, `HtmlEscaper` |
+| `Nene2\Mcp` | `LocalMcpServer`, `LocalMcpHttpClientInterface`, `LocalMcpHttpResponse`, `LocalMcpException` |
+
+### 4. Explicitly outside the stability guarantee
+
+- `Nene2\Example\*` — reference implementation (see decision 2)
+- `Nene2\Log\*` — internal logging plumbing; PSR-3 (`LoggerInterface`) is the stable boundary
+- `Nene2\Http\RuntimeServiceProvider` — internal wiring; application code should not reference it directly
+- `Nene2\Config\ConfigLoader` — internal; applications receive `AppConfig` / `DatabaseConfig` DTOs
+- Concrete PDO adapters (`PdoConnectionFactory`, `PdoDatabaseQueryExecutor`, `PdoDatabaseTransactionManager`) — implementation detail; the `*Interface` types are the stable boundary
+- `tools/` scripts — developer tooling, not part of the library API
+- `docs/mcp/tools.json` — catalog for the shipped example; applications define their own
+
+### 5. MCP stability caveat
+
+`LocalMcpServer` and `LocalMcpToolCatalog` track the MCP specification, which is externally controlled. If the MCP protocol introduces a breaking change, NENE2 will adapt and document it as an exception to the breaking-change rule, noting the upstream cause.
+
+## Consequences
+
+**Benefits**
+
+- Application authors know exactly which surfaces they can depend on across major versions.
+- `src/Example/` can evolve freely as a living tutorial without creating version pressure.
+- The MySQL integration test suite remains intact with no cross-repository dependency.
+
+**Costs / follow-up work**
+
+- The `composer.json` description or README should note the `src/Example/` status so adopters understand when they install the package.
+- Future additions to the stable surface require a conscious decision (and ideally an ADR or at minimum a CHANGELOG entry).
+- PHPDoc `@internal` annotations should be added to classes in the "outside the guarantee" category to help IDEs surface the boundary.
+
+## Related
+
+- Issue: `#334`
+- Supersedes: ADR 0006 (deferred `src/Example/` decision)
+- See also: `CHANGELOG.md`, `docs/development/release-checklist.md`

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -14,6 +14,7 @@ Architecture decisions are recorded here as lightweight ADRs. Each record captur
 | [0006](0006-v0.2.0-scope-and-packagist-policy.md) | v0.2.0 scope and Packagist policy |
 | [0007](0007-put-vs-patch-policy.md) | PUT vs PATCH policy |
 | [0008](0008-jwt-authentication.md) | JWT authentication direction |
+| [0009](0009-v1.0-public-api-scope.md) | v1.0 public API scope and stability guarantee |
 
 ## Template
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -350,6 +350,13 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] test(tag): `PdoTagRepositoryMySqlTest` 追加（save/findAll/update/delete 7 ケース）. `#312`
 - [x] feat(frontend): `api/tags.ts` + `TagList` + `TagForm` — Tag CRUD をブラウザから操作可能に. `#314`
 
+## Phase 40: v1.0 公開 API スコープ定義
+
+- [x] docs(adr): ADR 0009 — v1.0 公開 API スコープと安定性保証を記録する. `#334`
+- [ ] docs(readme): `src/Example/` が参照実装（安定保証外）である旨を README に追記する. `#334`
+- [ ] chore(phpdoc): 安定保証外クラスに `@internal` アノテーションを追加する. `#334`
+- [ ] docs(roadmap): Phase 40 をロードマップに追加する. `#334`
+
 ## Operating Notes
 
 - Keep this file short.


### PR DESCRIPTION
## Summary

- ADR 0009 を追加: v1.0 で何を「安定した公開 API」と宣言するかを記録
- `src/Example/` はコアに同梱し続けるが **安定保証の対象外** と明示（ADR 0006 の判断を確定）
- 安定保証対象の名前空間・クラス・定数を表形式で列挙
- MCP は外部仕様追従のため例外条項を付記
- `docs/todo/current.md` に Phase 40 の残タスク（README 追記・@internal 付与・ロードマップ更新）を追加

## Self-review

- [x] docs-policy

## Closes

Closes #334