### PR TITLE
chore(release): v1.5.2 — FT18 F-1/F-2/F-3 対応まとめ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
-- `docs/howto/use-transactions.md` — explains the transactional repository pattern: why `transactional()` provides a fresh executor, how to instantiate concrete repositories inside the callback, how to test with a file-based SQLite, and rollback verification. (#549)
-
 ---
 
 ## [1.5.2] — 2026-05-20
 
 ### Added
 - `RuntimeApplicationFactory::$requestMaxBodyBytes` — configures the request body size limit passed to `RequestSizeLimitMiddleware`. Defaults to 1 MiB (1 048 576 bytes). Increase for bulk-import or large-payload endpoints. (#547)
+- `docs/howto/use-transactions.md` — explains the transactional repository pattern: why `transactional()` provides a fresh executor, how to instantiate concrete repositories inside the callback, how to test with a file-based SQLite, and rollback verification. (#549)
 
 ### Fixed
 - `ApiKeyAuthenticationMiddleware`: `$protectedPaths` and `$protectedPathPrefixes` are now evaluated in **union mode** — a path is protected when it matches any exact entry in `$protectedPaths` OR starts with any prefix in `$protectedPathPrefixes`. Previously, a non-empty `$protectedPaths` suppressed all prefix evaluation, causing `$protectedPathPrefixes` to be silently ignored when both were set. (#548)

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.1`（2026-05-20 リリース済み）
+- Latest release: `v1.5.2`（2026-05-20 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed
@@ -118,7 +118,6 @@ FT12-A / FT12-B / FT12-C / FT13 のすべてが完了。主要成果:
 
 ## 次のアクション候補
 
-- v1.5.2 リリース（F-2・F-3 修正を含む）
 - 追加フィールドトライアル — 新テーマで品質を継続検証
 - v1.5.x パッチ — セキュリティ修正（Content-Length バイパス・WWW-Authenticate インジェクション・CORS maxAge）のドキュメント整備（ADR 0011 に記録済み）
 


### PR DESCRIPTION
## Summary

FT18 摩擦対応 3 件（PR #550・#551）を v1.5.2 としてリリース。

- CHANGELOG [Unreleased] → [1.5.2] に統合
- `docs/todo/current.md` の最新リリースを v1.5.2 に更新

## 含まれる変更（#550・#551 から）

### Added
- `RuntimeApplicationFactory::$requestMaxBodyBytes` (#547)
- `docs/howto/use-transactions.md` (#549)

### Fixed
- `ApiKeyAuthenticationMiddleware` union 評価 (#548)

Closes #547
Closes #548
Closes #549

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)