### PR TITLE
docs(validation): バルクエンドポイント indexed エラーパターン howto (FT28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.12] — 2026-05-20
+
+### Added
+- `docs/howto/implement-bulk-endpoint.md` — new howto covering the complete bulk create pattern: envelope validation, per-item validation with `"scores[{i}].field"` indexed error names, size limiting, route registration order, and transaction note. (#591)
+
+---
+
 ## [1.5.11] — 2026-05-20
 
 ### Changed

--- a/docs/field-trials/2026-05-field-trial-28.md
+++ b/docs/field-trials/2026-05-field-trial-28.md
@@ -1,0 +1,102 @@
+# Field Trial 28 — Leaderboard API (scorelog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/scorelog/`
+**NENE2 version**: 1.5.11
+**Theme**: Bulk create endpoint, window function ranking (`RANK() OVER`), indexed validation errors for bulk payloads
+
+## What was built
+
+A game score/leaderboard API with:
+
+- `GET /scores` — list with `?game=` and `?player=` filters, pagination
+- `POST /scores` — submit a single score (player, game, score integer, played_at date)
+- `POST /scores/bulk` — submit up to 100 scores in one request; each entry validated individually
+- `GET /scores/leaderboard?game=tetris&top=10` — ranked leaderboard using `RANK() OVER (ORDER BY MAX(score) DESC)`
+- `GET /scores/{id}` — fetch by ID
+- `DELETE /scores/{id}` — delete
+
+The leaderboard uses `GROUP BY player` + `RANK() OVER` window function — SQLite 3.25+ supports window functions.
+
+27/27 tests pass. PHPStan level 8 clean. PHP-CS-Fixer clean.
+
+## Frictions found
+
+### 1. Bulk endpoint validation: indexed field names (`scores[0].player`) — no framework helper (Medium)
+
+**Description**: For bulk POST endpoints, validation errors need to identify which entry and which field failed (e.g., `scores[1].player`). `ValidationError` accepts any string as the field name, so this works, but the caller must prefix every field name manually. There is no per-item validation wrapper.
+
+**Severity**: Medium
+
+**Reproduction**:
+```php
+foreach ($entriesRaw as $i => $entry) {
+    $entryErrors = $this->validateScoreEntry($entry, "scores[{$i}].");
+    // ValidationError('scores[0].player', 'player is required.', 'required')
+}
+```
+
+The result is correct but requires looping with prefix injection. A `ValidationException::forIndex(int $i, array $errors)` helper or a validator runner that supports indexed entries would reduce boilerplate.
+
+**Potential fix**: Document this pattern in a "Bulk endpoint validation" section of `implement-patch-endpoint.md` or a new howto.
+
+---
+
+### 2. `RANK() OVER` window function — no ORM needed, SQLite 3.25+ supports it (Positive)
+
+**Description**: SQLite 3.25+ (released 2018, included in PHP's bundled SQLite) supports window functions including `RANK()`. Using raw SQL with the executor works perfectly.
+
+**Pattern used**:
+```sql
+SELECT player, MAX(score) AS best_score, COUNT(*) AS play_count,
+       RANK() OVER (ORDER BY MAX(score) DESC) AS rank
+  FROM scores
+ WHERE game = ?
+ GROUP BY player
+ ORDER BY best_score DESC
+ LIMIT ?
+```
+
+No friction — raw SQL executor handles this cleanly. This confirms NENE2's thin-SQL design works for analytics queries.
+
+---
+
+### 3. Bulk size limit validation — no `maxItems` constraint on arrays (Low)
+
+**Description**: Limiting bulk payload size (e.g., max 100 items) requires manual `count()` check. There is no `@MaxItems` or similar constraint in the validation layer.
+
+**Severity**: Low
+
+**Pattern used**:
+```php
+if (count($entriesRaw) > 100) {
+    throw new ValidationException([
+        new ValidationError('scores', 'scores may contain at most 100 entries.', 'out_of_range'),
+    ]);
+}
+```
+
+Simple and explicit — not a significant friction, just boilerplate.
+
+---
+
+### 4. CS-Fixer: trailing whitespace in aligned array literals (Low)
+
+**Description**: PHP-CS-Fixer (`@PSR12`) disallows extra spaces used for alignment. Code written with aligned columns for readability requires post-hoc `cs:fix` run.
+
+**Example**:
+```php
+// Written:
+$this->submitScore('Bob',   'tetris', 2000); // extra space before 'tetris'
+
+// CS-Fixer normalises to:
+$this->submitScore('Bob', 'tetris', 2000);
+```
+
+**Severity**: Low (tooling expectation, not a framework issue).
+
+## Tests
+
+27 tests, 52 assertions — all pass.
+
+Coverage: list (empty, pagination, game filter, player filter), submit (201, zero score allowed, missing player, negative score, invalid date, multiple scores same player), bulk (201 with 3 entries, empty array, missing field, invalid entry, over-100 limit), leaderboard (ranked by best score with play_count, top-N limit, missing game, invalid top, empty game), show (200, 404), delete (204, 404), infrastructure (security headers + X-Request-Id, unknown route 404).

--- a/docs/howto/implement-bulk-endpoint.md
+++ b/docs/howto/implement-bulk-endpoint.md
@@ -1,0 +1,183 @@
+# How-to: Implement a Bulk Create Endpoint
+
+A bulk endpoint accepts multiple resources in a single request — reducing round trips for
+batch imports, score submissions, and similar workflows. This guide covers the complete
+pattern: parsing, per-item validation with indexed error fields, size limiting, and the route.
+
+---
+
+## 1. Schema
+
+The request body wraps items in a named array key so the envelope can carry metadata:
+
+```json
+{
+  "scores": [
+    { "player": "Alice", "game": "tetris", "score": 1000, "played_at": "2026-01-15" },
+    { "player": "Bob",   "game": "tetris", "score": 2000, "played_at": "2026-01-16" }
+  ]
+}
+```
+
+The response returns the created count and the created items:
+
+```json
+{ "created": 2, "scores": [ /* ... */ ] }
+```
+
+---
+
+## 2. Route
+
+Register the bulk route **before** the parameterised single-resource route to avoid shadowing
+(see [add-custom-route.md](add-custom-route.md)):
+
+```php
+$router->post('/scores/bulk', $this->bulkSubmit(...)); // static first
+$router->post('/scores/{id}', $this->show(...));        // parameterised after
+```
+
+---
+
+## 3. Handler
+
+```php
+private function bulkSubmit(ServerRequestInterface $request): ResponseInterface
+{
+    $body = JsonRequestBodyParser::parse($request);
+
+    // 1. Validate the envelope
+    if (!isset($body['scores']) || !is_array($body['scores'])) {
+        throw new ValidationException([
+            new ValidationError('scores', 'scores must be a non-empty array.', 'required'),
+        ]);
+    }
+
+    /** @var array<mixed> $entriesRaw */
+    $entriesRaw = $body['scores'];
+
+    if (count($entriesRaw) === 0) {
+        throw new ValidationException([
+            new ValidationError('scores', 'scores must contain at least one entry.', 'required'),
+        ]);
+    }
+
+    // 2. Enforce size limit before iterating
+    if (count($entriesRaw) > 100) {
+        throw new ValidationException([
+            new ValidationError('scores', 'scores may contain at most 100 entries per request.', 'out_of_range'),
+        ]);
+    }
+
+    // 3. Validate each entry, prefixing field names with the index
+    $allErrors = [];
+    $entries   = [];
+
+    foreach ($entriesRaw as $i => $entry) {
+        if (!is_array($entry)) {
+            $allErrors[] = new ValidationError("scores[{$i}]", 'Each entry must be an object.', 'invalid_type');
+            continue;
+        }
+
+        /** @var array<string, mixed> $entry */
+        $entryErrors = $this->validateEntry($entry, "scores[{$i}].");
+        if ($entryErrors !== []) {
+            $allErrors = [...$allErrors, ...$entryErrors];
+        } else {
+            $entries[] = $entry;
+        }
+    }
+
+    // 4. Fail the whole request if any entry is invalid
+    if ($allErrors !== []) {
+        throw new ValidationException($allErrors);
+    }
+
+    // 5. Persist all entries and return
+    $now     = (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+    $created = $this->repository->bulkCreate($entries, $now);
+
+    return $this->json->create([
+        'created' => count($created),
+        'scores'  => array_map(fn ($s) => $this->serialize($s), $created),
+    ], 201);
+}
+```
+
+---
+
+## 4. Per-item validation with indexed field names
+
+Use a private helper that accepts a `string $prefix` argument. The prefix is `"scores[{$i}]."`:
+
+```php
+/**
+ * @param array<string, mixed> $body
+ * @return list<ValidationError>
+ */
+private function validateEntry(array $body, string $prefix = ''): array
+{
+    $errors = [];
+
+    if (!isset($body['player']) || !is_string($body['player']) || $body['player'] === '') {
+        $errors[] = new ValidationError($prefix . 'player', 'player is required.', 'required');
+    }
+
+    if (!isset($body['score']) || !is_int($body['score'])) {
+        $errors[] = new ValidationError($prefix . 'score', 'score is required (integer).', 'required');
+    } elseif ($body['score'] < 0) {
+        $errors[] = new ValidationError($prefix . 'score', 'score must be 0 or greater.', 'out_of_range');
+    }
+
+    return $errors;
+}
+```
+
+**Why `$prefix`?** `ValidationError` accepts any string as the field name. Passing
+`"scores[0]."` as a prefix produces error fields like `"scores[0].player"` — making it
+immediately clear which entry and field failed. A single prefix argument is enough; no
+framework change is needed.
+
+The resulting 422 response body:
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "errors": [
+    { "field": "scores[1].player", "message": "player is required.", "code": "required" }
+  ]
+}
+```
+
+---
+
+## 5. Repository contract
+
+Accept a list of pre-validated entries and return the created entities:
+
+```php
+/**
+ * @param list<array{player: string, game: string, score: int, played_at: string}> $entries
+ * @return list<Score>
+ */
+public function bulkCreate(array $entries, string $now): array
+{
+    $results = [];
+    foreach ($entries as $entry) {
+        $results[] = $this->create($entry['player'], $entry['game'], $entry['score'], $entry['played_at'], $now);
+    }
+    return $results;
+}
+```
+
+> **Atomicity**: The loop above inserts one row at a time. Wrap in
+> `DatabaseTransactionManagerInterface::transactional()` if you need all-or-nothing
+> behaviour — see [use-transactions.md](use-transactions.md).
+
+---
+
+## 6. Related how-tos
+
+- [`add-pagination.md`](add-pagination.md) — list endpoint pattern
+- [`use-transactions.md`](use-transactions.md) — wrap bulk inserts in a transaction
+- [`add-domain-exception-handler.md`](add-domain-exception-handler.md) — domain-specific 404/409

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.11
+  version: 1.5.12
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.11';
+    public const string VERSION = '1.5.12';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `implement-bulk-endpoint.md` 新規作成: バルク POST エンドポイントの完全パターン（エンベロープ検証・per-item indexed エラー・サイズ制限・route 登録順・トランザクション注記）
- FT28 (scorelog) field trial report 追加

## Test plan

- [x] `composer check` — 321 tests, PHPStan level 8, CS-Fixer, version 1.5.12 OK

## Related

Closes #591

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)