### PR TITLE
chore(docs): nene2.dev 取得確認反映 — #405 クローズ・Phase 59 更新

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -624,18 +624,22 @@ from scratch without referencing the existing Note/Tag implementation as a codeb
 
 Tracked by `docs/milestones/2026-05-field-trial-10.md`.
 
-## Phase 59: Problem Details Domain Policy (#405)
+## Phase 59: Problem Details Base URL Configurability (#409)
 
-Goal: resolve the `nene2.dev` placeholder domain used in Problem Details `type` URIs so that
-client projects adopting NENE2 have a clear, production-safe path for error type identification.
+Goal: allow client projects to use their own domain for custom Problem Details `type` URIs,
+while keeping `nene2.dev` as the default for all framework built-in error types.
 
-- Decide between registering `nene2.dev` as the framework's official documentation domain
-  (Option A) or treating it as a placeholder that clients must replace (Option B)
-- Record the decision in an ADR or a dedicated section in `docs/development/authentication-boundary.md`
-- Update `docs/development/client-project-start.md` and `docs/howto/deploy-production.md`
-  with concrete steps for whichever option is chosen
-- If Option B: consider adding `problemDetailsBaseUrl` to `AppConfig` so the base URI is
-  configurable without touching framework code
+Background: `nene2.dev` is the registered framework domain (confirmed). Framework-built-in
+problem types (`not-found`, `validation-failed`, etc.) resolve correctly under this domain.
+The remaining gap is that `ProblemDetailsResponseFactory` hardcodes the base URL, so
+client-specific custom problem types also point to `nene2.dev`.
+
+- Add `problemDetailsBaseUrl` to `AppConfig` (default: `https://nene2.dev/problems/`)
+- `ProblemDetailsResponseFactory` receives the base URL via constructor injection
+- `RuntimeServiceProvider` wires the value from `AppConfig`
+- `.env.example` gets a commented-out `PROBLEM_DETAILS_BASE_URL` entry
+- `docs/development/client-project-start.md` or `docs/howto/deploy-production.md` documents
+  how to override the base URL for a client project's custom problem types
 
 ## Non-Goals
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -7,6 +7,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - Latest release: `v1.3.0` (Phase 53 — Packagist 反映済み)
 - Field Trial 9 完了 (Phase 56) — #371・#372 フォローアップ済み
 - レビュー所見反映 (#407) — FT8 stub 作成・ロードマップ Phase 58–59 追加
+- nene2.dev ドメイン取得確認 — #405 クローズ、#409 に残論点を分離
 - Current branch: `main` — clean
 
 ## Recently Completed
@@ -17,11 +18,12 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - **#388 / PR #389**: Post-v1.0 ドキュメント整合性クリーンアップ
 - **#400 / PR #401**: 5 locale 同期・README・env-vars・roadmap 修正
 - **#407**: レビュー所見反映 — FT8 stub・FT10 マイルストーン・ロードマップ Phase 58–59
+- **#405**: nene2.dev ドメイン取得確認 → Option A 確定、クローズ
 
 ## Next Candidates
 
 - **Phase 58 / Field Trial 10** (#404): v1.3.0 を起点に Note/Tag 以外の新ドメインをスクラッチ実装（ユーザー手作業必須）
-- **Phase 59 / nene2.dev 方針** (#405): Problem Details type URI のドメイン方針を決定し client-project-start.md に反映
+- **Phase 59 / type URI 設定化** (#409): `ProblemDetailsResponseFactory` の base URL を `AppConfig` 経由で設定可能にする
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary

- `nene2.dev` ドメイン取得確認 → Option A（公式ドメインとして維持）確定
- #405 をクローズし、残論点（クライアント独自 type URI）を #409 に分離

## 変更内容

| ファイル | 変更 |
|---|---|
| `docs/todo/current.md` | #405 クローズ記録、Next Candidates を #409 に差し替え |
| `docs/roadmap.md` | Phase 59 をドメイン方針決定済みとして base URL 設定化（#409）に更新 |

## 関連 Issue

- References #405（クローズ済み）
- References #409（新 Issue: type URI base URL 設定化）

Self-review: docs-policy