### PR TITLE
docs(v1.5.0): llms.txt・README・howto・ADR 0011 を v1.5.0 に整合 (#536)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The foundation currently includes:
 - Typed app and database configuration through `.env` loading boundaries.
 - PSR-11 dependency injection with explicit runtime service wiring.
 - PDO connection, query executor, transaction manager, SQLite tests, and opt-in MySQL verification through Docker Compose.
-- API-key middleware for the first protected machine-client path.
+- Bearer JWT middleware with allowlist, blocklist, and prefix path options; `CompositeAuthMiddleware` for three-tier access models (public / Bearer / API key).
+- API-key middleware with path and method filters for machine-client endpoints.
+- Server-rendered HTML via `NativePhpViewRenderer` and `HtmlResponseFactory` — thin HTML coexists with JSON API routes.
 - Local MCP server support for read/write tools aligned with OpenAPI, with an authentication guard on write operations.
 - React + TypeScript + Vite starter kept optional and decoupled from backend runtime behavior.
 
@@ -183,6 +185,21 @@ composer test:database:mysql
 See `docs/development/php-runtime.md` and `docs/development/docker.md` for runtime and tooling details.
 
 NENE2's quality baseline includes PHP-CS-Fixer for backend style checks and npm, ESLint, TypeScript, and Prettier for the React frontend starter. The frontend starter targets active Node.js LTS, commits `package-lock.json`, and keeps dependencies modern through update automation. Framework public APIs should use PHPDoc or TSDoc where comments explain contracts or extension rules. See `docs/development/quality-tools.md`, `docs/development/frontend-integration.md`, and `docs/development/documentation-comments.md`.
+
+## How-to guides
+
+Step-by-step recipes for common tasks:
+
+- [Add a custom route](docs/howto/add-custom-route.md)
+- [Add a database-backed endpoint](docs/howto/add-database-endpoint.md)
+- [Add a second entity](docs/howto/add-second-entity.md)
+- [Add pagination](docs/howto/add-pagination.md)
+- [Add JWT authentication](docs/howto/add-jwt-authentication.md)
+- [Add rate limiting](docs/howto/add-rate-limiting.md)
+- [Add a health check](docs/howto/add-health-check.md)
+- [Add an HTML view](docs/howto/add-html-view.md)
+- [Add MCP tools](docs/howto/add-mcp-tools.md)
+- [Deploy to production](docs/howto/deploy-production.md)
 
 ## Delivery Starter Docs
 

--- a/docs/adr/0011-security-review-policy.md
+++ b/docs/adr/0011-security-review-policy.md
@@ -1,0 +1,94 @@
+# ADR 0011: Security Review Policy — Adversarial Review and HTTP Security Invariants
+
+## Status
+
+accepted
+
+## Context
+
+During v1.5.0 development, a structured adversarial review of the NENE2 codebase identified
+several exploitable flaws in the default middleware configuration. The findings fell into two
+categories:
+
+**Bypasses and injections (P1/P2)**
+- `RequestSizeLimitMiddleware`: negative or non-numeric `Content-Length` values (e.g. `-1`,
+  `abc`) bypassed both the header check and the body-stream fallback, allowing unlimited payload
+  delivery with no limit enforcement.
+- `BearerTokenMiddleware`: `WWW-Authenticate` header values were built from
+  `TokenVerificationException::getMessage()` without sanitisation. An exception message
+  containing `"` or `\r\n` (CRLF) could produce a malformed or split header — a class of
+  HTTP response splitting and header injection vulnerabilities.
+
+**Footguns and missing guards (P3)**
+- `CorsMiddleware`: passing `allowedOrigins: ['*']` performs a literal string match against the
+  `Origin` header. No browser sends `Origin: *`, so the intent of "open all origins" is silently
+  defeated. The constructor now throws `\InvalidArgumentException` to make the misconfiguration
+  explicit.
+- `CorsMiddleware`: the `$maxAge` parameter previously accepted `0` or negative values silently,
+  producing an invalid `Access-Control-Max-Age: 0` header. The constructor now enforces a
+  positive integer at runtime.
+
+## Decision
+
+### 1. Structured adversarial reviews are part of the release process
+
+Before each minor or major release, one review pass is conducted from an attacker's perspective:
+assume the defaults are misconfigured, assume attacker-controlled input reaches every parameter,
+and attempt to find bypasses, injections, and information-disclosure paths. Findings are triaged
+as P1 (critical / exploitable bypass), P2 (injection / privilege escalation), or P3 (footgun /
+defence-in-depth gap) and tracked in GitHub Issues.
+
+### 2. HTTP security invariants for middleware
+
+The following invariants must hold for all shipped middleware:
+
+| Invariant | Rationale |
+|---|---|
+| `Content-Length` must be a non-negative decimal integer (RFC 9110 §8.6); any other value is treated as oversized | Prevents bypass of the request size limit |
+| All values placed into HTTP response headers must have `\r\n` stripped and embedded `"` escaped (RFC 7230 §3.2) | Prevents HTTP response splitting and header injection |
+| Constructor guards reject obviously invalid configuration at construction time, not silently at request time | Fail-fast; surfaces misconfiguration in tests, not in production |
+| `allowedOrigins: ['*']` is explicitly rejected because it is a common misconception that produces a silently broken CORS configuration | The literal string `*` is never sent as a browser `Origin`; use per-origin allowlists |
+
+### 3. Error logging is unconditional
+
+`ErrorHandlerMiddleware` logs every unhandled exception at PSR-3 `error` level regardless of
+the `$debug` flag. The `$debug` flag controls only whether the exception message is exposed in
+the HTTP response body — never whether the server-side log entry is written. This ensures that
+production incidents are always observable.
+
+### 4. Test coverage for security-relevant paths
+
+Every bypass, injection, and footgun identified in a security review must be covered by a
+dedicated test before the fix is merged. Tests are named to make the security intent explicit
+(e.g. `testRequestSizeLimitRejectsNegativeContentLength`,
+`testWwwAuthenticateStripsCrlfFromDescription`).
+
+## Consequences
+
+**Benefits**
+- Common classes of middleware bypass and header injection are closed at the framework level,
+  so consumer projects inherit the fixes automatically via Composer update.
+- The adversarial review cadence creates an explicit checklist that can be extended as new
+  middleware is added.
+- Fail-fast constructor guards surface misconfiguration in unit tests rather than in production
+  traffic.
+
+**Costs**
+- Consumer code that passes `allowedOrigins: ['*']` will receive a runtime `\InvalidArgumentException`
+  after upgrading. This is intentional — the previous silent behaviour was always wrong.
+- Consumer code that passes `maxAge: 0` to `CorsMiddleware` will also receive an exception.
+  Positive integers only.
+
+**Follow-up**
+- The adversarial review checklist should be added to `docs/review/middleware-security.md` so
+  it is applied consistently before each release.
+
+## Related
+
+- Issue: `#528` — `Content-Length` bypass in `RequestSizeLimitMiddleware`
+- Issue: `#529` — WWW-Authenticate CRLF/quote injection in `BearerTokenMiddleware`
+- Issue: `#530` — CORS `['*']` footgun guard
+- Issue: `#532` — `CorsMiddleware` `$maxAge` runtime validation
+- PR: `#534`, `#535` — implementation
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -16,6 +16,7 @@ Architecture decisions are recorded here as lightweight ADRs. Each record captur
 | [0008](0008-jwt-authentication.md) | JWT authentication direction |
 | [0009](0009-v1.0-public-api-scope.md) | v1.0 public API scope and stability guarantee |
 | [0010](0010-rate-limiting.md) | Rate limiting design |
+| [0011](0011-security-review-policy.md) | Security review policy — adversarial review and HTTP security invariants |
 
 ## Template
 

--- a/docs/howto/add-jwt-authentication.md
+++ b/docs/howto/add-jwt-authentication.md
@@ -265,6 +265,30 @@ $app = (new RuntimeApplicationFactory(
 ))->create();
 ```
 
+### Path-scoping options
+
+`BearerTokenMiddleware` supports three mutually exclusive path-scoping strategies.
+Choose the one that matches your access model:
+
+| Strategy | Parameter | Use when |
+|---|---|---|
+| Blocklist (most common) | `$excludedPaths` | All routes require auth **except** a short list of public ones |
+| Allowlist | `$protectedPaths` | Only a fixed, known set of routes require auth |
+| Prefix allowlist | `$protectedPathPrefixes` | A whole path subtree requires auth (e.g. `/me/`, `/admin/`) |
+
+**Prefix allowlist example** — protect every path under `/me/` without listing each one:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails:         $problems,
+    verifier:               $verifier,
+    protectedPathPrefixes:  ['/me/'],
+);
+```
+
+A request to `/me/favorites/42` matches the prefix and requires a valid Bearer token.
+A request to `/products/1` does not match and passes through without authentication.
+
 ---
 
 ## Step 5 — Read claims in a protected handler

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.4.2`（2026-05-19 リリース済み）
+- Latest release: `v1.5.0`（2026-05-20 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed
@@ -99,10 +99,14 @@ FT12-A / FT12-B / FT12-C / FT13 のすべてが完了。主要成果:
 | 72 | 評価指摘のテスト不足 → 実際には既にカバー済みと確認 | — |
 | v1.5.0 | CHANGELOG 昇格・VERSION bump・タグ・GitHub Release | #495 |
 
+## Recently Completed (v1.5.0 ドキュメント整備)
+
+- **#536**: llms.txt・README・add-jwt-authentication.md・current.md・ADR 0011 を v1.5.0 に整合
+
 ## 次のアクション候補
 
 - FT17 (追加フィールドトライアル) — 新テーマで品質を継続検証
-- v1.5.x パッチ — FT15/FT16 フォローアップ Issue があれば対応
+- v1.5.x パッチ — セキュリティ修正（Content-Length バイパス・WWW-Authenticate インジェクション・CORS maxAge）のドキュメント整備（ADR 0011 に記録済み）
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -32,16 +32,21 @@ The spec covers all shipped JSON endpoints including health, examples (Note/Tag 
 - [Add rate limiting](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-rate-limiting.md)
 - [Add a second entity](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-second-entity.md)
 - [Add a health check](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-health-check.md)
+- [Add an HTML view](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-html-view.md)
+- [Add MCP tools](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-mcp-tools.md)
 - [Deploy to production](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/deploy-production.md)
 
 ## Key source files
 
 - [`src/Http/RuntimeApplicationFactory.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Http/RuntimeApplicationFactory.php): Main entry point — wires the full PSR-15 middleware stack and router.
