### PR TITLE
refactor(http): ExampleServiceProvider 導入 — RuntimeServiceProvider の Example 依存を集約

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - `ApiKeyAuthenticationMiddleware::$protectedPathPrefixes` — prefix allowlist parameter; protects paths starting with any listed prefix (e.g. `/admin/` matches `/admin/users/42`). Evaluated only when `$protectedPaths` is empty, mirroring `BearerTokenMiddleware` behaviour. (#461, #482)
 - `ApiKeyAuthenticationMiddleware::$protectedMethods` — method filter; when non-empty, only requests whose HTTP method is in the list are protected. Enables "GET is public, POST/DELETE require API key" patterns without a custom middleware. (#461, #482)
+- `ExampleServiceProvider` (`Nene2\Example`) — bundles Note and Tag example services and exposes `ROUTE_REGISTRARS` / `EXCEPTION_HANDLERS` string keys so framework infrastructure code can wire example routes without importing individual example classes (#463)
 - `docs/adr/0009`: `nene2.auth.credential_type` and `nene2.auth.claims` request attributes documented as part of the stable public API (#462)
 - `docs/development/quality-tools.md`: PHPStan `memory_limit` section for consumer projects that hit OOM in Docker (#469)
 - `docs/howto/add-database-endpoint.md`: M:N many-to-many relationship section — join table schema, idempotent `attachTag`/`detachTag` repository pattern, MySQL `INSERT IGNORE` note (#457)

--- a/src/Example/ExampleServiceProvider.php
+++ b/src/Example/ExampleServiceProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Example;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Example\Note\NoteNotFoundExceptionHandler;
+use Nene2\Example\Note\NoteServiceProvider;
+use Nene2\Example\Tag\TagNotFoundExceptionHandler;
+use Nene2\Example\Tag\TagServiceProvider;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Registers all built-in NENE2 example services (Note, Tag) and exposes
+ * aggregate string-keyed services so framework infrastructure code can wire
+ * example routes and exception handlers without importing individual example classes.
+ *
+ * @internal
+ */
+final readonly class ExampleServiceProvider implements ServiceProviderInterface
+{
+    /** Container key for the list of example route registrar callables. */
+    public const ROUTE_REGISTRARS = 'nene2.example.route_registrars';
+
+    /** Container key for the list of example domain exception handlers. */
+    public const EXCEPTION_HANDLERS = 'nene2.example.exception_handlers';
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->addProvider(new NoteServiceProvider());
+        $builder->addProvider(new TagServiceProvider());
+
+        $builder
+            ->set(
+                self::ROUTE_REGISTRARS,
+                static function (ContainerInterface $container): array {
+                    $note = $container->get('nene2.route_registrar.note');
+                    $tag  = $container->get('nene2.route_registrar.tag');
+
+                    if (!is_callable($note)) {
+                        throw new LogicException('Note route registrar service is invalid.');
+                    }
+
+                    if (!is_callable($tag)) {
+                        throw new LogicException('Tag route registrar service is invalid.');
+                    }
+
+                    return [$note, $tag];
+                },
+            )
+            ->set(
+                self::EXCEPTION_HANDLERS,
+                static function (ContainerInterface $container): array {
+                    $note = $container->get(NoteNotFoundExceptionHandler::class);
+                    $tag  = $container->get(TagNotFoundExceptionHandler::class);
+
+                    if (!$note instanceof DomainExceptionHandlerInterface) {
+                        throw new LogicException('Note exception handler service is invalid.');
+                    }
+
+                    if (!$tag instanceof DomainExceptionHandlerInterface) {
+                        throw new LogicException('Tag exception handler service is invalid.');
+                    }
+
+                    return [$note, $tag];
+                },
+            );
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -17,13 +17,9 @@ use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Database\PdoDatabaseTransactionManager;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
-use Nene2\Example\Note\NoteNotFoundExceptionHandler;
-use Nene2\Example\Note\NoteRouteRegistrar;
-use Nene2\Example\Note\NoteServiceProvider;
-use Nene2\Example\Tag\TagNotFoundExceptionHandler;
-use Nene2\Example\Tag\TagRouteRegistrar;
-use Nene2\Example\Tag\TagServiceProvider;
+use Nene2\Example\ExampleServiceProvider;
 use Nene2\Log\MonologLoggerFactory;
 use Nene2\Log\RequestIdHolder;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -40,8 +36,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 
     public function register(ContainerBuilder $builder): void
     {
-        $builder->addProvider(new NoteServiceProvider());
-        $builder->addProvider(new TagServiceProvider());
+        $builder->addProvider(new ExampleServiceProvider());
 
         $builder
             ->set(
@@ -182,15 +177,13 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
             ->set(
                 RuntimeApplicationFactory::class,
                 static function (ContainerInterface $container): RuntimeApplicationFactory {
-                    $responseFactory = $container->get(ResponseFactoryInterface::class);
-                    $streamFactory = $container->get(StreamFactoryInterface::class);
-                    $logger = $container->get(LoggerInterface::class);
-                    $config = $container->get(AppConfig::class);
-                    $noteNotFoundHandler = $container->get(NoteNotFoundExceptionHandler::class);
-                    $tagNotFoundHandler = $container->get(TagNotFoundExceptionHandler::class);
-                    $noteRegistrar = $container->get('nene2.route_registrar.note');
-                    $tagRegistrar = $container->get('nene2.route_registrar.tag');
-                    $requestIdHolder = $container->get(RequestIdHolder::class);
+                    $responseFactory     = $container->get(ResponseFactoryInterface::class);
+                    $streamFactory       = $container->get(StreamFactoryInterface::class);
+                    $logger              = $container->get(LoggerInterface::class);
+                    $config              = $container->get(AppConfig::class);
+                    $exceptionHandlers   = $container->get(ExampleServiceProvider::EXCEPTION_HANDLERS);
+                    $routeRegistrars     = $container->get(ExampleServiceProvider::ROUTE_REGISTRARS);
+                    $requestIdHolder     = $container->get(RequestIdHolder::class);
 
                     if (!$responseFactory instanceof ResponseFactoryInterface) {
                         throw new LogicException('Response factory service is invalid.');
@@ -208,21 +201,16 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Application config service is invalid.');
                     }
 
-                    if (!$noteNotFoundHandler instanceof NoteNotFoundExceptionHandler) {
-                        throw new LogicException('NoteNotFoundException handler service is invalid.');
+                    if (!is_array($exceptionHandlers) || !array_is_list($exceptionHandlers)) {
+                        throw new LogicException('Example exception handlers service is invalid.');
                     }
 
-                    if (!$tagNotFoundHandler instanceof TagNotFoundExceptionHandler) {
-                        throw new LogicException('TagNotFoundException handler service is invalid.');
+                    if (!is_array($routeRegistrars) || !array_is_list($routeRegistrars)) {
+                        throw new LogicException('Example route registrars service is invalid.');
                     }
 
-                    if (!$noteRegistrar instanceof NoteRouteRegistrar) {
-                        throw new LogicException('Note route registrar service is invalid.');
-                    }
-
-                    if (!$tagRegistrar instanceof TagRouteRegistrar) {
-                        throw new LogicException('Tag route registrar service is invalid.');
-                    }
+                    /** @var list<DomainExceptionHandlerInterface> $exceptionHandlers */
+                    /** @var list<callable(\Nene2\Routing\Router): void> $routeRegistrars */
 
                     if (!$requestIdHolder instanceof RequestIdHolder) {
                         throw new LogicException('RequestIdHolder service is invalid.');
@@ -249,9 +237,9 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         $streamFactory,
                         $logger,
                         $config->machineApiKey,
-                        [$noteNotFoundHandler, $tagNotFoundHandler],
+                        $exceptionHandlers,
                         $requestIdHolder,
-                        [$noteRegistrar, $tagRegistrar],
+                        $routeRegistrars,
                         $bearerMiddleware,
                         [],
                         null,


### PR DESCRIPTION
## Summary

`RuntimeServiceProvider` が `src/Example/` の 6 クラスを直接 import していた構造を解消する。

**Before**: `RuntimeServiceProvider` → `NoteNotFoundExceptionHandler`, `NoteRouteRegistrar`, `NoteServiceProvider`, `TagNotFoundExceptionHandler`, `TagRouteRegistrar`, `TagServiceProvider` (6 imports)

**After**: `RuntimeServiceProvider` → `ExampleServiceProvider` (1 import)

`ExampleServiceProvider` が全 Note/Tag サービスを登録し、
`ROUTE_REGISTRARS` / `EXCEPTION_HANDLERS` の文字列キーで集約値を提供する。

動作変更なし。

## Test plan

- [x] `composer check` 全通過（236/236・PHPStan・PHP-CS-Fixer）

Closes #463

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)