### PR TITLE
chore(release): v1.5.0 — View 層・MCP 層強化・FT15・FT16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,29 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.5.0] — 2026-05-20
+
 ### Added
 - `ApiKeyAuthenticationMiddleware::$protectedPathPrefixes` — prefix allowlist parameter; protects paths starting with any listed prefix (e.g. `/admin/` matches `/admin/users/42`). Evaluated only when `$protectedPaths` is empty, mirroring `BearerTokenMiddleware` behaviour. (#461, #482)
 - `ApiKeyAuthenticationMiddleware::$protectedMethods` — method filter; when non-empty, only requests whose HTTP method is in the list are protected. Enables "GET is public, POST/DELETE require API key" patterns without a custom middleware. (#461, #482)
 - `ExampleServiceProvider` (`Nene2\Example`) — bundles Note and Tag example services and exposes `ROUTE_REGISTRARS` / `EXCEPTION_HANDLERS` string keys so framework infrastructure code can wire example routes without importing individual example classes (#463)
+- `LocalMcpToolCatalog` — `is_file()` guard before `file_get_contents()` to avoid PHP warnings on missing catalog files
 - `docs/adr/0009`: `nene2.auth.credential_type` and `nene2.auth.claims` request attributes documented as part of the stable public API (#462)
-- `docs/development/quality-tools.md`: PHPStan `memory_limit` section for consumer projects that hit OOM in Docker (#469)
+- `docs/howto/add-html-view.md` — new howto: server-rendered HTML with `NativePhpViewRenderer` and `HtmlResponseFactory` (#487)
+- `docs/howto/add-mcp-tools.md` — new howto: MCP tool catalog setup, read/write tools, JWT protection, MCP server startup, Claude Code/Desktop config (#489)
 - `docs/howto/add-database-endpoint.md`: M:N many-to-many relationship section — join table schema, idempotent `attachTag`/`detachTag` repository pattern, MySQL `INSERT IGNORE` note (#457)
+- `docs/howto/add-custom-route.md`: "Reserved framework paths" section — lists built-in paths (`/`, `/health`, etc.) that cannot be overridden by user route registrars (#493)
+- `docs/development/quality-tools.md`: PHPStan `memory_limit` guidance updated — `memory_limit` in `phpstan.neon` is not supported in PHPStan 2.x; use `--memory-limit` CLI flag instead (#469, #493)
+
+### Improved
+- `tests/View/NativePhpViewRendererTest`: 5 → 13 tests — added boundary cases for `HtmlEscaper` (null, numeric types, empty string, multibyte UTF-8), `HtmlResponseFactory` (default status, multiple headers), and `NativePhpViewRenderer` (exception buffer cleanup, subdirectory resolution) (#486)
+- `tests/Mcp/LocalMcpToolCatalogTest`: 3 → 15 tests — added error cases (file not found, invalid JSON, missing keys), safety level variants, method uppercasing, and `responseSchemaRef` handling (#489)
+
+### Field Trials (FT15 · FT16)
+- **FT15** — noteboard (HTML View): `NativePhpViewRenderer` + `HtmlResponseFactory` — 7 endpoints, 10/10 tests, PHPStan level 8, PHP-CS-Fixer clean. Frictions: F-1 `GET /` reserved (→ add-custom-route.md), F-2 `Router::PARAMETERS_ATTRIBUTE` usage, F-3 PHPStan neon `memory_limit` (→ quality-tools.md)
+- **FT16** — noteboard MCP: 3 MCP tools (2 read + 1 write) added to FT15 app. `composer mcp --root=.` validates cleanly with v1.4.2+. No friction — `add-mcp-tools.md` howto works as written.
 
 ---
 
@@ -308,7 +324,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Governance docs: workflow, coding standards, ADR policy, review checklists (#1)
 - ADR 0001–0004: HTTP runtime, DI container, phpdotenv, Phinx
 
-[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v1.4.2...HEAD
+[Unreleased]: https://github.com/hideyukiMORI/NENE2/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.4.2...v1.5.0
 [1.4.2]: https://github.com/hideyukiMORI/NENE2/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/hideyukiMORI/NENE2/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/hideyukiMORI/NENE2/compare/v1.3.0...v1.4.0

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -85,39 +85,24 @@ FT12-A / FT12-B / FT12-C / FT13 のすべてが完了。主要成果:
 | #469 | PHPStan memory_limit howto | PR #484 (quality-tools.md) |
 | #481 | v1.4.2 リリース | GitHub Release 作成済み |
 
-## 次の目標: View 層 + MCP 層の強化
+## 完了: Phase 70〜71 + v1.5.0 リリース（2026-05-20）
 
-総合評価（2026-05-20）で「テストが薄い・howto がない」と指摘された 2 領域を集中的に補強する。
+| Phase | 成果 | PR |
+|---|---|---|
+| 70-1 | View テスト 5→13（HtmlEscaper・HtmlResponseFactory 境界ケース） | #491 |
+| 70-2 | `add-html-view.md` howto 新規作成 | #491 |
+| 70-3 | FT15 noteboard（HTML View）: 10/10 テスト・摩擦 3 件 → #493 で解消 | noteboard repo |
+| 71-1 | MCP テスト 3→15（エラーケース・safety バリアント・メソッド正規化） | #492 |
+| 71-2 | `add-mcp-tools.md` howto 新規作成 | #492 |
+| 71-3 | Write ツール認証ドキュメント（add-mcp-tools.md §5） | #492 |
+| 71-4 | FT16 noteboard-mcp: MCP 3 ツール追加・摩擦なし | noteboard repo |
+| 72 | 評価指摘のテスト不足 → 実際には既にカバー済みと確認 | — |
+| v1.5.0 | CHANGELOG 昇格・VERSION bump・タグ・GitHub Release | #495 |
 
-### Phase 70 — View 層強化
+## 次のアクション候補
 
-| # | タスク | 内容 | 優先度 |
-|---|---|---|---|
-| 70-1 | View テスト拡充 | `HtmlEscaper`（境界条件・特殊文字・null）、`HtmlResponseFactory`（ステータス・Content-Type）の追加ユニットテスト | 高 |
-| 70-2 | howto 追加 | `docs/howto/add-html-view.md` — `templates/` 配置 → `NativePhpViewRenderer` → `HtmlResponseFactory` の全手順を 6 言語で | 高 |
-| 70-3 | FT15: HTML View FT | HTML レスポンスを主軸にしたアプリ（例: ブログ一覧・フォーム）を `composer require` から構築して摩擦記録 | 中 |
-
-### Phase 71 — MCP 層強化
-
-| # | タスク | 内容 | 優先度 |
-|---|---|---|---|
-| 71-1 | MCP テスト拡充 | `LocalMcpToolCatalog` の 3 テストを拡充（ツール検証・スキーマ生成・エラーケース） | 高 |
-| 71-2 | howto 追加 | `docs/howto/add-mcp-tools.md` — Consumer プロジェクトでの MCP ツール定義・認証・テストの全手順 | 高 |
-| 71-3 | Write ツール認証ドキュメント | JWT 保護 Write ツールのパターンを howto またはコード例で明示 | 中 |
-| 71-4 | FT16: MCP 中心 FT | MCP ツール（read + write）を主目的にしたアプリを構築して摩擦記録 | 中 |
-
-### Phase 72 — テストカバレッジ補完（評価レポート指摘）
-
-| # | タスク | 内容 | 優先度 |
-|---|---|---|---|
-| 72-1 | BearerTokenMiddleware 境界テスト | token expiry / malformed header / missing `Bearer ` prefix の各ケース | 中 |
-| 72-2 | ThrottleMiddleware テスト | 現在テストなし — 基本動作・制限超過・リセットを追加 | 中 |
-| 72-3 | PaginationQueryParser テスト | 現在テストなし — デフォルト値・不正入力・上限を追加 | 低 |
-
-### v1.5.0 リリース準備
-
-上記 Phase 70〜72 が完了したタイミングで v1.5.0 を検討。
-FT12〜FT14 の実績＋ View/MCP 強化がセットになったリリースにする。
+- FT17 (追加フィールドトライアル) — 新テーマで品質を継続検証
+- v1.5.x パッチ — FT15/FT16 フォローアップ Issue があれば対応
 
 ---
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.4.2';
+    public const string VERSION = '1.5.0';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- **Phase 70**: View 層テスト拡充（5→13）・`add-html-view.md` howto 新規作成
- **Phase 71**: MCP 層テスト拡充（3→15）・`add-mcp-tools.md` howto 新規作成
- **Phase 72**: テストカバレッジ補完（既に十分なカバレッジを確認）
- **FT15**: noteboard（HTML View）10/10 テスト通過、摩擦 3 件 → #493 で解消
- **FT16**: noteboard-mcp MCP 3 ツール追加、摩擦なし
- `FrameworkInfo::VERSION` を `1.5.0` に更新
- CHANGELOG `[Unreleased]` → `[1.5.0] — 2026-05-20` に昇格

## Closes

Closes #486, #487, #488, #489, #490, #491, #492, #493, #494, #495

## Test plan

- [x] PHPUnit: OK (256 tests, 722 assertions)
- [x] PHPStan level 8: 0 errors
- [x] PHP-CS-Fixer: 0 violations
- [x] OpenAPI validator: valid
- [x] MCP validator: valid

Self-review: release-ci, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)