### PR TITLE
docs(howto): FT15 摩擦対応 — 組み込みパス注記・PHPStan memory_limit 修正

### DIFF
--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -123,14 +123,7 @@ Out of memory (Reached memory limit of 128 MB)
 Increase your memory limit in php.ini or run PHPStan with --memory-limit CLI option.
 ```
 
-Add a `memory_limit` setting to your `phpstan.neon`:
-
-```yaml
-parameters:
-    memory_limit: 512M
-```
-
-Or pass `--memory-limit 512M` directly in your `composer.json` analyse script:
+Pass `--memory-limit 512M` directly in your `composer.json` analyse script:
 
 ```json
 {

--- a/docs/howto/add-custom-route.md
+++ b/docs/howto/add-custom-route.md
@@ -144,6 +144,25 @@ Or split across multiple registrar functions for clarity when the route list gro
 
 ---
 
+## Reserved framework paths
+
+The following paths are registered by `RuntimeApplicationFactory` before your route
+registrars run. User-registered routes for these paths will never match because the
+framework's routes are checked first.
+
+| Path | Method | Description |
+|---|---|---|
+| `/` | GET | Framework smoke endpoint (name, description, status) |
+| `/health` | GET | Health check |
+| `/machine/health` | GET | Machine-client health check (requires API key) |
+| `/examples/ping` | GET | Example ping |
+| `/examples/protected` | GET | Example protected endpoint (when JWT configured) |
+
+If your application needs a home page, use a different path (e.g. `/welcome`, `/home`)
+or serve the HTML via the framework's smoke response by registering a health check.
+
+---
+
 ## Next step
 
 If your route needs to read from or write to a database, see


### PR DESCRIPTION
## Summary

FT15（noteboard HTML View フィールドトライアル）で発見した摩擦 F-1・F-3 の修正。

- `add-custom-route.md`: 「Reserved framework paths」セクション追加
  - `/`, `/health`, `/machine/health`, `/examples/*` は組み込みルートが優先され上書き不可
  - 代替パス（`/welcome`, `/home`）の案内
- `quality-tools.md`: `phpstan.neon` の `memory_limit` パラメータ削除
  - PHPStan 2.x では neon に `memory_limit` を記述しても無効（Invalid configuration エラー）
  - CLI フラグ `--memory-limit=512M` のみを案内するよう統一

## Checklist

- [x] 256 tests, 0 PHPStan errors, 0 CS violations
- [x] Closes #493

Self-review: docs-policy