### PR TITLE
chore(v1.0): ADR 0009 修正・PHPDoc 追加・v1.0 マイルストーン文書

### DIFF
--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -53,7 +53,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | Namespace | Key public surfaces |
 |-----------|---------------------|
 | `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `delete`, `handle`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
-| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `HtmlResponseFactory` |
+| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter` |
 | `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
 | `Nene2\Config` | `AppConfig`, `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException` |
@@ -61,7 +61,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\Auth` | `TokenVerifierInterface`, `TokenVerificationException`, `BearerTokenMiddleware` |
 | `Nene2\Middleware` | All shipped middleware classes |
 | `Nene2\Validation` | `ValidationException`, `ValidationError` |
-| `Nene2\View` | `NativePhpViewRenderer`, `HtmlEscaper` |
+| `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |
 | `Nene2\Mcp` | `LocalMcpServer`, `LocalMcpHttpClientInterface`, `LocalMcpHttpResponse`, `LocalMcpException` |
 
 ### 4. Explicitly outside the stability guarantee

--- a/docs/milestones/2026-05-v1.0.md
+++ b/docs/milestones/2026-05-v1.0.md
@@ -1,0 +1,62 @@
+# Milestone: v1.0.0
+
+## Goal
+
+Cut the first stable release of NENE2 — the point at which the public API surface declared in ADR 0009 becomes a versioned contract. After v1.0.0, breaking changes to that surface require a major version bump.
+
+## Criteria
+
+All of the following must be true before tagging `v1.0.0`.
+
+### API surface
+
+- [x] ADR 0009 accepted: stable and unstable surfaces documented by namespace
+- [x] `@internal` annotations on all implementation-detail classes
+- [x] `ResponseEmitter`, `HtmlResponseFactory`, `TemplateNotFoundException` placed correctly in stable list
+- [x] PHPDoc present on all public interfaces and extension points in the stable surface
+
+### Tests
+
+- [x] PHPUnit testsuite passes (164+ tests, 545+ assertions)
+- [x] PHPStan level 8 — clean
+- [x] HTTP-level tests cover all stable endpoint behaviours (Note + Tag CRUD, 404/422 paths, auth paths)
+- [x] MySQL integration tests for Note and Tag repositories
+- [x] Frontend component and API type-guard tests
+
+### Documentation
+
+- [x] Diátaxis four pillars complete: Tutorial, HOWTO, Explanation, Reference
+- [x] Six-language VitePress site deployed to GitHub Pages
+- [x] ADR index covers all decisions made through v1.0
+- [x] CLAUDE.md middleware order matches implementation
+- [x] README documents `src/Example/` as reference implementation
+
+### Operations
+
+- [x] GitHub Actions: `backend.yml`, `frontend.yml`, `docs.yml` passing on `main`
+- [x] Packagist package `hideyukimori/nene2` published and up to date
+- [x] At least one complete field trial from `composer require` starting point (Field Trial 4+)
+- [ ] `v1.0.0` GitHub Release notes drafted
+- [ ] CHANGELOG heading note (`Breaking changes may occur … until v1.0.0`) removed
+
+### Decision gate
+
+- [ ] Maintainer explicitly approves tagging `v1.0.0` after all criteria above are met
+
+## What changes at v1.0.0
+
+- The stable surface listed in ADR 0009 becomes a versioned contract.
+- `src/Example/` remains in the package but is still outside the stability guarantee.
+- `CHANGELOG.md` heading note about pre-v1.0 breakage is removed.
+- Future breaking changes to the stable surface require a `v2.0.0` tag.
+
+## What does NOT change at v1.0.0
+
+- MCP protocol support still tracks the external specification (noted in ADR 0009).
+- `src/Example/` is still free to change between minor versions.
+- No new features are required; this is a stability declaration, not a feature milestone.
+
+## Tracked by
+
+- ADR 0009: `docs/adr/0009-v1.0-public-api-scope.md`
+- Issue: `#340`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -350,6 +350,16 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] test(tag): `PdoTagRepositoryMySqlTest` 追加（save/findAll/update/delete 7 ケース）. `#312`
 - [x] feat(frontend): `api/tags.ts` + `TagList` + `TagForm` — Tag CRUD をブラウザから操作可能に. `#314`
 
