### PR TITLE
feat(http): RuntimeApplicationFactory に machineApiKeyProtectedMethods・machineApiKeyProtectedPathPrefixes を追加 (#540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `RuntimeApplicationFactory::$machineApiKeyProtectedPathPrefixes` — exposes `ApiKeyAuthenticationMiddleware::$protectedPathPrefixes` through the factory; protects paths starting with any listed prefix without enumerating each route individually (#540)
+- `RuntimeApplicationFactory::$machineApiKeyProtectedMethods` — exposes `ApiKeyAuthenticationMiddleware::$protectedMethods` through the factory; enables "public read / key-gated write" patterns (e.g. GET is open, POST/PUT/DELETE require the API key) without manual middleware construction (#540)
+
 ---
 
 ## [1.5.0] — 2026-05-20

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -60,6 +60,15 @@ final readonly class RuntimeApplicationFactory
      *                                                   mode). Defaults to `['/machine/health']`. Set to `[]`
      *                                                   combined with `$machineApiKeyExcludedPaths` to protect
      *                                                   all paths except the excluded ones.
+     * @param list<string> $machineApiKeyProtectedPathPrefixes Path prefixes protected by the machine API key
+     *                                                          (e.g. `['/admin/']` matches `/admin/users/42`).
+     *                                                          Evaluated only when `$machineApiKeyProtectedPaths`
+     *                                                          is empty.
+     * @param list<string> $machineApiKeyProtectedMethods HTTP methods that require the machine API key
+     *                                                     (uppercase, e.g. `['POST', 'PUT', 'DELETE']`).
+     *                                                     When non-empty, GET/HEAD requests pass through
+     *                                                     without a key even on protected paths. Useful for
+     *                                                     "public read / key-gated write" patterns.
      * @param bool $debug When true, unhandled exception messages are exposed in 500 `detail`.
      *                    Never set to true in production.
      */
@@ -78,6 +87,8 @@ final readonly class RuntimeApplicationFactory
         private array $allowedOrigins = [],
         private array $machineApiKeyExcludedPaths = [],
         private array $machineApiKeyProtectedPaths = ['/machine/health'],
+        private array $machineApiKeyProtectedPathPrefixes = [],
+        private array $machineApiKeyProtectedMethods = [],
     ) {
     }
 
@@ -182,7 +193,9 @@ final readonly class RuntimeApplicationFactory
                 $problemDetails,
                 $this->machineApiKey,
                 $this->machineApiKeyProtectedPaths,
-                excludedPaths: $this->machineApiKeyExcludedPaths,
+                excludedPaths:          $this->machineApiKeyExcludedPaths,
+                protectedPathPrefixes:  $this->machineApiKeyProtectedPathPrefixes,
+                protectedMethods:       $this->machineApiKeyProtectedMethods,
             ),
         ];
 

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -310,6 +310,66 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
     }
 
+    public function testMachineApiKeyProtectedMethodsAllowsGetWithoutKey(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            machineApiKey:                      'test-key',
+            machineApiKeyProtectedPaths:         [],
+            machineApiKeyProtectedPathPrefixes:  ['/machine/'],
+            machineApiKeyProtectedMethods:       ['POST', 'PUT', 'DELETE'],
+        ))->create();
+
+        $response = $application->handle(
+            $factory->createServerRequest('GET', 'https://example.test/machine/health'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testMachineApiKeyProtectedMethodsBlocksPostWithoutKey(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            machineApiKey:                      'test-key',
+            machineApiKeyProtectedPaths:         [],
+            machineApiKeyProtectedPathPrefixes:  ['/machine/'],
+            machineApiKeyProtectedMethods:       ['POST', 'PUT', 'DELETE'],
+        ))->create();
+
+        $response = $application->handle(
+            $factory->createServerRequest('POST', 'https://example.test/machine/health'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('https://nene2.dev/problems/unauthorized', $payload['type']);
+    }
+
+    public function testMachineApiKeyProtectedPathPrefixesProtectsDynamicPath(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            machineApiKey:                      'test-key',
+            machineApiKeyProtectedPaths:         [],
+            machineApiKeyProtectedPathPrefixes:  ['/machine/'],
+        ))->create();
+
+        $response = $application->handle(
+            $factory->createServerRequest('GET', 'https://example.test/machine/health'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('https://nene2.dev/problems/unauthorized', $payload['type']);
+    }
+
     /**
      * @return array<string, mixed>
      */


### PR DESCRIPTION
## Summary

FT17（quotelog）F-1 対応。`ApiKeyAuthenticationMiddleware` の `$protectedMethods` と `$protectedPathPrefixes` を `RuntimeApplicationFactory` から直接指定できるようにする。

## Before / After

**Before（手動構築が必要）:**
```php
$apiKeyMiddleware = new ApiKeyAuthenticationMiddleware(
    $problems,
    $machineApiKey,
    protectedPathPrefixes: ['/quotes'],
    protectedMethods:      ['POST', 'PUT', 'DELETE'],
);
$app = (new RuntimeApplicationFactory(..., authMiddleware: $apiKeyMiddleware))->create();
// ↑ $authMiddleware はセマンティック的に Bearer 用で紛らわしい
```

**After（factory から直接指定）:**
```php
$app = (new RuntimeApplicationFactory(
    ...,
    machineApiKeyProtectedPathPrefixes: ['/quotes'],
    machineApiKeyProtectedMethods:      ['POST', 'PUT', 'DELETE'],
))->create();
```

## Changes

- `src/Http/RuntimeApplicationFactory.php` — `$machineApiKeyProtectedPathPrefixes`・`$machineApiKeyProtectedMethods` を追加、PHPDoc 追記、`ApiKeyAuthenticationMiddleware` 構築時に転送
- `tests/HttpRuntimeTest.php` — method filter・prefix の統合テスト 3 本追加（291→294）
- `CHANGELOG.md` — `[Unreleased]` に追記

## Test plan

- [x] `composer check` — 294 tests, 784 assertions, PHPStan OK, CS OK

Closes #540

Self-review: backend-api, middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)