### PR TITLE
feat(auth): CompositeAuthMiddleware — 複数認証ミドルウェアを合成するヘルパー

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `composer.json` `suggest` entry for `symfony/yaml` — consumer projects are guided to add it when using the MCP validator (#460)
 - CLAUDE.md section on how to wire the MCP validator in a consumer project
 - `BearerTokenMiddleware::$protectedPathPrefixes` — prefix allowlist parameter; protects all paths starting with the listed prefixes (e.g. `/me/` matches `/me/favorites/42`); evaluated after `$protectedPaths` and before `$excludedPaths` (#467)
+- `CompositeAuthMiddleware` — chains multiple `MiddlewareInterface` instances as a single auth middleware; enables three-tier access models (public / Bearer / API key) by composing path-scoped middlewares in order (#466)
 
 ### Changed
 - `LocalBearerTokenVerifier` — removed `@internal` tag; now part of the public API stability guarantee (see ADR 0009) (#468)

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -58,7 +58,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException` |
 | `Nene2\Error` | `DomainExceptionHandlerInterface`, `ProblemDetailsResponseFactory` |
-| `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware`, `LocalBearerTokenVerifier` |
+| `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware`, `LocalBearerTokenVerifier`, `CompositeAuthMiddleware` |
 | `Nene2\Middleware` | All shipped middleware classes, `RateLimitStorageInterface`, `ThrottleMiddleware` |
 | `Nene2\Validation` | `ValidationException`, `ValidationError` |
 | `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |

--- a/src/Auth/CompositeAuthMiddleware.php
+++ b/src/Auth/CompositeAuthMiddleware.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Chains multiple authentication middlewares into a single PSR-15 middleware.
+ *
+ * Each middleware in the chain handles only the paths it is configured for.
+ * When a middleware determines that the current request does not require
+ * authentication (based on its path/prefix/exclusion settings), it passes
+ * the request to the next entry in the chain automatically.
+ *
+ * Typical use case — three-tier access model:
+ *
+ * ```php
+ * $authMiddleware = new CompositeAuthMiddleware([
+ *     new BearerTokenMiddleware($problemDetails, $verifier, protectedPathPrefixes: ['/me/']),
+ *     new ApiKeyAuthenticationMiddleware($problemDetails, $apiKey, protectedPaths: ['/admin/...']),
+ * ]);
+ * ```
+ *
+ * Evaluation order:
+ * 1. Each middleware processes the request in the order it appears in `$middlewares`.
+ * 2. If a middleware decides the path is not its responsibility, it calls the next handler,
+ *    which forwards to the subsequent middleware.
+ * 3. The final handler after all middlewares is the original downstream handler.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final readonly class CompositeAuthMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param list<MiddlewareInterface> $middlewares Authentication middlewares to compose, evaluated in order.
+     */
+    public function __construct(private array $middlewares)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $this->buildChain(0, $handler)->handle($request);
+    }
+
+    private function buildChain(int $index, RequestHandlerInterface $tail): RequestHandlerInterface
+    {
+        if ($index >= count($this->middlewares)) {
+            return $tail;
+        }
+
+        $middleware = $this->middlewares[$index];
+        $next = $this->buildChain($index + 1, $tail);
+
+        return new class ($middleware, $next) implements RequestHandlerInterface {
+            public function __construct(
+                private readonly MiddlewareInterface $middleware,
+                private readonly RequestHandlerInterface $next,
+            ) {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->middleware->process($request, $this->next);
+            }
+        };
+    }
+}

--- a/tests/Auth/CompositeAuthMiddlewareTest.php
+++ b/tests/Auth/CompositeAuthMiddlewareTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Auth;
+
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\CompositeAuthMiddleware;
+use Nene2\Auth\TokenVerifierInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Middleware\ApiKeyAuthenticationMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class CompositeAuthMiddlewareTest extends TestCase
+{
+    public function testEmptyCompositePassesThrough(): void
+    {
+        $factory = new Psr17Factory();
+        $composite = new CompositeAuthMiddleware([]);
+        $request = $factory->createServerRequest('GET', 'https://example.test/any');
+
+        $response = $composite->process($request, $this->okHandler($factory));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testSingleMiddlewareIsApplied(): void
+    {
+        $factory = new Psr17Factory();
+        $composite = new CompositeAuthMiddleware([
+            $this->rejectingMiddleware($factory),
+        ]);
+        $request = $factory->createServerRequest('GET', 'https://example.test/protected');
+
+        $response = $composite->process($request, $this->okHandler($factory));
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function testBearerMiddlewareProtectsItsPrefixOtherPathPassesThrough(): void
+    {
+        $factory = new Psr17Factory();
+        $bearer = new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $this->acceptingVerifier(),
+            protectedPathPrefixes: ['/me/'],
+        );
+        $composite = new CompositeAuthMiddleware([$bearer]);
+
+        // /public is not under /me/ → should pass through without auth
+        $request = $factory->createServerRequest('GET', 'https://example.test/public');
+        $response = $composite->process($request, $this->okHandler($factory));
+        self::assertSame(200, $response->getStatusCode());
+
+        // /me/profile without token → 401
+        $request = $factory->createServerRequest('GET', 'https://example.test/me/profile');
+        $response = $composite->process($request, $this->okHandler($factory));
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function testThreeTierAuthModel(): void
+    {
+        // Three-tier model:
+        //   - /me/* → Bearer auth required
+        //   - /admin → API key required (all methods)
+        //   - /events → public (neither middleware claims it)
+        $factory = new Psr17Factory();
+        $problemDetails = new ProblemDetailsResponseFactory($factory, $factory);
+
+        $bearer = new BearerTokenMiddleware(
+            $problemDetails,
+            $this->acceptingVerifier(['sub' => '42']),
+            protectedPathPrefixes: ['/me/'],
+        );
+        $apiKey = new ApiKeyAuthenticationMiddleware(
+            $problemDetails,
+            'secret-key',
+            protectedPaths: ['/admin'],
+        );
+
+        $composite = new CompositeAuthMiddleware([$bearer, $apiKey]);
+
+        // GET /events (public) → neither middleware claims it → handler
+        $request = $factory->createServerRequest('GET', 'https://example.test/events');
+        $response = $composite->process($request, $this->okHandler($factory));
+        self::assertSame(200, $response->getStatusCode());
+
+        // GET /admin without API key → Bearer passes through; ApiKey rejects
+        $request = $factory->createServerRequest('GET', 'https://example.test/admin');
+        $response = $composite->process($request, $this->okHandler($factory));
+        self::assertSame(401, $response->getStatusCode());
+
+        // GET /admin with valid API key → passes both middlewares
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/admin')
+            ->withHeader('X-NENE2-API-Key', 'secret-key');
+        $response = $composite->process($request, $this->okHandler($factory));
+        self::assertSame(200, $response->getStatusCode());
+
+        // GET /me/profile without Bearer → BearerMiddleware rejects
+        $request = $factory->createServerRequest('GET', 'https://example.test/me/profile');
+        $response = $composite->process($request, $this->okHandler($factory));
+        self::assertSame(401, $response->getStatusCode());
+
+        // GET /me/profile with Bearer → Bearer passes; ApiKey does not claim /me/ → handler
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/me/profile')
+            ->withHeader('Authorization', 'Bearer valid.token');
+        $response = $composite->process($request, $this->okHandler($factory));
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testAuthAttributesAreForwardedDownstream(): void
+    {
+        $factory = new Psr17Factory();
+        $claims = ['sub' => 'user-1'];
+        $bearer = new BearerTokenMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            $this->acceptingVerifier($claims),
+            protectedPathPrefixes: ['/me/'],
+        );
+        $composite = new CompositeAuthMiddleware([$bearer]);
+
+        $capture = new \stdClass();
+        $capture->request = null;
+        $handler = new class ($factory, $capture) implements RequestHandlerInterface {
+            public function __construct(
+                private readonly Psr17Factory $factory,
+                private readonly \stdClass $capture,
+            ) {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->capture->request = $request;
+
+                return $this->factory->createResponse(200);
+            }
+        };
+
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/me/profile')
+            ->withHeader('Authorization', 'Bearer valid.token');
+
+        $composite->process($request, $handler);
+
+        self::assertNotNull($capture->request);
+        self::assertSame('bearer', $capture->request->getAttribute('nene2.auth.credential_type'));
+        self::assertSame($claims, $capture->request->getAttribute('nene2.auth.claims'));
+    }
+
+    private function okHandler(Psr17Factory $factory): RequestHandlerInterface
+    {
+        return new class ($factory) implements RequestHandlerInterface {
+            public function __construct(private readonly Psr17Factory $factory)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse(200);
+            }
+        };
+    }
+
+    private function rejectingMiddleware(Psr17Factory $factory): MiddlewareInterface
+    {
+        return new class ($factory) implements MiddlewareInterface {
+            public function __construct(private readonly Psr17Factory $factory)
+            {
+            }
+
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+            {
+                return $this->factory->createResponse(401);
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $claims
+     */
+    private function acceptingVerifier(array $claims = []): TokenVerifierInterface
+    {
+        return new class ($claims) implements TokenVerifierInterface {
+            /** @param array<string, mixed> $claims */
+            public function __construct(private readonly array $claims)
+            {
+            }
+
+            public function verify(string $token): array
+            {
+                return $this->claims;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

FT12-C (shoplog) で発見した摩擦 F-1 の解消。
`RuntimeApplicationFactory` の `$authMiddleware` スロットは 1 つしか受け取れないため、
Bearer + API Key のような複数認証が必要なアプリは独自の合成クラスを書く必要があった。

`CompositeAuthMiddleware` を追加することで、この合成パターンを NENE2 公式ヘルパーとして提供する。

### 使い方（3 層アクセスモデル）

```php
$authMiddleware = new CompositeAuthMiddleware([
    new BearerTokenMiddleware($problemDetails, $verifier, protectedPathPrefixes: ['/me/']),
    new ApiKeyAuthenticationMiddleware($problemDetails, $apiKey, protectedPaths: ['/admin']),
]);
// → RuntimeApplicationFactory($psr17, $psr17, authMiddleware: $authMiddleware)
```

評価順: 各ミドルウェアが自分の path config に基づいて「担当するか否か」を判断し、
担当しない場合は次のミドルウェアへ自動委譲する。

## Test plan

- [x] `composer check` 全通過（PHPUnit 224/224・PHPStan level 8・PHP-CS-Fixer）
- [x] 5 テスト追加: 空合成・単体・prefix 保護・3 層モデル・属性伝播
- [x] ADR 0009 公開 API リストに追加
- [x] CHANGELOG [Unreleased] に追記

Closes #466

Self-review: backend-api, middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)