### PR TITLE
fix(security,error): エラーロギング・CSP・CORS allowedOrigins 対応 (#514 #515 #516)

### DIFF
--- a/src/Error/ErrorHandlerMiddleware.php
+++ b/src/Error/ErrorHandlerMiddleware.php
@@ -12,6 +12,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Throwable;
 
 final readonly class ErrorHandlerMiddleware implements MiddlewareInterface
@@ -20,11 +22,14 @@ final readonly class ErrorHandlerMiddleware implements MiddlewareInterface
      * @param list<DomainExceptionHandlerInterface> $domainHandlers
      * @param bool $debug When true, the exception message is included in the 500 response `detail`
      *                    field. Never set to true in production.
+     * @param LoggerInterface $logger Unhandled exceptions are logged at ERROR level regardless of $debug.
+     *                                Pass a NullLogger (default) to suppress.
      */
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
         private array $domainHandlers = [],
         private bool $debug = false,
+        private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
@@ -75,6 +80,11 @@ final readonly class ErrorHandlerMiddleware implements MiddlewareInterface
                     return $domainHandler->handle($exception, $request);
                 }
             }
+
+            $this->logger->error($exception->getMessage(), [
+                'exception' => $exception,
+                'request_id' => $request->getHeaderLine('X-Request-Id'),
+            ]);
 
             return $this->problemDetails->create(
                 $request,

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -47,6 +47,9 @@ final readonly class RuntimeApplicationFactory
      *                                              {@see \Nene2\Auth\BearerTokenMiddleware} or a custom
      *                                              implementation that uses prefix matching.
      * @param list<HealthCheckInterface> $healthChecks
+     * @param list<string> $allowedOrigins CORS-allowed origins (e.g. `['https://app.example.com']`).
+     *                                     An empty list (the default) silently disables all CORS headers.
+     *                                     Always set this explicitly in production.
      * @param bool $debug When true, unhandled exception messages are exposed in 500 `detail`.
      *                    Never set to true in production.
      */
@@ -62,6 +65,7 @@ final readonly class RuntimeApplicationFactory
         private array $healthChecks = [],
         private ?ThrottleMiddleware $throttleMiddleware = null,
         private bool $debug = false,
+        private array $allowedOrigins = [],
     ) {
     }
 
@@ -159,8 +163,8 @@ final readonly class RuntimeApplicationFactory
             new RequestIdMiddleware('X-Request-Id', $this->requestIdHolder),
             new RequestLoggingMiddleware($logger),
             new SecurityHeadersMiddleware(),
-            new CorsMiddleware($this->responseFactory),
-            new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers, $this->debug),
+            new CorsMiddleware($this->responseFactory, $this->allowedOrigins),
+            new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers, $this->debug, $logger),
             new RequestSizeLimitMiddleware($problemDetails),
             new ApiKeyAuthenticationMiddleware($problemDetails, $this->machineApiKey, ['/machine/health']),
         ];

--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -10,7 +10,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * Adds security-related HTTP response headers (e.g. `X-Content-Type-Options`, `X-Frame-Options`).
+ * Adds security-related HTTP response headers (e.g. `Content-Security-Policy`, `X-Frame-Options`).
  * Headers are injected before the pipeline processes the request so they appear on error responses too.
  *
  * Part of the public API stability guarantee (see ADR 0009).
