### PR TITLE
test(view) + docs(howto): View 層テスト拡充・add-html-view.md 追加

### DIFF
--- a/docs/howto/add-html-view.md
+++ b/docs/howto/add-html-view.md
@@ -1,0 +1,288 @@
+# Add HTML Views
+
+This guide shows how to add server-rendered HTML responses to a NENE2 application
+using `NativePhpViewRenderer` and `HtmlResponseFactory`.
+
+**Prerequisite**: You have a working NENE2 application with at least one route. If not,
+start with [Add a custom route](./add-custom-route.md).
+
+---
+
+## Overview
+
+NENE2 ships a minimal, zero-dependency HTML rendering layer:
+
+| Class | Role |
+|---|---|
+| `NativePhpViewRenderer` | Renders `.php` templates in an isolated scope |
+| `HtmlEscaper` | Escapes values for safe HTML output (`htmlspecialchars` / UTF-8 / full quotes) |
+| `HtmlResponseFactory` | Wraps rendered HTML in a `text/html; charset=utf-8` PSR-7 response |
+| `TemplateNotFoundException` | Thrown when a template file is missing or the path is invalid |
+
+HTML responses coexist with JSON endpoints — add them to the same application without
+removing any existing routes.
+
+---
+
+## 1. Create your templates
+
+NENE2 expects native PHP template files under a single root directory. The conventional
+location is `templates/` at the project root.
+
+```
+my-app/
+├── templates/
+│   ├── layout.php       (optional shared layout)
+│   ├── home.php
+│   └── notes/
+│       ├── index.php
+│       └── show.php
+```
+
+Each template receives:
+
+- `$e` — the escaping helper (`HtmlEscaper::escape()`). Always use it for user-supplied data.
+- All keys from the `$data` array passed to `render()` as individual variables.
+
+**`templates/home.php`**
+
+```php
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title><?= $e($title) ?></title></head>
+<body>
+  <h1><?= $e($title) ?></h1>
+  <p><?= $e($description) ?></p>
+</body>
+</html>
+```
+
+**`templates/notes/index.php`**
+
+```php
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Notes</title></head>
+<body>
+  <h1>Notes</h1>
+  <ul>
+    <?php foreach ($notes as $note): ?>
+      <li><a href="/notes/<?= $e($note['id']) ?>"><?= $e($note['title']) ?></a></li>
+    <?php endforeach; ?>
+  </ul>
+</body>
+</html>
+```
+
+> **Security**: always call `$e(...)` around any value that originated from user input,
+> a database, or an external system. Omitting it introduces XSS vulnerabilities.
+
+---
+
+## 2. Wire the renderer in your ServiceProvider
+
+Register `NativePhpViewRenderer` and `HtmlResponseFactory` in your application's
+`ServiceProviderInterface`:
+
+```php
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class AppServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                NativePhpViewRenderer::class,
+                static function (ContainerInterface $container): NativePhpViewRenderer {
+                    // Resolve the template root relative to your project root.
+                    return new NativePhpViewRenderer(dirname(__DIR__) . '/templates');
+                },
+            )
+            ->set(
+                HtmlResponseFactory::class,
+                static function (ContainerInterface $container): HtmlResponseFactory {
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    $streamFactory   = $container->get(StreamFactoryInterface::class);
+                    $renderer        = $container->get(NativePhpViewRenderer::class);
+
+                    return new HtmlResponseFactory($responseFactory, $streamFactory, $renderer);
+                },
+            );
+    }
+}
+```
+
+---
+
+## 3. Use HtmlResponseFactory in a handler
+
+Inject `HtmlResponseFactory` into your handler and call `create()`:
+
+```php
+use Nene2\View\HtmlResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class HomeHandler
+{
+    public function __construct(private HtmlResponseFactory $html) {}
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->html->create('home.php', [
+            'title'       => 'Welcome',
+            'description' => 'A NENE2-powered application.',
+        ]);
+    }
+}
+```
+
+`create()` signature:
+
+```php
+public function create(
+    string $template,           // path relative to templateRoot
+    array  $data    = [],       // variables exposed to the template
+    int    $status  = 200,      // HTTP status code
+    array  $headers = [],       // additional response headers
+): ResponseInterface
+```
+
+---
+
+## 4. Register the route
+
+```php
+// In your route registrar callable passed to RuntimeApplicationFactory:
+$router->get('/', new HomeHandler($container->get(HtmlResponseFactory::class)));
+$router->get('/notes', new NoteListHandler($container->get(HtmlResponseFactory::class)));
+```
+
+---
+
+## 5. Handle TemplateNotFoundException
+
+`NativePhpViewRenderer::render()` throws `TemplateNotFoundException` when:
+
+- The template file does not exist.
+- The template path is empty.
+- The template path contains `..` (directory traversal is blocked).
+
+Register a domain exception handler to return a meaningful HTTP response:
+
+```php
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\View\TemplateNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class TemplateNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(private ProblemDetailsResponseFactory $problemDetails) {}
+
+    public function handles(\Throwable $exception): bool
+    {
+        return $exception instanceof TemplateNotFoundException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'not-found', 'Not Found', 404);
+    }
+}
+```
+
+Pass it to `RuntimeApplicationFactory`:
+
+```php
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    domainExceptionHandlers: [new TemplateNotFoundExceptionHandler($problemDetails)],
+    routeRegistrars: [$registerRoutes],
+))->create();
+```
+
+---
+
+## 6. Mix HTML and JSON endpoints
+
+JSON and HTML endpoints coexist on the same `Router`. There is no special configuration:
+
+```php
+$registerRoutes = static function (Router $router) use ($container): void {
+    // JSON API
+    $router->get('/api/notes',     $container->get(NoteListJsonHandler::class));
+    $router->post('/api/notes',    $container->get(NoteCreateHandler::class));
+
+    // HTML views
+    $router->get('/',              $container->get(HomeHandler::class));
+    $router->get('/notes',         $container->get(NoteListHtmlHandler::class));
+    $router->get('/notes/{id}',    $container->get(NoteShowHtmlHandler::class));
+};
+```
+
+---
+
+## 7. Testing HTML handlers
+
+Test the full response without mocking the renderer — just supply a real template directory:
+
+```php
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
+
+public function testHomeReturnsHtml(): void
+{
+    $templateRoot = sys_get_temp_dir() . '/test-templates-' . bin2hex(random_bytes(4));
+    mkdir($templateRoot);
+    file_put_contents($templateRoot . '/home.php', '<h1><?= $e($title) ?></h1>');
+
+    $psr17   = new Psr17Factory();
+    $factory = new HtmlResponseFactory($psr17, $psr17, new NativePhpViewRenderer($templateRoot));
+    $handler = new HomeHandler($factory);
+
+    $response = $handler(new ServerRequest('GET', '/'));
+
+    self::assertSame(200, $response->getStatusCode());
+    self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+    self::assertStringContainsString('<h1>Welcome</h1>', (string) $response->getBody());
+
+    unlink($templateRoot . '/home.php');
+    rmdir($templateRoot);
+}
+```
+
+---
+
+## Design notes
+
+- Templates run in a closure scope — they cannot access `$this` or class internals.
+  Variables are injected via `extract()` with `EXTR_SKIP` (existing variables are not
+  overwritten).
+- `HtmlEscaper` uses `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5` — both `"` and `'` are
+  escaped, and invalid UTF-8 sequences are silently substituted rather than discarded.
+- Directory traversal (`../`) is blocked at the path-resolution step; no file-system access
+  happens before the check.
+
+See [ADR 0009](../adr/0009-v1.0-public-api-scope.md) for the stability guarantee covering
+`Nene2\View\*`.
+
+---
+
+## Next steps
+
+- [Add a custom route](./add-custom-route.md) — wire handlers into the router
+- [Add rate limiting](./add-rate-limiting.md) — protect HTML endpoints from abuse
+- [Add JWT authentication](./add-jwt-authentication.md) — restrict HTML pages to authenticated users

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -85,10 +85,39 @@ FT12-A / FT12-B / FT12-C / FT13 のすべてが完了。主要成果:
 | #469 | PHPStan memory_limit howto | PR #484 (quality-tools.md) |
 | #481 | v1.4.2 リリース | GitHub Release 作成済み |
 
