### PR TITLE
feat(health): HealthCheckInterface + GET /health 拡張 (Phase 44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `HealthCheckInterface` and `HealthStatus` — stable public interface for dependency health checks (`Nene2\Http`) (#346)
+- `RuntimeApplicationFactory` extended with `list<HealthCheckInterface> $healthChecks = []`; `GET /health` returns `checks` map and 503 when any check reports `error` (#346)
+- `DatabaseHealthCheck` reference implementation in `src/Example/Health/` (#346)
+- OpenAPI `HealthResponse` schema extended with optional `checks` field; `503` response added to `/health` path (#346)
+
 ---
 
 ## [1.0.0] — 2026-05-18

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -53,7 +53,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | Namespace | Key public surfaces |
 |-----------|---------------------|
 | `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `delete`, `handle`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
-| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter` |
+| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus` |
 | `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
 | `Nene2\Config` | `AppConfig`, `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException` |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -43,21 +43,46 @@ paths:
       tags:
         - System
       summary: Health endpoint
-      description: Returns a minimal JSON response for local operational health checks.
+      description: >
+        Returns a JSON response for operational health checks.
+        When no health checks are configured the response is always 200.
+        When health checks are configured the response includes a `checks` map;
+        if any check fails the status is `degraded` and the HTTP status code is 503.
       operationId: getHealth
       responses:
         '200':
-          description: Health response.
+          description: All configured checks passed (or no checks configured).
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthResponse'
               examples:
                 ok:
-                  summary: Healthy response
+                  summary: Healthy response (no checks)
                   value:
                     status: ok
                     service: NENE2
+                ok_with_checks:
+                  summary: Healthy response (with checks)
+                  value:
+                    status: ok
+                    service: NENE2
+                    checks:
+                      database: ok
+        '503':
+          description: One or more health checks failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+              examples:
+                degraded:
+                  summary: Degraded response
+                  value:
+                    status: degraded
+                    service: NENE2
+                    checks:
+                      database: error
         '413':
           $ref: '#/components/responses/PayloadTooLarge'
         '500':
@@ -745,10 +770,23 @@ components:
           type: string
           enum:
             - ok
+            - degraded
           example: ok
         service:
           type: string
           example: NENE2
+        checks:
+          type: object
+          description: >
+            Present only when health checks are configured.
+            Each key is a check name; each value is "ok" or "error".
+          additionalProperties:
+            type: string
+            enum:
+              - ok
+              - error
+          example:
+            database: ok
     MachineHealthResponse:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -374,14 +374,14 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [ ] docs: CLAUDE.md ミドルウェア順を更新（position 8、Auth 後）
 - [ ] docs: セルフレビューチェックリストに rate limit チェックポイントを追加
 
-## Phase 44: DB Health Check (#344)
+## Phase 44: DB Health Check (#346)
 
-- [ ] feat: `HealthCheckInterface` を追加する（stable surface）
-- [ ] feat: `RuntimeApplicationFactory` に `list<HealthCheckInterface> $healthChecks = []` を追加する
-- [ ] feat: `GET /health` レスポンスを拡張する（checks フィールド、503 degraded）
-- [ ] feat: `DatabaseHealthCheck` 参照実装を `src/Example/` に追加する
-- [ ] docs(openapi): health エンドポイントのスキーマを更新する
-- [ ] test: healthy / degraded / no-checks パスのテスト
+- [x] feat: `HealthCheckInterface` を追加する（stable surface）
+- [x] feat: `RuntimeApplicationFactory` に `list<HealthCheckInterface> $healthChecks = []` を追加する
+- [x] feat: `GET /health` レスポンスを拡張する（checks フィールド、503 degraded）
+- [x] feat: `DatabaseHealthCheck` 参照実装を `src/Example/Health/` に追加する
+- [x] docs(openapi): health エンドポイントのスキーマを更新する
+- [x] test: healthy / degraded / throws パスのテスト
 
 ## Phase 43: v1.0 readiness (#340)
 

--- a/src/Example/Health/DatabaseHealthCheck.php
+++ b/src/Example/Health/DatabaseHealthCheck.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example\Health;
+
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;
+use Throwable;
+
+/**
+ * Reference implementation of HealthCheckInterface that pings the database.
+ *
+ * Copy and adapt this class into your own application; do not import it as a
+ * library dependency — it is outside the public API stability guarantee.
+ */
+final readonly class DatabaseHealthCheck implements HealthCheckInterface
+{
+    public function __construct(
+        private DatabaseConnectionFactoryInterface $connectionFactory,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'database';
+    }
+
+    public function check(): HealthStatus
+    {
+        try {
+            $pdo = $this->connectionFactory->create();
+            $pdo->query('SELECT 1');
+
+            return HealthStatus::Ok;
+        } catch (Throwable) {
+            return HealthStatus::Error;
+        }
+    }
+}

--- a/src/Http/HealthCheckInterface.php
+++ b/src/Http/HealthCheckInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+/**
+ * Reports the health of a single dependency (e.g. database, cache, external API).
+ *
+ * Implement this interface and pass instances to RuntimeApplicationFactory to extend
+ * the GET /health endpoint with dependency-level checks.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+interface HealthCheckInterface
+{
+    /** A short, machine-readable name used as the key in the health response (e.g. "database"). */
+    public function name(): string;
+
+    public function check(): HealthStatus;
+}

--- a/src/Http/HealthStatus.php
+++ b/src/Http/HealthStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+enum HealthStatus: string
+{
+    case Ok = 'ok';
+    case Error = 'error';
+}

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -24,12 +24,14 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Throwable;
 
 final readonly class RuntimeApplicationFactory
 {
     /**
      * @param list<DomainExceptionHandlerInterface> $domainExceptionHandlers
      * @param list<callable(Router): void> $routeRegistrars
+     * @param list<HealthCheckInterface> $healthChecks
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
@@ -40,6 +42,7 @@ final readonly class RuntimeApplicationFactory
         private ?RequestIdHolder $requestIdHolder = null,
         private array $routeRegistrars = [],
         private ?BearerTokenMiddleware $bearerTokenMiddleware = null,
+        private array $healthChecks = [],
     ) {
     }
 
@@ -67,10 +70,40 @@ final readonly class RuntimeApplicationFactory
             )
             ->get(
                 '/health',
-                static fn (ServerRequestInterface $request) => $jsonResponses->create([
-                    'status' => 'ok',
-                    'service' => $framework->name(),
-                ]),
+                function (ServerRequestInterface $request) use ($jsonResponses, $framework) {
+                    if ($this->healthChecks === []) {
+                        return $jsonResponses->create([
+                            'status' => 'ok',
+                            'service' => $framework->name(),
+                        ]);
+                    }
+
+                    $checks = [];
+                    $degraded = false;
+
+                    foreach ($this->healthChecks as $check) {
+                        try {
+                            $status = $check->check();
+                        } catch (Throwable) {
+                            $status = HealthStatus::Error;
+                        }
+
+                        $checks[$check->name()] = $status->value;
+
+                        if ($status === HealthStatus::Error) {
+                            $degraded = true;
+                        }
+                    }
+
+                    return $jsonResponses->create(
+                        [
+                            'status' => $degraded ? 'degraded' : 'ok',
+                            'service' => $framework->name(),
+                            'checks' => $checks,
+                        ],
+                        $degraded ? 503 : 200,
+                    );
+                },
             )
             ->get(
                 '/machine/health',

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Nene2\Tests;
 
+use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Routing\Router;
@@ -187,6 +189,77 @@ final class HttpRuntimeTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('Hello, NENE2!', $payload['message']);
+    }
+
+    public function testHealthEndpointWithHealthyCheck(): void
+    {
+        $factory = new Psr17Factory();
+
+        $check = new class implements HealthCheckInterface {
+            public function name(): string { return 'database'; }
+            public function check(): HealthStatus { return HealthStatus::Ok; }
+        };
+
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            healthChecks: [$check],
+        ))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/health'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('ok', $payload['status']);
+        self::assertSame('NENE2', $payload['service']);
+        self::assertSame(['database' => 'ok'], $payload['checks']);
+    }
+
+    public function testHealthEndpointWithDegradedCheck(): void
+    {
+        $factory = new Psr17Factory();
+
+        $check = new class implements HealthCheckInterface {
+            public function name(): string { return 'database'; }
+            public function check(): HealthStatus { return HealthStatus::Error; }
+        };
+
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            healthChecks: [$check],
+        ))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/health'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(503, $response->getStatusCode());
+        self::assertSame('degraded', $payload['status']);
+        self::assertSame('NENE2', $payload['service']);
+        self::assertSame(['database' => 'error'], $payload['checks']);
+    }
+
+    public function testHealthEndpointWithCheckThatThrows(): void
+    {
+        $factory = new Psr17Factory();
+
+        $check = new class implements HealthCheckInterface {
+            public function name(): string { return 'external'; }
+            public function check(): HealthStatus { throw new \RuntimeException('connection refused'); }
+        };
+
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            healthChecks: [$check],
+        ))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/health'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(503, $response->getStatusCode());
+        self::assertSame('degraded', $payload['status']);
+        self::assertSame(['external' => 'error'], $payload['checks']);
     }
 
     /**


### PR DESCRIPTION
## Summary

- `HealthCheckInterface` / `HealthStatus` を `Nene2\Http` に追加（ADR 0009 stable surface に追記）
- `RuntimeApplicationFactory` に `list<HealthCheckInterface> $healthChecks = []` を追加
  - checks なし → 200 `{"status":"ok","service":"NENE2"}`（後方互換）
  - checks あり・全 ok → 200 + `"checks":{"database":"ok"}`
  - checks あり・1件以上 error（例外投げも含む）→ 503 + `"status":"degraded"`
- `DatabaseHealthCheck` 参照実装を `src/Example/Health/` に追加
- OpenAPI `HealthResponse` スキーマ拡張（`checks` フィールド、503 レスポンス追加）
- `HttpRuntimeTest` に healthy / degraded / throws の 3 テストケース追加

## Test plan

- [ ] `testHealthEndpointRunsThroughRuntime` — 従来の 200 パスが壊れていないこと
- [ ] `testHealthEndpointWithHealthyCheck` — 200 + checks フィールドが返ること
- [ ] `testHealthEndpointWithDegradedCheck` — 503 + "degraded" が返ること
- [ ] `testHealthEndpointWithCheckThatThrows` — 例外時も 503 になること
- [ ] `composer check` が全部通ること

Closes #346

Self-review: backend-api, openapi-contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)