### PR TITLE
docs: FT34/FT35 フィールドトライアルレポート + 例外ハンドラー howto トラブルシューティング追加

### DIFF
--- a/docs/field-trials/2026-05-field-trial-34.md
+++ b/docs/field-trials/2026-05-field-trial-34.md
@@ -1,0 +1,81 @@
+# Field Trial 34 — Coupon Management API (couponlog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/couponlog/`
+**NENE2 version**: 1.5.17
+**Theme**: Nullable fields, atomic coupon redemption, duplicate detection, v1.5.17 float encoding validation
+
+## Overview
+
+Built a coupon/discount code management API with atomic redemption (check active + not expired + not exhausted, then increment used_count in a transaction), nullable `expires_at`, unlimited vs limited-use coupons, and redemption history.
+
+The FT also validates the `JSON_PRESERVE_ZERO_FRACTION` fix from v1.5.17: a dedicated test asserts that `discount_value: 10.0` appears as `10.0` (not `10`) in the raw JSON response body.
+
+## Endpoints Implemented
+
+- `POST /coupons` — create coupon (code, type, discount_value, max_uses?, is_active?, expires_at?)
+- `GET /coupons` — list active coupons (not expired, not exhausted), paginated
+- `GET /coupons/{code}` — show coupon by code
+- `POST /coupons/{code}/redeem` — atomic redeem; 409 on inactive/expired/exhausted
+- `GET /coupons/{code}/redemptions` — redemption history, paginated
+
+## Test Results
+
+25 tests, 54 assertions — all pass after 1 PHPStan fix.
+
+---
+
+## Frictions Found
+
+### Friction 1 — PHPStan level 8: `isset()` makes subsequent `!== null` always true [LOW]
+
+**Symptom**: PHPStan 8 reported:
+
+```
+Strict comparison using !== between mixed and null will always evaluate to true.
+Type null has already been eliminated from mixed.
+```
+
+for this pattern in `hydrateCoupon()`:
+
+```php
+isset($row['expires_at']) && $row['expires_at'] !== null ? (string) $row['expires_at'] : null,
+```
+
+**Root cause**: `isset()` returns true only when the value is not null. After `isset($row['expires_at'])` is true, PHPStan narrows the type to exclude null, so the subsequent `!== null` is always true.
+
+**Fix**: Remove the redundant null check:
+
+```php
+isset($row['expires_at']) ? (string) $row['expires_at'] : null,
+```
+
+**NENE2 impact**: Low — this is PHPStan level 8 strictness, not a framework issue. Good to know for documentation.
+
+---
+
+### Friction 2 — Duplicate coupon code produces 500 (unhandled DomainException) [MEDIUM]
+
+**Symptom**: Creating a coupon with an already-used code throws `\DomainException("Coupon code already exists: …")`. Since no `DomainExceptionHandler` for this exception is registered in `RuntimeApplicationFactory`, it falls through to the generic 500 handler.
+
+**Workaround**: Add a `DuplicateCouponCodeException` with a registered handler (same as `DuplicateSkuException` in inventorylog).
+
+**Root cause**: The pattern of catching `DatabaseConnectionException → UNIQUE constraint failed → throw DomainException` requires the caller to register a handler for the new exception type. This is correct behaviour, but when you forget to register the handler, the error surface changes from 409 → 500 with no obvious clue.
+
+**NENE2 impact**: Could add a hint in `docs/howto/add-domain-exception-handler.md`: if a domain exception produces 500 instead of your expected error code, check that you've registered its handler in `domainExceptionHandlers`.
+
+---
+
+## v1.5.17 Float Encoding Validation ✓
+
+`testDiscountValueEncodedAsFloat` confirms that `"discount_value": 10.0` (not `10`) appears in the raw JSON response, validating the `JSON_PRESERVE_ZERO_FRACTION` fix.
+
+---
+
+## NENE2 Changes Required
+
+| # | Change | Priority |
+|---|--------|----------|
+| 1 | Add hint to `add-domain-exception-handler.md`: unregistered handler produces 500 | Low |
+
+No version bump needed — documentation-only change is a low-priority addition to an existing howto; will bundle with the next substantive change.

