### PR TITLE
docs(howto): JWT 認証フロー実装ガイドを追加（6言語）

### DIFF
--- a/docs/de/howto/add-jwt-authentication.md
+++ b/docs/de/howto/add-jwt-authentication.md
@@ -1,0 +1,166 @@
+# JWT-Authentifizierung hinzufügen
+
+Diese Anleitung zeigt, wie Sie JWT Bearer-Authentifizierung zu einer NENE2-Anwendung hinzufügen —
+Benutzerregistrierung, Login (Token-Ausstellung) und geschützte Endpunkte.
+
+**Voraussetzung**: Sie haben eine funktionierende NENE2-Anwendung mit mindestens einer Route.
+Falls nicht, beginnen Sie mit [Eine benutzerdefinierte Route hinzufügen](./add-custom-route.md).
+
+---
+
+## Übersicht
+
+NENE2 liefert die benötigten Middleware und Interfaces; Ihre Anwendung stellt den konkreten
+JWT-Issuer, die Verifier-Verdrahtung und die Domain-Logik bereit.
+
+| Klasse / Interface | Rolle |
+|---|---|
+| `TokenIssuerInterface` | Vertrag für die Ausstellung eines signierten JWT |
+| `TokenVerifierInterface` | Vertrag für die Verifikation eines JWT und Rückgabe der Claims |
+| `LocalBearerTokenVerifier` | Entwicklungs-HS256-Implementierung (beide Interfaces) |
+| `BearerTokenMiddleware` | PSR-15-Middleware, die Bearer-Token auf Requests erzwingt |
+| `RuntimeApplicationFactory` | Akzeptiert beliebige `MiddlewareInterface` als `$authMiddleware` |
+
+---
+
+## Schritt 1 — Umgebungsvariable setzen
+
+Fügen Sie `NENE2_LOCAL_JWT_SECRET` zu Ihrer `.env` hinzu:
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-dev-secret-at-least-32-chars
+```
+
+---
+
+## Schritt 2 — Auth-Domain erstellen
+
+### 2a — User-Entity
+
+```php
+final readonly class User
+{
+    public function __construct(
+        public int    $id,
+        public string $email,
+        public string $passwordHash,
+    ) {}
+}
+```
+
+### 2b — Repository-Interface
+
+```php
+interface UserRepositoryInterface
+{
+    public function findByEmail(string $email): ?User;
+    public function create(string $email, string $passwordHash): User;
+}
+```
+
+### 2c — Register-UseCase
+
+```php
+final class RegisterUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        // Validierung, Duplikatprüfung, Passwort-Hashing ...
+        $user  = $this->users->create($email, password_hash($password, PASSWORD_BCRYPT));
+        $token = $this->issuer->issue(['sub' => (string) $user->id, 'email' => $user->email]);
+
+        return ['token' => $token];
+    }
+}
+```
+
+### 2d — Login-UseCase
+
+```php
+final class LoginUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        $user = $this->users->findByEmail($email);
+
+        if ($user === null || !password_verify($password, $user->passwordHash)) {
+            throw new ValidationException([
+                new ValidationError('credentials', 'Invalid email or password.', 'invalid_credentials'),
+            ]);
+        }
+
+        return ['token' => $this->issuer->issue(['sub' => (string) $user->id])];
+    }
+}
+```
+
+---
+
+## Schritt 3 — Bearer-Middleware einbinden
+
+Verwenden Sie `$excludedPaths`, um alle Routen **außer** den öffentlichen Auth-Endpunkten zu schützen:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier:       $verifier,
+    excludedPaths:  ['/auth/register', '/auth/login'],
+);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [$authRegistrar, $taskRegistrar],
+    authMiddleware:  $authMiddleware,
+))->create();
+```
+
+---
+
+## Schritt 4 — Claims im Handler lesen
+
+```php
+$claims = $request->getAttribute('nene2.auth.claims');
+$userId = (int) ($claims['sub'] ?? 0);
+```
+
+---
+
+## Schritt 5 — 403 für fremde Ressourcen zurückgeben
+
+Eigentumsüberprüfungen gehören in den UseCase, nicht in die Middleware:
+
+```php
+if ($task->userId !== $requestingUserId) {
+    throw new AccessDeniedException();
+}
+```
+
+Bilden Sie `AccessDeniedException` über einen `DomainExceptionHandlerInterface` auf 403 ab.
+
+---
+
+## Für die Produktion: JWT-Bibliothek verwenden
+
+Implementieren Sie `TokenVerifierInterface` und `TokenIssuerInterface` mit einer JWT-Bibliothek
+wie `firebase/php-jwt` und injizieren Sie diese statt `LocalBearerTokenVerifier`.
+
+---
+
+## Weiterführende Links
+
+- [ADR 0008 — JWT-Authentifizierung](../adr/0008-jwt-authentication.md)
+- [Rate-Limiting hinzufügen](./add-rate-limiting.md)
+- Englische Vollversion: [add-jwt-authentication.md](../../howto/add-jwt-authentication.md)

