### PR TITLE
docs: 多言語翻訳追加・FT11〜14フィールドトライアルレポート・JWT本番警告

### DIFF
--- a/docs/de/howto/add-html-view.md
+++ b/docs/de/howto/add-html-view.md
@@ -1,0 +1,95 @@
+# HTML-Ansichten hinzufügen
+
+Diese Anleitung zeigt, wie Sie mit `NativePhpViewRenderer` und `HtmlResponseFactory` serverseitig gerenderte HTML-Antworten zu einer NENE2-Anwendung hinzufügen.
+
+**Voraussetzung**: Sie haben eine funktionierende NENE2-Anwendung mit mindestens einer Route. Falls nicht, beginnen Sie mit [Eine benutzerdefinierte Route hinzufügen](./add-custom-route.md).
+
+---
+
+## Übersicht
+
+NENE2 liefert eine minimale, abhängigkeitsfreie HTML-Rendering-Schicht:
+
+| Klasse | Rolle |
+|---|---|
+| `NativePhpViewRenderer` | Rendert `.php`-Templates in einem isolierten Scope |
+| `HtmlEscaper` | Maskiert Werte für sichere HTML-Ausgabe (`htmlspecialchars` / UTF-8 / vollständige Anführungszeichen) |
+| `HtmlResponseFactory` | Verpackt gerendertes HTML in eine `text/html; charset=utf-8` PSR-7-Antwort |
+| `TemplateNotFoundException` | Wird geworfen, wenn eine Template-Datei fehlt oder der Pfad ungültig ist |
+
+HTML-Antworten koexistieren mit JSON-Endpunkten — fügen Sie sie zur gleichen Anwendung hinzu, ohne bestehende Routen zu entfernen.
+
+---
+
+## 1. Templates erstellen
+
+Legen Sie native PHP-Template-Dateien in einem einzigen Stammverzeichnis ab. Der übliche Ort ist `templates/` im Projektstamm.
+
+> **Sicherheit**: Rufen Sie immer `$e(...)` für Werte auf, die aus Benutzereingaben, einer Datenbank oder einem externen System stammen. Das Weglassen führt zu XSS-Schwachstellen.
+
+---
+
+## 2. Renderer im ServiceProvider verdrahten
+
+Registrieren Sie `NativePhpViewRenderer` und `HtmlResponseFactory` in Ihrem `ServiceProviderInterface`:
+
+```php
+$builder->set(NativePhpViewRenderer::class, static fn () =>
+    new NativePhpViewRenderer(dirname(__DIR__) . '/templates')
+);
+$builder->set(HtmlResponseFactory::class, static fn ($c) =>
+    new HtmlResponseFactory($c->get(ResponseFactoryInterface::class), $c->get(StreamFactoryInterface::class), $c->get(NativePhpViewRenderer::class))
+);
+```
+
+---
+
+## 3. HtmlResponseFactory im Handler verwenden
+
+```php
+final readonly class HomeHandler
+{
+    public function __construct(private HtmlResponseFactory $html) {}
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->html->create('home.php', ['title' => 'Willkommen']);
+    }
+}
+```
+
+---
+
+## 4. Route registrieren
+
+```php
+$router->get('/', new HomeHandler($container->get(HtmlResponseFactory::class)));
+```
+
+---
+
+## 5. TemplateNotFoundException behandeln
+
+Registrieren Sie einen Domain-Ausnahme-Handler, der eine sinnvolle HTTP-Antwort zurückgibt, wenn ein Template nicht gefunden wird.
+
+---
+
+## 6. HTML und JSON-Endpunkte mischen
+
+JSON- und HTML-Endpunkte koexistieren im gleichen `Router` ohne spezielle Konfiguration.
+
+---
+
+## Design-Hinweise
+
+- Templates laufen in einem Closure-Scope — kein Zugriff auf `$this`.
+- `HtmlEscaper` verwendet `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5`.
+- Verzeichnis-Traversal (`../`) wird im Pfadauflösungsschritt blockiert.
+
+---
+
+## Nächste Schritte
+
+- [Eine benutzerdefinierte Route hinzufügen](./add-custom-route.md)
+- [Rate-Limiting hinzufügen](./add-rate-limiting.md)
+- [JWT-Authentifizierung hinzufügen](./add-jwt-authentication.md)

--- a/docs/de/howto/add-mcp-tools.md
+++ b/docs/de/howto/add-mcp-tools.md
@@ -1,0 +1,78 @@
+# MCP-Tools hinzufügen
+
+Diese Anleitung zeigt, wie Sie die API-Endpunkte Ihrer NENE2-Anwendung als MCP-Tools bereitstellen, damit KI-Assistenten (Claude, Cursor usw.) Ihre API über das Model Context Protocol aufrufen können.
+
+**Voraussetzung**: Eine funktionierende NENE2-Anwendung mit mindestens einer Route und einer `docs/openapi/openapi.yaml`-Datei.
+
+---
+
+## Übersicht
+
+NENE2 liefert einen lokalen MCP-Server (`LocalMcpServer`), der JSON-RPC-MCP-Nachrichten in HTTP-Aufrufe an Ihre API übersetzt. Der Tool-Katalog (`docs/mcp/tools.json`) deklariert, welche Endpunkte als MCP-Tools verfügbar sind.
+
+---
+
+## 1. Validator-Skript hinzufügen
+
+In `composer.json`:
+
+```json
+{
+  "require-dev": { "symfony/yaml": "^7.0" },
+  "scripts": {
+    "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=."
+  }
+}
+```
+
+Installation: `composer require --dev symfony/yaml`
+
+---
+
+## 2. Tool-Katalog erstellen
+
+Erstellen Sie `docs/mcp/tools.json`. Jeder Eintrag in `tools` entspricht einem API-Endpunkt.
+
+### Sicherheitsstufen
+
+| Stufe | Bedeutung |
+|---|---|
+| `read` | Sicher ohne Nebenwirkungen (GET-Anfragen) |
+| `write` | Erstellt oder modifiziert Daten (POST / PUT / PATCH) |
+| `admin` | Verwaltungsvorgang — mit Vorsicht verwenden |
+| `destructive` | Löscht Daten dauerhaft — erfordert explizite Bestätigung |
+
+---
+
+## 3. Katalog validieren
+
+```bash
+composer mcp
+```
+
+---
+
+## 4. MCP-Server starten
+
+```bash
+NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_JWT_SECRET=your-local-secret \
+php vendor/hideyukimori/nene2/tools/local-mcp-server.php
+```
+
+---
+
+## 5. MCP-Schicht testen
+
+```php
+$catalog = new LocalMcpToolCatalog(dirname(__DIR__) . '/docs/mcp/tools.json');
+$tool = $catalog->find('listNotes');
+self::assertSame('read', $tool['safety']);
+```
+
+---
+
+## Nächste Schritte
+
+- [JWT-Authentifizierung hinzufügen](./add-jwt-authentication.md)
+- [Rate-Limiting hinzufügen](./add-rate-limiting.md)

--- a/docs/field-trials/2026-05-field-trial-11.md
+++ b/docs/field-trials/2026-05-field-trial-11.md
@@ -1,0 +1,113 @@
+# Field Trial 11 — tasklog: JWT 認証フロー実地検証
+
+## Date
+
+2026-05-19
+
+## Baseline
+
+- NENE2 v1.4.0（`hideyukimori/nene2: ^1.4`）
+- PHP 8.4（Docker: `php:8.4-cli` ベースイメージ）
+- プロジェクト: **tasklog** — タスク管理 JSON API
+- エンティティ: `User` / `Task`（2ドメイン、7エンドポイント）
+- テスト: PHPUnit・PHPStan level 8・PHP-CS-Fixer
+- DB: SQLite（ローカル）
+
+## Goal
+
+JWT Bearer 認証フロー（ユーザー登録・ログイン・認証保護エンドポイント）が、
+NENE2 のドキュメントだけを参照した Claude が迷わず実装できるかを検証する。
+
+---
+
+## Steps Taken
+
+1. `docs/adr/0008-jwt-authentication.md`、`src/Auth/`、`src/Example/Tag/` を参照し、設計パターンを把握。
+2. `User`, `UserRepositoryInterface`, `PdoUserRepository`, `TokenIssuerInterface`, `LocalJwtIssuer` を作成。
+   登録・ログインの UseCase/Handler/RouteRegistrar/ServiceProvider を実装。
+3. `Task` ドメイン（7エンドポイント）を実装。`GET/PUT/DELETE /tasks/{id}` でオーナーシップチェック（403）。
+4. `BearerTokenMiddleware` が exact-path のみのため、カスタムミドルウェア `TaskBearerAuthMiddleware` を新設（F-1）。
+5. `RuntimeApplicationFactory` の型制約により、カスタムミドルウェアを渡せないため手動パイプライン構築（F-2）。
+6. `composer check` 全通過・全7エンドポイント動作確認。
+
+---
+
+## Findings
+
+### F-1: `BearerTokenMiddleware` の protected パスがダイナミックルートに非対応 [高]
+
+`BearerTokenMiddleware` の `$protectedPaths` は exact-path マッチング（`in_array`）のみ。
+`/tasks/{id}` のような動的パスを列挙できず、`$protectedPaths = []`（全パス保護）では `/auth/*` も 401 になる。
+
+**解決**: プレフィックスマッチを行う独自ミドルウェア `TaskBearerAuthMiddleware` を実装。
+
+**提案**: `BearerTokenMiddleware` に `$protectedPathPrefixes` オプションを追加する。
+
+---
+
+### F-2: `RuntimeApplicationFactory` にカスタム `MiddlewareInterface` を渡せない [中]
+
+`RuntimeApplicationFactory` の `$authMiddleware` パラメータは `?BearerTokenMiddleware` 型に固定。
+`MiddlewareInterface` 実装のカスタムミドルウェアを注入できない。`BearerTokenMiddleware` は `final` のため継承も不可。
+
+**解決**: `RuntimeApplicationFactory` を使わず、個別ミドルウェアを組み合わせて手動パイプライン構築。
+
+**提案**: `$authMiddleware` の型を `?MiddlewareInterface` に緩和する。
+
+---
+
+### F-3: JWT 発行 API が安定インターフェースとして未公開 [中]
+
+`TokenVerifierInterface`（検証）は公開 API だが、`issue()` は `LocalBearerTokenVerifier`（`@internal`）に存在するのみ。
+`TokenIssuerInterface` の公開 API がない。
+
+**解決**: アプリ内で `TokenIssuerInterface` を独自定義し、`LocalBearerTokenVerifier::issue()` をラップ。
+
+**提案**: `TokenIssuerInterface` を公開 API に追加し、`LocalBearerTokenVerifier` が実装するようにする。
+
+---
+
+### F-4: 開発ソース（`../NENE2/src/`）とインストール済みパッケージの API 乖離 [低]
+
+`../NENE2/src/` に存在する `PaginationResponse` 等が `vendor/hideyukimori/nene2/` v1.4.0 にない。
+PHPStan level 8 を実行するまで気づかなかった。
+
+**提案**: CLAUDE.md に「`vendor/` を優先確認する」旨の注記を追加する。
+
+---
+
+## Test Results
+
+```
+PHPUnit:         12/12 tests passed
+PHPStan level 8: No errors
+PHP-CS-Fixer:    0 files to fix
+```
+
+---
+
+## Friction Summary
+
+| # | 内容 | 深刻度 | 種別 |
+|---|---|---|---|
+| F-1 | `BearerTokenMiddleware` がダイナミックルートに非対応 | 高 | ミドルウェア設計 |
+| F-2 | `RuntimeApplicationFactory` にカスタムミドルウェアを渡せない | 中 | 拡張性 |
+| F-3 | JWT 発行 API が安定インターフェース未定義 | 中 | API 設計 |
+| F-4 | 開発ソースと公開パッケージの API 乖離 | 低 | ドキュメント |
+
+---
+
+## Recommendations
+
+1. `BearerTokenMiddleware` にプレフィックスマッチ or 除外パスオプションを追加（F-1 対応、最優先）
+2. `RuntimeApplicationFactory` の auth 引数型を `MiddlewareInterface` に緩める（F-2 対応）
+3. `TokenIssuerInterface` を公開 API に追加し、how-to に JWT 発行フローを文書化（F-3 対応）
+4. JWT 認証フロー実装ガイド（登録・ログイン・保護エンドポイントの最小構成例）を how-to に追加
+
+---
+
+## Overall Impression
+
+NENE2 の基本設計（PSR-15 パイプライン、ServiceProvider、UseCase/Handler 分離、ValidationException → 422 自動マッピング）は一貫していて、Tag/Note のサンプルコードを参照すれば Task ドメインの実装は迷わず進められた。
+
+JWT 認証フロー固有の課題は主に「`BearerTokenMiddleware` のパスマッチング方式」と「RuntimeApplicationFactory の柔軟性」の2点。どちらも深刻ではなく回避策があるが、how-to がなければ初見の実装者は同じところで躓く可能性が高い。

