### PR TITLE
fix(routing,mcp): Router HEAD 対応（RFC 7231）・MCP PATCH サポート追加

### DIFF
--- a/src/Mcp/LocalMcpHttpClientInterface.php
+++ b/src/Mcp/LocalMcpHttpClientInterface.php
@@ -20,6 +20,9 @@ interface LocalMcpHttpClientInterface
     /** @param array<string, mixed> $body */
     public function put(string $baseUrl, string $path, array $body): LocalMcpHttpResponse;
 
+    /** @param array<string, mixed> $body */
+    public function patch(string $baseUrl, string $path, array $body): LocalMcpHttpResponse;
+
     public function delete(string $baseUrl, string $path): LocalMcpHttpResponse;
 
     public function hasAuthentication(): bool;

--- a/src/Mcp/LocalMcpServer.php
+++ b/src/Mcp/LocalMcpServer.php
@@ -164,6 +164,7 @@ final readonly class LocalMcpServer
             'GET'    => $this->httpClient->get($this->apiBaseUrl, $this->appendQuery($path, $remainingArgs)),
             'POST'   => $this->httpClient->post($this->apiBaseUrl, $path, $remainingArgs),
             'PUT'    => $this->httpClient->put($this->apiBaseUrl, $path, $remainingArgs),
+            'PATCH'  => $this->httpClient->patch($this->apiBaseUrl, $path, $remainingArgs),
             'DELETE' => $this->httpClient->delete($this->apiBaseUrl, $path),
             default  => throw new LocalMcpException(sprintf('HTTP method "%s" is not supported.', $method)),
         };

--- a/src/Mcp/NativeLocalMcpHttpClient.php
+++ b/src/Mcp/NativeLocalMcpHttpClient.php
@@ -28,6 +28,12 @@ final readonly class NativeLocalMcpHttpClient implements LocalMcpHttpClientInter
         return $this->request('PUT', $baseUrl, $path, $body);
     }
 
+    /** @param array<string, mixed> $body */
+    public function patch(string $baseUrl, string $path, array $body): LocalMcpHttpResponse
+    {
+        return $this->request('PATCH', $baseUrl, $path, $body);
+    }
+
     public function delete(string $baseUrl, string $path): LocalMcpHttpResponse
     {
         return $this->request('DELETE', $baseUrl, $path, null);

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -71,6 +71,10 @@ final class Router implements RequestHandlerInterface
     {
         $method = strtoupper($request->getMethod());
         $path = $request->getUri()->getPath() ?: '/';
+
+        // RFC 7231 §4.3.2: HEAD is identical to GET but without a response body.
+        // Match against GET routes when the incoming method is HEAD.
+        $lookupMethod = $method === 'HEAD' ? 'GET' : $method;
         $allowedMethods = [];
 
         foreach ($this->routes as $route) {
@@ -80,7 +84,7 @@ final class Router implements RequestHandlerInterface
                 continue;
             }
 
-            if ($route['method'] === $method) {
+            if ($route['method'] === $lookupMethod) {
                 return $route['handler'](
                     $request->withAttribute(self::PARAMETERS_ATTRIBUTE, $parameters)
                 );

--- a/tests/Mcp/LocalMcpServerTest.php
+++ b/tests/Mcp/LocalMcpServerTest.php
@@ -322,6 +322,17 @@ final class RecordingLocalMcpHttpClient implements LocalMcpHttpClientInterface
         return $this->response;
     }
 
+    /** @param array<string, mixed> $body */
+    public function patch(string $baseUrl, string $path, array $body): LocalMcpHttpResponse
+    {
+        $this->lastMethod = 'patch';
+        $this->baseUrl = $baseUrl;
+        $this->path = $path;
+        $this->body = $body;
+
+        return $this->response;
+    }
+
     public function delete(string $baseUrl, string $path): LocalMcpHttpResponse
     {
         $this->lastMethod = 'delete';

--- a/tests/Mcp/NativeLocalMcpHttpClientTest.php
+++ b/tests/Mcp/NativeLocalMcpHttpClientTest.php
@@ -64,6 +64,15 @@ final class NativeLocalMcpHttpClientTest extends TestCase
         $client->put('http://127.0.0.1:19999', '/notes/1', ['title' => 'updated']);
     }
 
+    public function testPatchThrowsLocalMcpExceptionOnUnreachableUrl(): void
+    {
+        $client = new NativeLocalMcpHttpClient();
+
+        $this->expectException(LocalMcpException::class);
+
+        $client->patch('http://127.0.0.1:19999', '/notes/1', ['title' => 'patched']);
+    }
+
     public function testDeleteThrowsLocalMcpExceptionOnUnreachableUrl(): void
     {
         $client = new NativeLocalMcpHttpClient();

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -91,6 +91,45 @@ final class RouterTest extends TestCase
         );
     }
 
+    public function testHeadRequestMatchesGetRoute(): void
+    {
+        $factory = new Psr17Factory();
+        $router = (new Router())->get(
+            '/health',
+            static fn (ServerRequestInterface $request): ResponseInterface => $factory->createResponse(200),
+        );
+
+        $response = $router->handle($factory->createServerRequest('HEAD', 'https://example.test/health'));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testHeadRequestReturns404WhenPathDoesNotExist(): void
+    {
+        $factory = new Psr17Factory();
+        $router = (new Router())->get(
+            '/health',
+            static fn (ServerRequestInterface $request): ResponseInterface => $factory->createResponse(200),
+        );
+
+        $this->expectException(RouteNotFoundException::class);
+
+        $router->handle($factory->createServerRequest('HEAD', 'https://example.test/unknown'));
+    }
+
+    public function testHeadRequestReturns405WhenOnlyNonGetRouteExists(): void
+    {
+        $factory = new Psr17Factory();
+        $router = (new Router())->post(
+            '/notes',
+            static fn (ServerRequestInterface $request): ResponseInterface => $factory->createResponse(201),
+        );
+
+        $this->expectException(MethodNotAllowedException::class);
+
+        $router->handle($factory->createServerRequest('HEAD', 'https://example.test/notes'));
+    }
+
     public function testPatchRouteMatchesOnlyPatchRequests(): void
     {
         $factory = new Psr17Factory();


### PR DESCRIPTION
## Summary

- **#512 Router HEAD**: `HEAD` リクエストを対応する `GET` ルートにマッチさせる（RFC 7231 §4.3.2 準拠）。`HEAD /health` → 200（以前は 405）
- **#513 MCP PATCH**: `LocalMcpHttpClientInterface` / `NativeLocalMcpHttpClient` / `LocalMcpServer` に PATCH サポートを追加

## Test plan

- [x] `testHeadRequestMatchesGetRoute` — HEAD + GET ルート → 200
- [x] `testHeadRequestReturns404WhenPathDoesNotExist` — 存在しないパス → 404
- [x] `testHeadRequestReturns405WhenOnlyNonGetRouteExists` — POST のみのパスへの HEAD → 405
- [x] `testPatchThrowsLocalMcpExceptionOnUnreachableUrl` — PATCH MCP テスト
- [x] `composer check` 275 tests / 743 assertions — OK

Closes #512
Closes #513

Self-review: backend-api