### PR TITLE
docs: openapi-to-md health/root 表記修正 + README MCP/9lick.me 鮮度修正 (#394)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 PHP micro-framework: JSON APIs first, minimal server HTML, easy React starter integration, structure friendly to AI tooling.
 
-NENE2 is a small, modern PHP framework foundation extracted from the lessons of the original NeNe framework and the 9lick.me modernization work. It is designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add a React frontend starter without turning the backend into frontend build glue.
+NENE2 is a small, modern PHP framework foundation designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add a React frontend starter without turning the backend into frontend build glue.
 
 The `v1.x` foundation covers full Note/Tag CRUD, rate limiting, health checks, Bearer JWT auth, pagination helpers, and a six-language VitePress documentation site. A maintainer can clone the repository, run a local API, share an OpenAPI contract, expose safe MCP tools through the API boundary, and verify database behavior in Docker Compose.
 
@@ -26,7 +26,7 @@ The foundation currently includes:
 - PSR-11 dependency injection with explicit runtime service wiring.
 - PDO connection, query executor, transaction manager, SQLite tests, and opt-in MySQL verification through Docker Compose.
 - API-key middleware for the first protected machine-client path.
-- Local MCP server support for read-only OpenAPI-aligned tools.
+- Local MCP server support for read/write tools aligned with OpenAPI, with an authentication guard on write operations.
 - React + TypeScript + Vite starter kept optional and decoupled from backend runtime behavior.
 
 ## Installation

--- a/docs/reference/http-endpoints.md
+++ b/docs/reference/http-endpoints.md
@@ -7,9 +7,9 @@ Every JSON response follows the schemas in `docs/openapi/openapi.yaml`.
 
 | Method | Path | Auth | Response |
 |---|---|---|---|
-| `GET` | `/health` | None | `200` `{ service, status, timestamp[, checks] }` · `503` when any check fails |
+| `GET` | `/health` | None | `200` `{ service, status[, checks] }` · `503` when any check fails |
 | `GET` | `/examples/ping` | None | `200` `{ message }` |
-| `GET` | `/` | None | `200` HTML welcome page |
+| `GET` | `/` | None | `200` `{ name, description, status }` JSON smoke response |
 
 ## Notes
 

--- a/tools/openapi-to-md.php
+++ b/tools/openapi-to-md.php
@@ -172,9 +172,9 @@ function buildHealthTable(array $entries, array $doc): string
 
         // Describe response inline for health/ping/root
         $desc = match ($e['path']) {
-            '/health'        => '`200` `{ service, status, timestamp[, checks] }` · `503` when any check fails',
+            '/health'        => '`200` `{ service, status[, checks] }` · `503` when any check fails',
             '/examples/ping' => '`200` `{ message }`',
-            '/'              => '`200` HTML welcome page',
+            '/'              => '`200` `{ name, description, status }` JSON smoke response',
             default          => $split['success'],
         };
 


### PR DESCRIPTION
Closes #394

## Changes

### tools/openapi-to-md.php + docs/reference/http-endpoints.md

| エンドポイント | 修正前 | 修正後 |
|---|---|---|
| `/health` | `{ service, status, timestamp[, checks] }` | `{ service, status[, checks] }` — OpenAPI スキーマに `timestamp` は存在しない |
| `/` | `200` HTML welcome page | `200` `{ name, description, status }` JSON smoke response — OpenAPI 定義・実装と一致 |

### README.md

- `read-only OpenAPI-aligned tools` → `read/write tools aligned with OpenAPI, with an authentication guard on write operations`
  （`docs/mcp/tools.json` に write tools が存在するため）
- `9lick.me modernization work` を削除（顧客サービス名を公開リポジトリに残さない）

## Self-review

`docs/review/docs-policy.md`