--- a/docs/field-trials/2026-05-field-trial-12a.md
+++ b/docs/field-trials/2026-05-field-trial-12a.md
@@ -1,0 +1,128 @@
+# Field Trial 12-A — tagmark: 多対多リレーション実地検証
+
+## Date
+
+2026-05-19
+
+## Baseline
+
+- NENE2 v1.4.x（`hideyukimori/nene2: ^1.4`）
+- PHP 8.4（Docker: `php:8.4-cli` ベースイメージ）
+- プロジェクト: **tagmark** — ブックマーク管理 JSON API
+- エンティティ: `User` / `Bookmark` / `Tag`（M:N）
+- テスト: PHPUnit・PHPStan level 8・PHP-CS-Fixer
+- DB: SQLite（ローカル）
+
+## Goal
+
+多対多リレーション（Bookmark ↔ Tag）を持つドメインが、NENE2 のドキュメントだけを参照した Claude が迷わず実装できるかを検証する。
+
+---
+
+## Steps Taken
+
+1. CLAUDE.md・`add-jwt-authentication.md`・`add-database-endpoint.md`・`add-second-entity.md` を読み込んだ。
+2. `vendor/hideyukimori/nene2/src/` を参照してメソッドシグネチャを確認した。
+3. Auth ドメイン（User・UserRepository・RegisterUseCase・LoginUseCase・AuthRouteRegistrar）を実装した。
+4. Tag ドメインと Bookmark ドメインを実装した。JOIN クエリ・CASCADE 削除・tag フィルタリングを含む。
+5. `BearerTokenMiddleware` が `excludedPaths`（除外リスト）ではなく `protectedPaths`（許可リスト）であることを発見し、`ExcludedPathsBearerMiddleware` ラッパーを実装した。
+6. `RuntimeApplicationFactory` の型制約により手動パイプライン構築。
+7. `database/schema.sql` を作成し、フロントコントローラー内で自動初期化するパターンを採用。
+8. PHPUnit テスト（19件）を作成し、全エンドポイント・M:N 操作・カスケード削除・所有権チェックを網羅。
+9. `composer check` 全通過を確認。
+
+---
+
+## Findings
+
+### F-1: `BearerTokenMiddleware` の `excludedPaths` パラメータが実在しない [高]
+
+`add-jwt-authentication.md` は `BearerTokenMiddleware` のパラメータ名を `excludedPaths`（除外リスト）と記述しているが、v1.4 の実装は `protectedPaths`（許可リスト）。ドキュメント通りに実装するとコンストラクタエラーになる。
+
+**解決**: `ExcludedPathsBearerMiddleware`（PSR-15 ラッパー）を自前実装。`RuntimeApplicationFactory` の型制約により、これを渡せないためパイプラインを手動構築した。
+
+**提案**:
+1. `BearerTokenMiddleware` に `excludedPaths` パラメータを追加する（またはドキュメントを実装に合わせて修正）。
+2. `RuntimeApplicationFactory` の `$bearerTokenMiddleware` パラメータの型を `?MiddlewareInterface` に緩和する。
+
+---
+
+### F-2: `add-jwt-authentication.md` の `TokenIssuerInterface` が v1.4 に存在しない [高]
+
+`RegisterUseCase` / `LoginUseCase` に JWT 発行機能を注入するため `Nene2\Auth\TokenIssuerInterface` を `use` したが、v1.4 の `vendor/` に存在しない。
+
+**解決**: `Tagmark\Auth\TokenIssuerInterface` を自前定義し、`LocalBearerTokenVerifier::issue()` へのブリッジを実装。
+
+**提案**: `Nene2\Auth\TokenIssuerInterface` を v1.4 に追加し、`LocalBearerTokenVerifier` が実装するようにする。ADR 0009 の公開 API 一覧にも追記する。
+
+---
+
+### F-3: `DomainExceptionHandlerInterface::handles()` が実際は `supports()` [中]
+
+`add-jwt-authentication.md` は `handles(Throwable $e): bool` と記述しているが、v1.4 の実装は `supports(Throwable $exception): bool`。
+
+**解決**: `vendor/` を確認して正しいメソッド名を使用。
+
+**提案**: howto のサンプルコードを修正する。
+
+---
+
+### F-4: ハンドラーが配列を返せるという記述が不正確 [中]
+
+`add-database-endpoint.md` は「ハンドラーは array を返せる」と説明しているが、v1.4 の Router は `callable(ServerRequestInterface): ResponseInterface` を要求する。
+
+**解決**: `JsonResponseFactory::create()` を使って `ResponseInterface` を返すパターンに従った。
+
+---
+
+### F-5: `getParsedBody()` で JSON ボディが読めない [中]
+
+howto のサンプルが `$request->getParsedBody()` を使っているが、JSON リクエストでは `null` を返す。`JsonRequestBodyParser::parse()` が必要。
+
+**解決**: `vendor/` 内のサンプルコードを参照して修正。
+
+---
+
+### F-6: M:N カスケード削除はアプリ側で手動管理が必要 [低]
+
+SQLite は `PRAGMA foreign_keys = ON` なしでは外部キー制約が機能しないため、中間テーブル行を手動削除する必要がある。
+
+**提案**: M:N パターンの howto に SQLite カスケード削除のパターンを追記する。
+
+---
+
+### F-7: `RuntimeApplicationFactory` に任意の認証ミドルウェアを渡せない [中]
+
+`$bearerTokenMiddleware` の型が `?BearerTokenMiddleware` に固定されているため、F-1 で作成した `ExcludedPathsBearerMiddleware` を注入できなかった。
+
+**提案**: F-1 と同じ — 型を `?MiddlewareInterface` に変更するか、`excludedPaths` オプションを追加する。
+
+---
+
+## Test Results
+
+```
+PHPUnit:         19/19 tests, 45 assertions
+PHPStan level 8: OK
+PHP-CS-Fixer:    0 files to fix
+```
+
+---
+
+## Friction Summary
+
+| # | 内容 | 深刻度 | 種別 |
+|---|---|---|---|
+| F-1 | `BearerTokenMiddleware` が `excludedPaths` ではなく `protectedPaths`（ドキュメント誤り） | 高 | ドキュメント誤り + API 設計 |
+| F-2 | `TokenIssuerInterface` が v1.4 に存在しない | 高 | API 欠損 |
+| F-3 | `DomainExceptionHandlerInterface::handles()` が正しくは `supports()` | 中 | ドキュメント誤り |
+| F-4 | ハンドラーが配列を返せると書かれているが実際は `ResponseInterface` 必須 | 中 | ドキュメント誤り |
+| F-5 | `getParsedBody()` で JSON が読めない（`JsonRequestBodyParser` 必須） | 中 | ドキュメント誤り |
+| F-6 | M:N カスケード削除パターンのドキュメントなし | 低 | ドキュメント欠損 |
+| F-7 | `RuntimeApplicationFactory` に任意の認証ミドルウェアを渡せない | 中 | API 設計 |
+
+---
+
+## Overall Impression
+
+NENE2 のコアアーキテクチャは直感的で、M:N 実装自体は迷わず書けた。最大の障害は**ドキュメントと v1.4 実装の乖離**（F-1〜F-5）で、`vendor/` を直接読まなければ実装を完成できなかった。`composer check` が PHPStan level 8 まで全通過した点は品質保証として有効に機能した。ドキュメントを v1.4 に追いつかせることで次の Field Trial は大幅に改善するはずである。

--- a/docs/field-trials/2026-05-field-trial-12b.md
+++ b/docs/field-trials/2026-05-field-trial-12b.md
@@ -1,0 +1,113 @@
+# Field Trial 12-B — knowledgelog: MCP Ergonomics 実地検証
+
+## Date
+
+2026-05-19
+
+## Baseline
+
+- NENE2 v1.4.1（`hideyukimori/nene2: ^1.4`）
+- PHP 8.4
+- プロジェクト: **knowledgelog** — ナレッジベース JSON API
+- エンティティ: `Article` / `Category`（2ドメイン）
+- テスト: PHPUnit・PHPStan level 8・PHP-CS-Fixer
+- DB: SQLite（ローカル）
+
+## Goal
+
+MCP ツールを主インターフェースとして設計した場合の摩擦を記録する。
+公開 read エンドポイントと管理者 write エンドポイントを実装し、`docs/mcp/tools.json` を定義して `composer check` と MCP バリデーションを通過させる。
+
+---
+
+## Steps Taken
+
+1. `docker compose run --rm app composer install` で依存解決。
+2. `vendor/hideyukimori/nene2/src/` を読んで実際のクラス・メソッドシグネチャを確認。
+3. `tasklog` (FT11) の `AppServiceProvider` パターンを参照してアプリケーション骨格を構築。
+4. SQLite スキーマ（`database/schema.sql`）とフロントコントローラーを実装。
+5. Article / Category ドメイン、Repository、RouteRegistrar を実装。
+6. 書き込み保護のため `WriteApiKeyMiddleware` を自作（F-1 参照）。
+7. PHPUnit / PHPStan / CS-Fixer 全通過。
+8. `docs/openapi/openapi.yaml` と `docs/mcp/tools.json`（7ツール）を作成。
+9. MCP バリデーター制約を調査し `tools/validate-mcp.php` ラッパーを実装（F-2 参照）。
+10. `symfony/yaml` を `require-dev` に追加（F-3 参照）。
+
+---
+
+## Findings
+
+### F-1: `ApiKeyAuthenticationMiddleware` が動的パスと HTTP メソッドの組み合わせに非対応 [中]
+
+`$protectedPaths` は exact-match のため、`/articles/{id}` のような動的パスや GET/POST の分岐に対応できない。
+
+**解決**: HTTP メソッド（POST/PUT/DELETE/PATCH）単位で API キー検証を行う `WriteApiKeyMiddleware` を自作。
+
+**提案**: `ApiKeyAuthenticationMiddleware` に `$protectedMethods` オプションを追加する。
+
+---
+
+### F-2: `vendor/hideyukimori/nene2/tools/validate-mcp-tools.php` が Consumer Project から動かない [高]
+
+スクリプト内の `$root = dirname(__DIR__)` が `vendor/hideyukimori/nene2/` を指すため、Consumer Project の `docs/mcp/tools.json` ではなく NENE2 パッケージ自身の docs を読もうとする。
+
+**解決**: `tools/validate-mcp.php` という同等ロジックのラッパーを Consumer Project に作成し、`$root` を Consumer Project ルートに向けた。
+
+**提案**: `validate-mcp-tools.php` に `--root=<path>` オプションを追加する（または Composer bin スクリプトとして公開する）。
+
+---
+
+### F-3: `symfony/yaml` が Consumer Project の `vendor` に存在しない [高]
+
+`validate-mcp-tools.php` は `symfony/yaml` を使っているが、NENE2 の `composer.json` では `require-dev` に分類されている。Consumer Project の `composer install` では dev 依存が含まれないため、クラスが見つからないエラーが発生した。
+
+**解決**: Consumer Project の `require-dev` に `symfony/yaml` を追加してインストール。
+
+**提案**: `require` へ移動するか、`symfony/yaml` を使わない実装に置き換える。または MCP バリデーターを独立した Composer パッケージとして公開する。
+
+---
+
+### F-4: `nene2.auth.*` リクエスト属性名がドキュメントにない [低]
+
+`ApiKeyAuthenticationMiddleware::process()` が付与する `nene2.auth.credential_type` 属性名がドキュメントに記載されていない。
+
+**提案**: ADR や PHPDoc に `nene2.auth.*` 属性名を記載するか、`RequestAttribute` 定数クラスとして公開する。
+
+---
+
+### F-5: `RuntimeApplicationFactory` が Note/Tag の ServiceProvider と密結合 [中]
+
+`RuntimeServiceProvider` が `NoteServiceProvider`・`TagServiceProvider` を必ず `addProvider()` する。Consumer Project は Note/Tag に依存したくないため `RuntimeApplicationFactory` を使用できなかった。
+
+**解決**: Consumer Project 専用の `AppServiceProvider`・`AppContainerFactory` を自作し、`MiddlewareDispatcher` + `Router` を直接組み立てた（FT11 と同じパターン）。
+
+**提案**: `RuntimeApplicationFactory` を Consumer Project 向けに拡張可能にする、または Example の Note/Tag をデフォルトで登録しないオプションを提供する。
+
+---
+
+## Test Results
+
+```
+PHPUnit:         10/10 tests, 30 assertions
+PHPStan level 8: No errors
+PHP-CS-Fixer:    0 files to fix
+MCP validation:  MCP tool catalog is valid.
+```
+
+---
+
+## Friction Summary
+
+| # | 内容 | 深刻度 | 種別 |
+|---|---|---|---|
+| F-1 | `ApiKeyAuthenticationMiddleware` が動的パスを保護できない | 中 | API 設計 |
+| F-2 | `validate-mcp-tools.php` が Consumer Project から動かない | 高 | ツール設計 |
+| F-3 | `symfony/yaml` が Consumer の `vendor` に存在しない | 高 | 依存管理 |
+| F-4 | `nene2.auth.*` 属性名がドキュメントにない | 低 | ドキュメント |
+| F-5 | `RuntimeApplicationFactory` が Note/Tag に密結合 | 中 | アーキテクチャ |
+
+---
+
+## Overall Impression
+
+NENE2 v1.4.1 のコア API は Consumer Project から非常に使いやすい。一方、**MCP ツール周辺のエルゴノミクスには改善余地がある**。`validate-mcp-tools.php` が Consumer Project から「そのまま使えない」のは MCP をフォーカスした今回の最大の摩擦だった。ラッパースクリプトで回避できるが、ドキュメントがなければ詰まるポイントであり、Next Release で優先的に解決すべき課題。

