### PR TITLE
chore(release): Phase 48-49 — JsonRequestBodyParser ロードマップ追記・v1.2.0 CHANGELOG 確定 (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.2.0] — 2026-05-18
+
 ### Added
 - `JsonRequestBodyParser` and `JsonBodyParseException` — parse request body as JSON object; throws on empty body, invalid JSON, or non-object JSON (`Nene2\Http`) (#354)
 - `ErrorHandlerMiddleware` maps `JsonBodyParseException` → `400 invalid-json` Problem Details, distinct from `422 validation-failed` (#354)
@@ -239,7 +243,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Governance docs: workflow, coding standards, ADR policy, review checklists (#1)
 - ADR 0001–0004: HTTP runtime, DI container, phpdotenv, Phinx
 
-[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.8.0...v1.0.0
 [0.8.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.7.0...v0.8.0

--- a/docs/milestones/2026-05-v1.1.md
+++ b/docs/milestones/2026-05-v1.1.md
@@ -54,11 +54,24 @@ Key deliverables:
 - [x] `ThrottleMiddleware` 429 + `Retry-After` + `X-RateLimit-*` headers verified
 - [x] `InMemoryRateLimitStorage` hit counter verified
 
+### Phase 48 — JsonRequestBodyParser (post-v1.1.0 addition)
+
+Separate 400 (malformed JSON) from 422 (valid JSON that fails business validation) following
+code review feedback. New stable surface additions released as v1.2.0.
+
+Key deliverables:
+
+- [x] `JsonBodyParseException` added to stable `Nene2\Http` surface
+- [x] `JsonRequestBodyParser::parse()` with `instanceof \stdClass` detection
+- [x] `ErrorHandlerMiddleware` catches `JsonBodyParseException` → 400 `invalid-json`
+- [x] 4 handlers migrated to `JsonRequestBodyParser::parse()`
+- [x] 7 unit tests + 3 HTTP-level 400-path tests
+
 ### Phase 47 — v1.1.0 Release
 
 - [x] CHANGELOG.md v1.1.0 section
 - [x] ADR 0010 finalized
-- [ ] Packagist auto-reflection confirmed
+- [x] Packagist auto-reflection confirmed
 - [x] `v1.1.0` tag
 
 ## Acceptance Criteria
@@ -88,7 +101,7 @@ All of the following must be true before tagging `v1.1.0`:
 ### Operations
 
 - [x] Field Trial 8 completed (Phase 46)
-- [ ] Packagist v1.1.0 published
+- [x] Packagist v1.1.0 published
 - [x] Maintainer explicitly approves tagging `v1.1.0`
 
 ## Tracked by

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -520,6 +520,27 @@ Goal: consolidate Phase 44–46 additions into a versioned release.
 
 Tracked by `docs/milestones/2026-05-v1.1.md`.
 
+## Phase 48: JsonRequestBodyParser — 400/422 分離 (#354)
+
+Goal: make the boundary between malformed JSON (400) and structurally valid but semantically
+invalid JSON (422) explicit, so clients can distinguish parse errors from validation errors.
+
+- `JsonBodyParseException` added to stable `Nene2\Http` surface
+- `JsonRequestBodyParser::parse()` — throws on empty body, syntactically invalid JSON, or
+  non-object JSON (array / string / number / null)
+- `ErrorHandlerMiddleware` maps `JsonBodyParseException` → `400 invalid-json` Problem Details
+- `CreateNoteHandler`, `UpdateNoteHandler`, `CreateTagHandler`, `UpdateTagHandler` migrated to
+  use `JsonRequestBodyParser::parse()` instead of raw `json_decode`
+- 7 unit tests in `JsonRequestBodyParserTest`; 3 new 400-path cases in `NoteHttpTest`
+
+## Phase 49: v1.2.0 Release (#356)
+
+Goal: consolidate Phase 48 additions into a versioned release.
+
+- CHANGELOG.md v1.2.0 section (Phase 48 — JsonRequestBodyParser)
+- Roadmap and TODO updated
+- `v1.2.0` tag
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -359,11 +359,19 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] test: `JsonRequestBodyParserTest` 7 ケース（正常・空・不正・非オブジェクト各種）
 - [x] test: `NoteHttpTest` に 400 パス 3 ケース追加
 
+## Phase 49: v1.2.0 リリース (#356)
+
+- [x] docs(roadmap): Phase 48-49 エントリを追加する
+- [x] docs(todo): current.md を更新する
+- [x] chore(changelog): `[Unreleased]` → `[1.2.0] — 2026-05-18` に確定する
+- [ ] chore(release): `v1.2.0` タグを打つ
+- [ ] chore(release): Packagist v1.2.0 自動反映確認
+
 ## Phase 47: v1.1.0 リリース
 
 - [x] chore(changelog): v1.1.0 セクション確定
 - [x] docs(adr): ADR 0010 最終化
-- [ ] chore(release): Packagist v1.1.0 自動反映確認
+- [x] chore(release): Packagist v1.1.0 自動反映確認
 - [x] chore(release): `v1.1.0` タグを打つ
 
 ## Phase 46: Field Trial 8 — v1.0 Stable Validation


### PR DESCRIPTION
## 目的

Phase 48 (JsonRequestBodyParser / JsonBodyParseException) をロードマップ・CHANGELOG に正式記録し、v1.2.0 リリースの準備を完了する。

## 変更内容

- `CHANGELOG.md` — `[Unreleased]` → `[1.2.0] — 2026-05-18` に確定、フッターリンク追加
- `docs/roadmap.md` — Phase 48・Phase 49 エントリを追加
- `docs/todo/current.md` — Phase 47 Packagist 確認済みマーク・Phase 49 タスク追加
- `docs/milestones/2026-05-v1.1.md` — Phase 47 完了・Phase 48 後日追加として記録

## 検証

ドキュメント変更のみ。`composer check` / `npm run check` は不要。

## 関連

- Closes #356
- Phase 48 実装: #354

Self-review: docs-policy