### PR TITLE
feat(auth): BearerTokenMiddleware に $excludedPaths（ブラックリスト）オプションを追加

### DIFF
--- a/src/Auth/BearerTokenMiddleware.php
+++ b/src/Auth/BearerTokenMiddleware.php
@@ -14,17 +14,26 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Validates the `Authorization: Bearer <token>` header using a {@see TokenVerifierInterface}.
  * Returns 401 Problem Details if the header is absent or the token fails verification.
  *
+ * Path matching modes (mutually exclusive — `$protectedPaths` takes precedence):
+ *
+ * - **Protect all** (default): both arrays empty → every path requires a token.
+ * - **Allowlist** (`$protectedPaths`): only the listed exact paths are protected.
+ * - **Blocklist** (`$excludedPaths`): all paths are protected *except* the listed exact paths.
+ *   Ideal when public paths (e.g. `/auth/register`, `/auth/login`) are the minority.
+ *
  * Part of the public API stability guarantee (see ADR 0009).
  */
 final readonly class BearerTokenMiddleware implements MiddlewareInterface
 {
     /**
-     * @param list<string> $protectedPaths Restrict protection to these paths. Empty list protects all paths.
+     * @param list<string> $protectedPaths Exact paths to protect (allowlist). Empty = no allowlist filtering.
+     * @param list<string> $excludedPaths  Exact paths to skip authentication (blocklist). Ignored when $protectedPaths is non-empty.
      */
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
         private TokenVerifierInterface $verifier,
         private array $protectedPaths = [],
+        private array $excludedPaths = [],
     ) {
     }
 
@@ -61,13 +70,17 @@ final readonly class BearerTokenMiddleware implements MiddlewareInterface
 
     private function requiresAuthentication(ServerRequestInterface $request): bool
     {
-        if ($this->protectedPaths === []) {
-            return true;
-        }
-
         $path = $request->getUri()->getPath() ?: '/';
 
-        return in_array($path, $this->protectedPaths, true);
+        if ($this->protectedPaths !== []) {
+            return in_array($path, $this->protectedPaths, true);
+        }
+
+        if ($this->excludedPaths !== []) {
+            return !in_array($path, $this->excludedPaths, true);
+        }
+
+        return true;
     }
 
     private function unauthorized(ServerRequestInterface $request, string $error, string $description): ResponseInterface

--- a/tests/Auth/BearerTokenMiddlewareTest.php
+++ b/tests/Auth/BearerTokenMiddlewareTest.php
@@ -103,12 +103,103 @@ final class BearerTokenMiddlewareTest extends TestCase
         self::assertSame($claims, $capture->request->getAttribute('nene2.auth.claims'));
     }
 
+    public function testProtectedPathsAllowlistSkipsUnlistedPath(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $this->acceptingVerifier(),
+            protectedPaths: ['/protected'],
+        );
+        $request = $factory->createServerRequest('GET', 'https://example.test/public');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testProtectedPathsAllowlistEnforcesListedPath(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $this->acceptingVerifier(),
+            protectedPaths: ['/protected'],
+        );
+        $request = $factory->createServerRequest('GET', 'https://example.test/protected');
+
+        $response = $middleware->process($request, $this->failHandler());
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function testExcludedPathsBlocklistSkipsExcludedPath(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $this->acceptingVerifier(),
+            excludedPaths: ['/auth/register', '/auth/login'],
+        );
+        $request = $factory->createServerRequest('POST', 'https://example.test/auth/register');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testExcludedPathsBlocklistEnforcesNonExcludedPath(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $this->acceptingVerifier(),
+            excludedPaths: ['/auth/register', '/auth/login'],
+        );
+        $request = $factory->createServerRequest('GET', 'https://example.test/tasks/1');
+
+        $response = $middleware->process($request, $this->failHandler());
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function testProtectedPathsTakesPrecedenceOverExcludedPaths(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $this->acceptingVerifier(),
+            protectedPaths: ['/protected'],
+            excludedPaths: ['/protected'],
+        );
+        // $protectedPaths wins: path is in the allowlist → must authenticate
+        $request = $factory->createServerRequest('GET', 'https://example.test/protected');
+
+        $response = $middleware->process($request, $this->failHandler());
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
     private function makeMiddleware(Psr17Factory $factory, TokenVerifierInterface $verifier): BearerTokenMiddleware
     {
         return new BearerTokenMiddleware(
             new ProblemDetailsResponseFactory($factory, $factory),
             $verifier,
         );
+    }
+
+    private function okHandler(Psr17Factory $factory): RequestHandlerInterface
+    {
+        return new class ($factory) implements RequestHandlerInterface {
+            public function __construct(private readonly Psr17Factory $factory)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse(200);
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
## Summary

- `BearerTokenMiddleware` に `$excludedPaths` パラメータを追加
- 全パス保護しつつ特定パス（`/auth/register` 等）だけを除外可能に
- `$protectedPaths`（アローリスト）が指定された場合は優先 → 後方互換あり

## パスマッチングモード

| `$protectedPaths` | `$excludedPaths` | 動作 |
|---|---|---|
| 空（デフォルト） | 空（デフォルト） | 全パス保護 |
| 非空 | — | 列挙パスのみ保護（アローリスト） |
| 空 | 非空 | 全パス保護、除外パスはスキップ（ブラックリスト） |
| 非空 | 非空 | `$protectedPaths` 優先 |

## 使用例（FT11 tasklog ユースケース）

```php
new BearerTokenMiddleware(
    $problemDetails,
    $verifier,
    excludedPaths: ['/auth/register', '/auth/login'],
);
```

## Test plan

- [x] 9/9 テスト通過（5 件新規追加）
- [x] PHPStan level 8 clean
- [x] PHP-CS-Fixer clean
- [x] `composer check` 全通過（217 tests）

Closes #440

Self-review: middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)