### PR TITLE
fix(http): JsonRequestBodyParser — 400 invalid-json と 422 validation-error を分離 (Phase 48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `JsonRequestBodyParser` and `JsonBodyParseException` — parse request body as JSON object; throws on empty body, invalid JSON, or non-object JSON (`Nene2\Http`) (#354)
+- `ErrorHandlerMiddleware` maps `JsonBodyParseException` → `400 invalid-json` Problem Details, distinct from `422 validation-failed` (#354)
+
+### Changed
+- `CreateNoteHandler`, `UpdateNoteHandler`, `CreateTagHandler`, `UpdateTagHandler` — replaced `(array) json_decode(...)` with `JsonRequestBodyParser::parse()` (#354)
+
 ---
 
 ## [1.1.0] — 2026-05-18

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -53,7 +53,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | Namespace | Key public surfaces |
 |-----------|---------------------|
 | `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `delete`, `handle`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
-| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus` |
+| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException` |
 | `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
 | `Nene2\Config` | `AppConfig`, `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException` |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -350,6 +350,15 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] test(tag): `PdoTagRepositoryMySqlTest` 追加（save/findAll/update/delete 7 ケース）. `#312`
 - [x] feat(frontend): `api/tags.ts` + `TagList` + `TagForm` — Tag CRUD をブラウザから操作可能に. `#314`
 
+## Phase 48: JsonRequestBodyParser — 400/422 分離 (#354)
+
+- [x] feat: `JsonBodyParseException` を追加する（Nene2\Http、stable surface）
+- [x] feat: `JsonRequestBodyParser::parse()` を追加する（空/不正/非オブジェクト JSON → 例外）
+- [x] fix: `ErrorHandlerMiddleware` に `JsonBodyParseException → 400 invalid-json` を追加
+- [x] fix: 4 ハンドラーで `JsonRequestBodyParser::parse()` に差し替え
+- [x] test: `JsonRequestBodyParserTest` 7 ケース（正常・空・不正・非オブジェクト各種）
+- [x] test: `NoteHttpTest` に 400 パス 3 ケース追加
+
 ## Phase 47: v1.1.0 リリース
 
 - [x] chore(changelog): v1.1.0 セクション確定

--- a/src/Error/ErrorHandlerMiddleware.php
+++ b/src/Error/ErrorHandlerMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Error;
 
+use Nene2\Http\JsonBodyParseException;
 use Nene2\Routing\MethodNotAllowedException;
 use Nene2\Routing\RouteNotFoundException;
 use Nene2\Validation\ValidationException;
@@ -44,6 +45,14 @@ final readonly class ErrorHandlerMiddleware implements MiddlewareInterface
                     'The requested resource does not support this HTTP method.',
                 )
                 ->withHeader('Allow', implode(', ', $exception->allowedMethods()));
+        } catch (JsonBodyParseException $exception) {
+            return $this->problemDetails->create(
+                $request,
+                'invalid-json',
+                'Invalid JSON',
+                400,
+                $exception->getMessage(),
+            );
         } catch (ValidationException $exception) {
             return $this->problemDetails->create(
                 $request,

--- a/src/Example/Note/CreateNoteHandler.php
+++ b/src/Example/Note/CreateNoteHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Example\Note;
 
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
@@ -20,7 +21,7 @@ final readonly class CreateNoteHandler
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $body = (array) json_decode((string) $request->getBody(), associative: true);
+        $body = JsonRequestBodyParser::parse($request);
 
         $errors = [];
 

--- a/src/Example/Note/UpdateNoteHandler.php
+++ b/src/Example/Note/UpdateNoteHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Example\Note;
 
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use Nene2\Validation\ValidationError;
@@ -28,7 +29,7 @@ final readonly class UpdateNoteHandler
             throw new NoteNotFoundException($id);
         }
 
-        $body = (array) json_decode((string) $request->getBody(), associative: true);
+        $body = JsonRequestBodyParser::parse($request);
 
         $errors = [];
 

--- a/src/Example/Tag/CreateTagHandler.php
+++ b/src/Example/Tag/CreateTagHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Example\Tag;
 
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
@@ -20,7 +21,7 @@ final readonly class CreateTagHandler
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $body = (array) json_decode((string) $request->getBody(), associative: true);
+        $body = JsonRequestBodyParser::parse($request);
 
         $name = trim((string) ($body['name'] ?? ''));
 

--- a/src/Example/Tag/UpdateTagHandler.php
+++ b/src/Example/Tag/UpdateTagHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Example\Tag;
 
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use Nene2\Validation\ValidationError;
@@ -28,7 +29,7 @@ final readonly class UpdateTagHandler
             throw new TagNotFoundException($id);
         }
 
-        $body = (array) json_decode((string) $request->getBody(), associative: true);
+        $body = JsonRequestBodyParser::parse($request);
 
         $name = trim((string) ($body['name'] ?? ''));
 

--- a/src/Http/JsonBodyParseException.php
+++ b/src/Http/JsonBodyParseException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use RuntimeException;
+
+/**
+ * Thrown when the request body cannot be parsed as a JSON object.
+ *
+ * ErrorHandlerMiddleware maps this to a 400 Problem Details response with
+ * type "invalid-json", keeping it distinct from 422 validation failures.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class JsonBodyParseException extends RuntimeException
+{
+}

--- a/src/Http/JsonRequestBodyParser.php
+++ b/src/Http/JsonRequestBodyParser.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use JsonException;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Parses the request body as a JSON object.
+ *
+ * Throws JsonBodyParseException (→ 400) for any of:
+ * - empty body
+ * - syntactically invalid JSON
+ * - valid JSON that is not an object (e.g. a string, number, or array)
+ *
+ * This keeps 400 (malformed input) distinct from 422 (structurally valid
+ * input that fails business validation).
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class JsonRequestBodyParser
+{
+    /**
+     * @return array<string, mixed>
+     * @throws JsonBodyParseException
+     */
+    public static function parse(ServerRequestInterface $request): array
+    {
+        $raw = (string) $request->getBody();
+
+        if ($raw === '') {
+            throw new JsonBodyParseException('Request body is empty. A JSON object is required.');
+        }
+
+        try {
+            $decoded = json_decode($raw, associative: true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new JsonBodyParseException(
+                'Request body contains invalid JSON: ' . $e->getMessage(),
+                previous: $e,
+            );
+        }
+
+        if (!is_array($decoded)) {
+            throw new JsonBodyParseException(
+                'Request body must be a JSON object, got ' . gettype($decoded) . '.',
+            );
+        }
+
+        return $decoded;
+    }
+}

--- a/src/Http/JsonRequestBodyParser.php
+++ b/src/Http/JsonRequestBodyParser.php
@@ -35,7 +35,9 @@ final class JsonRequestBodyParser
         }
 
         try {
-            $decoded = json_decode($raw, associative: true, flags: JSON_THROW_ON_ERROR);
+            // Decode without associative: true so JSON objects become stdClass and
+            // JSON arrays remain array — allowing us to tell them apart.
+            $decoded = json_decode($raw, associative: false, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw new JsonBodyParseException(
                 'Request body contains invalid JSON: ' . $e->getMessage(),
@@ -43,12 +45,14 @@ final class JsonRequestBodyParser
             );
         }
 
-        if (!is_array($decoded)) {
+        if (!$decoded instanceof \stdClass) {
             throw new JsonBodyParseException(
-                'Request body must be a JSON object, got ' . gettype($decoded) . '.',
+                'Request body must be a JSON object, got ' . get_debug_type($decoded) . '.',
             );
         }
 
-        return $decoded;
+        // Re-decode as associative to return array<string, mixed> for handler use.
+        /** @var array<string, mixed> */
+        return (array) json_decode($raw, associative: true, flags: JSON_THROW_ON_ERROR);
     }
 }

