### PR TITLE
docs(milestone): FT12-C 完了マーク・FT12 シリーズ総括

### DIFF
--- a/docs/milestones/2026-05-field-trial-12c.md
+++ b/docs/milestones/2026-05-field-trial-12c.md
@@ -58,26 +58,58 @@ API キー認証と JWT Bearer 認証を同一アプリで組み合わせ、
 
 ## Phases
 
-### Phase 67 — Field Trial 12-C Execution
+### Phase 67 — Field Trial 12-C Execution ✅ 完了 (2026-05-19)
 
-- [ ] shoplog リポジトリを作成し、`composer require hideyukimori/nene2:^1.4` で初期化
-- [ ] Product / Category ドメインを実装（公開 GET + API キー管理）
-- [ ] User / Auth ドメインを実装（JWT Bearer）
-- [ ] Favorite ドメインを実装（Bearer 必須、M:N）
-- [ ] `composer check` 全通過（PHPUnit・PHPStan level 8・PHP-CS-Fixer）
-- [ ] 全エンドポイント動作確認（3 層アクセスモデル）
-- [ ] 摩擦記録を `docs/field-trial-report.md` に残す
-- [ ] フォローアップ Issue を開く
+- [x] shoplog リポジトリを作成し、`composer require hideyukimori/nene2:^1.4.1` で初期化
+- [x] Product / Category ドメインを実装（公開 GET + API キー管理）
+- [x] User / Auth ドメインを実装（JWT Bearer）
+- [x] Favorite ドメインを実装（Bearer 必須、M:N）
+- [x] `composer check` 全通過（PHPUnit 29/29・PHPStan level 8・PHP-CS-Fixer）
+- [x] 全エンドポイント動作確認（3 層アクセスモデル: 公開 / Bearer / API キー）
+- [x] 摩擦記録を `docs/field-trial-report.md` に残す（6 件: F-1〜F-6）
+- [x] フォローアップ Issue を開く（#466–#469）
+
+## 結果
+
+### テスト
+
+```
+PHPUnit 11: 29 tests, OK
+PHPStan level 8: No errors
+PHP-CS-Fixer: 0 files to fix
+```
+
+### Multi-Auth 設計パターン（FT12-C 採用）
+
+```
+Request
+  └── MultiAuthMiddleware
+        ├── /me/* → BearerTokenMiddleware (全パス保護)
+        └── other → WriteApiKeyMiddleware (POST/PUT/DELETE → API キー)
+```
+
+### 摩擦サマリー
+
+| # | 種別 | 深刻度 | 対応 |
+|---|---|---|---|
+| F-1 | RuntimeApplicationFactory が 1 つの $authMiddleware しか受け取れない | 高 | Issue #466 — 後続実装（CompositeAuthMiddleware） |
+| F-2 | BearerTokenMiddleware の $protectedPaths が動的パスに対応しない | 高 | PR #470 で解消（$protectedPathPrefixes 追加） |
+| F-3 | ApiKeyAuthenticationMiddleware が動的パス + メソッドに対応しない | 高 | Issue #461 — 後続実装 |
+| F-4 | excludedPaths と Multi-Auth の組み合わせが分かりにくい | 中 | Issue #466 の howto で案内 |
+| F-5 | LocalBearerTokenVerifier が @internal で使いにくい | 低 | PR #470 で解消（公開 API 昇格） |
+| F-6 | PHPStan が Docker でメモリ不足になる | 低 | Issue #469 — howto 追記 |
 
 ## 完了条件
 
-- `composer check` 全通過
-- 3 層アクセスモデルが動作（公開 / Bearer / API キー）
-- 摩擦記録あり
-- フォローアップ Issue 作成済み
+- [x] `composer check` 全通過
+- [x] 3 層アクセスモデルが動作（公開 / Bearer / API キー）
+- [x] 摩擦記録あり
+- [x] フォローアップ Issue 作成済み
 
 ## 備考
 
 - 実施者: Claude Code（自律実装）
 - Issue: #455
