### PR TITLE
chore(v1.0-gaps): @internal 漏れ補完・ミドルウェア順修正・CHANGELOG 更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- ADR 0009: v1.0 public API scope and stability guarantee — `src/Example/` declared as reference implementation outside the stability promise (#334)
+- `@internal` annotations on implementation-detail classes: `ConfigLoader`, `PdoConnectionFactory`, `PdoDatabaseQueryExecutor`, `PdoDatabaseTransactionManager`, `RuntimeServiceProvider`, `RuntimeContainerFactory`, `MonologLoggerFactory`, `RequestIdHolder`, `RequestIdProcessor`, `LocalMcpToolCatalog`, `LocalBearerTokenVerifier`, `NativeLocalMcpHttpClient`, `LocalMcpHttpResponse` (#334 #337)
+- `PdoTagRepositoryMySqlTest` — MySQL integration tests for Tag repository (save / findAll / update / delete, 7 cases) (#312)
+- Frontend Tag support: `frontend/src/api/tags.ts` typed fetch wrapper, `TagList` and `TagForm` React components with live API integration (#314)
+- Frontend component tests for `TagList` and `TagForm` (#321)
+- Frontend API type-guard tests for `tags.ts` (#321)
+
+### Changed
+- README: `src/Example/` documented as reference implementation not covered by the stability guarantee (#334)
+- CLAUDE.md § 5 middleware order corrected to match `RuntimeApplicationFactory` implementation: `RequestId → Logging → Security → CORS → Error → RequestSize → Auth` (#337)
+- ADR 0008 middleware placement table corrected to match implementation (#337)
+- Roadmap: Phase 38–39–40 entries added (#334)
+
 ---
 
 ## [0.7.0] — 2026-05-18

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,15 +196,17 @@ UseCase     : ビジネス不変条件、認可ルール、状態依存ルール
 ## 5. ミドルウェア順序
 
 ```
-1. Error handling
-2. Request id
+1. Request id
+2. Request logging
 3. Security headers
 4. CORS
-5. Request size limit
-6. Authentication / authorization
-7. OpenAPI or request validation
+5. Error handling
+6. Request size limit
+7. Authentication / authorization
 8. Routing / handler dispatch
 ```
+
+> **順序の意図**: RequestId と Security headers は Error handling より外側に置くことで、エラーレスポンスにも `X-Request-Id` やセキュリティヘッダーが付く。CORS も同様に外側に置き、エラーレスポンスにも `Access-Control-Allow-Origin` が返る。
 
 - CORS は config 駆動。本番ではオリジンを明示的に allowlist に入れる。
 - ログにシークレット・トークン・Cookie・Authorization ヘッダー・生リクエストボディを含めない。

--- a/docs/adr/0008-jwt-authentication.md
+++ b/docs/adr/0008-jwt-authentication.md
@@ -30,16 +30,16 @@ The options evaluated:
 3. Ship **no concrete JWT verifier** in the framework core. Applications wire their preferred library through the interface.
 4. Add a `firebase/php-jwt` integration note to `authentication-boundary.md` as the recommended starting point.
 
-### Middleware placement (pipeline position 6)
+### Middleware placement (pipeline position 7)
 
 ```
-1. Error handling
-2. Request id
+1. Request id
+2. Request logging
 3. Security headers
 4. CORS
-5. Request size limit
-6. Authentication / authorization  ← BearerTokenMiddleware or ApiKeyAuthenticationMiddleware
-7. OpenAPI or request validation
+5. Error handling
+6. Request size limit
+7. Authentication / authorization  ← BearerTokenMiddleware or ApiKeyAuthenticationMiddleware
 8. Routing / handler dispatch
 ```
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -350,6 +350,13 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] test(tag): `PdoTagRepositoryMySqlTest` 追加（save/findAll/update/delete 7 ケース）. `#312`
 - [x] feat(frontend): `api/tags.ts` + `TagList` + `TagForm` — Tag CRUD をブラウザから操作可能に. `#314`
 
+## Phase 41: v1.0 ギャップ補完 (#337)
+
+- [x] chore: `@internal` 漏れ補完 — `LocalBearerTokenVerifier` / `NativeLocalMcpHttpClient` / `LocalMcpHttpResponse`
+- [x] docs: CLAUDE.md § 5 ミドルウェア順を実装に合わせる（RequestId → Logging → Security → CORS → Error → RequestSize → Auth）
+- [x] docs: ADR 0008 ミドルウェア配置表を実装に合わせる
+- [x] chore(changelog): `[Unreleased]` に Phase 38–40 の変更を記載する
+
 ## Phase 40: v1.0 公開 API スコープ定義
 
 - [x] docs(adr): ADR 0009 — v1.0 公開 API スコープと安定性保証を記録する. `#334`

--- a/src/Auth/LocalBearerTokenVerifier.php
+++ b/src/Auth/LocalBearerTokenVerifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Nene2\Auth;
 
 /**
+ * @internal
  * HMAC-HS256 JWT verifier for local development.
  * Uses no external library — suitable only for controlled local environments.
  * Production deployments should inject a library-backed TokenVerifierInterface.

--- a/src/Mcp/LocalMcpHttpResponse.php
+++ b/src/Mcp/LocalMcpHttpResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Mcp;
 
+/** @internal */
 final readonly class LocalMcpHttpResponse
 {
     /**

--- a/src/Mcp/NativeLocalMcpHttpClient.php
+++ b/src/Mcp/NativeLocalMcpHttpClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Mcp;
 
+/** @internal */
 final readonly class NativeLocalMcpHttpClient implements LocalMcpHttpClientInterface
 {
     public function __construct(private ?string $bearerToken = null)


### PR DESCRIPTION
## Summary

v1.0 に向けた残りのギャップを3点まとめて対処。

- **@internal 漏れ補完**: `LocalBearerTokenVerifier` / `NativeLocalMcpHttpClient` / `LocalMcpHttpResponse`
- **ミドルウェア順ドキュメント修正**: CLAUDE.md § 5 と ADR 0008 の記載が実装と食い違っていた（Error が1番と書いてあったが実際は RequestId → Logging → Security → CORS → Error → RequestSize → Auth）。実装が正しいのでドキュメントを修正。順序の意図も注記追加
- **CHANGELOG `[Unreleased]`**: Phase 38–40 の変更（MySQL Tag テスト・フロントエンド Tag 対応・ADR 0009・@internal 追加）を記載

## Self-review

- [x] docs-policy
- [x] middleware-security

## Closes

Closes #337