### PR TITLE
chore(release): v0.8.0 CHANGELOG 確定

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.8.0] — 2026-05-18
+
 ### Added
 - ADR 0009: v1.0 public API scope and stability guarantee — `src/Example/` declared as reference implementation outside the stability promise (#334)
 - `@internal` annotations on implementation-detail classes: `ConfigLoader`, `PdoConnectionFactory`, `PdoDatabaseQueryExecutor`, `PdoDatabaseTransactionManager`, `RuntimeServiceProvider`, `RuntimeContainerFactory`, `MonologLoggerFactory`, `RequestIdHolder`, `RequestIdProcessor`, `LocalMcpToolCatalog`, `LocalBearerTokenVerifier`, `NativeLocalMcpHttpClient`, `LocalMcpHttpResponse` (#334 #337)
@@ -23,7 +27,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - README: `src/Example/` documented as reference implementation not covered by the stability guarantee (#334)
 - CLAUDE.md § 5 middleware order corrected to match `RuntimeApplicationFactory` implementation: `RequestId → Logging → Security → CORS → Error → RequestSize → Auth` (#337)
 - ADR 0008 middleware placement table corrected to match implementation (#337)
-- Roadmap: Phase 38–39–40 entries added (#334)
+- Roadmap: Phase 38–39–40–41 entries added (#334 #337)
 
 ---
 
@@ -203,7 +207,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Governance docs: workflow, coding standards, ADR policy, review checklists (#1)
 - ADR 0001–0004: HTTP runtime, DI container, phpdotenv, Phinx
 
-[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.4.0...v0.5.0

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -350,6 +350,12 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] test(tag): `PdoTagRepositoryMySqlTest` 追加（save/findAll/update/delete 7 ケース）. `#312`
 - [x] feat(frontend): `api/tags.ts` + `TagList` + `TagForm` — Tag CRUD をブラウザから操作可能に. `#314`
 
+## Phase 42: v0.8.0 リリース
+
+- [x] chore(changelog): v0.8.0 セクション確定
+- [x] chore(release): `v0.8.0` タグを打つ
+- [ ] Packagist: v0.8.0 自動反映確認
+
 ## Phase 41: v1.0 ギャップ補完 (#337)
 
 - [x] chore: `@internal` 漏れ補完 — `LocalBearerTokenVerifier` / `NativeLocalMcpHttpClient` / `LocalMcpHttpResponse`


### PR DESCRIPTION
## Summary

v0.8.0 リリース準備。

- CHANGELOG `[Unreleased]` → `[0.8.0] — 2026-05-18` に確定
- フッターリンク `[0.8.0]` / `[Unreleased]` を追加
- `docs/todo/current.md` に Phase 42 (v0.8.0) を記録

## Highlights (v0.8.0)

- ADR 0009: v1.0 公開 API スコープと安定性保証の宣言
- `@internal` アノテーション 13 クラスに付与（境界を IDE に伝える）
- MySQL Tag 統合テスト追加
- フロントエンド Tag CRUD 対応（`TagList` / `TagForm` / `api/tags.ts`）
- フロントエンドコンポーネント・API テスト追加
- CLAUDE.md + ADR 0008 ミドルウェア順ドキュメント修正

## Breaking changes

None.

## Self-review

- [x] release-ci

## Closes

n/a (release prep)