@@ -18,10 +18,13 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class SecurityHeadersMiddleware implements MiddlewareInterface
 {
     /**
-     * @param array<string, string> $headers
+     * @param array<string, string> $headers Override or extend the default security headers.
+     *                                        CSP is set to `default-src 'self'` by default; tighten
+     *                                        this for apps that load scripts/styles from external origins.
      */
     public function __construct(
         private array $headers = [
+            'Content-Security-Policy' => "default-src 'self'",
             'X-Content-Type-Options' => 'nosniff',
             'Referrer-Policy' => 'no-referrer-when-downgrade',
             'X-Frame-Options' => 'SAMEORIGIN',

--- a/tests/Error/ErrorHandlerMiddlewareTest.php
+++ b/tests/Error/ErrorHandlerMiddlewareTest.php
@@ -16,7 +16,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\AbstractLogger;
 use RuntimeException;
+use Stringable;
 use Throwable;
 
 final class ErrorHandlerMiddlewareTest extends TestCase
@@ -226,5 +228,107 @@ final class ErrorHandlerMiddlewareTest extends TestCase
         );
 
         self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testUnhandledExceptionIsLoggedAtErrorLevelRegardlessOfDebug(): void
+    {
+        $spyLogger = new class () extends AbstractLogger {
+            /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            public function log(mixed $level, string|Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+
+        $middleware = new ErrorHandlerMiddleware($this->problemDetails, [], debug: false, logger: $spyLogger);
+        $request = $this->factory->createServerRequest('GET', 'https://example.test/crash')
+            ->withHeader('X-Request-Id', 'req-test-123');
+
+        $middleware->process(
+            $request,
+            new class () implements RequestHandlerInterface {
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    throw new RuntimeException('db connection refused');
+                }
+            },
+        );
+
+        self::assertCount(1, $spyLogger->records);
+        self::assertSame('error', $spyLogger->records[0]['level']);
+        self::assertSame('db connection refused', $spyLogger->records[0]['message']);
+        self::assertSame('req-test-123', $spyLogger->records[0]['context']['request_id']);
+        self::assertInstanceOf(RuntimeException::class, $spyLogger->records[0]['context']['exception']);
+    }
+
+    public function testUnhandledExceptionIsLoggedEvenInDebugMode(): void
+    {
+        $spyLogger = new class () extends AbstractLogger {
+            /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            public function log(mixed $level, string|Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+
+        $middleware = new ErrorHandlerMiddleware($this->problemDetails, [], debug: true, logger: $spyLogger);
+        $request = $this->factory->createServerRequest('GET', 'https://example.test/crash');
+
+        $middleware->process(
+            $request,
+            new class () implements RequestHandlerInterface {
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    throw new RuntimeException('secret internal error');
+                }
+            },
+        );
+
+        self::assertCount(1, $spyLogger->records);
+        self::assertSame('error', $spyLogger->records[0]['level']);
+    }
+
+    public function testDomainHandledExceptionIsNotLogged(): void
+    {
+        $spyLogger = new class () extends AbstractLogger {
+            /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            public function log(mixed $level, string|Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+
+        $domainHandler = new class () implements DomainExceptionHandlerInterface {
+            public function supports(Throwable $exception): bool
+            {
+                return $exception instanceof RuntimeException;
+            }
+
+            public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+            {
+                return (new Psr17Factory())->createResponse(409);
+            }
+        };
+
+        $middleware = new ErrorHandlerMiddleware($this->problemDetails, [$domainHandler], logger: $spyLogger);
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/resource');
+
+        $middleware->process(
+            $request,
+            new class () implements RequestHandlerInterface {
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    throw new RuntimeException('conflict');
+                }
+            },
+        );
+
+        self::assertCount(0, $spyLogger->records, 'Domain-handled exceptions must not be logged by ErrorHandlerMiddleware.');
     }
 }

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -28,6 +28,7 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
         self::assertMatchesRegularExpression('/\A[a-f0-9]{32}\z/', $response->getHeaderLine('X-Request-Id'));
         self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
+        self::assertSame("default-src 'self'", $response->getHeaderLine('Content-Security-Policy'));
         self::assertSame('NENE2', $payload['name']);
         self::assertSame('ok', $payload['status']);
     }


### PR DESCRIPTION
## Summary

- **#514**: `ErrorHandlerMiddleware` に PSR-3 ロガーを注入。`debug` フラグに依存せず、未処理例外を常時 ERROR レベルでログ。`RuntimeApplicationFactory` が `$logger` を渡すよう修正
- **#515**: `SecurityHeadersMiddleware` デフォルトヘッダーに `Content-Security-Policy: default-src 'self'` を追加
- **#516**: `RuntimeApplicationFactory` に `$allowedOrigins` パラメータを追加し `CorsMiddleware` へ委譲。PHPDoc に「空配列は CORS を無効にする」旨を明記

## Test plan

- [x] `ErrorHandlerMiddlewareTest` に spy ロガーテスト 3 件追加（ERROR ログ確認・debug 両モード・ドメインハンドラ除外）
- [x] `HttpRuntimeTest` に CSP ヘッダーアサーションを追加
- [x] `composer check` — 278 tests / 752 assertions, PHPStan level 8 クリア

Self-review: backend-api, middleware-security

Closes #514
Closes #515
Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)