### PR TITLE
docs(quality-tools): PHP-CS-Fixer risky fixer の設定方法を追記 (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `docs/development/quality-tools.md`: "PHP-CS-Fixer Risky Fixers in Consumer Projects" section — explains `setRiskyAllowed(true)` and `--allow-risky=yes` required when using `declare_strict_types` and other risky rules in consumer projects (#542)
 - `RuntimeApplicationFactory::$machineApiKeyProtectedPathPrefixes` — exposes `ApiKeyAuthenticationMiddleware::$protectedPathPrefixes` through the factory; protects paths starting with any listed prefix without enumerating each route individually (#540)
 - `RuntimeApplicationFactory::$machineApiKeyProtectedMethods` — exposes `ApiKeyAuthenticationMiddleware::$protectedMethods` through the factory; enables "public read / key-gated write" patterns (e.g. GET is open, POST/PUT/DELETE require the API key) without manual middleware construction (#540)
 

--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -136,6 +136,50 @@ Pass `--memory-limit 512M` directly in your `composer.json` analyse script:
 The `512M` figure is sufficient for most NENE2 consumer projects up to ~200 source files.
 Larger projects may need `1G`. Avoid setting an unlimited value (`-1`) in shared environments.
 
+## PHP-CS-Fixer Risky Fixers in Consumer Projects
+
+Some PHP-CS-Fixer rules are classified as **risky** because they change code behaviour in
+edge cases (e.g. `declare_strict_types` adds strict type declarations, which affects how PHP
+coerces arguments). They are disabled by default and must be explicitly opted in.
+
+If your `.php-cs-fixer.php` uses any risky rule and you run the fixer without `--allow-risky=yes`,
+PHP-CS-Fixer exits with an error:
+
+```
+The rules contain risky fixers ("declare_strict_types"), but they are not allowed to run.
+Perhaps you forget to use --allow-risky=yes option?
+```
+
+### Fix: enable in the config file
+
+Add `->setRiskyAllowed(true)` to your `.php-cs-fixer.php`:
+
+```php
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)   // ← required when any risky rule is enabled
+    ->setRules([
+        '@PSR12'             => true,
+        'declare_strict_types' => true,  // risky — needs setRiskyAllowed(true)
+        // …
+    ])
+    ->setFinder($finder);
+```
+
+### Fix: add the flag to composer scripts
+
+```json
+{
+    "scripts": {
+        "cs":     "php-cs-fixer fix --dry-run --diff --allow-risky=yes",
+        "cs:fix": "php-cs-fixer fix --allow-risky=yes"
+    }
+}
+```
+
+Both changes are needed: `setRiskyAllowed(true)` tells the config object that risky rules are
+intentional; `--allow-risky=yes` tells the CLI to honour them. Omitting either one causes the
+error above.
+
 ## Non-Goals
 
 - Forcing React on framework consumers.


### PR DESCRIPTION
## Summary

FT17（quotelog）F-2 対応。`declare_strict_types` など risky fixer を使う consumer project 向けに `quality-tools.md` へ設定手順を追加。

## 追加内容

`docs/development/quality-tools.md` に **"PHP-CS-Fixer Risky Fixers in Consumer Projects"** セクションを新設:

- `setRiskyAllowed(true)` を `.php-cs-fixer.php` に追加する方法
- `--allow-risky=yes` を composer scripts の `cs` / `cs:fix` に追加する方法
- エラーメッセージの引用（"The rules contain risky fixers..."）

## Test plan

- [x] `composer check` — 294 tests, PHPStan OK, CS OK

Closes #542

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)