### PR TITLE
chore(phase40): v1.0 公開 API スコープ — README・@internal・ロードマップ更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ docker compose run --rm app composer test:database:mysql
 
 ## Domain Layer Example
 
-`src/Example/Note/` is the canonical reference for how each framework layer works together end-to-end. It implements a full Note CRUD with:
+`src/Example/Note/` and `src/Example/Tag/` are **reference implementations** — they demonstrate how to use the framework, but are not part of the public API stability guarantee (see [ADR 0009](docs/adr/0009-v1.0-public-api-scope.md)). Copy and adapt the patterns into your own application; do not import these classes as library dependencies.
+
+`src/Example/Note/` implements a full Note CRUD with:
 
 | Layer | File(s) |
 |---|---|

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -444,6 +444,26 @@ Goal: consolidate Phase 35–36 changes into a tagged release.
 - VitePress version badge updated to v0.7.0
 - `v0.7.0` tag
 
+## Phase 38–39: Coverage and Frontend Parity
+
+Goal: close test coverage gaps and bring the frontend to feature parity with the backend.
+
+- `UpdateTagUseCase` / `DeleteTagUseCase` unit tests (+4)
+- `PdoTagRepository::update()` / `delete()` adapter tests (+2)
+- `PdoTagRepositoryMySqlTest` — MySQL integration (7 cases)
+- `frontend/src/api/tags.ts` typed fetch wrapper
+- `TagList` and `TagForm` React components with live API integration
+
+## Phase 40: v1.0 Public API Scope
+
+Goal: declare the stable public API surface before cutting v1.0, so adopters know which interfaces and classes NENE2 commits not to break across major versions.
+
+- ADR 0009: `src/Example/` stays in core as reference implementation, explicitly outside the stability guarantee
+- Stable surface documented: `Routing`, `Http`, `DependencyInjection`, `Config`, `Database` interfaces, `Error`, `Auth`, `Middleware`, `Validation`, `View`, `Mcp`
+- `@internal` annotations added to implementation-detail classes (`ConfigLoader`, PDO adapters, `Log/*`, `RuntimeServiceProvider`, `LocalMcpToolCatalog`)
+- README updated to note `src/Example/` is a reference implementation, not a dependency target
+- Roadmap updated with Phase 40 entry
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -353,9 +353,9 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 ## Phase 40: v1.0 公開 API スコープ定義
 
 - [x] docs(adr): ADR 0009 — v1.0 公開 API スコープと安定性保証を記録する. `#334`
-- [ ] docs(readme): `src/Example/` が参照実装（安定保証外）である旨を README に追記する. `#334`
-- [ ] chore(phpdoc): 安定保証外クラスに `@internal` アノテーションを追加する. `#334`
-- [ ] docs(roadmap): Phase 40 をロードマップに追加する. `#334`
+- [x] docs(readme): `src/Example/` が参照実装（安定保証外）である旨を README に追記する. `#334`
+- [x] chore(phpdoc): 安定保証外クラスに `@internal` アノテーションを追加する. `#334`
+- [x] docs(roadmap): Phase 40 をロードマップに追加する. `#334`
 
 ## Operating Notes
 

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -6,6 +6,7 @@ namespace Nene2\Config;
 
 use Dotenv\Dotenv;
 
+/** @internal */
 final readonly class ConfigLoader
 {
     /**

--- a/src/Database/PdoConnectionFactory.php
+++ b/src/Database/PdoConnectionFactory.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use PDO;
 use PDOException;
 
+/** @internal */
 final readonly class PdoConnectionFactory implements DatabaseConnectionFactoryInterface
 {
     public function __construct(

--- a/src/Database/PdoDatabaseQueryExecutor.php
+++ b/src/Database/PdoDatabaseQueryExecutor.php
@@ -9,6 +9,7 @@ use PDOException;
 use PDOStatement;
 
 /**
+ * @internal
  * @phpstan-import-type SqlParameters from DatabaseQueryExecutorInterface
  * @phpstan-import-type SqlRow from DatabaseQueryExecutorInterface
  */

--- a/src/Database/PdoDatabaseTransactionManager.php
+++ b/src/Database/PdoDatabaseTransactionManager.php
@@ -7,6 +7,7 @@ namespace Nene2\Database;
 use PDOException;
 use Throwable;
 
+/** @internal */
 final readonly class PdoDatabaseTransactionManager implements DatabaseTransactionManagerInterface
 {
     public function __construct(

--- a/src/Http/RuntimeContainerFactory.php
+++ b/src/Http/RuntimeContainerFactory.php
@@ -7,6 +7,7 @@ namespace Nene2\Http;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Psr\Container\ContainerInterface;
 
+/** @internal */
 final readonly class RuntimeContainerFactory
 {
     public function __construct(

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -33,6 +33,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 
+/** @internal */
 final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 {
     public const PROJECT_ROOT = 'nene2.project_root';

--- a/src/Log/MonologLoggerFactory.php
+++ b/src/Log/MonologLoggerFactory.php
@@ -10,6 +10,7 @@ use Monolog\Level;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 
+/** @internal */
 final readonly class MonologLoggerFactory
 {
     public function create(string $channel, bool $debug = false, ?RequestIdHolder $requestIdHolder = null): LoggerInterface

--- a/src/Log/RequestIdHolder.php
+++ b/src/Log/RequestIdHolder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Log;
 
+/** @internal */
 final class RequestIdHolder
 {
     private string $requestId = '';

--- a/src/Log/RequestIdProcessor.php
+++ b/src/Log/RequestIdProcessor.php
@@ -6,6 +6,7 @@ namespace Nene2\Log;
 
 use Monolog\LogRecord;
 
+/** @internal */
 final readonly class RequestIdProcessor
 {
     public function __construct(

--- a/src/Mcp/LocalMcpToolCatalog.php
+++ b/src/Mcp/LocalMcpToolCatalog.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Nene2\Mcp;
 
 /**
+ * @internal
  * @phpstan-type McpToolSource array{type: string, operationId: string, method: string, path: string}
  * @phpstan-type McpTool array{name: string, title: string, description: string, safety: string, source: McpToolSource, inputSchema: array<string, mixed>, responseSchemaRef: string|null}
  */


### PR DESCRIPTION
## Summary

ADR 0009 の決定を実装に反映する Phase 40 フォローアップ。

- **README**: `src/Example/` が参照実装（安定保証外）である旨を ADR 0009 へのリンク付きで追記
- **@internal**: 安定保証外クラス 10 個にアノテーションを付与（IDE がライブラリ内部として扱えるようになる）
  - `ConfigLoader`, PDO 実装 3 クラス, `RuntimeServiceProvider`, `RuntimeContainerFactory`, `Log/*` 3 クラス, `LocalMcpToolCatalog`
- **roadmap.md**: Phase 38–39 サマリーと Phase 40 エントリを追加
- **todo/current.md**: Phase 40 全タスクを完了マーク

## Self-review

- [x] docs-policy
- [x] backend-api（@internal は PHPDoc の範囲）

## Closes

Closes #334