--- a/docs/field-trials/2026-05-field-trial-12c.md
+++ b/docs/field-trials/2026-05-field-trial-12c.md
@@ -1,0 +1,138 @@
+# Field Trial 12-C — shoplog: Multi-Auth Ergonomics 実地検証
+
+## Date
+
+2026-05-19
+
+## Baseline
+
+- NENE2 v1.4.1（`hideyukimori/nene2: ^1.4`）
+- PHP 8.4
+- プロジェクト: **shoplog** — 商品カタログ JSON API
+- エンティティ: `Product` / `Category` / `Favorite`（3層アクセスモデル）
+- テスト: PHPUnit（29テスト）・PHPStan level 8・PHP-CS-Fixer
+- DB: SQLite（ローカル）
+
+## Goal
+
+3層アクセスモデル（公開 / JWT Bearer / API キー）を単一アプリで実現し、設計の摩擦を記録する。
+
+| 層 | 認証方式 | 操作 |
+|---|---|---|
+| 公開 | なし | 商品・カテゴリ一覧・詳細（読み取り専用） |
+| ユーザー | JWT Bearer | お気に入り登録・削除・一覧（`NENE2_LOCAL_JWT_SECRET`） |
+| 管理者 | API キー | 商品・カテゴリの CRUD（`NENE2_MACHINE_API_KEY`） |
+
+---
+
+## Findings
+
+### F-1: `RuntimeApplicationFactory` が受け取れる `$authMiddleware` は 1 つのみ [高]
+
+Bearer と API キーを同時に適用したい場合、単一の引数では両方を表現できない。
+
+**解決**: `MultiAuthMiddleware` を新設し、パスプレフィックスで振り分けることで合成した。
+```php
+final readonly class MultiAuthMiddleware implements MiddlewareInterface {
+    public function process(...): ResponseInterface {
+        if (str_starts_with($path, '/me/')) {
+            return $this->bearerMiddleware->process($request, $handler);
+        }
+        return $this->writeApiKeyMiddleware->process($request, $handler);
+    }
+}
+```
+
+**提案**: `RuntimeApplicationFactory` に `$authMiddlewares: list<MiddlewareInterface>` を受け取れるようにするか、フレームワークで `CompositeAuthMiddleware` を提供する。
+
+---
+
+### F-2: `BearerTokenMiddleware::$protectedPaths` が動的パスに非対応 [高]
+
+`/me/favorites/{productId}` のような動的パスは完全一致リストにマッチしない。
+
+**解決**: `MultiAuthMiddleware` が `/me/` プレフィックスのルーティングを担当し、内部では `protectedPaths: []`（全パス保護）で Bearer を設定。
+
+**提案**: `$protectedPaths` にプレフィックスマッチング（または `$protectedPathPrefixes` パラメータ）を追加する。
+
+---
+
+### F-3: `ApiKeyAuthenticationMiddleware` がパスパターンと HTTP メソッドの組み合わせに非対応 [高]
+
+GET /products（公開）と POST /products（管理者）が同じパスで HTTP メソッドが違うため、パスのみでの保護では GET も 401 になる。
+
+**解決**: `WriteApiKeyMiddleware` をカスタム実装。HTTP メソッドで判断（POST/PUT/DELETE → 認証必須、GET → スルー）し、`/auth/*` と `/me/*` プレフィックスは除外。
+
+**提案**: `ApiKeyAuthenticationMiddleware` にメソッドフィルタリングと動的パスマッチングを追加する。
+
+---
+
+### F-4: `BearerTokenMiddleware` の `excludedPaths` と `RuntimeApplicationFactory` の組み合わせが難しい [中]
+
+`BearerTokenMiddleware` は `$excludedPaths` を持つが、`RuntimeApplicationFactory` 経由では全パス保護モードで注入する際に `/auth/*` も保護されてしまう問題がある。
+
+**解決**: FT12-C では `MultiAuthMiddleware` が `/me/` 以外を `WriteApiKeyMiddleware` に渡すため、Bearer は `/me/*` にしか適用されず、自然に回避された。
+
+---
+
+### F-5: `LocalBearerTokenVerifier` が `@internal` だが直接使用が最もシンプル [低]
+
+`TokenIssuerInterface` は公開 API として存在し、`LocalBearerTokenVerifier` はそれを実装している。`@internal` タグはあるが、型で受け取れば機能上の問題はない。
+
+**提案**: `LocalBearerTokenVerifier` の `@internal` タグを削除するか、公開クラス `LocalTokenVerifier` を用意する。
+
+---
+
+### F-6: `composer analyse` がデフォルトのメモリ制限で OOM になる [低]
+
+並列ワーカーが 128MB を超えて OOM でクラッシュした。
+
+**解決**: `composer.json` の `analyse` スクリプトに `php -d memory_limit=512M` を追加。
+
+**提案**: NENE2 の composer.json テンプレートに `memory_limit` の設定を記載する。
+
+---
+
+## Multi-Auth 設計パターン
+
+```
+Request
+  │
+  ├── MultiAuthMiddleware
+  │     ├── /me/* → BearerTokenMiddleware（全パス保護モード）
+  │     └── other → WriteApiKeyMiddleware
+  │           ├── GET/HEAD → pass through（公開）
+  │           ├── /auth/* → pass through（公開）
+  │           ├── /me/* → pass through（Bearer が処理）
+  │           └── POST/PUT/DELETE → X-NENE2-API-Key 必須
+  └── Router → handler
+```
+
+---
+
+## Test Results
+
+```
+PHPUnit:         29/29 tests
+PHPStan level 8: No errors
+PHP-CS-Fixer:    0 files to fix
+```
+
+---
+
+## Friction Summary
+
+| # | 内容 | 深刻度 | 種別 |
+|---|---|---|---|
+| F-1 | `RuntimeApplicationFactory` が 1 つの認証ミドルウェアしか受け取れない | 高 | 拡張性 |
+| F-2 | `BearerTokenMiddleware` が動的パスに非対応 | 高 | API 設計 |
+| F-3 | `ApiKeyAuthenticationMiddleware` がメソッド単位での保護に非対応 | 高 | API 設計 |
+| F-4 | `BearerTokenMiddleware::excludedPaths` と `RuntimeApplicationFactory` の組み合わせが難しい | 中 | API 設計 |
+| F-5 | `LocalBearerTokenVerifier` が `@internal` だが実質的に直接使う必要がある | 低 | API 設計 |
+| F-6 | PHPStan の OOM（`memory_limit` 設定が必要） | 低 | ドキュメント |
+
+---
+
+## Overall Impression
+
+3層アクセスモデル自体は `MultiAuthMiddleware` パターンで実現できたが、フレームワークにこの合成パターンのサポートがないため毎回自作が必要。FT12-B (knowledgelog) でも同じ問題が出ており、`CompositeAuthMiddleware` または `$authMiddlewares` 複数受け取りが重要な改善ポイント。

--- a/docs/field-trials/2026-05-field-trial-13.md
+++ b/docs/field-trials/2026-05-field-trial-13.md
@@ -1,0 +1,110 @@
+# Field Trial 13 — eventlog: MySQL + Phinx マイグレーション実地検証
+
+## Date
+
+2026-05-19
+
+## Baseline
+
+- NENE2 v1.4.1（`hideyukimori/nene2: ^1.4`）
+- PHP 8.4
+- プロジェクト: **eventlog** — イベント管理 JSON API
+- エンティティ: `User` / `Event` / `Registration`（3テーブル）
+- テスト: PHPUnit（14テスト）・PHPStan level 8・PHP-CS-Fixer
+- DB: MySQL（本番） / SQLite インメモリ（テスト）
+- マイグレーション: Phinx
+
+## Goal
+
+SQLite ではなく MySQL をバックエンドとした場合の Phinx マイグレーションセットアップの摩擦点を記録する。
+
+---
+
+## Findings
+
+### F-1: `compose.yaml` の `working_on` が無効なキー [低]
+
+`working_on: /var/www/html` という誤ったキーが含まれており、Docker Compose がバリデーションエラーを出した。正しいキーは `working_dir`。
+
+**解決**: `working_on` → `working_dir` に修正。
+
+**提案**: CLAUDE.md のスキャフォールドテンプレートを修正する。
+
+---
+
+### F-2: `ConfigLoader` が `DB_PASS` ではなく `DB_PASSWORD` を読む [中]
+
+`compose.yaml` に `DB_PASS: eventlog_secret` を設定したが、`ConfigLoader` は `DB_PASSWORD` を読む。`DB_PASS` は無視され、パスワードが空文字列になり認証失敗した。
+
+**解決**: `compose.yaml` に `DB_PASSWORD: eventlog_secret` を追加。
+
+**提案**: NENE2 の CLAUDE.md・compose.yaml テンプレート・README で `DB_PASSWORD`（`DB_PASS` ではなく）を明示する。
+
+---
+
+### F-3: Phinx の MySQL 外部キー — 符号なし整数の型不一致 [高]
+
+Phinx が MySQL の `id` カラムを `INT UNSIGNED AUTO_INCREMENT` として作成するのに対し、外部キー側の `integer` 型は `INT`（符号付き）。MySQL はこの組み合わせを拒否する。
+
+```
+"Referencing column 'user_id' and referenced column 'id' in foreign key constraint are incompatible"
+```
+
+SQLite では型チェックが緩いため同じコードが動いてしまい、MySQL 移行時に初めて気づくパターン。
+
+**解決**: 外部キーカラムに `'signed' => false` を追加した:
+```php
+->addColumn('user_id', 'integer', ['null' => false, 'signed' => false])
+->addColumn('event_id', 'integer', ['null' => false, 'signed' => false])
+```
+
+**提案**: NENE2 ドキュメント（`add-database-endpoint.md` または新規 howto）に MySQL 外部キーの注意点として `'signed' => false` が必要である旨を明記する。
+
+---
+
+### F-4: Phinx rollback が部分適用マイグレーション後にテーブルを残す [中]
+
+F-3 のエラー発生後、rollback して migration を修正・再実行しようとした。`registrations` テーブルの作成が失敗した後、Phinx の `change()` メソッドの自動ロールバックは `CREATE TABLE` まで戻せず、テーブルが作成済みだが phinxlog に記録されていない状態になった。
+
+次の `migrations:migrate` で "Table 'registrations' already exists" エラーが出た。
+
+**解決**: MySQL に直接接続して `DROP TABLE IF EXISTS registrations;` を手動実行してから再実行。
+
+**提案**: NENE2 の howto に「失敗した migration の手動ロールバック手順」を追記する。または `up()` / `down()` を明示的に分けて書く方針を推奨する。
+
+---
+
+### F-5: PHPUnit テストは MySQL なしでも動く（SQLite インメモリ戦略が有効）[情報]
+
+テストでは SQLite インメモリ DSN を使用し、専用の SQLite スキーマファイル `database/schema.sqlite.sql` を用意した。`PdoDatabaseQueryExecutor` に PDO を匿名クラスで渡すことで、MySQL/SQLite の切り替えが実現した。
+
+**所感**: `DatabaseQueryExecutorInterface` の抽象化が test-friendliness を高めている。ただし MySQL と SQLite の型システムの差（符号付き整数）は SQLite テストでは見えないため、MySQL 統合テストも CI に含めることが望ましい。
+
+---
+
+## Test Results
+
+```
+PHPUnit:              14/14 tests
+PHPStan level 8:      No errors
+PHP-CS-Fixer:         0 files to fix
+MySQL migration:      3 tables (users / events / registrations)
+```
+
+---
+
+## Friction Summary
+
+| # | 内容 | 深刻度 | 種別 |
+|---|---|---|---|
+| F-1 | `compose.yaml` の `working_on` キー誤り | 低 | テンプレート誤り |
+| F-2 | `DB_PASS` ではなく `DB_PASSWORD` を読む | 中 | ドキュメント欠如 |
+| F-3 | MySQL 外部キーで `'signed' => false` が必要 | 高 | ドキュメント欠如 |
+| F-4 | 部分適用マイグレーションの手動ロールバックが必要 | 中 | ドキュメント欠如 |
+| F-5 | SQLite インメモリ戦略は有効（情報） | — | 情報 |
+
+---
+
+## Overall Impression
+
+Phinx のセットアップ自体は簡単（`phinx.php` を 1 ファイル追加するだけ）。ただし MySQL 特有の制約（外部キーの型一致）が SQLite 開発時には見えず、初回 MySQL 移行時に気づくパターンが発生した。`DB_PASSWORD` などの環境変数名の揺れは、スキャフォールドを充実させれば防げる類の摩擦。全体として MySQL + Phinx の ergonomics は検証目的を達成できた。