-- [`src/Auth/BearerTokenMiddleware.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Auth/BearerTokenMiddleware.php): JWT Bearer authentication middleware with allowlist / blocklist path options.
+- [`src/Auth/BearerTokenMiddleware.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Auth/BearerTokenMiddleware.php): JWT Bearer authentication middleware with allowlist / blocklist / prefix path options.
+- [`src/Auth/CompositeAuthMiddleware.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Auth/CompositeAuthMiddleware.php): Chains multiple auth middlewares — enables three-tier access models (public / Bearer / API key).
 - [`src/Auth/TokenVerifierInterface.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Auth/TokenVerifierInterface.php): Stable interface for JWT verification.
 - [`src/Auth/TokenIssuerInterface.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Auth/TokenIssuerInterface.php): Stable interface for JWT issuance.
-- [`src/Error/ErrorHandlerMiddleware.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Error/ErrorHandlerMiddleware.php): RFC 9457 Problem Details error handling.
+- [`src/Error/ErrorHandlerMiddleware.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Error/ErrorHandlerMiddleware.php): RFC 9457 Problem Details error handling with structured PSR-3 logging.
 - [`src/Routing/Router.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Routing/Router.php): Explicit route table — no magic annotation scanning.
+- [`src/View/HtmlResponseFactory.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/View/HtmlResponseFactory.php): Renders PHP templates into PSR-7 HTML responses.
+- [`src/View/NativePhpViewRenderer.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/View/NativePhpViewRenderer.php): Native PHP template renderer — no external template engine dependency.
 - [`src/Mcp/LocalMcpServer.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Mcp/LocalMcpServer.php): Local MCP server backed by the OpenAPI contract.
 - [`src/Example/`](https://github.com/hideyukiMORI/NENE2/tree/main/src/Example/): Reference Note/Tag CRUD implementation — canonical patterns for routes, use cases, repositories.
 
@@ -51,6 +56,13 @@ AI-autonomously built applications using NENE2 as a Composer dependency, with re
 
 - [FT10 — hoplog (craft beer tasting notes API)](https://github.com/hideyukiMORI/hoplog): 3 domains, 15 routes, 9 friction points → resolved in v1.4.
 - [FT11 — tasklog (JWT-authenticated task API)](https://github.com/hideyukiMORI/tasklog): 2 domains, 7 routes, 4 friction points → resolved in v1.4.1+.
+- [FT12-A — tagmark (bookmark + M:N tag API)](https://github.com/hideyukiMORI/tagmark): 3 entities, 13 endpoints, 7 friction points → resolved in v1.4.1+.
+- [FT12-B — knowledgelog (knowledge base + MCP tools)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-12b.md): 8 endpoints, 7 MCP tools, 5 friction points → resolved in v1.4.2+.
+- [FT12-C — shoplog (three-tier access model)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-12c.md): 12 endpoints, 6 friction points → resolved in v1.4.2+.
+- [FT13 — eventlog (MySQL + Phinx migrations)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-13.md): 10 endpoints, 5 friction points → resolved in v1.4.2+.
+- [FT14 — postboard (CompositeAuthMiddleware + M:N)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-14.md): 13 endpoints, 4 friction points → resolved in v1.4.2+.
+- [FT15 — noteboard (HTML View layer)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-15.md): 7 endpoints (HTML + JSON coexist), 3 friction points → resolved in v1.5.0.
+- [FT16 — noteboard (MCP tool layer)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-16.md): 3 MCP tools (2 read + 1 write), no friction — `add-mcp-tools.md` howto validated end-to-end.
 
 ## Design principles
 


### PR DESCRIPTION
## Summary

v1.5.0 リリース後のドキュメント整備。

- **`llms.txt`**: FT12-A〜FT16 の 5 本のフィールドトライアルを追記、`add-html-view.md`・`add-mcp-tools.md` howto を追加、`CompositeAuthMiddleware`・`HtmlResponseFactory`・`NativePhpViewRenderer` を Key source files に追加
- **`README.md`**: Current Capabilities に HTML View・CompositeAuthMiddleware・API-key method filter を追記、How-to guides セクションを新設（10件）
- **`docs/howto/add-jwt-authentication.md`**: `BearerTokenMiddleware` の `$protectedPathPrefixes`（prefix allowlist）説明とコード例を Step 4 に追加
- **`docs/todo/current.md`**: 最新リリースを v1.5.0 に更新
- **`docs/adr/0011-security-review-policy.md`**: adversarial review 方針・HTTP セキュリティ不変条件・v1.5.0 セキュリティ修正の決定記録を新規作成
- **`docs/adr/index.md`**: ADR 0011 を索引に追加

## Test plan

- [x] `composer check` — 291 tests, PHPStan OK, CS OK, version 1.5.0 consistent
- [x] 各ファイルのリンク整合性を目視確認

Closes #536

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)