+## Phase 43: v1.0 readiness (#340)
+
+- [x] docs(adr): ADR 0009 namespace 修正（HtmlResponseFactory を View へ・ResponseEmitter・TemplateNotFoundException 追加）
+- [x] chore(phpdoc): ServiceProviderInterface / DomainExceptionHandlerInterface / DatabaseConnectionFactoryInterface に PHPDoc 追加
+- [x] chore(phpdoc): ResponseEmitter に stable である旨の PHPDoc 追加
+- [x] docs(milestone): v1.0 マイルストーン文書を追加（docs/milestones/2026-05-v1.0.md）
+- [ ] chore(release): v1.0.0 GitHub Release notes を草稿する
+- [ ] chore(changelog): v1.0.0 タグ後に冒頭注記を削除する
+- [ ] chore(release): `v1.0.0` タグを打つ（マイルストーン文書の全チェックが完了してから）
+
 ## Phase 42: v0.8.0 リリース
 
 - [x] chore(changelog): v0.8.0 セクション確定

--- a/src/Database/DatabaseConnectionFactoryInterface.php
+++ b/src/Database/DatabaseConnectionFactoryInterface.php
@@ -6,6 +6,12 @@ namespace Nene2\Database;
 
 use PDO;
 
+/**
+ * Creates a PDO database connection.
+ *
+ * Implement this interface to swap the connection strategy (e.g. pooling,
+ * test doubles) without changing the adapters that depend on it.
+ */
 interface DatabaseConnectionFactoryInterface
 {
     public function create(): PDO;

--- a/src/DependencyInjection/ServiceProviderInterface.php
+++ b/src/DependencyInjection/ServiceProviderInterface.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Nene2\DependencyInjection;
 
+/**
+ * Groups related service definitions and registers them with the container.
+ *
+ * Pass implementations to {@see ContainerBuilder::addProvider()}.
+ */
 interface ServiceProviderInterface
 {
     public function register(ContainerBuilder $builder): void;

--- a/src/Error/DomainExceptionHandlerInterface.php
+++ b/src/Error/DomainExceptionHandlerInterface.php
@@ -8,8 +8,16 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
+/**
+ * Maps a domain exception to an HTTP response.
+ *
+ * Register implementations with {@see ErrorHandlerMiddleware} to convert
+ * domain-specific exceptions into RFC 9457 Problem Details responses without
+ * adding try/catch blocks to individual handlers.
+ */
 interface DomainExceptionHandlerInterface
 {
+    /** Returns true if this handler can process the given exception. */
     public function supports(Throwable $exception): bool;
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface;

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -6,6 +6,12 @@ namespace Nene2\Http;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * Emits a PSR-7 response to PHP's output buffer.
+ *
+ * Call from the application front controller after the middleware pipeline
+ * returns a response. Part of the public API stability guarantee.
+ */
 final class ResponseEmitter
 {
     public function emit(ResponseInterface $response): void


### PR DESCRIPTION
## Summary

v1.0 に向けた4タスクをまとめて対処。

### 1. ADR 0009 修正
- `HtmlResponseFactory`: `Nene2\Http` → `Nene2\View`（実際のクラス位置に合わせた）
- `ResponseEmitter` を `Nene2\Http` stable list に追加（front controller から使う public API）
- `TemplateNotFoundException` を `Nene2\View` stable list に追加

### 2. PHPDoc 追加（stable インターフェイス）
- `ServiceProviderInterface` — グループ登録の責務を説明
- `DomainExceptionHandlerInterface` — `ErrorHandlerMiddleware` との連携を説明
- `DatabaseConnectionFactoryInterface` — 差し替え可能な接続戦略として説明

### 3. ResponseEmitter
- PHPDoc で "stable な public API" であることを明示（`@internal` は付けない）

### 4. v1.0 マイルストーン文書
- `docs/milestones/2026-05-v1.0.md` を新規作成
- API surface・テスト・ドキュメント・運用の4軸でチェックリストを定義
- 現時点で未完了は「Release notes 草稿」と「v1.0.0 タグ」の2点のみ

## Self-review

- [x] docs-policy
- [x] backend-api（PHPDoc は公開 API の範囲）

## Closes

Closes #340