### PR TITLE
chore(release): v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.5.1] — 2026-05-20
+
 ### Added
-- `docs/development/quality-tools.md`: "PHP-CS-Fixer Risky Fixers in Consumer Projects" section — explains `setRiskyAllowed(true)` and `--allow-risky=yes` required when using `declare_strict_types` and other risky rules in consumer projects (#542)
 - `RuntimeApplicationFactory::$machineApiKeyProtectedPathPrefixes` — exposes `ApiKeyAuthenticationMiddleware::$protectedPathPrefixes` through the factory; protects paths starting with any listed prefix without enumerating each route individually (#540)
 - `RuntimeApplicationFactory::$machineApiKeyProtectedMethods` — exposes `ApiKeyAuthenticationMiddleware::$protectedMethods` through the factory; enables "public read / key-gated write" patterns (e.g. GET is open, POST/PUT/DELETE require the API key) without manual middleware construction (#540)
+- `docs/development/quality-tools.md`: "PHP-CS-Fixer Risky Fixers in Consumer Projects" section — explains `setRiskyAllowed(true)` and `--allow-risky=yes` required when using `declare_strict_types` and other risky rules in consumer projects (#542)
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.0
+  version: 1.5.1
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.0';
+    public const string VERSION = '1.5.1';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

FT17 フォローアップ 2 件を v1.5.1 としてリリース。

### Added
- `RuntimeApplicationFactory::$machineApiKeyProtectedPathPrefixes` — `ApiKeyAuthenticationMiddleware::$protectedPathPrefixes` を factory 経由で設定可能に (#540)
- `RuntimeApplicationFactory::$machineApiKeyProtectedMethods` — `ApiKeyAuthenticationMiddleware::$protectedMethods` を factory 経由で設定可能に。GET はパブリック・POST/DELETE は API key 必須のパターンが手動構築不要で実現できる (#540)
- `docs/development/quality-tools.md`: PHP-CS-Fixer risky fixer 設定方法を追記 (#542)

## Test plan

- [x] `composer check` — 294 tests, PHPStan OK, CS OK, Version consistency OK: 1.5.1

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)