### PR TITLE
docs(howto): FTS5検索 howto + FT36-38フィールドトライアル記録

### DIFF
--- a/docs/field-trials/2026-05-field-trial-36.md
+++ b/docs/field-trials/2026-05-field-trial-36.md
@@ -1,0 +1,111 @@
+# Field Trial 36 — Analytics Event Tracking API (statslog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/statslog/`
+**NENE2 version**: 1.5.17
+**Theme**: JSON properties stored as TEXT, `json_extract()` filtering, `strftime()` date aggregation, `GROUP BY` computed date expressions, `COUNT(DISTINCT …)` for unique users
+
+## Overview
+
+Built an analytics event tracking API where each event stores arbitrary JSON properties as a TEXT column. Used SQLite's `json_extract()` function to filter events by property value without deserializing at the PHP layer. Used `strftime('%Y-%m-%d', occurred_at)` for date-level grouping in aggregation queries.
+
+## Endpoints Implemented
+
+- `POST /events` — record event (event_type, user_id, session_id?, properties?, occurred_at?)
+- `GET /events` — list all events, paginated, most recent first
+- `GET /events/{id}` — show single event
+- `GET /events/by-property?key=K&value=V` — filter events by JSON property value via `json_extract()`
+- `GET /stats/per-day?from=…&to=…` — event count per day via `strftime('%Y-%m-%d', …)`
+- `GET /stats/per-type?from=…&to=…` — event count grouped by type
+- `GET /stats/unique-users?from=…&to=…` — `COUNT(DISTINCT user_id)` per day
+
+## Test Results
+
+20 tests, 49 assertions — all pass with 1 fix (route ordering).
+
+---
+
+## Frictions Found
+
+### Friction 1 — Route ordering: static `/events/by-property` matched by `/events/{id}` [LOW]
+
+**Symptom**: `GET /events/by-property?key=page&value=/home` returned 404 with body indicating `Event #0 not found` (after `(int)"by-property"` evaluated to `0`).
+
+**Root cause**: `/events/by-property` was registered after `/events/{id}`. The router matched `by-property` as the `{id}` parameter value. `(int)"by-property"` evaluated to `0`, the repository threw `EventNotFoundException("Event #0 not found.")`, which the handler correctly mapped to 404.
+
+**Fix**: Move static routes before parameterized routes:
+
+```php
+// WRONG — by-property matches {id} = "by-property"
+$router->get('/events/{id}', $this->showEvent(...));
+$router->get('/events/by-property', $this->eventsByProperty(...));
+
+// CORRECT — static first
+$router->get('/events/by-property', $this->eventsByProperty(...));
+$router->get('/events/{id}', $this->showEvent(...));
+```
+
+**Notable aspect**: This friction is subtle because `/events/by-property` contains only alphabetic characters — it doesn't look like an ID. However, the router still matches it as `{id} = "by-property"`. The rule is absolute: any static route segment that shares a URL prefix with a parameterized route must be registered first.
+
+**NENE2 impact**: The howto for routing (if one exists) should emphasize this rule explicitly with an example involving non-numeric static segments. Currently documented in FT30 projtrack and FT35 softlog — this is the third occurrence with a different flavour (property-filter endpoint that naturally has a query string, not an ID).
+
+**Priority**: Low — documented pattern, correct behaviour.
+
+---
+
+## Patterns Validated
+
+### json_extract() for property filtering
+
+Filtering by a JSON property value works cleanly without deserializing at the PHP layer:
+
+```sql
+SELECT * FROM events WHERE json_extract(properties, ?) = ? ORDER BY occurred_at DESC LIMIT ? OFFSET ?
+-- bound as: ['$.page', '/home', 50, 0]
+```
+
+The path argument (`$.key`) is constructed from user input with a `$.` prefix. No escaping needed beyond PDO binding.
+
+### strftime() date aggregation
+
+```sql
+SELECT strftime('%Y-%m-%d', occurred_at) AS day, COUNT(*) AS count
+FROM events
+WHERE occurred_at >= ? AND occurred_at < ?
+GROUP BY strftime('%Y-%m-%d', occurred_at)
+ORDER BY day ASC
+```
+
+ISO 8601 strings (`2026-05-01T10:00:00Z`) compare lexicographically — `>=` / `<` for date ranges work correctly. The `to` bound is exclusive (uses `<` not `<=`), matching the typical half-open interval `[from, to)`.
+
+### COUNT(DISTINCT …) for unique users
+
+```sql
+SELECT strftime('%Y-%m-%d', occurred_at) AS day, COUNT(DISTINCT user_id) AS unique_users
+FROM events
+WHERE occurred_at >= ? AND occurred_at < ?
+GROUP BY strftime('%Y-%m-%d', occurred_at)
+ORDER BY day ASC
+```
+
+Works with PDO binding without any special treatment — `COUNT(DISTINCT …)` is not a HAVING clause, so no `CAST()` workaround needed (unlike the FT32 HAVING bug).
+
+### Properties deserialization in PHP
+
+Properties are stored as TEXT (`'{}'` default), returned deserialized in the response:
+
+```php
+'properties' => json_decode($event->properties, true, 512, JSON_THROW_ON_ERROR),
+```
+
+`json_decode` returns `[]` (empty array) for `'{}'` — serializes back to `{}` in JSON. No friction.
+
+---
+
+## NENE2 Changes Required
+
+| # | Change | Priority |
+|---|--------|----------|
+| 1 | Document static-before-parameterized rule with non-numeric segment example in routing howto | Low |
+
+No version bump needed — the route ordering rule is correct existing behaviour; this is documentation only. Will bundle with next substantive change.