--- a/docs/fr/howto/add-jwt-authentication.md
+++ b/docs/fr/howto/add-jwt-authentication.md
@@ -1,0 +1,166 @@
+# Ajouter l'authentification JWT
+
+Ce guide montre comment ajouter l'authentification JWT Bearer à une application NENE2 —
+inscription des utilisateurs, connexion (émission de token) et endpoints protégés.
+
+**Prérequis** : Vous avez une application NENE2 fonctionnelle avec au moins une route.
+Sinon, commencez par [Ajouter une route personnalisée](./add-custom-route.md).
+
+---
+
+## Vue d'ensemble
+
+NENE2 fournit le middleware et les interfaces nécessaires ; votre application fournit
+l'implémentation concrète du JWT issuer, le câblage du verifier et la logique métier.
+
+| Classe / Interface | Rôle |
+|---|---|
+| `TokenIssuerInterface` | Contrat pour émettre un JWT signé |
+| `TokenVerifierInterface` | Contrat pour vérifier un JWT et retourner les claims |
+| `LocalBearerTokenVerifier` | Implémentation HS256 de développement (les deux interfaces) |
+| `BearerTokenMiddleware` | Middleware PSR-15 qui enforce le Bearer token sur les requêtes |
+| `RuntimeApplicationFactory` | Accepte tout `MiddlewareInterface` en tant que `$authMiddleware` |
+
+---
+
+## Étape 1 — Configurer la variable d'environnement
+
+Ajoutez `NENE2_LOCAL_JWT_SECRET` à votre `.env` :
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-dev-secret-at-least-32-chars
+```
+
+---
+
+## Étape 2 — Créer le domaine Auth
+
+### 2a — Entité User
+
+```php
+final readonly class User
+{
+    public function __construct(
+        public int    $id,
+        public string $email,
+        public string $passwordHash,
+    ) {}
+}
+```
+
+### 2b — Interface du repository
+
+```php
+interface UserRepositoryInterface
+{
+    public function findByEmail(string $email): ?User;
+    public function create(string $email, string $passwordHash): User;
+}
+```
+
+### 2c — UseCase Register
+
+```php
+final class RegisterUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        // Validation, vérification des doublons, hachage du mot de passe ...
+        $user  = $this->users->create($email, password_hash($password, PASSWORD_BCRYPT));
+        $token = $this->issuer->issue(['sub' => (string) $user->id, 'email' => $user->email]);
+
+        return ['token' => $token];
+    }
+}
+```
+
+### 2d — UseCase Login
+
+```php
+final class LoginUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        $user = $this->users->findByEmail($email);
+
+        if ($user === null || !password_verify($password, $user->passwordHash)) {
+            throw new ValidationException([
+                new ValidationError('credentials', 'Invalid email or password.', 'invalid_credentials'),
+            ]);
+        }
+
+        return ['token' => $this->issuer->issue(['sub' => (string) $user->id])];
+    }
+}
+```
+
+---
+
+## Étape 3 — Intégrer le middleware Bearer
+
+Utilisez `$excludedPaths` pour protéger toutes les routes **sauf** les endpoints publics :
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier:       $verifier,
+    excludedPaths:  ['/auth/register', '/auth/login'],
+);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [$authRegistrar, $taskRegistrar],
+    authMiddleware:  $authMiddleware,
+))->create();
+```
+
+---
+
+## Étape 4 — Lire les claims dans un handler
+
+```php
+$claims = $request->getAttribute('nene2.auth.claims');
+$userId = (int) ($claims['sub'] ?? 0);
+```
+
+---
+
+## Étape 5 — Retourner 403 pour les ressources d'autres utilisateurs
+
+Les vérifications de propriété appartiennent au UseCase, pas au middleware :
+
+```php
+if ($task->userId !== $requestingUserId) {
+    throw new AccessDeniedException();
+}
+```
+
+Mappez `AccessDeniedException` vers 403 via un `DomainExceptionHandlerInterface`.
+
+---
+
+## Pour la production : utiliser une bibliothèque JWT
+
+Implémentez `TokenVerifierInterface` et `TokenIssuerInterface` avec une bibliothèque JWT
+comme `firebase/php-jwt` et injectez-la à la place de `LocalBearerTokenVerifier`.
+
+---
+
+## Références
+
+- [ADR 0008 — Authentification JWT](../adr/0008-jwt-authentication.md)
+- [Ajouter la limitation de débit](./add-rate-limiting.md)
+- Version complète en anglais : [add-jwt-authentication.md](../../howto/add-jwt-authentication.md)

