### PR TITLE
docs(transactions): トランザクション内リポジトリ再利用禁止の警告強化・SQLite テストパターン追記 (#578 #579 #580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.7] — 2026-05-20
+
+### Changed
+- `DatabaseTransactionManagerInterface::transactional()` — added PHPDoc warning: repositories injected at construction time must not be reused inside the callback; they execute on a different connection outside the transaction. (#579)
+- `DatabaseConfig` — added PHPDoc noting that for SQLite only `adapter` and `name` are required; `host`, `user`, `password`, `charset` accept empty strings. (#580)
+- `docs/howto/use-transactions.md` — added prominent `> **Warning**` callout about the injected-repository anti-pattern; expanded "Test with a file-based SQLite database" section with `DatabaseConfig` + `PdoConnectionFactory` setup, `:memory:` limitation explanation, and notes on SQLite optional fields. (#578 #579 #580)
+
+---
+
 ## [1.5.6] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-23.md
+++ b/docs/field-trials/2026-05-field-trial-23.md
@@ -1,0 +1,213 @@
+# Field Trial 23 — budgetlog: DatabaseTransactionManagerInterface・QueryStringParser 複合フィルタ・集計クエリ実地検証
+
+## Date
+
+2026-05-20
+
+## Baseline
+
+- NENE2 v1.5.6（`hideyukimori/nene2: ^1.5`、Packagist から取得）
+- PHP 8.4
+- プロジェクト: **budgetlog** — 家計簿 API
+- エンティティ: `Account`（name, balance）/ `Transaction`（account_id, amount, type, category, recurring）
+- DB: SQLite（テストごとに一時ファイル生成・削除）
+- テスト: PHPUnit 23/23・PHPStan level 8・PHP-CS-Fixer 全通過
+
+## Goal
+
+v1.5.6 で未検証だった公開 API の実地検証:
+
+- `DatabaseTransactionManagerInterface` を使った原子的な複数ステップ操作（口座間送金）
+- `QueryStringParser` の複合フィルタ（`string` + `int` + `bool` の同時使用）
+- SQL `GROUP BY` / `SUM()` による集計クエリ（カテゴリ別支出合計）
+- `PaginationQueryParser` との組み合わせ（フィルタ + ページネーション）
+
+---
+
+## 実装ログ
+
+1. `/home/xi/docker/NENE2-FT/budgetlog/` に新規 PHP プロジェクト作成
+2. `composer require hideyukimori/nene2:^1.5` — v1.5.6 インストール成功
+3. SQLite スキーマ（accounts / transactions）と各リポジトリを実装
+4. `RouteRegistrar` に GET・POST・フィルタ・集計・送金ルートを実装
+5. `TransferFundsUseCase` で `DatabaseTransactionManagerInterface` を使用
+6. テスト実行 → 1 件失敗（F-1: `PdoDatabaseQueryExecutor` が `PDO` を直接受け取れない）
+7. 修正後 → F-2 発見（トランザクション内でのリポジトリ再利用不可）
+8. `use-transactions.md` の記述どおりにコールバック内でリポジトリを再インスタンス化
+9. 23/23 通過。PHPStan level 8: 0 エラー。PHP-CS-Fixer: 0 件。
+
+---
+
+## 摩擦記録
+
+### F-1（中）: `PdoDatabaseQueryExecutor` がコンストラクタに `PDO` を直接受け取れない
+
+**状況**: テストでは `:memory:` の `PDO` を直接インスタンス化して渡したかった:
+
+```php
+$pdo = new \PDO('sqlite::memory:');
+$executor = new PdoDatabaseQueryExecutor($pdo); // TypeError
+```
+
+しかし `PdoDatabaseQueryExecutor::__construct()` の第 1 引数は `DatabaseConnectionFactoryInterface` であり、`PDO` は受け取れない。
+
+回避策として `DatabaseConfig` + `PdoConnectionFactory` を経由してインスタンス化する必要があった:
+
+```php
+$dbConfig = new DatabaseConfig(
+    url: null, environment: 'test', adapter: 'sqlite',
+    host: '', port: 1, name: $this->dbFile,
+    user: '', password: '', charset: '',
+);
+$factory  = new PdoConnectionFactory($dbConfig);
+$executor = new PdoDatabaseQueryExecutor($factory);
+```
+
+さらに `:memory:` が使えない理由が付随: `PdoConnectionFactory::create()` は毎回新規接続を開くため、`:memory:` では接続ごとに空のデータベースになってしまう。テストには一時ファイルが必要。
+
+**期待する解決策**:
+
+- `PdoDatabaseQueryExecutor` に `PDO` を直接渡せるファクトリメソッドまたはコンビニエンスコンストラクタを追加する
+- または howto に「テストで直接 PDO を使う」パターンを記載する
+
+---
+
+### F-2（高）: `transactional()` コールバック内で注入済みリポジトリが使えない
+
+**状況**: `TransferFundsUseCase` で注入済みの `AccountRepositoryInterface` をトランザクション内でそのまま使おうとした:
+
+```php
+// NG: コールバック外のリポジトリはトランザクション外の接続を使う
+$this->txManager->transactional(function () use ($fromId, $toId, $amount): void {
+    $from = $this->accounts->findById($fromId); // 別接続
+    // ...
+});
+```
+
+`PdoDatabaseTransactionManager::transactional()` はコールバックに**別接続のエグゼキューター**を渡す。注入済みリポジトリは別の接続を持っており、トランザクション外でクエリを実行する。ロールバックしても注入済みリポジトリ経由の変更は巻き戻らない。
+
+正しいパターンは `docs/howto/use-transactions.md` に記載されているが、初見では気づきにくい:
+
+```php
+// OK: コールバック引数の $tx を使ってリポジトリを再インスタンス化
+$this->txManager->transactional(function (DatabaseQueryExecutorInterface $tx) use ($fromId, $toId, $amount): void {
+    $accounts     = new SqliteAccountRepository($tx);     // この $tx はトランザクションの接続
+    $transactions = new SqliteTransactionRepository($tx);
+    // ...
+});
+```
+
+**影響**: 誤ったパターンで実装するとトランザクションが効いているように見えて実は効いていない（サイレント不整合）。
+
+**期待する解決策**:
+
+- `use-transactions.md` に「注入済みリポジトリを再利用してはいけない理由」のより目立つ警告を追加する
+- または `transactional()` のコールバックシグネチャに PHPDoc で警告を追記する
+
+---
+
+### F-3（低）: `DatabaseConfig` の SQLite 向けフィールド要件が不明確
+
+**状況**: SQLite で `DatabaseConfig` を構築する際、`host`・`user`・`password`・`charset` に空文字を渡せるか不明だった。
+ソースを読んで `requiredValues()` が SQLite では `DB_ENV`・`DB_ADAPTER`・`DB_NAME` しか検証しないことを確認した。
+
+```php
+$dbConfig = new DatabaseConfig(
+    url: null, environment: 'test', adapter: 'sqlite',
+    host: '',  // OK — SQLite ではチェックされない
+    port: 1,   // OK — SQLite ではポート範囲チェックなし
+    name: $this->dbFile,
+    user: '',     // OK
+    password: '', // OK
+    charset: '',  // OK
+);
+```
+
+**期待する解決策**: `DatabaseConfig` の PHPDoc または howto に SQLite では `host`/`user`/`password`/`charset` が任意であることを明記する。
+
+---
+
+## QueryStringParser 複合フィルタ検証
+
+| フィルタ | パラメータ | 検証結果 |
+|---|---|---|
+| `string` | `?category=food` | ✓ |
+| `int` (min) | `?min_amount=500` | ✓ |
+| `int` (max) | `?max_amount=200` | ✓ |
+| `bool` (true) | `?recurring=true` | ✓ |
+| `bool` (false) | `?recurring=false` | ✓ |
+| フィルタなし | (なし) | ✓ 全件返却 |
+| 複合 | `?category=food&min_amount=200` | ✓ AND 結合 |
+
+3 種類のパラメータ型を同時に使用するシナリオで `QueryStringParser` が正常に動作することを確認。
+
+---
+
+## DatabaseTransactionManagerInterface 検証
+
+| 検証内容 | 結果 |
+|---|---|
+| 送金で両口座の残高が原子的に更新される | ✓ |
+| 送金で両口座に取引レコードが作成される | ✓ |
+| 残高不足で 422 を返す | ✓ |
+| 同一口座への送金を 422 で拒否 | ✓ |
+| 存在しない送金元で 422 を返す | ✓ |
+| コールバック内で例外を投げると ValidationException が正しく伝播 | ✓ |
+
+---
+
+## 集計クエリ検証
+
+`SUM(amount) GROUP BY category` のパターンを `DatabaseQueryExecutorInterface::fetchAll()` で直接実行し、カテゴリ別支出合計を返す API を実装。
+
+- food: 500 + 100 = 600 の集計が正確
+- rent: 1000 の集計が正確
+- income と expense を別クエリで集計し 1 レスポンスに統合
+
+NENE2 には集計抽象化層はなく、`fetchAll()` に生 SQL を渡すのが標準パターン。
+
+---
+
+## テストカバレッジ
+
+| テスト | 検証内容 |
+|---|---|
+| `testListAccountsReturnsEmpty` | GET /accounts → 空リスト |
+| `testCreateAccountReturns201` | POST /accounts → 201 |
+| `testCreateAccountRejectsMissingName` | 422・`required` コード |
+| `testCreateAccountRejectsNegativeBalance` | 422 |
+| `testGetAccountReturns404ForMissing` | 404 |
+| `testCreateTransactionIncome` | income → 残高増加 |
+| `testCreateTransactionExpense` | expense → 残高減少 |
+| `testCreateTransactionRejectsInvalidType` | transfer タイプ → 422 |
+| `testCreateTransactionRejectsZeroAmount` | 金額 0 → 422 |
+| `testFilterByCategoryString` | ?category=food フィルタ |
+| `testFilterByMinAmountInt` | ?min_amount=500 フィルタ |
+| `testFilterByMaxAmountInt` | ?max_amount=200 フィルタ |
+| `testFilterByRecurringTrue` | ?recurring=true フィルタ |
+| `testFilterByRecurringFalse` | ?recurring=false フィルタ |
+| `testNoFilterReturnsAll` | フィルタなし → 全件 |
+| `testCombinedFilters` | category + min_amount の AND 複合 |
+| `testPagination` | limit=2&offset=0 → 2 件 / total=4 |
+| `testSummaryAggregatesByCategory` | カテゴリ別 SUM 集計 |
+| `testTransferMovesFundsBetweenAccounts` | 送金 → 両残高更新 |
+| `testTransferCreatesTransactionRecords` | 送金 → 両取引レコード生成 |
+| `testTransferRejectsInsufficientBalance` | 残高不足 → 422 |
+| `testTransferRejectsSameAccount` | 同一口座 → 422 |
+| `testTransferRejectsNonExistentSourceAccount` | 存在しない口座 → 422 |
+
+**合計**: 23/23 通過
+
+---
+
+## 総評
+
+`DatabaseTransactionManagerInterface`・`QueryStringParser` 複合・集計クエリは NENE2 v1.5.6 で正常に動作した。
+
+主な摩擦は F-2（トランザクション内でのリポジトリ再利用不可）の初見での発見しにくさ。
+`use-transactions.md` に記載はあるが、インジェクションパターンに慣れた開発者が誤ったパターンで実装してもテストが一見通ってしまうリスクがある。
+
+次のアクション候補:
+1. F-1 → howto に「テストでの PDO 直接注入」パターンを追記（または `DatabaseQueryExecutorInterface` のコンビニエンスファクトリを公開）
+2. F-2 → `use-transactions.md` に警告を強化、`transactional()` PHPDoc に注釈追加
+3. F-3 → `DatabaseConfig` の SQLite 向けフィールド要件をドキュメント化

--- a/docs/howto/use-transactions.md
+++ b/docs/howto/use-transactions.md
@@ -26,12 +26,18 @@ transaction. **This executor is different from the one you inject at constructio
 
 ## The transactional repository pattern
 
-Because the callback provides its own executor, you cannot safely reuse repositories that were
-injected at construction time — they would execute queries on a separate connection that sits
-outside the transaction.
+> **Warning — do not reuse injected repositories inside the callback.**
+>
+> Repositories injected at construction time hold a **different connection** than the one
+> the transaction runs on. Using them inside the callback means their queries execute
+> outside the transaction: rollbacks will not undo those changes, and uncommitted
+> rows written inside the callback may not be visible to them.
+>
+> This mistake compiles and tests may pass — the bug only surfaces under concurrent
+> writes or when you rely on rollback behaviour.
 
-The solution: **instantiate repository classes inside the callback** using the executor the
-callback provides.
+Because the callback provides its own executor, you must **instantiate repository classes
+inside the callback** using the executor the callback provides.
 
 ```php
 <?php
@@ -125,6 +131,24 @@ protected function setUp(): void
     $this->dbFile = sys_get_temp_dir() . '/test-' . bin2hex(random_bytes(8)) . '.sqlite';
     $pdo = new \PDO('sqlite:' . $this->dbFile, options: [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
     $pdo->exec(file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+    unset($pdo); // close the init connection before the factory opens its own
+
+    $dbConfig = new DatabaseConfig(
+        url:         null,
+        environment: 'test',
+        adapter:     'sqlite',
+        host:        '',      // unused for SQLite
+        port:        1,       // unused for SQLite
+        name:        $this->dbFile,
+        user:        '',      // unused for SQLite
+        password:    '',      // unused for SQLite
+        charset:     '',      // unused for SQLite
+    );
+
+    $factory   = new PdoConnectionFactory($dbConfig);
+    $executor  = new PdoDatabaseQueryExecutor($factory);
+    $txManager = new PdoDatabaseTransactionManager($factory);
+    // ... wire repositories and use cases
 }
 
 protected function tearDown(): void
@@ -133,19 +157,18 @@ protected function tearDown(): void
         unlink($this->dbFile);
     }
 }
-
-private function dbConfig(): DatabaseConfig
-{
-    return new DatabaseConfig(
-        url: null, environment: 'test', adapter: 'sqlite',
-        host: 'localhost', port: 1, name: $this->dbFile,
-        user: 'myapp', password: '', charset: 'utf8',
-    );
-}
 ```
 
 Each test gets a fresh file, both `PdoDatabaseQueryExecutor` and
 `PdoDatabaseTransactionManager` connect to the same file, and `tearDown` deletes it.
+
+> **Note on SQLite `DatabaseConfig` fields**: For SQLite, only `adapter` and `name`
+> are required. Pass empty strings for `host`, `user`, `password`, and `charset` — they
+> are not validated when `adapter` is `'sqlite'`.
+
+> **Note**: `PdoDatabaseQueryExecutor` does not accept a raw `PDO` as its constructor
+> argument — it requires a `DatabaseConnectionFactoryInterface`. Use `PdoConnectionFactory`
+> (shown above) to bridge a raw `PDO` setup to the executor.
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.6
+  version: 1.5.7
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/Config/DatabaseConfig.php
+++ b/src/Config/DatabaseConfig.php
@@ -7,6 +7,10 @@ namespace Nene2\Config;
 /**
  * Typed database configuration assembled by {@see ConfigLoader} from environment variables.
  *
+ * **SQLite**: only `adapter` and `name` are required. Pass empty strings for
+ * `host`, `user`, `password`, and `charset` — they are not validated when
+ * `adapter` is `'sqlite'`. `port` is also ignored; any value (e.g. `1`) is accepted.
+ *
  * Part of the public API stability guarantee (see ADR 0009).
  */
 final readonly class DatabaseConfig

--- a/src/Database/DatabaseTransactionManagerInterface.php
+++ b/src/Database/DatabaseTransactionManagerInterface.php
@@ -12,6 +12,13 @@ namespace Nene2\Database;
 interface DatabaseTransactionManagerInterface
 {
     /**
+     * Executes the callback inside a database transaction and returns its result.
+     *
+     * The callback receives a `DatabaseQueryExecutorInterface` bound to the transaction's
+     * connection. **Instantiate all repositories inside the callback using this executor.**
+     * Repositories injected at construction time use a different connection and execute
+     * outside the transaction — rollbacks will not undo their changes.
+     *
      * @template T
      * @param callable(DatabaseQueryExecutorInterface): T $callback
      * @return T

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.6';
+    public const string VERSION = '1.5.7';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `DatabaseTransactionManagerInterface::transactional()` PHPDoc に注入済みリポジトリをコールバック内で再利用してはいけない旨を明記
- `DatabaseConfig` PHPDoc に SQLite では `host`/`user`/`password`/`charset` が任意であることを追記
- `docs/howto/use-transactions.md` にアンチパターン警告ブロックと完全なテストセットアップ例を追加

## Background

FT23（budgetlog: 家計簿 API）実地検証で発見した摩擦 3 件の対応。

| # | 重要度 | 内容 | 対応 |
|---|---|---|---|
| F-1（中）| `PdoDatabaseQueryExecutor` が `PDO` を直接受け取れない | `use-transactions.md` に `DatabaseConfig` + `PdoConnectionFactory` のテストパターン追記 |
| F-2（高）| トランザクション内で注入済みリポジトリが使えない（サイレント不整合） | PHPDoc + `use-transactions.md` に警告ブロック追加 |
| F-3（低）| `DatabaseConfig` の SQLite 向けフィールド要件が不明確 | PHPDoc に明記 |

## Test plan

- [ ] `docker compose run --rm app composer check` 全通過（テスト・PHPStan・CS・OpenAPI・MCP）
- [ ] バージョン 1.5.7 の整合確認

## Self-review: docs-policy

Closes #578 #579 #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)