### PR TITLE
feat(http): PaginationQuery / PaginationQueryParser を stable surface に追加する

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -541,6 +541,35 @@ Goal: consolidate Phase 48 additions into a versioned release.
 - Roadmap and TODO updated
 - `v1.2.0` tag
 
+## Phase 51: Pagination Helper (#360)
+
+Goal: extract the duplicated `?limit=&offset=` parsing logic from collection handlers into a
+reusable `PaginationQuery` / `PaginationQueryParser` pair in the stable `Nene2\Http` surface.
+
+- `PaginationQuery` — readonly DTO holding `limit: int` and `offset: int`
+- `PaginationQueryParser::parse()` — parses and validates query params, throws `ValidationException` on
+  out-of-range values; accepts `$defaultLimit` and `$maxLimit` parameters
+- `ListNotesHandler` and `ListTagsHandler` migrated to use the parser (duplicate logic removed)
+- 9 unit tests in `PaginationQueryParserTest`
+
+## Phase 52: OpenAPI 3.1 Upgrade
+
+Goal: upgrade the OpenAPI document from 3.0.x to 3.1 to gain JSON Schema alignment and
+deprecate `nullable: true` in favour of type arrays.
+
+## Phase 53: OpenAPI → Markdown Generation
+
+Goal: add a CLI script (`tools/openapi-to-md.php` or `composer openapi:docs`) that reads
+`docs/openapi/openapi.yaml` and writes the Reference section Markdown pages, keeping them
+in sync with the API contract.
+
+## Phase 54: v1.3.0 Release
+
+Goal: consolidate Phase 51–53 additions into a versioned release.
+
+- CHANGELOG.md v1.3.0 section
+- `v1.3.0` tag
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -359,6 +359,14 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] test: `JsonRequestBodyParserTest` 7 ケース（正常・空・不正・非オブジェクト各種）
 - [x] test: `NoteHttpTest` に 400 パス 3 ケース追加
 
+## Phase 51: Pagination Helper (#360)
+
+- [x] feat: `PaginationQuery` readonly DTO を `Nene2\Http` に追加する
+- [x] feat: `PaginationQueryParser::parse()` を `Nene2\Http` に追加する（`ValidationException` スロー）
+- [x] refactor: `ListNotesHandler` / `ListTagsHandler` を `PaginationQueryParser` に移行する
+- [x] test: `PaginationQueryParserTest` 9 ケース追加
+- [ ] CI グリーン確認・PR マージ
+
 ## Phase 50: VitePress v1.2.0 対応ドキュメント (#358)
 
 - [x] docs(vitepress): HOWTO add-rate-limiting (6 言語) を追加する

--- a/src/Example/Note/ListNotesHandler.php
+++ b/src/Example/Note/ListNotesHandler.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace Nene2\Example\Note;
 
 use Nene2\Http\JsonResponseFactory;