--- a/docs/field-trials/2026-05-field-trial-37.md
+++ b/docs/field-trials/2026-05-field-trial-37.md
@@ -1,0 +1,116 @@
+# Field Trial 37 — Document Versioning API (doclog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/doclog/`
+**NENE2 version**: 1.5.17
+**Theme**: Document versioning with `document_versions` table, transaction spanning INSERT+UPDATE, revert-to-version pattern, JOIN with current version, version number scoped per document
+
+## Overview
+
+Built a document versioning API. Each document has a `document_versions` table with an `is_current` flag. Adding a new version involves a transaction: deactivate the current version (`UPDATE … SET is_current = 0`), insert the new version (`INSERT … is_current = 1`), update the document's `updated_at`. Revert creates a new version whose content is a copy of the target version — preserving the full history rather than discarding intermediate versions.
+
+## Endpoints Implemented
+
+- `POST /documents` — create document with initial version (title, content)
+- `GET /documents` — list all documents with current version, paginated
+- `GET /documents/{id}` — show document with current version
+- `POST /documents/{id}/versions` — add new version (content); transaction bump
+- `GET /documents/{id}/versions` — full version history, paginated, most recent first
+- `POST /documents/{id}/revert/{version}` — revert to version N (creates new version N+1 with same content)
+
+## Test Results
+
+20 tests, 42 assertions — all pass after 1 PHPStan fix.
+
+---
+
+## Frictions Found
+
+### Friction 1 — PHPStan level 8: `isset()` + `!== null` redundant check (recurring) [LOW]
+
+**Symptom**: Same as FT34. In `hydrateDocument()`:
+
+```php
+$version = isset($row['vid']) && $row['vid'] !== null
+    ? new DocumentVersion(...)
+    : null;
+```
+
+PHPStan error: `Strict comparison using !== between mixed and null will always evaluate to true. Type null has already been eliminated from mixed.`
+
+**Fix**: Remove the redundant check:
+
+```php
+$version = isset($row['vid'])
+    ? new DocumentVersion(...)
+    : null;
+```
+
+**NENE2 impact**: Already documented in FT34 and listed in `add-domain-exception-handler.md` Common Mistakes. This is a PHP/PHPStan pattern, not a NENE2 issue. No new documentation needed.
+
+---
+
+## Patterns Validated
+
+### Transaction spanning multiple statements
+
+The `transactional()` callback receives a `$tx` executor already bound to the PDO transaction. No `new self($tx, ...)` required — use `$tx` directly:
+
+```php
+$this->txManager->transactional(function (DatabaseQueryExecutorInterface $tx) use (...): Document {
+    $tx->execute('UPDATE document_versions SET is_current = 0 WHERE document_id = ? AND is_current = 1', [$documentId]);
+    $versionId = $tx->insert('INSERT INTO document_versions (...) VALUES (?, ?, ?, 1, ?)', [...]);
+    $tx->execute('UPDATE documents SET updated_at = ? WHERE id = ?', [$now, $documentId]);
+    // ...
+});
+```
+
+### JOIN with is_current flag for single-query document fetch
+
+```sql
+SELECT d.*, dv.id AS vid, dv.content, dv.version_num, dv.is_current, dv.created_at AS version_created_at
+FROM documents d
+LEFT JOIN document_versions dv ON dv.document_id = d.id AND dv.is_current = 1
+WHERE d.id = ?
+```
+
+`LEFT JOIN` (not `INNER JOIN`) ensures documents without any version (edge case) still return a row — the version fields are NULL and `hydrateDocument()` handles this with `isset($row['vid'])`.
+
+### Version-scoped auto-increment using MAX
+
+```sql
+SELECT MAX(version_num) AS max_ver FROM document_versions WHERE document_id = ?
+```
+
+SQLite's `AUTOINCREMENT` is global. To get a per-document version number, query `MAX(version_num)` within the transaction and add 1. This is safe because the transaction serialises access.
+
+### Revert-as-copy pattern
+
+Revert does not roll back the `is_current` pointer to an old version — it creates a new version whose content is a copy of the target. This preserves the full audit trail:
+
+```
+v1 (created) → v2 (edited) → v3 (revert of v1, content = v1's content)
+```
+
+History always grows monotonically; no version is ever deleted.
+
+### Route ordering for nested sub-routes
+
+Routes with shared `{id}` prefix require static sub-routes to come before the parameterized catch-all:
+
+```php
+$router->get('/documents/{id}/versions', $this->listVersions(...));
+$router->post('/documents/{id}/versions', $this->addVersion(...));
+$router->post('/documents/{id}/revert/{version}', $this->revertToVersion(...));
+$router->get('/documents/{id}', $this->showDocument(...)); // catch-all last
+```
+
+`/documents/{id}/versions` and `/documents/{id}/revert/{version}` are not ambiguous with `/documents/{id}` because they have additional path segments — registration order doesn't matter here. But `GET /documents/{id}` must still come after `GET /documents` (the static list route), which it does.
+
+---
+
+## NENE2 Changes Required
+
+None — zero new frictions, and the one PHPStan fix is a known PHP pattern already documented.
+
+No version bump needed.

