### PR TITLE
feat(http): RequestScopedHolder・authMiddleware リスト対応・request-scoped-state howto 追加 (#555 #556 #557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.3] — 2026-05-20
+
+### Added
+- `RequestScopedHolder<T>` (`Nene2\Http\RequestScopedHolder`) — a generic mutable holder for request-scoped values. Inject one shared instance into a middleware (writer) and a route handler or repository (reader) to pass extracted values — tenant ID, decoded claims, trace context — without threading the PSR-7 request object through every layer. Includes `set()`, `get()`, `isSet()`, and `reset()` (for async runtimes). (#555)
+- `RuntimeApplicationFactory::$authMiddleware` now accepts `list<MiddlewareInterface>` in addition to a single `MiddlewareInterface|null`. Pass a list to stack multiple middlewares in sequence (first item runs first) without wrapping them in a composite — e.g. a tenant extractor followed by a JWT verifier. Existing single-middleware callers are unaffected. (#556)
+- `docs/howto/request-scoped-state.md` — explains the holder pattern, when to prefer it over PSR-7 request attributes, how to stack multiple auth middlewares, and the async-runtime caveat (PHP shared-nothing model). (#557)
+
+---
+
 ## [1.5.2] — 2026-05-20
 
 ### Added

--- a/docs/howto/request-scoped-state.md
+++ b/docs/howto/request-scoped-state.md
@@ -1,0 +1,96 @@
+# How to pass request-scoped state between middleware and handlers
+
+Some middlewares extract a value from the incoming request — a tenant ID, a decoded JWT claim, a
+trace context — and route handlers need that value downstream. This guide shows the recommended
+pattern using `RequestScopedHolder`.
+
+## The holder pattern
+
+`RequestScopedHolder<T>` is a small mutable container. Inject **one shared instance** into both
+the middleware that writes it and the handler (or repository) that reads it:
+
+```php
+use Nene2\Http\RequestScopedHolder;
+
+// Shared instance — wired once at the composition root.
+/** @var RequestScopedHolder<int> $teamId */
+$teamId = new RequestScopedHolder();
+
+// Middleware writes it.
+$tenantMiddleware = new TenantMiddleware($teamId, $problemDetails);
+
+// Route handler reads it.
+$routeRegistrar = new TaskRouteRegistrar($repository, $teamId, $json);
+```
+
+Inside the middleware:
+
+```php
+public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+{
+    $raw = $request->getHeaderLine('X-Team-Id');
+    // ... validate ...
+    $this->teamId->set((int) $raw);   // write
+    return $handler->handle($request);
+}
+```
+
+Inside the route handler:
+
+```php
+$id = $this->teamId->get();  // read — throws LogicException if middleware did not run
+```
+
+## Why not PSR-7 request attributes?
+
+PSR-7 request attributes are immutable — each `withAttribute()` call returns a new instance. To
+pass an attribute from middleware to a handler you must thread the new request object through the
+entire call chain, which NENE2's dispatcher already does. Using `withAttribute()` is fine when the
+downstream code receives the `$request` directly.
+
+`RequestScopedHolder` is the right tool when the downstream consumer does **not** receive the
+`$request` — for example, a repository that only knows about your domain types and cannot accept a
+PSR-7 request as a dependency.
+
+## Stacking multiple middlewares
+
+Pass a list to `RuntimeApplicationFactory::$authMiddleware` to run several middlewares in sequence:
+
+```php
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    authMiddleware: [
+        new TenantMiddleware($teamId, $probs),        // runs first
+        new BearerTokenMiddleware($probs, $verifier), // runs second
+    ],
+))->create();
+```
+
+Both middlewares share the same pipeline position (after the request size limit, before rate
+limiting). The first item in the list processes the request before the second.
+
+## Safety: PHP shared-nothing model
+
+In PHP-FPM and CLI, every request runs in a fresh process. The `RequestScopedHolder` value set
+during request A is never visible to request B because each process exits after handling one
+request. The holder is safe to use as-is under this model.
+
+### Async runtimes (Swoole, ReactPHP, FrankenPHP worker mode)
+
+When multiple requests share the same PHP process, a holder written during request A will retain
+its value into request B unless explicitly cleared. Call `reset()` at the start (or end) of each
+request cycle:
+
+```php
+// Example Swoole request handler
+$server->on('request', function ($request, $response) use ($app, $teamId) {
+    $teamId->reset();            // clear previous request's value
+    $psrRequest = /* convert */;
+    $psrResponse = $app->handle($psrRequest);
+    // emit $psrResponse ...
+});
+```
+
+NENE2 currently targets PHP-FPM / CLI and does not ship built-in async support. If you run an
+async runtime, you are responsible for resetting shared holders between requests.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.2
+  version: 1.5.3
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.2';
+    public const string VERSION = '1.5.3';
 
     public function name(): string
     {

--- a/src/Http/RequestScopedHolder.php
+++ b/src/Http/RequestScopedHolder.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use LogicException;
+
+/**
+ * A type-safe mutable holder for a single request-scoped value.
+ *
+ * Inject one shared instance into both the middleware that writes (e.g. a tenant extractor)
+ * and the route handler / repository that reads. Because PHP-FPM and CLI follow the
+ * shared-nothing model (one process per request), the holder value is never shared across
+ * requests. See {@see https://nene2.dev/howto/request-scoped-state} for the full pattern
+ * and the async-runtime caveat.
+ *
+ * Usage:
+ * ```php
+ * $tenantId = new RequestScopedHolder();
+ * // In middleware:    $tenantId->set($extractedId);
+ * // In route handler: $id = $tenantId->get();
+ * ```
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ *
+ * @template T
+ */
+final class RequestScopedHolder
+{
+    /** @var T|null */
+    private mixed $value = null;
+
+    /**
+     * @param T $value
+     */
+    public function set(mixed $value): void
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Returns the held value.
+     *
+     * @return T
+     * @throws LogicException when called before {@see set()}.
+     */
+    public function get(): mixed
+    {
+        if ($this->value === null) {
+            throw new LogicException(
+                static::class . '::get() called before set() — make sure the middleware that populates this holder runs before the route handler.',
+            );
+        }
+
+        return $this->value;
+    }
+
+    public function isSet(): bool
+    {
+        return $this->value !== null;
+    }
+
+    /**
+     * Clears the held value. Useful in long-running processes (Swoole, ReactPHP)
+     * to reset state between requests.
+     */
+    public function reset(): void
+    {
+        $this->value = null;
+    }
+}

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -41,11 +41,12 @@ final readonly class RuntimeApplicationFactory
     /**
      * @param list<DomainExceptionHandlerInterface> $domainExceptionHandlers
      * @param list<callable(Router): void> $routeRegistrars
-     * @param ?MiddlewareInterface $authMiddleware Authentication middleware injected into the pipeline
-     *                                              after the request size limit. Pass any PSR-15
-     *                                              {@see MiddlewareInterface} — e.g. the built-in
-     *                                              {@see \Nene2\Auth\BearerTokenMiddleware} or a custom
-     *                                              implementation that uses prefix matching.
+     * @param MiddlewareInterface|list<MiddlewareInterface>|null $authMiddleware Authentication middleware injected
+     *                                              into the pipeline after the request size limit. Accepts a single
+     *                                              {@see MiddlewareInterface} or a list of middlewares that are
+     *                                              pushed in order (first item runs first). Use a list to stack
+     *                                              multiple middlewares — e.g. a tenant extractor followed by a JWT
+     *                                              verifier — without wrapping them in a composite.
      * @param list<HealthCheckInterface> $healthChecks
      * @param list<string> $allowedOrigins CORS-allowed origins (e.g. `['https://app.example.com']`).
      *                                     An empty list (the default) silently disables all CORS headers.
@@ -83,7 +84,7 @@ final readonly class RuntimeApplicationFactory
         private array $domainExceptionHandlers = [],
         private ?RequestIdHolder $requestIdHolder = null,
         private array $routeRegistrars = [],
-        private ?MiddlewareInterface $authMiddleware = null,
+        private MiddlewareInterface|array|null $authMiddleware = null,
         private array $healthChecks = [],
         private ?ThrottleMiddleware $throttleMiddleware = null,
         private bool $debug = false,
@@ -100,9 +101,16 @@ final readonly class RuntimeApplicationFactory
     {
         $logger = $this->logger ?? new NullLogger();
 
+        /** @var list<MiddlewareInterface> $authMiddlewares */
+        $authMiddlewares = match (true) {
+            $this->authMiddleware === null  => [],
+            is_array($this->authMiddleware) => $this->authMiddleware,
+            default                         => [$this->authMiddleware],
+        };
+
         $logger->info('NENE2 runtime started.', [
             'machine_api_key' => $this->machineApiKey !== null,
-            'auth_middleware' => $this->authMiddleware !== null,
+            'auth_middleware' => $authMiddlewares !== [],
         ]);
 
         $jsonResponses = new JsonResponseFactory($this->responseFactory, $this->streamFactory);
@@ -172,7 +180,7 @@ final readonly class RuntimeApplicationFactory
             )
         ;
 
-        if ($this->authMiddleware !== null) {
+        if ($authMiddlewares !== []) {
             $router->get(
                 '/examples/protected',
                 static fn (ServerRequestInterface $request) => $jsonResponses->create([
@@ -203,8 +211,8 @@ final readonly class RuntimeApplicationFactory
             ),
         ];
 
-        if ($this->authMiddleware !== null) {
-            $middlewareStack[] = $this->authMiddleware;
+        foreach ($authMiddlewares as $authMiddleware) {
+            $middlewareStack[] = $authMiddleware;
         }
 
         if ($this->throttleMiddleware !== null) {

--- a/tests/Auth/ProtectedEndpointHttpTest.php
+++ b/tests/Auth/ProtectedEndpointHttpTest.php
@@ -7,10 +7,13 @@ namespace Nene2\Tests\Auth;
 use Nene2\Auth\BearerTokenMiddleware;
 use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 final class ProtectedEndpointHttpTest extends TestCase
@@ -75,6 +78,62 @@ final class ProtectedEndpointHttpTest extends TestCase
         $response = $this->request('GET', '/health');
 
         self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testAuthMiddlewareAcceptsListOfMiddlewares(): void
+    {
+        $factory = new Psr17Factory();
+        $probs   = new ProblemDetailsResponseFactory($factory, $factory);
+
+        /** @var RequestScopedHolder<string> $holder */
+        $holder = new RequestScopedHolder();
+
+        $first = new class ($holder) implements MiddlewareInterface {
+            /** @param RequestScopedHolder<string> $holder */
+            public function __construct(private readonly RequestScopedHolder $holder)
+            {
+            }
+
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+            {
+                $this->holder->set('first-ran');
+                return $handler->handle($request);
+            }
+        };
+
+        $second = new class ($holder) implements MiddlewareInterface {
+            /** @param RequestScopedHolder<string> $holder */
+            public function __construct(private readonly RequestScopedHolder $holder)
+            {
+            }
+
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+            {
+                $request = $request->withAttribute('test-order', $this->holder->get() . '+second-ran');
+                return $handler->handle($request);
+            }
+        };
+
+        $app = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            authMiddleware: [$first, $second],
+            routeRegistrars: [
+                static function (\Nene2\Routing\Router $router) use ($factory): void {
+                    $jsonFactory = new \Nene2\Http\JsonResponseFactory($factory, $factory);
+                    $router->get('/probe', static fn (ServerRequestInterface $req) => $jsonFactory->create([
+                        'order' => $req->getAttribute('test-order'),
+                    ]));
+                },
+            ],
+        ))->create();
+
+        $request  = $factory->createServerRequest('GET', 'http://localhost/probe');
+        $response = $app->handle($request);
+        $payload  = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('first-ran+second-ran', $payload['order']);
     }
 
     /**

--- a/tests/Http/RequestScopedHolderTest.php
+++ b/tests/Http/RequestScopedHolderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use LogicException;
+use Nene2\Http\RequestScopedHolder;
+use PHPUnit\Framework\TestCase;
+
+final class RequestScopedHolderTest extends TestCase
+{
+    public function testSetAndGet(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set(42);
+
+        self::assertSame(42, $holder->get());
+    }
+
+    public function testIsSetReturnsFalseBeforeSet(): void
+    {
+        $holder = new RequestScopedHolder();
+
+        self::assertFalse($holder->isSet());
+    }
+
+    public function testIsSetReturnsTrueAfterSet(): void
+    {
+        /** @var RequestScopedHolder<string> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set('tenant-42');
+
+        self::assertTrue($holder->isSet());
+    }
+
+    public function testGetThrowsWhenNotInitialized(): void
+    {
+        $holder = new RequestScopedHolder();
+
+        $this->expectException(LogicException::class);
+        $holder->get();
+    }
+
+    public function testResetClearsValue(): void
+    {
+        /** @var RequestScopedHolder<string> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set('hello');
+        $holder->reset();
+
+        self::assertFalse($holder->isSet());
+    }
+
+    public function testResetMakesGetThrow(): void
+    {
+        /** @var RequestScopedHolder<string> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set('hello');
+        $holder->reset();
+
+        $this->expectException(LogicException::class);
+        $holder->get();
+    }
+
+    public function testSetOverwritesPreviousValue(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set(1);
+        $holder->set(99);
+
+        self::assertSame(99, $holder->get());
+    }
+
+    public function testWorksWithObjects(): void
+    {
+        $obj = new \stdClass();
+        $obj->name = 'test';
+
+        /** @var RequestScopedHolder<\stdClass> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set($obj);
+
+        self::assertSame($obj, $holder->get());
+    }
+}


### PR DESCRIPTION
## Summary

FT19（teamlog マルチテナンシー）で発見した摩擦 3 件に対応。v1.5.3 リリース準備。

- **#555 (F-1・高)**: `RequestScopedHolder<T>` 公開クラス追加 — ミドルウェア→ハンドラー間の型安全なリクエストスコープ値受け渡し
- **#556 (F-2・中)**: `authMiddleware` が `list<MiddlewareInterface>` を受け付けるよう拡張 — 複数ミドルウェアのスタックが可能に
- **#557 (F-3・低)**: `docs/howto/request-scoped-state.md` 新規作成 — PHP 同期モデル前提と async ランタイム注意点をドキュメント化

## Changes

| ファイル | 内容 |
|---|---|
| `src/Http/RequestScopedHolder.php` | 新規 — `@template T` 汎用ホルダークラス |
| `src/Http/RuntimeApplicationFactory.php` | `$authMiddleware` を `MiddlewareInterface\|array\|null` に拡張 |
| `tests/Http/RequestScopedHolderTest.php` | 新規 — 8 テスト |
| `tests/Auth/ProtectedEndpointHttpTest.php` | `testAuthMiddlewareAcceptsListOfMiddlewares` 追加 |
| `docs/howto/request-scoped-state.md` | 新規 howto |
| `src/FrameworkInfo.php` | VERSION 1.5.2 → 1.5.3 |
| `docs/openapi/openapi.yaml` | version 1.5.3 |
| `CHANGELOG.md` | [1.5.3] セクション追加 |

## Test plan

- [x] `composer check` 全通過（307 tests, 808 assertions → 315 tests）
- [x] PHPStan level 8: 0 エラー
- [x] PHP-CS-Fixer: 0 件
- [x] Version consistency OK: 1.5.3
- [x] `$authMiddleware` 単体渡し・null 渡し: 既存テストで BC 確認
- [x] `$authMiddleware` リスト渡し: `testAuthMiddlewareAcceptsListOfMiddlewares` で順序確認

## Self-review

Self-review: backend-api, middleware-security

Closes #555
Closes #556
Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)