### PR TITLE
docs(api): FrameworkInfo::VERSION 定数追加・LocalMcpServer バージョン修正・安定 API 全クラスに class-level PHPDoc 追加

### DIFF
--- a/src/Auth/BearerTokenMiddleware.php
+++ b/src/Auth/BearerTokenMiddleware.php
@@ -10,6 +10,12 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Validates the `Authorization: Bearer <token>` header using a {@see TokenVerifierInterface}.
+ * Returns 401 Problem Details if the header is absent or the token fails verification.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class BearerTokenMiddleware implements MiddlewareInterface
 {
     /**

--- a/src/Auth/TokenVerificationException.php
+++ b/src/Auth/TokenVerificationException.php
@@ -6,6 +6,12 @@ namespace Nene2\Auth;
 
 use RuntimeException;
 
+/**
+ * Thrown by {@see TokenVerifierInterface} implementations when a bearer token is invalid.
+ * BearerTokenMiddleware maps this to a 401 Problem Details response.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final class TokenVerificationException extends RuntimeException
 {
 }

--- a/src/Config/AppConfig.php
+++ b/src/Config/AppConfig.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Nene2\Config;
 
+/**
+ * Typed application configuration assembled by {@see ConfigLoader} from environment variables.
+ *
+ * Inject this value object wherever application-level settings are needed; never call
+ * `getenv()` or `$_ENV` directly outside `ConfigLoader`.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class AppConfig
 {
     public function __construct(

--- a/src/Config/AppEnvironment.php
+++ b/src/Config/AppEnvironment.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Nene2\Config;
 
+/**
+ * Runtime environment derived from the `APP_ENV` environment variable.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 enum AppEnvironment: string
 {
     case Local = 'local';

--- a/src/Config/ConfigException.php
+++ b/src/Config/ConfigException.php
@@ -6,6 +6,11 @@ namespace Nene2\Config;
 
 use InvalidArgumentException;
 
+/**
+ * Thrown by {@see ConfigLoader} when a required environment variable is missing or invalid.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final class ConfigException extends InvalidArgumentException
 {
 }

--- a/src/Config/DatabaseConfig.php
+++ b/src/Config/DatabaseConfig.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Nene2\Config;
 
+/**
+ * Typed database configuration assembled by {@see ConfigLoader} from environment variables.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class DatabaseConfig
 {
     public function __construct(

--- a/src/Database/DatabaseConnectionException.php
+++ b/src/Database/DatabaseConnectionException.php
@@ -6,6 +6,11 @@ namespace Nene2\Database;
 
 use RuntimeException;
 
+/**
+ * Thrown when a database connection cannot be established.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final class DatabaseConnectionException extends RuntimeException
 {
 }

--- a/src/Database/DatabaseQueryExecutorInterface.php
+++ b/src/Database/DatabaseQueryExecutorInterface.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 namespace Nene2\Database;
 
 /**
+ * Executes parameterised SQL queries against the database connection.
+ *
+ * Implement this interface to swap the persistence backend (e.g. SQLite for tests,
+ * MySQL for production) without changing repository code.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ *
  * @phpstan-type SqlParameter string|int|float|bool|null
  * @phpstan-type SqlParameters array<string|int, SqlParameter>
  * @phpstan-type SqlRow array<string, mixed>

--- a/src/Database/DatabaseTransactionManagerInterface.php
+++ b/src/Database/DatabaseTransactionManagerInterface.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Nene2\Database;
 
+/**
+ * Wraps a unit of work in a database transaction.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 interface DatabaseTransactionManagerInterface
 {
     /**

--- a/src/DependencyInjection/ContainerBuilder.php
+++ b/src/DependencyInjection/ContainerBuilder.php
@@ -7,6 +7,13 @@ namespace Nene2\DependencyInjection;
 use Psr\Container\ContainerInterface;
 
 /**
+ * Fluent builder for the PSR-11 service container.
+ *
+ * Register service factories with {@see set()} and {@see value()}, group related services
+ * with {@see addProvider()}, then call {@see build()} to obtain the immutable container.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ *
  * @phpstan-import-type ServiceFactory from Container
  */
 final class ContainerBuilder

--- a/src/Error/ProblemDetailsResponseFactory.php
+++ b/src/Error/ProblemDetailsResponseFactory.php
@@ -9,6 +9,14 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
+/**
+ * Builds RFC 9457 `application/problem+json` responses.
+ *
+ * The `type` field is prefixed with `$problemDetailsBaseUrl` (default: `https://nene2.dev/problems/`).
+ * Override via the `PROBLEM_DETAILS_BASE_URL` environment variable for custom problem types.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class ProblemDetailsResponseFactory
 {
     public function __construct(

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Nene2;
 
+/**
+ * Metadata about the NENE2 framework itself.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class FrameworkInfo
 {
+    public const string VERSION = '1.4.0';
+
     public function name(): string
     {
         return 'NENE2';

--- a/src/Http/HealthStatus.php
+++ b/src/Http/HealthStatus.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Nene2\Http;
 
+/**
+ * Health check outcome reported by {@see HealthCheckInterface}.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 enum HealthStatus: string
 {
     case Ok = 'ok';

--- a/src/Http/JsonResponseFactory.php
+++ b/src/Http/JsonResponseFactory.php
@@ -8,6 +8,11 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
+/**
+ * Creates PSR-7 `application/json` responses from PHP values.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class JsonResponseFactory
 {
     public function __construct(

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -27,6 +27,15 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
 
+/**
+ * Assembles the full PSR-15 middleware pipeline and {@see Router} for a NENE2 application.
+ *
+ * Construct this once at the application entry point, pass your route registrars, health
+ * checks, and optional middleware, then call {@see create()} to obtain the request handler
+ * that your front controller dispatches to.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class RuntimeApplicationFactory
 {
     /**

--- a/src/Mcp/LocalMcpException.php
+++ b/src/Mcp/LocalMcpException.php
@@ -6,6 +6,11 @@ namespace Nene2\Mcp;
 
 use RuntimeException;
 
+/**
+ * Thrown by {@see LocalMcpServer} when a tool call or JSON-RPC request cannot be processed.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final class LocalMcpException extends RuntimeException
 {
 }

--- a/src/Mcp/LocalMcpHttpClientInterface.php
+++ b/src/Mcp/LocalMcpHttpClientInterface.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Nene2\Mcp;
 
+/**
+ * HTTP client used by {@see LocalMcpServer} to proxy tool calls to the application API.
+ * Implement this interface to inject custom transport or test doubles.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 interface LocalMcpHttpClientInterface
 {
     public function get(string $baseUrl, string $path): LocalMcpHttpResponse;

--- a/src/Mcp/LocalMcpServer.php
+++ b/src/Mcp/LocalMcpServer.php
@@ -4,7 +4,16 @@ declare(strict_types=1);
 
 namespace Nene2\Mcp;
 
+use Nene2\FrameworkInfo;
+
 /**
+ * JSON-RPC 2.0 / MCP server that exposes framework API operations as tools.
+ *
+ * Run via `tools/local-mcp-server.php`. Reads its tool catalog from
+ * `docs/mcp/tools.json` and proxies tool calls through {@see LocalMcpHttpClientInterface}.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ *
  * @phpstan-import-type McpTool from LocalMcpToolCatalog
  */
 final readonly class LocalMcpServer
@@ -59,7 +68,7 @@ final readonly class LocalMcpServer
             ],
             'serverInfo' => [
                 'name' => 'nene2-local-mcp',
-                'version' => '0.1.0',
+                'version' => FrameworkInfo::VERSION,
             ],
         ];
     }

