### PR TITLE
chore(release): v1.3.0 リリース — CHANGELOG 確定・タグ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.3.0] — 2026-05-18
+
+### Added
+- `PaginationQuery` readonly DTO — holds validated `limit` and `offset` values (`Nene2\Http`) (#360)
+- `PaginationQueryParser::parse()` — parses and validates `?limit=&offset=` query parameters; throws `ValidationException` on out-of-range values; accepts `$defaultLimit` and `$maxLimit` parameters (`Nene2\Http`) (#360)
+- `tools/openapi-to-md.php` — generates `docs/reference/http-endpoints.md` from `docs/openapi/openapi.yaml`; runnable via `composer openapi:docs` (#362)
+- `InvalidJson` and `TooManyRequests` response components added to `openapi.yaml`; POST/PUT endpoints now reference the 400 `InvalidJson` response (#362)
+- `public_html/problems/invalid-json/` and `public_html/problems/too-many-requests/` human-readable Problem Details type pages (#362)
+
+### Changed
+- `ListNotesHandler` and `ListTagsHandler` — replaced duplicated limit/offset parsing logic with `PaginationQueryParser::parse()` (#360)
+
+---
+
 ## [1.2.0] — 2026-05-18
 
 ### Added
@@ -244,6 +258,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - ADR 0001–0004: HTTP runtime, DI container, phpdotenv, Phinx
 
 [Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v1.2.0...HEAD
+[1.3.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/hideyukiMORI/NENE2/compare/v0.8.0...v1.0.0

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -373,7 +373,14 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] `tools/openapi-to-md.php` — openapi.yaml から英語リファレンス Markdown を生成する
 - [x] `openapi.yaml` に InvalidJson/TooManyRequests レスポンス追加・POST/PUT に 400 を追加
 - [x] `composer.json` に `openapi:docs` スクリプトを追加する
-- [ ] CI グリーン確認・PR マージ (#363)
+- [x] CI グリーン確認・PR マージ (#363)
+
+## Phase 53: v1.3.0 リリース
+
+- [x] Issue 作成・ブランチ作成
+- [x] chore(changelog): v1.3.0 セクション確定
+- [ ] chore(release): `v1.3.0` タグを打つ
+- [ ] CI グリーン確認・PR マージ
 
 ## Phase 50: VitePress v1.2.0 対応ドキュメント (#358)
 


### PR DESCRIPTION
## Summary

- CHANGELOG.md `[Unreleased]` → `[1.3.0] — 2026-05-18`
- v1.3.0 フッターリンク追加
- Phase 51: `PaginationQuery` / `PaginationQueryParser` を stable surface に追加
- Phase 52: `tools/openapi-to-md.php` + `composer openapi:docs` + OpenAPI 400/429 追加

## Test plan

- [ ] CI green
- [ ] `v1.3.0` タグを main に打つ
- [ ] Packagist v1.3.0 反映確認

Self-review: release-ci

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)