### PR TITLE
feat(database): DatabaseConstraintException for UNIQUE/FK violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.23] — 2026-05-20
+
+### Added
+- `DatabaseConstraintException` — new exception class (extends `DatabaseConnectionException`) thrown by `PdoDatabaseQueryExecutor` when a DB constraint is violated (UNIQUE, FK, NOT NULL, CHECK). Catch this type to handle duplicate-key or FK violations without catching all connection errors. (#669)
+
+### Changed
+- `DatabaseConnectionException` — removed `final` modifier to allow `DatabaseConstraintException` to extend it. Existing `catch (DatabaseConnectionException)` blocks now also catch `DatabaseConstraintException` (Liskov-compatible). (#669)
+
+---
+
 ## [1.5.22] — 2026-05-20
 
 ### Changed

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -56,7 +56,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException`, `PaginationQuery`, `PaginationQueryParser`, `ConditionalGetHelper` |
 | `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
 | `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
-| `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException` |
+| `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException`, `DatabaseConstraintException` |
 | `Nene2\Error` | `DomainExceptionHandlerInterface`, `ProblemDetailsResponseFactory` |
 | `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware`, `LocalBearerTokenVerifier`, `CompositeAuthMiddleware` |
 | `Nene2\Middleware` | All shipped middleware classes, `RateLimitStorageInterface`, `ThrottleMiddleware` |

--- a/docs/field-trials/2026-05-field-trial-76.md
+++ b/docs/field-trials/2026-05-field-trial-76.md
@@ -1,0 +1,83 @@
+# Field Trial 76 — Leaderboard with Ranking and Percentile (leaderboardlog)
+
+**Date**: 2026-05-20
+**NENE2 version**: 1.5.22
+**Project**: `/home/xi/docker/NENE2-FT/leaderboardlog/`
+**Theme**: Score leaderboard with per-board isolation, upsert pattern, dense ranking (tied scores share same rank), and user rank lookup.
+
+---
+
+## What was built
+
+A leaderboard API where users submit scores to named boards. Each user has at most one score per board (upsert). Rankings use dense ranking — tied scores share the same rank number, and the next rank skips accordingly.
+
+### Domain
+
+- `Score` — `board`, `userId`, `score`, `metadata` (`array<string, mixed>`), `createdAt`, `rank`
+- Rank computed via correlated subquery: `COUNT(*) + 1 WHERE score > user's score`
+- Same score → same rank (dense ranking); scores below a tie group get rank = tied_count + 1
+
+### Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS scores (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    board      TEXT NOT NULL DEFAULT 'global',
+    user_id    TEXT NOT NULL,
+    score      INTEGER NOT NULL,
+    metadata   TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    UNIQUE(board, user_id)
+);
+```
+
+`UNIQUE(board, user_id)` enforces one score per user per board; upsert is implemented with `INSERT ... ON CONFLICT DO UPDATE SET`.
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/boards/{board}/scores/{userId}` | Upsert user score on a board |
+| GET | `/boards/{board}/scores` | Ranked list for a board (optional `?limit=N`, default 10, max 100) |
+| GET | `/boards/{board}/scores/{userId}` | Get a user's score with their current rank |
+
+### Key design decisions
+
+**Upsert with `ON CONFLICT DO UPDATE`**: SQLite's upsert syntax replaces a dedicated "update or insert" branch in application code. `created_at` is preserved on update (only `score` and `metadata` are overwritten).
+
+**Dense ranking via correlated subquery**: The rank is computed as `(SELECT COUNT(*) FROM scores s2 WHERE s2.board = s.board AND s2.score > s.score) + 1`. This is a standard dense ranking: every user with the same score gets the same rank, and the next rank after a tie group equals (number of users with higher score) + 1.
+
+**Tie-breaking in sorted output**: `ORDER BY score DESC, user_id ASC` gives a deterministic ordering within a rank tier. The rank field itself is the same for all tied users.
+
+**Board isolation**: All queries are scoped to `board`. Different boards are fully independent even for the same `user_id`.
+
+**Metadata as JSON in TEXT column**: `json_encode()` on write, `json_decode()` on hydrate — same pattern as prior FTs (auditlog, deadletterlog).
+
+**`limit` cap at 100**: Query param clamped: `max(1, min(100, $limit))`. Default 10.
+
+### Test results
+
+```
+OK (12 tests, 32 assertions)
+PHPStan level 8: No errors
+PHP-CS-Fixer: 0 files to fix
+```
+
+---
+
+## Friction log
+
+No frictions encountered. NENE2 v1.5.22 handled all patterns cleanly:
+
+- Two path parameters (`{board}/{userId}`): ✅
+- `PUT` method routing: ✅
+- `?limit=N` query param: ✅ (read via `$request->getQueryParams()`)
+- SQLite `ON CONFLICT DO UPDATE` upsert: ✅ (framework-agnostic — raw SQL)
+- Correlated subquery for rank: ✅ (framework-agnostic — raw SQL)
+- JSON metadata in TEXT column: ✅
+
+---
+
+## Summary
+
+Leaderboard with dense ranking works cleanly with NENE2 v1.5.22. The rank computation (correlated subquery) and upsert (`ON CONFLICT DO UPDATE`) are both raw SQL idioms that the framework does not interfere with. No framework changes needed.

--- a/docs/field-trials/2026-05-field-trial-77.md
+++ b/docs/field-trials/2026-05-field-trial-77.md
@@ -1,0 +1,105 @@
+# Field Trial 77 — Poll/Voting API with Aggregation and State Machine (polllog)
+
+**Date**: 2026-05-20
+**NENE2 version**: 1.5.22
+**Project**: `/home/xi/docker/NENE2-FT/polllog/`
+**Theme**: Poll/voting API with multi-option creation, one-vote-per-user enforcement, vote count aggregation, and open/closed state machine.
+
+---
+
+## What was built
+
+A poll API where polls are created with multiple options. Each voter can vote exactly once per poll (enforced by `UNIQUE(poll_id, voter_id)`). Vote counts are aggregated per option. Polls can be closed, after which voting is rejected.
+
+### Domain
+
+- `Poll` — `title`, `question`, `status` (open/closed), `createdBy`, `closedAt`, `options`, `totalVotes`
+- `PollOption` — `text`, `votes` (COUNT of votes for that option)
+- `PollStatus` — string-backed enum: `open`, `closed`
+- `total_votes` computed in `toArray()` as `array_sum()` of option vote counts
+
+### Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS polls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL, question TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open',
+    created_by TEXT NOT NULL, created_at TEXT NOT NULL, closed_at TEXT
+);
+CREATE TABLE IF NOT EXISTS poll_options (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    poll_id INTEGER NOT NULL REFERENCES polls(id),
+    text TEXT NOT NULL, created_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS poll_votes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    poll_id INTEGER NOT NULL REFERENCES polls(id),
+    option_id INTEGER NOT NULL REFERENCES poll_options(id),
+    voter_id TEXT NOT NULL, created_at TEXT NOT NULL,
+    UNIQUE(poll_id, voter_id)
+);
+```
+
+`UNIQUE(poll_id, voter_id)` enforces one vote per voter per poll at the DB level.
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/polls` | Create poll with options (min 2 options required) |
+| GET | `/polls` | List polls (optional `?status=open\|closed`) |
+| GET | `/polls/{id}` | Get poll with vote counts per option |
+| POST | `/polls/{id}/vote` | Vote (body: `option_id`, `voter_id`) |
+| POST | `/polls/{id}/close` | Close poll (no further voting allowed) |
+
+### Key design decisions
+
+**Multi-row creation in one operation**: `create()` inserts the poll, then iterates options with individual `INSERT` statements. SQLite auto-increments `id`; `last_insert_rowid()` retrieves the poll ID.
+
+**Duplicate vote via UNIQUE constraint**: Rather than a pre-check SELECT (which would be a TOCTOU race), the UNIQUE constraint is the guard. A caught `DatabaseConnectionException` with a `PDOException` cause containing "UNIQUE constraint failed" maps to a 409 response.
+
+**Vote count aggregation**: `fetchOptions()` uses `LEFT JOIN poll_votes ON v.option_id = o.id ... COUNT(v.id) AS votes GROUP BY o.id` — single query per poll load; no N+1.
+
+**State machine close is idempotent-via-404**: `close()` returns null when the poll is already closed, mapping to 404. Alternative would be 409, but 404 ("not found as an open poll") is cleaner for callers.
+
+**`PollStatus::tryFrom()` for filter param**: `?status=open|closed` uses `PollStatus::tryFrom($statusRaw)` — unknown values produce `null` (no filter), which is the correct graceful handling.
+
+### Test results
+
+```
+OK (17 tests, 34 assertions)
+PHPStan level 8: No errors
+PHP-CS-Fixer: 0 files to fix
+```
+
+---
+
+## Friction log
+
+### F-1 (Low) — `DatabaseQueryExecutorInterface::execute()` wraps `PDOException` in `DatabaseConnectionException`
+
+**What happened**: Catching `\PDOException` in `SqlitePollRepository::vote()` to detect UNIQUE constraint violations silently failed — the exception was never caught, resulting in a 500 instead of 409.
+
+**Root cause**: `PdoDatabaseQueryExecutor::statement()` wraps every `PDOException` in `Nene2\Database\DatabaseConnectionException`. User code cannot catch the original `PDOException` from calls to `execute()`.
+
+**Workaround used**:
+```php
+} catch (DatabaseConnectionException $e) {
+    $prev = $e->getPrevious();
+    if ($prev instanceof \PDOException && str_contains($prev->getMessage(), 'UNIQUE constraint failed')) {
+        return false;
+    }
+    throw $e;
+}
+```
+
+**Impact**: Any user code that wants to handle specific DB errors (UNIQUE constraint, FK violation) must know to catch `DatabaseConnectionException` and inspect `getPrevious()`. This is non-obvious and not documented.
+
+**Suggested fix**: Either (a) expose a dedicated method `executeAndCatch(string $sql, array $params): bool` for upsert/conflict scenarios, or (b) define and document when `DatabaseConnectionException` is thrown and how to detect constraint violations (howto or ADR note). Alternatively, add a specific `DatabaseConstraintException` for UNIQUE/FK violations.
+
+---
+
+## Summary
+
+Poll/voting API with aggregation and state machine works with NENE2 v1.5.22. One friction found: catching UNIQUE constraint violations requires catching `DatabaseConnectionException` and inspecting the previous `PDOException`, not catching `PDOException` directly. This is undocumented and counter-intuitive.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.22
+  version: 1.5.23
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/Database/DatabaseConnectionException.php
+++ b/src/Database/DatabaseConnectionException.php
@@ -7,10 +7,11 @@ namespace Nene2\Database;
 use RuntimeException;
 
 /**
- * Thrown when a database connection cannot be established.
+ * Thrown when a database operation fails due to a connection or execution error.
+ * Extended by DatabaseConstraintException for constraint violations.
  *
  * Part of the public API stability guarantee (see ADR 0009).
  */
