### PR TITLE
docs(routing): POST アクションエンドポイントパターン追記 (FT27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.11] — 2026-05-20
+
+### Changed
+- `docs/howto/add-custom-route.md` — added "Action endpoints" section documenting the `POST /resource/{id}/action` pattern (archive, restore, publish, approve) with registration-order note; updated HTTP methods table to include PATCH. (#589)
+
+---
+
 ## [1.5.10] — 2026-05-20
 
 ### Changed

--- a/docs/field-trials/2026-05-field-trial-27.md
+++ b/docs/field-trials/2026-05-field-trial-27.md
@@ -1,0 +1,108 @@
+# Field Trial 27 — Movie/TV Watchlist API (watchlog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/watchlog/`
+**NENE2 version**: 1.5.10
+**Theme**: Soft deletion (archive/restore), PHP enums as domain types, status transition validation, action endpoints
+
+## What was built
+
+A movie/TV show watchlist API with:
+
+- `GET /watch` — list active entries (`?include_archived=true` to include archived, `?status=`, `?media_type=` filters)
+- `POST /watch` — create with title and media_type (`movie` | `tv`); starts at `want-to-watch`
+- `GET /watch/{id}` — fetch by ID
+- `PATCH /watch/{id}/status` — transition status with validation, optional rating and note
+- `POST /watch/{id}/archive` — soft-archive (sets `archived_at`)
+- `POST /watch/{id}/restore` — restore (clears `archived_at`)
+- `DELETE /watch/{id}` — hard delete
+
+Status machine: `want-to-watch` → `watching` | `dropped`; `watching` → `completed` | `dropped` | `want-to-watch`; `completed`/`dropped` → `want-to-watch`.
+
+31/31 tests pass. PHPStan level 8 clean. PHP-CS-Fixer clean.
+
+## Frictions found
+
+### 1. PHP enum values validated by `WatchStatus::tryFrom()` — no framework enum validator (Low)
+
+**Description**: Validating that a query parameter or body field is a valid enum value requires calling `Enum::tryFrom()` and checking for `null`. There is no framework helper to convert a raw string to an enum with a typed `ValidationError` on failure.
+
+**Severity**: Low
+
+**Reproduction**:
+```php
+$statusRaw = QueryStringParser::string($request, 'status');
+$status    = $statusRaw !== null ? WatchStatus::tryFrom($statusRaw) : null;
+
+if ($statusRaw !== null && $status === null) {
+    $errors[] = new ValidationError('status', 'Invalid status value.', 'invalid_value');
+}
+```
+
+This pattern is repeated for every enum field (status, media_type in list; status, rating in update). **Positive finding**: PHP 8.1+ backed enums make this clean and explicit — no string-comparison errors possible.
+
+---
+
+### 2. PHPStan: `const array` with typed offsets — `?? []` redundant (Low)
+
+**Description**: When a `const array` has typed keys covering all enum values, PHPStan correctly infers that offset access always exists and flags `?? []` as redundant (`nullCoalesce.offset`).
+
+**Severity**: Low (PHPStan correctness, easy fix)
+
+**Reproduction**:
+```php
+private const array TRANSITIONS = [
+    'want-to-watch' => ['watching', 'dropped'],
+    'watching'      => ['completed', 'dropped', 'want-to-watch'],
+    'completed'     => ['want-to-watch'],
+    'dropped'       => ['want-to-watch'],
+];
+
+// PHPStan error: "?? [] always exists and is not nullable"
+$allowed = self::TRANSITIONS[$existing->status->value] ?? [];
+
+// Fix: remove the fallback
+$allowed = self::TRANSITIONS[$existing->status->value];
+```
+
+**Fix**: PHPStan correctly identifies that the key always exists when enum values map 1:1 with the const array keys. Remove the `?? []` fallback.
+
+---
+
+### 3. Action endpoints (`/archive`, `/restore`) vs PATCH — no framework guidance (Medium)
+
+**Description**: When building action endpoints that don't fit CRUD semantics (archive, restore, publish, approve), the choice between `POST /resource/{id}/action` vs `PATCH /resource/{id}` with an action field is not documented. Both work in NENE2, but the pattern is not established.
+
+**Severity**: Medium
+
+**Pattern used** (POST action endpoint):
+```php
+$router->post('/watch/{id}/archive', $this->archive(...));
+$router->post('/watch/{id}/restore', $this->restore(...));
+```
+
+Response: `200 OK` with the updated resource body.
+
+**Positive finding**: Action endpoints map cleanly to route handlers. The `POST /resource/{id}/action` pattern reads naturally. The router supports arbitrary nesting. No friction in implementation — only documentation gap.
+
+**Potential fix**: Document the POST action endpoint pattern in `add-custom-route.md` or a new `implement-action-endpoints.md` howto.
+
+---
+
+### 4. Soft deletion with `include_archived` boolean query param — works cleanly (Positive)
+
+**Description**: `QueryStringParser::bool()` correctly handles `?include_archived=true/false`. Default `false` filters out archived rows using `WHERE archived_at IS NULL`.
+
+**Pattern used**:
+```php
+$includeArchived = QueryStringParser::bool($request, 'include_archived') ?? false;
+// In SQL: if (!$includeArchived) { $sql .= ' AND archived_at IS NULL'; }
+```
+
+No friction. `QueryStringParser::bool()` returning `null` for absent keys and the `?? false` default is clean and explicit.
+
+## Tests
+
+31 tests, 52 assertions — all pass.
+
+Coverage: list (empty, active-only by default, include_archived, filter by status, filter by media_type, invalid enum values, pagination), create (201, missing title, missing/invalid media_type), show (200, 404), status transitions (want→watching, watching→completed+rating, watching→dropped, invalid want→completed, with note, invalid rating, missing status, 404), archive (sets archived_at, excluded from default list, 404), restore (clears archived_at, appears in list), delete (204, 404), infrastructure (security headers + X-Request-Id, unknown route 404 problem details).

--- a/docs/howto/add-custom-route.md
+++ b/docs/howto/add-custom-route.md
@@ -149,13 +149,43 @@ Or split across multiple registrar functions for clarity when the route list gro
 
 ---
 
+## Action endpoints (non-CRUD operations)
+
+Some operations don't fit the standard CRUD shape — archiving, publishing, approving, restoring.
+Use `POST /resource/{id}/action` for these. The response is `200 OK` with the updated resource body.
+
+```php
+$router->post('/items/{id}/archive', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->archive($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+
+$router->post('/items/{id}/restore', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->restore($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+```
+
+> **Registration order**: Action routes (`/items/{id}/archive`) share the `{id}` segment with
+> the show/update routes — they work correctly because the action path has an additional static
+> segment after `{id}`, making them unambiguous regardless of registration order.
+
+---
+
 ## Available HTTP methods
 
 | Method | Router method | Typical use |
 |---|---|---|
 | GET | `$router->get()` | Read a resource |
-| POST | `$router->post()` | Create a resource |
+| POST | `$router->post()` | Create a resource or trigger an action |
 | PUT | `$router->put()` | Replace a resource (full update) |
+| PATCH | `$router->patch()` | Partial update |
 | DELETE | `$router->delete()` | Remove a resource |
 
 ---

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.10
+  version: 1.5.11
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.10';
+    public const string VERSION = '1.5.11';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `add-custom-route.md` に「Action endpoints」節を追加: `POST /resource/{id}/action` パターン（archive, restore, publish, approve）の実装例と登録順の注意
- HTTP メソッド表に PATCH を追記

## Test plan

- [x] `composer check` — 321 tests, PHPStan level 8, CS-Fixer, version 1.5.11 OK

## Related

Closes #589

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)