### PR TITLE
docs(database): FT13 フォローアップ — MySQL FK / DB_PASSWORD / Phinx cleanup howto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,8 +399,15 @@ tools/                バリデーションスクリプト
 | `APP_ENV` | `local` / `test` / `production` |
 | `APP_DEBUG` | boolean |
 | `APP_NAME` | アプリ名 |
-| `DATABASE_URL` | DB URL |
+| `DATABASE_URL` | DB URL（設定するとホスト/ポート等の個別変数を上書き） |
 | `DB_ADAPTER` | `sqlite` / `mysql` / `pgsql` |
+| `DB_HOST` | DB ホスト（デフォルト: `127.0.0.1`） |
+| `DB_PORT` | DB ポート（デフォルト: `3306`） |
+| `DB_NAME` | DB 名（デフォルト: `nene2`） |
+| `DB_USER` | DB ユーザー（デフォルト: `nene2`） |
+| `DB_PASSWORD` | DB パスワード — **`DB_PASS` ではなく `DB_PASSWORD`**（ConfigLoader が読む） |
+| `DB_CHARSET` | 文字セット（デフォルト: `utf8mb4`） |
+| `DB_ENV` | Phinx 用環境名（デフォルト: `local`） |
 | `NENE2_MACHINE_API_KEY` | マシンクライアント API キー（未設定でパブリックのみ） |
 | `NENE2_LOCAL_JWT_SECRET` | HMAC-HS256 シークレット（Bearer JWT / MCP 書き込みツール保護） |
 | `NENE2_LOCAL_API_BASE_URL` | ローカル MCP サーバーの API ベース URL |

--- a/docs/howto/add-database-endpoint.md
+++ b/docs/howto/add-database-endpoint.md
@@ -297,6 +297,52 @@ The resulting response body:
 
 ---
 
+## MySQL foreign key columns: use `'signed' => false`
+
+When using MySQL with Phinx, primary key columns are created as `INT UNSIGNED AUTO_INCREMENT`
+by default. Foreign key columns that reference them must also be unsigned — otherwise MySQL
+rejects the migration:
+
+```
+Referencing column 'user_id' and referenced column 'id' in foreign key constraint are incompatible
+```
+
+SQLite does not enforce this type constraint, so the same migration runs fine in SQLite and
+only fails when you switch to MySQL. To avoid the mismatch, always add `'signed' => false` to
+integer columns that act as foreign keys:
+
+```php
+$this->table('registrations')
+    ->addColumn('user_id',  'integer', ['null' => false, 'signed' => false])
+    ->addColumn('event_id', 'integer', ['null' => false, 'signed' => false])
+    ->addForeignKey('user_id',  'users',  'id', ['delete' => 'CASCADE'])
+    ->addForeignKey('event_id', 'events', 'id', ['delete' => 'CASCADE'])
+    ->create();
+```
+
+### If a migration fails partway through
+
+Phinx's `change()` method cannot always roll back a `CREATE TABLE` that succeeded before a
+later step failed. The table will exist in MySQL but will not appear in `phinxlog`, so the
+next `migrations:migrate` fails with "Table already exists."
+
+Manual cleanup:
+
+```bash
+# Connect to MySQL inside the container
+docker compose exec db mysql -u <user> -p<password> <dbname>
+DROP TABLE IF EXISTS registrations;
+exit
+
+# Re-run the migration
+docker compose run --rm app composer migrations:migrate
+```
+
+Alternatively, split the migration into `up()` and `down()` methods instead of `change()` so
+the down path is explicit and predictable.
+
+---
+
 ## Initialize a SQLite database
 
 When using SQLite (`DB_ADAPTER=sqlite`), there is no server to create the database; the `.db`

--- a/docs/milestones/2026-05-field-trial-13.md
+++ b/docs/milestones/2026-05-field-trial-13.md
@@ -51,24 +51,34 @@ MySQL + Phinx マイグレーションを必須とする。
 
 ## Phases
 
-### Phase 68 — Field Trial 13 Execution
+### Phase 68 — Field Trial 13 Execution ✓
 
