### PR TITLE
docs(howto): Router::PARAMETERS_ATTRIBUTE パス取得例 + FT48 レポート (#624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.19] — 2026-05-20
+
+### Added
+- `docs/howto/add-database-endpoint.md` — added "Path parameters" callout explaining `Router::PARAMETERS_ATTRIBUTE` extraction pattern; notes that `getAttribute('id')` returns `null` and causes silent 404s. (#624)
+- `docs/field-trials/2026-05-field-trial-48.md` — FT48 (webhooklog) field trial report.
+
+---
+
 ## [1.5.18] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-48.md
+++ b/docs/field-trials/2026-05-field-trial-48.md
@@ -1,0 +1,125 @@
+# Field Trial 48 — Webhook Delivery System (webhooklog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/webhooklog/`
+**NENE2 version**: 1.5.18
+**Theme**: Webhook registration + event dispatching + delivery tracking with retry, interface-based HTTP client, multi-table state machines
+
+## Overview
+
+Built a webhook delivery system API. Users register webhook endpoints (URL + optional secret + event type subscriptions), then dispatch events. The system fans out to all active matching webhooks and records each delivery attempt (status, HTTP status, response body, error). Failed deliveries can be retried.
+
+## Endpoints Implemented
+
+- `POST /webhooks` — register webhook (url, secret, events[])
+- `GET /webhooks` — list all webhooks
+- `GET /webhooks/{id}` — show webhook
+- `DELETE /webhooks/{id}` — unregister webhook
+- `GET /webhooks/{id}/deliveries` — list delivery attempts for a webhook
+- `POST /events/dispatch` — dispatch event_type + payload to matching webhooks (fan-out)
+- `POST /deliveries/{id}/retry` — retry a specific delivery
+
+## Test Results
+
+19 tests, 41 assertions — all pass. PHPStan level 8: no errors. PHP-CS-Fixer: no issues.
+
+---
+
+## Frictions Found
+
+### Friction 1 — `Router::PARAMETERS_ATTRIBUTE` is required; direct `getAttribute('id')` returns null [MEDIUM]
+
+**Symptom**: `GET /webhooks/1` returned 404. All ID-based routes failed silently.
+
+**Root cause**: `Router` stores path parameters under `$request->getAttribute(Router::PARAMETERS_ATTRIBUTE)` (a named constant `'nene2.route.parameters'`), not directly as individual attributes. Calling `$request->getAttribute('id')` returns `null`, causing `(int) null === 0` which then fails to find the record.
+
+**Fix**:
+```php
+// Wrong — returns null
+$id = (int) $request->getAttribute('id');
+
+// Correct — unpack from PARAMETERS_ATTRIBUTE
+$params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+$id     = (int) ($params['id'] ?? 0);
+```
+
+**NENE2 impact**: This pattern is already documented in some howto files, but is easily missed when starting from scratch. The `add-database-endpoint.md` howto should include a clear example of the `Router::PARAMETERS_ATTRIBUTE` pattern in path parameter extraction sections.
+
+---
+
+## Patterns Validated
+
+### Interface-based HTTP client for testability
+
+```php
+interface HttpDeliveryClientInterface {
+    /** @param array<string, mixed> $payload */
+    public function post(string url, array $payload, string $secret): DeliveryResult;
+}
+```
+
+Two test implementations (`SuccessDeliveryClient`, `FailDeliveryClient`) allow testing both success and failure paths without real HTTP calls.
+
+### Backed enum for delivery status
+
+```php
+enum DeliveryStatus: string {
+    case Pending = 'pending';
+    case Success = 'success';
+    case Failed  = 'failed';
+}
+```
+
+`DeliveryStatus::from((string) $row['status'])` cleanly deserializes from SQLite text.
+
+### Fan-out dispatch (loop over matching webhooks)
+
+```php
+$webhooks = $repo->findActiveForEvent($eventType);
+foreach ($webhooks as $webhook) {
+    $deliveries[] = $repo->deliver($webhook, $eventType, $payload, $client, $now)->toArray();
+}
+```
+
+`events = []` (empty array) means "subscribe to all events". Matching uses `in_array()`.
+
+### JSON serialization for event lists in SQLite
+
+Webhook `events[]` stored as JSON text in SQLite. `json_encode` on insert, `json_decode` on hydrate:
+```php
+$eventsJson = json_encode($events, JSON_THROW_ON_ERROR);
+// INSERT ... VALUES (?, ..., ?, ...)  -- $eventsJson as string
+$events = json_decode((string) $row['events'], true, 512, JSON_THROW_ON_ERROR);
+```
+
+### Delivery retry with UPDATE
+
+```php
+$this->executor->execute(
+    'UPDATE deliveries SET status = ?, http_status = ?, response = ?, error = ?, attempted_at = ? WHERE id = ?',
+    [$status->value, $result->httpStatus, $result->response, $result->error, $now, $deliveryId],
+);
+```
+
+Retry re-uses the existing delivery row rather than creating a new one, keeping history clean.
+
+### Secret masking in API response
+
+```php
+public function toArray(): array {
+    return [
+        'secret' => $this->secret !== '' ? '***' : '',
+        // ...
+    ];
+}
+```
+
+The secret is stored in DB for HMAC signing (out of scope for this FT) but masked in all API responses.
+
+---
+
+## NENE2 Changes Required
+
+- **Howto update**: `docs/howto/add-database-endpoint.md` should have a prominent example of `Router::PARAMETERS_ATTRIBUTE` in its path parameter section — this is the second or third time a FT hit this gotcha on first use (the constant name is not intuitive). LOW priority since workaround is a one-liner, but HIGH discoverability value.
+
+No version bump needed (no NENE2 code changes; only doc enhancement candidate).

--- a/docs/howto/add-database-endpoint.md
+++ b/docs/howto/add-database-endpoint.md
@@ -193,6 +193,19 @@ $app = (new RuntimeApplicationFactory(
 > and inject typed config objects instead of raw PDO connection strings.
 > See `src/DependencyInjection/` and `docs/development/domain-layer.md` for the full pattern.
 
+> **Path parameters**: Route parameters like `{id}` are stored under a named constant, not as
+> individual request attributes. Always use `Router::PARAMETERS_ATTRIBUTE` to extract them:
+>
+> ```php
+> use Nene2\Routing\Router;
+>
+> $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+> $id     = (int) ($params['id'] ?? 0);
+> ```
+>
+> Calling `$request->getAttribute('id')` directly returns `null` — a common source of silent 404s
+> when the record lookup then fails against id `0`.
+
 ---
 
 ## Test the use case without a database

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.18
+  version: 1.5.19
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.18';
+    public const string VERSION = '1.5.19';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/add-database-endpoint.md` に **Path parameters** 注意書きを追加
  - `Router::PARAMETERS_ATTRIBUTE` の正しい取得パターンを明示
  - `getAttribute('id')` が `null` を返してサイレント 404 になる落とし穴を説明
- FT48 (webhooklog) フィールドトライアルレポートを追加

## 背景

FT48 で `GET /webhooks/{id}` が 404 を返す問題が発生。ドキュメントにはすでにコード例に `Router::PARAMETERS_ATTRIBUTE` が含まれていたが、冒頭に警告がなく気づきにくかった。

## Test plan

- [x] `composer check` 全通過 (321 tests, 826 assertions, PHPStan OK, CS OK, OpenAPI OK, version 1.5.19)

## Closes

Closes #624

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)