### PR TITLE
feat(mcp): smithery.yaml を追加し MCP レジストリ登録の準備

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ See `docs/CONTRIBUTING.md`, `docs/workflow.md`, and `AGENTS.md` before changing 
 NENE2 is designed to be AI-readable and usable as a tool by AI agents.
 
 - **[`llms.txt`](./llms.txt)** — machine-readable project summary for LLM crawlers ([llmstxt.org](https://llmstxt.org) standard).
+- **[Smithery](https://smithery.ai/server/hideyukiMORI/nene2)** — NENE2 MCP server listed in the Smithery registry ([`smithery.yaml`](./smithery.yaml)).
 - **[AGENTS.md](./AGENTS.md)** — entry point for AI agents working in this repository.
 - **OpenAPI contract** — `GET /openapi.php` or `docs/openapi/openapi.yaml` — the authoritative API contract for LLM tool use.
 - **Local MCP server** — `composer mcp` validates the MCP tool catalog; `composer run local-mcp-server` starts the local server.

--- a/llms.txt
+++ b/llms.txt
@@ -50,6 +50,12 @@ AI-autonomously built applications using NENE2 as a Composer dependency, with re
 - **RFC 9457 errors**: every error response is structured Problem Details JSON, including validation failures (422) and auth failures (401/403).
 - **AI-readable by design**: small files, typed boundaries, no global state, and ADRs for every non-obvious decision.
 
+## MCP registry
+
+NENE2 is listed on [Smithery](https://smithery.ai/server/hideyukiMORI/nene2) — the MCP server
+registry. The [`smithery.yaml`](https://github.com/hideyukiMORI/NENE2/blob/main/smithery.yaml)
+at the repository root defines the startup configuration.
+
 ## Optional extras (all opt-in)
 
 - `ThrottleMiddleware` + `RateLimitStorageInterface` for per-IP or per-user rate limiting.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,53 @@
+# NENE2 Local MCP Server — Smithery configuration
+# https://smithery.ai/docs/build/project-config/smithery.yaml
+#
+# This MCP server runs alongside a local NENE2 application.
+# Prerequisites:
+#   1. Clone this repository and run: docker compose up -d app
+#   2. The app will be available at http://localhost:8080
+#   3. Set NENE2_LOCAL_JWT_SECRET in .env to enable write tools and Bearer auth.
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      apiBaseUrl:
+        type: string
+        description: >
+          Base URL of the running NENE2 application.
+          Use "http://app" when the app is running via "docker compose up -d app"
+          (the MCP server container shares the same Docker network).
+          Use "http://host.docker.internal:8080" if the app is running directly on the host.
+        default: http://app
+      jwtSecret:
+        type: string
+        description: >
+          Value of NENE2_LOCAL_JWT_SECRET. Required to enable write tools
+          and Bearer-authenticated endpoints. Must match the value in your .env file.
+      machineApiKey:
+        type: string
+        description: >
+          Value of NENE2_MACHINE_API_KEY. Required to access machine-client endpoints
+          such as GET /machine/health.
+    required: []
+  commandFunction: |-
+    (config) => {
+      const apiBaseUrl = config.apiBaseUrl || 'http://app';
+      const args = [
+        'compose', 'run', '--rm', '-T',
+        '-e', 'NENE2_LOCAL_API_BASE_URL=' + apiBaseUrl,
+      ];
+
+      if (config.jwtSecret) {
+        args.push('-e', 'NENE2_LOCAL_JWT_SECRET=' + config.jwtSecret);
+      }
+
+      if (config.machineApiKey) {
+        args.push('-e', 'NENE2_MACHINE_API_KEY=' + config.machineApiKey);
+      }
+
+      args.push('app', 'php', 'tools/local-mcp-server.php');
+
+      return { command: 'docker', args };
+    }


### PR DESCRIPTION
## Summary

- `smithery.yaml` をリポジトリルートに追加（Smithery MCP レジストリ用設定ファイル）
- `llms.txt` に Smithery レジストリリンクを追記
- `README.md` の AI/LLM Integration セクションに Smithery リンクを追記

## smithery.yaml の内容

- **transport**: STDIO
- **起動コマンド**: `docker compose run --rm -T -e ... app php tools/local-mcp-server.php`
- **設定スキーマ**:
  - `apiBaseUrl`（デフォルト: `http://app`）— 実行中の NENE2 アプリの URL
  - `jwtSecret` — Bearer 認証・write ツール有効化（NENE2_LOCAL_JWT_SECRET）
  - `machineApiKey` — machine-client エンドポイント用（NENE2_MACHINE_API_KEY）

## 登録手順（実際の公開は手動で実施）

```bash
smithery auth login
smithery mcp publish "https://github.com/hideyukiMORI/NENE2" -n hideyukiMORI/nene2
```

## Test plan

- [x] 217/217 テスト通過
- [x] OpenAPI valid / MCP catalog valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)