### PR TITLE
fix(middleware,test): CorsMiddleware maxAge バリデーション・HEAD テスト追加 (#532 #533)

### DIFF
--- a/src/Middleware/CorsMiddleware.php
+++ b/src/Middleware/CorsMiddleware.php
@@ -27,8 +27,8 @@ final readonly class CorsMiddleware implements MiddlewareInterface
      *                                     a custom middleware that echoes the request Origin unconditionally.
      * @param list<string> $allowedMethods
      * @param list<string> $allowedHeaders
-     * @param positive-int $maxAge Seconds the browser may cache the preflight response
-     *                             (`Access-Control-Max-Age`). Defaults to 3600 (1 hour).
+     * @param int $maxAge Seconds the browser may cache the preflight response
+     *                   (`Access-Control-Max-Age`). Must be a positive integer. Defaults to 3600 (1 hour).
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
@@ -43,6 +43,12 @@ final readonly class CorsMiddleware implements MiddlewareInterface
                 'CorsMiddleware: do not pass \'*\' in $allowedOrigins. '
                 . 'It matches only the literal string "*" as an Origin (no browser sends this). '
                 . 'List each allowed origin explicitly instead.',
+            );
+        }
+
+        if ($maxAge <= 0) {
+            throw new \InvalidArgumentException(
+                sprintf('CorsMiddleware: $maxAge must be a positive integer, got %d.', $maxAge),
             );
         }
     }

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -284,6 +284,32 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame(['external' => 'error'], $payload['checks']);
     }
 
+    public function testHeadRequestReceivesSecurityHeadersAndXRequestId(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory))->create();
+
+        $response = $application->handle($factory->createServerRequest('HEAD', 'https://example.test/'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertMatchesRegularExpression('/\A[a-f0-9]{32}\z/', $response->getHeaderLine('X-Request-Id'));
+        self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
+        self::assertSame("default-src 'self'", $response->getHeaderLine('Content-Security-Policy'));
+        self::assertSame('SAMEORIGIN', $response->getHeaderLine('X-Frame-Options'));
+    }
+
+    public function testHeadRequestToUnknownRouteReturns404WithHeaders(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory))->create();
+
+        $response = $application->handle($factory->createServerRequest('HEAD', 'https://example.test/no-such-route'));
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertMatchesRegularExpression('/\A[a-f0-9]{32}\z/', $response->getHeaderLine('X-Request-Id'));
+        self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Middleware/BaselineMiddlewareTest.php
+++ b/tests/Middleware/BaselineMiddlewareTest.php
@@ -126,6 +126,14 @@ final class BaselineMiddlewareTest extends TestCase
         new CorsMiddleware((new Psr17Factory()), ['*']);
     }
 
+    public function testCorsThrowsWhenMaxAgeIsZeroOrNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$maxAge must be a positive integer');
+
+        new CorsMiddleware((new Psr17Factory()), [], maxAge: 0);
+    }
+
     public function testCorsSimpleRequestDoesNotIncludeMaxAge(): void
     {
         $factory = new Psr17Factory();


### PR DESCRIPTION
## Summary

- `CorsMiddleware` の PHPDoc を `positive-int` → `int` に変更し、コンストラクタ内の `$maxAge <= 0` 実行時ガードを PHPStan level 8 で通るよう修正 (#532)
- `BaselineMiddlewareTest`: `maxAge: 0` 渡しで `InvalidArgumentException` がスローされるテスト追加
- `HttpRuntimeTest`: HEAD リクエストに SecurityHeaders・X-Request-Id が付くこと、存在しないルートへの HEAD が 404 を返すことを統合テストで検証 (#533)

## Changes

- `src/Middleware/CorsMiddleware.php` — PHPDoc `@param positive-int` → `@param int` (runtime guard provides enforcement)
- `tests/Middleware/BaselineMiddlewareTest.php` — `testCorsThrowsWhenMaxAgeIsZeroOrNegative()` 追加
- `tests/HttpRuntimeTest.php` — `testHeadRequestReceivesSecurityHeadersAndXRequestId()` / `testHeadRequestToUnknownRouteReturns404WithHeaders()` 追加

## Test plan

- [x] `composer check` — 291 tests, 777 assertions, PHPStan OK, CS OK
- [x] Version consistency OK: 1.5.0

Closes #532
Closes #533

Self-review: middleware-security, backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)