### PR TITLE
feat(docs): OpenAPI contract を前面に — バッジ・raw URL・llms.txt セクション追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # NENE2
 
+[![PHP](https://img.shields.io/badge/PHP-8.4%2B-8892BF)](https://www.php.net/)
+[![Packagist](https://img.shields.io/packagist/v/hideyukimori/nene2)](https://packagist.org/packages/hideyukimori/nene2)
+[![OpenAPI](https://img.shields.io/badge/OpenAPI-3.1-85EA2D)](https://raw.githubusercontent.com/hideyukiMORI/NENE2/main/docs/openapi/openapi.yaml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
 PHP micro-framework: JSON APIs first, minimal server HTML, easy React starter integration, structure friendly to AI tooling.
+
+**[OpenAPI contract](https://raw.githubusercontent.com/hideyukiMORI/NENE2/main/docs/openapi/openapi.yaml)** — machine-readable API spec (OpenAPI 3.1). Live Swagger UI at `http://localhost:8080/docs/` after `docker compose up -d app`.
 
 NENE2 is a small, modern PHP framework foundation designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add a React frontend starter without turning the backend into frontend build glue.
 

--- a/llms.txt
+++ b/llms.txt
@@ -4,6 +4,16 @@
 
 NENE2 lets you ship a JSON API with OpenAPI contract, optional React frontend, and a safe MCP tool surface in a single repository. The framework ships only the pieces you need — routing, middleware pipeline, dependency injection, database adapters, and auth primitives — without magic conventions or hidden control flow.
 
+## OpenAPI contract
+
+The authoritative machine-readable API specification is available at:
+
+- **Raw YAML**: `https://raw.githubusercontent.com/hideyukiMORI/NENE2/main/docs/openapi/openapi.yaml`
+- **Live Swagger UI** (local): `http://localhost:8080/docs/` (after `docker compose up -d app`)
+- **Live spec endpoint** (local): `http://localhost:8080/openapi.php`
+
+The spec covers all shipped JSON endpoints including health, examples (Note/Tag CRUD), and machine-client endpoints. RFC 9457 Problem Details error schemas are included for every operation.
+
 ## Docs
 
 - [README](https://github.com/hideyukiMORI/NENE2/blob/main/README.md): Installation, quick start, project philosophy.


### PR DESCRIPTION
## Summary

- `README.md` にバッジ行（PHP 8.4+ / Packagist / OpenAPI 3.1 / MIT）を追加
- README 冒頭に OpenAPI contract への prominent リンクを追加
- `llms.txt` に「OpenAPI contract」セクションを新設（raw YAML URL 明示）

## 変更の意図

AI クローラーや LLM ツールが:
1. `llms.txt` を読んで raw spec URL を把握できる
2. `https://raw.githubusercontent.com/hideyukiMORI/NENE2/main/docs/openapi/openapi.yaml` から直接 OpenAPI 3.1 仕様を取得できる
3. README の冒頭バッジで OpenAPI 対応を一目で認識できる

## Test plan

- [x] 217/217 テスト通過
- [x] OpenAPI valid / MCP valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)