### PR TITLE
docs(routing,http): ルート登録順・PATCH array_key_exists パターン追記 (FT26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.10] — 2026-05-20
+
+### Changed
+- `docs/howto/add-custom-route.md` — added warning: static route segments must be registered before parameterised routes sharing the same prefix. Includes example of the silent misbehaviour and the correct ordering. (#586)
+- `docs/howto/implement-patch-endpoint.md` — added Step 4 "Validating PATCH fields": explains `array_key_exists` vs `isset` for PATCH field detection, validation pattern for optional fields, and nullable repository parameter pattern. (#587)
+
+---
+
 ## [1.5.9] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-26.md
+++ b/docs/field-trials/2026-05-field-trial-26.md
@@ -1,0 +1,107 @@
+# Field Trial 26 — Expense Tracker API (expenselog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/expenselog/`
+**NENE2 version**: 1.5.9
+**Theme**: PATCH partial updates, date-range filtering, monthly aggregation, route ordering with static segments vs path parameters
+
+## What was built
+
+A personal expense tracker API with:
+
+- `GET /expenses` — list with `?from=`, `?to=`, `?category=` filters and pagination
+- `POST /expenses` — create with date (YYYY-MM-DD), amount (integer cents), category, note
+- `GET /expenses/summary?month=YYYY-MM` — monthly aggregate: total, count, per-category breakdown
+- `GET /expenses/{id}` — fetch by ID
+- `PATCH /expenses/{id}` — partial update (any subset of: date, amount, category, note)
+- `DELETE /expenses/{id}` — delete
+
+`amount` stored as integer (cents) to avoid floating-point issues. SQLite `strftime('%Y-%m', date)` used for monthly grouping.
+
+34/34 tests pass. PHPStan level 8 clean. PHP-CS-Fixer clean.
+
+## Frictions found
+
+### 1. Route ordering: static segments must precede path parameters (Medium)
+
+**Description**: The router matches in registration order. The static route `GET /expenses/summary` must be registered before the parameterised route `GET /expenses/{id}`. If `{id}` is registered first, a request to `/expenses/summary` matches it with `id = "summary"`, which then fails with a domain-specific 404 (`expense-not-found`) rather than a meaningful routing error.
+
+**Severity**: Medium
+
+**Reproduction**:
+```php
+// WRONG order — summary hits {id} with id="summary"
+$router->get('/expenses/{id}', $this->show(...));
+$router->get('/expenses/summary', $this->summary(...)); // never reached
+
+// CORRECT order — static segment matched first
+$router->get('/expenses/summary', $this->summary(...));
+$router->get('/expenses/{id}', $this->show(...));
+```
+
+**Impact**: Silent misbehaviour — no routing error, just a wrong 404 with a confusing message. Easy to introduce when adding sub-resource routes to an existing controller.
+
+**Potential fix**: Document this in `add-custom-route.md`. Optionally warn when a static route is registered after a parameterised route that would shadow it.
+
+---
+
+### 2. PATCH requires `array_key_exists` — no framework helper (Medium)
+
+**Description**: PATCH semantics require distinguishing "field not in body" (keep existing value) from "field present with null/empty" (treat as update). PHP's `isset()` conflates absent with null, requiring `array_key_exists()` at every field.
+
+**Severity**: Medium
+
+**Reproduction**:
+```php
+$body = JsonRequestBodyParser::parse($request); // array<string, mixed>
+
+// Wrong: isset() cannot distinguish absent from null
+$amount = isset($body['amount']) ? $body['amount'] : null;
+
+// Correct but verbose:
+$amount = array_key_exists('amount', $body) ? $body['amount'] : null;
+```
+
+With five patchable fields, this produces five boilerplate lines of `array_key_exists`. The framework has no helper to extract a PATCH diff.
+
+**Potential fix**: A `PatchExtractor` helper or a note in `implement-patch-endpoint.md` explaining why `array_key_exists` is necessary.
+
+---
+
+### 3. Date format validation — no built-in helper (Low)
+
+**Description**: Validating that a string matches `YYYY-MM-DD` requires a manual `preg_match`. There is no `ValidationError` factory method or format-check helper in the framework.
+
+**Severity**: Low
+
+**Reproduction**:
+```php
+if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+    $errors[] = new ValidationError('date', 'date must be in YYYY-MM-DD format.', 'invalid_format');
+}
+```
+
+**Impact**: Minor boilerplate. Consistent pattern once learned; no framework change needed immediately.
+
+---
+
+### 4. Aggregation requires raw SQL — no query builder (Positive / By Design)
+
+**Description**: The monthly summary endpoint uses raw `strftime('%Y-%m', date)` in a GROUP BY query. There is no query builder or aggregation helper. This is intentional in NENE2's thin-SQL design — it is not a friction, just a documentation opportunity.
+
+**Pattern used**:
+```sql
+SELECT category, SUM(amount) AS total, COUNT(*) AS cnt
+  FROM expenses
+ WHERE strftime('%Y-%m', date) = ?
+ GROUP BY category
+ ORDER BY total DESC
+```
+
+This worked correctly. SQLite's `strftime` is standard and portable within SQLite.
+
+## Tests
+
+34 tests, 67 assertions — all pass.
+
+Coverage: list (empty, pagination, date-from filter, date-to filter, date range, category filter, invalid limit), create (201 with all fields, missing date, invalid date format, negative amount, zero amount, missing category, default note), show (200, 404), PATCH (amount, category, date, preserves unchanged fields, invalid amount, invalid date, 404), delete (204, removes, 404), summary (empty month, aggregates by category, missing month, invalid format), infrastructure (security headers + X-Request-Id, unknown route 404, method not allowed 405).

--- a/docs/howto/add-custom-route.md
+++ b/docs/howto/add-custom-route.md
@@ -131,6 +131,22 @@ routeRegistrars: [
 
 Or split across multiple registrar functions for clarity when the route list grows long.
 
+> **Route registration order**: The router matches in registration order. **Always register
+> static routes before parameterised ones** when both share the same prefix. If you register
+> `GET /items/{id}` first and then `GET /items/summary`, a request to `/items/summary` will
+> match the `{id}` route with `id = "summary"` — producing a confusing domain-specific 404
+> rather than a routing error.
+>
+> ```php
+> // WRONG — /items/summary matches {id} with id="summary"
+> $router->get('/items/{id}',    $this->show(...));
+> $router->get('/items/summary', $this->summary(...)); // never reached
+>
+> // CORRECT — static segment matched first
+> $router->get('/items/summary', $this->summary(...));
+> $router->get('/items/{id}',    $this->show(...));
+> ```
+
 ---
 
 ## Available HTTP methods

--- a/docs/howto/implement-patch-endpoint.md
+++ b/docs/howto/implement-patch-endpoint.md
@@ -88,7 +88,74 @@ JSON object `{}`.
 
 ---
 
-## 4. Repository contract
+## 4. Validating PATCH fields
+
+Validate only the fields that are **present**. Skip validation for absent fields — they won't be
+touched. Use nullable parameters in the repository signature to make intent explicit:
+
+```php
+$body   = JsonRequestBodyParser::parse($request);
+$errors = [];
+
+// Extract only present fields (array_key_exists, not isset)
+$amount   = array_key_exists('amount', $body) ? $body['amount'] : null;
+$category = array_key_exists('category', $body) ? $body['category'] : null;
+$date     = array_key_exists('date', $body) ? $body['date'] : null;
+
+// Validate only the fields that were sent
+if ($amount !== null) {
+    if (!is_int($amount) || $amount <= 0) {
+        $errors[] = new ValidationError('amount', 'amount must be a positive integer.', 'out_of_range');
+    }
+}
+
+if ($date !== null) {
+    if (!is_string($date) || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+        $errors[] = new ValidationError('date', 'date must be in YYYY-MM-DD format.', 'invalid_format');
+    }
+}
+
+if ($errors !== []) {
+    throw new ValidationException($errors);
+}
+
+// Call repository with nullable args — repository uses existing value when null
+$entity = $this->repository->update(
+    id:       $id,
+    amount:   is_int($amount) ? $amount : null,
+    category: is_string($category) && $category !== '' ? $category : null,
+    date:     is_string($date) && $date !== '' ? $date : null,
+    now:      (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'),
+);
+```
+
+In the repository, use `??` to fall back to the existing value:
+
+```php
+public function update(int $id, ?int $amount, ?string $category, ?string $date, string $now): Entity
+{
+    $existing    = $this->findById($id); // throws NotFoundException when missing
+    $newAmount   = $amount   ?? $existing->amount;
+    $newCategory = $category ?? $existing->category;
+    $newDate     = $date     ?? $existing->date;
+
+    $this->executor->execute(
+        'UPDATE entities SET amount = ?, category = ?, date = ?, updated_at = ? WHERE id = ?',
+        [$newAmount, $newCategory, $newDate, $now, $id],
+    );
+
+    return new Entity($id, $newDate, $newAmount, $newCategory, $existing->createdAt, $now);
+}
+```
+
+> **Why `array_key_exists` and not `isset`?** `isset($body['field'])` returns `false` for both
+> a missing key and a key present with value `null`. For PATCH, that distinction matters:
+> "not sent" means "keep the existing value", while `null` may mean "clear this field".
+> Always use `array_key_exists` for PATCH field detection.
+
+---
+
+## 5. Repository contract
 
 Your repository's `update()` should accept only the fields passed in and return
 the updated entity (or `null` when not found):

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.9
+  version: 1.5.10
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.9';
+    public const string VERSION = '1.5.10';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `add-custom-route.md` — 静的ルートはパスパラメータより前に登録すること。サイレントな誤マッチ（`/items/summary` が `{id}` にマッチ）の説明と正しい順序を追記
- `implement-patch-endpoint.md` — Step 4 追加: `array_key_exists` vs `isset` の違い、PATCH フィールドのバリデーション、nullable リポジトリパターン

## Test plan

- [x] `composer check` — 321 tests, PHPStan level 8, CS-Fixer, version 1.5.10 OK

## Related

Closes #586
Closes #587

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)