### PR TITLE
docs(vitepress): Pagination HOWTO + v1.3.0 バッジ + CI openapi:docs チェック

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -47,3 +47,8 @@ jobs:
 
       - name: Run backend checks
         run: composer check
+
+      - name: Verify OpenAPI docs are up to date
+        run: |
+          composer openapi:docs
+          git diff --exit-code docs/reference/http-endpoints.md

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -9,7 +9,7 @@ function nav(t: {
     { text: t.explanation, link: 'explanation/why-psr',           activeMatch: 'explanation/' },
     { text: t.reference,   link: 'reference/index',               activeMatch: 'reference/' },
     {
-      text: 'v1.2.0',
+      text: 'v1.3.0',
       items: [
         { text: 'Changelog',  link: 'https://github.com/hideyukiMORI/NENE2/blob/main/CHANGELOG.md' },
         { text: 'Releases',   link: 'https://github.com/hideyukiMORI/NENE2/releases' },
@@ -21,7 +21,7 @@ function nav(t: {
 
 function sidebar(t: {
   tutorialGroup: string; firstApi: string
-  howtoGroup: string; addRoute: string; addDb: string; addEntity: string; deploy: string; addRateLimit: string; addHealthCheck: string
+  howtoGroup: string; addRoute: string; addDb: string; addEntity: string; deploy: string; addRateLimit: string; addHealthCheck: string; addPagination: string
   explGroup: string; whyPsr: string; whyDi: string; whyPd: string; whyMcp: string
   devGroup: string; intGroup: string
   refGroup: string; envVars: string; endpoints: string; problemTypes: string
@@ -37,6 +37,7 @@ function sidebar(t: {
         { text: t.deploy,         link: 'howto/deploy-production' },
         { text: t.addRateLimit,   link: 'howto/add-rate-limiting' },
         { text: t.addHealthCheck, link: 'howto/add-health-check' },
+        { text: t.addPagination,  link: 'howto/add-pagination' },
       ],
     }],
     '/explanation/': [{
@@ -99,7 +100,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'HOWTO', explanation: 'Explanation', reference: 'Reference' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Your first API',
-          howtoGroup: 'HOWTO', addRoute: 'Add a custom route', addDb: 'Add a database-backed endpoint', addEntity: 'Add a second entity', deploy: 'Deploy to production', addRateLimit: 'Add rate limiting', addHealthCheck: 'Add a health check',
+          howtoGroup: 'HOWTO', addRoute: 'Add a custom route', addDb: 'Add a database-backed endpoint', addEntity: 'Add a second entity', deploy: 'Deploy to production', addRateLimit: 'Add rate limiting', addHealthCheck: 'Add a health check', addPagination: 'Add pagination',
           explGroup: 'Explanation', whyPsr: 'Why PSR standards?', whyDi: 'Why explicit wiring?', whyPd: 'Why Problem Details?', whyMcp: 'Why MCP?',
           devGroup: 'Development', intGroup: 'Integrations',
           refGroup: 'Reference', envVars: 'Environment variables', endpoints: 'HTTP endpoints', problemTypes: 'Problem Details types',
@@ -116,7 +117,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'チュートリアル', howto: 'HOWTO', explanation: '解説', reference: 'リファレンス' }),
         sidebar: sidebar({
           tutorialGroup: 'チュートリアル', firstApi: '最初の API を動かす',
-          howtoGroup: 'HOWTO', addRoute: 'カスタムルートを追加する', addDb: 'DB 付きエンドポイントを追加する', addEntity: '2 つ目のエンティティを追加する', deploy: '本番環境へデプロイする', addRateLimit: 'レート制限を追加する', addHealthCheck: 'ヘルスチェックを追加する',
+          howtoGroup: 'HOWTO', addRoute: 'カスタムルートを追加する', addDb: 'DB 付きエンドポイントを追加する', addEntity: '2 つ目のエンティティを追加する', deploy: '本番環境へデプロイする', addRateLimit: 'レート制限を追加する', addHealthCheck: 'ヘルスチェックを追加する', addPagination: 'ページネーションを追加する',
           explGroup: '解説', whyPsr: 'なぜ PSR 標準？', whyDi: 'なぜ明示的 DI？', whyPd: 'なぜ Problem Details？', whyMcp: 'なぜ MCP？',
           devGroup: '開発ガイド', intGroup: 'インテグレーション',
           refGroup: 'リファレンス', envVars: '環境変数', endpoints: 'HTTP エンドポイント', problemTypes: 'Problem Details タイプ',
@@ -138,7 +139,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutoriel', howto: 'Guides', explanation: 'Explication', reference: 'Référence' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutoriel', firstApi: 'Votre première API',
-          howtoGroup: 'Guides pratiques', addRoute: 'Ajouter une route', addDb: 'Ajouter un endpoint avec BDD', addEntity: 'Ajouter une deuxième entité', deploy: 'Déployer en production', addRateLimit: 'Ajouter la limitation de débit', addHealthCheck: 'Ajouter un contrôle de santé',
+          howtoGroup: 'Guides pratiques', addRoute: 'Ajouter une route', addDb: 'Ajouter un endpoint avec BDD', addEntity: 'Ajouter une deuxième entité', deploy: 'Déployer en production', addRateLimit: 'Ajouter la limitation de débit', addHealthCheck: 'Ajouter un contrôle de santé', addPagination: 'Ajouter la pagination',
           explGroup: 'Explication', whyPsr: 'Pourquoi PSR ?', whyDi: 'Pourquoi le câblage explicite ?', whyPd: 'Pourquoi Problem Details ?', whyMcp: 'Pourquoi MCP ?',
           devGroup: 'Développement', intGroup: 'Intégrations',
           refGroup: 'Référence', envVars: "Variables d'environnement", endpoints: 'Endpoints HTTP', problemTypes: 'Types Problem Details',
@@ -158,7 +159,7 @@ export default defineConfig({
         nav: nav({ tutorial: '教程', howto: '操作指南', explanation: '说明', reference: '参考' }),
         sidebar: sidebar({
           tutorialGroup: '教程', firstApi: '创建您的第一个 API',
-          howtoGroup: '操作指南', addRoute: '添加自定义路由', addDb: '添加数据库端点', addEntity: '添加第二个实体', deploy: '部署到生产环境', addRateLimit: '添加速率限制', addHealthCheck: '添加健康检查',
+          howtoGroup: '操作指南', addRoute: '添加自定义路由', addDb: '添加数据库端点', addEntity: '添加第二个实体', deploy: '部署到生产环境', addRateLimit: '添加速率限制', addHealthCheck: '添加健康检查', addPagination: '添加分页',
           explGroup: '说明', whyPsr: '为什么选择 PSR？', whyDi: '为什么显式依赖注入？', whyPd: '为什么使用 Problem Details？', whyMcp: '为什么选择 MCP？',
           devGroup: '开发指南', intGroup: '集成',
           refGroup: '参考', envVars: '环境变量', endpoints: 'HTTP 端点', problemTypes: 'Problem Details 类型',
@@ -180,7 +181,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'Guias', explanation: 'Explicação', reference: 'Referência' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Sua primeira API',
-          howtoGroup: 'Guias práticos', addRoute: 'Adicionar uma rota', addDb: 'Adicionar endpoint com banco de dados', addEntity: 'Adicionar segunda entidade', deploy: 'Implantar em produção', addRateLimit: 'Adicionar limitação de taxa', addHealthCheck: 'Adicionar verificação de saúde',
+          howtoGroup: 'Guias práticos', addRoute: 'Adicionar uma rota', addDb: 'Adicionar endpoint com banco de dados', addEntity: 'Adicionar segunda entidade', deploy: 'Implantar em produção', addRateLimit: 'Adicionar limitação de taxa', addHealthCheck: 'Adicionar verificação de saúde', addPagination: 'Adicionar paginação',
           explGroup: 'Explicação', whyPsr: 'Por que PSR?', whyDi: 'Por que injeção explícita?', whyPd: 'Por que Problem Details?', whyMcp: 'Por que MCP?',
           devGroup: 'Desenvolvimento', intGroup: 'Integrações',
           refGroup: 'Referência', envVars: 'Variáveis de ambiente', endpoints: 'Endpoints HTTP', problemTypes: 'Tipos Problem Details',
@@ -200,7 +201,7 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'Anleitungen', explanation: 'Erklärung', reference: 'Referenz' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Ihre erste API',
-          howtoGroup: 'Anleitungen', addRoute: 'Route hinzufügen', addDb: 'Datenbankendpunkt hinzufügen', addEntity: 'Zweite Entität hinzufügen', deploy: 'In Produktion deployen', addRateLimit: 'Rate Limiting hinzufügen', addHealthCheck: 'Health Check hinzufügen',
+          howtoGroup: 'Anleitungen', addRoute: 'Route hinzufügen', addDb: 'Datenbankendpunkt hinzufügen', addEntity: 'Zweite Entität hinzufügen', deploy: 'In Produktion deployen', addRateLimit: 'Rate Limiting hinzufügen', addHealthCheck: 'Health Check hinzufügen', addPagination: 'Paginierung hinzufügen',
           explGroup: 'Erklärung', whyPsr: 'Warum PSR?', whyDi: 'Warum explizites Wiring?', whyPd: 'Warum Problem Details?', whyMcp: 'Warum MCP?',
           devGroup: 'Entwicklung', intGroup: 'Integrationen',
           refGroup: 'Referenz', envVars: 'Umgebungsvariablen', endpoints: 'HTTP-Endpunkte', problemTypes: 'Problem Details-Typen',

--- a/docs/de/howto/add-pagination.md
+++ b/docs/de/howto/add-pagination.md
@@ -1,0 +1,81 @@
+# Paginierung hinzufügen
+
+Diese Anleitung zeigt, wie Sie mit dem `PaginationQueryParser`-Helper aus `Nene2\Http` eine `?limit=` / `?offset=` Paginierung zu einem Collection-Endpoint hinzufügen.
+
+## Voraussetzungen
+
+- Ein funktionierender Collection-Handler (z.B. `ListNotesHandler`).
+- Der Handler gibt einen JSON-Envelope mit `items`, `limit` und `offset` zurück.
+
+## Schritt 1 — `PaginationQueryParser::parse()` aufrufen
+
+Ersetzen Sie die manuelle Query-Parameter-Extraktion durch den Parser. Er validiert die Werte und wirft `ValidationException` (→ 422), wenn sie außerhalb des Bereichs liegen.
+
+```php
+use Nene2\Http\PaginationQueryParser;
+
+public function handle(ServerRequestInterface $request): ResponseInterface
+{
+    $pagination = PaginationQueryParser::parse($request); // Standard: limit=20, max=100
+
+    $output = $this->useCase->execute(
+        new ListWidgetsInput($pagination->limit, $pagination->offset),
+    );
+
+    return $this->response->create([
+        'items'  => /* $output->items mappen */,
+        'limit'  => $output->limit,
+        'offset' => $output->offset,
+    ]);
+}
+```
+
+`PaginationQuery` ist ein readonly DTO mit zwei Eigenschaften: `limit: int` und `offset: int`.
+
+## Schritt 2 — Limits anpassen (optional)
+
+Übergeben Sie `$defaultLimit` und `$maxLimit`, um die Standardwerte (20 und 100) zu überschreiben:
+
+```php
+$pagination = PaginationQueryParser::parse($request, defaultLimit: 10, maxLimit: 50);
+```
+
+| Parameter | Standard | Bedeutung |
+|---|---|---|
+| `$defaultLimit` | `20` | Wird verwendet, wenn `?limit=` fehlt |
+| `$maxLimit` | `100` | Maximal erlaubter Wert; gibt 422 zurück wenn überschritten |
+
+## Schritt 3 — Den 422-Fehler behandeln
+
+`PaginationQueryParser::parse()` wirft `ValidationException` wenn:
+
+- `limit < 1` oder `limit > $maxLimit`
+- `offset < 0`
+
+`ErrorHandlerMiddleware` mappt `ValidationException` automatisch auf `422 validation-failed`.
+Im Handler ist keine zusätzliche Fehlerbehandlung erforderlich.
+
+**Beispiel 422-Antwort:**
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation Failed",
+  "status": 422,
+  "detail": "The request body contains invalid values.",
+  "errors": [
+    { "field": "limit", "message": "limit must be between 1 and 100.", "code": "out_of_range" }
+  ]
+}
+```
+
+## So funktioniert es
+
+`PaginationQueryParser::parse()` liest `getQueryParams()` aus der PSR-7-Anfrage, castet Werte zu `int`, validiert sie und gibt ein `PaginationQuery`-DTO zurück. Nicht-numerische Werte werden zu `0` gecastet (PHP-`(int)`-Cast-Verhalten) und dann durch die `limit < 1`-Prüfung abgefangen.
+
+## Siehe auch
+
+- `src/Example/Note/ListNotesHandler.php` — Referenzimplementierung mit dem Parser
+- `src/Example/Tag/ListTagsHandler.php` — zweites Beispiel
+- `Nene2\Http\PaginationQuery` — readonly DTO
+- `Nene2\Http\PaginationQueryParser` — die Parser-Klasse

--- a/docs/fr/howto/add-pagination.md
+++ b/docs/fr/howto/add-pagination.md
@@ -1,0 +1,81 @@
+# Ajouter la pagination
+
+Ce guide explique comment ajouter la pagination `?limit=` / `?offset=` à un endpoint de collection à l'aide du helper `PaginationQueryParser` de `Nene2\Http`.
+
+## Prérequis
+
+- Un handler de collection fonctionnel (ex. `ListNotesHandler`).
+- Le handler retourne une enveloppe JSON avec `items`, `limit` et `offset`.
+
+## Étape 1 — Appeler `PaginationQueryParser::parse()`
+
+Remplacez l'extraction manuelle des paramètres de requête par le parseur. Il valide les valeurs et lance `ValidationException` (→ 422) si elles sont hors plage.
+
+```php
+use Nene2\Http\PaginationQueryParser;
+
+public function handle(ServerRequestInterface $request): ResponseInterface
+{
+    $pagination = PaginationQueryParser::parse($request); // défaut : limit=20, max=100
+
+    $output = $this->useCase->execute(
+        new ListWidgetsInput($pagination->limit, $pagination->offset),
+    );
+
+    return $this->response->create([
+        'items'  => /* mapper $output->items */,
+        'limit'  => $output->limit,
+        'offset' => $output->offset,
+    ]);
+}
+```
+
+`PaginationQuery` est un DTO readonly avec deux propriétés : `limit: int` et `offset: int`.
+
+## Étape 2 — Personnaliser les limites (optionnel)
+
+Passez `$defaultLimit` et `$maxLimit` pour remplacer les valeurs par défaut (20 et 100) :
+
+```php
+$pagination = PaginationQueryParser::parse($request, defaultLimit: 10, maxLimit: 50);
+```
+
+| Paramètre | Défaut | Signification |
+|---|---|---|
+| `$defaultLimit` | `20` | Utilisé quand `?limit=` est absent |
+| `$maxLimit` | `100` | Valeur maximale autorisée ; retourne 422 si dépassée |
+
+## Étape 3 — Gérer l'erreur 422
+
+`PaginationQueryParser::parse()` lance `ValidationException` quand :
+
+- `limit < 1` ou `limit > $maxLimit`
+- `offset < 0`
+
+`ErrorHandlerMiddleware` mappe automatiquement `ValidationException` → `422 validation-failed`.
+Aucune gestion d'erreur supplémentaire n'est nécessaire dans le handler.
+
+**Exemple de réponse 422 :**
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation Failed",
+  "status": 422,
+  "detail": "The request body contains invalid values.",
+  "errors": [
+    { "field": "limit", "message": "limit must be between 1 and 100.", "code": "out_of_range" }
+  ]
+}
+```
+
+## Fonctionnement
+
+`PaginationQueryParser::parse()` lit `getQueryParams()` de la requête PSR-7, caste les valeurs en `int`, les valide et retourne un DTO `PaginationQuery`. Les valeurs non numériques sont castées en `0` (comportement PHP de `(int)`) puis interceptées par la vérification `limit < 1`.
+
+## Voir aussi
+
+- `src/Example/Note/ListNotesHandler.php` — implémentation de référence utilisant le parseur
+- `src/Example/Tag/ListTagsHandler.php` — deuxième exemple
+- `Nene2\Http\PaginationQuery` — DTO readonly
+- `Nene2\Http\PaginationQueryParser` — la classe parseur

--- a/docs/howto/add-pagination.md
+++ b/docs/howto/add-pagination.md
@@ -1,0 +1,85 @@
+# Add pagination
+
+This guide shows how to add `?limit=` / `?offset=` pagination to a collection endpoint using the
+`PaginationQueryParser` helper from `Nene2\Http`.
+
+## Prerequisites
+
+- A working collection handler (e.g. `ListNotesHandler`).
+- The handler returns a JSON envelope with `items`, `limit`, and `offset`.
+
+## Step 1 — Call `PaginationQueryParser::parse()`
+
+Replace manual query-param extraction with the parser. It validates the values and throws
+`ValidationException` (→ 422) when they are out of range.
+
+```php
+use Nene2\Http\PaginationQueryParser;
+
+public function handle(ServerRequestInterface $request): ResponseInterface
+{
+    $pagination = PaginationQueryParser::parse($request); // default: limit=20, max=100
+
+    $output = $this->useCase->execute(
+        new ListWidgetsInput($pagination->limit, $pagination->offset),
+    );
+
+    return $this->response->create([
+        'items'  => /* map $output->items */,
+        'limit'  => $output->limit,
+        'offset' => $output->offset,
+    ]);
+}
+```
+
+`PaginationQuery` is a readonly DTO with two properties: `limit: int` and `offset: int`.
+
+## Step 2 — Customise limits (optional)
+
+Pass `$defaultLimit` and `$maxLimit` to override the defaults (20 and 100):
+
+```php
+$pagination = PaginationQueryParser::parse($request, defaultLimit: 10, maxLimit: 50);
+```
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `$defaultLimit` | `20` | Returned when `?limit=` is absent |
+| `$maxLimit` | `100` | Maximum allowed value; returns 422 if exceeded |
+
+## Step 3 — Handle the 422 error
+
+`PaginationQueryParser::parse()` throws `ValidationException` when:
+
+- `limit < 1` or `limit > $maxLimit`
+- `offset < 0`
+
+`ErrorHandlerMiddleware` maps `ValidationException` → `422 validation-failed` automatically.
+No additional error handling is needed in the handler.
+
+**Example 422 response:**
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation Failed",
+  "status": 422,
+  "detail": "The request body contains invalid values.",
+  "errors": [
+    { "field": "limit", "message": "limit must be between 1 and 100.", "code": "out_of_range" }
+  ]
+}
+```
+
+## How it works
+
+`PaginationQueryParser::parse()` reads `getQueryParams()` from the PSR-7 request, casts values to
+`int`, validates them, and returns a `PaginationQuery` DTO. Non-numeric values are coerced to `0`
+(PHP's `(int)` casting behaviour) and then caught by the `limit < 1` check.
+
+## See also
+
+- `src/Example/Note/ListNotesHandler.php` — reference implementation using the parser
+- `src/Example/Tag/ListTagsHandler.php` — second example
+- `Nene2\Http\PaginationQuery` — readonly DTO
+- `Nene2\Http\PaginationQueryParser` — the parser class

--- a/docs/ja/howto/add-pagination.md
+++ b/docs/ja/howto/add-pagination.md
@@ -1,0 +1,80 @@
+# ページネーションを追加する
+
+このガイドでは、`Nene2\Http` の `PaginationQueryParser` ヘルパーを使って、コレクションエンドポイントに `?limit=` / `?offset=` ページネーションを追加する方法を説明します。
+
+## 前提条件
+
+- 動作するコレクションハンドラーがある（例: `ListNotesHandler`）。
+- ハンドラーが `items`、`limit`、`offset` を含む JSON エンベロープを返す。
+
+## ステップ 1 — `PaginationQueryParser::parse()` を呼ぶ
+
+クエリパラメーターの手動抽出をパーサーに置き換えます。値のバリデーションを行い、範囲外の場合は `ValidationException`（→ 422）をスローします。
+
+```php
+use Nene2\Http\PaginationQueryParser;
+
+public function handle(ServerRequestInterface $request): ResponseInterface
+{
+    $pagination = PaginationQueryParser::parse($request); // デフォルト: limit=20, max=100
+
+    $output = $this->useCase->execute(
+        new ListWidgetsInput($pagination->limit, $pagination->offset),
+    );
+
+    return $this->response->create([
+        'items'  => /* $output->items をマッピング */,
+        'limit'  => $output->limit,
+        'offset' => $output->offset,
+    ]);
+}
+```
+
+`PaginationQuery` は `limit: int` と `offset: int` の 2 プロパティを持つ readonly DTO です。
+
+## ステップ 2 — 上限をカスタマイズする（オプション）
+
+`$defaultLimit` と `$maxLimit` を渡してデフォルト（20 と 100）を上書きできます。
+
+```php
+$pagination = PaginationQueryParser::parse($request, defaultLimit: 10, maxLimit: 50);
+```
+
+| パラメーター | デフォルト | 意味 |
+|---|---|---|
+| `$defaultLimit` | `20` | `?limit=` がない場合に使用される値 |
+| `$maxLimit` | `100` | 許可される最大値。超えると 422 を返す |
+
+## ステップ 3 — 422 エラーへの対応
+
+`PaginationQueryParser::parse()` は次の場合に `ValidationException` をスローします。
+
+- `limit < 1` または `limit > $maxLimit`
+- `offset < 0`
+
+`ErrorHandlerMiddleware` が `ValidationException` → `422 validation-failed` に自動的にマッピングするため、ハンドラー内で追加のエラーハンドリングは不要です。
+
+**422 レスポンスの例:**
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation Failed",
+  "status": 422,
+  "detail": "The request body contains invalid values.",
+  "errors": [
+    { "field": "limit", "message": "limit must be between 1 and 100.", "code": "out_of_range" }
+  ]
+}
+```
+
+## 仕組み
+
+`PaginationQueryParser::parse()` は PSR-7 リクエストの `getQueryParams()` を読み取り、値を `int` にキャストしてバリデーションを行い、`PaginationQuery` DTO を返します。数値以外の値は `0` にキャストされ（PHP の `(int)` キャスト動作）、`limit < 1` チェックで捕捉されます。
+
+## 参考
+
+- `src/Example/Note/ListNotesHandler.php` — パーサーを使ったリファレンス実装
+- `src/Example/Tag/ListTagsHandler.php` — 2 つ目の例
+- `Nene2\Http\PaginationQuery` — readonly DTO
+- `Nene2\Http\PaginationQueryParser` — パーサークラス

--- a/docs/pt-br/howto/add-pagination.md
+++ b/docs/pt-br/howto/add-pagination.md
@@ -1,0 +1,81 @@
+# Adicionar paginação
+
+Este guia mostra como adicionar paginação `?limit=` / `?offset=` a um endpoint de coleção usando o helper `PaginationQueryParser` do `Nene2\Http`.
+
+## Pré-requisitos
+
+- Um handler de coleção funcional (ex. `ListNotesHandler`).
+- O handler retorna um envelope JSON com `items`, `limit` e `offset`.
+
+## Passo 1 — Chamar `PaginationQueryParser::parse()`
+
+Substitua a extração manual de parâmetros de query pelo parser. Ele valida os valores e lança `ValidationException` (→ 422) quando estão fora do intervalo.
+
+```php
+use Nene2\Http\PaginationQueryParser;
+
+public function handle(ServerRequestInterface $request): ResponseInterface
+{
+    $pagination = PaginationQueryParser::parse($request); // padrão: limit=20, max=100
+
+    $output = $this->useCase->execute(
+        new ListWidgetsInput($pagination->limit, $pagination->offset),
+    );
+
+    return $this->response->create([
+        'items'  => /* mapear $output->items */,
+        'limit'  => $output->limit,
+        'offset' => $output->offset,
+    ]);
+}
+```
+
+`PaginationQuery` é um DTO readonly com duas propriedades: `limit: int` e `offset: int`.
+
+## Passo 2 — Personalizar os limites (opcional)
+
+Passe `$defaultLimit` e `$maxLimit` para substituir os padrões (20 e 100):
+
+```php
+$pagination = PaginationQueryParser::parse($request, defaultLimit: 10, maxLimit: 50);
+```
+
+| Parâmetro | Padrão | Significado |
+|---|---|---|
+| `$defaultLimit` | `20` | Usado quando `?limit=` está ausente |
+| `$maxLimit` | `100` | Valor máximo permitido; retorna 422 se excedido |
+
+## Passo 3 — Tratar o erro 422
+
+`PaginationQueryParser::parse()` lança `ValidationException` quando:
+
+- `limit < 1` ou `limit > $maxLimit`
+- `offset < 0`
+
+`ErrorHandlerMiddleware` mapeia automaticamente `ValidationException` → `422 validation-failed`.
+Nenhum tratamento de erro adicional é necessário no handler.
+
+**Exemplo de resposta 422:**
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation Failed",
+  "status": 422,
+  "detail": "The request body contains invalid values.",
+  "errors": [
+    { "field": "limit", "message": "limit must be between 1 and 100.", "code": "out_of_range" }
+  ]
+}
+```
+
+## Como funciona
+
+`PaginationQueryParser::parse()` lê `getQueryParams()` da requisição PSR-7, converte os valores para `int`, valida-os e retorna um DTO `PaginationQuery`. Valores não numéricos são convertidos para `0` (comportamento de cast `(int)` do PHP) e então capturados pela verificação `limit < 1`.
+
+## Veja também
+
+- `src/Example/Note/ListNotesHandler.php` — implementação de referência usando o parser
+- `src/Example/Tag/ListTagsHandler.php` — segundo exemplo
+- `Nene2\Http\PaginationQuery` — DTO readonly
+- `Nene2\Http\PaginationQueryParser` — a classe parser

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -563,6 +563,15 @@ API contract automatically.
 - `openapi.yaml` extended with `InvalidJson` (400) and `TooManyRequests` (429) response components
 - POST/PUT endpoints reference the new `InvalidJson` response (Phase 48 alignment)
 
+## Phase 54: VitePress v1.3.0 Update (#366)
+
+Goal: update the VitePress documentation site for the v1.3.0 release.
+
+- Version badge updated to `v1.3.0`
+- `add-pagination` HOWTO page added in 6 languages (covers `PaginationQueryParser` usage)
+- `backend.yml` CI step added: `composer openapi:docs && git diff --exit-code` ensures
+  `http-endpoints.md` stays in sync with `openapi.yaml`
+
 ## Phase 53: v1.3.0 Release
 
 Goal: consolidate Phase 51–52 additions into a versioned release.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -375,6 +375,14 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] `composer.json` に `openapi:docs` スクリプトを追加する
 - [x] CI グリーン確認・PR マージ (#363)
 
+## Phase 54: VitePress v1.3.0 対応 (#366)
+
+- [x] config.mts バージョンバッジ v1.2.0 → v1.3.0
+- [x] config.mts サイドバーに addPagination 追加（6 ロケール）
+- [x] docs/howto/add-pagination.md + 5 ロケール翻訳追加
+- [x] .github/workflows/backend.yml に openapi:docs 同期チェック追加
+- [ ] CI グリーン確認・PR マージ
+
 ## Phase 53: v1.3.0 リリース
 
 - [x] Issue 作成・ブランチ作成

--- a/docs/zh/howto/add-pagination.md
+++ b/docs/zh/howto/add-pagination.md
@@ -1,0 +1,80 @@
+# 添加分页
+
+本指南介绍如何使用 `Nene2\Http` 中的 `PaginationQueryParser` 助手，为集合端点添加 `?limit=` / `?offset=` 分页功能。
+
+## 前提条件
+
+- 有一个可用的集合处理器（如 `ListNotesHandler`）。
+- 处理器返回包含 `items`、`limit` 和 `offset` 的 JSON 信封。
+
+## 步骤 1 — 调用 `PaginationQueryParser::parse()`
+
+用解析器替换手动查询参数提取。它会验证值，并在超出范围时抛出 `ValidationException`（→ 422）。
+
+```php
+use Nene2\Http\PaginationQueryParser;
+
+public function handle(ServerRequestInterface $request): ResponseInterface
+{
+    $pagination = PaginationQueryParser::parse($request); // 默认：limit=20, max=100
+
+    $output = $this->useCase->execute(
+        new ListWidgetsInput($pagination->limit, $pagination->offset),
+    );
+
+    return $this->response->create([
+        'items'  => /* 映射 $output->items */,
+        'limit'  => $output->limit,
+        'offset' => $output->offset,
+    ]);
+}
+```
+
+`PaginationQuery` 是一个包含两个属性的 readonly DTO：`limit: int` 和 `offset: int`。
+
+## 步骤 2 — 自定义限制（可选）
+
+传入 `$defaultLimit` 和 `$maxLimit` 来覆盖默认值（20 和 100）：
+
+```php
+$pagination = PaginationQueryParser::parse($request, defaultLimit: 10, maxLimit: 50);
+```
+
+| 参数 | 默认值 | 含义 |
+|---|---|---|
+| `$defaultLimit` | `20` | 当 `?limit=` 缺失时使用的值 |
+| `$maxLimit` | `100` | 允许的最大值；超出则返回 422 |
+
+## 步骤 3 — 处理 422 错误
+
+`PaginationQueryParser::parse()` 在以下情况下抛出 `ValidationException`：
+
+- `limit < 1` 或 `limit > $maxLimit`
+- `offset < 0`
+
+`ErrorHandlerMiddleware` 会自动将 `ValidationException` 映射为 `422 validation-failed`，处理器中无需额外错误处理。
+
+**422 响应示例：**
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation Failed",
+  "status": 422,
+  "detail": "The request body contains invalid values.",
+  "errors": [
+    { "field": "limit", "message": "limit must be between 1 and 100.", "code": "out_of_range" }
+  ]
+}
+```
+
+## 工作原理
+
+`PaginationQueryParser::parse()` 读取 PSR-7 请求的 `getQueryParams()`，将值转换为 `int`，进行验证后返回 `PaginationQuery` DTO。非数字值会被转换为 `0`（PHP 的 `(int)` 转换行为），然后被 `limit < 1` 检查捕获。
+
+## 另请参阅
+
+- `src/Example/Note/ListNotesHandler.php` — 使用解析器的参考实现
+- `src/Example/Tag/ListTagsHandler.php` — 第二个示例
+- `Nene2\Http\PaginationQuery` — readonly DTO
+- `Nene2\Http\PaginationQueryParser` — 解析器类


### PR DESCRIPTION
## Summary

- `config.mts` バージョンバッジ `v1.2.0` → `v1.3.0`
- `config.mts` サイドバーに `addPagination` エントリ追加（6 ロケール）
- `docs/howto/add-pagination.md` + ja/fr/zh/pt-br/de 翻訳 — `PaginationQueryParser` の使い方を 3 ステップで解説
- `.github/workflows/backend.yml` に `composer openapi:docs && git diff --exit-code` を追加 — `openapi.yaml` 変更時に `http-endpoints.md` の再生成を強制

## Test plan

- [ ] `npm run docs:build` — ビルドグリーン
- [ ] CI Composer Check + npm Check グリーン
- [ ] サイドバーに "Add pagination" が表示されることを確認

Self-review: docs-policy

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)