--- a/src/Middleware/ApiKeyAuthenticationMiddleware.php
+++ b/src/Middleware/ApiKeyAuthenticationMiddleware.php
@@ -10,6 +10,12 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Validates the `X-NENE2-API-Key` request header for machine client endpoints.
+ * Returns 401 Problem Details when the key is absent or does not match `NENE2_MACHINE_API_KEY`.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class ApiKeyAuthenticationMiddleware implements MiddlewareInterface
 {
     /**

--- a/src/Middleware/CorsMiddleware.php
+++ b/src/Middleware/CorsMiddleware.php
@@ -10,6 +10,12 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Handles CORS preflight requests and adds `Access-Control-*` headers to responses.
+ * Allowed origins are injected at construction time; use an explicit allowlist in production.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class CorsMiddleware implements MiddlewareInterface
 {
     /**

--- a/src/Middleware/MiddlewareDispatcher.php
+++ b/src/Middleware/MiddlewareDispatcher.php
@@ -9,6 +9,11 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Runs a fixed list of PSR-15 middleware in order, then falls through to the inner handler.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class MiddlewareDispatcher implements RequestHandlerInterface
 {
     /**

--- a/src/Middleware/RequestIdMiddleware.php
+++ b/src/Middleware/RequestIdMiddleware.php
@@ -10,6 +10,12 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Assigns a unique `X-Request-Id` to every request and propagates it to response headers.
+ * The ID is available downstream via the `nene2.request_id` request attribute ({@see RequestIdMiddleware::ATTRIBUTE}).
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class RequestIdMiddleware implements MiddlewareInterface
 {
     public const ATTRIBUTE = 'nene2.request_id';

--- a/src/Middleware/RequestLoggingMiddleware.php
+++ b/src/Middleware/RequestLoggingMiddleware.php
@@ -10,6 +10,12 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Logs each request's method, path, status, and duration via PSR-3 `LoggerInterface`.
+ * Sensitive headers (Authorization, cookies, API keys) are never included.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class RequestLoggingMiddleware implements MiddlewareInterface
 {
     public function __construct(

--- a/src/Middleware/RequestSizeLimitMiddleware.php
+++ b/src/Middleware/RequestSizeLimitMiddleware.php
@@ -10,6 +10,11 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Rejects requests whose body exceeds a configured byte limit with a 413 Problem Details response.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class RequestSizeLimitMiddleware implements MiddlewareInterface
 {
     public function __construct(

--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -9,6 +9,12 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Adds security-related HTTP response headers (e.g. `X-Content-Type-Options`, `X-Frame-Options`).
+ * Headers are injected before the pipeline processes the request so they appear on error responses too.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class SecurityHeadersMiddleware implements MiddlewareInterface
 {
     /**

--- a/src/Routing/MethodNotAllowedException.php
+++ b/src/Routing/MethodNotAllowedException.php
@@ -6,6 +6,12 @@ namespace Nene2\Routing;
 
 use RuntimeException;
 
+/**
+ * Thrown by {@see Router} when the path matches but the HTTP method does not.
+ * ErrorHandlerMiddleware maps this to a 405 Problem Details response.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final class MethodNotAllowedException extends RuntimeException
 {
     /**

--- a/src/Routing/RouteNotFoundException.php
+++ b/src/Routing/RouteNotFoundException.php
@@ -6,6 +6,12 @@ namespace Nene2\Routing;
 
 use RuntimeException;
 
+/**
+ * Thrown by {@see Router} when no registered route matches the request path.
+ * ErrorHandlerMiddleware maps this to a 404 Problem Details response.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final class RouteNotFoundException extends RuntimeException
 {
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -10,6 +10,14 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
+ * Registers named-parameter routes and dispatches incoming requests to the matching handler.
+ *
+ * Routes are matched in registration order. Path parameters (e.g. `/users/{id}`) are
+ * stored in the `nene2.route.parameters` request attribute ({@see Router::PARAMETERS_ATTRIBUTE}).
+ * Throws {@see RouteNotFoundException} (404) or {@see MethodNotAllowedException} (405) on mismatch.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ *
  * @phpstan-type Route array{method: non-empty-string, path: non-empty-string, pattern: string, parameterNames: list<non-empty-string>, handler: callable(ServerRequestInterface): ResponseInterface}
  */
 final class Router implements RequestHandlerInterface

--- a/src/Validation/ValidationError.php
+++ b/src/Validation/ValidationError.php
@@ -6,6 +6,11 @@ namespace Nene2\Validation;
 
 use InvalidArgumentException;
 
+/**
+ * A single field-level validation failure carried by {@see ValidationException}.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class ValidationError
 {
     public function __construct(

--- a/src/Validation/ValidationException.php
+++ b/src/Validation/ValidationException.php
@@ -7,6 +7,13 @@ namespace Nene2\Validation;
 use InvalidArgumentException;
 use RuntimeException;
 
+/**
+ * Thrown when request input fails business-rule validation.
+ * ErrorHandlerMiddleware maps this to a 422 `validation-failed` Problem Details response
+ * containing a structured `errors` array.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final class ValidationException extends RuntimeException
 {
     /** @var non-empty-list<ValidationError> */

--- a/src/View/HtmlEscaper.php
+++ b/src/View/HtmlEscaper.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Nene2\View;
 
+/**
+ * Escapes values for safe HTML output using `htmlspecialchars` with UTF-8 and full quoting.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class HtmlEscaper
 {
     public function escape(mixed $value): string

--- a/src/View/HtmlResponseFactory.php
+++ b/src/View/HtmlResponseFactory.php
@@ -8,6 +8,11 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
+/**
+ * Creates PSR-7 `text/html; charset=UTF-8` responses from rendered template strings.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class HtmlResponseFactory
 {
     public function __construct(

--- a/src/View/NativePhpViewRenderer.php
+++ b/src/View/NativePhpViewRenderer.php
@@ -6,6 +6,13 @@ namespace Nene2\View;
 
 use Throwable;
 
+/**
+ * Renders native PHP template files (`.php`) by including them in an isolated scope.
+ * Templates receive variables via the `$data` argument; use {@see HtmlEscaper} or `$this->escaper`
+ * to escape output safely.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final readonly class NativePhpViewRenderer
 {
     public function __construct(

--- a/src/View/TemplateNotFoundException.php
+++ b/src/View/TemplateNotFoundException.php
@@ -6,6 +6,11 @@ namespace Nene2\View;
 
 use RuntimeException;
 
+/**
+ * Thrown by {@see NativePhpViewRenderer} when the requested template file does not exist.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
 final class TemplateNotFoundException extends RuntimeException
 {
 }


### PR DESCRIPTION
## Summary

- `FrameworkInfo::VERSION = '1.4.0'` 定数を追加
- `LocalMcpServer` の MCP initialize レスポンスのハードコード `'0.1.0'` を `FrameworkInfo::VERSION` に置き換え
- ADR 0009 安定公開 API 全クラス 33 クラス（34 ファイル）に class-level PHPDoc を追加

## Changes

### FrameworkInfo
- `VERSION` 定数追加（`'1.4.0'`）
- クラス説明 PHPDoc 追加

### LocalMcpServer
- `initialize` レスポンスの `'version'` を `FrameworkInfo::VERSION` を使うよう変更
- `use Nene2\FrameworkInfo;` import 追加
- クラス説明 PHPDoc 追加

### 安定 API PHPDoc 追加対象（#418）
`Routing`・`Http`・`Config`・`Database`・`Error`・`Auth`・`Middleware`・`Validation`・`View`・`Mcp` の各 namespace 全クラス

## Validation

- `composer check` 通過: 202 tests / PHPStan level 8 / CS Fixer / OpenAPI / MCP catalog すべてクリア

Closes #417
Closes #418

Self-review: docs-policy