--- a/docs/field-trials/2026-05-field-trial-14.md
+++ b/docs/field-trials/2026-05-field-trial-14.md
@@ -1,0 +1,124 @@
+# Field Trial 14 — postboard: CompositeAuthMiddleware + M:N 実地検証
+
+## Date
+
+2026-05-19
+
+## Baseline
+
+- NENE2 dev-main（c3513df、Packagist v1.4.1 には未収録）
+- PHP 8.4
+- プロジェクト: **postboard** — 投稿ボード JSON API
+- エンティティ: `Post` / `Tag` / `PostTag`（M:N 中間テーブル）
+- テスト: PHPUnit（31テスト）・PHPStan level 8・PHP-CS-Fixer
+- DB: SQLite（ローカル）
+
+## Goal
+
+1. `CompositeAuthMiddleware` を使って 3 層アクセスモデルを実現し、FT12-C (shoplog) で必要だった独自 `MultiAuthMiddleware` が不要になっているかを検証する。
+2. M:N リレーション実装を howto なしで行い、摩擦を記録する。
+
+---
+
+## Findings
+
+### F-1: `CompositeAuthMiddleware` が Packagist v1.4.1 に未収録 [高]
+
+FT14 の主要検証ポイントである `CompositeAuthMiddleware` が、Packagist にリリース済みの v1.4.1 の `vendor/` に存在しなかった。
+
+**解決**: `composer.json` に `path` リポジトリを追加し、`compose.yaml` で `../NENE2` をコンテナにマウントして `@dev` バージョンをインストール。
+
+```json
+"repositories": [{"type": "path", "url": "/nene2", "options": {"symlink": false}}],
+"require": {"hideyukimori/nene2": "@dev"}
+```
+
+**提案**: `CompositeAuthMiddleware` を v1.5.0 としてリリースする（FT12-C の摩擦点を解消する機能のため優先度高い）。→ v1.5.0 でリリース済み。
+
+---
+
+### F-2: `ApiKeyAuthenticationMiddleware` がメソッド単位での保護に非対応 [中]
+
+GET /tags は公開、POST /tags は API キー必須という設計を実装しようとした。`protectedPaths: ['/tags']` とすると GET /tags も POST /tags も同様に保護されてしまう。
+
+**解決**: `CompositeAuthMiddleware` の API キーミドルウェア側に `/tags` を列挙せず、`TagRouteRegistrar` のハンドラー内で手動チェックする回避策を採用。
+
+**提案**: `ApiKeyAuthenticationMiddleware` に `protectedMethods` 配列、または `[path => [method, ...]]` 形式の設定を追加する（Issue #461 と一致）。
+
+---
+
+### F-3: `ApiKeyAuthenticationMiddleware` がパスパラメーター（パターン）に非対応 [中]
+
+DELETE /tags/{id} を API キー必須にしようとした。`protectedPaths` は完全一致で評価されるため、`/tags/{id}` のようなパターン文字列は動作しない。
+
+**解決**: F-2 と同様にハンドラー内での手動チェックで回避。
+
+**提案**: `ApiKeyAuthenticationMiddleware` に `protectedPathPrefixes` を追加するか、`BearerTokenMiddleware` と同様の prefix マッチオプションを提供する。
+
+---
+
+### F-4: `CompositeAuthMiddleware` の基本動作は直感的で成功 [情報]
+
+`new CompositeAuthMiddleware([...middlewares])` とリスト渡しするだけで動作し、FT12-C で必要だった独自 `MultiAuthMiddleware` が不要になった。
+
+`BearerTokenMiddleware` の `protectedPathPrefixes: ['/me/']` は `/me/posts`、`/me/posts/{id}`、`/me/posts/{id}/tags/{tagId}` すべてに正しく適用され、公開エンドポイント（`/posts`、`/auth/*`、`/tags`）は通過した。
+
+---
+
+## M:N リレーション実装パターン（howto なし）
+
+NENE2 には M:N 専用の抽象化も howto も存在しないが、以下のパターンで実装できた:
+
+1. `post_tags(post_id, tag_id, PRIMARY KEY(post_id, tag_id))` 中間テーブルを SQLite で定義。
+2. `PostRepositoryInterface` に `attachTag(int $postId, int $tagId): void` と `detachTag()` を追加。
+3. `INSERT OR IGNORE` で冪等な attach を実現。
+4. `PRAGMA foreign_keys = ON` で SQLite 外部キーを有効化。
+
+特段の摩擦はなかった。ただし、タグ一覧をポスト詳細と一緒に返す JOIN パターンを示す howto や example がない点は改善余地あり。
+
+---
+
+## CompositeAuthMiddleware 動作確認
+
+| エンドポイント | 認証 | 実装方法 | 結果 |
+|---|---|---|---|
+| GET /posts | なし | — | ✅ |
+| GET /posts/{id} | なし | — | ✅ |
+| POST /auth/register | なし | — | ✅ |
+| POST /auth/login | なし | — | ✅ |
+| GET /me/posts | Bearer | BearerTokenMiddleware（prefix） | ✅ |
+| POST /me/posts | Bearer | BearerTokenMiddleware（prefix） | ✅ |
+| PUT /me/posts/{id} | Bearer | BearerTokenMiddleware（prefix） | ✅ |
+| DELETE /me/posts/{id} | Bearer | BearerTokenMiddleware（prefix） | ✅ |
+| POST /me/posts/{id}/tags/{tagId} | Bearer | BearerTokenMiddleware（prefix） | ✅ |
+| DELETE /me/posts/{id}/tags/{tagId} | Bearer | BearerTokenMiddleware（prefix） | ✅ |
+| GET /tags | なし | — | ✅ |
+| POST /tags | API キー | 手動チェック（F-2 回避策） | ✅ |
+| DELETE /tags/{id} | API キー | 手動チェック（F-3 回避策） | ✅ |
+
+---
+
+## Test Results
+
+```
+PHPUnit:         31/31 tests
+PHPStan level 8: No errors
+PHP-CS-Fixer:    0 violations
+```
+
+---
+
+## Friction Summary
+
+| # | 内容 | 深刻度 | 種別 |
+|---|---|---|---|
+| F-1 | `CompositeAuthMiddleware` が Packagist v1.4.1 に未収録 | 高 | リリース漏れ |
+| F-2 | `ApiKeyAuthenticationMiddleware` がメソッド単位での保護に非対応 | 中 | API 設計 |
+| F-3 | `ApiKeyAuthenticationMiddleware` がパスパターンに非対応 | 中 | API 設計 |
+| F-4 | `CompositeAuthMiddleware` の基本 API は直感的（情報） | — | 情報 |
+
+---
+
+## Overall Impression
+
+`CompositeAuthMiddleware` の基本 API は直感的で、FT12-C で発生した「独自 MultiAuthMiddleware を書く必要がある」問題は解決されている。ただし `ApiKeyAuthenticationMiddleware` のパスパターン・メソッドフィルタリング非対応により、「GET は公開、POST は API キー必須」という一般的なユースケースに `CompositeAuthMiddleware` 単体では対応できず、ハンドラー内での手動チェック回避策が必要になる。F-1（リリース未収録）は v1.5.0 でリリースし解消済み。

