### PR TITLE
chore(changelog): FrameworkInfo::VERSION を [Unreleased] に追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `FrameworkInfo::VERSION` — public string constant exposing the current framework version (`Nene2\FrameworkInfo`) (#417)
+
 ---
 
 ## [1.4.0] — 2026-05-18


### PR DESCRIPTION
## Summary

- `[Unreleased]` に `FrameworkInfo::VERSION` の Added エントリを追加

## Background

#419 で追加した `FrameworkInfo::VERSION` 公開定数が CHANGELOG に未記載だったため補完。

Closes #420

Self-review: docs-policy