### PR TITLE
feat(auth): BearerTokenMiddleware prefix matching + LocalBearerTokenVerifier 公開 API 昇格

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `validate-mcp-tools.php` — `--root=<path>` CLI option; falls back to `getcwd()` so consumer projects can run the validator without a wrapper script (#459)
 - `composer.json` `suggest` entry for `symfony/yaml` — consumer projects are guided to add it when using the MCP validator (#460)
 - CLAUDE.md section on how to wire the MCP validator in a consumer project
+- `BearerTokenMiddleware::$protectedPathPrefixes` — prefix allowlist parameter; protects all paths starting with the listed prefixes (e.g. `/me/` matches `/me/favorites/42`); evaluated after `$protectedPaths` and before `$excludedPaths` (#467)
+
+### Changed
+- `LocalBearerTokenVerifier` — removed `@internal` tag; now part of the public API stability guarantee (see ADR 0009) (#468)
 
 ---
 

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -58,7 +58,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException` |
 | `Nene2\Error` | `DomainExceptionHandlerInterface`, `ProblemDetailsResponseFactory` |
-| `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware` |
+| `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware`, `LocalBearerTokenVerifier` |
 | `Nene2\Middleware` | All shipped middleware classes, `RateLimitStorageInterface`, `ThrottleMiddleware` |
 | `Nene2\Validation` | `ValidationException`, `ValidationError` |
 | `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |

--- a/src/Auth/BearerTokenMiddleware.php
+++ b/src/Auth/BearerTokenMiddleware.php
@@ -14,25 +14,29 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Validates the `Authorization: Bearer <token>` header using a {@see TokenVerifierInterface}.
  * Returns 401 Problem Details if the header is absent or the token fails verification.
  *
- * Path matching modes (mutually exclusive — `$protectedPaths` takes precedence):
+ * Path matching modes (evaluated in priority order — first match wins):
  *
- * - **Protect all** (default): both arrays empty → every path requires a token.
- * - **Allowlist** (`$protectedPaths`): only the listed exact paths are protected.
- * - **Blocklist** (`$excludedPaths`): all paths are protected *except* the listed exact paths.
- *   Ideal when public paths (e.g. `/auth/register`, `/auth/login`) are the minority.
+ * 1. **Allowlist** (`$protectedPaths`): only the listed exact paths are protected.
+ * 2. **Prefix allowlist** (`$protectedPathPrefixes`): paths starting with any listed prefix are protected.
+ *    Ideal for dynamic routes such as `/me/favorites/{id}` → prefix `/me/`.
+ * 3. **Blocklist** (`$excludedPaths`): all paths are protected *except* the listed exact paths.
+ *    Ideal when public paths (e.g. `/auth/register`, `/auth/login`) are the minority.
+ * 4. **Protect all** (default): all four arrays empty → every path requires a token.
  *
  * Part of the public API stability guarantee (see ADR 0009).
  */
 final readonly class BearerTokenMiddleware implements MiddlewareInterface
 {
     /**
-     * @param list<string> $protectedPaths Exact paths to protect (allowlist). Empty = no allowlist filtering.
-     * @param list<string> $excludedPaths  Exact paths to skip authentication (blocklist). Ignored when $protectedPaths is non-empty.
+     * @param list<string> $protectedPaths        Exact paths to protect (allowlist). Takes precedence over all other modes.
+     * @param list<string> $protectedPathPrefixes  Path prefixes to protect (prefix allowlist). Matches e.g. `/me/` → `/me/favorites/1`.
+     * @param list<string> $excludedPaths          Exact paths to skip authentication (blocklist). Ignored when $protectedPaths or $protectedPathPrefixes is non-empty.
      */
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
         private TokenVerifierInterface $verifier,
         private array $protectedPaths = [],
+        private array $protectedPathPrefixes = [],
         private array $excludedPaths = [],
     ) {
     }
@@ -74,6 +78,16 @@ final readonly class BearerTokenMiddleware implements MiddlewareInterface
 
         if ($this->protectedPaths !== []) {
             return in_array($path, $this->protectedPaths, true);
+        }
+
+        if ($this->protectedPathPrefixes !== []) {
+            foreach ($this->protectedPathPrefixes as $prefix) {
+                if (str_starts_with($path, $prefix)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         if ($this->excludedPaths !== []) {

--- a/src/Auth/LocalBearerTokenVerifier.php
+++ b/src/Auth/LocalBearerTokenVerifier.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Nene2\Auth;
 
 /**
- * @internal
- * HMAC-HS256 JWT verifier and issuer for local development.
+ * HMAC-HS256 JWT verifier and issuer for local development and testing.
  * Uses no external library — suitable only for controlled local environments.
  * Production deployments should inject library-backed implementations of
  * {@see TokenVerifierInterface} and {@see TokenIssuerInterface}.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
  */
 final readonly class LocalBearerTokenVerifier implements TokenVerifierInterface, TokenIssuerInterface
 {

--- a/tests/Auth/BearerTokenMiddlewareTest.php
+++ b/tests/Auth/BearerTokenMiddlewareTest.php
@@ -163,6 +163,36 @@ final class BearerTokenMiddlewareTest extends TestCase
         self::assertSame(401, $response->getStatusCode());
     }
 
+    public function testProtectedPathPrefixesAllowlistSkipsNonMatchingPath(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $this->acceptingVerifier(),
+            protectedPathPrefixes: ['/me/'],
+        );
+        $request = $factory->createServerRequest('GET', 'https://example.test/products/1');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testProtectedPathPrefixesAllowlistProtectsDynamicPath(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $this->acceptingVerifier(),
+            protectedPathPrefixes: ['/me/'],
+        );
+        $request = $factory->createServerRequest('DELETE', 'https://example.test/me/favorites/42');
+
+        $response = $middleware->process($request, $this->failHandler());
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
     public function testProtectedPathsTakesPrecedenceOverExcludedPaths(): void
     {
         $factory = new Psr17Factory();


### PR DESCRIPTION
## Summary

### BearerTokenMiddleware — `$protectedPathPrefixes` 追加

動的ルートをプレフィックスで一括保護できるようになった:

```php
new BearerTokenMiddleware(
    problemDetails: $problemDetails,
    verifier:       $verifier,
    protectedPathPrefixes: ['/me/'],  // /me/favorites/42 なども保護
);
```

評価順序: `$protectedPaths`（完全一致） > `$protectedPathPrefixes`（プレフィックス） > `$excludedPaths`（除外） > 全保護

### LocalBearerTokenVerifier — 公開 API 昇格

- `@internal` タグを削除し、`LocalBearerTokenVerifier` を公開 API として明示
- ADR 0009 の公開 API 一覧に追記

## Test plan

- [x] `composer check` 全通過 (219 tests, PHPStan, CS-Fixer)
- [x] 新テスト 2 件: prefix skip / prefix enforce

## 背景

Field Trial 12-C (shoplog) #455:
- F-2: `/me/favorites/{productId}` を Bearer で保護できない → `$protectedPathPrefixes` で解消
- F-5: `LocalBearerTokenVerifier` が `@internal` で Consumer Project が使いにくい → 公開 API 昇格

Closes #467
Closes #468
Closes #436

Self-review: middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)