### PR TITLE
fix(phpstan): composer check の PHPStan OOM を防ぐ — --memory-limit 512M 追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "test": "phpunit --testsuite NENE2,Database",
     "test:database": "phpunit --testsuite Database",
     "test:database:mysql": "phpunit --testsuite DatabaseMySQL",
-    "analyse": "phpstan analyse",
+    "analyse": "phpstan analyse --memory-limit 512M",
     "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
     "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
     "openapi": "php tools/validate-openapi.php",


### PR DESCRIPTION
## Summary

- `composer.json` の `analyse` スクリプトに `--memory-limit 512M` を追加
- Docker コンテナ内で `composer check` が PHPStan OOM で失敗する問題を解消

## Background

Field Trial 9 (F-1) で発見: Docker の PHP `memory_limit` デフォルト `128M` では PHPStan 並列解析が失敗する。

## Test plan

- [x] `docker compose run --rm app composer check` が全ステップ通過することを確認

Closes #371

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)