--- a/docs/field-trials/2026-05-field-trial-35.md
+++ b/docs/field-trials/2026-05-field-trial-35.md
@@ -1,0 +1,63 @@
+# Field Trial 35 — Soft-Deletion Pattern (softlog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/softlog/`
+**NENE2 version**: 1.5.17
+**Theme**: Soft-deletion with `deleted_at`, restore, permanent delete, trash list, purge all
+
+## Overview
+
+Built a notes API demonstrating the soft-deletion pattern: `DELETE /notes/{id}` sets `deleted_at` without removing the row; `GET /notes` excludes deleted rows (`WHERE deleted_at IS NULL`); `GET /notes/trash` shows only deleted rows; `POST /notes/{id}/restore` clears `deleted_at`; `DELETE /notes/{id}/permanent` permanently removes the row; `POST /notes/trash/purge` bulk-deletes all trash rows and returns the count.
+
+The repository uses `bool $includeDeleted = false` on `findById()` to allow restore/hardDelete to look up rows that are in the trash, while regular show/update operations get 404 for deleted notes.
+
+## Endpoints Implemented
+
+- `GET /notes` — list active notes, pinned first
+- `POST /notes` — create note (title, body, is_pinned), 201
+- `GET /notes/trash` — list deleted notes with `deleted_at` populated
+- `POST /notes/trash/purge` — bulk delete all trash, returns `{ "purged": N }`
+- `GET /notes/{id}` — show active note, 404 for deleted
+- `PUT /notes/{id}` — full update (title, body, is_pinned), 404 for deleted
+- `DELETE /notes/{id}` — soft delete (sets `deleted_at`), 204
+- `POST /notes/{id}/restore` — restore from trash (clears `deleted_at`)
+- `DELETE /notes/{id}/permanent` — hard delete (removes row), 204
+
+## Test Results
+
+26 tests, 46 assertions — all pass with no fixes needed (zero frictions encountered).
+
+---
+
+## Frictions Found
+
+None. The soft-deletion pattern is straightforward to implement with NENE2's database layer:
+- Nullable `deleted_at` column handled naturally in `DatabaseQueryExecutorInterface::fetchOne()` results
+- `execute()` returning affected row count makes `purgeDeleted()` trivial
+- `WHERE deleted_at IS NULL` / `IS NOT NULL` conditions work correctly in all queries
+
+The `bool $includeDeleted = false` parameter on `findById()` cleanly separates concerns without requiring a second method, keeping the repository surface minimal.
+
+---
+
+## Route Ordering Note
+
+Static routes must be registered before parameterized routes to avoid conflicts:
+
+```php
+$router->get('/notes/trash', ...);           // static — must come first
+$router->post('/notes/trash/purge', ...);    // static — must come first
+$router->get('/notes/{id}', ...);            // param — must come after
+```
+
+If `GET /notes/{id}` were registered first, a request to `GET /notes/trash` would match with `{id} = "trash"` and throw a `NoteNotFoundException` instead of listing the trash. This is consistent with all prior FTs (documented in FT30 projtrack).
+
+---
+
+## NENE2 Changes Required
+
+None — zero frictions.
+
+## Version
+
+No NENE2 changes needed. Will bundle the FT34 documentation hint (unregistered handler → 500) with the next substantive change.

--- a/docs/howto/add-domain-exception-handler.md
+++ b/docs/howto/add-domain-exception-handler.md
@@ -120,3 +120,22 @@ A 404 response produced by the example above:
 ```
 
 `instance` is populated automatically from `$request->getUri()->getPath()`.
+
+## Troubleshooting: getting 500 instead of your expected error code
+
+If a domain exception produces a **500 Internal Server Error** instead of the expected
+4xx response, the most common cause is a missing or mis-registered handler:
+
+1. **Handler not added to `domainExceptionHandlers`** — double-check that the handler
+   class is included in the array passed to `RuntimeApplicationFactory`.
+2. **`supports()` method mismatch** — ensure `supports()` checks for the exact exception
+   class that is actually thrown. If the thrown exception is a subclass and `supports()`
+   uses `instanceof ExactClass`, child-class exceptions will still match. But if the
+   class hierarchy is inverted (handler checks a parent, exception is a different branch),
+   no handler will match.
+3. **Handler registered but wrong order** — handlers are tried in order. If a catch-all
+   handler appears first and its `supports()` is too broad, it may swallow exceptions
+   that a later handler should handle.
+
+A quick diagnostic: temporarily add `error_log(get_class($exception))` before the
+`supports()` check to print the actual exception class name.


### PR DESCRIPTION
## Summary

- FT34 (couponlog) レポート追加: nullable datetime, アトミック引き換え, v1.5.17 float エンコーディング検証
- FT35 (softlog) レポート追加: soft-delete パターン — zero frictions
- `add-domain-exception-handler.md` にトラブルシューティングセクション追加 (#605)

## Test plan

- [x] `composer check` 全通過（version 1.5.17 維持）

Closes #605

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)