### PR TITLE
feat(http): ConditionalGetHelper — ETag + If-None-Match → 304 Not Modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.20] — 2026-05-20
+
+### Added
+- `ConditionalGetHelper` — static utility for ETag / conditional-GET support. `check($request, $responseFactory, $etag, $lastModified)` returns a 304 Not Modified response (with `ETag` and `Last-Modified` headers) when `If-None-Match` or `If-Modified-Since` indicates the client already has a fresh copy, or `null` when the handler should return the full 200 response. (#637)
+
+---
+
 ## [1.5.19] — 2026-05-20
 
 ### Added

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -53,7 +53,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | Namespace | Key public surfaces |
 |-----------|---------------------|
 | `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `patch`, `delete`, `handle`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
-| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException`, `PaginationQuery`, `PaginationQueryParser` |
+| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException`, `PaginationQuery`, `PaginationQueryParser`, `ConditionalGetHelper` |
 | `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
 | `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException` |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.19
+  version: 1.5.20
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.19';
+    public const string VERSION = '1.5.20';
 
     public function name(): string
     {

--- a/src/Http/ConditionalGetHelper.php
+++ b/src/Http/ConditionalGetHelper.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Checks HTTP conditional-GET headers and returns a 304 Not Modified response when appropriate.
+ *
+ * Call {@see check()} at the start of any GET handler that supports caching. If it returns a
+ * response, send it immediately. If it returns `null`, continue building the full 200 response.
+ *
+ * ```php
+ * $etag = '"' . md5($resource->updatedAt . $resource->id) . '"';
+ * $notModified = ConditionalGetHelper::check($request, $responseFactory, $etag, $resource->updatedAt);
+ * if ($notModified !== null) {
+ *     return $notModified; // 304 with ETag + Last-Modified
+ * }
+ * return $this->json->create($resource->toArray())
+ *     ->withHeader('ETag', $etag)
+ *     ->withHeader('Last-Modified', $resource->updatedAt);
+ * ```
+ *
+ * **ETag format**: always pass a strong ETag with surrounding double quotes (e.g. `"abc123"`).
+ * Weak ETags (`W/"..."`) are not compared.
+ *
+ * **Last-Modified format**: ISO 8601 string (e.g. `2026-05-20T12:00:00Z`). If omitted,
+ * only `If-None-Match` is evaluated.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class ConditionalGetHelper
+{
+    /**
+     * Returns a 304 Not Modified response when `If-None-Match` or `If-Modified-Since` indicates
+     * the client already has a fresh copy. Returns `null` when a full response must be sent.
+     *
+     * @param string $etag         Strong ETag including surrounding double quotes (e.g. `"abc123"`)
+     * @param string $lastModified ISO 8601 timestamp string (e.g. `2026-05-20T12:00:00Z`).
+     *                             Leave empty to skip `If-Modified-Since` evaluation.
+     */
+    public static function check(
+        ServerRequestInterface $request,
+        ResponseFactoryInterface $responseFactory,
+        string $etag,
+        string $lastModified = '',
+    ): ?ResponseInterface {
+        $ifNoneMatch = $request->getHeaderLine('If-None-Match');
+        if ($ifNoneMatch !== '' && $ifNoneMatch === $etag) {
+            return self::notModified($responseFactory, $etag, $lastModified);
+        }
+
+        if ($lastModified !== '') {
+            $ifModifiedSince = $request->getHeaderLine('If-Modified-Since');
+            if ($ifModifiedSince !== '' && $ifModifiedSince >= $lastModified) {
+                return self::notModified($responseFactory, $etag, $lastModified);
+            }
+        }
+
+        return null;
+    }
+
+    private static function notModified(
+        ResponseFactoryInterface $responseFactory,
+        string $etag,
+        string $lastModified,
+    ): ResponseInterface {
+        $response = $responseFactory->createResponse(304)->withHeader('ETag', $etag);
+
+        if ($lastModified !== '') {
+            $response = $response->withHeader('Last-Modified', $lastModified);
+        }
+
+        return $response;
+    }
+}

--- a/tests/Http/ConditionalGetHelperTest.php
+++ b/tests/Http/ConditionalGetHelperTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\ConditionalGetHelper;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ConditionalGetHelperTest extends TestCase
+{
+    private Psr17Factory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new Psr17Factory();
+    }
+
+    private function request(string $ifNoneMatch = '', string $ifModifiedSince = ''): ServerRequestInterface
+    {
+        $req = $this->factory->createServerRequest('GET', 'https://example.test/resource');
+
+        if ($ifNoneMatch !== '') {
+            $req = $req->withHeader('If-None-Match', $ifNoneMatch);
+        }
+
+        if ($ifModifiedSince !== '') {
+            $req = $req->withHeader('If-Modified-Since', $ifModifiedSince);
+        }
+
+        return $req;
+    }
+
+    // --- If-None-Match ---
+
+    public function testMatchingEtagReturns304(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(ifNoneMatch: '"abc123"'),
+            $this->factory,
+            '"abc123"',
+        );
+
+        self::assertNotNull($res);
+        self::assertSame(304, $res->getStatusCode());
+    }
+
+    public function testMatchingEtagResponseCarriesEtagHeader(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(ifNoneMatch: '"abc123"'),
+            $this->factory,
+            '"abc123"',
+        );
+
+        self::assertNotNull($res);
+        self::assertSame('"abc123"', $res->getHeaderLine('ETag'));
+    }
+
+    public function testNonMatchingEtagReturnsNull(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(ifNoneMatch: '"stale"'),
+            $this->factory,
+            '"fresh"',
+        );
+
+        self::assertNull($res);
+    }
+
+    public function testAbsentIfNoneMatchReturnsNull(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(),
+            $this->factory,
+            '"abc123"',
+        );
+
+        self::assertNull($res);
+    }
+
+    // --- If-Modified-Since ---
+
+    public function testCurrentLastModifiedReturns304(): void
+    {
+        $ts  = '2026-05-20T12:00:00Z';
+        $res = ConditionalGetHelper::check(
+            $this->request(ifModifiedSince: $ts),
+            $this->factory,
+            '"tag"',
+            $ts,
+        );
+
+        self::assertNotNull($res);
+        self::assertSame(304, $res->getStatusCode());
+    }
+
+    public function testFutureIfModifiedSinceReturns304(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(ifModifiedSince: '2026-05-20T13:00:00Z'),
+            $this->factory,
+            '"tag"',
+            '2026-05-20T12:00:00Z',
+        );
+
+        self::assertNotNull($res);
+        self::assertSame(304, $res->getStatusCode());
+    }
+
+    public function testOldIfModifiedSinceReturnsNull(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(ifModifiedSince: '2020-01-01T00:00:00Z'),
+            $this->factory,
+            '"tag"',
+            '2026-05-20T12:00:00Z',
+        );
+
+        self::assertNull($res);
+    }
+
+    public function testAbsentIfModifiedSinceReturnsNull(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(),
+            $this->factory,
+            '"tag"',
+            '2026-05-20T12:00:00Z',
+        );
+
+        self::assertNull($res);
+    }
+
+    public function testLastModifiedResponseCarriesLastModifiedHeader(): void
+    {
+        $ts  = '2026-05-20T12:00:00Z';
+        $res = ConditionalGetHelper::check(
+            $this->request(ifModifiedSince: $ts),
+            $this->factory,
+            '"tag"',
+            $ts,
+        );
+
+        self::assertNotNull($res);
+        self::assertSame($ts, $res->getHeaderLine('Last-Modified'));
+    }
+
+    // --- Last-Modified omitted ---
+
+    public function testOmittedLastModifiedSkipsIfModifiedSinceCheck(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(ifModifiedSince: '2026-05-20T13:00:00Z'),
+            $this->factory,
+            '"tag"',
+            // no lastModified argument
+        );
+
+        self::assertNull($res);
+    }
+
+    public function test304WithoutLastModifiedHasNoLastModifiedHeader(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(ifNoneMatch: '"tag"'),
+            $this->factory,
+            '"tag"',
+        );
+
+        self::assertNotNull($res);
+        self::assertSame('', $res->getHeaderLine('Last-Modified'));
+    }
+
+    // --- If-None-Match takes priority ---
+
+    public function testEtagMatchWhenBothHeadersPresent(): void
+    {
+        $res = ConditionalGetHelper::check(
+            $this->request(ifNoneMatch: '"tag"', ifModifiedSince: '2020-01-01T00:00:00Z'),
+            $this->factory,
+            '"tag"',
+            '2026-05-20T12:00:00Z',
+        );
+
+        self::assertNotNull($res);
+        self::assertSame(304, $res->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary

`ConditionalGetHelper` static utility を追加する (FT56 etaglog 摩擦対応)。

- `check($request, $responseFactory, $etag, $lastModified)` → `?ResponseInterface`
- `If-None-Match === $etag` → 304 with ETag header
- `If-Modified-Since >= $lastModified` → 304 with ETag + Last-Modified headers
- Mismatch → `null` (handler builds full 200 response)
- 12 tests, 19 assertions — all pass
- PHPStan level 8: no errors, PHP-CS-Fixer: no issues

## Changes

- `src/Http/ConditionalGetHelper.php` — new class
- `tests/Http/ConditionalGetHelperTest.php` — tests
- `src/FrameworkInfo.php` — bump 1.5.19 → 1.5.20
- `CHANGELOG.md` — v1.5.20 entry
- `docs/openapi/openapi.yaml` — version bump
- `docs/adr/0009-v1.0-public-api-scope.md` — add ConditionalGetHelper to public API list

Closes #637

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)