### PR TITLE
docs(field-trials): FT41 treelog + FT42 cursorlog レポート追加 (#611)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-41.md
+++ b/docs/field-trials/2026-05-field-trial-41.md
@@ -1,0 +1,126 @@
+# Field Trial 41 — Hierarchical Categories with Recursive CTE (treelog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/treelog/`
+**NENE2 version**: 1.5.17
+**Theme**: Self-referential FK, computed depth column, recursive CTE for ancestor/descendant traversal, 409 on delete-with-children
+
+## Overview
+
+Built a category tree API with a `parent_id` self-referential FK. Each category stores a pre-computed `depth` field (root=0, children=1, etc.) for ordering. Ancestor and descendant traversal use recursive CTEs with `WITH RECURSIVE`.
+
+## Endpoints Implemented
+
+- `POST /categories` — create (name, parent_id?); depth computed from parent
+- `GET /categories` — list root categories (parent_id IS NULL)
+- `GET /categories/{id}` — show
+- `GET /categories/{id}/children` — immediate children only
+- `GET /categories/{id}/ancestors` — path from root to parent (breadcrumb order, depth ASC)
+- `GET /categories/{id}/descendants` — full subtree (breadth-first, depth ASC)
+- `DELETE /categories/{id}` — 409 if has children, 404 if not found
+
+## Test Results
+
+21 tests, 41 assertions — pass after 1 logic fix (ORDER BY direction).
+
+---
+
+## Frictions Found
+
+### Friction 1 — Recursive CTE ORDER BY direction: depth DESC ≠ root-first [LOW]
+
+**Symptom**: `GET /categories/{id}/ancestors` returned `[Child, Root]` instead of `[Root, Child]`.
+
+**Root cause**: Initial code used `ORDER BY depth DESC`. Since Root has `depth=0` and Child has `depth=1`, descending order returns Child (1) before Root (0). Correct order for breadcrumb traversal is `ORDER BY depth ASC`.
+
+**Fix**: `SELECT * FROM ancestors ORDER BY depth ASC`
+
+**NENE2 impact**: None — this is a SQL logic error in the application, not a framework issue.
+
+---
+
+## Patterns Validated
+
+### Recursive CTE for ancestors
+
+```sql
+WITH RECURSIVE ancestors(id, name, parent_id, depth, created_at) AS (
+    -- Seed: start from the immediate parent
+    SELECT c.id, c.name, c.parent_id, c.depth, c.created_at
+    FROM categories c
+    WHERE c.id = (SELECT parent_id FROM categories WHERE id = ?)
+    UNION ALL
+    -- Recurse: walk up via parent_id
+    SELECT c.id, c.name, c.parent_id, c.depth, c.created_at
+    FROM categories c
+    INNER JOIN ancestors a ON a.parent_id = c.id
+)
+SELECT * FROM ancestors ORDER BY depth ASC
+-- Result: [root, ..., immediate_parent] — breadcrumb order
+```
+
+### Recursive CTE for descendants
+
+```sql
+WITH RECURSIVE descendants(id, name, parent_id, depth, created_at) AS (
+    -- Seed: immediate children
+    SELECT c.id, c.name, c.parent_id, c.depth, c.created_at
+    FROM categories c
+    WHERE c.parent_id = ?
+    UNION ALL
+    -- Recurse: walk down via parent_id
+    SELECT c.id, c.name, c.parent_id, c.depth, c.created_at
+    FROM categories c
+    INNER JOIN descendants d ON c.parent_id = d.id
+)
+SELECT * FROM descendants ORDER BY depth ASC, name ASC
+```
+
+### Pre-computed depth column
+
+Computing depth at write time (from parent's depth + 1) avoids querying depth in recursive CTEs:
+
+```php
+$depth = 0;
+if ($parentId !== null) {
+    $parentRow = $this->executor->fetchOne('SELECT depth FROM categories WHERE id = ?', [$parentId]);
+    $depth = ((int) $parentRow['depth']) + 1;
+}
+```
+
+This is correct for a simple adjacency list where categories don't move (no re-parenting). If re-parenting is needed, depth must be recomputed for the entire subtree on each move.
+
+### DELETE with children protection
+
+```php
+$children = $this->executor->fetchOne(
+    'SELECT COUNT(*) AS cnt FROM categories WHERE parent_id = ?',
+    [$id],
+);
+
+if ((int) ($children['cnt'] ?? 0) > 0) {
+    throw new \DomainException("Cannot delete category #{$id}: it has children.");
+}
+```
+
+Uses a count query instead of relying on the `ON DELETE RESTRICT` FK constraint — because the constraint error from SQLite comes as a `PDOException` (DatabaseConnectionException), not a domain exception, making it harder to surface a clean 409.
+
+### `HasChildrenExceptionHandler` matching on message content
+
+```php
+public function supports(Throwable $exception): bool
+{
+    return $exception instanceof \DomainException
+        && str_contains($exception->getMessage(), 'has children');
+}
+```
+
+This is a smell — matching on string content is fragile. A dedicated `HasChildrenException` class would be cleaner and is the recommended pattern.
+
+---
+
+## NENE2 Changes Required
+
+None — zero NENE2 frictions; the two issues were application-level (ORDER BY direction, string-match exception handler).
+
+No version bump needed.

--- a/docs/field-trials/2026-05-field-trial-42.md
+++ b/docs/field-trials/2026-05-field-trial-42.md
@@ -1,0 +1,114 @@
+# Field Trial 42 — Cursor-based Pagination (cursorlog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/cursorlog/`
+**NENE2 version**: 1.5.17
+**Theme**: Keyset (cursor) pagination with opaque base64url tokens, newest-first stable ordering, 400 on invalid cursor
+
+## Overview
+
+Built a social-feed message API that uses keyset (cursor) pagination instead of offset-based pagination. Cursors encode a `(created_at, id)` pair as base64url JSON, providing stable ordering even during concurrent inserts. Invalid cursor tokens return a structured 409 Problem Details response.
+
+## Endpoints Implemented
+
+- `POST /messages` — create (author, content); timestamps server-side
+- `GET /messages` — list (cursor pagination): `?limit=N&after=<cursor>`; returns `{items, total, has_more, next_cursor}`
+- `GET /messages/{id}` — show
+
+## Test Results
+
+17 tests, 41 assertions — pass with no fixes required.
+
+---
+
+## Frictions Found
+
+None. All patterns worked as expected on first attempt.
+
+---
+
+## Patterns Validated
+
+### Keyset (cursor) pagination SQL
+
+```sql
+-- First page (no cursor):
+SELECT * FROM messages ORDER BY created_at DESC, id DESC LIMIT ?
+
+-- Subsequent pages (with cursor at created_at=C, id=I):
+SELECT * FROM messages
+WHERE (created_at < ? OR (created_at = ? AND id < ?))
+ORDER BY created_at DESC, id DESC
+LIMIT ?
+```
+
+Fetching `$limit + 1` rows and discarding the last one is the standard probe for `has_more`.
+
+### Opaque cursor encoding
+
+```php
+final readonly class Cursor
+{
+    public static function decode(string $token): ?self
+    {
+        $json = base64_decode(strtr($token, '-_', '+/'), true);
+        if ($json === false) {
+            return null;
+        }
+        $data = json_decode($json, true);
+        if (!is_array($data) || !isset($data['c'], $data['i']) || ...) {
+            return null;
+        }
+        return new self((string) $data['c'], (int) $data['i']);
+    }
+
+    public function encode(): string
+    {
+        $json = json_encode(['c' => $this->createdAt, 'i' => $this->id], JSON_THROW_ON_ERROR);
+        return strtr(base64_encode($json), '+/', '-_');
+    }
+}
+```
+
+Using `strtr(base64_encode(...), '+/', '-_')` produces base64url (URL-safe, no padding issues with query strings).
+
+### Limit clamping
+
+```php
+$limit = QueryStringParser::int($request, 'limit') ?? 20;
+$limit = max(1, min(100, $limit));
+```
+
+`QueryStringParser::int()` returns `?int`, so clamping is applied after the default fallback.
+
+### Invalid cursor → 400 Problem Details
+
+```php
+$after = Cursor::decode($afterToken);
+if ($after === null) {
+    throw new InvalidCursorException($afterToken);
+}
+```
+
+`InvalidCursorExceptionHandler::supports()` checks `instanceof InvalidCursorException` — the clean typed-exception pattern (cf. the string-match smell noted in FT41's `HasChildrenExceptionHandler`).
+
+### Response shape
+
+```json
+{
+  "items": [...],
+  "total": 3,
+  "has_more": true,
+  "next_cursor": "eyJjIjoiMjAyNi0wNS0yMFQxMjowMDowMFoiLCJpIjo1fQ=="
+}
+```
+
+`total` reflects the count of items returned in *this page*, not the total in the database — consistent with how `PaginationResponse` works in NENE2 core.
+
+---
+
+## NENE2 Changes Required
+
+None — zero frictions. The existing `QueryStringParser`, `JsonRequestBodyParser`, `DomainExceptionHandlerInterface`, and `ProblemDetailsResponseFactory` APIs were sufficient.
+
+No version bump needed.


### PR DESCRIPTION
## Summary

- FT41 treelog: 再帰CTEによる階層カテゴリAPI。自己参照FK、depth事前計算、祖先・子孫CTE、子ありDELETE 409。21テスト/41アサーション通過。NENE2変更なし。
- FT42 cursorlog: キーセット（カーソル）ページネーションAPI。不透明base64urlトークン（`created_at`, `id`エンコード）、最新順安定ソート、不正カーソル400。17テスト/41アサーション通過。NENE2変更なし。

## Test plan
- [x] FT41: 21 tests, 41 assertions — pass
- [x] FT42: 17 tests, 41 assertions — pass
- [x] PHPStan level 8 — no errors (both FTs)
- [x] PHP-CS-Fixer — no issues (both FTs)

Closes #611

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)