--- a/docs/fr/howto/add-html-view.md
+++ b/docs/fr/howto/add-html-view.md
@@ -1,0 +1,261 @@
+# Ajouter des vues HTML
+
+Ce guide explique comment ajouter des réponses HTML rendues côté serveur à une application NENE2
+en utilisant `NativePhpViewRenderer` et `HtmlResponseFactory`.
+
+**Prérequis** : Vous avez une application NENE2 fonctionnelle avec au moins une route. Sinon, commencez par [Ajouter une route personnalisée](./add-custom-route.md).
+
+---
+
+## Vue d'ensemble
+
+NENE2 fournit une couche de rendu HTML minimale sans dépendances externes :
+
+| Classe | Rôle |
+|---|---|
+| `NativePhpViewRenderer` | Rend les templates `.php` dans une portée isolée |
+| `HtmlEscaper` | Échappe les valeurs pour une sortie HTML sûre (`htmlspecialchars` / UTF-8 / guillemets complets) |
+| `HtmlResponseFactory` | Encapsule le HTML rendu dans une réponse PSR-7 `text/html; charset=utf-8` |
+| `TemplateNotFoundException` | Levée si le fichier template n'existe pas ou si le chemin est invalide |
+
+Les réponses HTML coexistent avec les endpoints JSON. Vous pouvez les ajouter à la même application sans supprimer les routes existantes.
+
+---
+
+## 1. Créer les templates
+
+NENE2 s'attend à ce que les fichiers templates PHP natifs soient placés sous un seul répertoire racine. L'emplacement standard est `templates/` à la racine du projet.
+
+```
+my-app/
+├── templates/
+│   ├── layout.php       (layout partagé optionnel)
+│   ├── home.php
+│   └── notes/
+│       ├── index.php
+│       └── show.php
+```
+
+Ce que chaque template reçoit :
+
+- `$e` — assistant d'échappement (`HtmlEscaper::escape()`). Toujours l'utiliser pour les valeurs utilisateur.
+- Chaque clé du tableau `$data` passé à `render()` est injectée comme variable individuelle.
+
+**`templates/home.php`**
+
+```php
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title><?= $e($title) ?></title></head>
+<body>
+  <h1><?= $e($title) ?></h1>
+  <p><?= $e($description) ?></p>
+</body>
+</html>
+```
+
+**`templates/notes/index.php`**
+
+```php
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Liste des notes</title></head>
+<body>
+  <h1>Notes</h1>
+  <ul>
+    <?php foreach ($notes as $note): ?>
+      <li><a href="/notes/<?= $e($note['id']) ?>"><?= $e($note['title']) ?></a></li>
+    <?php endforeach; ?>
+  </ul>
+</body>
+</html>
+```
+
+> **Sécurité** : Utilisez toujours `$e(...)` pour les valeurs provenant de l'utilisateur, de la base de données ou de systèmes externes. L'omettre crée des vulnérabilités XSS.
+
+---
+
+## 2. Câbler le renderer dans le ServiceProvider
+
+Enregistrez `NativePhpViewRenderer` et `HtmlResponseFactory` dans le `ServiceProviderInterface` de votre application :
+
+```php
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class AppServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                NativePhpViewRenderer::class,
+                static function (ContainerInterface $container): NativePhpViewRenderer {
+                    return new NativePhpViewRenderer(dirname(__DIR__) . '/templates');
+                },
+            )
+            ->set(
+                HtmlResponseFactory::class,
+                static function (ContainerInterface $container): HtmlResponseFactory {
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    $streamFactory   = $container->get(StreamFactoryInterface::class);
+                    $renderer        = $container->get(NativePhpViewRenderer::class);
+
+                    return new HtmlResponseFactory($responseFactory, $streamFactory, $renderer);
+                },
+            );
+    }
+}
+```
+
+---
+
+## 3. Utiliser HtmlResponseFactory dans un handler
+
+Injectez `HtmlResponseFactory` dans votre handler et appelez `create()` :
+
+```php
+use Nene2\View\HtmlResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class HomeHandler
+{
+    public function __construct(private HtmlResponseFactory $html) {}
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->html->create('home.php', [
+            'title'       => 'Bienvenue',
+            'description' => 'Application construite avec NENE2.',
+        ]);
+    }
+}
+```
+
+Signature de `create()` :
+
+```php
+public function create(
+    string $template,           // chemin relatif depuis templateRoot
+    array  $data    = [],       // variables transmises au template
+    int    $status  = 200,      // code de statut HTTP
+    array  $headers = [],       // en-têtes de réponse supplémentaires
+): ResponseInterface
+```
+
+---
+
+## 4. Enregistrer les routes
+
+```php
+$router->get('/', new HomeHandler($container->get(HtmlResponseFactory::class)));
+$router->get('/notes', new NoteListHandler($container->get(HtmlResponseFactory::class)));
+```
+
+---
+
+## 5. Gérer TemplateNotFoundException
+
+`NativePhpViewRenderer::render()` lève `TemplateNotFoundException` dans ces cas :
+
+- Le fichier template n'existe pas
+- Le chemin du template est vide
+- Le chemin du template contient `..` (traversée de répertoire bloquée)
+
+Enregistrez un handler d'exception de domaine pour retourner une réponse HTTP appropriée :
+
+```php
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\View\TemplateNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class TemplateNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(private ProblemDetailsResponseFactory $problemDetails) {}
+
+    public function handles(\Throwable $exception): bool
+    {
+        return $exception instanceof TemplateNotFoundException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'not-found', 'Not Found', 404);
+    }
+}
+```
+
+---
+
+## 6. Mélanger des endpoints HTML et JSON
+
+```php
+$registerRoutes = static function (Router $router) use ($container): void {
+    // API JSON
+    $router->get('/api/notes',     $container->get(NoteListJsonHandler::class));
+    $router->post('/api/notes',    $container->get(NoteCreateHandler::class));
+
+    // Vues HTML
+    $router->get('/',              $container->get(HomeHandler::class));
+    $router->get('/notes',         $container->get(NoteListHtmlHandler::class));
+    $router->get('/notes/{id}',    $container->get(NoteShowHtmlHandler::class));
+};
+```
+
+---
+
+## 7. Tester les handlers HTML
+
+```php
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
+
+public function testHomeReturnsHtml(): void
+{
+    $templateRoot = sys_get_temp_dir() . '/test-templates-' . bin2hex(random_bytes(4));
+    mkdir($templateRoot);
+    file_put_contents($templateRoot . '/home.php', '<h1><?= $e($title) ?></h1>');
+
+    $psr17   = new Psr17Factory();
+    $factory = new HtmlResponseFactory($psr17, $psr17, new NativePhpViewRenderer($templateRoot));
+    $handler = new HomeHandler($factory);
+
+    $response = $handler(new ServerRequest('GET', '/'));
+
+    self::assertSame(200, $response->getStatusCode());
+    self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+    self::assertStringContainsString('<h1>Bienvenue</h1>', (string) $response->getBody());
+
+    unlink($templateRoot . '/home.php');
+    rmdir($templateRoot);
+}
+```
+
+---
+
+## Notes de conception
+
+- Les templates s'exécutent dans une portée de closure, ils n'ont donc pas accès à `$this` ni aux internes de classe. Les variables sont injectées via `extract()` + `EXTR_SKIP` (les variables existantes ne sont pas écrasées).
+- `HtmlEscaper` utilise `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5`. `"` et `'` sont tous deux échappés, et les séquences UTF-8 invalides sont substituées plutôt que supprimées.
+- La traversée de répertoire (`../`) est bloquée à l'étape de résolution de chemin. Aucun accès au système de fichiers n'a lieu avant cette vérification.
+
+Pour les garanties d'API stable de `Nene2\View\*`, consultez [ADR 0009](../adr/0009-v1.0-public-api-scope.md).
+
+---
+
+## Étapes suivantes
+
+- [Ajouter une route personnalisée](./add-custom-route.md)
+- [Ajouter la limitation de débit](./add-rate-limiting.md)
+- [Ajouter l'authentification JWT](./add-jwt-authentication.md)

--- a/docs/fr/howto/add-mcp-tools.md
+++ b/docs/fr/howto/add-mcp-tools.md
@@ -1,0 +1,251 @@
+# Ajouter des outils MCP
+
+Ce guide explique comment exposer les endpoints API d'une application NENE2 en tant qu'outils MCP,
+permettant aux assistants IA (Claude, Cursor, etc.) d'appeler l'API via le Model Context Protocol.
+
+**Prérequis** : Vous avez une application NENE2 fonctionnelle avec au moins une route et un fichier `docs/openapi/openapi.yaml`. Sinon, commencez par [Ajouter une route personnalisée](./add-custom-route.md).
+
+---
+
+## Vue d'ensemble
+
+NENE2 fournit un serveur MCP local (`LocalMcpServer`) qui traduit les messages JSON-RPC MCP en appels HTTP vers l'API. Le catalogue d'outils (`docs/mcp/tools.json`) déclare quels endpoints exposer en tant qu'outils MCP et leur niveau de sécurité.
+
+```
+Assistant IA → JSON-RPC (stdio) → LocalMcpServer → HTTP → Application NENE2
+```
+
+Le catalogue est validé par rapport à la spec OpenAPI avec `composer mcp`.
+
+---
+
+## 1. Ajouter le script de validation
+
+Ajoutez dans `composer.json` :
+
+```json
+{
+  "require-dev": {
+    "symfony/yaml": "^7.0"
+  },
+  "scripts": {
+    "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=."
+  }
+}
+```
+
+Installez la dépendance de développement :
+
+```bash
+composer require --dev symfony/yaml
+```
+
+---
+
+## 2. Créer le catalogue d'outils
+
+Créez `docs/mcp/tools.json`. Chaque entrée dans `tools` correspond à un endpoint API.
+
+```json
+{
+  "version": 1,
+  "source": "docs/openapi/openapi.yaml",
+  "tools": [
+    {
+      "name": "listNotes",
+      "title": "Liste des notes",
+      "description": "Retourne toutes les notes depuis la base de données.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "listNotes",
+        "method": "GET",
+        "path": "/notes"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit":  { "type": "integer", "description": "Nombre maximum de résultats à retourner." },
+          "offset": { "type": "integer", "description": "Nombre de résultats à ignorer." }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/NoteListResponse"
+    }
+  ]
+}
+```
+
+### Champs d'un outil
+
+| Champ | Requis | Description |
+|---|---|---|
+| `name` | Oui | Identifiant camelCase unique |
+| `title` | Oui | Libellé lisible par l'humain |
+| `description` | Oui | Texte expliquant l'objectif à l'assistant IA |
+| `safety` | Oui | `read` / `write` / `admin` / `destructive` |
+| `source.operationId` | Oui | Doit correspondre à l'`operationId` dans la spec OpenAPI |
+| `source.method` | Oui | Méthode HTTP (casse indifférente, stockée en majuscules) |
+| `source.path` | Oui | Chemin URL avec paramètres au format `{param}` |
+| `inputSchema` | Oui | JSON Schema des arguments de l'outil |
+| `responseSchemaRef` | Non | `$ref` vers un schema de composant OpenAPI, ou `null` |
+
+### Niveaux de sécurité
+
+| Niveau | Signification |
+|---|---|
+| `read` | Peut être appelé sans effets de bord (requêtes GET) |
+| `write` | Crée ou modifie des données (POST / PUT / PATCH) |
+| `admin` | Actions d'administration — à utiliser avec précaution |
+| `destructive` | Supprime définitivement des données — confirmation explicite requise |
+
+Commencez avec uniquement des outils `read`, ajoutez les outils `write` une fois l'authentification en place.
+
+---
+
+## 3. Valider le catalogue
+
+```bash
+composer mcp
+```
+
+Le validateur vérifie :
+
+- L'`operationId` de chaque outil existe dans la spec OpenAPI
+- Le chemin de chaque outil correspond à la définition de chemin OpenAPI
+- Le champ `safety` est l'une des quatre valeurs autorisées
+- `responseSchemaRef` (si non null) se résout vers un schema de composant existant
+
+Corrigez toutes les erreurs avant de démarrer le serveur MCP.
+
+---
+
+## 4. Ajouter des outils en écriture
+
+```json
+{
+  "name": "createNote",
+  "title": "Créer une note",
+  "description": "Crée une nouvelle note.",
+  "safety": "write",
+  "source": {
+    "type": "openapi",
+    "operationId": "createNote",
+    "method": "POST",
+    "path": "/notes"
+  },
+  "inputSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["title", "content"],
+    "properties": {
+      "title":   { "type": "string", "description": "Titre de la note." },
+      "content": { "type": "string", "description": "Corps de la note." }
+    }
+  },
+  "responseSchemaRef": null
+}
+```
+
+---
+
+## 5. Protéger les outils en écriture avec JWT
+
+`LocalMcpServer` vérifie un en-tête `Authorization: Bearer <token>` pour chaque appel d'outil `write`, `admin` ou `destructive`. Configurez la variable d'environnement :
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-secret
+```
+
+Sans cette variable, les appels d'outils en écriture retournent une erreur MCP sans transmettre la requête.
+
+Protégez également les endpoints correspondants côté application avec `BearerTokenMiddleware` :
+
+```php
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+
+$secret = getenv('NENE2_LOCAL_JWT_SECRET') ?: null;
+
+$authMiddleware = $secret !== null
+    ? new BearerTokenMiddleware(
+        $problemDetails,
+        new LocalBearerTokenVerifier($secret),
+        excludedPaths: ['/notes'],
+        protectedPathPrefixes: ['/notes/'],
+    )
+    : null;
+```
+
+---
+
+## 6. Démarrer le serveur MCP
+
+```bash
+NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_JWT_SECRET=your-local-secret \
+php vendor/hideyukimori/nene2/tools/local-mcp-server.php
+```
+
+Le serveur lit depuis `stdin` et écrit sur `stdout` via le transport stdio MCP.
+
+---
+
+## 7. Configurer Claude Code ou Claude Desktop
+
+### Claude Code (`~/.claude/claude_code_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "/path/to/my-app/mcp-server.sh"
+    }
+  }
+}
+```
+
+### Claude Desktop (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "bash",
+      "args": ["/path/to/my-app/mcp-server.sh"]
+    }
+  }
+}
+```
+
+Redémarrez Claude et les outils déclarés dans le catalogue apparaîtront comme actions disponibles.
+
+---
+
+## 8. Tester la couche MCP
+
+Testez `LocalMcpToolCatalog` directement. Aucun serveur HTTP n'est requis :
+
+```php
+use Nene2\Mcp\LocalMcpToolCatalog;
+
+public function testListNotesToolIsPresent(): void
+{
+    $catalog = new LocalMcpToolCatalog(dirname(__DIR__) . '/docs/mcp/tools.json');
+
+    $tool = $catalog->find('listNotes');
+
+    self::assertNotNull($tool);
+    self::assertSame('read', $tool['safety']);
+    self::assertSame('GET', $tool['source']['method']);
+    self::assertSame('/notes', $tool['source']['path']);
+}
+```
+
+---
+
+## Étapes suivantes
+
+- [Ajouter l'authentification JWT](./add-jwt-authentication.md)
+- [Ajouter la limitation de débit](./add-rate-limiting.md)
+- [Ajouter un health check](./add-health-check.md)

--- a/docs/howto/deploy-production.md
+++ b/docs/howto/deploy-production.md
@@ -161,7 +161,26 @@ Caddy automatically provisions TLS certificates via Let's Encrypt.
 
 ---
 
-## 4. Production security checklist
+## 4. JWT authentication in production
+
+> **Warning**: `LocalBearerTokenVerifier` (the built-in HMAC-HS256 implementation) is intended
+> **for local development and testing only**. It uses no external library and lacks the security
+> hardening required for production JWT validation (key rotation, RS256 asymmetric keys, revocation,
+> clock-skew tolerance beyond basic `exp`/`nbf` checks, etc.).
+>
+> Before deploying an application that uses Bearer JWT authentication:
+>
+> 1. Implement `TokenVerifierInterface` and `TokenIssuerInterface` using a production-grade library
+>    such as [`firebase/php-jwt`](https://github.com/firebase/php-jwt) or [`lcobuzi/jwt`](https://github.com/lcobuzi/jwt).
+> 2. Use asymmetric keys (RS256 or ES256) so the API can verify tokens without holding the signing key.
+> 3. Keep `NENE2_LOCAL_JWT_SECRET` out of your production environment — it should only appear in
+>    development `.env` files.
+>
+> See [ADR 0008](../adr/0008-jwt-authentication.md) for the full rationale.
+
+---
+
+## 5. Production security checklist
 
 Before accepting traffic, verify:
 
@@ -169,6 +188,8 @@ Before accepting traffic, verify:
 - [ ] `APP_DEBUG=false` — suppresses stack traces in HTTP responses
 - [ ] Database credentials come from a secret store, not from `.env` in the image
 - [ ] `NENE2_MACHINE_API_KEY` is a strong random value (≥ 32 characters)
+- [ ] JWT: `LocalBearerTokenVerifier` replaced with a production library (see §4 above)
+- [ ] `NENE2_LOCAL_JWT_SECRET` is **not** set in production
 - [ ] The container port is bound to loopback (`127.0.0.1:8080`) or a private network, not `0.0.0.0`
 - [ ] TLS is terminated at the reverse proxy
 - [ ] `X-Forwarded-For` / `X-Real-IP` headers are set by the proxy only
@@ -176,7 +197,7 @@ Before accepting traffic, verify:
 
 ---
 
-## 5. Verify after deployment
+## 6. Verify after deployment
 
 ```bash
 # Health check
@@ -194,7 +215,7 @@ Expected responses:
 
 ---
 
-## 6. Problem Details type URIs
+## 7. Problem Details type URIs
 
 NENE2 error responses include a `type` URI such as:
 

--- a/docs/ja/howto/add-html-view.md
+++ b/docs/ja/howto/add-html-view.md
@@ -1,0 +1,260 @@
+# HTML ビューを追加する
+
+このガイドでは、`NativePhpViewRenderer` と `HtmlResponseFactory` を使って NENE2 アプリケーションにサーバーレンダリングの HTML レスポンスを追加する方法を説明します。
+
+**前提条件**: ルートが 1 つ以上ある動作する NENE2 アプリケーションがあること。まだの場合は [カスタムルートを追加する](./add-custom-route.md) から始めてください。
+
+---
+
+## 概要
+
+NENE2 はゼロ依存のミニマルな HTML レンダリング層を提供します:
+
+| クラス | 役割 |
+|---|---|
+| `NativePhpViewRenderer` | 独立したスコープで `.php` テンプレートをレンダリング |
+| `HtmlEscaper` | 安全な HTML 出力のための値のエスケープ（`htmlspecialchars` / UTF-8 / フルクォート） |
+| `HtmlResponseFactory` | レンダリングした HTML を `text/html; charset=utf-8` PSR-7 レスポンスにラップ |
+| `TemplateNotFoundException` | テンプレートファイルが存在しない、またはパスが無効な場合にスロー |
+
+HTML レスポンスは JSON エンドポイントと共存します。既存のルートを削除せずに同じアプリケーションに追加できます。
+
+---
+
+## 1. テンプレートを作成する
+
+NENE2 は単一のルートディレクトリ以下にネイティブ PHP テンプレートファイルを配置することを期待します。標準的な場所はプロジェクトルートの `templates/` です。
+
+```
+my-app/
+├── templates/
+│   ├── layout.php       (オプションの共有レイアウト)
+│   ├── home.php
+│   └── notes/
+│       ├── index.php
+│       └── show.php
+```
+
+各テンプレートが受け取るもの:
+
+- `$e` — エスケープヘルパー（`HtmlEscaper::escape()`）。ユーザー入力値には必ず使うこと。
+- `render()` に渡した `$data` 配列の各キーが個別の変数として展開される。
+
+**`templates/home.php`**
+
+```php
+<!doctype html>
+<html lang="ja">
+<head><meta charset="utf-8"><title><?= $e($title) ?></title></head>
+<body>
+  <h1><?= $e($title) ?></h1>
+  <p><?= $e($description) ?></p>
+</body>
+</html>
+```
+
+**`templates/notes/index.php`**
+
+```php
+<!doctype html>
+<html lang="ja">
+<head><meta charset="utf-8"><title>ノート一覧</title></head>
+<body>
+  <h1>ノート</h1>
+  <ul>
+    <?php foreach ($notes as $note): ?>
+      <li><a href="/notes/<?= $e($note['id']) ?>"><?= $e($note['title']) ?></a></li>
+    <?php endforeach; ?>
+  </ul>
+</body>
+</html>
+```
+
+> **セキュリティ**: ユーザー入力・データベース・外部システム由来の値には必ず `$e(...)` を使うこと。省略すると XSS 脆弱性が生まれます。
+
+---
+
+## 2. ServiceProvider でレンダラーをワイヤリングする
+
+アプリケーションの `ServiceProviderInterface` に `NativePhpViewRenderer` と `HtmlResponseFactory` を登録します:
+
+```php
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class AppServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                NativePhpViewRenderer::class,
+                static function (ContainerInterface $container): NativePhpViewRenderer {
+                    return new NativePhpViewRenderer(dirname(__DIR__) . '/templates');
+                },
+            )
+            ->set(
+                HtmlResponseFactory::class,
+                static function (ContainerInterface $container): HtmlResponseFactory {
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    $streamFactory   = $container->get(StreamFactoryInterface::class);
+                    $renderer        = $container->get(NativePhpViewRenderer::class);
+
+                    return new HtmlResponseFactory($responseFactory, $streamFactory, $renderer);
+                },
+            );
+    }
+}
+```
+
+---
+
+## 3. ハンドラで HtmlResponseFactory を使う
+
+`HtmlResponseFactory` をハンドラにインジェクトして `create()` を呼び出します:
+
+```php
+use Nene2\View\HtmlResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class HomeHandler
+{
+    public function __construct(private HtmlResponseFactory $html) {}
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->html->create('home.php', [
+            'title'       => 'ようこそ',
+            'description' => 'NENE2 製アプリケーションです。',
+        ]);
+    }
+}
+```
+
+`create()` シグネチャ:
+
+```php
+public function create(
+    string $template,           // templateRoot からの相対パス
+    array  $data    = [],       // テンプレートに渡す変数
+    int    $status  = 200,      // HTTP ステータスコード
+    array  $headers = [],       // 追加レスポンスヘッダー
+): ResponseInterface
+```
+
+---
+
+## 4. ルートを登録する
+
+```php
+$router->get('/', new HomeHandler($container->get(HtmlResponseFactory::class)));
+$router->get('/notes', new NoteListHandler($container->get(HtmlResponseFactory::class)));
+```
+
+---
+
+## 5. TemplateNotFoundException を処理する
+
+`NativePhpViewRenderer::render()` は以下の場合に `TemplateNotFoundException` をスローします:
+
+- テンプレートファイルが存在しない
+- テンプレートパスが空
+- テンプレートパスに `..` が含まれる（ディレクトリトラバーサルはブロックされる）
+
+ドメイン例外ハンドラーを登録して適切な HTTP レスポンスを返します:
+
+```php
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\View\TemplateNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class TemplateNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(private ProblemDetailsResponseFactory $problemDetails) {}
+
+    public function handles(\Throwable $exception): bool
+    {
+        return $exception instanceof TemplateNotFoundException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'not-found', 'Not Found', 404);
+    }
+}
+```
+
+---
+
+## 6. HTML と JSON エンドポイントを混在させる
+
+```php
+$registerRoutes = static function (Router $router) use ($container): void {
+    // JSON API
+    $router->get('/api/notes',     $container->get(NoteListJsonHandler::class));
+    $router->post('/api/notes',    $container->get(NoteCreateHandler::class));
+
+    // HTML ビュー
+    $router->get('/',              $container->get(HomeHandler::class));
+    $router->get('/notes',         $container->get(NoteListHtmlHandler::class));
+    $router->get('/notes/{id}',    $container->get(NoteShowHtmlHandler::class));
+};
+```
+
+---
+
+## 7. HTML ハンドラをテストする
+
+```php
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
+
+public function testHomeReturnsHtml(): void
+{
+    $templateRoot = sys_get_temp_dir() . '/test-templates-' . bin2hex(random_bytes(4));
+    mkdir($templateRoot);
+    file_put_contents($templateRoot . '/home.php', '<h1><?= $e($title) ?></h1>');
+
+    $psr17   = new Psr17Factory();
+    $factory = new HtmlResponseFactory($psr17, $psr17, new NativePhpViewRenderer($templateRoot));
+    $handler = new HomeHandler($factory);
+
+    $response = $handler(new ServerRequest('GET', '/'));
+
+    self::assertSame(200, $response->getStatusCode());
+    self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+    self::assertStringContainsString('<h1>ようこそ</h1>', (string) $response->getBody());
+
+    unlink($templateRoot . '/home.php');
+    rmdir($templateRoot);
+}
+```
+
+---
+
+## 設計上の注意
+
+- テンプレートはクロージャスコープ内で実行されるため、`$this` やクラスの内部にはアクセスできません。変数は `extract()` + `EXTR_SKIP` で展開されます（既存の変数は上書きされません）。
+- `HtmlEscaper` は `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5` を使用します。`"` と `'` の両方がエスケープされ、無効な UTF-8 シーケンスはドロップではなく置換されます。
+- ディレクトリトラバーサル（`../`）はパス解決ステップでブロックされます。チェック前にファイルシステムアクセスは発生しません。
+
+`Nene2\View\*` の安定 API 保証については [ADR 0009](../adr/0009-v1.0-public-api-scope.md) を参照してください。
+
+---
+
+## 次のステップ
+
+- [カスタムルートを追加する](./add-custom-route.md)
+- [レートリミットを追加する](./add-rate-limiting.md)
+- [JWT 認証を追加する](./add-jwt-authentication.md)

