### PR TITLE
fix(security): Content-Length バイパス・WWW-Authenticate インジェクション・CORS フットガン・factory excludedPaths (#528-531)

### DIFF
--- a/src/Auth/BearerTokenMiddleware.php
+++ b/src/Auth/BearerTokenMiddleware.php
@@ -103,7 +103,17 @@ final readonly class BearerTokenMiddleware implements MiddlewareInterface
             ->create($request, 'unauthorized', 'Unauthorized', 401, $description)
             ->withHeader(
                 'WWW-Authenticate',
-                sprintf('Bearer realm="NENE2", error="%s", error_description="%s"', $error, $description),
+                sprintf(
+                    'Bearer realm="NENE2", error="%s", error_description="%s"',
+                    $error,
+                    $this->sanitizeHeaderParam($description),
+                ),
             );
+    }
+
+    private function sanitizeHeaderParam(string $value): string
+    {
+        // Strip CRLF (HTTP header injection) then escape double-quotes per RFC 7235 quoted-string.
+        return str_replace('"', '\\"', preg_replace('/\r?\n|\r/', ' ', $value) ?? $value);
     }
 }

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -50,6 +50,16 @@ final readonly class RuntimeApplicationFactory
      * @param list<string> $allowedOrigins CORS-allowed origins (e.g. `['https://app.example.com']`).
      *                                     An empty list (the default) silently disables all CORS headers.
      *                                     Always set this explicitly in production.
+     * @param list<string> $machineApiKeyExcludedPaths Paths that bypass the machine API key check even when
+     *                                                  `$machineApiKey` is set. Useful when a route should remain
+     *                                                  public while all other routes require an API key.
+     *                                                  Only has effect when `$machineApiKey` is non-null and
+     *                                                  `$machineApiKeyProtectedPaths` is empty.
+     * @param list<string> $machineApiKeyProtectedPaths Exact paths protected by the machine API key. When
+     *                                                   non-empty, ONLY these paths require the key (allowlist
+     *                                                   mode). Defaults to `['/machine/health']`. Set to `[]`
+     *                                                   combined with `$machineApiKeyExcludedPaths` to protect
+     *                                                   all paths except the excluded ones.
      * @param bool $debug When true, unhandled exception messages are exposed in 500 `detail`.
      *                    Never set to true in production.
      */
@@ -66,6 +76,8 @@ final readonly class RuntimeApplicationFactory
         private ?ThrottleMiddleware $throttleMiddleware = null,
         private bool $debug = false,
         private array $allowedOrigins = [],
+        private array $machineApiKeyExcludedPaths = [],
+        private array $machineApiKeyProtectedPaths = ['/machine/health'],
     ) {
     }
 
@@ -166,7 +178,12 @@ final readonly class RuntimeApplicationFactory
             new CorsMiddleware($this->responseFactory, $this->allowedOrigins),
             new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers, $this->debug, $logger),
             new RequestSizeLimitMiddleware($problemDetails),