-- [ ] eventlog リポジトリを作成し、`composer require hideyukimori/nene2:^1.4` で初期化
-- [ ] MySQL Docker サービスを起動・接続確認
-- [ ] Phinx マイグレーションファイルを作成・実行
-- [ ] Event / Registration / Auth ドメインを実装
-- [ ] `composer check` 全通過（PHPUnit・PHPStan level 8・PHP-CS-Fixer）
-- [ ] MySQL で全エンドポイント動作確認
-- [ ] 摩擦記録を `docs/field-trial-report.md` に残す
-- [ ] フォローアップ Issue を開く
+- [x] eventlog リポジトリを作成し、`composer require hideyukimori/nene2:^1.4` で初期化
+- [x] MySQL Docker サービスを起動・接続確認
+- [x] Phinx マイグレーションファイルを作成・実行
+- [x] Event / Registration / Auth ドメインを実装
+- [x] `composer check` 全通過（PHPUnit 14/14・PHPStan level 8・PHP-CS-Fixer）
+- [x] MySQL で全エンドポイント動作確認（3 テーブル migrate/status/rollback）
+- [x] 摩擦記録を `docs/field-trial-report.md` に残す（F-1〜F-5、4 件 + 情報 1 件）
+- [x] フォローアップ Issue を開く（#474 / #475 / #476）
 
-## 完了条件
+## 摩擦サマリ
 
-- `composer check` 全通過
-- MySQL で全エンドポイント動作確認
+| ID | 重要度 | タイトル | 対応 |
+|---|---|---|---|
+| F-1 | 低 | compose.yaml `working_on` → `working_dir` | 自律修正済み |
+| F-2 | 中 | `DB_PASS` ではなく `DB_PASSWORD` が正しい変数名 | Issue #474 → PR で修正 |
+| F-3 | 高 | MySQL 外部キーに `'signed' => false` 必要 | Issue #475 → howto 追記 |
+| F-4 | 中 | Phinx 部分失敗後のテーブルが残り再 migrate 不可 | Issue #476 → howto 追記 |
+| F-5 | 情報 | SQLite インメモリでテストが MySQL なしで動く（良い設計） | — |
+
+## 完了条件 ✓
+
+- `composer check` 全通過（PHPUnit 14/14・PHPStan level 8・PHP-CS-Fixer）
+- MySQL で全エンドポイント動作確認済み
 - Phinx マイグレーション（migrate/status/rollback）が動作
-- 摩擦記録あり
-- フォローアップ Issue 作成済み
+- 摩擦記録あり（`/home/xi/docker/eventlog/docs/field-trial-report.md`）
+- フォローアップ Issue #474/#475/#476 作成済み
 
 ## 備考
 
