### PR TITLE
fix(cors,throttle,ci): CORS Max-Age・ThrottleMiddleware 警告・バージョン整合チェック (#520 #521 #522)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "openapi": "php tools/validate-openapi.php",
     "openapi:docs": "php tools/openapi-to-md.php",
     "mcp": "php tools/validate-mcp-tools.php",
+    "version:check": "php tools/validate-version.php",
     "migrations:status": "phinx status -c phinx.php",
     "migrations:migrate": "phinx migrate -c phinx.php",
     "migrations:rollback": "phinx rollback -c phinx.php",
@@ -43,7 +44,8 @@
       "@analyse",
       "@cs",
       "@openapi",
-      "@mcp"
+      "@mcp",
+      "@version:check"
     ]
   },
   "suggest": {

--- a/src/Middleware/CorsMiddleware.php
+++ b/src/Middleware/CorsMiddleware.php
@@ -22,6 +22,8 @@ final readonly class CorsMiddleware implements MiddlewareInterface
      * @param list<string> $allowedOrigins
      * @param list<string> $allowedMethods
      * @param list<string> $allowedHeaders
+     * @param positive-int $maxAge Seconds the browser may cache the preflight response
+     *                             (`Access-Control-Max-Age`). Defaults to 3600 (1 hour).
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
@@ -29,16 +31,17 @@ final readonly class CorsMiddleware implements MiddlewareInterface
         private array $allowedMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
         private array $allowedHeaders = ['Content-Type', 'Authorization', 'X-Request-Id'],
         private bool $allowCredentials = false,
+        private int $maxAge = 3600,
     ) {
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($this->isPreflightRequest($request)) {
-            return $this->addCorsHeaders($request, $this->responseFactory->createResponse(204));
+            return $this->addCorsHeaders($request, $this->responseFactory->createResponse(204), preflight: true);
         }
 
-        return $this->addCorsHeaders($request, $handler->handle($request));
+        return $this->addCorsHeaders($request, $handler->handle($request), preflight: false);
     }
 
     private function isPreflightRequest(ServerRequestInterface $request): bool
@@ -48,8 +51,11 @@ final readonly class CorsMiddleware implements MiddlewareInterface
             && $request->hasHeader('Access-Control-Request-Method');
     }
 
