### PR TITLE
chore(docs): post-v1.0 古い記述を一括修正する (#388)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,20 @@ updates:
       - github-actions
 
   - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)
+    labels:
+      - dependencies
+      - docs
+
+  - package-ecosystem: npm
     directory: /frontend
     schedule:
       interval: weekly

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PHP micro-framework: JSON APIs first, minimal server HTML, easy React starter in
 
 NENE2 is a small, modern PHP framework foundation extracted from the lessons of the original NeNe framework and the 9lick.me modernization work. It is designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add a React frontend starter without turning the backend into frontend build glue.
 
-The current `v0.3.x` direction is a practical starter for LLM-assisted client delivery: a maintainer can clone the repository, run a local API, share an OpenAPI contract, expose safe read-only MCP tools through the API boundary, and verify database behavior in Docker.
+The `v1.x` foundation covers full Note/Tag CRUD, rate limiting, health checks, Bearer JWT auth, pagination helpers, and a six-language VitePress documentation site. A maintainer can clone the repository, run a local API, share an OpenAPI contract, expose safe MCP tools through the API boundary, and verify database behavior in Docker Compose.
 
 ## Theme
 
@@ -45,9 +45,6 @@ If you want to use NENE2 as a Composer dependency in an existing project:
 ```bash
 composer require hideyukimori/nene2
 ```
-
-> **Note:** NENE2 is currently `0.x.y`. The public API is still stabilising.
-> Expect breaking changes between minor versions until `v1.0.0`.
 
 ---
 
@@ -126,14 +123,20 @@ NENE2 uses a single repository with Composer at the root, PHP framework code in 
 .
 ├── composer.json
 ├── src/                 # NENE2 framework core
+│   ├── Auth/
 │   ├── Config/
+│   ├── Database/
 │   ├── DependencyInjection/
+│   ├── Error/
 │   ├── Http/
 │   ├── Log/
-│   ├── Routing/
+│   ├── Mcp/
 │   ├── Middleware/
-│   ├── Error/
-│   └── Example/Note/    # canonical domain layer example (full CRUD)
+│   ├── Routing/
+│   ├── Validation/
+│   ├── View/
+│   ├── Example/Note/    # canonical domain layer example (full CRUD)
+│   └── Example/Tag/     # second entity example
 ├── tests/               # PHPUnit / architecture / contract tests
 ├── config/              # framework default config or examples
 ├── database/            # migrations, seeds, and schema docs
@@ -172,14 +175,13 @@ composer test:database:mysql
 
 See `docs/development/php-runtime.md` and `docs/development/docker.md` for runtime and tooling details.
 
-NENE2's planned quality baseline adds PHP-CS-Fixer for backend style checks and npm, ESLint, TypeScript, and Prettier for the React frontend starter. The frontend starter targets active Node.js LTS, commits `package-lock.json`, and keeps dependencies modern through update automation. Framework public APIs should use PHPDoc or TSDoc where comments explain contracts or extension rules. See `docs/development/quality-tools.md`, `docs/development/frontend-integration.md`, and `docs/development/documentation-comments.md`.
+NENE2's quality baseline includes PHP-CS-Fixer for backend style checks and npm, ESLint, TypeScript, and Prettier for the React frontend starter. The frontend starter targets active Node.js LTS, commits `package-lock.json`, and keeps dependencies modern through update automation. Framework public APIs should use PHPDoc or TSDoc where comments explain contracts or extension rules. See `docs/development/quality-tools.md`, `docs/development/frontend-integration.md`, and `docs/development/documentation-comments.md`.
 
 ## Delivery Starter Docs
 
 Start with these docs when adapting NENE2 for a small client-style API:
 
 - Direction: `docs/integrations/llm-delivery-starter.md`
-- Current milestone: `docs/milestones/2026-05-client-delivery-hardening.md`
 - Client project start guide: `docs/development/client-project-start.md`
 - Endpoint workflow: `docs/development/endpoint-scaffold.md`
 - Local MCP server: `docs/integrations/local-mcp-server.md`