-final class DatabaseConnectionException extends RuntimeException
+class DatabaseConnectionException extends RuntimeException
 {
 }

--- a/src/Database/DatabaseConstraintException.php
+++ b/src/Database/DatabaseConstraintException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database;
+
+/**
+ * Thrown when a database constraint is violated (UNIQUE, FK, NOT NULL, CHECK).
+ *
+ * Extends DatabaseConnectionException so existing catch blocks are unaffected.
+ * Catch this specific type to handle constraint violations (e.g. duplicate key)
+ * without catching all connection errors.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class DatabaseConstraintException extends DatabaseConnectionException
+{
+}

--- a/src/Database/PdoDatabaseQueryExecutor.php
+++ b/src/Database/PdoDatabaseQueryExecutor.php
@@ -77,8 +77,22 @@ final class PdoDatabaseQueryExecutor implements DatabaseQueryExecutorInterface
 
             return $statement;
         } catch (PDOException $exception) {
+            if ($this->isConstraintViolation($exception)) {
+                throw new DatabaseConstraintException('Database constraint violated.', previous: $exception);
+            }
             throw new DatabaseConnectionException('Database query could not be executed.', previous: $exception);
         }
+    }
+
+    private function isConstraintViolation(PDOException $e): bool
+    {
+        // SQLSTATE 23xxx = Integrity Constraint Violation (UNIQUE, FK, NOT NULL, CHECK)
+        $code = (string) $e->getCode();
+        return str_starts_with($code, '23')
+            || str_contains($e->getMessage(), 'UNIQUE constraint failed')
+            || str_contains($e->getMessage(), 'FOREIGN KEY constraint failed')
+            || str_contains($e->getMessage(), 'NOT NULL constraint failed')
+            || str_contains($e->getMessage(), 'CHECK constraint failed');
     }
 
     private function connection(): PDO

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.22';
+    public const string VERSION = '1.5.23';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `DatabaseConstraintException` (extends `DatabaseConnectionException`) 追加 — UNIQUE・FK・NOT NULL・CHECK制約違反時に throw
- `DatabaseConnectionException` から `final` を削除して継承可能に
- `PdoDatabaseQueryExecutor` の constraint 検出ロジック追加（SQLSTATE 23xxx またはメッセージ文字列で判定）
- ADR 0009 の公開 API 一覧に `DatabaseConstraintException` 追加
- v1.5.23 リリース準備（VERSION・CHANGELOG・OpenAPI バージョン更新）

## 動機

FT77 (polllog) で UNIQUE 制約違反を `\PDOException` でキャッチしようとしたが、
`PdoDatabaseQueryExecutor` が全例外を `DatabaseConnectionException` にラップするため
500 エラーになった（#669）。

以前のワークアラウンド:
```php
catch (DatabaseConnectionException $e) {
    $prev = $e->getPrevious();
    if ($prev instanceof \PDOException && str_contains($prev->getMessage(), 'UNIQUE constraint failed')) {
        return false;
    }
}
```

対応後:
```php
catch (DatabaseConstraintException $e) {
    return false; // duplicate key
}
```

## Test plan

- [x] `composer check` — 341 tests, 860 assertions, PHPStan level 8, CS: 0 files, Version 1.5.23
- [x] FT77 polllog: 17/17 テスト、`DatabaseConstraintException` で重複投票を 409 で処理

## 後方互換性

`DatabaseConstraintException extends DatabaseConnectionException` のため、
既存の `catch (DatabaseConnectionException)` ブロックは変更不要。

Closes #669

Self-review: backend-api, database

🤖 Generated with [Claude Code](https://claude.com/claude-code)