### PR TITLE
docs(howto): オプションボディパターン追加 + FT39-40 フィールドトライアル記録

### DIFF
--- a/docs/field-trials/2026-05-field-trial-39.md
+++ b/docs/field-trials/2026-05-field-trial-39.md
@@ -1,0 +1,122 @@
+# Field Trial 39 — Optimistic Locking API (locklog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/locklog/`
+**NENE2 version**: 1.5.17
+**Theme**: Optimistic locking with a `version` column, conditional UPDATE, 409 Conflict detection, sequential-edit workflow
+
+## Overview
+
+Built a shared note API demonstrating the optimistic locking pattern. Each note carries an integer `version` field. When updating, the client must send its known version. If the server's current version differs, the update is rejected with 409 Conflict. Successful updates increment the version atomically.
+
+## Endpoints Implemented
+
+- `POST /notes` — create (title, content?); response includes `version: 1`
+- `GET /notes` — list, paginated; each item includes `version`
+- `GET /notes/{id}` — show with version
+- `PUT /notes/{id}` — full update; requires `version` field; 409 on mismatch
+- `DELETE /notes/{id}` — delete (no version check required)
+
+## Test Results
+
+17 tests, 42 assertions — all pass on first run with zero fixes needed.
+
+---
+
+## Frictions Found
+
+None. The optimistic locking pattern is straightforward with NENE2's database layer:
+
+- `execute()` returns the affected row count — checking `$affected === 0` after a conditional `UPDATE … WHERE id = ? AND version = ?` cleanly detects concurrent modification.
+- `DomainExceptionHandlerInterface` for `ConflictException → 409` works exactly the same as for 404 exceptions.
+- No transaction needed for the read-then-conditional-update, since the conditional update is itself the atomic check. (SQLite's single-writer model prevents true races in tests, but the pattern is correct for multi-writer production databases too.)
+
+---
+
+## Patterns Validated
+
+### Optimistic locking: conditional UPDATE + affected-row check
+
+```php
+public function update(int $id, string $title, string $content, int $expectedVersion, string $now): Note
+{
+    $current = $this->findById($id); // raises NoteNotFoundException if gone
+
+    if ($current->version !== $expectedVersion) {
+        throw new ConflictException($id, $expectedVersion, $current->version);
+    }
+
+    $nextVersion = $current->version + 1;
+
+    $affected = $this->executor->execute(
+        'UPDATE notes SET title = ?, content = ?, version = ?, updated_at = ?
+         WHERE id = ? AND version = ?',
+        [$title, $content, $nextVersion, $now, $id, $expectedVersion],
+    );
+
+    if ($affected === 0) {
+        // A concurrent writer changed the version between our read and this update
+        $actual = $this->findById($id);
+        throw new ConflictException($id, $expectedVersion, $actual->version);
+    }
+
+    return new Note($id, $title, $content, $nextVersion, $current->createdAt, $now);
+}
+```
+
+The two-phase check (`read first, then conditional UPDATE`) defends against:
+1. Reading a matching version and then seeing a concurrent write between read and UPDATE (second check)
+2. Client sending a version older than the current one (first check, faster path)
+
+### 409 Conflict via DomainExceptionHandlerInterface
+
+```php
+final class ConflictException extends \RuntimeException {}
+
+final readonly class ConflictExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ConflictException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->probs->create(
+            request: $request,
+            type: 'conflict',
+            title: 'Conflict',
+            status: 409,
+            detail: $exception->getMessage(),
+        );
+    }
+}
+```
+
+### Version field validation
+
+```php
+if (!isset($body['version']) || !is_int($body['version']) || $body['version'] < 1) {
+    $errors[] = new ValidationError('version', 'version (current integer) is required for optimistic locking.', 'required');
+}
+```
+
+JSON integers decode as PHP `int` — `is_int()` is correct here. A version of `0` or negative is rejected at validation, not at the database level.
+
+### Client workflow
+
+```
+GET /notes/42          → { ..., "version": 3 }
+PUT /notes/42 { ..., "version": 3 }  → 200 { ..., "version": 4 }
+PUT /notes/42 { ..., "version": 3 }  → 409 Conflict (version is now 4)
+GET /notes/42          → { ..., "version": 4 }  (fetch fresh)
+PUT /notes/42 { ..., "version": 4 }  → 200 { ..., "version": 5 }
+```
+
+---
+
+## NENE2 Changes Required
+
+None — zero frictions.
+
+No version bump needed.

--- a/docs/field-trials/2026-05-field-trial-40.md
+++ b/docs/field-trials/2026-05-field-trial-40.md
@@ -1,0 +1,120 @@
+# Field Trial 40 — Approval Workflow / State Machine API (flowlog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/flowlog/`
+**NENE2 version**: 1.5.17
+**Theme**: State machine enum, valid transition enforcement, 422 on invalid transitions, `PostStatus` backed enum, optional body for action endpoints
+
+## Overview
+
+Built a content moderation API with a four-state workflow:
+`draft → submitted → approved | rejected`
+
+Each post tracks its `status` column (SQLite `CHECK` constraint). State transitions are enforced by a `PostStatus` PHP enum with a `canTransitionTo()` method. Invalid transitions throw `InvalidTransitionException → 422`. The `reject` action accepts an optional `reason` field in the request body.
+
+## Endpoints Implemented
+
+- `POST /posts` — create (title, body, author), status starts at `draft`
+- `GET /posts` — list, paginated, optional `?status=` filter
+- `GET /posts/{id}` — show with current status
+- `POST /posts/{id}/submit` — draft → submitted
+- `POST /posts/{id}/approve` — submitted → approved
+- `POST /posts/{id}/reject` — submitted → rejected (optional `reason` body)
+
+## Test Results
+
+22 tests, 40 assertions — pass after 1 fix (optional body handling).
+
+---
+
+## Frictions Found
+
+### Friction 1 — `JsonRequestBodyParser::parse()` throws 400 for empty body on action endpoints [LOW]
+
+**Symptom**: `POST /posts/{id}/reject` (no request body) returns 400 instead of executing the transition.
+
+**Root cause**: `JsonRequestBodyParser::parse()` throws `JsonBodyParseException` (→ 400 Bad Request) when the request body is empty. This is documented and correct for endpoints where a body is required. However, the `reject` action accepts an optional `reason` — if no body is sent, the reason should default to `null`.
+
+**Pattern**:
+
+```php
+// WRONG — throws 400 when body is absent
+$body   = JsonRequestBodyParser::parse($request);
+$reason = isset($body['reason']) ? $body['reason'] : null;
+
+// CORRECT — check for empty body first
+$raw    = (string) $request->getBody();
+$reason = null;
+if ($raw !== '') {
+    $body   = JsonRequestBodyParser::parse($request);
+    $reason = isset($body['reason']) && is_string($body['reason']) ? trim($body['reason']) : null;
+}
+```
+
+**NENE2 impact**: Low — the behaviour is correct (body is required by default). The pattern for optional bodies is straightforward once discovered. Should add a note to `docs/howto/add-custom-route.md` or the PATCH howto about optional body handling.
+
+---
+
+## Patterns Validated
+
+### PHP Backed Enum for state machine
+
+```php
+enum PostStatus: string
+{
+    case Draft     = 'draft';
+    case Submitted = 'submitted';
+    case Approved  = 'approved';
+    case Rejected  = 'rejected';
+
+    public function canTransitionTo(self $target): bool
+    {
+        return match ($this) {
+            self::Draft     => $target === self::Submitted,
+            self::Submitted => $target === self::Approved || $target === self::Rejected,
+            self::Approved,
+            self::Rejected  => false,
+        };
+    }
+}
+```
+
+Backed enums hydrate cleanly from SQLite TEXT with `PostStatus::from((string) $row['status'])`. `tryFrom()` returns `null` for invalid values.
+
+### SQLite CHECK constraint for status column
+
+```sql
+status TEXT NOT NULL DEFAULT 'draft'
+       CHECK(status IN ('draft', 'submitted', 'approved', 'rejected'))
+```
+
+The CHECK constraint provides a database-level safety net, but the application layer enforces transitions first and provides better error messages.
+
+### Status filter with `PostStatus::tryFrom()`
+
+```php
+$statusStr = QueryStringParser::string($request, 'status');
+if ($statusStr !== null) {
+    $status = PostStatus::tryFrom($statusStr);
+    if ($status === null) {
+        throw new ValidationException([...]);
+    }
+    // filter by status
+}
+```
+
+`tryFrom()` + `null` check converts the 422 path cleanly without a try-catch.
+
+### InvalidTransitionException → 422 via DomainExceptionHandlerInterface
+
+Using `status: 422` (not 409) for invalid state transitions is intentional — 422 Unprocessable Content means the server understands the request format but cannot process it due to semantic errors (invalid transition). 409 Conflict is reserved for resource-level conflicts (e.g., optimistic locking).
+
+---
+
+## NENE2 Changes Required
+
+| # | Change | Priority |
+|---|--------|----------|
+| 1 | Add optional body handling note to action endpoint howto | Low |
+
+No version bump needed.

--- a/docs/howto/add-custom-route.md
+++ b/docs/howto/add-custom-route.md
@@ -176,6 +176,30 @@ $router->post('/items/{id}/restore', static function (ServerRequestInterface $re
 > the show/update routes — they work correctly because the action path has an additional static
 > segment after `{id}`, making them unambiguous regardless of registration order.
 
+### Action endpoints with an optional body
+
+Some actions accept an optional JSON body (e.g., a `reject` action with an optional `reason`).
+`JsonRequestBodyParser::parse()` throws a 400 if the body is empty — check for an empty body
+before calling the parser:
+
+```php
+$router->post('/items/{id}/reject', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $raw    = (string) $req->getBody();
+    $reason = null;
+
+    if ($raw !== '') {
+        $body   = JsonRequestBodyParser::parse($req);
+        $reason = isset($body['reason']) && is_string($body['reason']) ? trim($body['reason']) : null;
+    }
+
+    $item = $repo->reject($id, $reason, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item));
+});
+```
+
 ---
 
 ## Available HTTP methods


### PR DESCRIPTION
## Summary

- `add-custom-route.md` にアクションエンドポイントのオプションリクエストボディハンドリングパターンを追加
- FT39 (locklog — 楽観的ロック) フィールドトライアル記録追加
- FT40 (flowlog — 状態機械) フィールドトライアル記録追加

## Key FT Findings

**FT39 (locklog)**: 楽観的ロックパターン（version カラム + 条件付き UPDATE）。NENE2 の `execute()` が返す影響行数でコンフリクト検出。409 Conflict は `DomainExceptionHandlerInterface` で処理。摩擦なし。

**FT40 (flowlog)**: PHP バックドエナム `PostStatus` による状態遷移管理。`canTransitionTo()` による遷移バリデーション。F-1（低）: `reject` アクションはオプションボディを持つが、`JsonRequestBodyParser::parse()` は空ボディで 400 を返す。回避策として空ボディチェックを先行実施するパターンを howto に追記。

## Self-review

Self-review: docs-policy

Closes #609