--- a/docs/howto/add-jwt-authentication.md
+++ b/docs/howto/add-jwt-authentication.md
@@ -1,0 +1,452 @@
+# Add JWT Authentication
+
+This guide shows how to add JWT Bearer authentication to a NENE2 application — user
+registration, login (token issuance), and protected endpoints.
+
+**Prerequisite**: You have a working NENE2 application with at least one route. If not,
+start with [Add a custom route](./add-custom-route.md).
+
+---
+
+## Overview
+
+NENE2 ships the middleware and interfaces you need; your application provides the
+concrete JWT issuer, verifier wiring, and domain logic.
+
+```
+POST /auth/register   →  create user, return 201
+POST /auth/login      →  verify password, issue JWT, return token
+GET  /tasks           →  protected — requires Bearer token
+POST /tasks           →  protected — requires Bearer token
+GET  /tasks/{id}      →  protected — requires Bearer token
+```
+
+The framework pieces:
+
+| Class / Interface | Role |
+|---|---|
+| `TokenIssuerInterface` | Contract for issuing a signed JWT |
+| `TokenVerifierInterface` | Contract for verifying a JWT and returning claims |
+| `LocalBearerTokenVerifier` | Dev-only HS256 implementation of both interfaces |
+| `BearerTokenMiddleware` | PSR-15 middleware that enforces Bearer token on requests |
+| `RuntimeApplicationFactory` | Accepts any `MiddlewareInterface` as `$authMiddleware` |
+
+---
+
+## Step 1 — Wire the environment variable
+
+Add `NENE2_LOCAL_JWT_SECRET` to your `.env`:
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-dev-secret-at-least-32-chars
+```
+
+For production replace `LocalBearerTokenVerifier` with a library-backed implementation
+(see [Swap to a production JWT library](#swap-to-a-production-jwt-library) below).
+
+---
+
+## Step 2 — Create the Auth domain
+
+### 2a — User entity
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+final readonly class User
+{
+    public function __construct(
+        public int    $id,
+        public string $email,
+        public string $passwordHash,
+    ) {}
+}
+```
+
+### 2b — Repository interface
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+interface UserRepositoryInterface
+{
+    public function findByEmail(string $email): ?User;
+    public function create(string $email, string $passwordHash): User;
+}
+```
+
+### 2c — Register use case
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+final class RegisterUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        $errors = [];
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = new ValidationError('email', 'Must be a valid email address.', 'invalid_email');
+        }
+
+        if (strlen($password) < 8) {
+            $errors[] = new ValidationError('password', 'Must be at least 8 characters.', 'too_short');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        if ($this->users->findByEmail($email) !== null) {
+            throw new ValidationException([
+                new ValidationError('email', 'Email is already registered.', 'duplicate_email'),
+            ]);
+        }
+
+        $user  = $this->users->create($email, password_hash($password, PASSWORD_BCRYPT));
+        $token = $this->issuer->issue(['sub' => (string) $user->id, 'email' => $user->email]);
+
+        return ['token' => $token];
+    }
+}
+```
+
+### 2d — Login use case
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+final class LoginUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        $user = $this->users->findByEmail($email);
+
+        if ($user === null || !password_verify($password, $user->passwordHash)) {
+            throw new ValidationException([
+                new ValidationError('credentials', 'Invalid email or password.', 'invalid_credentials'),
+            ]);
+        }
+
+        $token = $this->issuer->issue(['sub' => (string) $user->id, 'email' => $user->email]);
+
+        return ['token' => $token];
+    }
+}
+```
+
+---
+
+## Step 3 — Create the HTTP handler
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class AuthRouteRegistrar
+{
+    public function __construct(
+        private RegisterUseCase $register,
+        private LoginUseCase    $login,
+    ) {}
+
+    public function __invoke(Router $router): void
+    {
+        $router->post('/auth/register', $this->handleRegister(...));
+        $router->post('/auth/login',    $this->handleLogin(...));
+    }
+
+    private function handleRegister(ServerRequestInterface $request): mixed
+    {
+        $body     = (array) $request->getParsedBody();
+        $email    = is_string($body['email'] ?? null)    ? $body['email']    : '';
+        $password = is_string($body['password'] ?? null) ? $body['password'] : '';
+
+        return $this->register->execute($email, $password);
+    }
+
+    private function handleLogin(ServerRequestInterface $request): mixed
+    {
+        $body     = (array) $request->getParsedBody();
+        $email    = is_string($body['email'] ?? null)    ? $body['email']    : '';
+        $password = is_string($body['password'] ?? null) ? $body['password'] : '';
+
+        return $this->login->execute($email, $password);
+    }
+}
+```
+
+> The router handler can return an array — NENE2 serialises it to JSON automatically.
+
+---
+
+## Step 4 — Wire the Bearer middleware
+
+Use `$excludedPaths` to protect all routes **except** the public auth endpoints.
+This avoids the need to enumerate every protected path individually.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+
+$psr17      = new Psr17Factory();
+$problems   = new ProblemDetailsResponseFactory($psr17, $psr17);
+$jwtSecret  = (string) getenv('NENE2_LOCAL_JWT_SECRET');
+$verifier   = new LocalBearerTokenVerifier($jwtSecret);
+$issuer     = $verifier;  // LocalBearerTokenVerifier implements both interfaces
+
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier:       $verifier,
+    excludedPaths:  ['/auth/register', '/auth/login'],
+);
+
+$authRegistrar = new AuthRouteRegistrar(
+    new RegisterUseCase($userRepository, $issuer),
+    new LoginUseCase($userRepository, $issuer),
+);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars:  [$authRegistrar, $taskRegistrar],
+    authMiddleware:   $authMiddleware,
+))->create();
+```
+
+---
+
+## Step 5 — Read claims in a protected handler
+
+After `BearerTokenMiddleware` verifies the token it stores the decoded claims as a
+request attribute. Read them in your handler:
+
+```php
+$claims = $request->getAttribute('nene2.auth.claims');
+$userId = (int) ($claims['sub'] ?? 0);
+```
+
+Use the `sub` claim to scope queries to the authenticated user:
+
+```php
+$router->get('/tasks', function (ServerRequestInterface $request) use ($listTasks): mixed {
+    $claims = $request->getAttribute('nene2.auth.claims');
+    $userId = (int) ($claims['sub'] ?? 0);
+
+    return $listTasks->execute($userId);
+});
+```
+
+---
+
+## Step 6 — Return 403 for other users' resources
+
+Ownership checks belong in the use case, not the middleware:
+
+```php
+final class GetTaskUseCase
+{
+    public function execute(int $taskId, int $requestingUserId): Task
+    {
+        $task = $this->tasks->findById($taskId)
+            ?? throw new TaskNotFoundException($taskId);
+
+        if ($task->userId !== $requestingUserId) {
+            throw new AccessDeniedException();
+        }
+
+        return $task;
+    }
+}
+```
+
+Map `AccessDeniedException` to 403 with a domain exception handler:
+
+```php
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class AccessDeniedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function handles(\Throwable $e): bool
+    {
+        return $e instanceof AccessDeniedException;
+    }
+
+    public function handle(
+        \Throwable $e,
+        ServerRequestInterface $request,
+        ProblemDetailsResponseFactory $problemDetails,
+    ): ResponseInterface {
+        return $problemDetails->create($request, 'forbidden', 'Forbidden', 403, 'Access denied.');
+    }
+}
+```
+
+Pass it to `RuntimeApplicationFactory`:
+
+```php
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    domainExceptionHandlers: [new AccessDeniedExceptionHandler()],
+    authMiddleware:          $authMiddleware,
+    routeRegistrars:         [$authRegistrar, $taskRegistrar],
+))->create();
+```
+
+---
+
+## Request / response examples
+
+### Register
+
+```http
+POST /auth/register
+Content-Type: application/json
+
+{"email": "alice@example.com", "password": "s3cr3tpass"}
+```
+
+```json
+{"token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."}
+```
+
+### Login
+
+```http
+POST /auth/login
+Content-Type: application/json
+
+{"email": "alice@example.com", "password": "s3cr3tpass"}
+```
+
+```json
+{"token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."}
+```
+
+### Protected endpoint
+
+```http
+GET /tasks
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...
+```
+
+Without a valid token:
+
+```json
+{
+  "type": "https://nene2.dev/problems/unauthorized",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "No Bearer token was provided."
+}
+```
+
+---
+
+## Swap to a production JWT library
+
+`LocalBearerTokenVerifier` uses no external library and is intentionally limited to
+local development. For production, implement `TokenVerifierInterface` and
+`TokenIssuerInterface` backed by a JWT library:
+
+```php
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+
+final class FirebaseJwtService implements TokenVerifierInterface, TokenIssuerInterface
+{
+    public function __construct(
+        private string $secret,
+        private int    $ttlSeconds = 3600,
+    ) {}
+
+    public function verify(string $token): array
+    {
+        try {
+            return (array) JWT::decode($token, new Key($this->secret, 'HS256'));
+        } catch (\Exception $e) {
+            throw new TokenVerificationException($e->getMessage());
+        }
+    }
+
+    /** @param array<string, mixed> $claims */
+    public function issue(array $claims): string
+    {
+        return JWT::encode(
+            array_merge($claims, ['iat' => time(), 'exp' => time() + $this->ttlSeconds]),
+            $this->secret,
+            'HS256',
+        );
+    }
+}
+```
+
+Inject it wherever `TokenVerifierInterface` / `TokenIssuerInterface` are required — no
+other application code changes.
+
+---
+
+## Design reference
+
+- [ADR 0008 — JWT Authentication](../adr/0008-jwt-authentication.md)
+- [ADR 0009 — Public API scope](../adr/0009-v1.0-public-api-scope.md) — stable Auth interfaces
+- [Add rate limiting](./add-rate-limiting.md) — per-user rate limits after auth

--- a/docs/ja/howto/add-jwt-authentication.md
+++ b/docs/ja/howto/add-jwt-authentication.md
@@ -1,0 +1,444 @@
+# JWT 認証の追加
+
+このガイドでは NENE2 アプリケーションに JWT Bearer 認証を追加する方法を示します。
+ユーザー登録、ログイン（トークン発行）、保護エンドポイントの実装を扱います。
+
+**前提条件**: 動作する NENE2 アプリケーションと少なくとも 1 つのルートが必要です。
+まだない場合は [カスタムルートの追加](./add-custom-route.md) から始めてください。
+
+---
+
+## 概要
+
+NENE2 は必要なミドルウェアとインターフェースを提供します。
+具体的な JWT 発行・検証の実装とドメインロジックはアプリ側で用意します。
+
+```
+POST /auth/register   →  ユーザー作成、201 を返す
+POST /auth/login      →  パスワード検証、JWT 発行、トークンを返す
+GET  /tasks           →  保護 — Bearer トークン必須
+POST /tasks           →  保護 — Bearer トークン必須
+GET  /tasks/{id}      →  保護 — Bearer トークン必須
+```
+
+フレームワーク側が提供するもの:
+
+| クラス / インターフェース | 役割 |
+|---|---|
+| `TokenIssuerInterface` | 署名済み JWT を発行するコントラクト |
+| `TokenVerifierInterface` | JWT を検証してクレームを返すコントラクト |
+| `LocalBearerTokenVerifier` | 開発用の HS256 実装（両インターフェースを実装） |
+| `BearerTokenMiddleware` | Bearer トークンを強制する PSR-15 ミドルウェア |
+| `RuntimeApplicationFactory` | `$authMiddleware` として任意の `MiddlewareInterface` を受け取る |
+
+---
+
+## ステップ 1 — 環境変数の設定
+
+`.env` に `NENE2_LOCAL_JWT_SECRET` を追加します:
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-dev-secret-at-least-32-chars
+```
+
+本番環境では `LocalBearerTokenVerifier` をライブラリ実装に差し替えてください
+（[本番向け JWT ライブラリへの切り替え](#本番向け-jwt-ライブラリへの切り替え) を参照）。
+
+---
+
+## ステップ 2 — Auth ドメインの作成
+
+### 2a — User エンティティ
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+final readonly class User
+{
+    public function __construct(
+        public int    $id,
+        public string $email,
+        public string $passwordHash,
+    ) {}
+}
+```
+
+### 2b — リポジトリインターフェース
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+interface UserRepositoryInterface
+{
+    public function findByEmail(string $email): ?User;
+    public function create(string $email, string $passwordHash): User;
+}
+```
+
+### 2c — Register ユースケース
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+final class RegisterUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        $errors = [];
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = new ValidationError('email', '有効なメールアドレスを入力してください。', 'invalid_email');
+        }
+
+        if (strlen($password) < 8) {
+            $errors[] = new ValidationError('password', '8 文字以上で入力してください。', 'too_short');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        if ($this->users->findByEmail($email) !== null) {
+            throw new ValidationException([
+                new ValidationError('email', 'このメールアドレスは既に登録されています。', 'duplicate_email'),
+            ]);
+        }
+
+        $user  = $this->users->create($email, password_hash($password, PASSWORD_BCRYPT));
+        $token = $this->issuer->issue(['sub' => (string) $user->id, 'email' => $user->email]);
+
+        return ['token' => $token];
+    }
+}
+```
+
+### 2d — Login ユースケース
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+final class LoginUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        $user = $this->users->findByEmail($email);
+
+        if ($user === null || !password_verify($password, $user->passwordHash)) {
+            throw new ValidationException([
+                new ValidationError('credentials', 'メールアドレスまたはパスワードが正しくありません。', 'invalid_credentials'),
+            ]);
+        }
+
+        $token = $this->issuer->issue(['sub' => (string) $user->id, 'email' => $user->email]);
+
+        return ['token' => $token];
+    }
+}
+```
+
+---
+
+## ステップ 3 — HTTP ハンドラーの作成
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Auth;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class AuthRouteRegistrar
+{
+    public function __construct(
+        private RegisterUseCase $register,
+        private LoginUseCase    $login,
+    ) {}
+
+    public function __invoke(Router $router): void
+    {
+        $router->post('/auth/register', $this->handleRegister(...));
+        $router->post('/auth/login',    $this->handleLogin(...));
+    }
+
+    private function handleRegister(ServerRequestInterface $request): mixed
+    {
+        $body     = (array) $request->getParsedBody();
+        $email    = is_string($body['email'] ?? null)    ? $body['email']    : '';
+        $password = is_string($body['password'] ?? null) ? $body['password'] : '';
+
+        return $this->register->execute($email, $password);
+    }
+
+    private function handleLogin(ServerRequestInterface $request): mixed
+    {
+        $body     = (array) $request->getParsedBody();
+        $email    = is_string($body['email'] ?? null)    ? $body['email']    : '';
+        $password = is_string($body['password'] ?? null) ? $body['password'] : '';
+
+        return $this->login->execute($email, $password);
+    }
+}
+```
+
+---
+
+## ステップ 4 — Bearer ミドルウェアの組み込み
+
+`$excludedPaths` を使って、公開エンドポイントを**除く全パスを保護**します。
+保護するパスを個別に列挙する必要がなく、`/tasks/{id}` のような動的ルートも自動で保護されます。
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+
+$psr17     = new Psr17Factory();
+$problems  = new ProblemDetailsResponseFactory($psr17, $psr17);
+$jwtSecret = (string) getenv('NENE2_LOCAL_JWT_SECRET');
+$verifier  = new LocalBearerTokenVerifier($jwtSecret);
+$issuer    = $verifier;  // LocalBearerTokenVerifier は両インターフェースを実装
+
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier:       $verifier,
+    excludedPaths:  ['/auth/register', '/auth/login'],
+);
+
+$authRegistrar = new AuthRouteRegistrar(
+    new RegisterUseCase($userRepository, $issuer),
+    new LoginUseCase($userRepository, $issuer),
+);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [$authRegistrar, $taskRegistrar],
+    authMiddleware:  $authMiddleware,
+))->create();
+```
+
+---
+
+## ステップ 5 — 保護されたハンドラーでクレームを読む
+
+`BearerTokenMiddleware` がトークンを検証すると、デコードされたクレームをリクエスト属性として保存します。
+ハンドラー内で次のように取得します:
+
+```php
+$claims = $request->getAttribute('nene2.auth.claims');
+$userId = (int) ($claims['sub'] ?? 0);
+```
+
+認証済みユーザーにスコープしたクエリを発行する例:
+
+```php
+$router->get('/tasks', function (ServerRequestInterface $request) use ($listTasks): mixed {
+    $claims = $request->getAttribute('nene2.auth.claims');
+    $userId = (int) ($claims['sub'] ?? 0);
+
+    return $listTasks->execute($userId);
+});
+```
+
+---
+
+## ステップ 6 — 他ユーザーのリソースに 403 を返す
+
+所有権チェックはミドルウェアではなくユースケースで行います:
+
+```php
+final class GetTaskUseCase
+{
+    public function execute(int $taskId, int $requestingUserId): Task
+    {
+        $task = $this->tasks->findById($taskId)
+            ?? throw new TaskNotFoundException($taskId);
+
+        if ($task->userId !== $requestingUserId) {
+            throw new AccessDeniedException();
+        }
+
+        return $task;
+    }
+}
+```
+
+`AccessDeniedException` を 403 にマッピングするドメイン例外ハンドラー:
+
+```php
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class AccessDeniedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function handles(\Throwable $e): bool
+    {
+        return $e instanceof AccessDeniedException;
+    }
+
+    public function handle(
+        \Throwable $e,
+        ServerRequestInterface $request,
+        ProblemDetailsResponseFactory $problemDetails,
+    ): ResponseInterface {
+        return $problemDetails->create($request, 'forbidden', 'Forbidden', 403, 'Access denied.');
+    }
+}
+```
+
+`RuntimeApplicationFactory` に渡します:
+
+```php
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    domainExceptionHandlers: [new AccessDeniedExceptionHandler()],
+    authMiddleware:          $authMiddleware,
+    routeRegistrars:         [$authRegistrar, $taskRegistrar],
+))->create();
+```
+
+---
+
+## リクエスト / レスポンスの例
+
+### 登録
+
+```http
+POST /auth/register
+Content-Type: application/json
+
+{"email": "alice@example.com", "password": "s3cr3tpass"}
+```
+
+```json
+{"token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."}
+```
+
+### ログイン
+
+```http
+POST /auth/login
+Content-Type: application/json
+
+{"email": "alice@example.com", "password": "s3cr3tpass"}
+```
+
+```json
+{"token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."}
+```
+
+### 保護エンドポイント（トークンなし）
+
+```http
+GET /tasks
+```
+
+```json
+{
+  "type": "https://nene2.dev/problems/unauthorized",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "No Bearer token was provided."
+}
+```
+
+---
+
+## 本番向け JWT ライブラリへの切り替え
+
+`LocalBearerTokenVerifier` は外部ライブラリを使用しない開発専用実装です。
+本番環境では `TokenVerifierInterface` と `TokenIssuerInterface` を実装したクラスに差し替えます:
+
+```php
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+
+final class FirebaseJwtService implements TokenVerifierInterface, TokenIssuerInterface
+{
+    public function __construct(
+        private string $secret,
+        private int    $ttlSeconds = 3600,
+    ) {}
+
+    public function verify(string $token): array
+    {
+        try {
+            return (array) JWT::decode($token, new Key($this->secret, 'HS256'));
+        } catch (\Exception $e) {
+            throw new TokenVerificationException($e->getMessage());
+        }
+    }
+
+    /** @param array<string, mixed> $claims */
+    public function issue(array $claims): string
+    {
+        return JWT::encode(
+            array_merge($claims, ['iat' => time(), 'exp' => time() + $this->ttlSeconds]),
+            $this->secret,
+            'HS256',
+        );
+    }
+}
+```
+
+`TokenVerifierInterface` / `TokenIssuerInterface` を注入している箇所に差し込むだけで、
+それ以外のアプリケーションコードは変更不要です。
+
+---
+
+## 設計参照
+
+- [ADR 0008 — JWT 認証](../adr/0008-jwt-authentication.md)
+- [ADR 0009 — 公開 API スコープ](../adr/0009-v1.0-public-api-scope.md) — 安定 Auth インターフェース
+- [レート制限の追加](./add-rate-limiting.md) — 認証後のユーザー単位レート制限