--- a/docs/milestones/2026-05-v1.0.md
+++ b/docs/milestones/2026-05-v1.0.md
@@ -36,12 +36,12 @@ All of the following must be true before tagging `v1.0.0`.
 - [x] GitHub Actions: `backend.yml`, `frontend.yml`, `docs.yml` passing on `main`
 - [x] Packagist package `hideyukimori/nene2` published and up to date
 - [x] At least one complete field trial from `composer require` starting point (Field Trial 4+)
-- [ ] `v1.0.0` GitHub Release notes drafted
-- [ ] CHANGELOG heading note (`Breaking changes may occur … until v1.0.0`) removed
+- [x] `v1.0.0` GitHub Release notes drafted
+- [x] CHANGELOG heading note (`Breaking changes may occur … until v1.0.0`) removed
 
 ### Decision gate
 
-- [ ] Maintainer explicitly approves tagging `v1.0.0` after all criteria above are met
+- [x] Maintainer explicitly approves tagging `v1.0.0` after all criteria above are met
 
 ## What changes at v1.0.0
 

--- a/docs/reference/http-endpoints.md
+++ b/docs/reference/http-endpoints.md
@@ -37,7 +37,7 @@ Every JSON response follows the schemas in `docs/openapi/openapi.yaml`.
 |---|---|---|---|---|
 | `GET` | `/examples/protected` | `Bearer` token | `200` | `401` |
 
-Requests to protected endpoints must include either the `X-NENE2-API-Key` header or a valid `Authorization: Bearer <token>` header.
+Requests to the protected endpoint must include a valid `Authorization: Bearer <token>` header with a JWT signed with `NENE2_LOCAL_JWT_SECRET`.
 
 ## Response shapes
 

--- a/tools/openapi-to-md.php
+++ b/tools/openapi-to-md.php
@@ -226,7 +226,7 @@ $md .= buildEndpointTable($groups['tags'], $openapi) . "\n\n";
 
 $md .= "## Protected (machine client)\n\n";
 $md .= buildEndpointTable($groups['protected'], $openapi) . "\n\n";
-$md .= "Requests to protected endpoints must include either the `X-NENE2-API-Key` header or a valid `Authorization: Bearer <token>` header.\n\n";
+$md .= "Requests to the protected endpoint must include a valid `Authorization: Bearer <token>` header with a JWT signed with `NENE2_LOCAL_JWT_SECRET`.\n\n";
 
 $md .= "## Response shapes\n\n";
 $md .= "**Collection envelope** (shared by Notes and Tags):\n\n";


### PR DESCRIPTION
Closes #388

## Summary

post-v1.0 リリース後の stale content を一括修正。リナ評価 + 手動監査で発見。

## Changes

### README.md
- `v0.3.x direction` → `v1.x foundation` 説明に更新
- `0.x.y` 警告ノート削除（v1.0.0 リリース済み）
- `src/` レイアウト表に Auth/Database/Mcp/Validation/View/Example/Tag 追加（7 ディレクトリ欠落していた）
- "planned quality baseline adds" → "quality baseline includes"（実装済み）
- stale milestone リンク（v0.3.x 時代）削除

### docs/milestones/2026-05-v1.0.md
- v1.0.0 タグ済みなので残存 3 つの `[ ]` を `[x]` に更新

### tools/openapi-to-md.php + docs/reference/http-endpoints.md
- Protected endpoint の Auth 説明を OpenAPI `bearerAuth` 定義と一致させる
- `X-NENE2-API-Key` の言及を削除（Bearer JWT のみが正しい）
- 両ファイルを同期（CI の `openapi:docs && git diff --exit-code` チェックが通る）

### .github/dependabot.yml
- root `/` の npm エントリ追加（VitePress `package.json` をカバー）

## Verification
- [x] diff --stat: 5 files, 30 insertions, 14 deletions
- [x] README の src/ layout が `ls src/` の実際の出力と一致することを確認
- [x] openapi-to-md.php と http-endpoints.md の prose が一致することを確認

## Self-review

`docs/review/docs-policy.md`, `docs/review/release-ci.md`