### PR TITLE
fix(test): ThrottleMiddlewareTest — withServerParams() を createServerRequest() 第3引数に修正

### DIFF
--- a/tests/Middleware/ThrottleMiddlewareTest.php
+++ b/tests/Middleware/ThrottleMiddlewareTest.php
@@ -35,8 +35,7 @@ final class ThrottleMiddlewareTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($factory, $factory);
         $middleware = new ThrottleMiddleware($problemDetails, $storage, limit: 5, windowSeconds: 60);
 
-        $request = $factory->createServerRequest('GET', 'https://example.test/health')
-            ->withServerParams(['REMOTE_ADDR' => '127.0.0.1']);
+        $request = $factory->createServerRequest('GET', 'https://example.test/health', ['REMOTE_ADDR' => '127.0.0.1']);
 
         $response = $middleware->process($request, $this->makeHandler());
 
@@ -53,8 +52,7 @@ final class ThrottleMiddlewareTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($factory, $factory);
         $middleware = new ThrottleMiddleware($problemDetails, $storage, limit: 3, windowSeconds: 60);
 
-        $request = $factory->createServerRequest('GET', 'https://example.test/health')
-            ->withServerParams(['REMOTE_ADDR' => '127.0.0.1']);
+        $request = $factory->createServerRequest('GET', 'https://example.test/health', ['REMOTE_ADDR' => '127.0.0.1']);
 
         $response = null;
 
@@ -75,8 +73,7 @@ final class ThrottleMiddlewareTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($factory, $factory);
         $middleware = new ThrottleMiddleware($problemDetails, $storage, limit: 2, windowSeconds: 60);
 
-        $request = $factory->createServerRequest('GET', 'https://example.test/health')
-            ->withServerParams(['REMOTE_ADDR' => '127.0.0.1']);
+        $request = $factory->createServerRequest('GET', 'https://example.test/health', ['REMOTE_ADDR' => '127.0.0.1']);
 
         for ($i = 0; $i < 2; $i++) {
             $middleware->process($request, $this->makeHandler());
@@ -103,10 +100,8 @@ final class ThrottleMiddlewareTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($factory, $factory);
         $middleware = new ThrottleMiddleware($problemDetails, $storage, limit: 1, windowSeconds: 60);
 
-        $request1 = $factory->createServerRequest('GET', 'https://example.test/health')
-            ->withServerParams(['REMOTE_ADDR' => '10.0.0.1']);
-        $request2 = $factory->createServerRequest('GET', 'https://example.test/health')
-            ->withServerParams(['REMOTE_ADDR' => '10.0.0.2']);
+        $request1 = $factory->createServerRequest('GET', 'https://example.test/health', ['REMOTE_ADDR' => '10.0.0.1']);
+        $request2 = $factory->createServerRequest('GET', 'https://example.test/health', ['REMOTE_ADDR' => '10.0.0.2']);
 
         $middleware->process($request1, $this->makeHandler());
         $response2 = $middleware->process($request2, $this->makeHandler());


### PR DESCRIPTION
## Problem

`Nyholm\Psr7\ServerRequest` は `withServerParams()` を実装していないため、CI で 4 テストが Error になっていた。

## Fix

`->withServerParams(['REMOTE_ADDR' => '...'])` を `createServerRequest($method, $uri, ['REMOTE_ADDR' => '...'])` に変更。

Closes #352

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)