--- a/docs/field-trials/2026-05-field-trial-38.md
+++ b/docs/field-trials/2026-05-field-trial-38.md
@@ -1,0 +1,143 @@
+# Field Trial 38 — Full-Text Search API (searchlog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/searchlog/`
+**NENE2 version**: 1.5.17
+**Theme**: SQLite FTS5 virtual table, `MATCH ?` queries, `snippet()`, trigger-based index sync, `content=` external content table
+
+## Overview
+
+Built an article management API backed by a SQLite FTS5 virtual table for full-text search. The FTS5 table uses `content=articles` (external content table) so article data lives in a normal table and only the FTS index is in the virtual table. Three AFTER INSERT/UPDATE/DELETE triggers keep the FTS index in sync.
+
+Endpoints:
+- `POST /articles` — create (title, body, author)
+- `GET /articles` — list, paginated
+- `GET /articles/search?q=…` — FTS5 MATCH search with `snippet()` highlighting
+- `GET /articles/{id}` — show
+- `PUT /articles/{id}` — full update
+- `DELETE /articles/{id}` — delete
+
+## Test Results
+
+23 tests, 38 assertions — all pass after fixing test expectations to match actual FTS5 query semantics.
+
+---
+
+## Frictions Found
+
+### Friction 1 — FTS5: `word-other` is a column filter, not a phrase [HIGH]
+
+**Symptom**: `GET /articles/search?q=full-text` returns HTTP 500 instead of search results.
+
+**Root cause**: FTS5 query syntax treats `word-` as a column filter prefix. `full-text` is parsed as `full:text` — "search the column named `full` for the query `text`". Since the FTS5 table has columns `title`, `body`, `author` (not `full`), SQLite throws:
+
+```
+General error: 1 no such column: text
+```
+
+The error propagates through `PdoDatabaseQueryExecutor` as a `PDOException`, which the framework's error handler surfaces as a 500 Internal Server Error — no domain exception handler can intercept it.
+
+**Verified behaviour**:
+
+```php
+// PDO prepared statement + FTS5 MATCH
+$stmt->execute(['full-text']); // → PDOException: no such column: text
+$stmt->execute(['full text']); // → normal AND query, works correctly
+$stmt->execute(['full']);      // → matches all docs with "full"
+```
+
+**Workaround**: Use space-separated terms (AND logic) or FTS5 phrase syntax:
+
+```
+full-text         ← ERROR: parsed as column filter full:text
+full text         ← OK: matches docs containing both "full" AND "text"
+"full text"       ← OK: phrase match (consecutive tokens)
+full OR text      ← OK: matches docs containing "full" OR "text"
+```
+
+**NENE2 impact**: Medium — user-supplied FTS5 queries with hyphens produce 500s instead of sensible errors. Options:
+1. Sanitize/escape the query before passing to FTS5 (strip or replace hyphens)
+2. Catch the `DatabaseConnectionException` in the search handler and return a 400 Bad Request
+3. Document the FTS5 query syntax gotchas in a howto
+
+**Priority**: Medium — should add a how-to note about FTS5 query sanitisation; sanitisation in the repository is the safest pattern.
+
+---
+
+### Friction 2 — FTS5: No stemming by default [LOW]
+
+**Symptom**: `q=framework` does not match articles containing "frameworks" (plural). The FTS5 `unicode61` tokenizer is a simple whitespace/punctuation tokenizer with no stemming.
+
+**Example**:
+
+```
+q=framework   → 0 results (articles have "frameworks")
+q=frameworks  → correct results
+q=framework*  ← prefix matching IS available (FTS5 supports `*` suffix on terms)
+```
+
+**Workaround**: 
+- Use exact word forms in both documents and queries
+- Use `framework*` prefix matching for "starts with" queries
+- Use the `porter` tokenizer for English stemming: `USING fts5(…, tokenize='porter ascii')`
+
+**NENE2 impact**: Low — this is standard FTS5 behaviour, not a NENE2 issue. Should be documented in a howto about FTS5.
+
+---
+
+## Patterns Validated
+
+### FTS5 virtual table with external content
+
+```sql
+CREATE VIRTUAL TABLE articles_fts USING fts5(
+    title, body, author,
+    content=articles,
+    content_rowid=id
+);
+```
+
+`content=articles` keeps article data in the real table. FTS5 stores only the search index. Triggers keep them in sync.
+
+### Trigger-based index sync
+
+```sql
+CREATE TRIGGER articles_ai AFTER INSERT ON articles BEGIN
+    INSERT INTO articles_fts(rowid, title, body, author) VALUES (new.id, new.title, new.body, new.author);
+END;
+
+CREATE TRIGGER articles_au AFTER UPDATE ON articles BEGIN
+    INSERT INTO articles_fts(articles_fts, rowid, title, body, author) VALUES ('delete', old.id, old.title, old.body, old.author);
+    INSERT INTO articles_fts(rowid, title, body, author) VALUES (new.id, new.title, new.body, new.author);
+END;
+
+CREATE TRIGGER articles_ad AFTER DELETE ON articles BEGIN
+    INSERT INTO articles_fts(articles_fts, rowid, title, body, author) VALUES ('delete', old.id, old.title, old.body, old.author);
+END;
+```
+
+The `INSERT INTO articles_fts(articles_fts, rowid, ...) VALUES ('delete', ...)` pattern is the FTS5 way to remove a row from the index.
+
+### snippet() function
+
+```sql
+SELECT snippet(articles_fts, 1, '<b>', '</b>', '…', 10) AS snippet
+FROM articles_fts
+WHERE articles_fts MATCH ?
+```
+
+`snippet(table, column_index, open, close, ellipsis, tokens)` returns a highlighted fragment. Column index 1 = `body` (0-based). Works correctly with PDO parameter binding — no special handling needed.
+
+### rank column for relevance sorting
+
+FTS5 exposes a `rank` column that reflects BM25 relevance. Lower (more negative) values are more relevant. `ORDER BY rank` returns most relevant first.
+
+---
+
+## NENE2 Changes Required
+
+| # | Change | Priority |
+|---|--------|----------|
+| 1 | Add `docs/howto/use-fts5-search.md` with FTS5 query syntax gotchas, schema pattern, and sanitisation advice | Medium |
+
+No version bump needed for documentation-only change.