@@ -76,3 +86,4 @@ MySQL + Phinx マイグレーションを必須とする。
 - Issue: #472
 - プロジェクト: `/home/xi/docker/eventlog/`
 - 前: FT12-C (#455) — Multi-Auth (shoplog)
+- テスト戦略: SQLite インメモリ（MySQL なしで `composer check` が動作）

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -719,12 +719,15 @@ App: **shoplog** — product catalog API with 3-tier access model
 - [x] MultiAuthMiddleware pattern: Bearer for /me/*, WriteApiKeyMiddleware for writes
 - [x] 6 friction points recorded (F-1〜F-6); F-2/F-5 resolved in PR #470; follow-up Issues #466–#469
 
-## Phase 68: Field Trial 13 — MySQL + Phinx マイグレーション（Event Management API）(#472)
+## Phase 68: Field Trial 13 — MySQL + Phinx マイグレーション（Event Management API）(#472) ✓
 
 Goal: validate database ergonomics — MySQL setup, Phinx migration authoring,
 DatabaseConfig wiring, and production-like environment from a consumer project.
 
 App: **eventlog** — イベント管理 API (MySQL + Phinx + M:N + Multi-Auth)
+
+Result: 14/14 PHPUnit, PHPStan level 8, PHP-CS-Fixer 全通過。摩擦 5 件（F-1〜F-5）。
+F-2/F-3/F-4 フォローアップ Issues #474–#476 → docs PR で解消。
 
 ## Non-Goals
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -44,25 +44,30 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 - **Phase 66 / Field Trial 12-B** (#454): knowledgelog（ナレッジベース API — Article / Category）を `composer require hideyukimori/nene2:^1.4.1` から 0 構築。8 エンドポイント・MCP 7 ツール・PHPUnit 10/10・PHPStan level 8・PHP-CS-Fixer 全通過。摩擦 5 件記録（F-1〜F-5）、F-2/F-3（高）は PR #464 で解消済み（--root オプション + suggest 追加）、F-1/F-4/F-5 は Issue #459–#463 として起票。
 - **Phase 67 / Field Trial 12-C** (#455): shoplog（商品カタログ API — 3 層アクセスモデル）を `composer require hideyukimori/nene2:^1.4.1` から 0 構築。12 エンドポイント・PHPUnit 29/29・PHPStan level 8・PHP-CS-Fixer 全通過。摩擦 6 件記録（F-1〜F-6）、F-2/F-5（高/低）は PR #470 で解消済み（$protectedPathPrefixes 追加・LocalBearerTokenVerifier 公開）、F-1/F-3/F-4/F-6 は Issue #466–#469 として起票。
 
-## FT12 シリーズ完了
+## FT12 + FT13 完了
 
-FT12-A / FT12-B / FT12-C のすべてが完了。主要成果:
+FT12-A / FT12-B / FT12-C / FT13 のすべてが完了。主要成果:
 
 | FT | アプリ | テスト | 主要摩擦 | 解消済み |
 |---|---|---|---|---|
 | 12-A | tagmark (M:N) | 19/19 | F-1〜F-7 | v1.4.1 + PR #464 |
 | 12-B | knowledgelog (MCP) | 10/10 | F-1〜F-5 | PR #464 (F-2/F-3) |
 | 12-C | shoplog (Multi-Auth) | 29/29 | F-1〜F-6 | PR #470 (F-2/F-5) |
+| 13 | eventlog (MySQL+Phinx) | 14/14 | F-1〜F-5 | PR (F-2/F-3/F-4 howto) |
 
-## Next: v1.5.0 リリース候補
+- **Phase 68 / Field Trial 13** (#472): eventlog（イベント管理 API）を `composer require hideyukimori/nene2:^1.4` から 0 構築。10 エンドポイント・MySQL + Phinx マイグレーション（3 テーブル）・PHPUnit 14/14・PHPStan level 8・PHP-CS-Fixer 全通過。摩擦 5 件記録（F-1〜F-5）、F-2/F-3/F-4 は Issue #474–#476 として起票（本 PR で howto 修正）。
 
-FT12 シリーズで発見した摩擦のうち未解消のもの:
+## 未解消フィールドトライアル摩擦（open issues）
+
 - Issue #457: M:N 多対多 howto（F-6 from FT12-A）
 - Issue #461: ApiKeyAuthenticationMiddleware メソッドベース保護（F-1 from FT12-B/C）
 - Issue #462: nene2.auth.* 属性名の公開（F-4 from FT12-B）
 - Issue #463: RuntimeApplicationFactory Example 切り離し（F-5 from FT12-B）
 - Issue #466: CompositeAuthMiddleware / howto（F-1 from FT12-C）
 - Issue #469: PHPStan memory_limit howto（F-6 from FT12-C）
+- Issue #474: DB_PASSWORD 環境変数名明示（F-2 from FT13） ← 本 PR で解消
+- Issue #475: MySQL FK `signed => false` howto（F-3 from FT13） ← 本 PR で解消
+- Issue #476: Phinx 部分失敗後クリーンアップ howto（F-4 from FT13） ← 本 PR で解消
 
 これらを整理して v1.5.0 をリリースするか、継続して追加フィールドトライアルを実施するか検討。
 


### PR DESCRIPTION
## Summary

Field Trial 13 (eventlog — MySQL + Phinx) で発見した 3 つのドキュメント摩擦を修正する。

- **F-2 [中]** `DB_PASS` でなく `DB_PASSWORD` が正しい変数名（ConfigLoader が読む） → CLAUDE.md セクション 12 に全 DB 環境変数を列挙し `DB_PASSWORD` を太字で明示
- **F-3 [高]** MySQL 外部キーに `'signed' => false` が必要（SQLite テストでは見えない）→ `docs/howto/add-database-endpoint.md` に新セクションを追加
- **F-4 [中]** Phinx `change()` で `CREATE TABLE` が途中失敗するとテーブルが残り次の migrate が失敗する → 手動 DROP 手順と `up()/down()` 推奨をドキュメントに追記

FT13 マイルストーン・ロードマップ・current.md も Phase 68 完了で更新。

## Test plan

- [ ] CLAUDE.md セクション 12 の環境変数表に `DB_PASSWORD` が明示されていることを確認
- [ ] `docs/howto/add-database-endpoint.md` に "MySQL foreign key columns" セクションが追加されていることを確認
- [ ] Phinx cleanup 手順が同ファイルに記載されていることを確認
- [ ] FT13 milestone の Phase 68 が ✓ になっていることを確認

Closes #474
Closes #475
Closes #476

Self-review: docs-policy, database

🤖 Generated with [Claude Code](https://claude.com/claude-code)