-use Nene2\Validation\ValidationError;
-use Nene2\Validation\ValidationException;
+use Nene2\Http\PaginationQueryParser;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class ListNotesHandler
 {
-    private const int MAX_LIMIT = 100;
-
     public function __construct(
         private ListNotesUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -22,25 +19,9 @@ final readonly class ListNotesHandler
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $query = $request->getQueryParams();
-        $limit = isset($query['limit']) ? (int) $query['limit'] : 20;
-        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+        $pagination = PaginationQueryParser::parse($request);
 
-        $errors = [];
-
-        if ($limit < 1 || $limit > self::MAX_LIMIT) {
-            $errors[] = new ValidationError('limit', 'limit must be between 1 and ' . self::MAX_LIMIT . '.', 'out_of_range');
-        }
-
-        if ($offset < 0) {
-            $errors[] = new ValidationError('offset', 'offset must be 0 or greater.', 'out_of_range');
-        }
-
-        if ($errors !== []) {
-            throw new ValidationException($errors);
-        }
-
-        $output = $this->useCase->execute(new ListNotesInput($limit, $offset));
+        $output = $this->useCase->execute(new ListNotesInput($pagination->limit, $pagination->offset));
 
         return $this->response->create([
             'items' => array_map(

--- a/src/Example/Tag/ListTagsHandler.php
+++ b/src/Example/Tag/ListTagsHandler.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace Nene2\Example\Tag;
 
 use Nene2\Http\JsonResponseFactory;
-use Nene2\Validation\ValidationError;
-use Nene2\Validation\ValidationException;
+use Nene2\Http\PaginationQueryParser;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class ListTagsHandler
 {
-    private const int MAX_LIMIT = 100;
-
     public function __construct(
         private ListTagsUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -22,25 +19,9 @@ final readonly class ListTagsHandler
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $query = $request->getQueryParams();
-        $limit = isset($query['limit']) ? (int) $query['limit'] : 20;
-        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+        $pagination = PaginationQueryParser::parse($request);
 
-        $errors = [];
-
-        if ($limit < 1 || $limit > self::MAX_LIMIT) {
-            $errors[] = new ValidationError('limit', 'limit must be between 1 and ' . self::MAX_LIMIT . '.', 'out_of_range');
-        }
-
-        if ($offset < 0) {
-            $errors[] = new ValidationError('offset', 'offset must be 0 or greater.', 'out_of_range');
-        }
-
-        if ($errors !== []) {
-            throw new ValidationException($errors);
-        }
-
-        $output = $this->useCase->execute(new ListTagsInput($limit, $offset));
+        $output = $this->useCase->execute(new ListTagsInput($pagination->limit, $pagination->offset));
 
         return $this->response->create([
             'items' => array_map(

--- a/src/Http/PaginationQuery.php
+++ b/src/Http/PaginationQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+/**
+ * Parsed and validated pagination parameters from a query string.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ *
+ * @see PaginationQueryParser
+ */
+final readonly class PaginationQuery
+{
+    public function __construct(
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Http/PaginationQueryParser.php
+++ b/src/Http/PaginationQueryParser.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Parses and validates ?limit= and ?offset= query parameters into a PaginationQuery.
+ *
+ * Throws ValidationException (→ 422) when either parameter is out of range.
+ * Non-numeric values are coerced to 0 (casting behaviour of PHP intval).
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class PaginationQueryParser
+{
+    /**
+     * @throws ValidationException
+     */
+    public static function parse(
+        ServerRequestInterface $request,
+        int $defaultLimit = 20,
+        int $maxLimit = 100,
+    ): PaginationQuery {
+        $query = $request->getQueryParams();
+        $limit = isset($query['limit']) ? (int) $query['limit'] : $defaultLimit;
+        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+
+        $errors = [];
+
+        if ($limit < 1 || $limit > $maxLimit) {
+            $errors[] = new ValidationError(
+                'limit',
+                'limit must be between 1 and ' . $maxLimit . '.',
+                'out_of_range',
+            );
+        }
+
+        if ($offset < 0) {
+            $errors[] = new ValidationError('offset', 'offset must be 0 or greater.', 'out_of_range');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        return new PaginationQuery(limit: $limit, offset: $offset);
+    }
+}

--- a/tests/Http/PaginationQueryParserTest.php
+++ b/tests/Http/PaginationQueryParserTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\PaginationQuery;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Validation\ValidationException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class PaginationQueryParserTest extends TestCase
+{
+    private function request(string $query = ''): \Psr\Http\Message\ServerRequestInterface
+    {
+        $factory = new Psr17Factory();
+        return $factory->createServerRequest('GET', 'https://example.test/?' . $query);
+    }
+
+    public function testDefaultsWhenNoQueryParams(): void
+    {
+        $result = PaginationQueryParser::parse($this->request());
+
+        self::assertSame(20, $result->limit);
+        self::assertSame(0, $result->offset);
+    }
+
+    public function testParsesExplicitLimitAndOffset(): void
+    {
+        $result = PaginationQueryParser::parse($this->request('limit=50&offset=100'));
+
+        self::assertSame(50, $result->limit);
+        self::assertSame(100, $result->offset);
+    }
+
+    public function testReturnsPaginationQueryInstance(): void
+    {
+        $result = PaginationQueryParser::parse($this->request('limit=10&offset=5'));
+
+        self::assertInstanceOf(PaginationQuery::class, $result);
+    }
+
+    public function testCustomDefaultLimit(): void
+    {
+        $result = PaginationQueryParser::parse($this->request(), defaultLimit: 5);
+
+        self::assertSame(5, $result->limit);
+    }
+
+    public function testCustomMaxLimit(): void
+    {
+        $result = PaginationQueryParser::parse($this->request('limit=200'), maxLimit: 500);
+
+        self::assertSame(200, $result->limit);
+    }
+
+    public function testThrowsWhenLimitTooLow(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        PaginationQueryParser::parse($this->request('limit=0'));
+    }
+
+    public function testThrowsWhenLimitExceedsMax(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        PaginationQueryParser::parse($this->request('limit=101'));
+    }
+
+    public function testThrowsWhenOffsetNegative(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        PaginationQueryParser::parse($this->request('offset=-1'));
+    }
+
+    public function testThrowsBothErrorsWhenBothInvalid(): void
+    {
+        try {
+            PaginationQueryParser::parse($this->request('limit=0&offset=-1'));
+            self::fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            self::assertCount(2, $e->errors());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `PaginationQuery` readonly DTO (`limit: int`, `offset: int`) を `Nene2\Http` に追加
- `PaginationQueryParser::parse()` を `Nene2\Http` に追加 — `?limit=&offset=` を解析・バリデーション、範囲外で `ValidationException` をスロー
- `ListNotesHandler` / `ListTagsHandler` の重複ロジックを削除し `PaginationQueryParser` に移行
- `PaginationQueryParserTest` — 9 ケース（デフォルト・正常・バリデーション異常・カスタム上限）

## 変更ファイル

- `src/Http/PaginationQuery.php` (新規 — stable surface)
- `src/Http/PaginationQueryParser.php` (新規 — stable surface)
- `src/Example/Note/ListNotesHandler.php` (リファクタ)
- `src/Example/Tag/ListTagsHandler.php` (リファクタ)
- `tests/Http/PaginationQueryParserTest.php` (新規)
- `docs/roadmap.md` / `docs/todo/current.md` (更新)

## Test plan

- [ ] `vendor/bin/phpunit tests/Http/PaginationQueryParserTest.php` — 9 tests green
- [ ] `composer check` — PHPUnit + PHPStan + CS 全通過
- [ ] CI green

Self-review: backend-api

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)