--- a/docs/pt-br/howto/add-jwt-authentication.md
+++ b/docs/pt-br/howto/add-jwt-authentication.md
@@ -1,0 +1,166 @@
+# Adicionar Autenticação JWT
+
+Este guia mostra como adicionar autenticação JWT Bearer a uma aplicação NENE2 —
+registro de usuários, login (emissão de token) e endpoints protegidos.
+
+**Pré-requisito**: Você tem uma aplicação NENE2 funcionando com pelo menos uma rota.
+Se não, comece com [Adicionar uma rota personalizada](./add-custom-route.md).
+
+---
+
+## Visão geral
+
+O NENE2 fornece o middleware e as interfaces necessárias; sua aplicação fornece a
+implementação concreta do emissor JWT, a configuração do verificador e a lógica de domínio.
+
+| Classe / Interface | Papel |
+|---|---|
+| `TokenIssuerInterface` | Contrato para emitir um JWT assinado |
+| `TokenVerifierInterface` | Contrato para verificar um JWT e retornar as claims |
+| `LocalBearerTokenVerifier` | Implementação HS256 para desenvolvimento (ambas as interfaces) |
+| `BearerTokenMiddleware` | Middleware PSR-15 que exige Bearer token nas requisições |
+| `RuntimeApplicationFactory` | Aceita qualquer `MiddlewareInterface` como `$authMiddleware` |
+
+---
+
+## Passo 1 — Configurar a variável de ambiente
+
+Adicione `NENE2_LOCAL_JWT_SECRET` ao seu `.env`:
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-dev-secret-at-least-32-chars
+```
+
+---
+
+## Passo 2 — Criar o domínio Auth
+
+### 2a — Entidade User
+
+```php
+final readonly class User
+{
+    public function __construct(
+        public int    $id,
+        public string $email,
+        public string $passwordHash,
+    ) {}
+}
+```
+
+### 2b — Interface do repositório
+
+```php
+interface UserRepositoryInterface
+{
+    public function findByEmail(string $email): ?User;
+    public function create(string $email, string $passwordHash): User;
+}
+```
+
+### 2c — UseCase Register
+
+```php
+final class RegisterUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        // Validação, verificação de duplicatas, hash de senha ...
+        $user  = $this->users->create($email, password_hash($password, PASSWORD_BCRYPT));
+        $token = $this->issuer->issue(['sub' => (string) $user->id, 'email' => $user->email]);
+
+        return ['token' => $token];
+    }
+}
+```
+
+### 2d — UseCase Login
+
+```php
+final class LoginUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        $user = $this->users->findByEmail($email);
+
+        if ($user === null || !password_verify($password, $user->passwordHash)) {
+            throw new ValidationException([
+                new ValidationError('credentials', 'Invalid email or password.', 'invalid_credentials'),
+            ]);
+        }
+
+        return ['token' => $this->issuer->issue(['sub' => (string) $user->id])];
+    }
+}
+```
+
+---
+
+## Passo 3 — Integrar o middleware Bearer
+
+Use `$excludedPaths` para proteger todas as rotas **exceto** os endpoints públicos de auth:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier:       $verifier,
+    excludedPaths:  ['/auth/register', '/auth/login'],
+);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [$authRegistrar, $taskRegistrar],
+    authMiddleware:  $authMiddleware,
+))->create();
+```
+
+---
+
+## Passo 4 — Ler as claims no handler
+
+```php
+$claims = $request->getAttribute('nene2.auth.claims');
+$userId = (int) ($claims['sub'] ?? 0);
+```
+
+---
+
+## Passo 5 — Retornar 403 para recursos de outros usuários
+
+Verificações de propriedade pertencem ao UseCase, não ao middleware:
+
+```php
+if ($task->userId !== $requestingUserId) {
+    throw new AccessDeniedException();
+}
+```
+
+Mapeie `AccessDeniedException` para 403 via `DomainExceptionHandlerInterface`.
+
+---
+
+## Para produção: usar uma biblioteca JWT
+
+Implemente `TokenVerifierInterface` e `TokenIssuerInterface` com uma biblioteca JWT
+como `firebase/php-jwt` e injete-a no lugar de `LocalBearerTokenVerifier`.
+
+---
+
+## Referências
+
+- [ADR 0008 — Autenticação JWT](../adr/0008-jwt-authentication.md)
+- [Adicionar rate limiting](./add-rate-limiting.md)
+- Versão completa em inglês: [add-jwt-authentication.md](../../howto/add-jwt-authentication.md)

