### PR TITLE
docs(roadmap): FT12-A/B/C マイルストーン・ロードマップ・TODO を追加

### DIFF
--- a/docs/milestones/2026-05-field-trial-12a.md
+++ b/docs/milestones/2026-05-field-trial-12a.md
@@ -1,0 +1,78 @@
+# Milestone: Field Trial 12-A — 多対多リレーションの AI 実装可能性検証
+
+## 仮説
+
+> 多対多リレーション（M:N）を持つドメインは、
+> NENE2 のドキュメントだけを見た Claude が迷わず実装できるか。
+
+Field Trial 11（tasklog）が見つけた摩擦は主に「認証エリア」系だった。
+FT12-A では **リレーショナルデータ設計エリア** を集中的に叩く。
+
+## テーマ: Relational Data Ergonomics
+
+NENE2 の `DatabaseQueryExecutorInterface` は SQL の直接実行を前提とするが、
+JOIN・中間テーブル・カスケード削除などの「複数テーブルにまたがる操作」に対する
+ガイドは薄い。新規プロジェクトで M:N を設計する際に何が詰まるかを記録する。
+
+## 実装するアプリ: tagmark
+
+**ブックマーク管理 API** — `composer require hideyukimori/nene2:^1.4` から 0 構築。
+
+### ドメイン
+
+- **User**: 登録・ログイン（FT11 パターンを再利用）
+- **Bookmark**: URL・タイトル・メモ（ユーザー所有）
+- **Tag**: 名前（ユーザー所有）
+- **Bookmark ↔ Tag**: 多対多（`bookmark_tags` 中間テーブル）
+
+### エンドポイント
+
+| Method | Path | 認証 | 備考 |
+|---|---|---|---|
+| POST | /auth/register | 不要 | |
+| POST | /auth/login | 不要 | |
+| GET | /bookmarks | Bearer | ページネーション + タグフィルタ |
+| POST | /bookmarks | Bearer | |
+| GET | /bookmarks/{id} | Bearer | タグ一覧を含む |
+| PUT | /bookmarks/{id} | Bearer | |
+| DELETE | /bookmarks/{id} | Bearer | 中間テーブルもカスケード削除 |
+| GET | /tags | Bearer | |
+| POST | /tags | Bearer | |
+| DELETE | /tags/{id} | Bearer | 中間テーブルもカスケード削除 |
+| POST | /bookmarks/{id}/tags/{tagId} | Bearer | タグ付与（冪等） |
+| DELETE | /bookmarks/{id}/tags/{tagId} | Bearer | タグ除去 |
+| GET | /bookmarks?tag={tagId} | Bearer | タグフィルタリング |
+
+### 注目する摩擦ポイント候補
+
+- M:N リポジトリ設計（中間テーブルの CRUD、JOIN クエリ）
+- カスケード削除の実装パターン
+- タグフィルタリング付きページネーション
+- 所有権チェック（他ユーザーの Bookmark/Tag への操作は 403）
+- FT11 パターン（JWT 認証）の再利用の容易さ
+
+## Phases
+
+### Phase 65 — Field Trial 12-A Execution
+
+- [ ] tagmark リポジトリを作成し、`composer require hideyukimori/nene2:^1.4` で初期化
+- [ ] User ドメイン（FT11 パターン再利用）を実装
+- [ ] Bookmark / Tag ドメイン（M:N）を実装
+- [ ] `composer check` 全通過（PHPUnit・PHPStan level 8・PHP-CS-Fixer）
+- [ ] 全エンドポイント動作確認（タグ付与・除去・フィルタリング・カスケード削除）
+- [ ] 摩擦記録を `docs/field-trial-report.md` に残す
+- [ ] フォローアップ Issue を開く
+
+## 完了条件
+
+- `composer check` 全通過
+- M:N 操作（タグ付与・除去・フィルタリング）が動作
+- カスケード削除が動作
+- 摩擦記録あり
+- フォローアップ Issue 作成済み
+
+## 備考
+
+- 実施者: Claude Code（自律実装）
+- Issue: #453
+- 次: FT12-B (#454) — MCP ファースト (knowledgelog)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -682,6 +682,35 @@ Goal: address the highest-impact friction points from Field Trial 11.
 - #441: Relax RuntimeApplicationFactory auth parameter type to MiddlewareInterface
 - Optional: add-jwt-authentication.md how-to guide (covers F-1〜F-3 workarounds)
 
+## Phase 65: Field Trial 12-A — 多対多リレーションの AI 実装可能性検証 (#453)
+
+Goal: validate that Claude can implement many-to-many relationships using only NENE2
+documentation, and record friction points in the relational data design area.
+
+Theme: **Relational Data Ergonomics** — JOIN queries, cascade deletes, M:N pagination,
+and tag-based filtering.
+
+App: **tagmark** — ブックマーク管理 API (`composer require hideyukimori/nene2:^1.4` から 0 構築)
+
+- User domain (reuse FT11 JWT auth pattern)
+- Bookmark / Tag domains with M:N join table
+- Tag assignment/removal, tag-based filtering, cascade deletes
+- Record all friction points → open follow-up Issues
+
+## Phase 66: Field Trial 12-B — MCP ファースト（Knowledge Base API）(#454)
+
+Goal: validate MCP tool authoring ergonomics — docs/mcp/tools.json authoring, safety levels,
+and the read/write tool workflow.
+
+App: **knowledgelog** — FAQ / document knowledge base API
+
+## Phase 67: Field Trial 12-C — 公開 + 管理者の二層アクセス（Product Catalog API）(#455)
+
+Goal: validate multi-auth ergonomics — API key + JWT Bearer + public access coexisting
+in one application.
+
+App: **shoplog** — product catalog API with 3-tier access model
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -37,13 +37,15 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 - **Phase 64**: `docs/howto/add-jwt-authentication.md` を 6 言語で追加（PR #449 マージ済み）
 
-## Next
+## Next: Phase 65 — Field Trial 12-A（tagmark）
 
-FT11 フォローアップ #440〜#443 および Phase 64 how-to 追加が完了。
-次の候補:
-- **FT12** — 別テーマのフィールドトライアル（例: MCP 統合・多対多リレーション・ファイルアップロード等）
-- **AI-Standard-Tool 方向**: `llms.txt` 設置 / MCP レジストリ（Smithery）登録
-- **nene2-python** 追加エンティティ / JWT 対応
+**仮説**: 多対多リレーション（M:N）は Claude が NENE2 ドキュメントだけで迷わず実装できるか。
+
+**アプリ**: tagmark（ブックマーク + タグ M:N API）— User/Bookmark/Tag ドメイン、13 エンドポイント
+
+Issue: #453 / マイルストーン: `docs/milestones/2026-05-field-trial-12a.md`
+
+その後: FT12-B (#454 knowledgelog) → FT12-C (#455 shoplog) の順で実施。
 
 ---
 


### PR DESCRIPTION
## Summary

- GitHub Issues #453 (tagmark) / #454 (knowledgelog) / #455 (shoplog) を作成
- Phase 65〜67 をロードマップに追加
- FT12-A マイルストーンファイル (`docs/milestones/2026-05-field-trial-12a.md`) を作成
- TODO を「Next: Phase 65 FT12-A」に更新

Closes なし（FT 実施 Issue は別途クローズ）

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)