### PR TITLE
docs(field-trials): FT15・FT16 レポート追加・MCP セットアップ改善 (#488 #490)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,8 +238,17 @@ UseCase     : ビジネス不変条件、認可ルール、状態依存ルール
 
 ### ローカル MCP サーバー起動
 
+NENE2 本体（開発用）:
+
 ```bash
 docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
+```
+
+Consumer Project（`vendor/` 経由）:
+
+```bash
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app \
+  php vendor/hideyukimori/nene2/tools/local-mcp-server.php
 ```
 
 ### Consumer Project から MCP バリデーターを使う

--- a/docs/field-trials/2026-05-field-trial-15.md
+++ b/docs/field-trials/2026-05-field-trial-15.md
@@ -1,0 +1,155 @@
+# Field Trial 15 — noteboard: HTML View 層の実地検証
+
+## Date
+
+2026-05-20
+
+## Baseline
+
+- NENE2 v1.5.0（`hideyukimori/nene2: ^1.5`）
+- PHP 8.4
+- プロジェクト: **noteboard** — シンプルなメモ共有ボード
+- エンティティ: `Note`（1 ドメイン、HTML 3ルート + JSON API 3ルート）
+- テスト: PHPUnit 13、PHPStan level 8、PHP-CS-Fixer
+- DB: SQLite（ローカル）
+- フロントエンド: なし（サーバーレンダリング HTML のみ）
+
+## Goal
+
+`HtmlResponseFactory` + `NativePhpViewRenderer` を使ったサーバー HTML レンダリング層を実地検証する。
+同一アプリに JSON API と HTML ルートを共存させ、NENE2 の「薄い HTML」方針が実用に耐えるかを確認する。
+
+---
+
+## Steps Taken
+
+### 1. HtmlResponseFactory と NativePhpViewRenderer のセットアップ
+
+```php
+$html = new HtmlResponseFactory(
+    $psr17,
+    $psr17,
+    new NativePhpViewRenderer(dirname(__DIR__) . '/templates'),
+);
+```
+
+`NativePhpViewRenderer` にはテンプレートルートディレクトリを渡す。以降、テンプレートパスはこのルートからの相対パスで指定する（例: `'notes/index.php'`）。
+
+### 2. ハンドラー実装
+
+HTML ハンドラーは JSON ハンドラーと対称的な構造で記述できる。
+
+```php
+final readonly class NoteListHandler
+{
+    public function __construct(
+        private HtmlResponseFactory $html,
+        private NoteRepository $notes,
+    ) {}
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->html->create('notes/index.php', ['notes' => $this->notes->all()]);
+    }
+}
+```
+
+`HtmlResponseFactory::create()` の第 2 引数に渡した連想配列は、テンプレート内でそのままローカル変数として展開される。
+
+### 3. ネイティブ PHP テンプレート
+
+テンプレートでは XSS エスケープヘルパー `$e()` が自動注入される。
+
+```php
+<?php foreach ($notes as $note): ?>
+  <li><a href="/notes/<?= $e($note->id) ?>"><?= $e($note->title) ?></a></li>
+<?php endforeach; ?>
+```
+
+`$e()` は `htmlspecialchars()` のショートカット。戻り値を出力する際は必ず使用する。
+
+### 4. HTML + JSON API のルート共存
+
+```php
+$router->get('/notes',       new NoteListHandler($html, $noteRepo));
+$router->get('/notes/{id}', new NoteShowHandler($html, $noteRepo, $problems));
+$router->get('/api/notes',       new NoteListApiHandler($json, $noteRepo));
+$router->post('/api/notes',      new NoteCreateApiHandler($json, $problems, $noteRepo));
+$router->get('/api/notes/{id}', new NoteShowApiHandler($json, $problems, $noteRepo));
+```
+
+HTML ルートと API ルートを `/notes/*` と `/api/notes/*` で明示的に分けることで、ルーティングテーブルが読みやすく保たれる。NENE2 のルーターはシンプルな完全一致 + プレースホルダーのみのため、この規約は特に有効。
+
+---
+
+## Findings
+
+### F-1: `HtmlResponseFactory` の DI が直感的で摩擦ゼロ [情報]
+
+`JsonResponseFactory` と同様のコンストラクタシグネチャで、既存の JSON ハンドラーパターンをそのまま転用できた。`NativePhpViewRenderer` の構築も 1 行で完結する。ドキュメントなしで実装できた。
+
+---
+
+### F-2: `$e()` ヘルパーが howto に記載されていない [中]
+
+テンプレート内の XSS エスケープが `$e()` で行えることを、ソースコードを読むまで把握できなかった。`add-html-view.md` howto はすでに追加されているが、`$e()` の存在と使い方に関する記述が薄い。
+
+**提案**: `add-html-view.md` に `$e()` の説明と、うっかり生出力した場合の XSS リスクを明示するセクションを追加する。
+
+---
+
+### F-3: HTML ルートで 404 を返す場合に Problem Details が混在する [低]
+
+`NoteShowHandler` で存在しない Note を参照した際、`ProblemDetailsResponseFactory` を使って `application/problem+json` のレスポンスを返した。HTML ビューでこのレスポンスを受け取ったブラウザはプレーンな JSON を表示する。
+
+```php
+return $this->problems->create($request, 'not-found', 'Not Found', 404, "Note {$id} not found.");
+```
+
+API クライアントにとっては問題ないが、HTML ユーザー向けには HTML の 404 エラーページが望ましい。
+
+**解決策（暫定）**: `NotFoundHandler` を HTML テンプレートで返す専用クラスとして用意し、HTML ルートでは `$problems` の代わりに使用する。
+
+**提案**: NENE2 に `HtmlErrorPage` ユーティリティを追加するか、`ErrorHandlerMiddleware` が HTML リクエスト（`Accept: text/html`）をハンドルする拡張ポイントを提供する。
+
+---
+
+### F-4: テストは `assertStringContainsString` でシンプルに書ける [情報]
+
+HTML エンドポイントのテストは `Content-Type` と本文の部分一致で十分に品質を担保できる。
+
+```php
+public function testNoteListHtmlShowsNotes(): void
+{
+    $this->noteRepo->create('Hello', 'World content');
+    $response = $this->app->handle(new ServerRequest('GET', '/notes'));
+
+    self::assertSame(200, $response->getStatusCode());
+    self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+    self::assertStringContainsString('Hello', (string) $response->getBody());
+}
+```
+
+ルーター → ハンドラー → テンプレートの全段を 1 テストで通せるため、結合度の高いアサーションが自然に書ける。HTML の DOM 構造を細かく検証する必要はほとんどなかった。
+
+---
+
+### F-5: `NativePhpViewRenderer` のパスが相対解決のみ [低]
+
+テンプレートルートを変えたい場合（例: テスト用に別ディレクトリを指定したい）、`NativePhpViewRenderer` のコンストラクタに別のルートを渡せば対応できる。ただし、テンプレートファイル名が存在しない場合の例外メッセージが汎用的で、デバッグ時に原因を特定しにくかった。
+
+**提案**: テンプレートファイルが見つからない場合に「テンプレートルート: ${templateRoot}/${path} が見つかりません」という明確なメッセージを出力する。
+
+---
+
+## Summary
+
+| 項目 | 結果 |
+|---|---|
+| `HtmlResponseFactory` セットアップ | 摩擦なし ✓ |
+| `$e()` XSS エスケープ | 動作するが発見性が低い △ |
+| HTML + JSON API 共存 | クリーンに分離できる ✓ |
+| HTML エラーハンドリング | Problem Details JSON が混在する △ |
+| HTML テスト | assertStringContainsString で十分 ✓ |
+
+NENE2 の HTML レンダリング層は最小限の API で実装できる。`$e()` の発見性とエラーページの HTML 化が次の改善候補。

--- a/docs/field-trials/2026-05-field-trial-16.md
+++ b/docs/field-trials/2026-05-field-trial-16.md
@@ -1,0 +1,171 @@
+# Field Trial 16 — noteboard: MCP ツール層の実地検証
+
+## Date
+
+2026-05-20
+
+## Baseline
+
+- NENE2 v1.5.0（`hideyukimori/nene2: ^1.4`、Packagist 経由）
+- PHP 8.4
+- プロジェクト: **noteboard** — シンプルなメモ共有ボード（FT15 と同プロジェクト）
+- エンティティ: `Note`（1 ドメイン、JSON API 3 エンドポイント）
+- MCP ツール: `listNotes` / `getNoteById`（read）・`createNote`（write）
+- テスト: PHPUnit 13、PHPStan level 8、PHP-CS-Fixer、`symfony/yaml`（require-dev）
+
+## Goal
+
+NENE2 の MCP ツール層を Consumer Project 視点で実地検証する。
+`docs/mcp/tools.json` 定義 → `composer mcp` バリデーション → `LocalMcpToolCatalog` テスト → `LocalMcpServer` 起動の一連のフローが摩擦なく完結するかを確認する。
+
+---
+
+## Steps Taken
+
+### 1. Consumer Project における MCP セットアップ
+
+CLAUDE.md の「Consumer Project から MCP バリデーターを使う」手順に従いセットアップ。
+
+1. `require-dev` に `symfony/yaml` を追加（`validate-mcp-tools.php` が依存）
+2. `composer.json` の `scripts` に `mcp` エントリを追加:
+   ```json
+   "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=."
+   ```
+3. `docs/mcp/tools.json` を作成（read 2 件 + write 1 件）
+4. `docs/openapi/openapi.yaml` に各エンドポイントを記述
+
+### 2. tools.json 定義
+
+```json
+{
+  "version": 1,
+  "source": "docs/openapi/openapi.yaml",
+  "tools": [
+    {
+      "name": "listNotes",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "listNotes",
+                  "method": "GET", "path": "/api/notes" },
+      "inputSchema": { "type": "object", "properties": {
+        "limit":  { "type": "integer" },
+        "offset": { "type": "integer" }
+      }},
+      "responseSchemaRef": "#/components/schemas/NoteListResponse"
+    },
+    {
+      "name": "createNote",
+      "safety": "write",
+      "source": { "type": "openapi", "operationId": "createNote",
+                  "method": "POST", "path": "/api/notes" },
+      "inputSchema": { "type": "object", "required": ["title"],
+                       "properties": { "title": { "type": "string" },
+                                       "content": { "type": "string" } }},
+      "responseSchemaRef": null
+    }
+  ]
+}
+```
+
+### 3. `composer mcp` バリデーション
+
+```bash
+composer mcp
+# → MCP tool catalog is valid.
+```
+
+`operationId` と OpenAPI パスの整合・`responseSchemaRef` の `$ref` 解決・`safety` の値チェックが自動的に行われる。
+
+### 4. `McpToolCatalogTest` による単体テスト
+
+Consumer Project で `LocalMcpToolCatalog` を直接使用してカタログの契約を検証するテストを記述した。
+
+```php
+final class McpToolCatalogTest extends TestCase
+{
+    public function testListNotesToolIsPresent(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__) . '/docs/mcp/tools.json');
+        $tool = $catalog->find('listNotes');
+
+        self::assertNotNull($tool);
+        self::assertSame('read', $tool['safety']);
+        self::assertSame('/api/notes', $tool['source']['path']);
+    }
+}
+```
+
+---
+
+## Findings
+
+### F-1: `symfony/yaml` の追加が CLAUDE.md に明記されているが見落としやすい [中]
+
+`validate-mcp-tools.php` は `symfony/yaml` を必要とするが、これは `require-dev` への手動追加が必要。`composer mcp` を最初に実行した際に `Composer\Autoload\ClassLoader` エラーで失敗し、原因特定に 5 分かかった。
+
+**CLAUDE.md** には記載があるが、エラーメッセージがわかりにくい。
+
+**提案**: `validate-mcp-tools.php` に `symfony/yaml` の存在チェックを追加し、未インストールの場合に明確なガイドメッセージを出力する。
+
+---
+
+### F-2: `write` ツールがベアラー認証なしで呼ばれた場合のエラーが明確 [情報]
+
+`createNote`（`safety: write`）を認証なしで呼ぶと、`LocalMcpServer` から以下のエラーが返る。
+
+```
+Write tool "createNote" requires bearer authentication.
+Set NENE2_LOCAL_JWT_SECRET in the MCP server environment.
+```
+
+エラーメッセージが具体的で、対処が即座にわかる。Claude Desktop や MCP Inspector での統合テストでもこのメッセージがそのまま表示されるため、開発体験が良い。
+
+---
+
+### F-3: `responseSchemaRef: null` が write ツールでは正しいが、補足ドキュメントがない [低]
+
+`createNote` のレスポンスは `null` を設定した。実際には 201 Created とレスポンスボディが存在するが、`tools.json` の MCP スキーマでは `responseSchemaRef` が必須でないため `null` を許容している。
+
+ただし `null` の意味（「スキーマ参照なし = 構造化コンテンツを返さない」）が `tools.json` のドキュメントに記載されておらず、意図的 `null` と未実装の区別がつかない。
+
+**提案**: `tools.json` スキーマドキュメントに `responseSchemaRef: null` の意味を明記する。
+
+---
+
+### F-4: `McpToolCatalogTest` が Consumer Project でのゴールデンパス [情報]
+
+`LocalMcpToolCatalog` を Consumer Project のテストで直接使用し、ツール名・safety・パスを検証するパターンが非常に安定していた。`composer mcp` の静的バリデーションとテストの動的検証を組み合わせることで、デプロイ前にカタログの破壊的変更を検出できる。
+
+このテストパターンを `add-mcp-tools.md` howto に組み込むことを推奨する。
+
+---
+
+### F-5: MCP サーバーの起動コマンドが Consumer Project 向けに整備されていない [中]
+
+NENE2 本体の `docs/` には以下の起動コマンドが記述されている。
+
+```bash
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php
+```
+
+しかし Consumer Project では `local-mcp-server.php` は `vendor/hideyukimori/nene2/tools/` にある。Consumer Project での正しい起動コマンドが CLAUDE.md に一行もない。
+
+**提案**: CLAUDE.md の「ローカル MCP サーバー起動」セクションに Consumer Project 向けコマンドを追記する。
+
+```bash
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app \
+  php vendor/hideyukimori/nene2/tools/local-mcp-server.php
+```
+
+---
+
+## Summary
+
+| 項目 | 結果 |
+|---|---|
+| `tools.json` 定義 + `composer mcp` | 摩擦小、`symfony/yaml` 追加が必要 △ |
+| `write` ツールの認証エラーメッセージ | 明確で開発体験が良い ✓ |
+| `McpToolCatalogTest` テストパターン | 安定・推奨パターンとして確立 ✓ |
+| Consumer Project MCP サーバー起動 | CLAUDE.md にコマンド不足 △ |
+| `responseSchemaRef: null` の意味 | ドキュメント不足 △ |
+
+MCP ツール層は `read` ツールの定義・バリデーション・テストの三点セットが機能している。`write` ツールの認証は直感的に動作する。Consumer Project での起動コマンドとスキーマドキュメントの補完が次の優先改善候補。

--- a/tools/validate-mcp-tools.php
+++ b/tools/validate-mcp-tools.php
@@ -19,6 +19,12 @@ foreach ($argv as $arg) {
 
 require $projectRoot . '/vendor/autoload.php';
 
+if (!class_exists(\Symfony\Component\Yaml\Yaml::class)) {
+    fwrite(STDERR, "Error: symfony/yaml is not installed.\n");
+    fwrite(STDERR, "Run: composer require --dev symfony/yaml\n");
+    exit(1);
+}
+
 $root = $projectRoot;
 $catalogPath = $root . '/docs/mcp/tools.json';
 $openApiPath = $root . '/docs/openapi/openapi.yaml';


### PR DESCRIPTION
## Summary

- **FT15** (`2026-05-field-trial-15.md`): noteboard を題材に `HtmlResponseFactory` + `NativePhpViewRenderer` の HTML View 層を実地検証。5 件の Findings（$e() 発見性、HTML エラーページ混在、テストパターン等）
- **FT16** (`2026-05-field-trial-16.md`): noteboard の MCP 層（tools.json 定義・compose mcp・write ツール認証・McpToolCatalogTest パターン）を実地検証。5 件の Findings
- **FT16 F-1 対応**: `validate-mcp-tools.php` に `symfony/yaml` 未インストール時のフレンドリーエラーを追加
- **FT16 F-5 対応**: `CLAUDE.md` の「ローカル MCP サーバー起動」セクションに Consumer Project 向けコマンドを追記

## Test plan

- [x] `composer check` — 283 tests / 758 assertions, PHPStan level 8 クリア

Self-review: docs-policy

Closes #488
Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)