### PR TITLE
chore(todo): Phase 56 完了マーク — Packagist 反映確認 + レポート最終化

### DIFF
--- a/docs/field-trials/2026-05-field-trial-9.md
+++ b/docs/field-trials/2026-05-field-trial-9.md
@@ -133,7 +133,7 @@ All checks pass. **Friction F-1**: `composer check` fails with OOM inside Docker
 
 ### 10. Packagist v1.3.0 reflection
 
-GitHub Releases for v1.3.0 was created during this trial (the previous session had only pushed the git tag, not created a GitHub Release). The Packagist webhook was manually triggered via the API update endpoint. At time of writing, v1.3.0 and v1.2.0 are not yet reflected on Packagist — the update job was queued (`"status":"success"`). Final confirmation pending.
+GitHub Releases for v1.3.0 was created during this trial (the previous session had only pushed the git tag, not created a GitHub Release). The Packagist webhook was manually triggered via the API update endpoint. After creating the GitHub Release and triggering the Packagist update API, v1.3.0 and v1.2.0 were confirmed on Packagist within the session. A fresh request (bypassing the CDN cache) confirmed both versions are available.
 
 ---
 
@@ -158,7 +158,7 @@ GitHub Releases for v1.3.0 was created during this trial (the previous session h
 | PHP-CS-Fixer | 0 fixable | ✓ | Pass |
 | OpenAPI contract valid | valid | ✓ | Pass |
 | PHPStan (with `--memory-limit 512M`) | no errors | ✓ | Pass |
-| Packagist v1.3.0 | reflected | ⏳ pending | — |
+| Packagist v1.3.0 | reflected | ✓ (v1.2.0 also confirmed) | Pass |
 
 ---
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,9 +4,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Current milestone: `docs/milestones/2026-05-v1.1.md` (v1.1 — Production Readiness)
-- Latest release: `v1.0.0` (Phase 43 complete)
-- Current branch: `docs/344-v1.1-roadmap`
+- Latest release: `v1.3.0` (Phase 53 complete — Packagist 反映済み)
+- Field Trial 9 完了 (Phase 56)
 
 ## Foundation Completed
 
@@ -383,7 +382,7 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] PHPUnit 199 tests, 630 assertions パス確認
 - [x] 観察レポート `docs/field-trials/2026-05-field-trial-9.md` 記録
 - [x] 摩擦 follow-up Issue 作成 (#371 PHPStan OOM、#372 リリースチェックリスト)
-- [ ] Packagist v1.3.0 反映確認
+- [x] Packagist v1.3.0 反映確認（v1.2.0 も同時反映）
 
 ## Phase 55: Dependabot 依存関係更新 (D メンテナンス)
 
@@ -408,7 +407,7 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] chore(changelog): v1.3.0 セクション確定
 - [x] chore(release): `v1.3.0` タグを打つ
 - [x] CI グリーン確認・PR マージ
-- [ ] chore(release): Packagist v1.3.0 自動反映確認
+- [x] chore(release): Packagist v1.3.0 自動反映確認
 
 ## Phase 50: VitePress v1.2.0 対応ドキュメント (#358)
 
@@ -425,7 +424,7 @@ _Friction follow-ups (docs): Issues `#167` (MCP JSON integers for path params), 
 - [x] docs(todo): current.md を更新する
 - [x] chore(changelog): `[Unreleased]` → `[1.2.0] — 2026-05-18` に確定する
 - [x] chore(release): `v1.2.0` タグを打つ
-- [ ] chore(release): Packagist v1.2.0 自動反映確認
+- [x] chore(release): Packagist v1.2.0 自動反映確認
 
 ## Phase 47: v1.1.0 リリース
 


### PR DESCRIPTION
## Summary

- Packagist v1.3.0・v1.2.0 反映確認済み → todo にチェックを入れる
- Field Trial 9 レポート最終化（Packagist status 更新）
- Status セクションを v1.3.0 に更新

Closes #376

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)