-    private function addCorsHeaders(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
-    {
+    private function addCorsHeaders(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        bool $preflight,
+    ): ResponseInterface {
         $origin = $request->getHeaderLine('Origin');
         $response = $response->withHeader('Vary', 'Origin');
 
@@ -61,6 +67,10 @@ final readonly class CorsMiddleware implements MiddlewareInterface
             ->withHeader('Access-Control-Allow-Origin', $origin)
             ->withHeader('Access-Control-Allow-Methods', implode(', ', $this->allowedMethods))
             ->withHeader('Access-Control-Allow-Headers', implode(', ', $this->allowedHeaders));
+
+        if ($preflight) {
+            $response = $response->withHeader('Access-Control-Max-Age', (string) $this->maxAge);
+        }
 
         if ($this->allowCredentials) {
             $response = $response->withHeader('Access-Control-Allow-Credentials', 'true');

--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -19,6 +19,23 @@ use Psr\Http\Server\RequestHandlerInterface;
  * The default key extractor uses REMOTE_ADDR. Pass a custom callable to key by
  * authenticated user, API key, or any other request attribute.
  *
+ * **Reverse proxy / load balancer warning**: behind a reverse proxy, `REMOTE_ADDR`
+ * is the proxy IP, not the real client IP, which means all clients share a single
+ * rate limit bucket. To fix this, inject a `$keyExtractor` that reads a trusted
+ * forwarded-IP header:
+ *
+ * ```php
+ * new ThrottleMiddleware(
+ *     $problemDetails,
+ *     $storage,
+ *     keyExtractor: static fn (ServerRequestInterface $r): string
+ *         => $r->getHeaderLine('X-Forwarded-For') ?: $r->getServerParams()['REMOTE_ADDR'] ?? 'unknown',
+ * )
+ * ```
+ *
+ * Only trust `X-Forwarded-For` when the proxy is under your control and sets it reliably.
+ * An attacker can spoof this header if traffic reaches the app directly.
+ *
  * **Production requirement**: inject a shared storage implementation (Redis, Memcached,
  * or a database-backed store) via {@see RateLimitStorageInterface}. The bundled
  * {@see InMemoryRateLimitStorage} does NOT share state across PHP-FPM worker processes

--- a/tests/Middleware/BaselineMiddlewareTest.php
+++ b/tests/Middleware/BaselineMiddlewareTest.php
@@ -115,6 +115,20 @@ final class BaselineMiddlewareTest extends TestCase
         self::assertSame(204, $response->getStatusCode());
         self::assertSame('https://app.example.test', $response->getHeaderLine('Access-Control-Allow-Origin'));
         self::assertSame('GET, POST, PUT, PATCH, DELETE, OPTIONS', $response->getHeaderLine('Access-Control-Allow-Methods'));
+        self::assertSame('3600', $response->getHeaderLine('Access-Control-Max-Age'));
+    }
+
+    public function testCorsSimpleRequestDoesNotIncludeMaxAge(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new CorsMiddleware($factory, ['https://app.example.test']);
+        $request = $factory
+            ->createServerRequest('GET', 'https://api.example.test/')
+            ->withHeader('Origin', 'https://app.example.test');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame('', $response->getHeaderLine('Access-Control-Max-Age'));
     }
 
     public function testRequestSizeLimitReturnsProblemDetailsForOversizedPayload(): void

--- a/tools/validate-version.php
+++ b/tools/validate-version.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Validates that FrameworkInfo::VERSION is consistent with:
+ *   - docs/openapi/openapi.yaml  info.version
+ *   - CHANGELOG.md               most recent released version heading
+ *
+ * Run via: composer version:check
+ */
+
+use Symfony\Component\Yaml\Yaml;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$root = dirname(__DIR__);
+$errors = [];
+
+// --- 1. Read FrameworkInfo::VERSION ---
+$frameworkInfoPath = $root . '/src/FrameworkInfo.php';
+$frameworkInfoSrc = file_get_contents($frameworkInfoPath);
+
+if ($frameworkInfoSrc === false) {
+    fwrite(STDERR, "Could not read {$frameworkInfoPath}\n");
+    exit(1);
+}
+
+if (!preg_match("/VERSION\s*=\s*'([^']+)'/", $frameworkInfoSrc, $m)) {
+    fwrite(STDERR, "Could not extract VERSION from FrameworkInfo.php\n");
+    exit(1);
+}
+
+$frameworkVersion = $m[1];
+
+// --- 2. Read OpenAPI info.version ---
+$openapiPath = $root . '/docs/openapi/openapi.yaml';
+$openapiDoc = Yaml::parseFile($openapiPath);
+$openapiVersion = is_array($openapiDoc) ? ($openapiDoc['info']['version'] ?? null) : null;
+
+if (!is_string($openapiVersion)) {
+    $errors[] = 'docs/openapi/openapi.yaml: info.version is missing or not a string.';
+} elseif ($openapiVersion !== $frameworkVersion) {
+    $errors[] = sprintf(
+        "docs/openapi/openapi.yaml info.version is '%s' but FrameworkInfo::VERSION is '%s'.",
+        $openapiVersion,
+        $frameworkVersion,
+    );
+}
+
+// --- 3. Read latest released version from CHANGELOG.md ---
+$changelogPath = $root . '/CHANGELOG.md';
+$changelog = file_get_contents($changelogPath);
+
+if ($changelog === false) {
+    fwrite(STDERR, "Could not read {$changelogPath}\n");
+    exit(1);
+}
+
+// Match the first non-Unreleased version heading: ## [1.2.3]
+if (!preg_match('/^##\s+\[(\d+\.\d+\.\d+)\]/m', $changelog, $cm)) {
+    $errors[] = "CHANGELOG.md: no released version heading found (expected '## [X.Y.Z]').";
+} else {
+    $changelogVersion = $cm[1];
+
+    if ($changelogVersion !== $frameworkVersion) {
+        $errors[] = sprintf(
+            "CHANGELOG.md latest released version is '%s' but FrameworkInfo::VERSION is '%s'.",
+            $changelogVersion,
+            $frameworkVersion,
+        );
+    }
+}
+
+// --- Report ---
+if ($errors !== []) {
+    foreach ($errors as $error) {
+        fwrite(STDERR, "Version consistency error: {$error}\n");
+    }
+
+    exit(1);
+}
+
+echo "Version consistency OK: {$frameworkVersion}\n";


### PR DESCRIPTION
## Summary

- **#520**: `CorsMiddleware` プリフライトレスポンスに `Access-Control-Max-Age` ヘッダーを追加。デフォルト 3600 秒、コンストラクタで設定可能
- **#521**: `ThrottleMiddleware` の PHPDoc にリバースプロキシ環境での `REMOTE_ADDR` 問題を明記。`X-Forwarded-For` を使うカスタム `$keyExtractor` のコード例を追加
- **#522**: `tools/validate-version.php` を追加。`FrameworkInfo::VERSION` と `docs/openapi/openapi.yaml` の `info.version` および `CHANGELOG.md` の最新リリースバージョンの整合性を検証。`composer version:check` / `composer check` に統合

## Test plan

- [x] `BaselineMiddlewareTest` に CORS `Max-Age` アサーション追加・シンプルリクエストには付与されないことも確認
- [x] `composer version:check` → `Version consistency OK: 1.5.0`
- [x] `composer check` — 283 tests / 758 assertions, PHPStan level 8 クリア

Self-review: middleware-security, release-ci

Closes #520
Closes #521
Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)