--- a/docs/ja/howto/add-mcp-tools.md
+++ b/docs/ja/howto/add-mcp-tools.md
@@ -1,0 +1,250 @@
+# MCP ツールを追加する
+
+このガイドでは、NENE2 アプリケーションの API エンドポイントを MCP ツールとして公開し、AI アシスタント（Claude、Cursor など）がモデルコンテキストプロトコル経由でAPIを呼び出せるようにする方法を説明します。
+
+**前提条件**: ルートが 1 つ以上あり、`docs/openapi/openapi.yaml` ファイルがある動作する NENE2 アプリケーションがあること。まだの場合は [カスタムルートを追加する](./add-custom-route.md) から始めてください。
+
+---
+
+## 概要
+
+NENE2 はローカル MCP サーバー（`LocalMcpServer`）を提供します。JSON-RPC MCP メッセージを API への HTTP 呼び出しに変換します。ツールカタログ（`docs/mcp/tools.json`）は、どのエンドポイントを MCP ツールとして公開するか、各ツールの安全性レベルを宣言します。
+
+```
+AI アシスタント → JSON-RPC (stdio) → LocalMcpServer → HTTP → NENE2 アプリ
+```
+
+カタログは `composer mcp` で OpenAPI スペックと照合して検証されます。
+
+---
+
+## 1. バリデータースクリプトを追加する
+
+`composer.json` に追加します:
+
+```json
+{
+  "require-dev": {
+    "symfony/yaml": "^7.0"
+  },
+  "scripts": {
+    "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=."
+  }
+}
+```
+
+dev 依存をインストールします:
+
+```bash
+composer require --dev symfony/yaml
+```
+
+---
+
+## 2. ツールカタログを作成する
+
+`docs/mcp/tools.json` を作成します。`tools` の各エントリが 1 つの API エンドポイントに対応します。
+
+```json
+{
+  "version": 1,
+  "source": "docs/openapi/openapi.yaml",
+  "tools": [
+    {
+      "name": "listNotes",
+      "title": "ノート一覧",
+      "description": "データベースから全ノートを返します。",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "listNotes",
+        "method": "GET",
+        "path": "/notes"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit":  { "type": "integer", "description": "返す最大件数。" },
+          "offset": { "type": "integer", "description": "スキップする件数。" }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/NoteListResponse"
+    }
+  ]
+}
+```
+
+### ツールフィールド
+
+| フィールド | 必須 | 説明 |
+|---|---|---|
+| `name` | Yes | ユニークなキャメルケース識別子 |
+| `title` | Yes | 人間向けラベル |
+| `description` | Yes | AI アシスタントに目的を説明するテキスト |
+| `safety` | Yes | `read` / `write` / `admin` / `destructive` |
+| `source.operationId` | Yes | OpenAPI スペックの `operationId` と一致する必要あり |
+| `source.method` | Yes | HTTP メソッド（大文字小文字不問、内部的に大文字で保存） |
+| `source.path` | Yes | パスパラメーターを `{param}` 形式で含む URL パス |
+| `inputSchema` | Yes | ツール引数の JSON Schema |
+| `responseSchemaRef` | No | OpenAPI コンポーネントスキーマへの `$ref`、または `null` |
+
+### 安全性レベル
+
+| レベル | 意味 |
+|---|---|
+| `read` | 副作用なしで呼び出し可能（GET リクエスト） |
+| `write` | データを作成または変更（POST / PUT / PATCH） |
+| `admin` | 管理アクション — 慎重に使用 |
+| `destructive` | データを永久削除 — 明示的な確認が必要 |
+
+まず `read` ツールのみから始め、認証が整ったら `write` ツールを追加してください。
+
+---
+
+## 3. カタログを検証する
+
+```bash
+composer mcp
+```
+
+バリデーターは以下を検証します:
+
+- 各ツールの `operationId` が OpenAPI スペックに存在する
+- 各ツールのパスが OpenAPI パス定義と一致する
+- `safety` フィールドが 4 つの許可された値のいずれかである
+- `responseSchemaRef`（null でない場合）が実在するコンポーネントスキーマに解決する
+
+MCP サーバーを起動する前にエラーをすべて修正してください。
+
+---
+
+## 4. 書き込みツールを追加する
+
+```json
+{
+  "name": "createNote",
+  "title": "ノートを作成",
+  "description": "新しいノートを作成します。",
+  "safety": "write",
+  "source": {
+    "type": "openapi",
+    "operationId": "createNote",
+    "method": "POST",
+    "path": "/notes"
+  },
+  "inputSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["title", "content"],
+    "properties": {
+      "title":   { "type": "string", "description": "ノートのタイトル。" },
+      "content": { "type": "string", "description": "ノートの本文。" }
+    }
+  },
+  "responseSchemaRef": null
+}
+```
+
+---
+
+## 5. JWT で書き込みツールを保護する
+
+`LocalMcpServer` は `write`、`admin`、`destructive` ツール呼び出しごとに `Authorization: Bearer <token>` ヘッダーを確認します。環境変数を設定します:
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-secret
+```
+
+この変数がない場合、書き込みツール呼び出しは MCP エラーを返し、リクエストを転送しません。
+
+アプリケーション側でも対応するエンドポイントを `BearerTokenMiddleware` で保護します:
+
+```php
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+
+$secret = getenv('NENE2_LOCAL_JWT_SECRET') ?: null;
+
+$authMiddleware = $secret !== null
+    ? new BearerTokenMiddleware(
+        $problemDetails,
+        new LocalBearerTokenVerifier($secret),
+        excludedPaths: ['/notes'],
+        protectedPathPrefixes: ['/notes/'],
+    )
+    : null;
+```
+
+---
+
+## 6. MCP サーバーを起動する
+
+```bash
+NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_JWT_SECRET=your-local-secret \
+php vendor/hideyukimori/nene2/tools/local-mcp-server.php
+```
+
+サーバーは MCP stdio トランスポートを使って `stdin` から読み取り `stdout` に書き込みます。
+
+---
+
+## 7. Claude Code または Claude Desktop を設定する
+
+### Claude Code (`~/.claude/claude_code_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "/path/to/my-app/mcp-server.sh"
+    }
+  }
+}
+```
+
+### Claude Desktop (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "bash",
+      "args": ["/path/to/my-app/mcp-server.sh"]
+    }
+  }
+}
+```
+
+Claude を再起動すると、カタログで宣言したツールが呼び出し可能なアクションとして表示されます。
+
+---
+
+## 8. MCP 層をテストする
+
+`LocalMcpToolCatalog` を直接テストします。HTTP サーバーは不要です:
+
+```php
+use Nene2\Mcp\LocalMcpToolCatalog;
+
+public function testListNotesToolIsPresent(): void
+{
+    $catalog = new LocalMcpToolCatalog(dirname(__DIR__) . '/docs/mcp/tools.json');
+
+    $tool = $catalog->find('listNotes');
+
+    self::assertNotNull($tool);
+    self::assertSame('read', $tool['safety']);
+    self::assertSame('GET', $tool['source']['method']);
+    self::assertSame('/notes', $tool['source']['path']);
+}
+```
+
+---
+
+## 次のステップ
+
+- [JWT 認証を追加する](./add-jwt-authentication.md)
+- [レートリミットを追加する](./add-rate-limiting.md)
+- [ヘルスチェックを追加する](./add-health-check.md)

