### PR TITLE
feat(auth): TokenIssuerInterface を公開 API に追加

### DIFF
--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -58,7 +58,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException` |
 | `Nene2\Error` | `DomainExceptionHandlerInterface`, `ProblemDetailsResponseFactory` |
-| `Nene2\Auth` | `TokenVerifierInterface`, `TokenVerificationException`, `BearerTokenMiddleware` |
+| `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware` |
 | `Nene2\Middleware` | All shipped middleware classes, `RateLimitStorageInterface`, `ThrottleMiddleware` |
 | `Nene2\Validation` | `ValidationException`, `ValidationError` |
 | `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |

--- a/src/Auth/LocalBearerTokenVerifier.php
+++ b/src/Auth/LocalBearerTokenVerifier.php
@@ -6,11 +6,12 @@ namespace Nene2\Auth;
 
 /**
  * @internal
- * HMAC-HS256 JWT verifier for local development.
+ * HMAC-HS256 JWT verifier and issuer for local development.
  * Uses no external library — suitable only for controlled local environments.
- * Production deployments should inject a library-backed TokenVerifierInterface.
+ * Production deployments should inject library-backed implementations of
+ * {@see TokenVerifierInterface} and {@see TokenIssuerInterface}.
  */
-final readonly class LocalBearerTokenVerifier implements TokenVerifierInterface
+final readonly class LocalBearerTokenVerifier implements TokenVerifierInterface, TokenIssuerInterface
 {
     public function __construct(private string $secret)
     {

--- a/src/Auth/TokenIssuerInterface.php
+++ b/src/Auth/TokenIssuerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+/**
+ * Issues a signed bearer token string from the given claims.
+ *
+ * Implementations are responsible for encoding and signing the token.
+ * The local development implementation ({@see LocalBearerTokenVerifier}) uses HMAC-HS256.
+ * Production deployments should inject a library-backed implementation
+ * (e.g. wrapping firebase/php-jwt or lcobucci/jwt).
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+interface TokenIssuerInterface
+{
+    /**
+     * @param array<string, mixed> $claims
+     */
+    public function issue(array $claims): string;
+}


### PR DESCRIPTION
## Summary

- `TokenIssuerInterface` を新規作成（`src/Auth/TokenIssuerInterface.php`）
- `LocalBearerTokenVerifier` が `TokenVerifierInterface` に加え `TokenIssuerInterface` も実装
- ADR 0009 の `Nene2\Auth` 安定 API テーブルに `TokenIssuerInterface` を追記

## 設計

```php
interface TokenIssuerInterface
{
    /** @param array<string, mixed> $claims */
    public function issue(array $claims): string;
}
```

アプリ側でログイン UseCase に `TokenIssuerInterface` を注入することで、`@internal` の `LocalBearerTokenVerifier` に直接依存せずに JWT を発行できる。
本番環境では `firebase/php-jwt` 等を使ったカスタム実装に差し替え可能。

## Test plan

- [x] 217/217 テスト通過
- [x] PHPStan level 8 clean
- [x] PHP-CS-Fixer clean

Closes #442

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)