### PR TITLE
fix(openapi,middleware,http): OpenAPI version 更新・excludedPaths 追加・JSON 二重デコード解消 (#517 #518 #519)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 0.1.0
+  version: 1.5.0
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/Http/JsonRequestBodyParser.php
+++ b/src/Http/JsonRequestBodyParser.php
@@ -51,8 +51,24 @@ final class JsonRequestBodyParser
             );
         }
 
-        // Re-decode as associative to return array<string, mixed> for handler use.
         /** @var array<string, mixed> */
-        return (array) json_decode($raw, associative: true, flags: JSON_THROW_ON_ERROR);
+        return self::toArray($decoded);
+    }
+
+    /**
+     * Recursively converts a stdClass tree (from json_decode associative:false)
+     * to a nested array<string, mixed> without a second json_decode call.
+     */
+    private static function toArray(mixed $value): mixed
+    {
+        if ($value instanceof \stdClass) {
+            return array_map(self::toArray(...), (array) $value);
+        }
+
+        if (is_array($value)) {
+            return array_map(self::toArray(...), $value);
+        }
+
+        return $value;
     }
 }

--- a/src/Middleware/ApiKeyAuthenticationMiddleware.php
+++ b/src/Middleware/ApiKeyAuthenticationMiddleware.php
@@ -16,6 +16,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  *
  * Path matching modes (evaluated in priority order — first match wins):
  *
+ * 0. **Exclude list** (`$excludedPaths`): paths that are always public regardless of other settings.
+ *    Useful with "protect all" mode: pass `excludedPaths: ['/health', '/']` to keep those open.
  * 1. **Allowlist** (`$protectedPaths`): only the listed exact paths are protected.
  * 2. **Prefix allowlist** (`$protectedPathPrefixes`): paths starting with any listed prefix are protected.
  *    Useful for dynamic routes such as `/admin/users/42` → prefix `/admin/`.
@@ -38,6 +40,9 @@ final readonly class ApiKeyAuthenticationMiddleware implements MiddlewareInterfa
      * @param list<string> $protectedMethods       HTTP methods to protect (uppercase). When non-empty, only requests
      *                                             whose method appears here are protected. Useful to allow GET while
      *                                             requiring an API key for POST/PUT/DELETE. OPTIONS is always excluded.
+     * @param list<string> $excludedPaths          Exact paths that are always public, checked before any protect mode.
+     *                                             Combine with the "protect all" default to make specific paths public:
+     *                                             `excludedPaths: ['/', '/health', '/examples/ping']`.
      */
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
@@ -46,6 +51,7 @@ final readonly class ApiKeyAuthenticationMiddleware implements MiddlewareInterfa
         private string $headerName = 'X-NENE2-API-Key',
         private array $protectedPathPrefixes = [],
         private array $protectedMethods = [],
+        private array $excludedPaths = [],
     ) {
     }
 
@@ -81,6 +87,10 @@ final readonly class ApiKeyAuthenticationMiddleware implements MiddlewareInterfa
         }
 
         $path = $request->getUri()->getPath() ?: '/';
+
+        if ($this->excludedPaths !== [] && in_array($path, $this->excludedPaths, true)) {
+            return false;
+        }
 
         if ($this->protectedPaths !== []) {
             return in_array($path, $this->protectedPaths, true);

--- a/tests/Http/JsonRequestBodyParserTest.php
+++ b/tests/Http/JsonRequestBodyParserTest.php
@@ -87,4 +87,15 @@ final class JsonRequestBodyParserTest extends TestCase
 
         JsonRequestBodyParser::parse($request);
     }
+
+    public function testParsesNestedObjectAsDeepArray(): void
+    {
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('POST', 'https://example.test/')
+            ->withBody($factory->createStream('{"user":{"name":"Alice","roles":["admin","editor"]}}'));
+
+        $result = JsonRequestBodyParser::parse($request);
+
+        self::assertSame(['user' => ['name' => 'Alice', 'roles' => ['admin', 'editor']]], $result);
+    }
 }

--- a/tests/Middleware/ApiKeyAuthenticationMiddlewareTest.php
+++ b/tests/Middleware/ApiKeyAuthenticationMiddlewareTest.php
@@ -171,16 +171,49 @@ final class ApiKeyAuthenticationMiddlewareTest extends TestCase
         self::assertSame('api_key', $capture->request->getAttribute('nene2.auth.credential_type'));
     }
 
+    // --- excludedPaths ---
+
+    public function testExcludedPathPassesThroughWithoutKeyInProtectAllMode(): void
+    {
+        $factory = new Psr17Factory();
+        // No protectedPaths / protectedPathPrefixes → protect-all mode; /health is excluded
+        $mw = $this->make($factory, excludedPaths: ['/health', '/']);
+        $request = $factory->createServerRequest('GET', 'https://example.test/health');
+
+        self::assertSame(200, $mw->process($request, $this->okHandler($factory))->getStatusCode());
+    }
+
+    public function testNonExcludedPathIsStillProtectedInProtectAllMode(): void
+    {
+        $factory = new Psr17Factory();
+        $mw = $this->make($factory, excludedPaths: ['/health']);
+        $request = $factory->createServerRequest('GET', 'https://example.test/admin');
+
+        self::assertSame(401, $mw->process($request, $this->okHandler($factory))->getStatusCode());
+    }
+
+    public function testExcludedPathTakesPrecedenceOverProtectedPaths(): void
+    {
+        $factory = new Psr17Factory();
+        $mw = $this->make($factory, protectedPaths: ['/health'], excludedPaths: ['/health']);
+        $request = $factory->createServerRequest('GET', 'https://example.test/health');
+
+        // excluded wins over protected
+        self::assertSame(200, $mw->process($request, $this->okHandler($factory))->getStatusCode());
+    }
+
     /**
      * @param list<string> $protectedPaths
      * @param list<string> $protectedPathPrefixes
      * @param list<string> $protectedMethods
+     * @param list<string> $excludedPaths
      */
     private function make(
         Psr17Factory $factory,
         array $protectedPaths = [],
         array $protectedPathPrefixes = [],
         array $protectedMethods = [],
+        array $excludedPaths = [],
     ): ApiKeyAuthenticationMiddleware {
         return new ApiKeyAuthenticationMiddleware(
             new ProblemDetailsResponseFactory($factory, $factory),
@@ -189,6 +222,7 @@ final class ApiKeyAuthenticationMiddlewareTest extends TestCase
             'X-NENE2-API-Key',
             $protectedPathPrefixes,
             $protectedMethods,
+            $excludedPaths,
         );
     }
 


### PR DESCRIPTION
## Summary

- **#517**: `docs/openapi/openapi.yaml` の `info.version` を `0.1.0` → `1.5.0` に修正（`FrameworkInfo::VERSION` と一致）
- **#518**: `ApiKeyAuthenticationMiddleware` に `$excludedPaths` パラメータを追加。protect-all モードで `/health` 等を公開化できるように
- **#519**: `JsonRequestBodyParser::parse()` の二重 `json_decode` を解消。`stdClass` ツリーを再帰キャストで `array<string, mixed>` に変換（ネストオブジェクトも正しく配列化）

## Test plan

- [x] `ApiKeyAuthenticationMiddlewareTest` に `excludedPaths` テスト 3 件追加
- [x] `JsonRequestBodyParserTest` にネストオブジェクトの深い配列変換テストを追加
- [x] `composer check` — 282 tests / 756 assertions, PHPStan level 8 クリア

Self-review: backend-api, middleware-security, openapi-contract

Closes #517
Closes #518
Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)