--- a/tests/Example/Note/NoteHttpTest.php
+++ b/tests/Example/Note/NoteHttpTest.php
@@ -268,6 +268,42 @@ final class NoteHttpTest extends TestCase
         self::assertContains('title', $fields);
     }
 
+    public function testPostNoteReturns400WhenBodyIsInvalidJson(): void
+    {
+        $body = $this->factory->createStream('{not valid json');
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/examples/notes')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('https://nene2.dev/problems/invalid-json', $payload['type']);
+        self::assertSame('Invalid JSON', $payload['title']);
+    }
+
+    public function testPostNoteReturns400WhenBodyIsEmpty(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/examples/notes'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('https://nene2.dev/problems/invalid-json', $payload['type']);
+    }
+
+    public function testPostNoteReturns400WhenBodyIsJsonString(): void
+    {
+        $body = $this->factory->createStream('"just a string"');
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/examples/notes')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('https://nene2.dev/problems/invalid-json', $payload['type']);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Http/JsonRequestBodyParserTest.php
+++ b/tests/Http/JsonRequestBodyParserTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\JsonBodyParseException;
+use Nene2\Http\JsonRequestBodyParser;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class JsonRequestBodyParserTest extends TestCase
+{
+    public function testParsesValidJsonObject(): void
+    {
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('POST', 'https://example.test/')
+            ->withBody($factory->createStream('{"title":"Hello","body":"World"}'));
+
+        $result = JsonRequestBodyParser::parse($request);
+
+        self::assertSame(['title' => 'Hello', 'body' => 'World'], $result);
+    }
+
+    public function testThrowsOnEmptyBody(): void
+    {
+        $this->expectException(JsonBodyParseException::class);
+
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('POST', 'https://example.test/')
+            ->withBody($factory->createStream(''));
+
+        JsonRequestBodyParser::parse($request);
+    }
+
+    public function testThrowsOnInvalidJson(): void
+    {
+        $this->expectException(JsonBodyParseException::class);
+
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('POST', 'https://example.test/')
+            ->withBody($factory->createStream('{not valid json'));
+
+        JsonRequestBodyParser::parse($request);
+    }
+
+    public function testThrowsOnJsonString(): void
+    {
+        $this->expectException(JsonBodyParseException::class);
+
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('POST', 'https://example.test/')
+            ->withBody($factory->createStream('"just a string"'));
+
+        JsonRequestBodyParser::parse($request);
+    }
+
+    public function testThrowsOnJsonNumber(): void
+    {
+        $this->expectException(JsonBodyParseException::class);
+
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('POST', 'https://example.test/')
+            ->withBody($factory->createStream('42'));
+
+        JsonRequestBodyParser::parse($request);
+    }
+
+    public function testThrowsOnJsonNull(): void
+    {
+        $this->expectException(JsonBodyParseException::class);
+
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('POST', 'https://example.test/')
+            ->withBody($factory->createStream('null'));
+
+        JsonRequestBodyParser::parse($request);
+    }
+
+    public function testThrowsOnJsonArray(): void
+    {
+        $this->expectException(JsonBodyParseException::class);
+
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('POST', 'https://example.test/')
+            ->withBody($factory->createStream('[1,2,3]'));
+
+        JsonRequestBodyParser::parse($request);
+    }
+}


### PR DESCRIPTION
## Problem

ハンドラーの `(array) json_decode(...)` は不正 JSON を無音で `[]` に変換し、
本来 400 を返すべき状況が 422 に化けていた。

## Solution

- `JsonBodyParseException` — 専用例外 (stable surface)
- `JsonRequestBodyParser::parse()` — 空/不正/非オブジェクト JSON で例外を投げる (stable surface)
- `ErrorHandlerMiddleware` に `JsonBodyParseException → 400 invalid-json` キャッチを追加
- 4 ハンドラーを差し替え

## Before / After

| 入力 | Before | After |
|---|---|---|
| 不正 JSON `{bad` | 422 validation-failed | **400 invalid-json** |
| 空ボディ | 422 validation-failed | **400 invalid-json** |
| JSON 文字列 `"str"` | 422 validation-failed | **400 invalid-json** |
| 正常 JSON | 201/200 | 201/200（変わらず） |

## Test plan

- [ ] `JsonRequestBodyParserTest` — 7 ケース（正常・空・不正・string/number/null/array）
- [ ] `NoteHttpTest` — 400 パス 3 ケース（invalid JSON / empty / JSON string）
- [ ] `composer check` グリーン

Closes #354

Self-review: backend-api, middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)