### PR TITLE
test(mcp) + docs(howto): MCP 層テスト拡充・add-mcp-tools.md 追加

### DIFF
--- a/docs/howto/add-mcp-tools.md
+++ b/docs/howto/add-mcp-tools.md
@@ -1,0 +1,333 @@
+# Add MCP Tools
+
+This guide shows how to expose your NENE2 application's API endpoints as MCP tools,
+allowing AI assistants (Claude, Cursor, etc.) to call your API through the Model Context Protocol.
+
+**Prerequisite**: You have a working NENE2 application with at least one route and an
+`docs/openapi/openapi.yaml` file. If not, start with [Add a custom route](./add-custom-route.md).
+
+---
+
+## Overview
+
+NENE2 ships a local MCP server (`LocalMcpServer`) that translates JSON-RPC MCP messages
+into HTTP calls against your API. The tool catalog (`docs/mcp/tools.json`) declares which
+endpoints are available as MCP tools and how safe each is to invoke.
+
+```
+AI assistant → JSON-RPC (stdio) → LocalMcpServer → HTTP → your NENE2 app
+```
+
+The catalog is validated against your OpenAPI spec with `composer mcp`.
+
+---
+
+## 1. Add the validator script
+
+In `composer.json`, add:
+
+```json
+{
+  "require-dev": {
+    "symfony/yaml": "^7.0"
+  },
+  "scripts": {
+    "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=."
+  }
+}
+```
+
+Then install the dev dependency:
+
+```bash
+composer require --dev symfony/yaml
+```
+
+---
+
+## 2. Create the tool catalog
+
+Create `docs/mcp/tools.json`. Each entry in `tools` corresponds to one API endpoint.
+
+```json
+{
+  "version": 1,
+  "source": "docs/openapi/openapi.yaml",
+  "tools": [
+    {
+      "name": "listNotes",
+      "title": "List Notes",
+      "description": "Return all notes from the database.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "listNotes",
+        "method": "GET",
+        "path": "/notes"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit":  { "type": "integer", "description": "Maximum results to return." },
+          "offset": { "type": "integer", "description": "Number of results to skip." }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/NoteListResponse"
+    },
+    {
+      "name": "getNoteById",
+      "title": "Get Note",
+      "description": "Return a single note by ID.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "getNoteById",
+        "method": "GET",
+        "path": "/notes/{id}"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "integer", "description": "Note ID." }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/NoteResponse"
+    }
+  ]
+}
+```
+
+### Tool fields
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | Yes | Unique camelCase identifier |
+| `title` | Yes | Human-readable label |
+| `description` | Yes | Shown to AI assistants to explain purpose |
+| `safety` | Yes | `read` / `write` / `admin` / `destructive` |
+| `source.operationId` | Yes | Must match an `operationId` in your OpenAPI spec |
+| `source.method` | Yes | HTTP method (case-insensitive, stored uppercase) |
+| `source.path` | Yes | URL path, with `{param}` for path parameters |
+| `inputSchema` | Yes | JSON Schema for the tool's arguments |
+| `responseSchemaRef` | No | `$ref` to an OpenAPI component schema, or `null` |
+
+### Safety levels
+
+| Level | Meaning |
+|---|---|
+| `read` | Safe to call without side effects (GET requests) |
+| `write` | Creates or modifies data (POST / PUT / PATCH) |
+| `admin` | Administrative action — use with care |
+| `destructive` | Permanently deletes data — requires explicit confirmation |
+
+Start with `read`-only tools and add `write` tools incrementally once you have authentication in place.
+
+---
+
+## 3. Validate the catalog
+
+```bash
+composer mcp
+```
+
+The validator checks:
+
+- Every tool's `operationId` exists in your OpenAPI spec.
+- Every tool's path matches the OpenAPI path definition.
+- The `safety` field is one of the four allowed values.
+- `responseSchemaRef` (when non-null) resolves to a real component schema.
+
+Fix any reported errors before starting the MCP server.
+
+---
+
+## 4. Add write tools
+
+Write tools call `POST`, `PUT`, `PATCH`, or `DELETE` endpoints. Add them to the catalog the
+same way — only the `safety` level and `inputSchema` change:
+
+```json
+{
+  "name": "createNote",
+  "title": "Create Note",
+  "description": "Create a new note.",
+  "safety": "write",
+  "source": {
+    "type": "openapi",
+    "operationId": "createNote",
+    "method": "POST",
+    "path": "/notes"
+  },
+  "inputSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["title", "content"],
+    "properties": {
+      "title":   { "type": "string", "description": "Note title." },
+      "content": { "type": "string", "description": "Note body text." }
+    }
+  },
+  "responseSchemaRef": null
+}
+```
+
+`LocalMcpServer` sends string-type arguments as JSON request body fields. Integer-type
+arguments in the path (e.g. `{id}`) are interpolated into the URL.
+
+---
+
+## 5. Protect write tools with JWT
+
+`LocalMcpServer` checks for an `Authorization: Bearer <token>` header on every `write`,
+`admin`, and `destructive` tool call. Set `NENE2_LOCAL_JWT_SECRET` in your environment:
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-secret
+```
+
+Without this variable, write tool calls return an MCP error rather than forwarding the request.
+
+In your application, protect the corresponding endpoints with `BearerTokenMiddleware`:
+
+```php
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+
+$secret = getenv('NENE2_LOCAL_JWT_SECRET') ?: null;
+
+$authMiddleware = $secret !== null
+    ? new BearerTokenMiddleware(
+        $problemDetails,
+        new LocalBearerTokenVerifier($secret),
+        excludedPaths: ['/notes'],           // GET /notes is public
+        protectedPathPrefixes: ['/notes/'],  // POST /notes, etc. are protected
+    )
+    : null;
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    authMiddleware: $authMiddleware,
+    routeRegistrars: [$registerRoutes],
+))->create();
+```
+
+Issue a token for the AI assistant and pass it in the MCP server configuration (see step 6).
+
+---
+
+## 6. Start the MCP server
+
+```bash
+NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_JWT_SECRET=your-local-secret \
+php vendor/hideyukimori/nene2/tools/local-mcp-server.php
+```
+
+The server reads from `stdin` and writes to `stdout` using the MCP stdio transport.
+
+> When using Docker, run the server inside the container and expose it via a wrapper script:
+>
+> ```bash
+> #!/bin/bash
+> docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app \
+>   -e NENE2_LOCAL_JWT_SECRET=your-local-secret \
+>   app php vendor/hideyukimori/nene2/tools/local-mcp-server.php
+> ```
+
+---
+
+## 7. Configure Claude Code or Claude Desktop
+
+### Claude Code (`~/.claude/claude_code_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "/path/to/my-app/mcp-server.sh"
+    }
+  }
+}
+```
+
+### Claude Desktop (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "bash",
+      "args": ["/path/to/my-app/mcp-server.sh"]
+    }
+  }
+}
+```
+
+After restarting Claude, the tools declared in your catalog appear as callable actions.
+
+---
+
+## 8. Test the MCP layer
+
+Test `LocalMcpToolCatalog` directly — no HTTP server required:
+
+```php
+use Nene2\Mcp\LocalMcpToolCatalog;
+
+public function testListNotesToolIsPresent(): void
+{
+    $catalog = new LocalMcpToolCatalog(dirname(__DIR__) . '/docs/mcp/tools.json');
+
+    $tool = $catalog->find('listNotes');
+
+    self::assertNotNull($tool);
+    self::assertSame('read', $tool['safety']);
+    self::assertSame('GET', $tool['source']['method']);
+    self::assertSame('/notes', $tool['source']['path']);
+}
+
+public function testCreateNoteToolIsWrite(): void
+{
+    $catalog = new LocalMcpToolCatalog(dirname(__DIR__) . '/docs/mcp/tools.json');
+
+    $tool = $catalog->find('createNote');
+
+    self::assertNotNull($tool);
+    self::assertSame('write', $tool['safety']);
+}
+```
+
+---
+
+## Path parameter interpolation
+
+`LocalMcpServer` interpolates integer-typed input schema properties whose names appear in
+the path as `{name}` placeholders. String-typed properties that do not appear in the path
+are sent as query parameters (GET) or JSON body fields (POST / PUT / PATCH).
+
+Example: for path `/notes/{id}` with `inputSchema` property `"id": { "type": "integer" }`,
+a call with `{ "id": 42 }` becomes `GET /notes/42`.
+
+---
+
+## Design notes
+
+- `LocalMcpServer` and `LocalMcpToolCatalog` track the MCP specification. If the MCP
+  protocol introduces a breaking change, NENE2 will adapt and document it as an exception
+  to the API stability rule (see ADR 0009, section 5).
+- The catalog is intentionally separate from the OpenAPI spec so that not every API
+  endpoint is exposed to AI tools by default — you opt in explicitly.
+- `safety: "read"` tools call your API without authentication. Ensure public GET endpoints
+  do not expose sensitive data before exposing them as MCP tools.
+
+---
+
+## Next steps
+
+- [Add JWT authentication](./add-jwt-authentication.md) — protect write tool endpoints
+- [Add rate limiting](./add-rate-limiting.md) — prevent AI assistants from overwhelming your API
+- [Add a health check](./add-health-check.md) — the `getHealth` tool is the standard first MCP tool

