### PR TITLE
feat(error,http): APP_DEBUG 例外詳細露出・PaginationResponse DTO 追加 (#426, #429)

### DIFF
--- a/docs/de/howto/add-pagination.md
+++ b/docs/de/howto/add-pagination.md
@@ -75,7 +75,41 @@ Im Handler ist keine zusätzliche Fehlerbehandlung erforderlich.
 
 ## Siehe auch
 
-- `src/Example/Note/ListNotesHandler.php` — Referenzimplementierung mit dem Parser
+## Schritt 4 — `PaginationResponse` zur Standardisierung des Envelopes verwenden
+
+`PaginationResponse` ist ein readonly DTO, das den Standard-Listenantwort-Envelope aufbaut:
+
+```php
+use Nene2\Http\PaginationResponse;
+
+return $this->response->create(
+    (new PaginationResponse(
+        items:  array_map(fn ($item) => ['id' => $item->id, 'name' => $item->name], $output->items),
+        limit:  $output->limit,
+        offset: $output->offset,
+    ))->toArray(),
+);
+```
+
+## Schritt 5 — Gesamtanzahl einschließen (optional)
+
+Übergeben Sie `total`, wenn das Repository eine Zählabfrage unterstützt:
+
+```php
+$total = $this->repository->countAll(); // SELECT COUNT(*) AS n FROM ...
+
+return $this->response->create(
+    (new PaginationResponse(items: /* ... */, limit: $output->limit, offset: $output->offset, total: $total))->toArray(),
+);
+```
+
+Wenn `total` `null` ist, wird der Schlüssel weggelassen.
+
+> **Abwägung**: `COUNT(*)` kostet eine zusätzliche Abfrage pro Request. Lassen Sie `total` weg,
+> wenn der Overhead nicht akzeptabel ist.
+
+- `src/Example/Note/ListNotesHandler.php` — Referenzimplementierung mit `PaginationResponse`
 - `src/Example/Tag/ListTagsHandler.php` — zweites Beispiel
 - `Nene2\Http\PaginationQuery` — readonly DTO
 - `Nene2\Http\PaginationQueryParser` — die Parser-Klasse
+- `Nene2\Http\PaginationResponse` — das Listen-Envelope-DTO

--- a/docs/fr/howto/add-pagination.md
+++ b/docs/fr/howto/add-pagination.md
@@ -73,9 +73,43 @@ Aucune gestion d'erreur supplémentaire n'est nécessaire dans le handler.
 
 `PaginationQueryParser::parse()` lit `getQueryParams()` de la requête PSR-7, caste les valeurs en `int`, les valide et retourne un DTO `PaginationQuery`. Les valeurs non numériques sont castées en `0` (comportement PHP de `(int)`) puis interceptées par la vérification `limit < 1`.
 
+## Étape 4 — Utiliser `PaginationResponse` pour standardiser l'envelope
+
+`PaginationResponse` est un DTO readonly qui construit l'envelope de liste standard :
+
+```php
+use Nene2\Http\PaginationResponse;
+
+return $this->response->create(
+    (new PaginationResponse(
+        items:  array_map(fn ($item) => ['id' => $item->id, 'name' => $item->name], $output->items),
+        limit:  $output->limit,
+        offset: $output->offset,
+    ))->toArray(),
+);
+```
+
+## Étape 5 — Inclure le nombre total d'enregistrements (optionnel)
+
+Passez `total` quand le repository supporte une requête COUNT :
+
+```php
+$total = $this->repository->countAll(); // SELECT COUNT(*) AS n FROM ...
+
+return $this->response->create(
+    (new PaginationResponse(items: /* ... */, limit: $output->limit, offset: $output->offset, total: $total))->toArray(),
+);
+```
+
+Quand `total` est `null` (défaut), la clé est omise de la réponse.
+
+> **Compromis** : `COUNT(*)` ajoute une requête par appel. Omettez `total` si l'overhead est
+> inacceptable et laissez les clients détecter la dernière page avec `items.length < limit`.
+
 ## Voir aussi
 
-- `src/Example/Note/ListNotesHandler.php` — implémentation de référence utilisant le parseur
+- `src/Example/Note/ListNotesHandler.php` — implémentation de référence avec `PaginationResponse`
 - `src/Example/Tag/ListTagsHandler.php` — deuxième exemple
 - `Nene2\Http\PaginationQuery` — DTO readonly
 - `Nene2\Http\PaginationQueryParser` — la classe parseur
+- `Nene2\Http\PaginationResponse` — le DTO envelope de liste

--- a/docs/howto/add-pagination.md
+++ b/docs/howto/add-pagination.md
@@ -77,9 +77,72 @@ No additional error handling is needed in the handler.
 `int`, validates them, and returns a `PaginationQuery` DTO. Non-numeric values are coerced to `0`
 (PHP's `(int)` casting behaviour) and then caught by the `limit < 1` check.
 
+## Step 4 — Use `PaginationResponse` to standardise the envelope
+
+`PaginationResponse` is a readonly DTO that builds the standard list envelope. Use it instead of
+constructing the array manually:
+
+```php
+use Nene2\Http\PaginationResponse;
+
+return $this->response->create(
+    (new PaginationResponse(
+        items:  array_map(fn ($item) => ['id' => $item->id, 'name' => $item->name], $output->items),
+        limit:  $output->limit,
+        offset: $output->offset,
+    ))->toArray(),
+);
+```
+
+`toArray()` returns `['items' => ..., 'limit' => ..., 'offset' => ...]`.
+
+## Step 5 — Include the total record count (optional)
+
+Pass `total` to `PaginationResponse` when the repository supports a count query. Clients use
+this to determine the last page without an extra request.
+
+```php
+// In the repository:
+public function countAll(): int
+{
+    $rows = $this->query->select('SELECT COUNT(*) AS n FROM widgets', []);
+    return (int) ($rows[0]['n'] ?? 0);
+}
+
+// In the handler:
+$total = $this->repository->countAll();
+
+return $this->response->create(
+    (new PaginationResponse(
+        items:  /* ... */,
+        limit:  $output->limit,
+        offset: $output->offset,
+        total:  $total,
+    ))->toArray(),
+);
+```
+
+The resulting response:
+
+```json
+{
+    "items":  [ /* ... */ ],
+    "limit":  20,
+    "offset": 0,
+    "total":  42
+}
+```
+
+When `total` is `null` (the default), the key is omitted from the response.
+
+> **Trade-off**: `COUNT(*)` adds one extra query per request. Omit `total` when the collection
+> is large and the overhead is unacceptable, and instruct clients to detect the last page by
+> checking `items.length < limit`.
+
 ## See also
 
-- `src/Example/Note/ListNotesHandler.php` — reference implementation using the parser
+- `src/Example/Note/ListNotesHandler.php` — reference implementation using `PaginationResponse`
 - `src/Example/Tag/ListTagsHandler.php` — second example
-- `Nene2\Http\PaginationQuery` — readonly DTO
+- `Nene2\Http\PaginationQuery` — readonly DTO for parsed parameters
 - `Nene2\Http\PaginationQueryParser` — the parser class
+- `Nene2\Http\PaginationResponse` — the list-envelope DTO

--- a/docs/ja/howto/add-pagination.md
+++ b/docs/ja/howto/add-pagination.md
@@ -72,9 +72,43 @@ $pagination = PaginationQueryParser::parse($request, defaultLimit: 10, maxLimit:
 
 `PaginationQueryParser::parse()` は PSR-7 リクエストの `getQueryParams()` を読み取り、値を `int` にキャストしてバリデーションを行い、`PaginationQuery` DTO を返します。数値以外の値は `0` にキャストされ（PHP の `(int)` キャスト動作）、`limit < 1` チェックで捕捉されます。
 
+## ステップ 4 — `PaginationResponse` でエンベロープを標準化する
+
+`PaginationResponse` は標準的なリストエンベロープを構築する readonly DTO です:
+
+```php
+use Nene2\Http\PaginationResponse;
+
+return $this->response->create(
+    (new PaginationResponse(
+        items:  array_map(fn ($item) => ['id' => $item->id, 'name' => $item->name], $output->items),
+        limit:  $output->limit,
+        offset: $output->offset,
+    ))->toArray(),
+);
+```
+
+## ステップ 5 — 総件数を含める（オプション）
+
+リポジトリがカウントクエリをサポートする場合、`total` を渡します:
+
+```php
+$total = $this->repository->countAll(); // SELECT COUNT(*) AS n FROM ...
+
+return $this->response->create(
+    (new PaginationResponse(items: /* ... */, limit: $output->limit, offset: $output->offset, total: $total))->toArray(),
+);
+```
+
+`total` が `null`（デフォルト）の場合、レスポンスにキーは含まれません。
+
+> **トレードオフ**: `COUNT(*)` はリクエストごとにクエリが 1 件追加されます。オーバーヘッドが
+> 許容できない場合は `total` を省略し、クライアントに `items.length < limit` で最終ページを検出させてください。
+
 ## 参考
 
-- `src/Example/Note/ListNotesHandler.php` — パーサーを使ったリファレンス実装
+- `src/Example/Note/ListNotesHandler.php` — `PaginationResponse` を使ったリファレンス実装
 - `src/Example/Tag/ListTagsHandler.php` — 2 つ目の例
-- `Nene2\Http\PaginationQuery` — readonly DTO
+- `Nene2\Http\PaginationQuery` — パース済みパラメーターの readonly DTO
 - `Nene2\Http\PaginationQueryParser` — パーサークラス
+- `Nene2\Http\PaginationResponse` — リストエンベロープ DTO

--- a/docs/pt-br/howto/add-pagination.md
+++ b/docs/pt-br/howto/add-pagination.md
@@ -73,9 +73,43 @@ Nenhum tratamento de erro adicional é necessário no handler.
 
 `PaginationQueryParser::parse()` lê `getQueryParams()` da requisição PSR-7, converte os valores para `int`, valida-os e retorna um DTO `PaginationQuery`. Valores não numéricos são convertidos para `0` (comportamento de cast `(int)` do PHP) e então capturados pela verificação `limit < 1`.
 
+## Passo 4 — Usar `PaginationResponse` para padronizar o envelope
+
+`PaginationResponse` é um DTO readonly que constrói o envelope de lista padrão:
+
+```php
+use Nene2\Http\PaginationResponse;
+
+return $this->response->create(
+    (new PaginationResponse(
+        items:  array_map(fn ($item) => ['id' => $item->id, 'name' => $item->name], $output->items),
+        limit:  $output->limit,
+        offset: $output->offset,
+    ))->toArray(),
+);
+```
+
+## Passo 5 — Incluir o total de registros (opcional)
+
+Passe `total` quando o repositório suportar uma consulta COUNT:
+
+```php
+$total = $this->repository->countAll(); // SELECT COUNT(*) AS n FROM ...
+
+return $this->response->create(
+    (new PaginationResponse(items: /* ... */, limit: $output->limit, offset: $output->offset, total: $total))->toArray(),
+);
+```
+
+Quando `total` é `null` (padrão), a chave é omitida da resposta.
+
+> **Compromisso**: `COUNT(*)` adiciona uma consulta por chamada. Omita `total` se o overhead
+> for inaceitável e deixe os clientes detectar a última página com `items.length < limit`.
+
 ## Veja também
 
-- `src/Example/Note/ListNotesHandler.php` — implementação de referência usando o parser
+- `src/Example/Note/ListNotesHandler.php` — implementação de referência com `PaginationResponse`
 - `src/Example/Tag/ListTagsHandler.php` — segundo exemplo
-- `Nene2\Http\PaginationQuery` — DTO readonly
+- `Nene2\Http\PaginationQuery` — DTO readonly para parâmetros analisados
 - `Nene2\Http\PaginationQueryParser` — a classe parser
+- `Nene2\Http\PaginationResponse` — o DTO de envelope de lista

--- a/docs/zh/howto/add-pagination.md
+++ b/docs/zh/howto/add-pagination.md
@@ -72,9 +72,43 @@ $pagination = PaginationQueryParser::parse($request, defaultLimit: 10, maxLimit:
 
 `PaginationQueryParser::parse()` 读取 PSR-7 请求的 `getQueryParams()`，将值转换为 `int`，进行验证后返回 `PaginationQuery` DTO。非数字值会被转换为 `0`（PHP 的 `(int)` 转换行为），然后被 `limit < 1` 检查捕获。
 
+## 第 4 步 — 使用 `PaginationResponse` 标准化响应结构
+
+`PaginationResponse` 是一个 readonly DTO，用于构建标准的列表响应结构：
+
+```php
+use Nene2\Http\PaginationResponse;
+
+return $this->response->create(
+    (new PaginationResponse(
+        items:  array_map(fn ($item) => ['id' => $item->id, 'name' => $item->name], $output->items),
+        limit:  $output->limit,
+        offset: $output->offset,
+    ))->toArray(),
+);
+```
+
+## 第 5 步 — 包含总记录数（可选）
+
+当仓储支持计数查询时传入 `total`：
+
+```php
+$total = $this->repository->countAll(); // SELECT COUNT(*) AS n FROM ...
+
+return $this->response->create(
+    (new PaginationResponse(items: /* ... */, limit: $output->limit, offset: $output->offset, total: $total))->toArray(),
+);
+```
+
+当 `total` 为 `null`（默认）时，响应中不包含该键。
+
+> **权衡**：`COUNT(*)` 每次请求增加一个查询。若开销不可接受，可省略 `total`，
+> 让客户端通过 `items.length < limit` 判断是否为最后一页。
+
 ## 另请参阅
 
-- `src/Example/Note/ListNotesHandler.php` — 使用解析器的参考实现
+- `src/Example/Note/ListNotesHandler.php` — 使用 `PaginationResponse` 的参考实现
 - `src/Example/Tag/ListTagsHandler.php` — 第二个示例
-- `Nene2\Http\PaginationQuery` — readonly DTO
+- `Nene2\Http\PaginationQuery` — 解析后参数的 readonly DTO
 - `Nene2\Http\PaginationQueryParser` — 解析器类
+- `Nene2\Http\PaginationResponse` — 列表结构 DTO

--- a/src/Error/ErrorHandlerMiddleware.php
+++ b/src/Error/ErrorHandlerMiddleware.php
@@ -16,10 +16,15 @@ use Throwable;
 
 final readonly class ErrorHandlerMiddleware implements MiddlewareInterface
 {
-    /** @param list<DomainExceptionHandlerInterface> $domainHandlers */
+    /**
+     * @param list<DomainExceptionHandlerInterface> $domainHandlers
+     * @param bool $debug When true, the exception message is included in the 500 response `detail`
+     *                    field. Never set to true in production.
+     */
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
         private array $domainHandlers = [],
+        private bool $debug = false,
     ) {
     }
 
@@ -76,7 +81,9 @@ final readonly class ErrorHandlerMiddleware implements MiddlewareInterface
                 'internal-server-error',
                 'Internal Server Error',
                 500,
-                'The server encountered an unexpected condition.',
+                $this->debug
+                    ? $exception->getMessage()
+                    : 'The server encountered an unexpected condition.',
             );
         }
     }

--- a/src/Example/Note/ListNotesHandler.php
+++ b/src/Example/Note/ListNotesHandler.php
@@ -6,6 +6,7 @@ namespace Nene2\Example\Note;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -23,17 +24,19 @@ final readonly class ListNotesHandler
 
         $output = $this->useCase->execute(new ListNotesInput($pagination->limit, $pagination->offset));
 
-        return $this->response->create([
-            'items' => array_map(
-                static fn (ListNoteItem $item) => [
-                    'id' => $item->id,
-                    'title' => $item->title,
-                    'body' => $item->body,
-                ],
-                $output->items,
-            ),
-            'limit' => $output->limit,
-            'offset' => $output->offset,
-        ]);
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (ListNoteItem $item) => [
+                        'id'    => $item->id,
+                        'title' => $item->title,
+                        'body'  => $item->body,
+                    ],
+                    $output->items,
+                ),
+                limit:  $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
     }
 }

