### PR TITLE
feat(http): QueryStringParser::commaSeparated() — カンマ区切りクエリパラメータヘルパー

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.9] — 2026-05-20
+
+### Added
+- `QueryStringParser::commaSeparated()` — splits a comma-separated query parameter into a `list<string>`, trimming whitespace and removing empty values. Returns `null` when the key is absent or produces an empty list. (#584)
+- `docs/howto/add-pagination.md` — added Step 6 documenting `QueryStringParser` helpers (`string`, `int`, `bool`, `commaSeparated`) with usage examples. (#584)
+
+---
+
 ## [1.5.8] — 2026-05-20
 
 ### Changed

--- a/docs/field-trials/2026-05-field-trial-25.md
+++ b/docs/field-trials/2026-05-field-trial-25.md
@@ -1,0 +1,108 @@
+# Field Trial 25 — URL Bookmark API (linklog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/linklog/`
+**NENE2 version**: 1.5.8
+**Theme**: Multi-value query parameter parsing, `DomainExceptionHandlerInterface` with multiple handlers, CSV tag storage, delete with `LinkNotFoundException`
+
+## What was built
+
+A URL bookmark API with:
+
+- `GET /links` — list with full-text search (`?search=`), tag filter (`?tags=php,lang`), pagination
+- `POST /links` — create with URL uniqueness enforcement → 409
+- `GET /links/{id}` — fetch by ID → 404 via `DomainExceptionHandlerInterface`
+- `DELETE /links/{id}` — delete by ID → 404 via `DomainExceptionHandlerInterface`
+
+Tags stored as CSV in a single SQLite TEXT column. Full-text search covers title and URL fields.
+
+26/26 tests pass. PHPStan level 8 clean. PHP-CS-Fixer clean.
+
+## Frictions found
+
+### 1. PHPDoc required on all `array` parameters — no inference from interface (Medium)
+
+**Description**: PHPStan level 8 requires explicit `list<string>` annotations on every `array`-typed parameter, even when the interface already declares them. Both the interface and implementation must be annotated.
+
+**Severity**: Medium
+
+**Reproduction**:
+```php
+// LinkRepositoryInterface.php — interface declares list<string>|null $tags
+// SqliteLinkRepository.php — still needs its own @param annotation
+public function count(?string $search = null, ?array $tags = null): int
+// PHPStan: "has parameter $tags with no value type specified in iterable type array"
+```
+
+**Fix**: Add `/** @param list<string>|null $tags */` to every method in the implementation that receives `array`. The interface annotation alone does not propagate.
+
+**Impact**: Boilerplate PHPDoc required on concrete classes that implement typed interfaces. Not a NENE2 bug — PHPStan behavior — but worth documenting for FT authors.
+
+---
+
+### 2. `array_values(array_filter(...))` inferred as `array<int, string>`, not `list<string>` (Low)
+
+**Description**: PHPStan does not narrow `array_values(array_filter(explode(...)))` to `list<string>`. A `/** @var list<string> $tags */` assertion is required to pass it as `list<string>` to constructors.
+
+**Severity**: Low
+
+**Reproduction**:
+```php
+$tags = array_values(array_filter(explode(',', $tagsStr)));
+// PHPStan: "array might not be a list" when passed to list<string> param
+```
+
+**Fix**:
+```php
+/** @var list<string> $tags */
+$tags = array_values(array_filter(explode(',', $tagsStr)));
+```
+
+**Impact**: Minor boilerplate. Well-understood PHPStan limitation.
+
+---
+
+### 3. `?tags=php,lang` multi-value query parameter has no built-in parser (Medium)
+
+**Description**: The framework provides `QueryStringParser::string()` for single values and `PaginationQueryParser` for limit/offset, but there is no helper for comma-separated multi-value parameters like `?tags=php,lang`. Developers must split, trim, and filter manually.
+
+**Severity**: Medium
+
+**Reproduction**:
+```php
+// Must write every time:
+$rawTags = QueryStringParser::string($request, 'tags');
+$tags = $rawTags !== null
+    ? array_values(array_filter(array_map('trim', explode(',', $rawTags))))
+    : null;
+```
+
+**Potential fix**: Add `QueryStringParser::commaSeparated(request, key): ?list<string>` that handles split + trim + filter + null-when-absent in one call.
+
+---
+
+### 4. `DomainExceptionHandlerInterface` works well with multiple handlers (Positive)
+
+**Description**: Registering two handlers (`LinkNotFoundExceptionHandler` → 404, `DuplicateUrlExceptionHandler` → 409) via `$domainExceptionHandlers` in `RuntimeApplicationFactory` worked exactly as expected. No try/catch in route handlers.
+
+**Severity**: N/A (positive finding)
+
+**Pattern used**:
+```php
+new RuntimeApplicationFactory(
+    $psr17, $psr17,
+    domainExceptionHandlers: [
+        new LinkNotFoundExceptionHandler($problems),
+        new DuplicateUrlExceptionHandler($problems),
+    ],
+    routeRegistrars: [...],
+)
+```
+
+Both handlers were exercised in tests and produced correct 404/409 Problem Details responses with appropriate `type` URIs.
+
+## Tests
+
+26 tests, 54 assertions — all pass.
+
+Coverage: list (empty, pagination, search by title, search by URL, tag filter, multi-tag AND, invalid limit/offset), create (201 with all fields, default tags, duplicate URL, missing url/title, invalid JSON), show (200, 404), delete (204, removes from list, 404, re-bookmark after delete), infrastructure (security headers on success+error, X-Request-Id, 404 on unknown route, 405 on wrong method).

--- a/docs/howto/add-pagination.md
+++ b/docs/howto/add-pagination.md
@@ -139,6 +139,24 @@ When `total` is `null` (the default), the key is omitted from the response.
 > is large and the overhead is unacceptable, and instruct clients to detect the last page by
 > checking `items.length < limit`.
 
+## Step 6 — Parse other query parameters with `QueryStringParser`
+
+Use `QueryStringParser` for additional filter parameters beyond `limit`/`offset`.
+
+```php
+use Nene2\Http\QueryStringParser;
+
+$search = QueryStringParser::string($request, 'search');   // ?string
+$page   = QueryStringParser::int($request, 'page');        // ?int
+$active = QueryStringParser::bool($request, 'is_active');  // ?bool
+
+// Comma-separated multi-value: ?tags=php,lang → ['php', 'lang']
+$tags = QueryStringParser::commaSeparated($request, 'tags'); // list<string>|null
+```
+
+`commaSeparated()` splits on commas, trims whitespace, removes empty values, and returns `null`
+when the parameter is absent or produces an empty list after filtering.
+
 ## See also
 
 - `src/Example/Note/ListNotesHandler.php` — reference implementation using `PaginationResponse`
@@ -146,3 +164,4 @@ When `total` is `null` (the default), the key is omitted from the response.
 - `Nene2\Http\PaginationQuery` — readonly DTO for parsed parameters
 - `Nene2\Http\PaginationQueryParser` — the parser class
 - `Nene2\Http\PaginationResponse` — the list-envelope DTO
+- `Nene2\Http\QueryStringParser` — typed helpers for other query parameters

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.8
+  version: 1.5.9
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.8';
+    public const string VERSION = '1.5.9';
 
     public function name(): string
     {

--- a/src/Http/QueryStringParser.php
+++ b/src/Http/QueryStringParser.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\ServerRequestInterface;
  *   $category = QueryStringParser::string($request, 'category');     // ?string
  *   $page     = QueryStringParser::int($request, 'page');            // ?int
  *   $isRead   = QueryStringParser::bool($request, 'is_read');        // ?bool (null when absent)
+ *   $tags     = QueryStringParser::commaSeparated($request, 'tags'); // list<string>|null
  *
  * Part of the public API stability guarantee (see ADR 0009).
  */
@@ -79,5 +80,29 @@ final class QueryStringParser
         }
 
         return !in_array($raw, ['0', 'false', 'no'], true);
+    }
+
+    /**
+     * Splits a comma-separated query parameter into a list of non-empty trimmed strings.
+     *
+     * Returns null when the key is absent or the value is an empty string.
+     * Each item is trimmed; empty items after trimming are removed.
+     *
+     * Common use case: `?tags=php,lang` → `['php', 'lang']`
+     *
+     * @return list<string>|null
+     */
+    public static function commaSeparated(ServerRequestInterface $request, string $key): ?array
+    {
+        $raw = self::string($request, $key);
+
+        if ($raw === null) {
+            return null;
+        }
+
+        /** @var list<string> $items */
+        $items = array_values(array_filter(array_map('trim', explode(',', $raw))));
+
+        return $items !== [] ? $items : null;
     }
 }


### PR DESCRIPTION
## Summary

- `QueryStringParser::commaSeparated(request, key): list<string>|null` を追加。カンマで分割・trim・空要素除去を一発で行う
- `docs/howto/add-pagination.md` に Step 6 として `QueryStringParser` 全メソッドの使用例を追記
- FT25 (linklog) の摩擦 #3 への対応: Field Trial 25 report を追加

## Test plan

- [x] `composer check` — 321 tests, 826 assertions, PHPStan level 8, CS-Fixer, OpenAPI/MCP/version consistency all pass
- [x] `?tags=php,lang` → `['php', 'lang']` (split + trim + filter)
- [x] `?tags=` → `null` (empty string treated as absent)
- [x] key absent → `null`
- [x] `?tags= php , , lang ` → `['php', 'lang']` (whitespace trimmed, empty removed)

## Related

Closes #584

Self-review: backend-api, openapi-contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)