--- a/docs/pt-br/howto/add-html-view.md
+++ b/docs/pt-br/howto/add-html-view.md
@@ -1,0 +1,261 @@
+# Adicionar vistas HTML
+
+Este guia explica como adicionar respostas HTML renderizadas no servidor a uma aplicação NENE2
+usando `NativePhpViewRenderer` e `HtmlResponseFactory`.
+
+**Pré-requisito**: Você tem uma aplicação NENE2 funcionando com pelo menos uma rota. Caso contrário, comece por [Adicionar uma rota personalizada](./add-custom-route.md).
+
+---
+
+## Visão geral
+
+NENE2 fornece uma camada de renderização HTML mínima sem dependências externas:
+
+| Classe | Função |
+|---|---|
+| `NativePhpViewRenderer` | Renderiza templates `.php` em escopo isolado |
+| `HtmlEscaper` | Escapa valores para saída HTML segura (`htmlspecialchars` / UTF-8 / aspas completas) |
+| `HtmlResponseFactory` | Encapsula o HTML renderizado em uma resposta PSR-7 `text/html; charset=utf-8` |
+| `TemplateNotFoundException` | Lançada quando o arquivo de template não existe ou o caminho é inválido |
+
+As respostas HTML coexistem com endpoints JSON. Você pode adicioná-las à mesma aplicação sem remover rotas existentes.
+
+---
+
+## 1. Criar os templates
+
+NENE2 espera que os arquivos de template PHP nativo fiquem dentro de um único diretório raiz. O local padrão é `templates/` na raiz do projeto.
+
+```
+my-app/
+├── templates/
+│   ├── layout.php       (layout compartilhado opcional)
+│   ├── home.php
+│   └── notes/
+│       ├── index.php
+│       └── show.php
+```
+
+O que cada template recebe:
+
+- `$e` — helper de escape (`HtmlEscaper::escape()`). Use sempre para valores do usuário.
+- Cada chave do array `$data` passado para `render()` é injetada como variável individual.
+
+**`templates/home.php`**
+
+```php
+<!doctype html>
+<html lang="pt-BR">
+<head><meta charset="utf-8"><title><?= $e($title) ?></title></head>
+<body>
+  <h1><?= $e($title) ?></h1>
+  <p><?= $e($description) ?></p>
+</body>
+</html>
+```
+
+**`templates/notes/index.php`**
+
+```php
+<!doctype html>
+<html lang="pt-BR">
+<head><meta charset="utf-8"><title>Lista de notas</title></head>
+<body>
+  <h1>Notas</h1>
+  <ul>
+    <?php foreach ($notes as $note): ?>
+      <li><a href="/notes/<?= $e($note['id']) ?>"><?= $e($note['title']) ?></a></li>
+    <?php endforeach; ?>
+  </ul>
+</body>
+</html>
+```
+
+> **Segurança**: Use sempre `$e(...)` para valores provenientes do usuário, banco de dados ou sistemas externos. Omitir isso cria vulnerabilidades XSS.
+
+---
+
+## 2. Registrar o renderer no ServiceProvider
+
+Registre `NativePhpViewRenderer` e `HtmlResponseFactory` no `ServiceProviderInterface` da sua aplicação:
+
+```php
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class AppServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                NativePhpViewRenderer::class,
+                static function (ContainerInterface $container): NativePhpViewRenderer {
+                    return new NativePhpViewRenderer(dirname(__DIR__) . '/templates');
+                },
+            )
+            ->set(
+                HtmlResponseFactory::class,
+                static function (ContainerInterface $container): HtmlResponseFactory {
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    $streamFactory   = $container->get(StreamFactoryInterface::class);
+                    $renderer        = $container->get(NativePhpViewRenderer::class);
+
+                    return new HtmlResponseFactory($responseFactory, $streamFactory, $renderer);
+                },
+            );
+    }
+}
+```
+
+---
+
+## 3. Usar HtmlResponseFactory em um handler
+
+Injete `HtmlResponseFactory` no seu handler e chame `create()`:
+
+```php
+use Nene2\View\HtmlResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class HomeHandler
+{
+    public function __construct(private HtmlResponseFactory $html) {}
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->html->create('home.php', [
+            'title'       => 'Bem-vindo',
+            'description' => 'Aplicação construída com NENE2.',
+        ]);
+    }
+}
+```
+
+Assinatura de `create()`:
+
+```php
+public function create(
+    string $template,           // caminho relativo a partir de templateRoot
+    array  $data    = [],       // variáveis passadas ao template
+    int    $status  = 200,      // código de status HTTP
+    array  $headers = [],       // cabeçalhos de resposta adicionais
+): ResponseInterface
+```
+
+---
+
+## 4. Registrar as rotas
+
+```php
+$router->get('/', new HomeHandler($container->get(HtmlResponseFactory::class)));
+$router->get('/notes', new NoteListHandler($container->get(HtmlResponseFactory::class)));
+```
+
+---
+
+## 5. Tratar TemplateNotFoundException
+
+`NativePhpViewRenderer::render()` lança `TemplateNotFoundException` nos seguintes casos:
+
+- O arquivo de template não existe
+- O caminho do template está vazio
+- O caminho do template contém `..` (traversal de diretório bloqueado)
+
+Registre um handler de exceção de domínio para retornar uma resposta HTTP adequada:
+
+```php
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\View\TemplateNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class TemplateNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(private ProblemDetailsResponseFactory $problemDetails) {}
+
+    public function handles(\Throwable $exception): bool
+    {
+        return $exception instanceof TemplateNotFoundException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'not-found', 'Not Found', 404);
+    }
+}
+```
+
+---
+
+## 6. Misturar endpoints HTML e JSON
+
+```php
+$registerRoutes = static function (Router $router) use ($container): void {
+    // API JSON
+    $router->get('/api/notes',     $container->get(NoteListJsonHandler::class));
+    $router->post('/api/notes',    $container->get(NoteCreateHandler::class));
+
+    // Vistas HTML
+    $router->get('/',              $container->get(HomeHandler::class));
+    $router->get('/notes',         $container->get(NoteListHtmlHandler::class));
+    $router->get('/notes/{id}',    $container->get(NoteShowHtmlHandler::class));
+};
+```
+
+---
+
+## 7. Testar os handlers HTML
+
+```php
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
+
+public function testHomeReturnsHtml(): void
+{
+    $templateRoot = sys_get_temp_dir() . '/test-templates-' . bin2hex(random_bytes(4));
+    mkdir($templateRoot);
+    file_put_contents($templateRoot . '/home.php', '<h1><?= $e($title) ?></h1>');
+
+    $psr17   = new Psr17Factory();
+    $factory = new HtmlResponseFactory($psr17, $psr17, new NativePhpViewRenderer($templateRoot));
+    $handler = new HomeHandler($factory);
+
+    $response = $handler(new ServerRequest('GET', '/'));
+
+    self::assertSame(200, $response->getStatusCode());
+    self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+    self::assertStringContainsString('<h1>Bem-vindo</h1>', (string) $response->getBody());
+
+    unlink($templateRoot . '/home.php');
+    rmdir($templateRoot);
+}
+```
+
+---
+
+## Notas de design
+
+- Os templates são executados dentro de uma closure, portanto não têm acesso a `$this` nem aos internos da classe. As variáveis são injetadas via `extract()` + `EXTR_SKIP` (variáveis existentes não são sobrescritas).
+- `HtmlEscaper` usa `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5`. `"` e `'` são ambos escapados, e sequências UTF-8 inválidas são substituídas em vez de descartadas.
+- Traversal de diretório (`../`) é bloqueado na etapa de resolução de caminho. Nenhum acesso ao sistema de arquivos ocorre antes dessa verificação.
+
+Para as garantias de API estável de `Nene2\View\*`, consulte [ADR 0009](../adr/0009-v1.0-public-api-scope.md).
+
+---
+
+## Próximos passos
+
+- [Adicionar uma rota personalizada](./add-custom-route.md)
+- [Adicionar limitação de taxa](./add-rate-limiting.md)
+- [Adicionar autenticação JWT](./add-jwt-authentication.md)

