### PR TITLE
feat/fix(p2): Router::patch・pgsql・ThrottleMiddleware 警告・LocalMcpToolCatalog 公開化

### DIFF
--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -52,7 +52,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 
 | Namespace | Key public surfaces |
 |-----------|---------------------|
-| `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `delete`, `handle`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
+| `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `patch`, `delete`, `handle`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
 | `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException`, `PaginationQuery`, `PaginationQueryParser` |
 | `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
 | `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
@@ -62,7 +62,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\Middleware` | All shipped middleware classes, `RateLimitStorageInterface`, `ThrottleMiddleware` |
 | `Nene2\Validation` | `ValidationException`, `ValidationError` |
 | `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |
-| `Nene2\Mcp` | `LocalMcpServer`, `LocalMcpHttpClientInterface`, `LocalMcpHttpResponse`, `LocalMcpException` |
+| `Nene2\Mcp` | `LocalMcpServer`, `LocalMcpToolCatalog`, `LocalMcpHttpClientInterface`, `LocalMcpHttpResponse`, `LocalMcpException` |
 
 ### 4. Stable request attributes set by authentication middleware
 

--- a/docs/howto/add-rate-limiting.md
+++ b/docs/howto/add-rate-limiting.md
@@ -7,10 +7,22 @@ This guide shows how to protect your NENE2 application with request rate limitin
 
 ---
 
+## Production requirement — shared storage
+
+> **Warning**: `InMemoryRateLimitStorage` (shown below in quick start) is **not suitable for
+> production**. PHP-FPM spawns multiple worker processes, and each process has its own in-memory
+> store. A client that hits 10 workers simultaneously will be counted only once per worker —
+> effectively bypassing the limit. Use a shared storage backend (Redis, Memcached, or a
+> database) in any multi-process or multi-server deployment.
+>
+> See [Swap the storage backend](#swap-the-storage-backend) for a Redis implementation.
+
+---
+
 ## Quick start
 
 Add `ThrottleMiddleware` to `RuntimeApplicationFactory`. The built-in `InMemoryRateLimitStorage`
-is suitable for local development and single-process deployments.
+is suitable for local development and single-process testing only.
 
 ```php
 use Nene2\Error\ProblemDetailsResponseFactory;

--- a/src/Database/PdoConnectionFactory.php
+++ b/src/Database/PdoConnectionFactory.php
@@ -49,6 +49,12 @@ final readonly class PdoConnectionFactory implements DatabaseConnectionFactoryIn
                 $this->config->name,
                 $this->config->charset,
             ),
+            'pgsql' => sprintf(
+                'pgsql:host=%s;port=%d;dbname=%s',
+                $this->config->host,
+                $this->config->port,
+                $this->config->name,
+            ),
             default => throw new DatabaseConnectionException(sprintf(
                 'Database adapter "%s" is not supported by the PDO factory.',
                 $this->config->adapter,

--- a/src/Mcp/LocalMcpToolCatalog.php
+++ b/src/Mcp/LocalMcpToolCatalog.php
@@ -5,7 +5,13 @@ declare(strict_types=1);
 namespace Nene2\Mcp;
 
 /**
- * @internal
+ * Loads and validates the MCP tool catalog from a `docs/mcp/tools.json` file.
+ *
+ * Consumer projects use this class directly in tests to verify their tool catalog:
+ * `new LocalMcpToolCatalog(__DIR__ . '/../docs/mcp/tools.json')`.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ *
  * @phpstan-type McpToolSource array{type: string, operationId: string, method: string, path: string}
  * @phpstan-type McpTool array{name: string, title: string, description: string, safety: string, source: McpToolSource, inputSchema: array<string, mixed>, responseSchemaRef: string|null}
  */

--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -19,6 +19,11 @@ use Psr\Http\Server\RequestHandlerInterface;
  * The default key extractor uses REMOTE_ADDR. Pass a custom callable to key by
  * authenticated user, API key, or any other request attribute.
  *
+ * **Production requirement**: inject a shared storage implementation (Redis, Memcached,
+ * or a database-backed store) via {@see RateLimitStorageInterface}. The bundled
+ * {@see InMemoryRateLimitStorage} does NOT share state across PHP-FPM worker processes
+ * and is therefore only suitable for local development and single-process testing.
+ *
  * Part of the public API stability guarantee (see ADR 0009, ADR 0010).
  */
 final class ThrottleMiddleware implements MiddlewareInterface

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -54,6 +54,14 @@ final class Router implements RequestHandlerInterface
     /**
      * @param callable(ServerRequestInterface): ResponseInterface $handler
      */
+    public function patch(string $path, callable $handler): self
+    {
+        return $this->add('PATCH', $path, $handler);
+    }
+
+    /**
+     * @param callable(ServerRequestInterface): ResponseInterface $handler
+     */
     public function delete(string $path, callable $handler): self
     {
         return $this->add('DELETE', $path, $handler);

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -90,4 +90,30 @@ final class RouterTest extends TestCase
             static fn (ServerRequestInterface $request): ResponseInterface => (new Psr17Factory())->createResponse(200),
         );
     }
+
+    public function testPatchRouteMatchesOnlyPatchRequests(): void
+    {
+        $factory = new Psr17Factory();
+        $router = (new Router())->patch(
+            '/notes/{id}',
+            static fn (ServerRequestInterface $request): ResponseInterface => $factory->createResponse(200),
+        );
+
+        $response = $router->handle($factory->createServerRequest('PATCH', 'https://example.test/notes/42'));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testPatchRouteReturns405ForGetRequest(): void
+    {
+        $factory = new Psr17Factory();
+        $router = (new Router())->patch(
+            '/notes/{id}',
+            static fn (ServerRequestInterface $request): ResponseInterface => $factory->createResponse(200),
+        );
+
+        $this->expectException(MethodNotAllowedException::class);
+
+        $router->handle($factory->createServerRequest('GET', 'https://example.test/notes/42'));
+    }
 }


### PR DESCRIPTION
## Summary

- **#499**: `Router::patch()` 追加。ADR 0007 が PATCH を認めていたが Router に実装がなかった。テスト 2 件追加。
- **#500**: `PdoConnectionFactory` — `pgsql` DSN 追加。`DB_ADAPTER=pgsql` がドキュメントにあるのに実行時 throw していた乖離を解消。
- **#501**: `ThrottleMiddleware` PHPDoc と `add-rate-limiting.md` 冒頭に PHP-FPM マルチプロセス非対応の Warning を追加。
- **#502**: `LocalMcpToolCatalog` — `@internal` 除去、ADR 0009 安定 API 表に追記。消費者の howto がテストで直接使用する旨を PHPDoc に明記。

## Test plan

- [x] PHPUnit: OK (264 tests, 731 assertions) — +2 tests
- [x] PHPStan level 8: 0 errors
- [x] PHP-CS-Fixer: 0 violations

Self-review: backend-api, docs-policy

Closes #499, #500, #501, #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)