### PR TITLE
fix(security): P1 セキュリティ修正 — nbf 検証・MCP パス encode・RequestSizeLimit

### DIFF
--- a/src/Auth/LocalBearerTokenVerifier.php
+++ b/src/Auth/LocalBearerTokenVerifier.php
@@ -49,6 +49,10 @@ final readonly class LocalBearerTokenVerifier implements TokenVerifierInterface,
 
         $claims = $this->decodeJsonSegment($payloadB64);
 
+        if (isset($claims['nbf']) && is_int($claims['nbf']) && $claims['nbf'] > time()) {
+            throw new TokenVerificationException('Token is not yet valid.');
+        }
+
         if (isset($claims['exp']) && is_int($claims['exp']) && $claims['exp'] < time()) {
             throw new TokenVerificationException('Token has expired.');
         }

--- a/src/Mcp/LocalMcpServer.php
+++ b/src/Mcp/LocalMcpServer.php
@@ -209,7 +209,7 @@ final readonly class LocalMcpServer
                 throw new LocalMcpException(sprintf('Required path parameter "%s" was not provided.', $param));
             }
 
-            $path = str_replace('{' . $param . '}', (string) $arguments[$param], $path);
+            $path = str_replace('{' . $param . '}', rawurlencode((string) $arguments[$param]), $path);
             unset($remaining[$param]);
         }
 

--- a/src/Middleware/RequestSizeLimitMiddleware.php
+++ b/src/Middleware/RequestSizeLimitMiddleware.php
@@ -28,19 +28,32 @@ final readonly class RequestSizeLimitMiddleware implements MiddlewareInterface
         $contentLength = $request->getHeaderLine('Content-Length');
 
         if ($contentLength !== '' && $this->isOversized($contentLength)) {
-            return $this->problemDetails->create(
-                $request,
-                'payload-too-large',
-                'Payload Too Large',
-                413,
-                'The request body exceeds the configured size limit.',
-                [
-                    'max_body_bytes' => $this->maxBodyBytes,
-                ],
-            );
+            return $this->tooLarge($request);
+        }
+
+        if ($contentLength === '') {
+            $bodySize = $request->getBody()->getSize();
+
+            if ($bodySize !== null && $bodySize > $this->maxBodyBytes) {
+                return $this->tooLarge($request);
+            }
         }
 
         return $handler->handle($request);
+    }
+
+    private function tooLarge(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'payload-too-large',
+            'Payload Too Large',
+            413,
+            'The request body exceeds the configured size limit.',
+            [
+                'max_body_bytes' => $this->maxBodyBytes,
+            ],
+        );
     }
 
     private function isOversized(string $contentLength): bool

--- a/tests/Auth/LocalBearerTokenVerifierTest.php
+++ b/tests/Auth/LocalBearerTokenVerifierTest.php
@@ -74,4 +74,34 @@ final class LocalBearerTokenVerifierTest extends TestCase
         $this->expectException(TokenVerificationException::class);
         $verifier->verify($token);
     }
+
+    public function testVerifyRejectsTokenNotYetValid(): void
+    {
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+        $token = $verifier->issue(['sub' => 'user-1', 'nbf' => time() + 600]);
+
+        $this->expectException(TokenVerificationException::class);
+        $this->expectExceptionMessage('not yet valid');
+        $verifier->verify($token);
+    }
+
+    public function testVerifyAcceptsTokenWithPastNbf(): void
+    {
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+        $token = $verifier->issue(['sub' => 'user-1', 'nbf' => time() - 60]);
+
+        $claims = $verifier->verify($token);
+
+        self::assertSame('user-1', $claims['sub']);
+    }
+
+    public function testVerifyIgnoresNonIntegerNbf(): void
+    {
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+        $token = $verifier->issue(['sub' => 'user-1', 'nbf' => 'not-an-int']);
+
+        $claims = $verifier->verify($token);
+
+        self::assertSame('user-1', $claims['sub']);
+    }
 }

--- a/tests/Mcp/LocalMcpServerTest.php
+++ b/tests/Mcp/LocalMcpServerTest.php
@@ -231,6 +231,24 @@ final class LocalMcpServerTest extends TestCase
         self::assertSame(false, $response['result']['isError'] ?? null);
     }
 
+    public function testPathParameterWithSpecialCharsIsUrlEncoded(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(200, [], '{}'));
+        $server = $this->server($client);
+
+        $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 9,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'getExampleNoteById',
+                'arguments' => ['id' => 'foo/bar'],
+            ],
+        ]);
+
+        self::assertSame('/examples/notes/foo%2Fbar', $client->path);
+    }
+
     public function testNotificationsDoNotReturnResponses(): void
     {
         $server = $this->server();

--- a/tests/Middleware/BaselineMiddlewareTest.php
+++ b/tests/Middleware/BaselineMiddlewareTest.php
@@ -137,6 +137,39 @@ final class BaselineMiddlewareTest extends TestCase
         self::assertSame(10, $payload['max_body_bytes']);
     }
 
+    public function testRequestSizeLimitAllowsBodyWithinLimit(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestSizeLimitMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            100,
+        );
+        $request = $factory
+            ->createServerRequest('POST', 'https://example.test/upload')
+            ->withHeader('Content-Length', '50');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRequestSizeLimitChecksBodyStreamSizeWhenContentLengthAbsent(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestSizeLimitMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            5,
+        );
+        $body = $factory->createStream('0123456789');
+        $request = $factory
+            ->createServerRequest('POST', 'https://example.test/upload')
+            ->withBody($body);
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame(413, $response->getStatusCode());
+    }
+
     public function testRequestLoggingIncludesSafeRequestContext(): void
     {
         $factory = new Psr17Factory();


### PR DESCRIPTION
## Summary

- **#496**: `LocalBearerTokenVerifier` — `nbf` クレーム未検証を修正。未来有効トークンを即時拒否するように。
- **#497**: `LocalMcpServer::interpolatePath()` — パスパラメータを `rawurlencode()` でエンコード。`/` や `?` によるパス/クエリ汚染を防ぐ。
- **#498**: `RequestSizeLimitMiddleware` — `Content-Length` 不在時に `getBody()->getSize()` で追加検査。chunked 転送でも PSR-7 ストリームサイズが既知なら検査できる。

## Test plan

- [x] PHPUnit: OK (262 tests, 729 assertions) — +6 assertions
- [x] PHPStan level 8: 0 errors
- [x] PHP-CS-Fixer: 0 violations

Self-review: middleware-security, backend-api

Closes #496, #497, #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)