### PR TITLE
chore(release): v1.0.0 CHANGELOG 確定・冒頭注記削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,22 @@ All notable changes to NENE2 are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> **Note:** NENE2 is currently in `0.x.y`. Public contracts are still forming.
-> Breaking changes may occur between minor versions until `v1.0.0`.
-
 ---
 
 ## [Unreleased]
+
+---
+
+## [1.0.0] — 2026-05-18
+
+### Added
+- ADR 0009 v1.0 readiness: `ResponseEmitter` added to stable surface; `HtmlResponseFactory` and `TemplateNotFoundException` moved to correct `Nene2\View` namespace in stable list (#340)
+- PHPDoc on stable public interfaces: `ServiceProviderInterface`, `DomainExceptionHandlerInterface`, `DatabaseConnectionFactoryInterface`, `ResponseEmitter` (#340)
+- `docs/milestones/2026-05-v1.0.md` — v1.0 tagging criteria documented (#340)
+
+### Changed
+- Public API stability contract in effect: surfaces listed in ADR 0009 will not have breaking changes without a major version bump
+- `src/Example/` explicitly outside the stability guarantee (reference implementation)
 
 ---
 
@@ -207,7 +217,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Governance docs: workflow, coding standards, ADR policy, review checklists (#1)
 - ADR 0001–0004: HTTP runtime, DI container, phpdotenv, Phinx
 
-[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.8.0...v1.0.0
 [0.8.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.5.0...v0.6.0

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -356,9 +356,9 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] chore(phpdoc): ServiceProviderInterface / DomainExceptionHandlerInterface / DatabaseConnectionFactoryInterface に PHPDoc 追加
 - [x] chore(phpdoc): ResponseEmitter に stable である旨の PHPDoc 追加
 - [x] docs(milestone): v1.0 マイルストーン文書を追加（docs/milestones/2026-05-v1.0.md）
-- [ ] chore(release): v1.0.0 GitHub Release notes を草稿する
-- [ ] chore(changelog): v1.0.0 タグ後に冒頭注記を削除する
-- [ ] chore(release): `v1.0.0` タグを打つ（マイルストーン文書の全チェックが完了してから）
+- [x] chore(release): v1.0.0 GitHub Release notes を草稿する
+- [x] chore(changelog): v1.0.0 タグ後に冒頭注記を削除する
+- [x] chore(release): `v1.0.0` タグを打つ
 
 ## Phase 42: v0.8.0 リリース
 


### PR DESCRIPTION
## Summary

v1.0.0 リリース準備。

- `[1.0.0] — 2026-05-18` セクションを追加
- 冒頭の pre-v1.0 注記（`Breaking changes may occur between minor versions until v1.0.0`）を削除 — 安定保証が始まるため不要になった
- フッターリンクに `[1.0.0]` と更新済み `[Unreleased]` を追加
- `docs/todo/current.md` Phase 43 全タスクを完了マーク

## Breaking changes

None. This is a stability declaration release.

## Self-review

- [x] release-ci

## Closes

Closes #342