### PR TITLE
fix(mcp): validate-mcp-tools.php を Consumer Project から使えるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `validate-mcp-tools.php` — `--root=<path>` CLI option; falls back to `getcwd()` so consumer projects can run the validator without a wrapper script (#459)
+- `composer.json` `suggest` entry for `symfony/yaml` — consumer projects are guided to add it when using the MCP validator (#460)
+- CLAUDE.md section on how to wire the MCP validator in a consumer project
+
 ---
 
 ## [1.4.1] — 2026-05-19

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,18 @@ UseCase     : ビジネス不変条件、認可ルール、状態依存ルール
 docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
 ```
 
+### Consumer Project から MCP バリデーターを使う
+
+Consumer Project（`composer require hideyukimori/nene2:^1.4`）では:
+
+1. `require-dev` に `symfony/yaml` を追加する（`composer require --dev symfony/yaml`）
+2. `composer.json` の `scripts` に追加する:
+   ```json
+   "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=."
+   ```
+3. `docs/mcp/tools.json` と `docs/openapi/openapi.yaml` を作成する
+4. `composer mcp` を実行する
+
 ### ローカル AI・MCP で使用可能なコマンド
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
       "@mcp"
     ]
   },
+  "suggest": {
+    "symfony/yaml": "Required to run validate-mcp-tools.php from a consumer project (add to your require-dev)"
+  },
   "config": {
     "sort-packages": true
   },

--- a/tools/validate-mcp-tools.php
+++ b/tools/validate-mcp-tools.php
@@ -4,9 +4,22 @@ declare(strict_types=1);
 
 use Symfony\Component\Yaml\Yaml;
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+// When run via `composer mcp` or directly, getcwd() is the project root.
+// --root=<path> overrides this for explicit invocation from another directory.
+$cwd = getcwd();
+$projectRoot = $cwd !== false ? $cwd : dirname(__DIR__);
 
-$root = dirname(__DIR__);
+foreach ($argv as $arg) {
+    if (str_starts_with($arg, '--root=')) {
+        $explicit = substr($arg, 7);
+        $projectRoot = realpath($explicit) ?: $explicit;
+        break;
+    }
+}
+
+require $projectRoot . '/vendor/autoload.php';
+
+$root = $projectRoot;
 $catalogPath = $root . '/docs/mcp/tools.json';
 $openApiPath = $root . '/docs/openapi/openapi.yaml';
 


### PR DESCRIPTION
## Summary

- `validate-mcp-tools.php` に `--root=<path>` CLI オプションを追加
  - Consumer Project で `php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=.` と実行できる
  - `--root` 未指定時は `getcwd()` をプロジェクトルートとして使う（Composer スクリプト経由で自動動作）
- `composer.json` に `suggest` セクションを追加し `symfony/yaml` の追加を案内
- `CLAUDE.md` に Consumer Project 向けのセットアップ手順を追記

## Consumer Project での使い方

`composer.json` の `scripts` に追加:
```json
"mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=."
```

`require-dev` に追加:
```bash
composer require --dev symfony/yaml
```

## Test plan

- [x] `composer check` 全通過 (217 tests, PHPStan, CS-Fixer)
- [x] `composer mcp` が NENE2 自体でも引き続き動作する
- [ ] Consumer Project で `--root=.` を使って `composer mcp` が動作する

## 背景

Field Trial 12-B (knowledgelog) #454 — F-2 / F-3 による発見

Closes #459
Closes #460

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)