### PR TITLE
feat(http): JsonResponseFactory に JSON_PRESERVE_ZERO_FRACTION 追加 + quality-tools howto 新規作成

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.17] — 2026-05-20
+
+### Fixed
+- `JsonResponseFactory::create()` now includes `JSON_PRESERVE_ZERO_FRACTION` so whole-number PHP floats (e.g. `12.0`) are encoded as JSON numbers with a decimal point (`12.0`) rather than integers (`12`). (#602)
+
+### Added
+- `docs/howto/quality-tools.md` — new guide covering PHPStan and PHP-CS-Fixer configuration, including the PHPStan 2.x `--memory-limit` CLI-flag requirement. (#603)
+- `docs/field-trials/2026-05-field-trial-33.md` — FT33 (shiftlog) field trial report.
+
+---
+
 ## [1.5.16] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-33.md
+++ b/docs/field-trials/2026-05-field-trial-33.md
@@ -1,0 +1,103 @@
+# Field Trial 33 — Employee Shift Scheduling (shiftlog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/shiftlog/`
+**NENE2 version**: 1.5.16
+**Theme**: Datetime arithmetic, overlap detection, float aggregates, HAVING with REAL threshold
+
+## Overview
+
+Built an employee shift scheduling API with overlap detection, weekly pay summaries, and overtime alerts. The repository uses `transactional()` for atomic overlap-check + insert, SQLite's `julianday()` function for hour calculations, and `HAVING total_hours > CAST(? AS REAL)` for overtime threshold filtering.
+
+## Endpoints Implemented
+
+- `POST /employees` — create employee (name, role, hourly_rate), 201
+- `GET /employees` — list employees with pagination
+- `GET /employees/{id}` — show employee, 404 on missing
+- `GET /employees/{id}/shifts` — paginated shifts for employee
+- `POST /shifts` — schedule shift (employee_id, starts_at, ends_at, location); 409 on overlap, 422 on invalid range
+- `GET /shifts/{id}` — show shift, 404 on missing
+- `DELETE /shifts/{id}` — cancel shift, 204 No Content
+- `GET /schedule?from=…&to=…` — all shifts in a date range
+- `GET /summary/weekly?from=…&to=…` — hours, pay, shift count per employee
+- `GET /summary/overtime?from=…&to=…&threshold=40` — employees exceeding hourly threshold
+
+## Test Results
+
+31 tests, 53 assertions — all pass after 2 fixes (see frictions below).
+
+---
+
+## Frictions Found
+
+### Friction 1 — `JsonResponseFactory` encodes whole-number floats as integers [HIGH]
+
+**Symptom**: The weekly summary endpoint returns `"total_hours": 12` instead of `"total_hours": 12.0`. When asserting `assertSame(12.0, $body['total_hours'])`, the test fails because PHP's `json_decode` returns integer `12`, not float `12.0`.
+
+**Root cause**: `JsonResponseFactory` calls `json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)` without `JSON_PRESERVE_ZERO_FRACTION`. PHP's default behavior encodes floats with no fractional part (e.g. `12.0`) as integers (`12`).
+
+**Impact**: Any endpoint returning float fields (prices, rates, hours, percentages) will silently produce integer JSON when the value is a whole number. Clients expecting `float` / `number` type fields will parse them as integers. This breaks strict type checking in typed clients and violates OpenAPI schemas that declare the field as `number`.
+
+**Reproduction**:
+
+```php
+$json = new JsonResponseFactory($psr17, $psr17);
+$res  = $json->create(['total_hours' => 12.0]);  // body: {"total_hours": 12}  ← integer!
+```
+
+**Expected**:
+
+```json
+{"total_hours": 12.0}
+```
+
+**Fix**: Add `JSON_PRESERVE_ZERO_FRACTION` to `json_encode` flags:
+
+```php
+json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION)
+```
+
+**Workaround used in this FT**: Changed test assertions from `assertSame(12.0, ...)` to `assertEqualsWithDelta(12.0, ..., 0.01)`.
+
+**NENE2 impact**: Fix in `JsonResponseFactory`. High priority — this silently changes the JSON type of float fields in every response.
+
+---
+
+### Friction 2 — PHPStan `memory_limit` is not a valid `.neon` parameter in v2.x [MEDIUM]
+
+**Symptom**: Adding `memory_limit: 512M` under `parameters:` in `phpstan.neon` causes:
+
+```
+Invalid configuration: Unexpected item 'parameters › memory_limit'.
+```
+
+**Root cause**: PHPStan 2.x removed `memory_limit` as a configuration parameter. It must now be passed as a CLI flag: `--memory-limit=512M`.
+
+**Reproduction**: PHPStan OOM with default 128M limit when analysing a project with many vendor classes (nene2 + nyholm/psr7).
+
+**Fix**: Pass via CLI:
+
+```bash
+phpstan analyse --memory-limit=512M src tests
+```
+
+Or in `composer.json` scripts:
+
+```json
+"analyse": "phpstan analyse --level=8 --memory-limit=512M src tests"
+```
+
+**NENE2 impact**: Update `quality-tools.md` howto to note that `memory_limit` is a CLI-only option in PHPStan 2.x. (Previously documented in FT12-C, but the neon approach was shown — now it's confirmed broken in v2.)
+
+---
+
+## NENE2 Changes Required
+
+| # | Change | Priority |
+|---|--------|----------|
+| 1 | Add `JSON_PRESERVE_ZERO_FRACTION` to `JsonResponseFactory::create()` | High |
+| 2 | Update `quality-tools.md` howto: PHPStan `--memory-limit` is CLI-only in v2.x | Medium |
+
+## Version
+
+NENE2 changes → v1.5.17

--- a/docs/howto/quality-tools.md
+++ b/docs/howto/quality-tools.md
@@ -1,0 +1,132 @@
+# Quality Tools
+
+This guide covers PHPStan, PHP-CS-Fixer, and common issues when running them in NENE2-based projects.
+
+---
+
+## PHPStan
+
+NENE2 targets PHPStan level 8. Consumer projects that install `hideyukimori/nene2` via Composer can configure PHPStan for their own source in a `phpstan.neon` file.
+
+### Minimal configuration
+
+```neon
+# phpstan.neon
+parameters:
+    level: 8
+    paths:
+        - src
+        - tests
+```
+
+### Memory limit
+
+PHPStan may run out of memory when analysing a project that imports many vendor packages (nene2 + psr/* + nyholm/psr7 + phpunit stubs add up quickly). The default PHP memory limit is 128 MB, which is often too low.
+
+**In PHPStan 2.x, `memory_limit` is a CLI-only option — it cannot be set in `phpstan.neon`.**
+
+Pass it on the command line instead:
+
+```bash
+phpstan analyse --level=8 --memory-limit=512M src tests
+```
+
+Or set it in the `scripts` section of `composer.json` so it applies consistently:
+
+```json
+{
+    "scripts": {
+        "analyse": "phpstan analyse --level=8 --memory-limit=512M src tests",
+        "check": ["@test", "@analyse", "@cs"]
+    }
+}
+```
+
+> **Note**: Adding `memory_limit: 512M` under `parameters:` in `phpstan.neon` causes
+> `Invalid configuration: Unexpected item 'parameters › memory_limit'.` in PHPStan 2.x.
+> Use the CLI flag instead.
+
+### Suppressing false positives
+
+If PHPStan emits a false positive that cannot be fixed (e.g., a PHPDoc mismatch in a vendor class), use an inline ignore:
+
+```php
+/** @phpstan-ignore-next-line */
+$value = $externalLib->getSomething();
+```
+
+Or add a baseline file:
+
+```bash
+phpstan analyse --generate-baseline
+```
+
+---
+
+## PHP-CS-Fixer
+
+NENE2 uses `@PSR12` as the base rule set, plus `strict_param` and `declare_strict_types`.
+
+### Minimal configuration
+
+Create `.php-cs-fixer.php` at the project root:
+
+```php
+<?php
+
+$finder = PhpCsFixer\Finder::create()->in([__DIR__ . '/src', __DIR__ . '/tests']);
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12'               => true,
+        'strict_param'         => true,
+        'declare_strict_types' => true,
+    ])
+    ->setFinder($finder);
+```
+
+### Common formatting issues
+
+**Constructor body expansion**: `@PSR12` requires constructor bodies to span multiple lines even when empty. CS-Fixer automatically expands:
+
+```php
+// Before (written by hand)
+public function __construct(private Foo $foo) {}
+
+// After CS-Fixer fix
+public function __construct(private Foo $foo)
+{
+}
+```
+
+Run `composer cs:fix` after writing new classes to avoid manual corrections.
+
+**`declare(strict_types=1)` placement**: The `declare_strict_types` rule adds this declaration automatically. If you write it manually, CS-Fixer will normalise whitespace around it.
+
+### Dry-run vs fix
+
+```bash
+composer cs        # dry-run, shows what would change
+composer cs:fix    # applies fixes
+```
+
+---
+
+## Combining checks
+
+Add a `check` composer script that runs all tools in sequence:
+
+```json
+{
+    "scripts": {
+        "test":     "phpunit",
+        "analyse":  "phpstan analyse --level=8 --memory-limit=512M src tests",
+        "cs":       "php-cs-fixer fix --dry-run --diff",
+        "cs:fix":   "php-cs-fixer fix",
+        "check":    ["@test", "@analyse", "@cs"]
+    }
+}
+```
+
+Run `composer check` before every commit to catch issues early. CI should run the same command.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.16
+  version: 1.5.17
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.16';
+    public const string VERSION = '1.5.17';
 
     public function name(): string
     {

--- a/src/Http/JsonResponseFactory.php
+++ b/src/Http/JsonResponseFactory.php
@@ -28,7 +28,7 @@ final readonly class JsonResponseFactory
     public function create(array $data, int $status = 200, array $headers = []): ResponseInterface
     {
         $body = $this->streamFactory->createStream(
-            json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)
+            json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION)
         );
 
         $response = $this->responseFactory


### PR DESCRIPTION
## Summary

- `JsonResponseFactory::create()` に `JSON_PRESERVE_ZERO_FRACTION` フラグを追加 — float の `12.0` が JSON で `12`（整数）になるバグを修正
- `docs/howto/quality-tools.md` を新規作成 — PHPStan 2.x の `--memory-limit` CLI フラグ、CS-Fixer 設定、check スクリプトのセットアップ手順を記載

## Test plan

- [x] `composer check` 全通過（321 tests, PHPStan level 8, CS-Fixer, OpenAPI, MCP, version 1.5.17）
- [x] FT33 PHPUnit 31 tests all pass

Closes #602
Closes #603

Self-review: backend-api, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)