--- a/src/Mcp/LocalMcpToolCatalog.php
+++ b/src/Mcp/LocalMcpToolCatalog.php
@@ -21,6 +21,10 @@ final readonly class LocalMcpToolCatalog
      */
     public function tools(): array
     {
+        if (!is_file($this->catalogPath)) {
+            throw new LocalMcpException(sprintf('MCP tool catalog could not be read from "%s".', $this->catalogPath));
+        }
+
         $contents = file_get_contents($this->catalogPath);
 
         if ($contents === false) {

--- a/tests/Mcp/LocalMcpToolCatalogTest.php
+++ b/tests/Mcp/LocalMcpToolCatalogTest.php
@@ -4,11 +4,30 @@ declare(strict_types=1);
 
 namespace Nene2\Tests\Mcp;
 
+use Nene2\Mcp\LocalMcpException;
 use Nene2\Mcp\LocalMcpToolCatalog;
 use PHPUnit\Framework\TestCase;
 
 final class LocalMcpToolCatalogTest extends TestCase
 {
+    private string $catalogPath;
+
+    protected function setUp(): void
+    {
+        $this->catalogPath = sys_get_temp_dir() . '/nene2-mcp-test-' . bin2hex(random_bytes(6)) . '.json';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->catalogPath)) {
+            unlink($this->catalogPath);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Existing catalog (committed)
+    // -----------------------------------------------------------------------
+
     public function testLoadsReadOnlyToolsFromCommittedCatalog(): void
     {
         $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
@@ -45,5 +64,237 @@ final class LocalMcpToolCatalogTest extends TestCase
         self::assertContains('createExampleNote', $names);
         self::assertContains('updateExampleNoteById', $names);
         self::assertContains('deleteExampleNoteById', $names);
+    }
+
+    // -----------------------------------------------------------------------
+    // File / parse errors
+    // -----------------------------------------------------------------------
+
+    public function testThrowsWhenCatalogFileDoesNotExist(): void
+    {
+        $catalog = new LocalMcpToolCatalog('/nonexistent/path/tools.json');
+
+        $this->expectException(LocalMcpException::class);
+
+        $catalog->tools();
+    }
+
+    public function testThrowsOnInvalidJson(): void
+    {
+        file_put_contents($this->catalogPath, 'not json {{');
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+
+        $this->expectException(\JsonException::class);
+
+        $catalog->tools();
+    }
+
+    public function testThrowsWhenCatalogRootIsNotObject(): void
+    {
+        // json_decode with assoc=true turns a JSON array into a PHP list array.
+        // The 'tools' key lookup then fails, producing the "tools array" message.
+        file_put_contents($this->catalogPath, json_encode([1, 2, 3]));
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+
+        $this->expectException(LocalMcpException::class);
+        $this->expectExceptionMessage('must contain a tools array');
+
+        $catalog->tools();
+    }
+
+    public function testThrowsWhenToolsKeyIsMissing(): void
+    {
+        file_put_contents($this->catalogPath, json_encode(['version' => 1]));
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+
+        $this->expectException(LocalMcpException::class);
+        $this->expectExceptionMessage('must contain a tools array');
+
+        $catalog->tools();
+    }
+
+    // -----------------------------------------------------------------------
+    // Individual tool validation
+    // -----------------------------------------------------------------------
+
+    public function testThrowsWhenToolMissingSourceKey(): void
+    {
+        file_put_contents($this->catalogPath, json_encode([
+            'version' => 1,
+            'tools' => [[
+                'name' => 'myTool',
+                'title' => 'My Tool',
+                'description' => 'desc',
+                'safety' => 'read',
+                'inputSchema' => ['type' => 'object', 'properties' => []],
+                // 'source' is intentionally missing
+            ]],
+        ]));
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+
+        $this->expectException(LocalMcpException::class);
+        $this->expectExceptionMessage('source');
+
+        $catalog->tools();
+    }
+
+    public function testThrowsWhenToolMissingInputSchemaKey(): void
+    {
+        file_put_contents($this->catalogPath, json_encode([
+            'version' => 1,
+            'tools' => [[
+                'name' => 'myTool',
+                'title' => 'My Tool',
+                'description' => 'desc',
+                'safety' => 'read',
+                'source' => ['type' => 'openapi', 'operationId' => 'op', 'method' => 'GET', 'path' => '/'],
+                // 'inputSchema' is intentionally missing
+            ]],
+        ]));
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+
+        $this->expectException(LocalMcpException::class);
+        $this->expectExceptionMessage('inputSchema');
+
+        $catalog->tools();
+    }
+
+    public function testThrowsWhenResponseSchemaRefIsEmptyString(): void
+    {
+        file_put_contents($this->catalogPath, json_encode([
+            'version' => 1,
+            'tools' => [[
+                'name' => 'myTool',
+                'title' => 'My Tool',
+                'description' => 'desc',
+                'safety' => 'read',
+                'source' => ['type' => 'openapi', 'operationId' => 'op', 'method' => 'GET', 'path' => '/'],
+                'inputSchema' => ['type' => 'object', 'properties' => []],
+                'responseSchemaRef' => '',
+            ]],
+        ]));
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+
+        $this->expectException(LocalMcpException::class);
+        $this->expectExceptionMessage('responseSchemaRef');
+
+        $catalog->tools();
+    }
+
+    // -----------------------------------------------------------------------
+    // find() behaviour
+    // -----------------------------------------------------------------------
+
+    public function testFindReturnsNullForUnknownToolName(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+
+        self::assertNull($catalog->find('nonExistentTool'));
+    }
+
+    // -----------------------------------------------------------------------
+    // Safety levels
+    // -----------------------------------------------------------------------
+
+    public function testAdminSafetyLevelIsAccepted(): void
+    {
+        file_put_contents($this->catalogPath, json_encode([
+            'version' => 1,
+            'tools' => [[
+                'name' => 'adminTool',
+                'title' => 'Admin Tool',
+                'description' => 'admin',
+                'safety' => 'admin',
+                'source' => ['type' => 'openapi', 'operationId' => 'op', 'method' => 'DELETE', 'path' => '/admin'],
+                'inputSchema' => ['type' => 'object', 'properties' => []],
+                'responseSchemaRef' => null,
+            ]],
+        ]));
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+        $tool = $catalog->find('adminTool');
+
+        self::assertNotNull($tool);
+        self::assertSame('admin', $tool['safety']);
+    }
+
+    public function testDestructiveSafetyLevelIsAccepted(): void
+    {
+        file_put_contents($this->catalogPath, json_encode([
+            'version' => 1,
+            'tools' => [[
+                'name' => 'nukeAll',
+                'title' => 'Nuke All',
+                'description' => 'destructive',
+                'safety' => 'destructive',
+                'source' => ['type' => 'openapi', 'operationId' => 'nukeAll', 'method' => 'DELETE', 'path' => '/all'],
+                'inputSchema' => ['type' => 'object', 'properties' => []],
+                'responseSchemaRef' => null,
+            ]],
+        ]));
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+        $tool = $catalog->find('nukeAll');
+
+        self::assertNotNull($tool);
+        self::assertSame('destructive', $tool['safety']);
+    }
+
+    // -----------------------------------------------------------------------
+    // HTTP method normalisation
+    // -----------------------------------------------------------------------
+
+    public function testSourceMethodIsUppercased(): void
+    {
+        file_put_contents($this->catalogPath, json_encode([
+            'version' => 1,
+            'tools' => [[
+                'name' => 'myTool',
+                'title' => 'My Tool',
+                'description' => 'desc',
+                'safety' => 'write',
+                'source' => ['type' => 'openapi', 'operationId' => 'op', 'method' => 'post', 'path' => '/items'],
+                'inputSchema' => ['type' => 'object', 'properties' => []],
+                'responseSchemaRef' => null,
+            ]],
+        ]));
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+        $tool = $catalog->find('myTool');
+
+        self::assertNotNull($tool);
+        self::assertSame('POST', $tool['source']['method']);
+    }
+
+    // -----------------------------------------------------------------------
+    // responseSchemaRef
+    // -----------------------------------------------------------------------
+
+    public function testResponseSchemaRefIsNullWhenAbsent(): void
+    {
+        file_put_contents($this->catalogPath, json_encode([
+            'version' => 1,
+            'tools' => [[
+                'name' => 'myTool',
+                'title' => 'My Tool',
+                'description' => 'desc',
+                'safety' => 'read',
+                'source' => ['type' => 'openapi', 'operationId' => 'op', 'method' => 'GET', 'path' => '/'],
+                'inputSchema' => ['type' => 'object', 'properties' => []],
+                // responseSchemaRef absent — should default to null
+            ]],
+        ]));
+
+        $catalog = new LocalMcpToolCatalog($this->catalogPath);
+        $tool = $catalog->find('myTool');
+
+        self::assertNotNull($tool);
+        self::assertNull($tool['responseSchemaRef']);
     }
 }


### PR DESCRIPTION
## Summary

- `tests/Mcp/LocalMcpToolCatalogTest.php`: 3 → 15 テスト
  - ファイル不存在 / 不正 JSON / tools キー欠落 / source・inputSchema 欠落
  - responseSchemaRef 空文字 / find() miss → null / safety admin・destructive
  - method 大文字正規化 / responseSchemaRef 省略 → null
- `src/Mcp/LocalMcpToolCatalog.php`: `is_file()` 事前チェック追加（PHP warning 解消）
- `docs/howto/add-mcp-tools.md` 新規作成

## Checklist

- [x] 256 tests, 0 PHPStan errors, 0 CS violations
- [x] Closes #489

Self-review: backend-api, docs-policy