### PR TITLE
docs(roadmap): v1.1 ロードマップ定義 — 本番実用性フェーズ (Phase 44–47)

### DIFF
--- a/docs/milestones/2026-05-v1.1.md
+++ b/docs/milestones/2026-05-v1.1.md
@@ -1,0 +1,97 @@
+# Milestone: v1.1.0
+
+## Goal
+
+Add the first set of production-oriented features to NENE2 after the v1.0 stable API contract:
+a dependency-injected DB health check and a configurable rate limiting middleware.
+Both are additive and backward-compatible — no breaking changes to the v1.0 stable surface.
+
+## Theme: Production Readiness
+
+v1.0 declared *what* the stable API is. v1.1 answers *"is the app healthy?"* and *"how do we protect it?"*
+
+## Phases
+
+### Phase 44 — DB Health Check
+
+Extend `GET /health` with an optional database connectivity check, injected through a stable
+`HealthCheckInterface`. The endpoint returns `200 {"status":"ok","checks":{"database":"ok"}}` on
+success and `503 {"status":"degraded","checks":{"database":"error"}}` on failure.
+
+Key deliverables:
+
+- [ ] `HealthCheckInterface` in the stable public surface
+- [ ] `RuntimeApplicationFactory` extended with `list<HealthCheckInterface> $healthChecks = []`
+- [ ] `GET /health` response schema updated in OpenAPI
+- [ ] `DatabaseHealthCheck` reference implementation in `src/Example/`
+- [ ] PHPUnit tests for healthy, degraded, and no-checks paths
+
+### Phase 45 — Rate Limiting
+
+Add `ThrottleMiddleware` backed by a `RateLimitStorageInterface` so adopters can enforce request
+rate limits in production. The default in-memory storage is for local development only; adopters
+swap it for a Redis adapter or similar.
+
+Key deliverables:
+
+- [ ] ADR 0010: rate limiting design (algorithm, header conventions, storage contract)
+- [ ] `RateLimitStorageInterface` in the stable public surface
+- [ ] `InMemoryRateLimitStorage` (`@internal`) for development and testing
+- [ ] `ThrottleMiddleware` — 429 Problem Details, `Retry-After`, `X-RateLimit-*` headers
+- [ ] PHPUnit tests: under / at / over limit, reset after window
+- [ ] Middleware order updated in CLAUDE.md (position 8, after Auth)
+- [ ] Self-review checklist updated with rate limit checkpoints
+
+### Phase 46 — Field Trial 8
+
+Validate the v1.0 stable surface and the new Phase 44–45 features from a clean
+`composer require hideyukimori/nene2:^1.0` starting point.
+
+Key deliverables:
+
+- [ ] New project directory, no git-clone dependency on the NENE2 repo
+- [ ] `DatabaseHealthCheck` wired and degraded path verified
+- [ ] `ThrottleMiddleware` wired and 429 path triggered
+- [ ] Friction notes converted to Issues
+
+### Phase 47 — v1.1.0 Release
+
+- [ ] CHANGELOG.md v1.1.0 section
+- [ ] ADR 0010 finalized
+- [ ] Packagist auto-reflection confirmed
+- [ ] `v1.1.0` tag
+
+## Acceptance Criteria
+
+All of the following must be true before tagging `v1.1.0`:
+
+### API surface
+
+- [ ] `HealthCheckInterface` in stable surface (ADR 0009 table updated)
+- [ ] `RateLimitStorageInterface` in stable surface
+- [ ] `ThrottleMiddleware` in stable surface (`Nene2\Middleware`)
+- [ ] No breaking changes to the v1.0 stable surface
+
+### Tests
+
+- [ ] PHPUnit suite passes with Phase 44–45 additions
+- [ ] PHPStan level 8 — clean
+- [ ] HTTP-level test covers the degraded health path
+- [ ] HTTP-level test covers the 429 rate limit path
+
+### Documentation
+
+- [ ] ADR 0010 accepted
+- [ ] CLAUDE.md middleware order updated with `ThrottleMiddleware` at position 8
+- [ ] OpenAPI schema updated for the extended health response
+
+### Operations
+
+- [ ] Field Trial 8 completed (Phase 46)
+- [ ] Packagist v1.1.0 published
+- [ ] Maintainer explicitly approves tagging `v1.1.0`
+
+## Tracked by
+
+- Issue: `#344`
+- Roadmap phases: 44–47 in `docs/roadmap.md`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -464,6 +464,62 @@ Goal: declare the stable public API surface before cutting v1.0, so adopters kno
 - README updated to note `src/Example/` is a reference implementation, not a dependency target
 - Roadmap updated with Phase 40 entry
 