--- a/src/Example/Tag/ListTagsHandler.php
+++ b/src/Example/Tag/ListTagsHandler.php
@@ -6,6 +6,7 @@ namespace Nene2\Example\Tag;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -23,13 +24,15 @@ final readonly class ListTagsHandler
 
         $output = $this->useCase->execute(new ListTagsInput($pagination->limit, $pagination->offset));
 
-        return $this->response->create([
-            'items' => array_map(
-                static fn (ListTagItem $item) => ['id' => $item->id, 'name' => $item->name],
-                $output->items,
-            ),
-            'limit' => $output->limit,
-            'offset' => $output->offset,
-        ]);
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (ListTagItem $item) => ['id' => $item->id, 'name' => $item->name],
+                    $output->items,
+                ),
+                limit:  $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
     }
 }

--- a/src/Http/PaginationResponse.php
+++ b/src/Http/PaginationResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+/**
+ * Standardised list-endpoint response envelope for paginated collections.
+ *
+ * Wraps the serialised items array with pagination metadata. The `$total` field is optional:
+ * omit it when the repository does not perform a COUNT query; include it when the total record
+ * count is available so that clients can determine the last page without an extra request.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ *
+ * @see PaginationQuery
+ * @see PaginationQueryParser
+ */
+final readonly class PaginationResponse
+{
+    /**
+     * @param list<mixed> $items Serialised resource items (already converted to arrays).
+     * @param int $limit         The effective limit that was applied.
+     * @param int $offset        The effective offset that was applied.
+     * @param int|null $total    Total number of matching records, or null when not counted.
+     */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public int $offset,
+        public ?int $total = null,
+    ) {
+    }
+
+    /**
+     * Returns the response payload ready to pass to {@see JsonResponseFactory::create()}.
+     *
+     * The `total` key is present only when a non-null value was provided.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'items'  => $this->items,
+            'limit'  => $this->limit,
+            'offset' => $this->offset,
+        ];
+
+        if ($this->total !== null) {
+            $data['total'] = $this->total;
+        }
+
+        return $data;
+    }
+}

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -42,6 +42,8 @@ final readonly class RuntimeApplicationFactory
      * @param list<DomainExceptionHandlerInterface> $domainExceptionHandlers
      * @param list<callable(Router): void> $routeRegistrars
      * @param list<HealthCheckInterface> $healthChecks
+     * @param bool $debug When true, unhandled exception messages are exposed in 500 `detail`.
+     *                    Never set to true in production.
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
@@ -54,6 +56,7 @@ final readonly class RuntimeApplicationFactory
         private ?BearerTokenMiddleware $bearerTokenMiddleware = null,
         private array $healthChecks = [],
         private ?ThrottleMiddleware $throttleMiddleware = null,
+        private bool $debug = false,
     ) {
     }
 
@@ -152,7 +155,7 @@ final readonly class RuntimeApplicationFactory
             new RequestLoggingMiddleware($logger),
             new SecurityHeadersMiddleware(),
             new CorsMiddleware($this->responseFactory),
-            new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers),
+            new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers, $this->debug),
             new RequestSizeLimitMiddleware($problemDetails),
             new ApiKeyAuthenticationMiddleware($problemDetails, $this->machineApiKey, ['/machine/health']),
         ];

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -253,6 +253,9 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         $requestIdHolder,
                         [$noteRegistrar, $tagRegistrar],
                         $bearerMiddleware,
+                        [],
+                        null,
+                        $config->debug,
                     );
                 },
             )

--- a/tests/Error/ErrorHandlerMiddlewareTest.php
+++ b/tests/Error/ErrorHandlerMiddlewareTest.php
@@ -168,6 +168,48 @@ final class ErrorHandlerMiddlewareTest extends TestCase
         self::assertSame('Internal Server Error', $payload['title']);
     }
 
+    public function testDebugModeExposesExceptionMessageInDetail(): void
+    {
+        $middleware = new ErrorHandlerMiddleware($this->problemDetails, [], debug: true);
+        $request = $this->factory->createServerRequest('GET', 'https://example.test/crash');
+
+        $response = $middleware->process(
+            $request,
+            new class () implements RequestHandlerInterface {
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    throw new RuntimeException('database connection refused');
+                }
+            },
+        );
+
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(500, $response->getStatusCode());
+        self::assertSame('database connection refused', $payload['detail']);
+    }
+
+    public function testNonDebugModeHidesExceptionMessage(): void
+    {
+        $middleware = new ErrorHandlerMiddleware($this->problemDetails, [], debug: false);
+        $request = $this->factory->createServerRequest('GET', 'https://example.test/crash');
+
+        $response = $middleware->process(
+            $request,
+            new class () implements RequestHandlerInterface {
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    throw new RuntimeException('database connection refused');
+                }
+            },
+        );
+
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(500, $response->getStatusCode());
+        self::assertSame('The server encountered an unexpected condition.', $payload['detail']);
+    }
+
     public function testSuccessPassthroughIsUnmodified(): void
     {
         $middleware = new ErrorHandlerMiddleware($this->problemDetails);

--- a/tests/Http/PaginationResponseTest.php
+++ b/tests/Http/PaginationResponseTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\PaginationResponse;
+use PHPUnit\Framework\TestCase;
+
+final class PaginationResponseTest extends TestCase
+{
+    public function testToArrayWithoutTotal(): void
+    {
+        $response = new PaginationResponse(
+            items:  [['id' => 1], ['id' => 2]],
+            limit:  20,
+            offset: 0,
+        );
+
+        $array = $response->toArray();
+
+        self::assertSame([['id' => 1], ['id' => 2]], $array['items']);
+        self::assertSame(20, $array['limit']);
+        self::assertSame(0, $array['offset']);
+        self::assertArrayNotHasKey('total', $array);
+    }
+
+    public function testToArrayWithTotal(): void
+    {
+        $response = new PaginationResponse(
+            items:  [['id' => 1]],
+            limit:  10,
+            offset: 20,
+            total:  42,
+        );
+
+        $array = $response->toArray();
+
+        self::assertSame(10, $array['limit']);
+        self::assertSame(20, $array['offset']);
+        self::assertSame(42, $array['total']);
+    }
+
+    public function testTotalNullOmitsKey(): void
+    {
+        $response = new PaginationResponse(items: [], limit: 20, offset: 0, total: null);
+
+        self::assertArrayNotHasKey('total', $response->toArray());
+    }
+
+    public function testTotalZeroIsIncluded(): void
+    {
+        $response = new PaginationResponse(items: [], limit: 20, offset: 0, total: 0);
+
+        self::assertSame(0, $response->toArray()['total']);
+    }
+}


### PR DESCRIPTION
## 概要

FT10 フォローアップ Phase 61 — hoplog の F-7 / F-8 に対応する機能追加 2 件。

- **#426**: `APP_DEBUG=true` 時に 500 エラーの `detail` フィールドへ例外メッセージを含める  
- **#429**: `PaginationResponse` readonly DTO を追加し、ページネーション応答を標準化 (オプション `total` フィールド付き)

## 変更点

### ErrorHandlerMiddleware / RuntimeApplicationFactory / RuntimeServiceProvider

- `ErrorHandlerMiddleware` に `bool $debug = false` コンストラクタ引数を追加
- `debug=true` 時: `Throwable::getMessage()` を 500 detail に含める
- `debug=false` 時 (デフォルト): 従来どおり汎用メッセージのみ
- `RuntimeApplicationFactory` → `RuntimeServiceProvider` を通じて `AppConfig::$debug` を伝播

### PaginationResponse DTO

- `Nene2\Http\PaginationResponse` を新設 (public API, ADR 0009 安定性保証対象)
- `items`, `limit`, `offset`, `?total` フィールド
- `total=null` (デフォルト) 時は JSON キーを省略; `total=0` は明示的に含める
- `ListNotesHandler` / `ListTagsHandler` を `PaginationResponse::toArray()` 利用に変更

### ドキュメント

- `docs/howto/add-pagination.md` に Step 4 (PaginationResponse) + Step 5 (total) を追加
- 同内容を JA / DE / FR / ZH / PT-BR の 5 ロケールに反映

## 検証

```
212 tests, 655 assertions — OK
PHPStan (level 8): No errors
CS-Fixer: 0 fixable files
OpenAPI: valid
MCP: valid
```

Closes #426  
Closes #429

Self-review: backend-api, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)