--- a/docs/howto/use-fts5-search.md
+++ b/docs/howto/use-fts5-search.md
@@ -1,0 +1,216 @@
+# Use SQLite FTS5 Full-Text Search
+
+SQLite's FTS5 extension provides full-text search using an inverted index. This guide covers the schema pattern, trigger-based sync, and the query syntax gotchas you will encounter when accepting user input.
+
+---
+
+## 1. Schema: virtual table + external content + triggers
+
+Use `content=<table>` to keep your data in a normal table and let FTS5 maintain only the search index:
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    author     TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE articles_fts USING fts5(
+    title,
+    body,
+    author,
+    content=articles,   -- FTS5 reads content from the articles table
+    content_rowid=id    -- maps FTS5 rowid to articles.id
+);
+
+-- Keep FTS index in sync with the base table
+CREATE TRIGGER articles_ai AFTER INSERT ON articles BEGIN
+    INSERT INTO articles_fts(rowid, title, body, author)
+    VALUES (new.id, new.title, new.body, new.author);
+END;
+
+CREATE TRIGGER articles_au AFTER UPDATE ON articles BEGIN
+    -- Delete old row from index, then insert updated row
+    INSERT INTO articles_fts(articles_fts, rowid, title, body, author)
+    VALUES ('delete', old.id, old.title, old.body, old.author);
+    INSERT INTO articles_fts(rowid, title, body, author)
+    VALUES (new.id, new.title, new.body, new.author);
+END;
+
+CREATE TRIGGER articles_ad AFTER DELETE ON articles BEGIN
+    INSERT INTO articles_fts(articles_fts, rowid, title, body, author)
+    VALUES ('delete', old.id, old.title, old.body, old.author);
+END;
+```
+
+> **Why triggers?** FTS5 with `content=` does not automatically track changes — you must maintain the index with triggers. The `INSERT INTO fts(fts, rowid, ...) VALUES ('delete', ...)` pattern is FTS5's way to remove a row from the index.
+
+---
+
+## 2. Search query
+
+```php
+$rows = $this->executor->fetchAll(
+    "SELECT a.*, snippet(articles_fts, 1, '<b>', '</b>', '…', 10) AS snippet, rank
+     FROM articles_fts
+     JOIN articles a ON a.id = articles_fts.rowid
+     WHERE articles_fts MATCH ?
+     ORDER BY rank
+     LIMIT ? OFFSET ?",
+    [$query, $limit, $offset],
+);
+```
+
+- `rank` is a virtual column exposed by FTS5. Lower (more negative) values are more relevant. `ORDER BY rank` puts best matches first.
+- `snippet(table, column_index, open, close, ellipsis, token_count)` returns a highlighted fragment. Column index is 0-based: `0` = title, `1` = body.
+
+---
+
+## 3. Query syntax gotchas
+
+### 3.1 Hyphen is a column filter prefix — not a phrase separator
+
+**This is the most common source of bugs when accepting user input.**
+
+FTS5 interprets `word-other` as a column filter: it searches the column named `word` for the term `other`. If `word` is not a column in the FTS5 table, SQLite throws an error:
+
+```
+General error: 1 no such column: text
+```
+
+```
+full-text   ← ERROR: "search column 'full' for 'text'" — but 'full' is not a column
+full text   ← OK: AND query (matches docs with both "full" AND "text")
+"full text" ← OK: phrase query (exact consecutive order)
+```
+
+This error propagates as a `DatabaseConnectionException` and results in a 500 response unless you sanitise the input first.
+
+**Sanitise user input before passing to FTS5:**
+
+```php
+private function sanitizeFtsQuery(string $query): string
+{
+    // Replace hyphens with spaces so "full-text" becomes "full text" (AND logic)
+    return str_replace('-', ' ', $query);
+}
+```
+
+Or escape with double-quotes for a phrase match:
+
+```php
+private function sanitizeFtsQuery(string $query): string
+{
+    // Wrap the entire query in double quotes to force phrase matching
+    $escaped = str_replace('"', '""', $query);
+    return '"' . $escaped . '"';
+}
+```
+
+### 3.2 No stemming by default
+
+The default `unicode61` tokenizer does not stem. `framework` does not match `frameworks`, and `run` does not match `running`.
+
+Options:
+
+| Approach | How |
+|---|---|
+| Exact match | Use exact word forms in both documents and queries |
+| Prefix match | Append `*` to the query term: `framework*` matches `framework`, `frameworks`, `framework-agnostic` |
+| Porter stemmer | Declare `tokenize='porter ascii'` in the `CREATE VIRTUAL TABLE` statement |
+
+**Prefix match example:**
+
+```php
+// User types "frame" → append * to match "framework", "frameworks", etc.
+$query = trim($userInput) . '*';
+```
+
+**Porter stemmer:**
+
+```sql
+CREATE VIRTUAL TABLE articles_fts USING fts5(
+    title, body, author,
+    content=articles,
+    content_rowid=id,
+    tokenize='porter ascii'  -- English stemming
+);
+```
+
+> The `porter` tokenizer is only available when SQLite is compiled with FTS5 support (standard builds include it). It is useful for English text; for other languages, consider external stemming before indexing.
+
+### 3.3 AND / OR / NOT operators
+
+FTS5 query syntax:
+
+| Syntax | Meaning |
+|---|---|
+| `one two` | AND: both must be present |
+| `one OR two` | OR: either must be present |
+| `one NOT two` | NOT: first present, second absent |
+| `"one two"` | Phrase: exact consecutive order |
+| `one*` | Prefix: matches `one`, `ones`, `only` (wait — prefix match on `one`) |
+| `title:query` | Column filter: restrict match to the `title` column |
+
+> **Note**: `NOT` must be uppercase. Lowercase `not` is treated as a search term.
+
+---
+
+## 4. Count search results
+
+Count with a separate query — `COUNT(*)` on the FTS5 match:
+
+```php
+$count = $this->executor->fetchOne(
+    'SELECT COUNT(*) AS cnt FROM articles_fts WHERE articles_fts MATCH ?',
+    [$query],
+);
+```
+
+---
+
+## 5. Complete repository example
+
+```php
+final readonly class ArticleRepository
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $executor,
+    ) {}
+
+    /** @return list<array<string, mixed>> */
+    public function search(string $userQuery, int $limit, int $offset): array
+    {
+        $query = $this->sanitizeFtsQuery($userQuery);
+
+        return $this->executor->fetchAll(
+            "SELECT a.*, snippet(articles_fts, 1, '<b>', '</b>', '…', 10) AS snippet, rank
+             FROM articles_fts
+             JOIN articles a ON a.id = articles_fts.rowid
+             WHERE articles_fts MATCH ?
+             ORDER BY rank
+             LIMIT ? OFFSET ?",
+            [$query, $limit, $offset],
+        );
+    }
+
+    public function countSearch(string $userQuery): int
+    {
+        $query = $this->sanitizeFtsQuery($userQuery);
+        $row   = $this->executor->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM articles_fts WHERE articles_fts MATCH ?',
+            [$query],
+        );
+
+        return (int) ($row['cnt'] ?? 0);
+    }
+
+    private function sanitizeFtsQuery(string $query): string
+    {
+        // Replace hyphens with spaces: "full-text" → "full text" (AND logic)
+        return str_replace('-', ' ', trim($query));
+    }
+}
+```


### PR DESCRIPTION
## Summary

- `docs/howto/use-fts5-search.md` を新規追加 — SQLite FTS5 の使い方（仮想テーブル・トリガー同期・query syntax 注意点・sanitizeFtsQuery パターン）
- FT36 (statslog), FT37 (doclog), FT38 (searchlog) のフィールドトライアル記録を追加

## Key FT Findings

**FT36 (statslog)**: JSON properties stored as TEXT, `json_extract()` filtering, `strftime()` date aggregation — all work cleanly. No NENE2 changes needed.

**FT37 (doclog)**: Document versioning with `document_versions` table. Transaction spanning INSERT+UPDATE validated. Revert-as-copy pattern (creates new version rather than rolling back). Zero new frictions.

**FT38 (searchlog)**: FTS5 full-text search.
- F-1 (Medium): `word-other` in FTS5 MATCH is parsed as column filter `word:other`, not a phrase — causes 500 if `word` is not a column name. Workaround: sanitise input with `str_replace('-', ' ', $query)`.
- F-2 (Low): No stemming by default — `framework` ≠ `frameworks`. Use prefix matching (`framework*`) or the `porter` tokenizer.

## Self-review

Self-review: docs-policy

Closes #607