-## 次のアクション候補
+## 次の目標: View 層 + MCP 層の強化
 
-- FT15 (追加フィールドトライアル) — 新テーマで API 品質を検証する
-- v1.5.0 リリース準備 — FT12〜FT14 で積み上がった改善を整理してタグ作成
+総合評価（2026-05-20）で「テストが薄い・howto がない」と指摘された 2 領域を集中的に補強する。
+
+### Phase 70 — View 層強化
+
+| # | タスク | 内容 | 優先度 |
+|---|---|---|---|
+| 70-1 | View テスト拡充 | `HtmlEscaper`（境界条件・特殊文字・null）、`HtmlResponseFactory`（ステータス・Content-Type）の追加ユニットテスト | 高 |
+| 70-2 | howto 追加 | `docs/howto/add-html-view.md` — `templates/` 配置 → `NativePhpViewRenderer` → `HtmlResponseFactory` の全手順を 6 言語で | 高 |
+| 70-3 | FT15: HTML View FT | HTML レスポンスを主軸にしたアプリ（例: ブログ一覧・フォーム）を `composer require` から構築して摩擦記録 | 中 |
+
+### Phase 71 — MCP 層強化
+
+| # | タスク | 内容 | 優先度 |
+|---|---|---|---|
+| 71-1 | MCP テスト拡充 | `LocalMcpToolCatalog` の 3 テストを拡充（ツール検証・スキーマ生成・エラーケース） | 高 |
+| 71-2 | howto 追加 | `docs/howto/add-mcp-tools.md` — Consumer プロジェクトでの MCP ツール定義・認証・テストの全手順 | 高 |
+| 71-3 | Write ツール認証ドキュメント | JWT 保護 Write ツールのパターンを howto またはコード例で明示 | 中 |
+| 71-4 | FT16: MCP 中心 FT | MCP ツール（read + write）を主目的にしたアプリを構築して摩擦記録 | 中 |
+
+### Phase 72 — テストカバレッジ補完（評価レポート指摘）
+
+| # | タスク | 内容 | 優先度 |
+|---|---|---|---|
+| 72-1 | BearerTokenMiddleware 境界テスト | token expiry / malformed header / missing `Bearer ` prefix の各ケース | 中 |
+| 72-2 | ThrottleMiddleware テスト | 現在テストなし — 基本動作・制限超過・リセットを追加 | 中 |
+| 72-3 | PaginationQueryParser テスト | 現在テストなし — デフォルト値・不正入力・上限を追加 | 低 |
+
+### v1.5.0 リリース準備
+
+上記 Phase 70〜72 が完了したタイミングで v1.5.0 を検討。
+FT12〜FT14 の実績＋ View/MCP 強化がセットになったリリースにする。
 
 ---
 