+## Phase 41: v1.0.0 Tagging and Readiness
+
+Goal: complete the v1.0.0 release criteria and tag the first stable release.
+
+- ADR 0009 gap fixes: `HtmlResponseFactory` and `TemplateNotFoundException` moved to correct `Nene2\View` namespace in the stable list; `ResponseEmitter` added
+- PHPDoc on all public interfaces and extension points in the stable surface
+- `docs/milestones/2026-05-v1.0.md` — v1.0 tagging criteria documented
+- CHANGELOG heading note ("Breaking changes may occur until v1.0.0") removed
+- `v1.0.0` tag
+
+Tracked by Issue `#340`.
+
+## Phase 44: DB Health Check
+
+Goal: extend the `GET /health` endpoint with an optional, dependency-injected database connectivity check so operators can verify that the application can reach its database, without coupling the framework core to any specific adapter.
+
+- `HealthCheckInterface { name(): string; check(): bool; }` — stable public interface in `Nene2\Http` or a new `Nene2\Health` namespace
+- `RuntimeApplicationFactory` accepts `list<HealthCheckInterface> $healthChecks = []` (default empty → current behavior unchanged)
+- `GET /health` response extended: `{"status":"ok","checks":{"database":"ok"}}` (503 + `"degraded"` when any check fails)
+- `DatabaseHealthCheck` example in `src/Example/` as a reference implementation
+- OpenAPI schema for the extended health response
+- PHPUnit tests: healthy path, degraded path, empty checks
+
+## Phase 45: Rate Limiting
+
+Goal: add production-grade rate limiting to the middleware pipeline with a storage-backend abstraction so adopters can swap from in-memory to Redis or another store without touching framework code.
+
+- ADR 0010: rate limiting design decisions (algorithm, header conventions, storage abstraction)
+- `RateLimitStorageInterface` — stable public interface; get / increment / ttl operations
+- `InMemoryRateLimitStorage` — `@internal` default for local development and testing
+- `ThrottleMiddleware` — PSR-15 middleware; position 8 (after Auth, before routing)
+  - 429 Problem Details response with `type: https://nene2.dev/problems/too-many-requests`
+  - `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers
+- `RuntimeApplicationFactory` accepts an optional `ThrottleMiddleware` (not wired by default)
+- PHPUnit tests: under limit, at limit, over limit, reset after window
+
+## Phase 46: Field Trial 8 — v1.0 Stable Validation
+
+Goal: validate the v1.0 stable API contract and the new production features in a realistic project scenario starting from `composer require hideyukimori/nene2:^1.0`.
+
+- Start a new project directory with `composer require hideyukimori/nene2:^1.0`
+- Verify the stable surface (Router, RuntimeApplicationFactory, interfaces) works as documented
+- Wire `DatabaseHealthCheck` into `GET /health` and confirm the degraded path
+- Wire `ThrottleMiddleware` + `InMemoryRateLimitStorage` and trigger the 429 path
+- Record friction and open follow-up Issues
+
+## Phase 47: v1.1.0 Release
+
+Goal: consolidate Phase 44–46 additions into a versioned release.
+
+- CHANGELOG.md v1.1.0 section (DB Health Check, Rate Limiting, Field Trial 8 findings)
+- ADR 0010 finalized
+- `v1.1.0` tag
+
+Tracked by `docs/milestones/2026-05-v1.1.md`.
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,9 +4,9 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: `docs/milestones/2026-05-field-trial-2.md` (Field Trial 2)
-- Latest release: `v0.2.0` (Phase 17 complete)
-- Current branch: `main`
+- Current milestone: `docs/milestones/2026-05-v1.1.md` (v1.1 — Production Readiness)
+- Latest release: `v1.0.0` (Phase 43 complete)
+- Current branch: `docs/344-v1.1-roadmap`
 
 ## Foundation Completed
 
@@ -349,6 +349,39 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 
 - [x] test(tag): `PdoTagRepositoryMySqlTest` 追加（save/findAll/update/delete 7 ケース）. `#312`
 - [x] feat(frontend): `api/tags.ts` + `TagList` + `TagForm` — Tag CRUD をブラウザから操作可能に. `#314`
