### PR TITLE
fix: ApiKeyAuthenticationMiddleware union 評価 + requestMaxBodyBytes パラメータ追加 (FT18 F-2・F-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.2] — 2026-05-20
+
+### Added
+- `RuntimeApplicationFactory::$requestMaxBodyBytes` — configures the request body size limit passed to `RequestSizeLimitMiddleware`. Defaults to 1 MiB (1 048 576 bytes). Increase for bulk-import or large-payload endpoints. (#547)
+
+### Fixed
+- `ApiKeyAuthenticationMiddleware`: `$protectedPaths` and `$protectedPathPrefixes` are now evaluated in **union mode** — a path is protected when it matches any exact entry in `$protectedPaths` OR starts with any prefix in `$protectedPathPrefixes`. Previously, a non-empty `$protectedPaths` suppressed all prefix evaluation, causing `$protectedPathPrefixes` to be silently ignored when both were set. (#548)
+
+---
+
 ## [1.5.1] — 2026-05-20
 
 ### Added

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.1
+  version: 1.5.2
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.1';
+    public const string VERSION = '1.5.2';
 
     public function name(): string
     {

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -55,15 +55,14 @@ final readonly class RuntimeApplicationFactory
      *                                                  public while all other routes require an API key.
      *                                                  Only has effect when `$machineApiKey` is non-null and
      *                                                  `$machineApiKeyProtectedPaths` is empty.
-     * @param list<string> $machineApiKeyProtectedPaths Exact paths protected by the machine API key. When
-     *                                                   non-empty, ONLY these paths require the key (allowlist
-     *                                                   mode). Defaults to `['/machine/health']`. Set to `[]`
-     *                                                   combined with `$machineApiKeyExcludedPaths` to protect
-     *                                                   all paths except the excluded ones.
+     * @param list<string> $machineApiKeyProtectedPaths Exact paths protected by the machine API key. Combined with
+     *                                                   `$machineApiKeyProtectedPathPrefixes` in union mode — a path
+     *                                                   is protected when it matches any exact entry OR any prefix.
+     *                                                   Defaults to `['/machine/health']`.
      * @param list<string> $machineApiKeyProtectedPathPrefixes Path prefixes protected by the machine API key
      *                                                          (e.g. `['/admin/']` matches `/admin/users/42`).
-     *                                                          Evaluated only when `$machineApiKeyProtectedPaths`
-     *                                                          is empty.
+     *                                                          Combined with `$machineApiKeyProtectedPaths` in union
+     *                                                          mode.
      * @param list<string> $machineApiKeyProtectedMethods HTTP methods that require the machine API key
      *                                                     (uppercase, e.g. `['POST', 'PUT', 'DELETE']`).
      *                                                     When non-empty, GET/HEAD requests pass through
@@ -71,6 +70,10 @@ final readonly class RuntimeApplicationFactory
      *                                                     "public read / key-gated write" patterns.
      * @param bool $debug When true, unhandled exception messages are exposed in 500 `detail`.
      *                    Never set to true in production.
+     * @param int $requestMaxBodyBytes Maximum allowed request body size in bytes. Requests exceeding
+     *                                 this limit are rejected with a 413 Problem Details response.
+     *                                 Defaults to 1 MiB (1 048 576 bytes). Increase for bulk-import
+     *                                 or large-payload endpoints.
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
@@ -89,6 +92,7 @@ final readonly class RuntimeApplicationFactory
         private array $machineApiKeyProtectedPaths = ['/machine/health'],
         private array $machineApiKeyProtectedPathPrefixes = [],
         private array $machineApiKeyProtectedMethods = [],
+        private int $requestMaxBodyBytes = 1_048_576,
     ) {
     }
 
@@ -188,7 +192,7 @@ final readonly class RuntimeApplicationFactory
             new SecurityHeadersMiddleware(),
             new CorsMiddleware($this->responseFactory, $this->allowedOrigins),
             new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers, $this->debug, $logger),
-            new RequestSizeLimitMiddleware($problemDetails),
+            new RequestSizeLimitMiddleware($problemDetails, $this->requestMaxBodyBytes),
             new ApiKeyAuthenticationMiddleware(
                 $problemDetails,
                 $this->machineApiKey,

--- a/src/Middleware/ApiKeyAuthenticationMiddleware.php
+++ b/src/Middleware/ApiKeyAuthenticationMiddleware.php
@@ -14,14 +14,15 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Validates the `X-NENE2-API-Key` request header for machine client endpoints.
  * Returns 401 Problem Details when the key is absent or does not match `NENE2_MACHINE_API_KEY`.
  *
- * Path matching modes (evaluated in priority order — first match wins):
+ * Path matching modes:
  *
  * 0. **Exclude list** (`$excludedPaths`): paths that are always public regardless of other settings.
  *    Useful with "protect all" mode: pass `excludedPaths: ['/health', '/']` to keep those open.
- * 1. **Allowlist** (`$protectedPaths`): only the listed exact paths are protected.
- * 2. **Prefix allowlist** (`$protectedPathPrefixes`): paths starting with any listed prefix are protected.
- *    Useful for dynamic routes such as `/admin/users/42` → prefix `/admin/`.
- * 3. **Protect all** (default): both arrays empty → every path requires an API key.
+ * 1. **Allowlist** (`$protectedPaths` + `$protectedPathPrefixes`, union): when either or both are
+ *    non-empty, a request is protected if its path matches any entry in `$protectedPaths` (exact)
+ *    OR starts with any entry in `$protectedPathPrefixes` (prefix). Both lists are evaluated
+ *    together — setting one does not suppress the other.
+ * 2. **Protect all** (default): both lists empty → every path requires an API key.
  *
  * In all modes, `OPTIONS` requests are always skipped (CORS preflight).
  *
@@ -34,9 +35,10 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ApiKeyAuthenticationMiddleware implements MiddlewareInterface
 {
     /**
-     * @param list<string> $protectedPaths        Exact paths to protect. Takes precedence over $protectedPathPrefixes.
+     * @param list<string> $protectedPaths        Exact paths to protect. Combined with $protectedPathPrefixes
+     *                                             in union mode — both lists are checked and either can match.
      * @param list<string> $protectedPathPrefixes  Path prefixes to protect (e.g. `/admin/` matches `/admin/users/42`).
-     *                                             Evaluated only when $protectedPaths is empty.
+     *                                             Combined with $protectedPaths in union mode.
      * @param list<string> $protectedMethods       HTTP methods to protect (uppercase). When non-empty, only requests
      *                                             whose method appears here are protected. Useful to allow GET while
      *                                             requiring an API key for POST/PUT/DELETE. OPTIONS is always excluded.
@@ -92,11 +94,13 @@ final readonly class ApiKeyAuthenticationMiddleware implements MiddlewareInterfa
             return false;
         }
 
-        if ($this->protectedPaths !== []) {
-            return in_array($path, $this->protectedPaths, true);
-        }
+        // Union mode: when either list is non-empty, protect if path matches any exact entry
+        // OR starts with any prefix. Both lists are evaluated together.
+        if ($this->protectedPaths !== [] || $this->protectedPathPrefixes !== []) {
+            if (in_array($path, $this->protectedPaths, true)) {
+                return true;
+            }
 
-        if ($this->protectedPathPrefixes !== []) {
             foreach ($this->protectedPathPrefixes as $prefix) {
                 if (str_starts_with($path, $prefix)) {
                     return true;

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -370,6 +370,63 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame('https://nene2.dev/problems/unauthorized', $payload['type']);
     }
 
+    public function testRequestMaxBodyBytesOverridesDefaultLimit(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            requestMaxBodyBytes: 10,
+        ))->create();
+
+        $response = $application->handle(
+            $factory
+                ->createServerRequest('POST', 'https://example.test/')
+                ->withHeader('Content-Length', '11'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(413, $response->getStatusCode());
+        self::assertSame('https://nene2.dev/problems/payload-too-large', $payload['type']);
+        self::assertSame(10, $payload['max_body_bytes']);
+    }
+
+    public function testUnionPathAndPrefixProtectionWithoutExplicitPathsClear(): void
+    {
+        // F-2 fix: protectedPaths=['/machine/health'] (default) + protectedPathPrefixes=['/products']
+        // Both lists are non-empty → union mode → /products prefix is protected without needing to
+        // clear machineApiKeyProtectedPaths first.
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            machineApiKey: 'test-key',
+            machineApiKeyProtectedPathPrefixes: ['/products'],
+            machineApiKeyProtectedMethods: ['POST'],
+        ))->create();
+
+        // POST /products → method + prefix match → protected
+        $postProducts = $application->handle(
+            $factory->createServerRequest('POST', 'https://example.test/products'),
+        );
+        self::assertSame(401, $postProducts->getStatusCode());
+
+        // POST /machine/health → method + exact path match (from default protectedPaths) → protected
+        // Key provided → middleware passes → router returns 405 (GET-only route), not 401
+        $postMachineHealth = $application->handle(
+            $factory
+                ->createServerRequest('POST', 'https://example.test/machine/health')
+                ->withHeader('X-NENE2-API-Key', 'test-key'),
+        );
+        self::assertSame(405, $postMachineHealth->getStatusCode()); // middleware passed, router rejected method
+
+        // POST /orders → method filter passes, no path/prefix match → not protected
+        $postOrders = $application->handle(
+            $factory->createServerRequest('POST', 'https://example.test/orders'),
+        );
+        self::assertSame(404, $postOrders->getStatusCode()); // route not registered, but not 401
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Middleware/ApiKeyAuthenticationMiddlewareTest.php
+++ b/tests/Middleware/ApiKeyAuthenticationMiddlewareTest.php
@@ -76,15 +76,61 @@ final class ApiKeyAuthenticationMiddlewareTest extends TestCase
         self::assertSame(200, $mw->process($request, $this->okHandler($factory))->getStatusCode());
     }
 
-    public function testProtectedPathsTakesPrecedenceOverPrefixes(): void
+    public function testPathsAndPrefixesAreEvaluatedAsUnion(): void
     {
         $factory = new Psr17Factory();
-        // /admin is in protectedPaths → exact match only; /admin/users is not in protectedPaths → pass through
+        // Both lists are non-empty — a path is protected if it matches either.
         $mw = $this->make($factory, protectedPaths: ['/admin'], protectedPathPrefixes: ['/admin/']);
-        $request = $factory->createServerRequest('GET', 'https://example.test/admin/users');
 
-        // protectedPaths mode: /admin/users not in list → passes through
+        // /admin matches protectedPaths exactly → protected
+        $exactRequest = $factory->createServerRequest('POST', 'https://example.test/admin');
+        self::assertSame(401, $mw->process($exactRequest, $this->okHandler($factory))->getStatusCode());
+
+        // /admin/users matches protectedPathPrefixes → protected (union, not priority)
+        $subRequest = $factory->createServerRequest('GET', 'https://example.test/admin/users');
+        self::assertSame(401, $mw->process($subRequest, $this->okHandler($factory))->getStatusCode());
+    }
+
+    public function testUnionModeDoesNotProtectUnmatchedPaths(): void
+    {
+        $factory = new Psr17Factory();
+        $mw = $this->make($factory, protectedPaths: ['/machine/health'], protectedPathPrefixes: ['/products']);
+
+        // /orders matches neither list → passes through even when both lists are non-empty
+        $request = $factory->createServerRequest('POST', 'https://example.test/orders');
         self::assertSame(200, $mw->process($request, $this->okHandler($factory))->getStatusCode());
+    }
+
+    public function testUnionModeCombinesExactAndPrefixProtection(): void
+    {
+        $factory = new Psr17Factory();
+        // FT18 scenario: protect /machine/health (exact) + /products/* (prefix) for POST only
+        $mw = $this->make(
+            $factory,
+            protectedPaths: ['/machine/health'],
+            protectedPathPrefixes: ['/products'],
+            protectedMethods: ['POST', 'PUT', 'DELETE'],
+        );
+
+        // GET /products → method filter → not protected
+        $getRequest = $factory->createServerRequest('GET', 'https://example.test/products');
+        self::assertSame(200, $mw->process($getRequest, $this->okHandler($factory))->getStatusCode());
+
+        // POST /products → method + prefix match → protected
+        $postRequest = $factory->createServerRequest('POST', 'https://example.test/products');
+        self::assertSame(401, $mw->process($postRequest, $this->okHandler($factory))->getStatusCode());
+
+        // POST /products/bulk → method + prefix match → protected
+        $bulkRequest = $factory->createServerRequest('POST', 'https://example.test/products/bulk');
+        self::assertSame(401, $mw->process($bulkRequest, $this->okHandler($factory))->getStatusCode());
+
+        // POST /orders → method passes, but no path/prefix match → not protected
+        $ordersRequest = $factory->createServerRequest('POST', 'https://example.test/orders');
+        self::assertSame(200, $mw->process($ordersRequest, $this->okHandler($factory))->getStatusCode());
+
+        // POST /machine/health → method + exact path match → protected
+        $machineRequest = $factory->createServerRequest('POST', 'https://example.test/machine/health');
+        self::assertSame(401, $mw->process($machineRequest, $this->okHandler($factory))->getStatusCode());
     }
 
     // --- protectedMethods ---


### PR DESCRIPTION
## Summary

FT18 (orderlog) で発見した 2 件の摩擦に対応。

### F-2: ApiKeyAuthenticationMiddleware union 評価 (#548)

`protectedPaths` と `protectedPathPrefixes` を **union mode** で評価するよう変更。
両リストが非空の場合、いずれかにマッチすれば保護対象となる。

**従来の動作（priority mode）**: `protectedPaths` が非空のとき `protectedPathPrefixes` を無視
**新しい動作（union mode）**: 両リストを同時評価、どちらにもマッチしなければスルー

```php
// 修正前: machineApiKeyProtectedPaths: [] を明示しないと prefix が効かない
// 修正後: デフォルト ['/machine/health'] が残ったままでも prefix が正しく機能する
(new RuntimeApplicationFactory($psr17, $psr17,
    machineApiKey: 'key',
    machineApiKeyProtectedPathPrefixes: ['/products'],
    machineApiKeyProtectedMethods: ['POST'],
))->create();
```

### F-3: requestMaxBodyBytes パラメータ追加 (#547)

`RuntimeApplicationFactory` に `requestMaxBodyBytes` パラメータを追加。
`RequestSizeLimitMiddleware` の上限をコンストラクタから変更可能に（デフォルト: 1 MiB）。

```php
(new RuntimeApplicationFactory($psr17, $psr17,
    requestMaxBodyBytes: 10_485_760,  // 10 MiB
))->create();
```

## Test plan

- [x] `composer test` — 298 tests / 798 assertions（+4 新規テスト）
- [x] `composer analyse` — PHPStan level 8 エラーなし
- [x] `composer cs` — CS クリーン
- [x] `composer openapi` + `composer mcp` — バリデーション OK
- [x] Version consistency: 1.5.1 → 1.5.2

Closes #547
Closes #548

Self-review: backend-api, middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)