--- a/tests/View/NativePhpViewRendererTest.php
+++ b/tests/View/NativePhpViewRendererTest.php
@@ -91,4 +91,100 @@ final class NativePhpViewRendererTest extends TestCase
         self::assertSame('native', $response->getHeaderLine('X-View'));
         self::assertSame('<main>OK</main>', (string) $response->getBody());
     }
+
+    public function testEscaperHandlesNull(): void
+    {
+        $escaper = new HtmlEscaper();
+
+        self::assertSame('', $escaper->escape(null));
+    }
+
+    public function testEscaperHandlesNumericTypes(): void
+    {
+        $escaper = new HtmlEscaper();
+
+        self::assertSame('42', $escaper->escape(42));
+        self::assertSame('3.14', $escaper->escape(3.14));
+    }
+
+    public function testEscaperHandlesEmptyString(): void
+    {
+        $escaper = new HtmlEscaper();
+
+        self::assertSame('', $escaper->escape(''));
+    }
+
+    public function testEscaperPassesMultibyteUtf8Unchanged(): void
+    {
+        $escaper = new HtmlEscaper();
+
+        self::assertSame('日本語テスト', $escaper->escape('日本語テスト'));
+        self::assertSame('🎉', $escaper->escape('🎉'));
+    }
+
+    public function testHtmlResponseFactoryDefaultStatus(): void
+    {
+        file_put_contents($this->templateRoot . '/index.php', 'ok');
+
+        $psr17Factory = new Psr17Factory();
+        $responseFactory = new HtmlResponseFactory(
+            $psr17Factory,
+            $psr17Factory,
+            new NativePhpViewRenderer($this->templateRoot),
+        );
+
+        $response = $responseFactory->create('index.php');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('text/html; charset=utf-8', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function testHtmlResponseFactoryMultipleHeaders(): void
+    {
+        file_put_contents($this->templateRoot . '/index.php', 'ok');
+
+        $psr17Factory = new Psr17Factory();
+        $responseFactory = new HtmlResponseFactory(
+            $psr17Factory,
+            $psr17Factory,
+            new NativePhpViewRenderer($this->templateRoot),
+        );
+
+        $response = $responseFactory->create('index.php', [], 200, [
+            'Cache-Control' => 'no-cache',
+            'X-Frame-Options' => 'DENY',
+        ]);
+
+        self::assertSame('no-cache', $response->getHeaderLine('Cache-Control'));
+        self::assertSame('DENY', $response->getHeaderLine('X-Frame-Options'));
+    }
+
+    public function testRendererClearsOutputBufferOnException(): void
+    {
+        file_put_contents($this->templateRoot . '/throws.php', '<?php echo "partial"; throw new \RuntimeException("boom"); ?>');
+
+        $renderer = new NativePhpViewRenderer($this->templateRoot);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $renderer->render('throws.php');
+
+        // Output buffer must not leak — if it did, ob_get_level() would be elevated.
+        // PHPUnit verifies the exception is thrown; the ob_end_clean() path is what prevents
+        // the partial output from being returned.
+    }
+
+    public function testRendererResolvesTemplateInSubdirectory(): void
+    {
+        mkdir($this->templateRoot . '/sub');
+        file_put_contents($this->templateRoot . '/sub/child.php', 'child');
+
+        $renderer = new NativePhpViewRenderer($this->templateRoot);
+
+        self::assertSame('child', $renderer->render('sub/child.php'));
+
+        unlink($this->templateRoot . '/sub/child.php');
+        rmdir($this->templateRoot . '/sub');
+    }
 }


### PR DESCRIPTION
## Summary

- `tests/View/NativePhpViewRendererTest.php`: 5 → 13 テストに拡充
  - `HtmlEscaper`: null / 数値型 / 空文字 / マルチバイト UTF-8 の境界ケース 4 件追加
  - `HtmlResponseFactory`: デフォルトステータス 200 / 複数ヘッダー 2 件追加
  - `NativePhpViewRenderer`: 例外時バッファクリーン / サブディレクトリ解決 2 件追加
- `docs/howto/add-html-view.md` 新規作成（Consumer 向け HTML ビュー完全ガイド）
- `docs/todo/current.md`: Phase 70〜72 + v1.5.0 計画追記

## Checklist

- [x] 244 tests, 0 PHPStan errors, 0 CS violations
- [x] Closes #486 #487

Self-review: backend-api, docs-policy