### PR TITLE
docs(database): SQLite FTS5 フルテキスト検索パターンを howto に追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.15] — 2026-05-20
+
+### Added
+- `docs/howto/add-database-endpoint.md` — added "Full-text search with SQLite FTS5" section: content table setup, sync triggers (AFTER INSERT/DELETE/UPDATE), JOIN + MATCH query pattern, prefix matching. (#598)
+- `docs/field-trials/2026-05-field-trial-31.md` — FT31 (feedlog) field trial report.
+
+---
+
 ## [1.5.14] — 2026-05-20
 
 ### Fixed

--- a/docs/field-trials/2026-05-field-trial-31.md
+++ b/docs/field-trials/2026-05-field-trial-31.md
@@ -1,0 +1,133 @@
+# Field Trial 31 — Feed Aggregator API with FTS5 Full-Text Search (feedlog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/feedlog/`
+**NENE2 version**: 1.5.14
+**Theme**: SQLite FTS5 full-text search (`MATCH`), multiple combined filters (source + keyword + date range + is_read), read/unread state toggle, bulk mark-all-read
+
+## What was built
+
+An RSS feed aggregator API with full-text search:
+
+- `GET /feed` — list items with `?source=`, `?q=` (FTS5 search), `?is_read=true/false`, `?from=`, `?to=` date filters, pagination
+- `POST /feed` — add a feed item (source, title, url, summary, published_at); 409 if URL already exists
+- `GET /feed/unread-count` — count of unread items
+- `POST /feed/mark-all-read` — mark all unread items as read; returns `{updated: N}`
+- `GET /feed/{id}` — show item
+- `DELETE /feed/{id}` — delete item
+- `POST /feed/{id}/mark-read` — mark single item as read; returns updated item
+- `POST /feed/{id}/mark-unread` — mark single item as unread; returns updated item
+
+**FTS5 implementation**: Content table with triggers to keep the virtual FTS table in sync:
+
+```sql
+CREATE VIRTUAL TABLE feed_items_fts USING fts5(
+    title, summary,
+    content='feed_items',
+    content_rowid='id'
+);
+CREATE TRIGGER feed_items_ai AFTER INSERT ON feed_items BEGIN
+    INSERT INTO feed_items_fts(rowid, title, summary) VALUES (new.id, new.title, new.summary);
+END;
+```
+
+Search query uses prefix matching: `fts.feed_items_fts MATCH ?` with `$query . '*'`.
+
+28/28 tests pass. PHPStan level 8 clean. PHP-CS-Fixer clean.
+
+## Frictions found
+
+### 1. FTS5 content table + trigger setup — no documentation or howto (Medium)
+
+**Description**: Integrating SQLite FTS5 requires:
+1. A `CREATE VIRTUAL TABLE ... USING fts5(content='main_table', content_rowid='id')` definition
+2. Three triggers (AFTER INSERT / AFTER DELETE / AFTER UPDATE) to keep the FTS index in sync
+3. A join query (`JOIN feed_items_fts fts ON f.id = fts.rowid WHERE fts.feed_items_fts MATCH ?`)
+
+None of this is documented in NENE2's howtos. Developers encounter it for the first time here and must know the SQLite FTS5 content table protocol.
+
+**Severity**: Medium — powerful feature, non-obvious setup.
+
+**Pattern used**:
+```sql
+-- FTS virtual table
+CREATE VIRTUAL TABLE feed_items_fts USING fts5(
+    title, summary, content='feed_items', content_rowid='id'
+);
+-- Sync triggers
+CREATE TRIGGER feed_items_ai AFTER INSERT ON feed_items BEGIN
+    INSERT INTO feed_items_fts(rowid, title, summary) VALUES (new.id, new.title, new.summary);
+END;
+```
+
+```php
+// Search query
+'SELECT f.* FROM feed_items f
+ JOIN feed_items_fts fts ON f.id = fts.rowid
+ WHERE fts.feed_items_fts MATCH ?'
+// Param: $query . '*'  (prefix match)
+```
+
+**Potential fix**: Add a "Full-text search with SQLite FTS5" section to `add-database-endpoint.md`.
+
+---
+
+### 2. `DatabaseQueryExecutorInterface::execute()` returns row count — useful for bulk updates (Positive)
+
+**Description**: `execute()` returns the number of affected rows, which is exactly what's needed for a "mark all read" endpoint that returns how many items were updated.
+
+```php
+public function markAllRead(): int
+{
+    return $this->executor->execute('UPDATE feed_items SET is_read = 1 WHERE is_read = 0', []);
+}
+```
+
+No friction — this design is clean and sufficient.
+
+---
+
+### 3. Combining FTS5 JOIN with other WHERE filters — no framework help (Low)
+
+**Description**: When combining FTS5 search with other filters (source, date range, is_read), the query builder must conditionally switch between two SELECT forms: one with the FTS join and one without.
+
+```php
+if ($query !== null) {
+    $select = 'SELECT f.* FROM feed_items f JOIN feed_items_fts fts ON f.id = fts.rowid';
+    $where  = ['fts.feed_items_fts MATCH ?'];
+} else {
+    $select = 'SELECT f.* FROM feed_items f';
+    $where  = [];
+}
+```
+
+Manageable but slightly awkward. A QueryBuilder (even simple) would help here — but this is a deliberate NENE2 non-goal (thin SQL design).
+
+**Severity**: Low — the pattern is clear, just verbose.
+
+---
+
+### 4. `is_read` boolean query param requires custom parsing — no `QueryStringParser::bool()` shortcut from valid values (Low)
+
+**Description**: `QueryStringParser::bool()` exists but treats any non-`'1'/'true'` string as `false`. For `?is_read=` which should reject invalid values (e.g., `?is_read=maybe` → 422), a manual check is needed:
+
+```php
+$isReadRaw = QueryStringParser::string($request, 'is_read');
+$isRead    = null;
+if ($isReadRaw !== null) {
+    if (!in_array($isReadRaw, ['true', 'false', '1', '0'], true)) {
+        throw new ValidationException([...]);
+    }
+    $isRead = in_array($isReadRaw, ['true', '1'], true);
+}
+```
+
+If `QueryStringParser::bool()` were used directly, `?is_read=maybe` would silently produce `false` instead of 422. This is the same behaviour as documented but worth noting.
+
+**Severity**: Low.
+
+## Tests
+
+28 tests, 49 assertions — all pass.
+
+Coverage: create (201, missing source/title/url 422, invalid date 422, duplicate URL 409), list (empty, returns items, source filter, is_read=false filter, is_read=true filter, date from filter, FTS5 title search, FTS5 summary search, pagination, invalid is_read 422), show (200, 404), mark-read (200, 404), mark-unread (200), unread-count (initially 0, updates on mark-read), mark-all-read (updated count, unread becomes 0), delete (204, 404), infrastructure (security headers + X-Request-Id, unknown route 404).

--- a/docs/howto/add-database-endpoint.md
+++ b/docs/howto/add-database-endpoint.md
@@ -566,6 +566,68 @@ $id = $this->executor->lastInsertId();
 
 ---
 
+## Full-text search with SQLite FTS5
+
+SQLite 3.9+ (bundled with PHP) supports the FTS5 extension for efficient full-text search.
+The recommended pattern uses a **content table** — the FTS index shadows a regular table,
+with triggers keeping them in sync.
+
+### Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS articles (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    title   TEXT NOT NULL,
+    body    TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
+    title,
+    body,
+    content='articles',
+    content_rowid='id'
+);
+
+-- Keep FTS index in sync with the base table
+CREATE TRIGGER IF NOT EXISTS articles_ai AFTER INSERT ON articles BEGIN
+    INSERT INTO articles_fts(rowid, title, body) VALUES (new.id, new.title, new.body);
+END;
+
+CREATE TRIGGER IF NOT EXISTS articles_ad AFTER DELETE ON articles BEGIN
+    INSERT INTO articles_fts(articles_fts, rowid, title, body) VALUES ('delete', old.id, old.title, old.body);
+END;
+
+CREATE TRIGGER IF NOT EXISTS articles_au AFTER UPDATE ON articles BEGIN
+    INSERT INTO articles_fts(articles_fts, rowid, title, body) VALUES ('delete', old.id, old.title, old.body);
+    INSERT INTO articles_fts(rowid, title, body) VALUES (new.id, new.title, new.body);
+END;
+```
+
+### Query
+
+Join the FTS table on `rowid` and use `MATCH` for the search predicate:
+
+```php
+$sql = 'SELECT a.*
+          FROM articles a
+          JOIN articles_fts fts ON a.id = fts.rowid
+         WHERE fts.articles_fts MATCH ?
+         ORDER BY a.created_at DESC
+         LIMIT ? OFFSET ?';
+
+$rows = $this->executor->fetchAll($sql, [$query . '*', $limit, $offset]);
+```
+
+Append `'*'` to the query string for **prefix matching** (`php*` matches "PHP", "phpstan", etc.).
+Omit it for exact-word matching.
+
+> **Combining with other filters**: When mixing FTS search with regular WHERE clauses
+> (e.g., `AND source = ?`), add extra conditions after the `MATCH` predicate in the same
+> WHERE clause. The FTS filter must come first so that it defines the rowid set that the
+> regular filters then narrow.
+
+---
+
 ## Next steps
 
 - Add OpenAPI documentation for your endpoint: see `docs/development/endpoint-scaffold.md`

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.14
+  version: 1.5.15
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.14';
+    public const string VERSION = '1.5.15';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `add-database-endpoint.md` に "Full-text search with SQLite FTS5" セクションを追加。
- content テーブル定義、3トリガー（AFTER INSERT/DELETE/UPDATE）、JOIN + MATCH クエリパターン、プレフィックスマッチを文書化。
- FT31 (feedlog) フィールドトライアルレポートを追加。

## Test plan

- [ ] `docker compose run --rm app composer check` — 321 tests + openapi + mcp + version consistency

Closes #598

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)