### PR TITLE
docs(howto): SQLite スキーマ初期化パターンをドキュメント化する (#432)

### DIFF
--- a/docs/de/howto/add-database-endpoint.md
+++ b/docs/de/howto/add-database-endpoint.md
@@ -267,6 +267,57 @@ if ($price <= 0) {
 
 ---
 
+## SQLite-Datenbank initialisieren
+
+Bei `DB_ADAPTER=sqlite` wird die `.db`-Datei automatisch erstellt, aber das Schema muss
+manuell eingespielt werden. Zwei gängige Muster:
+
+### Muster A — `composer db:init`-Skript (empfohlen)
+
+`database/schema.sql` erstellen:
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    name  TEXT    NOT NULL,
+    price INTEGER NOT NULL
+);
+```
+
+Skript in `composer.json` eintragen:
+
+```json
+{
+    "scripts": {
+        "db:init": "php -r \"$pdo = new PDO('sqlite:' . getenv('DB_NAME')); $pdo->exec(file_get_contents('database/schema.sql')); echo 'Schema applied.' . PHP_EOL;\""
+    }
+}
+```
+
+Einmalig vor dem Serverstart ausführen:
+
+```bash
+DB_NAME=./myapp.db composer db:init
+```
+
+### Muster B — Auto-Initialisierung im Front-Controller
+
+Für kleine Projekte: Dateiexistenz in `public_html/index.php` prüfen:
+
+```php
+// Schema beim ersten Start automatisch einspielen.
+$dbFile = getenv('DB_NAME') ?: ':memory:';
+if ($dbFile !== ':memory:' && !file_exists($dbFile)) {
+    $pdo = new PDO('sqlite:' . $dbFile);
+    $pdo->exec((string) file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+}
+```
+
+> **Abwägung**: Muster A macht die Initialisierung explizit und ist in CI reproduzierbar.
+> Muster B ist in der Entwicklung bequem, koppelt aber Startlogik an den Front-Controller.
+
+---
+
 ## Nächste Schritte
 
 - OpenAPI-Dokumentation für Ihren Endpoint hinzufügen: siehe `docs/development/endpoint-scaffold.md`

--- a/docs/fr/howto/add-database-endpoint.md
+++ b/docs/fr/howto/add-database-endpoint.md
@@ -267,6 +267,57 @@ if ($price <= 0) {
 
 ---
 
+## Initialiser une base de données SQLite
+
+Avec `DB_ADAPTER=sqlite`, le fichier `.db` est créé automatiquement, mais le schéma doit
+être appliqué manuellement. Deux approches courantes :
+
+### Approche A — script `composer db:init` (recommandée)
+
+Créer `database/schema.sql` :
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    name  TEXT    NOT NULL,
+    price INTEGER NOT NULL
+);
+```
+
+Ajouter un script dans `composer.json` :
+
+```json
+{
+    "scripts": {
+        "db:init": "php -r \"$pdo = new PDO('sqlite:' . getenv('DB_NAME')); $pdo->exec(file_get_contents('database/schema.sql')); echo 'Schema applied.' . PHP_EOL;\""
+    }
+}
+```
+
+Exécuter une fois avant de démarrer le serveur :
+
+```bash
+DB_NAME=./myapp.db composer db:init
+```
+
+### Approche B — auto-initialisation dans le contrôleur frontal
+
+Pour les petits projets, vérifier l'existence du fichier dans `public_html/index.php` :
+
+```php
+// Appliquer le schéma SQLite automatiquement au premier démarrage.
+$dbFile = getenv('DB_NAME') ?: ':memory:';
+if ($dbFile !== ':memory:' && !file_exists($dbFile)) {
+    $pdo = new PDO('sqlite:' . $dbFile);
+    $pdo->exec((string) file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+}
+```
+
+> **Compromis** : l'approche A rend l'initialisation explicite et reproductible en CI.
+> L'approche B est commode en développement mais couple la logique de démarrage au contrôleur frontal.
+
+---
+
 ## Étapes suivantes
 
 - Ajouter la documentation OpenAPI pour votre endpoint : voir `docs/development/endpoint-scaffold.md`

--- a/docs/howto/add-database-endpoint.md
+++ b/docs/howto/add-database-endpoint.md
@@ -297,6 +297,59 @@ The resulting response body:
 
 ---
 
+## Initialize a SQLite database
+
+When using SQLite (`DB_ADAPTER=sqlite`), there is no server to create the database; the `.db`
+file is created on demand. You are responsible for applying the schema before the first request.
+Two common patterns:
+
+### Pattern A — `composer db:init` script (recommended)
+
+Create `database/schema.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    name  TEXT    NOT NULL,
+    price INTEGER NOT NULL
+);
+```
+
+Add a script to `composer.json`:
+
+```json
+{
+    "scripts": {
+        "db:init": "php -r \"$pdo = new PDO('sqlite:' . getenv('DB_NAME')); $pdo->exec(file_get_contents('database/schema.sql')); echo 'Schema applied.' . PHP_EOL;\""
+    }
+}
+```
+
+Run once before starting the server:
+
+```bash
+DB_NAME=./myapp.db composer db:init
+```
+
+### Pattern B — Auto-initialize in the front controller
+
+For small projects, check whether the file exists inside `public_html/index.php` before
+creating the application:
+
+```php
+// Auto-create the SQLite schema on first run.
+$dbFile = getenv('DB_NAME') ?: ':memory:';
+if ($dbFile !== ':memory:' && !file_exists($dbFile)) {
+    $pdo = new PDO('sqlite:' . $dbFile);
+    $pdo->exec((string) file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+}
+```
+
+> **Trade-off**: Pattern A makes schema initialization explicit and easy to repeat in CI.
+> Pattern B is convenient for development but couples startup logic to the front controller.
+
+---
+
 ## Next steps
 
 - Add OpenAPI documentation for your endpoint: see `docs/development/endpoint-scaffold.md`

--- a/docs/ja/howto/add-database-endpoint.md
+++ b/docs/ja/howto/add-database-endpoint.md
@@ -273,6 +273,57 @@ if ($price <= 0) {
 
 ---
 
+## SQLite データベースの初期化
+
+`DB_ADAPTER=sqlite` を使用する場合、データベースファイルは自動作成されますが、
+スキーマの適用は開発者が行う必要があります。よく使われる 2 つのパターンを示します。
+
+### パターン A — `composer db:init` スクリプト（推奨）
+
+`database/schema.sql` を作成する:
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    name  TEXT    NOT NULL,
+    price INTEGER NOT NULL
+);
+```
+
+`composer.json` にスクリプトを追加する:
+
+```json
+{
+    "scripts": {
+        "db:init": "php -r \"$pdo = new PDO('sqlite:' . getenv('DB_NAME')); $pdo->exec(file_get_contents('database/schema.sql')); echo 'Schema applied.' . PHP_EOL;\""
+    }
+}
+```
+
+サーバー起動前に一度実行する:
+
+```bash
+DB_NAME=./myapp.db composer db:init
+```
+
+### パターン B — フロントコントローラーで自動初期化
+
+小規模プロジェクト向けに、`public_html/index.php` でファイルの存在を確認する:
+
+```php
+// 初回起動時に SQLite スキーマを自動適用する。
+$dbFile = getenv('DB_NAME') ?: ':memory:';
+if ($dbFile !== ':memory:' && !file_exists($dbFile)) {
+    $pdo = new PDO('sqlite:' . $dbFile);
+    $pdo->exec((string) file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+}
+```
+
+> **トレードオフ**: パターン A は初期化を明示的にし CI で再現しやすい。
+> パターン B は開発時に便利だが、起動ロジックがフロントコントローラーに混入する。
+
+---
+
 ## 次のステップ
 
 - エンドポイントの OpenAPI ドキュメントを追加する: `docs/development/endpoint-scaffold.md` を参照

--- a/docs/pt-br/howto/add-database-endpoint.md
+++ b/docs/pt-br/howto/add-database-endpoint.md
@@ -267,6 +267,57 @@ if ($price <= 0) {
 
 ---
 
+## Inicializar um banco de dados SQLite
+
+Com `DB_ADAPTER=sqlite`, o arquivo `.db` é criado automaticamente, mas o schema precisa ser
+aplicado manualmente. Dois padrões comuns:
+
+### Padrão A — script `composer db:init` (recomendado)
+
+Criar `database/schema.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    name  TEXT    NOT NULL,
+    price INTEGER NOT NULL
+);
+```
+
+Adicionar um script em `composer.json`:
+
+```json
+{
+    "scripts": {
+        "db:init": "php -r \"$pdo = new PDO('sqlite:' . getenv('DB_NAME')); $pdo->exec(file_get_contents('database/schema.sql')); echo 'Schema applied.' . PHP_EOL;\""
+    }
+}
+```
+
+Executar uma vez antes de iniciar o servidor:
+
+```bash
+DB_NAME=./myapp.db composer db:init
+```
+
+### Padrão B — auto-inicialização no controlador frontal
+
+Para projetos pequenos, verificar se o arquivo existe em `public_html/index.php`:
+
+```php
+// Aplicar o schema SQLite automaticamente na primeira execução.
+$dbFile = getenv('DB_NAME') ?: ':memory:';
+if ($dbFile !== ':memory:' && !file_exists($dbFile)) {
+    $pdo = new PDO('sqlite:' . $dbFile);
+    $pdo->exec((string) file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+}
+```
+
+> **Compromisso**: o padrão A torna a inicialização explícita e reproduzível no CI.
+> O padrão B é conveniente no desenvolvimento, mas acopla a lógica de inicialização ao controlador frontal.
+
+---
+
 ## Próximos passos
 
 - Adicionar documentação OpenAPI para seu endpoint: veja `docs/development/endpoint-scaffold.md`

--- a/docs/zh/howto/add-database-endpoint.md
+++ b/docs/zh/howto/add-database-endpoint.md
@@ -266,6 +266,57 @@ if ($price <= 0) {
 
 ---
 
+## 初始化 SQLite 数据库
+
+使用 `DB_ADAPTER=sqlite` 时，`.db` 文件会自动创建，但需要手动应用 Schema。
+以下是两种常见模式：
+
+### 模式 A — `composer db:init` 脚本（推荐）
+
+创建 `database/schema.sql`：
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    name  TEXT    NOT NULL,
+    price INTEGER NOT NULL
+);
+```
+
+在 `composer.json` 中添加脚本：
+
+```json
+{
+    "scripts": {
+        "db:init": "php -r \"$pdo = new PDO('sqlite:' . getenv('DB_NAME')); $pdo->exec(file_get_contents('database/schema.sql')); echo 'Schema applied.' . PHP_EOL;\""
+    }
+}
+```
+
+启动服务器前运行一次：
+
+```bash
+DB_NAME=./myapp.db composer db:init
+```
+
+### 模式 B — 在前端控制器中自动初始化
+
+对于小项目，在 `public_html/index.php` 中检查文件是否存在：
+
+```php
+// 首次启动时自动应用 SQLite Schema。
+$dbFile = getenv('DB_NAME') ?: ':memory:';
+if ($dbFile !== ':memory:' && !file_exists($dbFile)) {
+    $pdo = new PDO('sqlite:' . $dbFile);
+    $pdo->exec((string) file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+}
+```
+
+> **权衡**：模式 A 使初始化显式化，便于在 CI 中复现。
+> 模式 B 开发时方便，但将启动逻辑耦合到了前端控制器。
+
+---
+
 ## 下一步
 
 - 为您的端点添加 OpenAPI 文档：参见 `docs/development/endpoint-scaffold.md`


### PR DESCRIPTION
## 概要

Field Trial 10 の摩擦点 F-6 への対応。

> **F-6**: ローカル開発において SQLite のスキーマ初期化を自動化する薄いユーティリティがあると便利。現状は新規プロジェクト側で自前実装が必要。

## 変更点

`docs/howto/add-database-endpoint.md`（EN/JA/DE/FR/ZH/PT-BR）に「SQLite データベースの初期化」セクションを追加:

- **パターン A**: `composer db:init` スクリプト（`database/schema.sql` + `composer.json` scripts）— 推奨
- **パターン B**: `public_html/index.php` でのファイル存在チェックによる自動初期化 — 小規模プロジェクト向け

各パターンにトレードオフの注記を付属。

## 検証

```
212 tests, 655 assertions — OK
PHPStan (level 8): No errors
CS-Fixer: 0 fixable files
OpenAPI: valid / MCP: valid
```

Closes #432

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)