### PR TITLE
docs: v1.1.0 milestone 未チェック修正・README opt-in 表現・composer.json SPA 統一 (#398)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PHP micro-framework: JSON APIs first, minimal server HTML, easy React starter in
 
 NENE2 is a small, modern PHP framework foundation designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add a React frontend starter without turning the backend into frontend build glue.
 
-The `v1.x` foundation covers full Note/Tag CRUD, rate limiting, health checks, Bearer JWT auth, pagination helpers, and a six-language VitePress documentation site. A maintainer can clone the repository, run a local API, share an OpenAPI contract, expose safe MCP tools through the API boundary, and verify database behavior in Docker Compose.
+The `v1.x` foundation covers full Note/Tag CRUD, Bearer JWT auth, pagination helpers, and a six-language VitePress documentation site, with opt-in rate limiting and database health checks available as production-ready middleware. A maintainer can clone the repository, run a local API, share an OpenAPI contract, expose safe MCP tools through the API boundary, and verify database behavior in Docker Compose.
 
 ## Theme
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "hideyukimori/nene2",
-  "description": "PHP micro-framework: JSON APIs first, minimal server HTML, easy React/Vue SPA integration, structure friendly to AI tooling.",
+  "description": "PHP micro-framework: JSON APIs first, minimal server HTML, easy React/SPA integration, structure friendly to AI tooling.",
   "type": "library",
   "license": "MIT",
   "require": {

--- a/docs/milestones/2026-05-v1.1.md
+++ b/docs/milestones/2026-05-v1.1.md
@@ -20,11 +20,11 @@ success and `503 {"status":"degraded","checks":{"database":"error"}}` on failure
 
 Key deliverables:
 
-- [ ] `HealthCheckInterface` in the stable public surface
-- [ ] `RuntimeApplicationFactory` extended with `list<HealthCheckInterface> $healthChecks = []`
-- [ ] `GET /health` response schema updated in OpenAPI
-- [ ] `DatabaseHealthCheck` reference implementation in `src/Example/`
-- [ ] PHPUnit tests for healthy, degraded, and no-checks paths
+- [x] `HealthCheckInterface` in the stable public surface
+- [x] `RuntimeApplicationFactory` extended with `list<HealthCheckInterface> $healthChecks = []`
+- [x] `GET /health` response schema updated in OpenAPI
+- [x] `DatabaseHealthCheck` reference implementation in `src/Example/`
+- [x] PHPUnit tests for healthy, degraded, and no-checks paths
 
 ### Phase 45 — Rate Limiting
 
@@ -34,9 +34,9 @@ swap it for a Redis adapter or similar.
 
 Key deliverables:
 
-- [ ] ADR 0010: rate limiting design (algorithm, header conventions, storage contract)
-- [ ] `RateLimitStorageInterface` in the stable public surface
-- [ ] `InMemoryRateLimitStorage` (`@internal`) for development and testing
+- [x] ADR 0010: rate limiting design (algorithm, header conventions, storage contract)
+- [x] `RateLimitStorageInterface` in the stable public surface
+- [x] `InMemoryRateLimitStorage` (`@internal`) for development and testing
 - [x] `ThrottleMiddleware` — 429 Problem Details, `Retry-After`, `X-RateLimit-*` headers
 - [x] PHPUnit tests: under / at / over limit, reset after window
 - [x] Middleware order updated in CLAUDE.md (position 8, after Auth)


### PR DESCRIPTION
Closes #398

## Changes

### docs/milestones/2026-05-v1.1.md
Phase 44/45 deliverables の `[ ]` 8件を `[x]` に更新。
Acceptance Criteria は全て `[x]` 済み・v1.1.0 タグ済みのため、前半 deliverables も実態に合わせる。

### README.md
`rate limiting, health checks` が標準搭載のように読めていた表現を修正:
> ~~rate limiting, health checks,~~ → `with opt-in rate limiting and database health checks available as production-ready middleware`

RuntimeServiceProvider のデフォルト配線では `healthChecks` / `ThrottleMiddleware` は渡されていないため。

### composer.json
`React/Vue SPA integration` → `React/SPA integration`
starter は React 実装なので Vue を外す。フレームワーク自体はフロントエンド中立なため `SPA` は保持。

## Self-review

`docs/review/docs-policy.md`