+- 報告書: `/home/xi/docker/shoplog/docs/field-trial-report.md`
+- F-2/F-5 対応 PR: #470 (マージ済み)
 - 前: FT12-B (#454) — MCP ファースト (knowledgelog)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -708,12 +708,16 @@ App: **knowledgelog** — FAQ / document knowledge base API
 - [x] 7 MCP tools (3 read + 4 write), OpenAPI spec, MCP validation passes
 - [x] 5 friction points recorded (F-1〜F-5); F-2/F-3 resolved in PR #464; follow-up Issues #459–#463
 
-## Phase 67: Field Trial 12-C — 公開 + 管理者の二層アクセス（Product Catalog API）(#455)
+## Phase 67: Field Trial 12-C — 公開 + 管理者の二層アクセス（Product Catalog API）(#455) ✓
 
 Goal: validate multi-auth ergonomics — API key + JWT Bearer + public access coexisting
 in one application.
 
 App: **shoplog** — product catalog API with 3-tier access model
+
+- [x] Product / Category / Favorite domains, 3-tier access model, 12 endpoints (29 tests)
+- [x] MultiAuthMiddleware pattern: Bearer for /me/*, WriteApiKeyMiddleware for writes
+- [x] 6 friction points recorded (F-1〜F-6); F-2/F-5 resolved in PR #470; follow-up Issues #466–#469
 
 ## Non-Goals
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -42,16 +42,29 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - **Phase 65 / Field Trial 12-A** (#453): tagmark（ブックマーク + タグ M:N API）を `composer require hideyukimori/nene2:^1.4.1` から 0 構築。3ドメイン・13エンドポイント・PHPUnit 19/19・PHPStan level 8・PHP-CS-Fixer 全通過。摩擦 7 件記録（F-1〜F-7）、F-1/F-2/F-7 は v1.4.1 で解消済み、F-3/F-4/F-5 は howto 修正済み、F-6 は Issue #457 として起票。
 - **v1.4.1**: FT11 フォローアップ修正（excludedPaths・MiddlewareInterface・TokenIssuerInterface）＋ FT12-A 発見の howto 誤り（F-3/F-4/F-5）修正。タグ・GitHub Release 作成済み。
 - **Phase 66 / Field Trial 12-B** (#454): knowledgelog（ナレッジベース API — Article / Category）を `composer require hideyukimori/nene2:^1.4.1` から 0 構築。8 エンドポイント・MCP 7 ツール・PHPUnit 10/10・PHPStan level 8・PHP-CS-Fixer 全通過。摩擦 5 件記録（F-1〜F-5）、F-2/F-3（高）は PR #464 で解消済み（--root オプション + suggest 追加）、F-1/F-4/F-5 は Issue #459–#463 として起票。
+- **Phase 67 / Field Trial 12-C** (#455): shoplog（商品カタログ API — 3 層アクセスモデル）を `composer require hideyukimori/nene2:^1.4.1` から 0 構築。12 エンドポイント・PHPUnit 29/29・PHPStan level 8・PHP-CS-Fixer 全通過。摩擦 6 件記録（F-1〜F-6）、F-2/F-5（高/低）は PR #470 で解消済み（$protectedPathPrefixes 追加・LocalBearerTokenVerifier 公開）、F-1/F-3/F-4/F-6 は Issue #466–#469 として起票。
 
-## Next: Phase 67 — Field Trial 12-C（shoplog）
+## FT12 シリーズ完了
 
-**仮説**: API キー認証（管理者）・JWT Bearer 認証（ユーザー）・認証なし（公開）の 3 層が共存するアプリを、NENE2 のドキュメントだけを参照した Claude が迷わず実装できるか。
+FT12-A / FT12-B / FT12-C のすべてが完了。主要成果:
 
-**テーマ**: Multi-Auth Ergonomics — 複数の認証方式が共存する設計の摩擦を記録する。
+| FT | アプリ | テスト | 主要摩擦 | 解消済み |
+|---|---|---|---|---|
+| 12-A | tagmark (M:N) | 19/19 | F-1〜F-7 | v1.4.1 + PR #464 |
+| 12-B | knowledgelog (MCP) | 10/10 | F-1〜F-5 | PR #464 (F-2/F-3) |
+| 12-C | shoplog (Multi-Auth) | 29/29 | F-1〜F-6 | PR #470 (F-2/F-5) |
 
-**アプリ**: shoplog（商品カタログ API — Product / Category / お気に入り）— 12 エンドポイント
+## Next: v1.5.0 リリース候補
 
-Issue: #455 / マイルストーン: `docs/milestones/2026-05-field-trial-12c.md`
+FT12 シリーズで発見した摩擦のうち未解消のもの:
+- Issue #457: M:N 多対多 howto（F-6 from FT12-A）
+- Issue #461: ApiKeyAuthenticationMiddleware メソッドベース保護（F-1 from FT12-B/C）
+- Issue #462: nene2.auth.* 属性名の公開（F-4 from FT12-B）
+- Issue #463: RuntimeApplicationFactory Example 切り離し（F-5 from FT12-B）
+- Issue #466: CompositeAuthMiddleware / howto（F-1 from FT12-C）
+- Issue #469: PHPStan memory_limit howto（F-6 from FT12-C）
+
+これらを整理して v1.5.0 をリリースするか、継続して追加フィールドトライアルを実施するか検討。
 
 ---
 


### PR DESCRIPTION
## Summary

- FT12-C (shoplog) Phase 67 を完了マーク — PHPUnit 29/29・PHPStan level 8・PHP-CS-Fixer 全通過
- 6 件摩擦サマリーを `docs/milestones/2026-05-field-trial-12c.md` に記録（F-2/F-5 は PR #470 で解消）
- `docs/todo/current.md` に FT12 シリーズ全体のサマリーを追加
- 未解消 Issue (#457/#461/#462/#463/#466/#469) を整理して next steps として記録

## FT12 シリーズ完了実績

| FT | アプリ | テスト | 主要摩擦 | 解消済み |
|---|---|---|---|---|
| 12-A | tagmark (M:N) | 19/19 | F-1〜F-7 | v1.4.1 + PR #464 |
| 12-B | knowledgelog (MCP) | 10/10 | F-1〜F-5 | PR #464 (F-2/F-3) |
| 12-C | shoplog (Multi-Auth) | 29/29 | F-1〜F-6 | PR #470 (F-2/F-5) |

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)