+
+## Phase 47: v1.1.0 リリース
+
+- [ ] chore(changelog): v1.1.0 セクション確定
+- [ ] docs(adr): ADR 0010 最終化
+- [ ] chore(release): Packagist v1.1.0 自動反映確認
+- [ ] chore(release): `v1.1.0` タグを打つ
+
+## Phase 46: Field Trial 8 — v1.0 Stable Validation
+
+- [ ] `composer require hideyukimori/nene2:^1.0` から新規プロジェクト開始
+- [ ] `DatabaseHealthCheck` を使って degraded パスを確認
+- [ ] `ThrottleMiddleware` を使って 429 パスを確認
+- [ ] 摩擦メモを Issue 化する
+
+## Phase 45: Rate Limiting (#344)
+
+- [ ] docs(adr): ADR 0010 — Rate Limiting 設計方針を記録する
+- [ ] feat: `RateLimitStorageInterface` を追加する（stable surface）
+- [ ] feat: `InMemoryRateLimitStorage` を追加する（`@internal`、開発・テスト用）
+- [ ] feat: `ThrottleMiddleware` を追加する（429 Problem Details、`Retry-After`、`X-RateLimit-*`）
+- [ ] test: under / at / over limit、reset after window のテスト
+- [ ] docs: CLAUDE.md ミドルウェア順を更新（position 8、Auth 後）
+- [ ] docs: セルフレビューチェックリストに rate limit チェックポイントを追加
+
+## Phase 44: DB Health Check (#344)
+
+- [ ] feat: `HealthCheckInterface` を追加する（stable surface）
+- [ ] feat: `RuntimeApplicationFactory` に `list<HealthCheckInterface> $healthChecks = []` を追加する
+- [ ] feat: `GET /health` レスポンスを拡張する（checks フィールド、503 degraded）
+- [ ] feat: `DatabaseHealthCheck` 参照実装を `src/Example/` に追加する
+- [ ] docs(openapi): health エンドポイントのスキーマを更新する
+- [ ] test: healthy / degraded / no-checks パスのテスト
 
 ## Phase 43: v1.0 readiness (#340)
 


### PR DESCRIPTION
## Summary

- Phase 44–47 を `docs/roadmap.md` に追加（DB Health Check → Rate Limiting → Field Trial 8 → v1.1.0 タグ）
- `docs/milestones/2026-05-v1.1.md` を新規作成（v1.1 受け入れ基準 4 軸）
- `docs/todo/current.md` の Status 更新 + Phase 44–47 タスクを追加

## Test plan

- [ ] roadmap.md に Phase 44–47 が正しく追加されていること
- [ ] milestones/2026-05-v1.1.md が存在し、受け入れ基準が全セクション揃っていること
- [ ] todo/current.md の Status が v1.0.0 / v1.1 マイルストーンを指していること

Closes #344

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)