### PR TITLE
feat(http): JsonResponseFactory::createList() — bare JSON array responses (#645)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.21] — 2026-05-20
+
+### Added
+- `JsonResponseFactory::createList()` — creates a bare JSON array response (`[{...}, ...]`). Accepts `list<mixed>` and encodes it as a top-level JSON array with `Content-Type: application/json`. Complements `create()` which is restricted to JSON objects (`array<string, mixed>`). (#645)
+
+---
+
 ## [1.5.20] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-59.md
+++ b/docs/field-trials/2026-05-field-trial-59.md
@@ -1,0 +1,103 @@
+# Field Trial 59 — Audit Log / Change History for Every Mutation (auditlog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/auditlog/`
+**NENE2 version**: 1.5.20
+**Theme**: Audit log — every PATCH records changed fields (old/new value), who changed it (`X-User-Id` header), and when, into a separate `audit_log` table
+
+## Overview
+
+Built a resource management API to validate the audit log pattern:
+- **Resources**: name, status, owner fields; created via `POST /resources`.
+- **Audit on PATCH**: every changed field gets its own `audit_log` row — field name, old value, new value, `changed_by` (from `X-User-Id` header or `"anonymous"`), and `changed_at` timestamp.
+- **History endpoint**: `GET /resources/{id}/history` returns the full ordered list of audit entries for a resource.
+- Unchanged fields (where old == new) are silently skipped — no spurious audit entries.
+
+## Endpoints Implemented
+
+- `POST /resources` — create a resource (name required)
+- `PATCH /resources/{id}` — partial update; records audit entries for changed fields only
+- `GET /resources/{id}` — fetch current resource state
+- `GET /resources/{id}/history` — return all audit log entries for the resource
+
+## Test Results
+
+16 tests, 41 assertions — all pass. PHPStan level 8: no errors. PHP-CS-Fixer: no issues.
+
+---
+
+## Frictions Found
+
+### Friction 1 — `JsonRequestBodyParser` throws 400 for JSON array `[]`, not just empty body (Low)
+
+**Context**: Testing that PATCH with no valid fields returns 422, I initially sent `json_encode([])` = `[]` (a JSON array) as the body. This triggered a 400 from `JsonRequestBodyParser`, not 422 from application logic.
+
+**Root cause**: `JsonRequestBodyParser::parse()` throws `JsonBodyParseException` (→ 400) for any JSON that is not an object. A PHP `[]` encoded to `"[]"` (JSON array) hits this path.
+
+**Fix in test**: Changed to `(object) []` which encodes to `"{}"` (an empty JSON object), which parses successfully and reaches the application validation (→ 422).
+
+**NENE2 status**: The existing hint message in `JsonRequestBodyParser` already says:
+> `Hint: in PHP, json_encode([]) produces "[]" (a JSON array). Use json_encode((object)[]) or new stdClass() to produce "{}" (a JSON object).`
+
+The behavior is intentional and documented inline. No NENE2 change needed. Recorded as a learning point for FT authors.
+
+---
+
+## Patterns Validated
+
+### Audit log table schema
+
+```sql
+CREATE TABLE IF NOT EXISTS audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL,
+    field       TEXT NOT NULL,
+    old_value   TEXT NOT NULL,
+    new_value   TEXT NOT NULL,
+    changed_by  TEXT NOT NULL,
+    changed_at  TEXT NOT NULL,
+    FOREIGN KEY (resource_id) REFERENCES resources (id)
+);
+```
+
+One row per changed field per PATCH call. Supports multiple changes atomically.
+
+### Repository-level audit diff
+
+```php
+public function patch(int $id, array $fields, string $changedBy, string $now): array
+{
+    $resource = $this->findById($id);
+    $mutable  = ['name' => $resource->name, 'status' => $resource->status, 'owner' => $resource->owner];
+    $entries  = [];
+
+    foreach ($fields as $field => $newValue) {
+        $oldValue = $mutable[$field];
+        if ($oldValue === $newValue) { continue; }   // skip no-op changes
+        $mutable[$field] = $newValue;
+        // INSERT INTO audit_log ...
+        $entries[] = new AuditEntry(...);
+    }
+
+    if ($entries !== []) {
+        // UPDATE resources SET ... WHERE id = ?
+    }
+    return $entries;
+}
+```
+
+Only writes to `resources` if at least one field actually changed. No spurious audit entries for unchanged values.
+
+### Anonymous fallback for `X-User-Id`
+
+```php
+$changedBy = $request->getHeaderLine('X-User-Id') ?: 'anonymous';
+```
+
+Empty or absent header defaults to `"anonymous"`. No auth required — identity is advisory.
+
+---
+
+## NENE2 Changes Required
+
+None. The audit log pattern is a pure application-layer concern. All required primitives (`DatabaseQueryExecutorInterface`, `JsonRequestBodyParser`, `ProblemDetailsResponseFactory`, `Router::PARAMETERS_ATTRIBUTE`) are available in v1.5.20.

--- a/docs/field-trials/2026-05-field-trial-60.md
+++ b/docs/field-trials/2026-05-field-trial-60.md
@@ -1,0 +1,105 @@
+# Field Trial 60 — Event Sourcing: Balance Derived from Event Replay (eventsourcelog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/eventsourcelog/`
+**NENE2 version**: 1.5.20
+**Theme**: Event sourcing — account balance is never stored, always derived by replaying an append-only `account_events` log
+
+## Overview
+
+Built a bank account API to validate the event sourcing pattern:
+- **Accounts**: created via `POST /accounts` with a user-supplied string ID and owner.
+- **Events**: append-only `account_events` table; event types are `account_opened`, `money_deposited`, `money_withdrawn`.
+- **Balance**: computed at read time by replaying all events for an account. No `balance` column exists in the schema.
+- **Insufficient funds**: withdrawal checks current balance (replayed) and returns 409 Conflict if the account cannot cover the amount.
+
+## Endpoints Implemented
+
+- `POST /accounts` — open an account (records `account_opened` event)
+- `GET /accounts/{id}` — current state with replayed balance
+- `GET /accounts/{id}/events` — full event stream in insertion order
+- `POST /accounts/{id}/deposits` — append `money_deposited` event
+- `POST /accounts/{id}/withdrawals` — append `money_withdrawn` event (409 if insufficient funds)
+
+## Test Results
+
+18 tests, 33 assertions — all pass. PHPStan level 8: no errors. PHP-CS-Fixer: no issues.
+
+---
+
+## Frictions Found
+
+None. The event sourcing pattern composed cleanly with NENE2's public API. The append-only event store maps naturally to `DatabaseQueryExecutorInterface::execute()` + `lastInsertId()`. Business rules (insufficient funds check) slot naturally into the repository before appending the event.
+
+---
+
+## Patterns Validated
+
+### Append-only event store schema
+
+```sql
+CREATE TABLE IF NOT EXISTS account_events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_id  TEXT NOT NULL,
+    type        TEXT NOT NULL,
+    amount      INTEGER NOT NULL DEFAULT 0,
+    recorded_at TEXT NOT NULL
+);
+```
+
+No `balance` column — the account state is always reconstructed from events.
+
+### Balance replayed from event stream
+
+```php
+private function replay(array $events): int
+{
+    $balance = 0;
+    foreach ($events as $event) {
+        $balance += match ($event->type) {
+            AccountEvent::TYPE_DEPOSITED => $event->amount,
+            AccountEvent::TYPE_WITHDRAWN => -$event->amount,
+            default                      => 0,
+        };
+    }
+    return $balance;
+}
+```
+
+`account_opened` contributes 0 — it acts as the stream anchor. `match` with a `default` arm makes it forward-compatible with new event types.
+
+### Insufficient funds check before append
+
+```php
+public function withdraw(string $accountId, int $amountCents, string $now): AccountEvent
+{
+    $events  = $this->events($accountId);
+    $balance = $this->replay($events);
+
+    if ($balance < $amountCents) {
+        throw new InsufficientFundsException($balance, $amountCents);
+    }
+    // ... INSERT INTO account_events ...
+}
+```
+
+The check reads the current event stream, replays balance, and only appends if the invariant holds. For SQLite (synchronous), this is race-condition-free within a single request.
+
+### Typed event constants
+
+```php
+final readonly class AccountEvent
+{
+    public const string TYPE_OPENED    = 'account_opened';
+    public const string TYPE_DEPOSITED = 'money_deposited';
+    public const string TYPE_WITHDRAWN = 'money_withdrawn';
+}
+```
+
+PHP 8.3+ typed class constants (`string`) give PHPStan level 8 full type coverage without extra annotation.
+
+---
+
+## NENE2 Changes Required
+
+None. Event sourcing is a pure application-layer pattern. All required primitives available in v1.5.20.

--- a/docs/field-trials/2026-05-field-trial-61.md
+++ b/docs/field-trials/2026-05-field-trial-61.md
@@ -1,0 +1,105 @@
+# Field Trial 61 — State Machine: Order Workflow with Enforced Transitions (statemachinelog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/statemachinelog/`
+**NENE2 version**: 1.5.20
+**Theme**: State machine — typed PHP enum for states, allowed-transitions map, 409 on invalid move, transition log
+
+## Overview
+
+Built an order workflow API to validate the state machine pattern with PHP 8.1+ backed enums:
+- **States**: `draft → submitted → approved/rejected`, `draft → cancelled`, `submitted → cancelled`. Terminal states have no outgoing transitions.
+- **Enum**: `OrderStatus` backed enum with an `allowedTransitions()` method returning the valid next states.
+- **Transition enforcement**: `canTransitionTo()` check in the repository; throws `InvalidTransitionException` (→ 409) on violation.
+- **Transition log**: every successful transition appends to `order_transitions` with `from_status`, `to_status`, and timestamp.
+
+## Endpoints Implemented
+
+- `POST /orders` — create order (starts in `draft`)
+- `GET /orders/{id}` — current order state
+- `POST /orders/{id}/transitions` — attempt a state transition; body: `{"status": "submitted"}`
+- `GET /orders/{id}/transitions` — full transition history
+
+## Test Results
+
+16 tests, 31 assertions — all pass. PHPStan level 8: no errors. PHP-CS-Fixer: no issues.
+
+---
+
+## Frictions Found
+
+None. The state machine pattern composed cleanly with NENE2's public API. PHP 8.1 backed enums with `tryFrom()` provided clean validation of the incoming status string; `match` in `allowedTransitions()` gives an exhaustive, PHPStan-verified transition table.
+
+---
+
+## Patterns Validated
+
+### Backed enum as state machine
+
+```php
+enum OrderStatus: string
+{
+    case Draft     = 'draft';
+    case Submitted = 'submitted';
+    case Approved  = 'approved';
+    case Rejected  = 'rejected';
+    case Cancelled = 'cancelled';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Draft     => [self::Submitted, self::Cancelled],
+            self::Submitted => [self::Approved, self::Rejected, self::Cancelled],
+            self::Approved  => [],
+            self::Rejected  => [],
+            self::Cancelled => [],
+        };
+    }
+
+    public function canTransitionTo(self $target): bool
+    {
+        return in_array($target, $this->allowedTransitions(), true);
+    }
+}
+```
+
+`match` is exhaustive — PHPStan level 8 catches missing cases at compile time.
+
+### Unknown status value — 422 via `tryFrom()`
+
+```php
+$targetEnum = OrderStatus::tryFrom($statusRaw);
+if ($targetEnum === null) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, ...);
+}
+```
+
+`tryFrom()` handles the "not a valid enum value" case cleanly, keeping 422 (malformed input) distinct from 409 (invalid transition).
+
+### 409 with structured `from`/`to` detail
+
+```php
+return $this->problems->create(
+    $request, 'invalid-transition', 'Invalid State Transition', 409,
+    $e->getMessage(),
+    ['from' => $order->status->value, 'to' => $targetEnum->value],
+);
+```
+
+The Problem Details `extensions` array carries machine-readable `from` and `to` values so the client can reason about which transition failed.
+
+### Transition log persisted alongside state update
+
+```php
+$this->executor->execute('UPDATE orders SET status = ?, updated_at = ? WHERE id = ?', ...);
+$this->executor->execute('INSERT INTO order_transitions (order_id, from_status, to_status, ...) VALUES ...', ...);
+```
+
+State update and transition record happen in the same repository method. Both rows are written or neither is (SQLite implicit transaction per statement; for strict atomicity a transaction wrapper would be added).
+
+---
+
+## NENE2 Changes Required
+
+None. The state machine pattern is a pure application-layer concern. All required primitives available in v1.5.20.

--- a/docs/field-trials/2026-05-field-trial-62.md
+++ b/docs/field-trials/2026-05-field-trial-62.md
@@ -1,0 +1,111 @@
+# Field Trial 62 — Soft Delete / Trash Bin (softdeletelog)
+
+**Date**: 2026-05-20
+**Project**: `/home/xi/docker/NENE2-FT/softdeletelog/`
+**NENE2 version**: 1.5.20
+**Theme**: Soft delete — `deleted_at` nullable column, hidden from active queries, restorable, permanently purgeable
+
+## Overview
+
+Built a notes API to validate the soft delete pattern:
+- **Soft delete**: `DELETE /notes/{id}` sets `deleted_at` timestamp; row is hidden from `GET /notes` (active list) and `GET /notes/{id}`.
+- **Trash bin**: `GET /notes/trash` shows only soft-deleted notes.
+- **Restore**: `POST /notes/{id}/restore` clears `deleted_at`; note reappears in the active list.
+- **Purge**: `DELETE /notes/{id}/purge` permanently deletes a trashed note; only allowed when `deleted_at` is set.
+
+## Endpoints Implemented
+
+- `POST /notes` — create note
+- `GET /notes` — active notes only (`deleted_at IS NULL`)
+- `GET /notes/trash` — trashed notes only (`deleted_at IS NOT NULL`)
+- `GET /notes/{id}` — fetch active note (404 if deleted)
+- `DELETE /notes/{id}` — soft delete
+- `POST /notes/{id}/restore` — restore from trash
+- `DELETE /notes/{id}/purge` — permanent delete (only from trash)
+
+## Test Results
+
+18 tests, 30 assertions — all pass. PHPStan level 8: no errors. PHP-CS-Fixer: no issues.
+
+---
+
+## Frictions Found
+
+### Friction 1 — `JsonResponseFactory::create()` cannot return a bare JSON array (Medium)
+
+**Context**: `GET /notes` and `GET /notes/trash` naturally return a JSON array (`[]`). REST convention: list endpoints return arrays. But `JsonResponseFactory::create()` is typed `array<string, mixed>` — only JSON objects are accepted.
+
+**Reproduction**:
+```php
+// Causes PHPStan error: list<array<string, mixed>> given, array<string, mixed> expected
+return $this->json->create(array_map(fn($n) => $n->toArray(), $notes));
+```
+
+**Workaround**: Wrap the list in an envelope object:
+```php
+return $this->json->create(['items' => array_map(fn($n) => $n->toArray(), $notes)]);
+```
+
+**Impact**: All list endpoints require an envelope wrapper, which changes the API shape from idiomatic REST (`[]`) to `{"items": [...]}`. Clients must be aware of this convention.
+
+**Suggested NENE2 fix**: Add a second method `JsonResponseFactory::createList(array $items, int $status = 200)` that accepts `list<mixed>` and encodes it as a top-level JSON array.
+
+---
+
+### Friction 2 — PHPStan catches redundant `isset() && !== null` pattern in hydrate methods (Low)
+
+**Context**: When hydrating a row from `fetchAll()`, I wrote:
+```php
+isset($row['deleted_at']) && $row['deleted_at'] !== null ? (string) $row['deleted_at'] : null
+```
+PHPStan (level 8) correctly flags: "Strict comparison using `!== null` will always evaluate to true" — because `isset()` already eliminates null values.
+
+**Fix**: Use `isset()` alone:
+```php
+isset($row['deleted_at']) ? (string) $row['deleted_at'] : null
+```
+
+**NENE2 status**: No change needed. This is a PHP idiom clarification for FT authors.
+
+---
+
+## Patterns Validated
+
+### `deleted_at IS NULL` filter on all active queries
+
+```sql
+SELECT * FROM notes WHERE deleted_at IS NULL ORDER BY created_at DESC
+SELECT * FROM notes WHERE id = ? AND deleted_at IS NULL
+```
+
+The `NULL` check is added consistently at the SQL level — no application-layer filtering.
+
+### Restore clears `deleted_at`
+
+```php
+$this->executor->execute('UPDATE notes SET deleted_at = NULL WHERE id = ?', [$id]);
+```
+
+NULL assignment in SQL is clean with PDO parameterized queries.
+
+### Purge requires the row to be in the trash first
+
+```php
+public function purge(int $id): bool
+{
+    $note = $this->findById($id, includeTrashed: true);
+    if ($note === null || !$note->isDeleted()) {
+        return false;  // 404 — either not found or not in trash
+    }
+    $this->executor->execute('DELETE FROM notes WHERE id = ?', [$id]);
+    return true;
+}
+```
+
+Two-step guard prevents accidentally purging an active note via the purge endpoint.
+
+---
+
+## NENE2 Changes Required
+
+**Issue to file**: `JsonResponseFactory` lacks a `createList()` method for bare JSON array responses. Medium severity — forces an envelope wrapper on all list endpoints.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.20
+  version: 1.5.21
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.20';
+    public const string VERSION = '1.5.21';
 
     public function name(): string
     {

--- a/src/Http/JsonResponseFactory.php
+++ b/src/Http/JsonResponseFactory.php
@@ -43,6 +43,32 @@ final readonly class JsonResponseFactory
     }
 
     /**
+     * Creates a `application/json` response from a list (bare JSON array).
+     *
+     * Use this instead of {@see create()} when the response body is a top-level JSON array,
+     * such as collection endpoints that return `[{...}, {...}]`.
+     *
+     * @param list<mixed> $items
+     * @param array<string, string> $headers
+     */
+    public function createList(array $items, int $status = 200, array $headers = []): ResponseInterface
+    {
+        $body = $this->streamFactory->createStream(
+            json_encode($items, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION)
+        );
+
+        $response = $this->responseFactory
+            ->createResponse($status)
+            ->withHeader('Content-Type', 'application/json; charset=utf-8');
+
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response->withBody($body);
+    }
+
+    /**
      * Creates an empty response with no body — intended for 204 No Content and similar status codes.
      */
     public function createEmpty(int $status = 204): ResponseInterface

--- a/tests/Http/JsonResponseFactoryTest.php
+++ b/tests/Http/JsonResponseFactoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\JsonResponseFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class JsonResponseFactoryTest extends TestCase
+{
+    private JsonResponseFactory $factory;
+
+    protected function setUp(): void
+    {
+        $psr17         = new Psr17Factory();
+        $this->factory = new JsonResponseFactory($psr17, $psr17);
+    }
+
+    public function testCreateReturnsJsonObject(): void
+    {
+        $response = $this->factory->create(['key' => 'value']);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/json', $response->getHeaderLine('Content-Type'));
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame(['key' => 'value'], $body);
+    }
+
+    public function testCreateWithCustomStatus(): void
+    {
+        $response = $this->factory->create(['id' => 1], 201);
+        self::assertSame(201, $response->getStatusCode());
+    }
+
+    public function testCreateWithCustomHeaders(): void
+    {
+        $response = $this->factory->create([], 200, ['X-Custom' => 'yes']);
+        self::assertSame('yes', $response->getHeaderLine('X-Custom'));
+    }
+
+    public function testCreateListReturnsBareJsonArray(): void
+    {
+        $items    = [['id' => 1, 'name' => 'a'], ['id' => 2, 'name' => 'b']];
+        $response = $this->factory->createList($items);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/json', $response->getHeaderLine('Content-Type'));
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertCount(2, $body);
+        self::assertSame(1, $body[0]['id']);
+    }
+
+    public function testCreateListWithEmptyArray(): void
+    {
+        $response = $this->factory->createList([]);
+        $body     = json_decode((string) $response->getBody(), true);
+
+        self::assertSame([], $body);
+    }
+
+    public function testCreateListWithCustomStatus(): void
+    {
+        $response = $this->factory->createList(['item'], 201);
+        self::assertSame(201, $response->getStatusCode());
+    }
+
+    public function testCreateListWithCustomHeaders(): void
+    {
+        $response = $this->factory->createList([], 200, ['X-Total-Count' => '0']);
+        self::assertSame('0', $response->getHeaderLine('X-Total-Count'));
+    }
+
+    public function testCreateEmptyReturns204(): void
+    {
+        $response = $this->factory->createEmpty();
+        self::assertSame(204, $response->getStatusCode());
+        self::assertSame('', (string) $response->getBody());
+    }
+}


### PR DESCRIPTION
## Summary

- FT62 (softdeletelog) で `JsonResponseFactory::create()` が `list<array<string, mixed>>` を受け付けないため PHPStan level 8 エラーになる摩擦を発見
- `JsonResponseFactory::createList(list<mixed> $items, int $status = 200, array $headers = [])` を追加
- 8 tests 追加（`JsonResponseFactoryTest`）
- FT59〜FT62 のフィールドトライアルレポートを同梱

## Test plan

- [ ] `composer check` — 341 tests, PHPStan level 8, CS-Fixer all pass
- [ ] `createList()` で bare `[]` が返る
- [ ] `create()` との一貫性（Content-Type / status / headers）確認済み

Self-review: backend-api

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)