### PR TITLE
docs(howto): use-transactions.md — トランザクション内リポジトリパターン (FT18 F-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `docs/howto/use-transactions.md` — explains the transactional repository pattern: why `transactional()` provides a fresh executor, how to instantiate concrete repositories inside the callback, how to test with a file-based SQLite, and rollback verification. (#549)
+
 ---
 
 ## [1.5.2] — 2026-05-20

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Step-by-step recipes for common tasks:
 
 - [Add a custom route](docs/howto/add-custom-route.md)
 - [Add a database-backed endpoint](docs/howto/add-database-endpoint.md)
+- [Use database transactions](docs/howto/use-transactions.md)
 - [Add a second entity](docs/howto/add-second-entity.md)
 - [Add pagination](docs/howto/add-pagination.md)
 - [Add JWT authentication](docs/howto/add-jwt-authentication.md)

--- a/docs/howto/use-transactions.md
+++ b/docs/howto/use-transactions.md
@@ -1,0 +1,188 @@
+# Use Database Transactions
+
+This guide explains how to perform atomic multi-step operations using
+`DatabaseTransactionManagerInterface` in NENE2.
+
+**Prerequisite**: You have a repository backed by `DatabaseQueryExecutorInterface`.
+If not, start with [Add a database-backed endpoint](./add-database-endpoint.md).
+
+---
+
+## Why transactions in NENE2
+
+`DatabaseTransactionManagerInterface` wraps multiple SQL statements in a single transaction:
+either all succeed (commit) or all are rolled back on any `Throwable`.
+
+The interface has one method:
+
+```php
+public function transactional(callable $callback): mixed;
+```
+
+The callback receives a **fresh** `DatabaseQueryExecutorInterface` bound to the open
+transaction. **This executor is different from the one you inject at construction time.**
+
+---
+
+## The transactional repository pattern
+
+Because the callback provides its own executor, you cannot safely reuse repositories that were
+injected at construction time — they would execute queries on a separate connection that sits
+outside the transaction.
+
+The solution: **instantiate repository classes inside the callback** using the executor the
+callback provides.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Order;
+
+use MyApp\Product\ProductNotFoundException;
+use MyApp\Product\SqliteProductRepository;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+
+final class CreateOrderUseCase
+{
+    public function __construct(
+        private readonly DatabaseTransactionManagerInterface $transactionManager,
+    ) {}
+
+    public function execute(int $productId, int $qty): Order
+    {
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($productId, $qty): Order {
+                // Must instantiate concrete classes here — the $tx executor is bound to
+                // this transaction's connection. Injected instances use a different executor.
+                $products = new SqliteProductRepository($tx);
+                $orders   = new SqliteOrderRepository($tx);
+
+                $product = $products->findById($productId)
+                    ?? throw new ProductNotFoundException($productId);
+
+                $products->decrementStock($productId, $qty);
+
+                return $orders->save($product->price * $qty, [
+                    new OrderItem($productId, $qty, $product->price),
+                ]);
+            },
+        );
+    }
+}
+```
+
+### Why not reuse injected repositories?
+
+`PdoDatabaseTransactionManager::transactional()` opens a **new connection** via
+`DatabaseConnectionFactoryInterface::create()` and begins a transaction on it.
+The callback's executor is bound to that specific connection.
+
+An injected `SqliteProductRepository` holds a separate `PdoDatabaseQueryExecutor` that
+lazily opens its own connection on first use. Queries through the injected repository
+run on that other connection — outside the transaction — so a rollback will not undo
+them, and an insert through the injected repository may not see uncommitted rows from
+the callback.
+
+---
+
+## Wire it up in your front controller
+
+You need two separate objects:
+
+| Object | Purpose |
+|---|---|
+| `PdoDatabaseQueryExecutor` | Non-transactional reads (e.g. `GET /products`) |
+| `PdoDatabaseTransactionManager` | Wraps multi-step writes in a transaction |
+
+Both share the same `PdoConnectionFactory`:
+
+```php
+$connectionFactory = new PdoConnectionFactory($dbConfig);
+
+$executor  = new PdoDatabaseQueryExecutor($connectionFactory);  // for read repositories
+$txManager = new PdoDatabaseTransactionManager($connectionFactory); // for use cases
+
+$products = new SqliteProductRepository($executor);  // used by GET /products
+$createOrder = new CreateOrderUseCase($txManager);   // uses $tx internally
+```
+
+---
+
+## Test with a file-based SQLite database
+
+In-memory SQLite (`sqlite::memory:`) creates a **separate database per connection**, so
+`PdoDatabaseTransactionManager` (which opens a new connection per `transactional()` call)
+would not see rows written by the `PdoDatabaseQueryExecutor` and vice versa.
+
+Use a **temp file** instead:
+
+```php
+protected function setUp(): void
+{
+    $this->dbFile = sys_get_temp_dir() . '/test-' . bin2hex(random_bytes(8)) . '.sqlite';
+    $pdo = new \PDO('sqlite:' . $this->dbFile, options: [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+    $pdo->exec(file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+}
+
+protected function tearDown(): void
+{
+    if (is_file($this->dbFile)) {
+        unlink($this->dbFile);
+    }
+}
+
+private function dbConfig(): DatabaseConfig
+{
+    return new DatabaseConfig(
+        url: null, environment: 'test', adapter: 'sqlite',
+        host: 'localhost', port: 1, name: $this->dbFile,
+        user: 'myapp', password: '', charset: 'utf8',
+    );
+}
+```
+
+Each test gets a fresh file, both `PdoDatabaseQueryExecutor` and
+`PdoDatabaseTransactionManager` connect to the same file, and `tearDown` deletes it.
+
+---
+
+## Verifying rollback behaviour
+
+Test that a failure mid-transaction undoes all preceding changes:
+
+```php
+public function testTransactionRollsBackOnDomainException(): void
+{
+    // seed two products
+    // ...
+
+    // Order that will fail on the second product (insufficient stock)
+    $response = $this->request('POST', '/orders', [
+        'items' => [
+            ['product_id' => $p1Id, 'qty' => 3],   // would succeed
+            ['product_id' => $p2Id, 'qty' => 99],  // will fail
+        ],
+    ]);
+
+    self::assertSame(409, $response->getStatusCode());
+
+    // Stock of product 1 must be unchanged — transaction was rolled back
+    $products = $this->json($this->request('GET', '/products'))['items'];
+    self::assertSame($originalStock1, $products[0]['stock']);
+}
+```
+
+---
+
+## Future direction
+
+The current pattern requires instantiating concrete repository classes inside the
+callback, which means the use case knows about the repository implementation
+(`SqliteProductRepository`) rather than its interface. This is a known limitation.
+
+A `RepositoryFactory` abstraction — an interface accepted by use cases that can produce
+a repository for a given executor — would restore full interface-only dependency.
+This is tracked for consideration in a future NENE2 version.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -108,15 +108,17 @@ FT12-A / FT12-B / FT12-C / FT13 のすべてが完了。主要成果:
 
 - **FT18 / #545**: orderlog（在庫管理付き注文 API）による v1.5.1 実地検証。トランザクション・バルク操作・パス×メソッドのアクセス制御を対象。15/15 テスト通過・PHPStan level 8・CS 全通過。摩擦 3 件記録（F-1: トランザクション内 DI・F-2: protectedPaths デフォルト競合・F-3: RequestSizeLimit 設定不可）。
 
-## 未解消 FT18 摩擦（要 Issue）
+## FT18 摩擦対応（完了）
 
-- **F-1（高）**: トランザクション内でリポジトリの DI インスタンスを再利用できない → `RepositoryFactory` 抽象またはコネクション共有の検討が必要
-- **F-2（中）**: `RuntimeApplicationFactory` の `machineApiKeyProtectedPaths` デフォルト `['/machine/health']` がプレフィックス保護と競合
-- **F-3（低）**: `RequestSizeLimitMiddleware` 上限が `RuntimeApplicationFactory` で設定不可
+| # | 重要度 | 対応 | PR |
+|---|---|---|---|
+| F-1（高）| トランザクション内 DI 制約 | `docs/howto/use-transactions.md` 新規作成 | #551 |
+| F-2（中）| protectedPaths デフォルト競合 | ApiKeyAuthenticationMiddleware union 評価に変更 | #550 |
+| F-3（低）| RequestSizeLimit 設定不可 | RuntimeApplicationFactory に requestMaxBodyBytes 追加 | #550 |
 
 ## 次のアクション候補
 
-- FT18 摩擦 → 新 Issue 起票（F-1 優先）
+- v1.5.2 リリース（F-2・F-3 修正を含む）
 - 追加フィールドトライアル — 新テーマで品質を継続検証
 - v1.5.x パッチ — セキュリティ修正（Content-Length バイパス・WWW-Authenticate インジェクション・CORS maxAge）のドキュメント整備（ADR 0011 に記録済み）
 

--- a/llms.txt
+++ b/llms.txt
@@ -27,6 +27,7 @@ The spec covers all shipped JSON endpoints including health, examples (Note/Tag 
 
 - [Add a custom route](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-custom-route.md)
 - [Add a database-backed endpoint](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-database-endpoint.md)
+- [Use database transactions](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/use-transactions.md)
 - [Add JWT authentication](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-jwt-authentication.md)
 - [Add pagination](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-pagination.md)
 - [Add rate limiting](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/add-rate-limiting.md)


### PR DESCRIPTION
## Summary

FT18 (orderlog) F-1 摩擦への対応。`docs/howto/use-transactions.md` を新規作成。

## 内容

- `transactional()` コールバックが **新規エグゼキュータ** を提供する理由（コネクション分離）
- コールバック内でリポジトリをインスタンス化する正しいパターン（具体コード例付き）
- 注入済みリポジトリを再利用できない理由の説明
- フロントコントローラーでの配線方法（`PdoDatabaseQueryExecutor` + `PdoDatabaseTransactionManager` の使い分け）
- ファイルベース SQLite を使ったテスト手法（in-memory との違い・`tearDown` クリーンアップ）
- ロールバック検証テストのサンプルコード
- 将来の方向性（`RepositoryFactory` 抽象）に関する注記

## Test plan

- [x] `composer check` — 298 tests, PHPStan level 8, CS, OpenAPI, MCP, version OK

Closes #549

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)