### PR TITLE
feat: InMemoryRateLimitStorage 公開化・HealthCheck howto 修正・UNIQUE 制約ガイド (v1.5.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.6] — 2026-05-20
+
+### Added
+- `docs/howto/add-database-endpoint.md` — added "Handling UNIQUE constraint violations" section: `DatabaseConnectionException` wraps `PDOException`; catch `DatabaseConnectionException` and inspect `getPrevious()` to detect constraint violations. Includes per-adapter message fragments (SQLite / MySQL / PostgreSQL). (#576)
+
+### Changed
+- `InMemoryRateLimitStorage` — removed `@internal` annotation; promoted to public API. The class is for local development and single-process testing; PHPDoc now explicitly documents that it is NOT shared across PHP-FPM workers. Consumers can now use it in tests without PHPStan warnings. (#574)
+- `docs/howto/add-health-check.md` — fixed `check()` return type from `bool` to `HealthStatus` in the Quick Start example; added inline note that `name()` return value becomes the key in the `checks` response map. (#575)
+
+---
+
 ## [1.5.5] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-22.md
+++ b/docs/field-trials/2026-05-field-trial-22.md
@@ -1,0 +1,206 @@
+# Field Trial 22 — votelog: ThrottleMiddleware・HealthCheckInterface・QueryStringParser 実地検証
+
+## Date
+
+2026-05-20
+
+## Baseline
+
+- NENE2 v1.5.5（`hideyukimori/nene2: ^1.5`、Packagist から取得）
+- PHP 8.4
+- プロジェクト: **votelog** — 投票/ポーリング管理 API
+- エンティティ: `Poll`（question, is_active, options[]）/ `PollOption`（label, position, vote_count）/ `Vote`（poll_id, option_id, voter_key）
+- DB: SQLite（テストごとにファイル新規生成・削除）
+- テスト: PHPUnit 18/18・PHPStan level 8・PHP-CS-Fixer 全通過
+
+## Goal
+
+v1.5.5 で未検証だった公開 API の実地検証:
+
+- `ThrottleMiddleware` + `RateLimitStorageInterface` の組み合わせ
+- `InMemoryRateLimitStorage`（`@internal` 指定あり）をテストで使用
+- `HealthCheckInterface` のカスタム実装
+- `QueryStringParser::bool()`（v1.5.5 新規追加）の実用確認
+
+---
+
+## 実装ログ
+
+1. `/home/xi/docker/NENE2-FT/votelog/` に新規 PHP プロジェクト作成
+2. `composer require hideyukimori/nene2:^1.5` — v1.5.5 インストール成功
+3. SQLite スキーマ（polls / poll_options / votes）と `SqlitePollRepository` を実装
+4. `PollRouteRegistrar` に GET・POST・GET/{id}・POST/{id}/vote を実装
+5. `DatabaseHealthCheck`（`HealthCheckInterface` 実装）を作成
+6. `ThrottleMiddleware` を `RuntimeApplicationFactory::$throttleMiddleware` に接続
+7. テスト実行 → 1 件失敗（F-4: PDOException が DatabaseConnectionException にラップされる）
+8. 修正後 18/18 通過。PHPStan level 8: 0 エラー。PHP-CS-Fixer: 0 件。
+
+---
+
+## 摩擦記録
+
+### F-1（低）: QueryStringParser::bool() — `?is_active=` の挙動が直感的
+
+**状況**: `QueryStringParser::bool($request, 'is_active')` は:
+- キー不在 → `null`（フィルタなし）
+- `?is_active=true` → `true`
+- `?is_active=false` → `false`
+- `?is_active=` → `null`（空文字は不在扱い）
+
+の挙動を持つ。摩擦ではなく **期待どおり動作した**。
+F-2 で発見した boolean クエリパラメータ問題が v1.5.5 で解消されていることを確認。
+
+---
+
+### F-2（中）: `InMemoryRateLimitStorage` が `@internal` なのにテストで必須
+
+**状況**: テストで `ThrottleMiddleware` を使う場合、rate limit を実際に消費せず
+テストを独立させるには `RateLimitStorageInterface` の実装が必要。
+
+`InMemoryRateLimitStorage` はまさにそのための実装だが、`@internal` アノテーションが付いており
+公開 API ではない。結果として consumer は:
+
+1. `@internal` のクラスを使う（PHPStan 警告が出る場合がある）
+2. 自分で `RateLimitStorageInterface` を実装する
+
+```php
+// テストで @internal な InMemoryRateLimitStorage を使う
+$storage = new InMemoryRateLimitStorage();
+$throttle = new ThrottleMiddleware($probs, $storage, limit: 1, windowSeconds: 60);
+```
+
+**期待する解決策**:
+- `InMemoryRateLimitStorage` を公開 API に昇格させる（`@internal` を外す）
+- または howto にテスト用ストレージの作り方を記載する
+
+---
+
+### F-3（低）: HealthCheckInterface のレスポンス形状が未ドキュメント
+
+**状況**: `GET /health` のレスポンス形状（`{status, checks: {name: "ok"|"error"}}`）が
+`HealthCheckInterface` の PHPDoc や howto に記載されていない。
+実装してテストを書くまで `checks.database` のキー名が `name()` の戻り値であることに
+気づかなかった。
+
+```json
+{
+    "status": "ok",
+    "checks": {
+        "database": "ok"
+    }
+}
+```
+
+**期待する解決策**: `docs/howto/add-health-check.md` にレスポンス形状の例を追記する。
+
+---
+
+### F-4（中）: `execute()` の UNIQUE 制約例外が `DatabaseConnectionException` にラップされる
+
+**状況**: `PdoDatabaseQueryExecutor::execute()` は内部で `PDOException` を
+`DatabaseConnectionException` に変換して投げる。
+
+UNIQUE 制約違反を検出したい consumer は `PDOException` をキャッチできず、
+`DatabaseConnectionException` をキャッチして `getPrevious()` でラップを剥がす
+必要がある。
+
+```php
+// 誤り: PDOException はキャッチできない
+} catch (\PDOException $e) {
+    if (str_contains($e->getMessage(), 'UNIQUE constraint failed')) {
+        throw new DuplicateVoteException();
+    }
+}
+
+// 正しい: DatabaseConnectionException をキャッチして previous を検査
+} catch (DatabaseConnectionException $e) {
+    $previous = $e->getPrevious();
+    if ($previous !== null && str_contains($previous->getMessage(), 'UNIQUE constraint failed')) {
+        throw new DuplicateVoteException();
+    }
+    throw $e;
+}
+```
+
+**期待する解決策**: `add-database-endpoint.md` または新 howto に UNIQUE 制約ハンドリング
+パターンを追記する。
+
+---
+
+## ThrottleMiddleware 検証
+
+| 検証内容 | 結果 |
+|---|---|
+| `RuntimeApplicationFactory::$throttleMiddleware` に直接渡せる | ✓ |
+| `X-RateLimit-Limit` / `Remaining` / `Reset` ヘッダーが付く | ✓ |
+| `limit=1` で 2 件目が 429 を返す | ✓ |
+| `Retry-After` ヘッダーが 429 に含まれる | 未検証（Problem Details レスポンスに含まれる） |
+| `keyExtractor` カスタマイズ | 未検証（デフォルトの REMOTE_ADDR で動作確認） |
+
+---
+
+## HealthCheckInterface 検証
+
+```php
+// 実装
+final readonly class DatabaseHealthCheck implements HealthCheckInterface
+{
+    public function name(): string { return 'database'; }
+    public function check(): HealthStatus
+    {
+        try {
+            $this->executor->fetchOne('SELECT 1 AS ping');
+            return HealthStatus::Ok;
+        } catch (\Throwable) {
+            return HealthStatus::Error;
+        }
+    }
+}
+
+// RuntimeApplicationFactory
+healthChecks: [new DatabaseHealthCheck($executor)],
+```
+
+`name()` の戻り値が `/health` レスポンスの `checks` のキーになることを確認。
+
+---
+
+## テストカバレッジ
+
+| テスト | 検証内容 |
+|---|---|
+| `testListPollsReturnsEmptyInitially` | GET /polls → 空・ページネーションメタ |
+| `testCreatePollReturns201` | POST /polls → 201 |
+| `testCreatePollRejectsMissingQuestion` | 422 |
+| `testCreatePollRejectsFewerThanTwoOptions` | 422（選択肢 1 件）|
+| `testGetPollById` | GET /polls/{id} → 200 |
+| `testGetNonExistentPollReturns404` | 404 |
+| `testFilterByIsActiveTrueReturnsActivePolls` | ?is_active=true フィルタ |
+| `testFilterByIsActiveFalseReturnsEmpty` | ?is_active=false フィルタ |
+| `testFilterAbsentIsActiveReturnsAll` | フィルタなし → 全件 |
+| `testVoteUpdatesVoteCount` | 投票 → vote_count 増加 |
+| `testDuplicateVoteReturns409` | 同一 IP 二重投票 → 409 |
+| `testDifferentVotersCanVoteOnSamePoll` | 別 IP は投票可能 |
+| `testVoteForInvalidOptionReturns422` | 存在しない optionId → 422 |
+| `testVoteOnNonExistentPollReturns404` | 存在しない poll → 404 |
+| `testRateLimitHeadersPresentOnSuccess` | X-RateLimit-* ヘッダー確認 |
+| `testThrottleReturns429WhenLimitExceeded` | limit=1 → 2 件目 429 |
+| `testHealthEndpointReturns200` | GET /health → status:ok, checks.database |
+| `testPaginationLimitAndOffset` | limit=2&offset=0 → 2 件 / total=5 |
+
+**合計**: 18/18 通過
+
+---
+
+## 総評
+
+`ThrottleMiddleware`・`HealthCheckInterface`・`QueryStringParser::bool()` は
+NENE2 v1.5.5 で正常に動作した。
+
+主な摩擦は `InMemoryRateLimitStorage` の `@internal` 問題（F-2）と
+`execute()` の例外ラップ（F-4）。F-2 は消費者が必ず遭遇するパターンで影響が大きい。
+
+次のアクション候補:
+1. F-2 → `InMemoryRateLimitStorage` を公開 API に昇格（`@internal` 削除）
+2. F-3 → `add-health-check.md` にレスポンス形状を追記
+3. F-4 → `add-database-endpoint.md` に UNIQUE 制約ハンドリング例を追記

--- a/docs/howto/add-database-endpoint.md
+++ b/docs/howto/add-database-endpoint.md
@@ -494,8 +494,53 @@ Or use `INSERT ... ON DUPLICATE KEY UPDATE` for the same idempotent effect.
 
 ---
 
+---
+
+## Handling UNIQUE constraint violations
+
+`PdoDatabaseQueryExecutor::execute()` catches `PDOException` internally and re-throws it as
+`DatabaseConnectionException`. To detect a UNIQUE constraint violation, catch
+`DatabaseConnectionException` and inspect `getPrevious()`:
+
+```php
+use Nene2\Database\DatabaseConnectionException;
+
+public function vote(int $pollId, string $voterKey): void
+{
+    try {
+        $this->executor->execute(
+            'INSERT INTO votes (poll_id, voter_key, created_at) VALUES (?, ?, ?)',
+            [$pollId, $voterKey, date('Y-m-d H:i:s')],
+        );
+    } catch (DatabaseConnectionException $e) {
+        // DatabaseConnectionException wraps the original PDOException.
+        // Inspect getPrevious() to detect constraint violations.
+        $previous = $e->getPrevious();
+        if ($previous !== null && str_contains($previous->getMessage(), 'UNIQUE constraint failed')) {
+            throw new DuplicateVoteException();
+        }
+        throw $e;
+    }
+}
+```
+
+The exact message fragment differs by database adapter:
+
+| Adapter | Fragment to check |
+|---|---|
+| SQLite | `'UNIQUE constraint failed'` |
+| MySQL | `'Duplicate entry'` |
+| PostgreSQL | `'duplicate key value violates unique constraint'` |
+
+> **Note**: `isset()` on the previous exception is not needed — `getPrevious()` returns `null`
+> when there is no wrapped exception, and `str_contains(null, ...)` is a type error.
+> Always check `$previous !== null` first.
+
+---
+
 ## Next steps
 
 - Add OpenAPI documentation for your endpoint: see `docs/development/endpoint-scaffold.md`
 - Add database migrations: see `docs/development/test-database-strategy.md`
 - See NENE2's built-in Note example as a reference: `src/Example/Note/`
+- PATCH endpoint pattern: see [`implement-patch-endpoint.md`](implement-patch-endpoint.md)

--- a/docs/howto/add-health-check.md
+++ b/docs/howto/add-health-check.md
@@ -28,17 +28,18 @@ Implement `HealthCheckInterface` and pass it to `RuntimeApplicationFactory`:
 
 ```php
 use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 
 final class CacheHealthCheck implements HealthCheckInterface
 {
+    // The return value of name() becomes the key in the "checks" map.
     public function name(): string { return 'cache'; }
 
-    public function check(): bool
+    public function check(): HealthStatus
     {
-        // Return true = healthy, false = degraded.
-        return $this->ping();
+        return $this->ping() ? HealthStatus::Ok : HealthStatus::Error;
     }
 
     private function ping(): bool { /* ... */ return true; }
@@ -92,7 +93,7 @@ $app = (new RuntimeApplicationFactory(
 ))->create();
 ```
 
-The check executes `SELECT 1` and returns `true` on success, `false` on any exception.
+The check executes `SELECT 1` and returns `HealthStatus::Ok` on success, `HealthStatus::Error` on any exception.
 
 > **Note**: `DatabaseHealthCheck` is in `src/Example/` — it is a reference implementation,
 > not a stable API surface. Copy it into your application and adapt it to your needs.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.5
+  version: 1.5.6
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.5';
+    public const string VERSION = '1.5.6';
 
     public function name(): string
     {

--- a/src/Middleware/InMemoryRateLimitStorage.php
+++ b/src/Middleware/InMemoryRateLimitStorage.php
@@ -5,10 +5,20 @@ declare(strict_types=1);
 namespace Nene2\Middleware;
 
 /**
- * @internal
+ * In-memory rate limit storage for local development and single-process testing.
  *
- * In-memory rate limit storage for local development and testing.
- * NOT safe for production: state is not shared between PHP-FPM processes.
+ * State is held in a plain PHP array and is therefore NOT shared between PHP-FPM
+ * worker processes. For production, inject a shared implementation (Redis, Memcached,
+ * or a database-backed store) via {@see RateLimitStorageInterface}.
+ *
+ * Typical test usage:
+ *
+ * ```php
+ * $storage = new InMemoryRateLimitStorage();
+ * $throttle = new ThrottleMiddleware($problemDetails, $storage, limit: 60, windowSeconds: 60);
+ * ```
+ *
+ * Part of the public API stability guarantee (see ADR 0009, ADR 0010).
  */
 final class InMemoryRateLimitStorage implements RateLimitStorageInterface
 {


### PR DESCRIPTION
## Summary

- `InMemoryRateLimitStorage` の `@internal` を削除 — テストで `ThrottleMiddleware` を使う際に PHPStan 警告なしで使えるようになった
- `add-health-check.md` の `check(): bool` を `check(): HealthStatus` に修正 + `name()` がレスポンスキーになることを明記
- `add-database-endpoint.md` に UNIQUE 制約違反の `DatabaseConnectionException` アンラップパターンを追記（アダプター別メッセージ一覧付き）

## Test plan

- [x] 321/321 PHPUnit 通過
- [x] PHPStan level 8: 0 エラー
- [x] PHP-CS-Fixer: 0 件
- [x] Version consistency OK: 1.5.6

Closes #574
Closes #575
Closes #576

Self-review: backend-api, docs-policy