### PR TITLE
chore(release): v1.4.0 — CHANGELOG 確定・current.md 更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.4.0] — 2026-05-18
+
 ### Added
 - `AppConfig::$problemDetailsBaseUrl` — configurable base URL for Problem Details `type` URIs (`Nene2\Config`); defaults to `https://nene2.dev/problems/` (#409)
 - `PROBLEM_DETAILS_BASE_URL` environment variable — override the base URL per project without touching framework code (#409)
@@ -266,7 +270,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Governance docs: workflow, coding standards, ADR policy, review checklists (#1)
 - ADR 0001–0004: HTTP runtime, DI container, phpdotenv, Phinx
 
-[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.0.0...v1.1.0

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,26 +4,21 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.3.0` (Phase 53 — Packagist 反映済み)
-- Field Trial 9 完了 (Phase 56) — #371・#372 フォローアップ済み
-- レビュー所見反映 (#407) — FT8 stub 作成・ロードマップ Phase 58–59 追加
-- nene2.dev ドメイン取得確認 — #405 クローズ、#409 に残論点を分離
+- Latest release: `v1.4.0` (Packagist 反映待ち)
+- v1.4.0: PROBLEM_DETAILS_BASE_URL 設定化 (#409) + ドキュメント整合 (#413)
 - Current branch: `main` — clean
 
 ## Recently Completed
 
-- **Phase 55**: Dependabot PR #324–#333 (10件) マージ
-- **Phase 56**: Field Trial 9 — v1.3.0 検証 (PaginationQueryParser / openapi:docs / 400/422 分離)
-- **Phase 57**: VitePress i18n リンク修正 (#380); locale http-endpoints.md 同期 (#384, PR #385)
-- **#388 / PR #389**: Post-v1.0 ドキュメント整合性クリーンアップ
-- **#400 / PR #401**: 5 locale 同期・README・env-vars・roadmap 修正
+- **Phase 56**: Field Trial 9 — v1.3.0 検証
 - **#407**: レビュー所見反映 — FT8 stub・FT10 マイルストーン・ロードマップ Phase 58–59
-- **#405**: nene2.dev ドメイン取得確認 → Option A 確定、クローズ
+- **#409**: ProblemDetailsResponseFactory base URL 設定化
+- **#413**: #409 実装後のドキュメント整合（deploy-production 6言語・ADR 0009・env-vars 6言語・CLAUDE.md）
+- **v1.4.0**: タグ・GitHub Release 作成、Packagist 反映確認
 
 ## Next Candidates
 
-- **Phase 58 / Field Trial 10** (#404): v1.3.0 を起点に Note/Tag 以外の新ドメインをスクラッチ実装（ユーザー手作業必須）
-- **Phase 59 / type URI 設定化** (#409): `ProblemDetailsResponseFactory` の base URL を `AppConfig` 経由で設定可能にする
+- **Phase 58 / Field Trial 10** (#404): v1.4.0 を起点に Note/Tag 以外の新ドメインをスクラッチ実装（ユーザー手作業必須）
 
 ## Operating Notes
 


### PR DESCRIPTION
## Summary

v1.4.0 リリース準備。

- `CHANGELOG.md`: `[Unreleased]` → `[1.4.0] — 2026-05-18` に確定、フッターリンク追加
- `docs/todo/current.md`: latest release を v1.4.0 に更新

## v1.4.0 に含まれる変更

- `PROBLEM_DETAILS_BASE_URL` 環境変数による Problem Details base URL 設定化 (#409)
- `deploy-production.md`・`environment-variables.md`・`ADR 0009`・`CLAUDE.md` ドキュメント整合 (#413)

Self-review: release-ci