--- a/docs/zh/howto/add-jwt-authentication.md
+++ b/docs/zh/howto/add-jwt-authentication.md
@@ -1,0 +1,164 @@
+# 添加 JWT 认证
+
+本指南介绍如何为 NENE2 应用程序添加 JWT Bearer 认证——用户注册、登录（令牌签发）和受保护端点。
+
+**前提条件**：您已有一个运行中的 NENE2 应用程序，至少包含一个路由。
+如果没有，请先阅读[添加自定义路由](./add-custom-route.md)。
+
+---
+
+## 概述
+
+NENE2 提供所需的中间件和接口；您的应用程序提供具体的 JWT 签发器、验证器实现和业务逻辑。
+
+| 类 / 接口 | 职责 |
+|---|---|
+| `TokenIssuerInterface` | 签发已签名 JWT 的契约 |
+| `TokenVerifierInterface` | 验证 JWT 并返回 Claims 的契约 |
+| `LocalBearerTokenVerifier` | 仅用于开发的 HS256 实现（实现两个接口） |
+| `BearerTokenMiddleware` | 在请求上强制执行 Bearer 令牌的 PSR-15 中间件 |
+| `RuntimeApplicationFactory` | 接受任何 `MiddlewareInterface` 作为 `$authMiddleware` |
+
+---
+
+## 第 1 步 — 配置环境变量
+
+在 `.env` 中添加 `NENE2_LOCAL_JWT_SECRET`：
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-dev-secret-at-least-32-chars
+```
+
+---
+
+## 第 2 步 — 创建 Auth 域
+
+### 2a — User 实体
+
+```php
+final readonly class User
+{
+    public function __construct(
+        public int    $id,
+        public string $email,
+        public string $passwordHash,
+    ) {}
+}
+```
+
+### 2b — 仓库接口
+
+```php
+interface UserRepositoryInterface
+{
+    public function findByEmail(string $email): ?User;
+    public function create(string $email, string $passwordHash): User;
+}
+```
+
+### 2c — 注册用例
+
+```php
+final class RegisterUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        // 验证、重复检查、密码哈希 ...
+        $user  = $this->users->create($email, password_hash($password, PASSWORD_BCRYPT));
+        $token = $this->issuer->issue(['sub' => (string) $user->id, 'email' => $user->email]);
+
+        return ['token' => $token];
+    }
+}
+```
+
+### 2d — 登录用例
+
+```php
+final class LoginUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface    $issuer,
+    ) {}
+
+    /** @return array{token: string} */
+    public function execute(string $email, string $password): array
+    {
+        $user = $this->users->findByEmail($email);
+
+        if ($user === null || !password_verify($password, $user->passwordHash)) {
+            throw new ValidationException([
+                new ValidationError('credentials', 'Invalid email or password.', 'invalid_credentials'),
+            ]);
+        }
+
+        return ['token' => $this->issuer->issue(['sub' => (string) $user->id])];
+    }
+}
+```
+
+---
+
+## 第 3 步 — 接入 Bearer 中间件
+
+使用 `$excludedPaths` 保护**除**公开 Auth 端点之外的所有路由：
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier:       $verifier,
+    excludedPaths:  ['/auth/register', '/auth/login'],
+);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [$authRegistrar, $taskRegistrar],
+    authMiddleware:  $authMiddleware,
+))->create();
+```
+
+---
+
+## 第 4 步 — 在处理器中读取 Claims
+
+```php
+$claims = $request->getAttribute('nene2.auth.claims');
+$userId = (int) ($claims['sub'] ?? 0);
+```
+
+---
+
+## 第 5 步 — 对其他用户的资源返回 403
+
+所有权检查应在用例中进行，而非中间件：
+
+```php
+if ($task->userId !== $requestingUserId) {
+    throw new AccessDeniedException();
+}
+```
+
+通过 `DomainExceptionHandlerInterface` 将 `AccessDeniedException` 映射为 403。
+
+---
+
+## 生产环境：使用 JWT 库
+
+使用 `firebase/php-jwt` 等 JWT 库实现 `TokenVerifierInterface` 和 `TokenIssuerInterface`，
+替换 `LocalBearerTokenVerifier` 注入即可，其他应用代码无需修改。
+
+---
+
+## 参考资料
+
+- [ADR 0008 — JWT 认证](../adr/0008-jwt-authentication.md)
+- [添加限流](./add-rate-limiting.md)
+- 英文完整版：[add-jwt-authentication.md](../../howto/add-jwt-authentication.md)


### PR DESCRIPTION
## Summary

- `docs/howto/add-jwt-authentication.md` を新規追加（英語 + 5言語）
- FT11 (tasklog) で発見した F-1〜F-3 の回避策・正しいパターンを文書化

## カバー内容

| トピック | 対応摩擦点 |
|---|---|
| `$excludedPaths` による動的ルートの保護 | F-1 |
| `RuntimeApplicationFactory` に `authMiddleware:` で渡す | F-2 |
| `TokenIssuerInterface` を使った JWT 発行 | F-3 |
| `nene2.auth.claims` attributes の読み取り | — |
| UseCase での 403 所有権チェック | — |
| 本番向け JWT ライブラリへの差し替え方針 | F-3 |

## 言語

- `docs/howto/add-jwt-authentication.md` — English（詳細版）
- `docs/ja/howto/` — 日本語
- `docs/de/howto/` — Deutsch
- `docs/fr/howto/` — Français
- `docs/zh/howto/` — 中文
- `docs/pt-br/howto/` — Português (Brasil)

## Test plan

- [x] 217/217 テスト通過
- [x] PHPStan level 8 / CS clean

Closes #442 (how-to 部分)

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)