### PR TITLE
fix(database): SQLite PRAGMA foreign_keys = ON を PdoConnectionFactory で自動設定

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.14] — 2026-05-20
+
+### Fixed
+- `PdoConnectionFactory` now runs `PRAGMA foreign_keys = ON` immediately after creating a SQLite connection. Previously, `ON DELETE CASCADE` and other foreign key constraints were silently ignored on SQLite. (#596)
+
+### Added
+- `docs/field-trials/2026-05-field-trial-30.md` — FT30 (projtrack) field trial report.
+
+---
+
 ## [1.5.13] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-30.md
+++ b/docs/field-trials/2026-05-field-trial-30.md
@@ -1,0 +1,98 @@
+# Field Trial 30 — Project + Task Nested Resource API (projtrack)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/projtrack/`
+**NENE2 version**: 1.5.13
+**Theme**: Nested resource routes (`/projects/{projectId}/tasks/{taskId}`), multiple path params, cross-entity validation, SQLite foreign key cascade
+
+## What was built
+
+A project and task tracking API with fully nested task routes:
+
+- `GET /projects` — list projects with pagination
+- `POST /projects` — create project (name required, description optional)
+- `GET /projects/{id}` — show project
+- `DELETE /projects/{id}` — delete project (cascade deletes tasks)
+- `GET /projects/{projectId}/tasks` — list tasks for a project; `?status=` filter, pagination
+- `POST /projects/{projectId}/tasks` — create task in a project
+- `GET /projects/{projectId}/tasks/{taskId}` — show task (validates project ownership)
+- `PATCH /projects/{projectId}/tasks/{taskId}` — update task title/status/priority
+- `DELETE /projects/{projectId}/tasks/{taskId}` — delete task
+
+Task status: `open` → `in_progress` → `done`. Tasks ordered by `priority DESC, created_at ASC`.
+
+31/31 tests pass. PHPStan level 8 clean. PHP-CS-Fixer clean.
+
+## Frictions found
+
+### 1. `PdoConnectionFactory` does not enable `PRAGMA foreign_keys = ON` for SQLite (High)
+
+**Description**: SQLite does not enforce foreign key constraints (including `ON DELETE CASCADE`) by default. The NENE2 `PdoConnectionFactory` did not set `PRAGMA foreign_keys = ON` after creating the connection. As a result, schemas with `REFERENCES ... ON DELETE CASCADE` silently fail to cascade: child rows are not deleted when a parent row is deleted.
+
+**Severity**: High — data integrity issue that silently corrupts state. Developers define cascade in the schema and naturally expect it to work.
+
+**Reproduction**:
+```sql
+-- schema.sql
+CREATE TABLE tasks (
+    project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    ...
+);
+```
+```php
+// Without PRAGMA foreign_keys = ON, this leaves orphaned tasks:
+$executor->execute('DELETE FROM projects WHERE id = ?', [$id]);
+```
+
+**Fix applied**: `PdoConnectionFactory::create()` now runs `PRAGMA foreign_keys = ON` immediately after creating a SQLite connection.
+
+---
+
+### 2. Multiple path params in nested routes work without friction (Positive)
+
+**Description**: Routes with two path params (e.g., `/projects/{projectId}/tasks/{taskId}`) are registered and dispatch correctly. Both params appear in `$request->getAttribute(Router::PARAMETERS_ATTRIBUTE)` as expected.
+
+**Pattern used**:
+```php
+$router->get('/projects/{projectId}/tasks/{taskId}', $this->showTask(...));
+
+// In handler:
+$params    = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+$projectId = (int) ($params['projectId'] ?? 0);
+$taskId    = (int) ($params['taskId'] ?? 0);
+```
+
+No friction — the router handles multiple params correctly.
+
+---
+
+### 3. Cross-entity ownership validation pattern — no helper (Low)
+
+**Description**: For nested resources, handlers must validate both that the parent exists (404 if project not found) and that the child belongs to the parent (404 if task not found in that project). This is manual but clear:
+
+```php
+private function showTask(ServerRequestInterface $request): ResponseInterface
+{
+    $params    = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $projectId = (int) ($params['projectId'] ?? 0);
+    $taskId    = (int) ($params['taskId'] ?? 0);
+
+    $this->projects->findById($projectId); // throws ProjectNotFoundException → 404
+    $task = $this->tasks->findByProjectAndId($projectId, $taskId); // throws TaskNotFoundException → 404
+    ...
+}
+```
+
+The two-step pattern is explicit and sufficient. No framework helper needed, but a howto section would help.
+
+---
+
+### 4. No convenient `insert()` usage in v1.5.12 FT — now resolved (Resolved in v1.5.13)
+
+`DatabaseQueryExecutorInterface::insert()` added in v1.5.13 — used throughout this FT project without friction.
+
+## Tests
+
+31 tests, 54 assertions — all pass.
+
+Coverage: list projects (empty, pagination), create project (201, missing name 422, empty name 422, default description), show project (200, 404), delete project (204, 404), cascade (delete project deletes tasks via `PRAGMA foreign_keys = ON`), list tasks (empty, unknown project 404, filter by status, invalid status 422, only project's tasks, pagination), create task (201, unknown project 404, missing title 422, default priority 0), show task (200, 404, cross-project 404), update task (title, status, invalid status 422, not found 404), delete task (204), sort by priority, infrastructure (security headers, X-Request-Id, unknown route 404).

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.13
+  version: 1.5.14
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/Database/PdoConnectionFactory.php
+++ b/src/Database/PdoConnectionFactory.php
@@ -19,7 +19,7 @@ final readonly class PdoConnectionFactory implements DatabaseConnectionFactoryIn
     public function create(): PDO
     {
         try {
-            return new PDO(
+            $pdo = new PDO(
                 $this->dsn(),
                 $this->config->user,
                 $this->config->password,
@@ -29,6 +29,12 @@ final readonly class PdoConnectionFactory implements DatabaseConnectionFactoryIn
                     PDO::ATTR_EMULATE_PREPARES => false,
                 ],
             );
+
+            if ($this->config->adapter === 'sqlite') {
+                $pdo->exec('PRAGMA foreign_keys = ON');
+            }
+
+            return $pdo;
         } catch (PDOException $exception) {
             throw new DatabaseConnectionException('Database connection could not be created.', previous: $exception);
         }

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.13';
+    public const string VERSION = '1.5.14';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- FT30 (projtrack) で発見した高重大度バグを修正。
- `PdoConnectionFactory::create()` で SQLite 接続直後に `PRAGMA foreign_keys = ON` を実行するよう変更。
- MySQL / PostgreSQL には影響なし（SQLite アダプターのみ）。

## Problem

SQLite はデフォルトで外部キー制約を無効にする。`ON DELETE CASCADE` を定義しても、プラグマなしでは子レコードが自動削除されず、データが孤立する。

## Changes

- `src/Database/PdoConnectionFactory.php` — SQLite 接続後に `PRAGMA foreign_keys = ON` を実行
- `docs/field-trials/2026-05-field-trial-30.md` — FT30 (projtrack) フィールドトライアルレポート

## Test plan

- [ ] `docker compose run --rm app composer check` — 321 tests pass
- [ ] FT30 projtrack: 31 tests — cascade delete test verifies foreign keys work

Closes #596

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)