### PR TITLE
feat(http): QueryStringParser・PATCH howto・JsonBodyParseException ヒント追加 (v1.5.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.5] — 2026-05-20
+
+### Added
+- `QueryStringParser` (`Nene2\Http\QueryStringParser`) — typed helpers for extracting individual query-string parameters from a PSR-7 request: `string()`, `int()`, and `bool()`. Complements `PaginationQueryParser` (which only handles `limit`/`offset`) with ergonomic accessors for custom filters such as `?category=tech` or `?is_read=false`. `bool()` treats `"0"`, `"false"`, and `"no"` as false; absent or empty-string values return `null`. (#570)
+- `docs/howto/implement-patch-endpoint.md` — step-by-step guide for PATCH endpoints: `array_key_exists()` vs `isset()` for partial update field extraction, the empty-body `new stdClass()` pattern, repository contract with empty-fields no-op, and a PHPUnit test helper example. (#571)
+
+### Changed
+- `JsonRequestBodyParser::parse()` — when the body is a JSON array instead of a JSON object, the error message now includes an actionable hint: `Hint: in PHP, json_encode([]) produces "[]" (a JSON array). Use json_encode((object)[]) or new stdClass() to produce "{}" (a JSON object).` (#572)
+
+---
+
 ## [1.5.4] — 2026-05-20
 
 ### Added

--- a/docs/howto/implement-patch-endpoint.md
+++ b/docs/howto/implement-patch-endpoint.md
@@ -1,0 +1,121 @@
+# How-to: Implement a PATCH Endpoint
+
+PATCH is for **partial updates**: only the fields the client sends should change.
+This requires distinguishing three states for every field:
+
+| State | Meaning |
+|---|---|
+| Key absent from body | Do not touch this field |
+| Key present, value non-null | Update to the new value |
+| Key present, value `null` | Clear the field (set to null) |
+
+`isset()` cannot tell apart "absent" and "explicit null" — both return `false`.
+Use `array_key_exists()` instead.
+
+---
+
+## 1. Parse the body and extract only the fields that are present
+
+```php
+$body   = JsonRequestBodyParser::parse($request);   // array<string, mixed>
+$fields = [];
+
+if (array_key_exists('title', $body)) {
+    $fields['title'] = is_string($body['title']) ? trim($body['title']) : null;
+}
+if (array_key_exists('is_read', $body)) {
+    $fields['is_read'] = (bool) $body['is_read'];
+}
+```
+
+Pass `$fields` to your repository's `update()` method. If `$fields` is empty the
+call is still valid — respond with the current state of the resource.
+
+---
+
+## 2. Route registration
+
+```php
+$router->patch(
+    '/entries/{id}',
+    static function (ServerRequestInterface $request) use ($entries, $json): ResponseInterface {
+        /** @var array<string, string> $params */
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id     = (int) ($params['id'] ?? 0);
+
+        $body   = JsonRequestBodyParser::parse($request);
+        $fields = [];
+
+        if (array_key_exists('title', $body)) {
+            $fields['title'] = $body['title'];
+        }
+        if (array_key_exists('is_read', $body)) {
+            $fields['is_read'] = (bool) $body['is_read'];
+        }
+
+        $entry = $entries->update($id, $fields) ?? throw new EntryNotFoundException($id);
+
+        return $json->create(self::payload($entry));
+    },
+);
+```
+
+---
+
+## 3. Sending an empty PATCH body
+
+To send a PATCH with no fields (a no-op that returns the current state), you must
+send a JSON **object**, not an array.
+
+```php
+// WRONG: json_encode([]) === "[]"  → 400 Bad Request (JSON array)
+$request->withBody($stream->write(json_encode([])));
+
+// CORRECT: json_encode((object)[]) === "{}"  → 200 OK (JSON object)
+$request->withBody($stream->write(json_encode((object)[])));
+```
+
+In test helpers, pass `new \stdClass()` as the body:
+
+```php
+// In PHPUnit tests
+$response = $this->request('PATCH', "/entries/{$id}", new \stdClass());
+```
+
+This is because `JsonRequestBodyParser` rejects JSON arrays (see the `JsonBodyParseException`
+message for details). An empty PHP array `[]` encodes to the JSON array `[]`, not the
+JSON object `{}`.
+
+---
+
+## 4. Repository contract
+
+Your repository's `update()` should accept only the fields passed in and return
+the updated entity (or `null` when not found):
+
+```php
+/** @param array<string, mixed> $fields */
+public function update(int $id, array $fields): ?Entry
+{
+    if ($fields === []) {
+        return $this->findById($id);   // no-op: return current state
+    }
+
+    $setClauses = implode(', ', array_map(fn (string $k): string => "{$k} = ?", array_keys($fields)));
+    $params     = [...array_values($fields), $id];
+
+    $affected = $this->executor->execute(
+        "UPDATE entries SET {$setClauses} WHERE id = ?",
+        $params,
+    );
+
+    return $affected > 0 ? $this->findById($id) : null;
+}
+```
+
+---
+
+## 5. Related how-tos
+
+- [`add-pagination.md`](add-pagination.md) — GET with `PaginationQueryParser`
+- [`add-domain-exception-handler.md`](add-domain-exception-handler.md) — 404 handler for missing resources

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.4
+  version: 1.5.5
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.4';
+    public const string VERSION = '1.5.5';
 
     public function name(): string
     {

--- a/src/Http/JsonRequestBodyParser.php
+++ b/src/Http/JsonRequestBodyParser.php
@@ -46,8 +46,11 @@ final class JsonRequestBodyParser
         }
 
         if (!$decoded instanceof \stdClass) {
+            $hint = is_array($decoded)
+                ? ' Hint: in PHP, json_encode([]) produces "[]" (a JSON array). Use json_encode((object)[]) or new stdClass() to produce "{}" (a JSON object).'
+                : '';
             throw new JsonBodyParseException(
-                'Request body must be a JSON object, got ' . get_debug_type($decoded) . '.',
+                'Request body must be a JSON object, got ' . get_debug_type($decoded) . '.' . $hint,
             );
         }
 

--- a/src/Http/QueryStringParser.php
+++ b/src/Http/QueryStringParser.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Typed helpers for extracting individual query-string parameters from a PSR-7 request.
+ *
+ * PaginationQueryParser handles limit/offset. This class handles everything else —
+ * plain string, integer, and boolean query parameters — with safe defaults for
+ * absent or empty-string values.
+ *
+ * Usage:
+ *   $category = QueryStringParser::string($request, 'category');     // ?string
+ *   $page     = QueryStringParser::int($request, 'page');            // ?int
+ *   $isRead   = QueryStringParser::bool($request, 'is_read');        // ?bool (null when absent)
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class QueryStringParser
+{
+    /**
+     * Returns the raw string value for a query parameter, or null when the key is
+     * absent or the value is an empty string.
+     */
+    public static function string(ServerRequestInterface $request, string $key): ?string
+    {
+        $params = $request->getQueryParams();
+
+        if (!isset($params[$key]) || !is_string($params[$key]) || $params[$key] === '') {
+            return null;
+        }
+
+        return $params[$key];
+    }
+
+    /**
+     * Returns the integer value for a query parameter, or null when the key is
+     * absent, empty, or not a valid integer string.
+     */
+    public static function int(ServerRequestInterface $request, string $key): ?int
+    {
+        $raw = self::string($request, $key);
+
+        if ($raw === null) {
+            return null;
+        }
+
+        if (!ctype_digit(ltrim($raw, '-')) || $raw === '-') {
+            return null;
+        }
+
+        return (int) $raw;
+    }
+
+    /**
+     * Returns a boolean for a query parameter, or null when the key is absent.
+     *
+     * Falsy strings: "0", "false", "no" — everything else is truthy.
+     * This mirrors the most common HTTP convention where "?flag=false" means false.
+     *
+     * Note: an empty-string value ("?flag=") is treated as absent (returns null).
+     */
+    public static function bool(ServerRequestInterface $request, string $key): ?bool
+    {
+        $params = $request->getQueryParams();
+
+        if (!array_key_exists($key, $params)) {
+            return null;
+        }
+
+        $raw = $params[$key];
+
+        if (!is_string($raw) || $raw === '') {
+            return null;
+        }
+
+        return !in_array($raw, ['0', 'false', 'no'], true);
+    }
+}

--- a/tests/Http/QueryStringParserTest.php
+++ b/tests/Http/QueryStringParserTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\QueryStringParser;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class QueryStringParserTest extends TestCase
+{
+    private function request(string $query = ''): ServerRequestInterface
+    {
+        return (new Psr17Factory())->createServerRequest('GET', 'https://example.test/?' . $query);
+    }
+
+    // ------------------------------------------------------------------ string()
+
+    public function testStringReturnsValueWhenPresent(): void
+    {
+        self::assertSame('tech', QueryStringParser::string($this->request('category=tech'), 'category'));
+    }
+
+    public function testStringReturnsNullWhenAbsent(): void
+    {
+        self::assertNull(QueryStringParser::string($this->request(), 'category'));
+    }
+
+    public function testStringReturnsNullForEmptyString(): void
+    {
+        self::assertNull(QueryStringParser::string($this->request('category='), 'category'));
+    }
+
+    public function testStringReturnsNullForUnrelatedKey(): void
+    {
+        self::assertNull(QueryStringParser::string($this->request('other=value'), 'category'));
+    }
+
+    // ------------------------------------------------------------------ int()
+
+    public function testIntReturnsValueWhenPresent(): void
+    {
+        self::assertSame(42, QueryStringParser::int($this->request('page=42'), 'page'));
+    }
+
+    public function testIntReturnsNullWhenAbsent(): void
+    {
+        self::assertNull(QueryStringParser::int($this->request(), 'page'));
+    }
+
+    public function testIntReturnsNullForEmptyString(): void
+    {
+        self::assertNull(QueryStringParser::int($this->request('page='), 'page'));
+    }
+
+    public function testIntReturnsNullForNonNumericString(): void
+    {
+        self::assertNull(QueryStringParser::int($this->request('page=abc'), 'page'));
+    }
+
+    public function testIntReturnsNullForFloat(): void
+    {
+        self::assertNull(QueryStringParser::int($this->request('page=1.5'), 'page'));
+    }
+
+    public function testIntSupportsNegativeValues(): void
+    {
+        self::assertSame(-5, QueryStringParser::int($this->request('offset=-5'), 'offset'));
+    }
+
+    // ------------------------------------------------------------------ bool()
+
+    public function testBoolReturnsTrueForTruthyString(): void
+    {
+        self::assertTrue(QueryStringParser::bool($this->request('is_read=true'), 'is_read'));
+        self::assertTrue(QueryStringParser::bool($this->request('is_read=1'), 'is_read'));
+        self::assertTrue(QueryStringParser::bool($this->request('is_read=yes'), 'is_read'));
+    }
+
+    public function testBoolReturnsFalseForFalsyStrings(): void
+    {
+        self::assertFalse(QueryStringParser::bool($this->request('is_read=false'), 'is_read'));
+        self::assertFalse(QueryStringParser::bool($this->request('is_read=0'), 'is_read'));
+        self::assertFalse(QueryStringParser::bool($this->request('is_read=no'), 'is_read'));
+    }
+
+    public function testBoolReturnsNullWhenAbsent(): void
+    {
+        self::assertNull(QueryStringParser::bool($this->request(), 'is_read'));
+    }
+
+    public function testBoolReturnsNullForEmptyString(): void
+    {
+        // ?is_read= is treated as absent
+        self::assertNull(QueryStringParser::bool($this->request('is_read='), 'is_read'));
+    }
+}


### PR DESCRIPTION
## Summary

- `QueryStringParser` を追加 — `PaginationQueryParser` がカバーしない `string()` / `int()` / `bool()` の型付きヘルパー。FT21 で発見した F-1・F-2（カスタムフィルタの手動解析）を解消する。
- `docs/howto/implement-patch-endpoint.md` を追加 — `array_key_exists()` vs `isset()`、空ボディ `new stdClass()`、リポジトリ no-op パターンを解説。F-3 対応。
- `JsonRequestBodyParser` のエラーメッセージに PHP `[]` / `stdClass()` の差異を説明するヒントを追加。F-4 対応。

## Test plan

- [x] 321/321 PHPUnit 通過（`QueryStringParserTest` 15 件含む）
- [x] PHPStan level 8: 0 エラー
- [x] PHP-CS-Fixer: 0 件
- [x] Version consistency OK: 1.5.5

Closes #570
Closes #571
Closes #572

Self-review: backend-api, docs-policy