### PR TITLE
chore(docs): レビュー所見反映 — FT8 stub・FT10 マイルストーン・ロードマップ Phase 58–59

### DIFF
--- a/docs/field-trials/2026-05-field-trial-8.md
+++ b/docs/field-trials/2026-05-field-trial-8.md
@@ -1,0 +1,49 @@
+# Field Trial 8 — v1.1.0 Production Features Validation
+
+## Date
+
+2026-05-18
+
+## Baseline
+
+- NENE2 v1.1.0 (via `composer require hideyukimori/nene2:dev-main`)
+- New in v1.1.0:
+  - `HealthCheckInterface` / `DatabaseHealthCheck` — DB connectivity check on `GET /health`
+  - `ThrottleMiddleware` / `InMemoryRateLimitStorage` / `RateLimitStorageInterface` — rate limiting
+- Environment: Ubuntu 24.04 + PHP 8.4 (Packagist install path, no git-clone)
+
+## Goal
+
+Validate v1.1.0 production features from a clean `composer require` starting point, verifying:
+
+1. `HealthCheckInterface` — healthy (200) and degraded (503) paths
+2. `ThrottleMiddleware` — 429 + `Retry-After` + `X-RateLimit-*` headers
+3. `InMemoryRateLimitStorage` — hit counter increments and resets correctly
+
+---
+
+## Note
+
+A detailed step-by-step trial log was not captured for this field trial.
+The completion status is recorded in `docs/milestones/2026-05-v1.1.md` (Phase 46).
+
+Verified outcomes per the milestone record:
+
+| Item | Result |
+|---|---|
+| New project directory (`~/ft8`), no git-clone dependency | ✓ |
+| `HealthCheckInterface` healthy → 200 / degraded → 503 | ✓ |
+| `ThrottleMiddleware` 429 + `Retry-After` + `X-RateLimit-*` headers | ✓ |
+| `InMemoryRateLimitStorage` hit counter | ✓ |
+
+---
+
+## Follow-up Issues
+
+None opened from this trial. Friction identified in subsequent code review (#371, #372) was
+addressed before v1.3.0.
+
+## Conclusion
+
+v1.1.0 production features (`HealthCheckInterface`, `ThrottleMiddleware`) validated on a clean
+`composer require` install path. All acceptance criteria in the milestone passed.

--- a/docs/milestones/2026-05-field-trial-10.md
+++ b/docs/milestones/2026-05-field-trial-10.md
@@ -1,0 +1,42 @@
+# Milestone: Field Trial 10 — New Domain Entity from Scratch
+
+## Goal
+
+Validate that the v1.3.0 scaffold workflow is sufficient to build a third domain entity
+entirely from scratch — one that does not exist anywhere in the NENE2 repository — and confirm
+that `PaginationQueryParser`, `JsonRequestBodyParser`, and the MCP tool path work correctly for
+the new entity.
+
+## Theme: Scaffold Ergonomics
+
+All prior field trials exercised features against Note and Tag, both of which ship as reference
+implementations in `src/Example/`. FT10 shifts focus: does the documentation alone guide
+a developer through adding a new entity, without leaning on the existing examples as a codebase
+crutch?
+
+## Phases
+
+### Phase 58 — Field Trial 10 Execution
+
+Key deliverables:
+
+- [ ] Choose a new domain entity distinct from Note and Tag (e.g. Task, Event, Product)
+- [ ] Follow `docs/development/endpoint-scaffold.md` as the only procedural guide
+- [ ] Implement full CRUD (GET / POST / PUT / DELETE) + list with pagination
+- [ ] Add OpenAPI paths and `docs/mcp/tools.json` entries for the new entity
+- [ ] Connect a local MCP client and verify tool calls against the new endpoints
+- [ ] Record friction in `docs/field-trials/2026-05-field-trial-10.md`
+- [ ] Open follow-up Issues for each friction point
+
+## Acceptance Criteria
+
+- [ ] New entity endpoints pass `composer check`
+- [ ] `PaginationQueryParser` used in the list handler
+- [ ] `JsonRequestBodyParser` used in write handlers
+- [ ] MCP tool calls succeed through the local MCP server
+- [ ] Field trial report created with friction log
+
+## Notes
+
+- User-executed trial; AI agent assists with planning and follow-up Issue creation.
+- Tracked by Issue #404.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -609,6 +609,34 @@ Goal: fix nav/sidebar links returning to English when navigating from a non-Engl
 - ADR cross-references in 5 locale `add-rate-limiting.md` files changed from broken relative path
   `../adr/0010-rate-limiting.md` to absolute `/adr/0010-rate-limiting` (ADRs are English-only per language policy)
 
+## Phase 58: Field Trial 10 — New Domain Entity from Scratch (#404)
+
+Goal: validate that the v1.3.0 scaffold workflow is sufficient to build a third domain entity
+from scratch without referencing the existing Note/Tag implementation as a codebase crutch.
+
+- Choose a new domain entity distinct from Note and Tag (e.g. Task, Event, Product)
+- Follow `docs/development/endpoint-scaffold.md` as the only procedural guide
+- Implement full CRUD (GET / POST / PUT / DELETE) + list with pagination
+- Add OpenAPI paths and `docs/mcp/tools.json` entries for the new entity
+- Connect a local MCP client and verify tool calls against the new endpoints
+- Record friction in `docs/field-trials/2026-05-field-trial-10.md`
+- Open follow-up Issues for each friction point
+
+Tracked by `docs/milestones/2026-05-field-trial-10.md`.
+
+## Phase 59: Problem Details Domain Policy (#405)
+
+Goal: resolve the `nene2.dev` placeholder domain used in Problem Details `type` URIs so that
+client projects adopting NENE2 have a clear, production-safe path for error type identification.
+
+- Decide between registering `nene2.dev` as the framework's official documentation domain
+  (Option A) or treating it as a placeholder that clients must replace (Option B)
+- Record the decision in an ADR or a dedicated section in `docs/development/authentication-boundary.md`
+- Update `docs/development/client-project-start.md` and `docs/howto/deploy-production.md`
+  with concrete steps for whichever option is chosen
+- If Option B: consider adding `problemDetailsBaseUrl` to `AppConfig` so the base URI is
+  configurable without touching framework code
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,8 +5,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Latest release: `v1.3.0` (Phase 53 — Packagist 反映済み)
-- Field Trial 9 完了 (Phase 56)
-- Post-v1.0 ドキュメント整合性クリーンアップ完了 (#388, PR #389)
+- Field Trial 9 完了 (Phase 56) — #371・#372 フォローアップ済み
+- レビュー所見反映 (#407) — FT8 stub 作成・ロードマップ Phase 58–59 追加
 - Current branch: `main` — clean
 
 ## Recently Completed
@@ -15,14 +15,13 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - **Phase 56**: Field Trial 9 — v1.3.0 検証 (PaginationQueryParser / openapi:docs / 400/422 分離)
 - **Phase 57**: VitePress i18n リンク修正 (#380); locale http-endpoints.md 同期 (#384, PR #385)
 - **#388 / PR #389**: Post-v1.0 ドキュメント整合性クリーンアップ
-  (README v0.3.x → v1.x、src/ レイアウト補完、milestones 完了チェック、openapi-to-md prose 修正、dependabot root npm 追加)
-- **#394 / PR #395**: openapi-to-md health/root 表記修正 + README MCP read/write・9lick.me 削除
-- **#398 / PR #399**: v1.1.0 milestone 未チェック修正・README opt-in 表現・composer.json SPA 統一
-- **#400 / PR #401**: 5 locale health/root 同期・README middleware→opt-in・env-vars JWT 説明・roadmap 順序修正
+- **#400 / PR #401**: 5 locale 同期・README・env-vars・roadmap 修正
+- **#407**: レビュー所見反映 — FT8 stub・FT10 マイルストーン・ロードマップ Phase 58–59
 
 ## Next Candidates
 
-- **Field Trial 10**: v1.3.0 を起点にした次の hands-on フィールドトライアル（ユーザー手作業必須）
+- **Phase 58 / Field Trial 10** (#404): v1.3.0 を起点に Note/Tag 以外の新ドメインをスクラッチ実装（ユーザー手作業必須）
+- **Phase 59 / nene2.dev 方針** (#405): Problem Details type URI のドメイン方針を決定し client-project-start.md に反映
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary

- v1.3.0 リリース後のコードベース全体レビューで得られた所見をプロジェクト追跡ドキュメントに反映
- FT8 レポートの欠落・FT10 計画・nene2.dev ドメイン方針という3つのアクション候補を Issue 化し、ドキュメントに記録

## 変更内容

| ファイル | 変更 |
|---|---|
| `docs/field-trials/2026-05-field-trial-8.md` | 新規作成 — FT8 stub（ログ欠落、milestone 記録から要点を補完） |
| `docs/milestones/2026-05-field-trial-10.md` | 新規作成 — FT10 マイルストーン（新ドメインをスクラッチ実装） |
| `docs/roadmap.md` | Phase 58（FT10）・Phase 59（nene2.dev 方針）を Non-Goals の前に追加 |
| `docs/todo/current.md` | Status と Next Candidates を最新状態に更新 |

## 関連 Issue

- Closes #407（本 PR のメタ Issue）
- Closes #406（FT8 stub 作成）
- References #404（Field Trial 10）
- References #405（nene2.dev 方針）

## 検証

ドキュメント変更のみ。コード変更なし。

Self-review: docs-policy