-            new ApiKeyAuthenticationMiddleware($problemDetails, $this->machineApiKey, ['/machine/health']),
+            new ApiKeyAuthenticationMiddleware(
+                $problemDetails,
+                $this->machineApiKey,
+                $this->machineApiKeyProtectedPaths,
+                excludedPaths: $this->machineApiKeyExcludedPaths,
+            ),
         ];
 
         if ($this->authMiddleware !== null) {

--- a/src/Middleware/CorsMiddleware.php
+++ b/src/Middleware/CorsMiddleware.php
@@ -19,7 +19,12 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class CorsMiddleware implements MiddlewareInterface
 {
     /**
-     * @param list<string> $allowedOrigins
+     * @param list<string> $allowedOrigins Exact origins to allow (e.g. `['https://app.example.com']`).
+     *                                     An empty list disables CORS headers entirely.
+     *                                     Do NOT pass `['*']` — that matches only the literal string `*`
+     *                                     (no browser sends that as an Origin) and effectively blocks all
+     *                                     CORS. To open all origins, list each one explicitly or implement
+     *                                     a custom middleware that echoes the request Origin unconditionally.
      * @param list<string> $allowedMethods
      * @param list<string> $allowedHeaders
      * @param positive-int $maxAge Seconds the browser may cache the preflight response
@@ -33,6 +38,13 @@ final readonly class CorsMiddleware implements MiddlewareInterface
         private bool $allowCredentials = false,
         private int $maxAge = 3600,
     ) {
+        if (in_array('*', $allowedOrigins, true)) {
+            throw new \InvalidArgumentException(
+                'CorsMiddleware: do not pass \'*\' in $allowedOrigins. '
+                . 'It matches only the literal string "*" as an Origin (no browser sends this). '
+                . 'List each allowed origin explicitly instead.',
+            );
+        }
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/src/Middleware/RequestSizeLimitMiddleware.php
+++ b/src/Middleware/RequestSizeLimitMiddleware.php
@@ -59,7 +59,9 @@ final readonly class RequestSizeLimitMiddleware implements MiddlewareInterface
     private function isOversized(string $contentLength): bool
     {
         if (preg_match('/\A\d+\z/', $contentLength) !== 1) {
-            return false;
+            // Invalid Content-Length (negative, decimal, hex, etc.) — treat as oversized.
+            // RFC 9110 §8.6 requires a non-negative decimal integer; reject anything else.
+            return true;
         }
 
         return (int) $contentLength > $this->maxBodyBytes;

--- a/tests/Auth/BearerTokenMiddlewareTest.php
+++ b/tests/Auth/BearerTokenMiddlewareTest.php
@@ -210,6 +210,52 @@ final class BearerTokenMiddlewareTest extends TestCase
         self::assertSame(401, $response->getStatusCode());
     }
 
+    public function testWwwAuthenticateEscapesDoubleQuotesInDescription(): void
+    {
+        $factory = new Psr17Factory();
+        $verifier = new class () implements TokenVerifierInterface {
+            public function verify(string $token): array
+            {
+                throw new TokenVerificationException('Expected claim "sub" to be present.');
+            }
+        };
+        $middleware = $this->makeMiddleware($factory, $verifier);
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/protected')
+            ->withHeader('Authorization', 'Bearer some.token.here');
+
+        $response = $middleware->process($request, $this->failHandler());
+
+        $header = $response->getHeaderLine('WWW-Authenticate');
+        self::assertSame(401, $response->getStatusCode());
+        // The double-quotes inside the description must be escaped so the header remains parseable.
+        self::assertStringContainsString('\\"sub\\"', $header);
+        // Must not contain unescaped raw quote that would break the header structure.
+        self::assertStringNotContainsString('error_description="Expected claim "sub"', $header);
+    }
+
+    public function testWwwAuthenticateStripsCrlfFromDescription(): void
+    {
+        $factory = new Psr17Factory();
+        $verifier = new class () implements TokenVerifierInterface {
+            public function verify(string $token): array
+            {
+                throw new TokenVerificationException("Line1\r\nX-Injected: evil");
+            }
+        };
+        $middleware = $this->makeMiddleware($factory, $verifier);
+        $request = $factory
+            ->createServerRequest('GET', 'https://example.test/protected')
+            ->withHeader('Authorization', 'Bearer some.token.here');
+
+        $response = $middleware->process($request, $this->failHandler());
+
+        $header = $response->getHeaderLine('WWW-Authenticate');
+        // CRLF must be stripped to prevent HTTP response splitting.
+        self::assertStringNotContainsString("\r\n", $header);
+        self::assertStringNotContainsString("\n", $header);
+    }
+
     private function makeMiddleware(Psr17Factory $factory, TokenVerifierInterface $verifier): BearerTokenMiddleware
     {
         return new BearerTokenMiddleware(

--- a/tests/Middleware/BaselineMiddlewareTest.php
+++ b/tests/Middleware/BaselineMiddlewareTest.php
@@ -118,6 +118,14 @@ final class BaselineMiddlewareTest extends TestCase
         self::assertSame('3600', $response->getHeaderLine('Access-Control-Max-Age'));
     }
 
+    public function testCorsThrowsWhenWildcardPassedAsAllowedOrigin(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('do not pass \'*\' in $allowedOrigins');
+
+        new CorsMiddleware((new Psr17Factory()), ['*']);
+    }
+
     public function testCorsSimpleRequestDoesNotIncludeMaxAge(): void
     {
         $factory = new Psr17Factory();
@@ -182,6 +190,38 @@ final class BaselineMiddlewareTest extends TestCase
         $response = $middleware->process($request, $this->okHandler($factory));
 
         self::assertSame(413, $response->getStatusCode());
+    }
+
+    public function testRequestSizeLimitRejectsNegativeContentLength(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestSizeLimitMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            10,
+        );
+        $request = $factory
+            ->createServerRequest('POST', 'https://example.test/upload')
+            ->withHeader('Content-Length', '-1');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame(413, $response->getStatusCode(), 'Negative Content-Length must be rejected.');
+    }
+
+    public function testRequestSizeLimitRejectsNonNumericContentLength(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestSizeLimitMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            10,
+        );
+        $request = $factory
+            ->createServerRequest('POST', 'https://example.test/upload')
+            ->withHeader('Content-Length', 'abc');
+
+        $response = $middleware->process($request, $this->okHandler($factory));
+
+        self::assertSame(413, $response->getStatusCode(), 'Non-numeric Content-Length must be rejected.');
     }
 
     public function testRequestLoggingIncludesSafeRequestContext(): void


### PR DESCRIPTION
## Summary

- **#528 P1**: `RequestSizeLimitMiddleware` — `Content-Length: -1` / `Content-Length: abc` 等の不正値が両方のサイズチェックをスキップするバイパスを修正。RFC 9110 §8.6 に従い非整数は oversized として拒否
- **#529 P2**: `BearerTokenMiddleware` — `error_description` パラメータの CRLF / ダブルクォートを sanitize して WWW-Authenticate ヘッダーインジェクションを防止
- **#530 P2**: `CorsMiddleware` — `allowedOrigins: ['*']` をコンストラクタで `InvalidArgumentException` として即時検出（「全許可」と誤解されるサイレントフットガン）
- **#531 P2**: `RuntimeApplicationFactory` に `$machineApiKeyProtectedPaths` / `$machineApiKeyExcludedPaths` を追加し、`ApiKeyAuthenticationMiddleware::$excludedPaths` を標準ファクトリ経由で利用可能に

## Test plan

- [x] `RequestSizeLimitMiddlewareTest`: 負値・非数値 Content-Length → 413 を追加
- [x] `BearerTokenMiddlewareTest`: WWW-Authenticate のダブルクォートエスケープ・CRLF 除去テストを追加
- [x] `BaselineMiddlewareTest`: CorsMiddleware `['*']` ガードテストを追加
- [x] `composer check` — 288 tests / 767 assertions, PHPStan level 8 クリア

Self-review: middleware-security, backend-api

Closes #528
Closes #529
Closes #530
Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)