### PR TITLE
docs: nene2.auth.* 属性・PHPStan memory_limit・M:N howto (#457 #462 #469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - `ApiKeyAuthenticationMiddleware::$protectedPathPrefixes` — prefix allowlist parameter; protects paths starting with any listed prefix (e.g. `/admin/` matches `/admin/users/42`). Evaluated only when `$protectedPaths` is empty, mirroring `BearerTokenMiddleware` behaviour. (#461, #482)
 - `ApiKeyAuthenticationMiddleware::$protectedMethods` — method filter; when non-empty, only requests whose HTTP method is in the list are protected. Enables "GET is public, POST/DELETE require API key" patterns without a custom middleware. (#461, #482)
+- `docs/adr/0009`: `nene2.auth.credential_type` and `nene2.auth.claims` request attributes documented as part of the stable public API (#462)
+- `docs/development/quality-tools.md`: PHPStan `memory_limit` section for consumer projects that hit OOM in Docker (#469)
+- `docs/howto/add-database-endpoint.md`: M:N many-to-many relationship section — join table schema, idempotent `attachTag`/`detachTag` repository pattern, MySQL `INSERT IGNORE` note (#457)
 
 ---
 

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -64,7 +64,21 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |
 | `Nene2\Mcp` | `LocalMcpServer`, `LocalMcpHttpClientInterface`, `LocalMcpHttpResponse`, `LocalMcpException` |
 
-### 4. Explicitly outside the stability guarantee
+### 4. Stable request attributes set by authentication middleware
+
+Authentication middleware communicates identity to downstream handlers via PSR-7 request
+attributes. The following attribute names are part of the stable public API:
+
+| Attribute | Set by | Value |
+|---|---|---|
+| `nene2.auth.credential_type` | `BearerTokenMiddleware`, `ApiKeyAuthenticationMiddleware` | `'bearer'` or `'api_key'` |
+| `nene2.auth.claims` | `BearerTokenMiddleware` (after successful token verification) | `array<string, mixed>` — the JWT claims returned by `TokenVerifierInterface::verify()` |
+
+Handlers read these attributes via `$request->getAttribute('nene2.auth.credential_type')` and
+`$request->getAttribute('nene2.auth.claims')`. The attribute names will not change in a
+backward-incompatible way within the v1.x line.
+
+### 5. Explicitly outside the stability guarantee
 
 - `Nene2\Example\*` — reference implementation (see decision 2)
 - `Nene2\Log\*` — internal logging plumbing; PSR-3 (`LoggerInterface`) is the stable boundary

--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -113,6 +113,36 @@ CI should start with backend `composer check` and expand only after each tool ha
 
 Safe local AI and MCP command usage is documented in `docs/integrations/local-ai-commands.md`.
 
+## PHPStan Memory Limit in Consumer Projects
+
+PHPStan's parallel analysis can exhaust PHP's default `memory_limit` (typically `128M`)
+in Docker environments. If `composer check` (or `composer analyse`) fails with:
+
+```
+Out of memory (Reached memory limit of 128 MB)
+Increase your memory limit in php.ini or run PHPStan with --memory-limit CLI option.
+```
+
+Add a `memory_limit` setting to your `phpstan.neon`:
+
+```yaml
+parameters:
+    memory_limit: 512M
+```
+
+Or pass `--memory-limit 512M` directly in your `composer.json` analyse script:
+
+```json
+{
+    "scripts": {
+        "analyse": "phpstan analyse --memory-limit 512M"
+    }
+}
+```
+
+The `512M` figure is sufficient for most NENE2 consumer projects up to ~200 source files.
+Larger projects may need `1G`. Avoid setting an unlimited value (`-1`) in shared environments.
+
 ## Non-Goals
 
 - Forcing React on framework consumers.

--- a/docs/howto/add-database-endpoint.md
+++ b/docs/howto/add-database-endpoint.md
@@ -396,6 +396,104 @@ if ($dbFile !== ':memory:' && !file_exists($dbFile)) {
 
 ---
 
+## Many-to-many relationships (M:N)
+
+NENE2 has no special M:N abstraction — use a join table and add `attach` / `detach` methods to
+the repository that owns the relationship.
+
+### Schema
+
+```sql
+-- SQLite
+CREATE TABLE IF NOT EXISTS post_tags (
+    post_id INTEGER NOT NULL REFERENCES posts(id)  ON DELETE CASCADE,
+    tag_id  INTEGER NOT NULL REFERENCES tags(id)   ON DELETE CASCADE,
+    PRIMARY KEY (post_id, tag_id)
+);
+```
+
+Enable cascade deletes in SQLite by adding `PRAGMA foreign_keys = ON` after opening the connection:
+
+```php
+$pdo = new PDO('sqlite::memory:');
+$pdo->exec('PRAGMA foreign_keys = ON');
+```
+
+### Repository methods
+
+Add `attachTag` and `detachTag` to `PostRepositoryInterface`:
+
+```php
+interface PostRepositoryInterface
+{
+    public function findById(int $id): ?Post;
+    public function attachTag(int $postId, int $tagId): void;
+    public function detachTag(int $postId, int $tagId): void;
+    /** @return list<Tag> */
+    public function findTags(int $postId): array;
+}
+```
+
+Implement with `INSERT OR IGNORE` for idempotent attach and a plain `DELETE` for detach:
+
+```php
+public function attachTag(int $postId, int $tagId): void
+{
+    $this->pdo
+        ->prepare('INSERT OR IGNORE INTO post_tags (post_id, tag_id) VALUES (?, ?)')
+        ->execute([$postId, $tagId]);
+}
+
+public function detachTag(int $postId, int $tagId): void
+{
+    $this->pdo
+        ->prepare('DELETE FROM post_tags WHERE post_id = ? AND tag_id = ?')
+        ->execute([$postId, $tagId]);
+}
+
+/** @return list<Tag> */
+public function findTags(int $postId): array
+{
+    $stmt = $this->pdo->prepare(
+        'SELECT t.id, t.name FROM tags t
+         JOIN post_tags pt ON pt.tag_id = t.id
+         WHERE pt.post_id = ?',
+    );
+    $stmt->execute([$postId]);
+
+    return array_map(
+        static fn (array $row) => new Tag((int) $row['id'], (string) $row['name']),
+        $stmt->fetchAll(PDO::FETCH_ASSOC),
+    );
+}
+```
+
+### Route handler
+
+```php
+// POST /me/posts/{id}/tags/{tagId}
+$router->post('/me/posts/{id}/tags/{tagId}', function (ServerRequestInterface $req) use ($json, $posts) {
+    $params  = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $postId  = (int) ($params['id']    ?? 0);
+    $tagId   = (int) ($params['tagId'] ?? 0);
+    $posts->attachTag($postId, $tagId);
+
+    return $json->create(['message' => 'Tag attached.']);
+});
+```
+
+### MySQL note
+
+MySQL does not support `INSERT OR IGNORE`. Use `INSERT IGNORE` instead:
+
+```php
+'INSERT IGNORE INTO post_tags (post_id, tag_id) VALUES (?, ?)'
+```
+
+Or use `INSERT ... ON DUPLICATE KEY UPDATE` for the same idempotent effect.
+
+---
+
 ## Next steps
 
 - Add OpenAPI documentation for your endpoint: see `docs/development/endpoint-scaffold.md`


### PR DESCRIPTION
## Summary

3 つのドキュメント Issue をまとめて解消する。

- **#462** `nene2.auth.*` 属性名を ADR 0009 の安定 API セクションとして明記
- **#469** PHPStan OOM 対策（`memory_limit` 設定）を `quality-tools.md` に追記
- **#457** M:N 多対多リレーション実装ガイドを `add-database-endpoint.md` に追加

## Test plan

- [x] `composer check` 全通過（236/236・PHPStan・PHP-CS-Fixer）

Closes #457
Closes #462
Closes #469

Self-review: docs-policy, database

🤖 Generated with [Claude Code](https://claude.com/claude-code)