### PR TITLE
feat(config): ProblemDetailsResponseFactory の base URL を AppConfig 経由で設定可能にする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ NENE2_MACHINE_API_KEY=
 # Set to a random string (>=32 chars) to enable GET /examples/protected with LocalBearerTokenVerifier.
 # Leave empty to disable the JWT demo endpoint.
 NENE2_LOCAL_JWT_SECRET=
+# Base URL for Problem Details type URIs. Override when deploying under your own domain.
+# Default resolves to the NENE2 framework documentation pages on nene2.dev.
+# PROBLEM_DETAILS_BASE_URL=https://nene2.dev/problems/
 
 DATABASE_URL=
 DB_ENV=local

--- a/src/Config/AppConfig.php
+++ b/src/Config/AppConfig.php
@@ -13,9 +13,14 @@ final readonly class AppConfig
         public DatabaseConfig $database,
         public ?string $machineApiKey,
         public ?string $localJwtSecret = null,
+        public string $problemDetailsBaseUrl = 'https://nene2.dev/problems/',
     ) {
         if ($this->name === '') {
             throw new ConfigException('APP_NAME must not be empty.');
+        }
+
+        if ($this->problemDetailsBaseUrl === '') {
+            throw new ConfigException('PROBLEM_DETAILS_BASE_URL must not be empty.');
         }
     }
 }

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -20,6 +20,7 @@ final readonly class ConfigLoader
             'APP_NAME' => 'NENE2',
             'NENE2_MACHINE_API_KEY' => '',
             'NENE2_LOCAL_JWT_SECRET' => '',
+            'PROBLEM_DETAILS_BASE_URL' => 'https://nene2.dev/problems/',
             'DATABASE_URL' => '',
             'DB_ENV' => 'local',
             'DB_ADAPTER' => 'mysql',
@@ -63,6 +64,7 @@ final readonly class ConfigLoader
             ),
             $this->optionalString($values['NENE2_MACHINE_API_KEY']),
             $this->optionalString($values['NENE2_LOCAL_JWT_SECRET']),
+            trim($values['PROBLEM_DETAILS_BASE_URL']),
         );
     }
 

--- a/src/Error/ProblemDetailsResponseFactory.php
+++ b/src/Error/ProblemDetailsResponseFactory.php
@@ -14,6 +14,7 @@ final readonly class ProblemDetailsResponseFactory
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        private string $problemDetailsBaseUrl = 'https://nene2.dev/problems/',
     ) {
     }
 
@@ -29,7 +30,7 @@ final readonly class ProblemDetailsResponseFactory
         array $extensions = [],
     ): ResponseInterface {
         $payload = [
-            'type' => 'https://nene2.dev/problems/' . $type,
+            'type' => $this->problemDetailsBaseUrl . $type,
             'title' => $title,
             'status' => $status,
             'instance' => $request->getUri()->getPath() ?: '/',

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -127,6 +127,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): ProblemDetailsResponseFactory {
                     $responseFactory = $container->get(ResponseFactoryInterface::class);
                     $streamFactory = $container->get(StreamFactoryInterface::class);
+                    $config = $container->get(AppConfig::class);
 
                     if (!$responseFactory instanceof ResponseFactoryInterface) {
                         throw new LogicException('Response factory service is invalid.');
@@ -136,7 +137,11 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Stream factory service is invalid.');
                     }
 
-                    return new ProblemDetailsResponseFactory($responseFactory, $streamFactory);
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    return new ProblemDetailsResponseFactory($responseFactory, $streamFactory, $config->problemDetailsBaseUrl);
                 },
             )
             ->set(

--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -122,6 +122,32 @@ final class ConfigLoaderTest extends TestCase
         ]);
     }
 
+    public function testDefaultProblemDetailsBaseUrl(): void
+    {
+        $config = (new ConfigLoader($this->emptyProjectRoot()))->load();
+
+        self::assertSame('https://nene2.dev/problems/', $config->problemDetailsBaseUrl);
+    }
+
+    public function testCustomProblemDetailsBaseUrlOverride(): void
+    {
+        $config = (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'PROBLEM_DETAILS_BASE_URL' => 'https://api.example.com/problems/',
+        ]);
+
+        self::assertSame('https://api.example.com/problems/', $config->problemDetailsBaseUrl);
+    }
+
+    public function testEmptyProblemDetailsBaseUrlFailsFast(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('PROBLEM_DETAILS_BASE_URL must not be empty.');
+
+        (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'PROBLEM_DETAILS_BASE_URL' => '   ',
+        ]);
+    }
+
     private function emptyProjectRoot(): string
     {
         return sys_get_temp_dir();


### PR DESCRIPTION
## Summary

- `PROBLEM_DETAILS_BASE_URL` 環境変数で Problem Details type URI のベース URL を上書きできるようにした
- デフォルト値は `https://nene2.dev/problems/` のまま — 既存の動作に変更なし

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/Config/AppConfig.php` | `problemDetailsBaseUrl` プロパティ追加（空文字バリデーション付き） |
| `src/Config/ConfigLoader.php` | `PROBLEM_DETAILS_BASE_URL` をデフォルト値付きで読み込み |
| `src/Error/ProblemDetailsResponseFactory.php` | コンストラクタで base URL を受け取る（デフォルト付き） |
| `src/Http/RuntimeServiceProvider.php` | `config->problemDetailsBaseUrl` を factory に渡すようワイヤリング更新 |
| `.env.example` | `PROBLEM_DETAILS_BASE_URL` のコメントアウト例を追加 |
| `tests/Config/ConfigLoaderTest.php` | 3ケース追加（デフォルト値・上書き・空文字エラー） |

## 使い方

クライアントプロジェクトで独自の問題型を使う場合:

```ini
# .env
PROBLEM_DETAILS_BASE_URL=https://api.example.com/problems/
```

```php
// 結果: type = "https://api.example.com/problems/payment-failed"
$factory->create($request, 'payment-failed', 'Payment Failed', 402);
```

## 検証

```
202 tests, 634 assertions — OK
PHPStan: No errors
PHP-CS-Fixer: 0 files to fix
OpenAPI: valid
MCP: valid
```

Closes #409

Self-review: backend-api