--- a/docs/pt-br/howto/add-mcp-tools.md
+++ b/docs/pt-br/howto/add-mcp-tools.md
@@ -1,0 +1,251 @@
+# Adicionar ferramentas MCP
+
+Este guia explica como expor os endpoints de API de uma aplicação NENE2 como ferramentas MCP,
+permitindo que assistentes de IA (Claude, Cursor, etc.) chamem a API via o Model Context Protocol.
+
+**Pré-requisito**: Você tem uma aplicação NENE2 funcionando com pelo menos uma rota e um arquivo `docs/openapi/openapi.yaml`. Caso contrário, comece por [Adicionar uma rota personalizada](./add-custom-route.md).
+
+---
+
+## Visão geral
+
+NENE2 fornece um servidor MCP local (`LocalMcpServer`) que traduz mensagens JSON-RPC MCP em chamadas HTTP para a API. O catálogo de ferramentas (`docs/mcp/tools.json`) declara quais endpoints expor como ferramentas MCP e o nível de segurança de cada uma.
+
+```
+Assistente IA → JSON-RPC (stdio) → LocalMcpServer → HTTP → Aplicação NENE2
+```
+
+O catálogo é validado em relação à spec OpenAPI com `composer mcp`.
+
+---
+
+## 1. Adicionar o script de validação
+
+Adicione em `composer.json`:
+
+```json
+{
+  "require-dev": {
+    "symfony/yaml": "^7.0"
+  },
+  "scripts": {
+    "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=."
+  }
+}
+```
+
+Instale a dependência de desenvolvimento:
+
+```bash
+composer require --dev symfony/yaml
+```
+
+---
+
+## 2. Criar o catálogo de ferramentas
+
+Crie `docs/mcp/tools.json`. Cada entrada em `tools` corresponde a um endpoint da API.
+
+```json
+{
+  "version": 1,
+  "source": "docs/openapi/openapi.yaml",
+  "tools": [
+    {
+      "name": "listNotes",
+      "title": "Lista de notas",
+      "description": "Retorna todas as notas do banco de dados.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "listNotes",
+        "method": "GET",
+        "path": "/notes"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit":  { "type": "integer", "description": "Número máximo de itens a retornar." },
+          "offset": { "type": "integer", "description": "Número de itens a ignorar." }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/NoteListResponse"
+    }
+  ]
+}
+```
+
+### Campos de uma ferramenta
+
+| Campo | Obrigatório | Descrição |
+|---|---|---|
+| `name` | Sim | Identificador camelCase único |
+| `title` | Sim | Rótulo legível por humanos |
+| `description` | Sim | Texto que explica o propósito ao assistente de IA |
+| `safety` | Sim | `read` / `write` / `admin` / `destructive` |
+| `source.operationId` | Sim | Deve corresponder ao `operationId` na spec OpenAPI |
+| `source.method` | Sim | Método HTTP (maiúsculas/minúsculas indiferente, armazenado em maiúsculas) |
+| `source.path` | Sim | Caminho URL com parâmetros no formato `{param}` |
+| `inputSchema` | Sim | JSON Schema dos argumentos da ferramenta |
+| `responseSchemaRef` | Não | `$ref` para um schema de componente OpenAPI, ou `null` |
+
+### Níveis de segurança
+
+| Nível | Significado |
+|---|---|
+| `read` | Pode ser chamado sem efeitos colaterais (requisições GET) |
+| `write` | Cria ou modifica dados (POST / PUT / PATCH) |
+| `admin` | Ações administrativas — usar com cautela |
+| `destructive` | Exclui dados permanentemente — confirmação explícita necessária |
+
+Comece apenas com ferramentas `read`, adicione ferramentas `write` quando a autenticação estiver configurada.
+
+---
+
+## 3. Validar o catálogo
+
+```bash
+composer mcp
+```
+
+O validador verifica:
+
+- O `operationId` de cada ferramenta existe na spec OpenAPI
+- O caminho de cada ferramenta corresponde à definição de caminho OpenAPI
+- O campo `safety` é um dos quatro valores permitidos
+- `responseSchemaRef` (se não nulo) resolve para um schema de componente existente
+
+Corrija todos os erros antes de iniciar o servidor MCP.
+
+---
+
+## 4. Adicionar ferramentas de escrita
+
+```json
+{
+  "name": "createNote",
+  "title": "Criar nota",
+  "description": "Cria uma nova nota.",
+  "safety": "write",
+  "source": {
+    "type": "openapi",
+    "operationId": "createNote",
+    "method": "POST",
+    "path": "/notes"
+  },
+  "inputSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["title", "content"],
+    "properties": {
+      "title":   { "type": "string", "description": "Título da nota." },
+      "content": { "type": "string", "description": "Conteúdo da nota." }
+    }
+  },
+  "responseSchemaRef": null
+}
+```
+
+---
+
+## 5. Proteger ferramentas de escrita com JWT
+
+`LocalMcpServer` verifica um cabeçalho `Authorization: Bearer <token>` para cada chamada de ferramenta `write`, `admin` ou `destructive`. Configure a variável de ambiente:
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=your-local-secret
+```
+
+Sem essa variável, chamadas de ferramentas de escrita retornam um erro MCP sem encaminhar a requisição.
+
+Proteja também os endpoints correspondentes no lado da aplicação com `BearerTokenMiddleware`:
+
+```php
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+
+$secret = getenv('NENE2_LOCAL_JWT_SECRET') ?: null;
+
+$authMiddleware = $secret !== null
+    ? new BearerTokenMiddleware(
+        $problemDetails,
+        new LocalBearerTokenVerifier($secret),
+        excludedPaths: ['/notes'],
+        protectedPathPrefixes: ['/notes/'],
+    )
+    : null;
+```
+
+---
+
+## 6. Iniciar o servidor MCP
+
+```bash
+NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_JWT_SECRET=your-local-secret \
+php vendor/hideyukimori/nene2/tools/local-mcp-server.php
+```
+
+O servidor lê de `stdin` e escreve em `stdout` via o transporte stdio do MCP.
+
+---
+
+## 7. Configurar Claude Code ou Claude Desktop
+
+### Claude Code (`~/.claude/claude_code_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "/path/to/my-app/mcp-server.sh"
+    }
+  }
+}
+```
+
+### Claude Desktop (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "command": "bash",
+      "args": ["/path/to/my-app/mcp-server.sh"]
+    }
+  }
+}
+```
+
+Reinicie o Claude e as ferramentas declaradas no catálogo aparecerão como ações disponíveis.
+
+---
+
+## 8. Testar a camada MCP
+
+Teste `LocalMcpToolCatalog` diretamente. Nenhum servidor HTTP é necessário:
+
+```php
+use Nene2\Mcp\LocalMcpToolCatalog;
+
+public function testListNotesToolIsPresent(): void
+{
+    $catalog = new LocalMcpToolCatalog(dirname(__DIR__) . '/docs/mcp/tools.json');
+
+    $tool = $catalog->find('listNotes');
+
+    self::assertNotNull($tool);
+    self::assertSame('read', $tool['safety']);
+    self::assertSame('GET', $tool['source']['method']);
+    self::assertSame('/notes', $tool['source']['path']);
+}
+```
+
+---
+
+## Próximos passos
+
+- [Adicionar autenticação JWT](./add-jwt-authentication.md)
+- [Adicionar limitação de taxa](./add-rate-limiting.md)
+- [Adicionar health check](./add-health-check.md)

--- a/docs/zh/howto/add-html-view.md
+++ b/docs/zh/howto/add-html-view.md
@@ -1,0 +1,119 @@
+# 添加 HTML 视图
+
+本指南展示如何使用 `NativePhpViewRenderer` 和 `HtmlResponseFactory` 为 NENE2 应用程序添加服务器渲染的 HTML 响应。
+
+**前提条件**：拥有至少包含一个路由的 NENE2 应用程序。如果还没有，请从 [添加自定义路由](./add-custom-route.md) 开始。
+
+---
+
+## 概览
+
+NENE2 提供零依赖的极简 HTML 渲染层：
+
+| 类 | 作用 |
+|---|---|
+| `NativePhpViewRenderer` | 在隔离作用域中渲染 `.php` 模板 |
+| `HtmlEscaper` | 安全 HTML 输出的值转义（`htmlspecialchars` / UTF-8 / 完整引号） |
+| `HtmlResponseFactory` | 将渲染的 HTML 包装为 `text/html; charset=utf-8` PSR-7 响应 |
+| `TemplateNotFoundException` | 模板文件缺失或路径无效时抛出 |
+
+HTML 响应与 JSON 端点共存，无需删除任何现有路由。
+
+---
+
+## 1. 创建模板
+
+将原生 PHP 模板文件放在单一根目录下，约定位置为项目根目录的 `templates/`。
+
+```
+my-app/
+├── templates/
+│   ├── layout.php
+│   ├── home.php
+│   └── notes/
+│       ├── index.php
+│       └── show.php
+```
+
+每个模板接收：
+
+- `$e` — 转义助手（`HtmlEscaper::escape()`）。对用户输入数据务必使用。
+- 传递给 `render()` 的 `$data` 数组中的所有键作为独立变量。
+
+> **安全**：对所有来自用户输入、数据库或外部系统的值都调用 `$e(...)`。省略将导致 XSS 漏洞。
+
+---
+
+## 2. 在 ServiceProvider 中注册渲染器
+
+在应用的 `ServiceProviderInterface` 中注册 `NativePhpViewRenderer` 和 `HtmlResponseFactory`：
+
+```php
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+
+// 在 ContainerBuilder 中注册
+$builder->set(NativePhpViewRenderer::class, static fn () =>
+    new NativePhpViewRenderer(dirname(__DIR__) . '/templates')
+);
+$builder->set(HtmlResponseFactory::class, static fn ($c) =>
+    new HtmlResponseFactory($c->get(ResponseFactoryInterface::class), $c->get(StreamFactoryInterface::class), $c->get(NativePhpViewRenderer::class))
+);
+```
+
+---
+
+## 3. 在处理器中使用 HtmlResponseFactory
+
+```php
+final readonly class HomeHandler
+{
+    public function __construct(private HtmlResponseFactory $html) {}
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->html->create('home.php', [
+            'title'       => '欢迎',
+            'description' => 'NENE2 驱动的应用程序。',
+        ]);
+    }
+}
+```
+
+---
+
+## 4. 注册路由
+
+```php
+$router->get('/', new HomeHandler($container->get(HtmlResponseFactory::class)));
+```
+
+---
+
+## 5. 处理 TemplateNotFoundException
+
+当模板文件不存在、路径为空或路径包含 `..` 时，`NativePhpViewRenderer::render()` 会抛出 `TemplateNotFoundException`。注册域异常处理器以返回有意义的 HTTP 响应。
+
+---
+
+## 6. 混合 HTML 和 JSON 端点
+
+JSON 和 HTML 端点在同一个 `Router` 上共存，无需特殊配置。
+
+---
+
+## 设计说明
+
+- 模板在闭包作用域中运行，无法访问 `$this`。变量通过 `extract()` + `EXTR_SKIP` 注入。
+- `HtmlEscaper` 使用 `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5`。
+- 目录遍历（`../`）在路径解析步骤中被阻止。
+
+参见 [ADR 0009](../adr/0009-v1.0-public-api-scope.md) 了解 `Nene2\View\*` 的稳定性保证。
+
+---
+
+## 后续步骤
+
+- [添加自定义路由](./add-custom-route.md)
+- [添加限速](./add-rate-limiting.md)
+- [添加 JWT 认证](./add-jwt-authentication.md)

--- a/docs/zh/howto/add-mcp-tools.md
+++ b/docs/zh/howto/add-mcp-tools.md
@@ -1,0 +1,96 @@
+# 添加 MCP 工具
+
+本指南展示如何将 NENE2 应用程序的 API 端点公开为 MCP 工具，使 AI 助手（Claude、Cursor 等）能够通过模型上下文协议调用您的 API。
+
+**前提条件**：拥有至少包含一个路由和 `docs/openapi/openapi.yaml` 文件的 NENE2 应用程序。
+
+---
+
+## 概览
+
+NENE2 提供本地 MCP 服务器（`LocalMcpServer`），将 JSON-RPC MCP 消息转换为对 API 的 HTTP 调用。工具目录（`docs/mcp/tools.json`）声明哪些端点作为 MCP 工具公开及其安全级别。
+
+```
+AI 助手 → JSON-RPC (stdio) → LocalMcpServer → HTTP → NENE2 应用
+```
+
+---
+
+## 1. 添加验证器脚本
+
+在 `composer.json` 中添加：
+
+```json
+{
+  "require-dev": { "symfony/yaml": "^7.0" },
+  "scripts": {
+    "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=."
+  }
+}
+```
+
+安装依赖：`composer require --dev symfony/yaml`
+
+---
+
+## 2. 创建工具目录
+
+创建 `docs/mcp/tools.json`，每个条目对应一个 API 端点。
+
+### 安全级别
+
+| 级别 | 含义 |
+|---|---|
+| `read` | 无副作用，可安全调用（GET 请求） |
+| `write` | 创建或修改数据（POST / PUT / PATCH） |
+| `admin` | 管理操作，谨慎使用 |
+| `destructive` | 永久删除数据，需明确确认 |
+
+---
+
+## 3. 验证目录
+
+```bash
+composer mcp
+```
+
+---
+
+## 4. 添加写入工具
+
+写入工具调用 `POST`、`PUT`、`PATCH` 或 `DELETE` 端点。以相同方式添加到目录，仅 `safety` 级别和 `inputSchema` 不同。
+
+---
+
+## 5. 用 JWT 保护写入工具
+
+在环境中设置 `NENE2_LOCAL_JWT_SECRET`。未设置时，写入工具调用返回 MCP 错误。
+
+---
+
+## 6. 启动 MCP 服务器
+
+```bash
+NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_JWT_SECRET=your-local-secret \
+php vendor/hideyukimori/nene2/tools/local-mcp-server.php
+```
+
+---
+
+## 7. 测试 MCP 层
+
+直接测试 `LocalMcpToolCatalog`，无需 HTTP 服务器：
+
+```php
+$catalog = new LocalMcpToolCatalog(dirname(__DIR__) . '/docs/mcp/tools.json');
+$tool = $catalog->find('listNotes');
+self::assertSame('read', $tool['safety']);
+```
+
+---
+
+## 后续步骤
+
+- [添加 JWT 认证](./add-jwt-authentication.md)
+- [添加限速](./add-rate-limiting.md)


### PR DESCRIPTION
## Summary

- **5言語翻訳追加**: `add-html-view.md` / `add-mcp-tools.md` を ja・zh・de・fr・pt-br の全6言語で揃える（ja・zh・de は前ブランチで作成、fr・pt-br を今回追加）
- **フィールドトライアルレポート追加**: FT11〜14（tasklog / tagmark / knowledgelog / shoplog / eventlog / postboard）の実地検証レポート（`docs/field-trials/2026-05-field-trial-{11,12a,12b,12c,13,14}.md`）を追加
- **JWT 本番警告追加**: `docs/howto/deploy-production.md` に `LocalBearerTokenVerifier` がローカル専用である旨の Warning セクションと本番セキュリティチェックリスト項目を追加

## Test plan

- [ ] `docs/fr/howto/` と `docs/pt-br/howto/` に `add-html-view.md` / `add-mcp-tools.md` が揃っていること
- [ ] `docs/field-trials/` に FT11〜14 の 6 ファイルが存在すること
- [ ] `docs/howto/deploy-production.md` のセクション番号が正しく振られていること

Closes #505
Closes #506
Closes #507

Self-review: docs-policy