### PR TITLE
feat(http): ConditionalWriteHelper — If-Match / 412 / 428 楽観的ロック (FT90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.24] — 2026-05-20
+
+### Added
+- `ConditionalWriteHelper` — static helper for HTTP conditional writes. Evaluates the `If-Match` header and returns a `412 Precondition Failed` or `428 Precondition Required` problem-details response when the precondition fails; returns `null` when the write may proceed. Complements the existing `ConditionalGetHelper` (which handles `If-None-Match` / 304). (#674)
+- `docs/howto/add-optimistic-locking.md` — how-to guide for implementing optimistic concurrency control with ETag / If-Match, including 428 usage, wildcard semantics, and conditional UPDATE pattern. (#674 #675)
+
+---
+
 ## [1.5.23] — 2026-05-20
 
 ### Added

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -53,7 +53,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | Namespace | Key public surfaces |
 |-----------|---------------------|
 | `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `patch`, `delete`, `handle`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
-| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException`, `PaginationQuery`, `PaginationQueryParser`, `ConditionalGetHelper` |
+| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException`, `PaginationQuery`, `PaginationQueryParser`, `ConditionalGetHelper`, `ConditionalWriteHelper` |
 | `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
 | `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException`, `DatabaseConstraintException` |

--- a/docs/field-trials/2026-05-field-trial-90.md
+++ b/docs/field-trials/2026-05-field-trial-90.md
@@ -1,0 +1,168 @@
+# Field Trial 90 — Optimistic Concurrency Control (ETag / If-Match)
+
+**Date:** 2026-05-20
+**Project:** `/home/xi/docker/NENE2-FT/locklog/`
+**NENE2 version:** 1.5.23
+**Theme:** HTTP conditional writes — preventing the lost-update problem with ETag + If-Match
+
+---
+
+## What was built
+
+A document editing API with optimistic locking. Each document carries a `version` counter.
+Clients receive an `ETag: "v{version}"` header on read and must echo it back as `If-Match: "v{version}"` on write.
+If the version has advanced (another writer won the race), the server returns `412 Precondition Failed`.
+Missing `If-Match` returns `428 Precondition Required`.
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/documents` | Create document; responds with `ETag: "v1"` |
+| GET | `/documents/{id}` | Fetch document; responds with `ETag: "v{n}"` |
+| PUT | `/documents/{id}` | Conditional update — requires `If-Match`; 412 on stale, 428 on missing |
+| DELETE | `/documents/{id}` | Conditional delete — same `If-Match` semantics |
+
+### Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS documents (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    version    INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT    NOT NULL
+);
+```
+
+---
+
+## Frictions found
+
+### 1. No `If-Match` conditional write support — must implement manually
+
+**Severity:** High (feature gap)
+
+NENE2 ships `ConditionalGetHelper` for read-side caching (`If-None-Match` → 304 Not Modified).
+There is no equivalent for the write side: `If-Match` header parsing, `*` wildcard handling, or
+`412 Precondition Failed` / `428 Precondition Required` response helpers.
+
+Every optimistic-locking endpoint requires:
+1. Reading `$request->getHeaderLine('If-Match')`
+2. Handling the `*` wildcard (RFC 9110 §13.1.1 — "match if resource exists")
+3. Parsing the quoted ETag format (`"v3"` → `3`)
+4. Emitting `412` (version mismatch) and `428` (missing header) manually
+
+In contrast, the GET-side is one call: `ConditionalGetHelper::check(...)`.
+The asymmetry means a developer who finds `ConditionalGetHelper` may assume write-side ETags
+are similarly handled, and then be surprised when they are not.
+
+**Reproduction:**
+```php
+// GET: one line — ConditionalGetHelper handles everything
+$notModified = ConditionalGetHelper::check($request, $psr17, $etag, $lastModified);
+
+// PUT: must manually parse, validate, and emit errors
+$ifMatch = $request->getHeaderLine('If-Match');
+if ($ifMatch === '') {
+    return $problems->create($request, 'precondition-required', 'Precondition Required', 428, '...');
+}
+if ($ifMatch !== '*') {
+    // parse "v3" → 3, compare, emit 412
+}
+```
+
+---
+
+### 2. `If-Match: *` wildcard semantics are non-obvious
+
+**Severity:** Medium (discoverability gap)
+
+RFC 9110 §13.1.1 defines `If-Match: *` to mean "the precondition succeeds if the target resource
+has a current representation" — i.e., the resource exists, any version.
+This is useful for "update-if-exists" semantics without knowing the current ETag.
+
+NENE2 documents nothing about this. Developers writing conditional APIs must discover it from
+the RFC or other framework docs. The test `testUpdateWithWildcardIfMatch` was written to verify
+the implementation handles it — a beginner would likely miss it entirely.
+
+---
+
+### 3. Race condition window between version check and update
+
+**Severity:** Low (architecture note)
+
+The implementation performs `findById()` + `UPDATE ... WHERE id = ? AND version = ?` as two
+separate queries. The version comparison in the WHERE clause is the actual lock guard, but
+between the initial `findById()` check (used to determine 404 vs 412) and the conditional UPDATE,
+a concurrent writer could interleave. SQLite's per-database write serialization makes this
+extremely unlikely, but on PostgreSQL under high concurrency it becomes a real TOCTOU window.
+
+The correct fix requires wrapping both in a `BEGIN IMMEDIATE` / `SERIALIZABLE` transaction.
+NENE2's `DatabaseTransactionManagerInterface` does not expose isolation levels.
+
+---
+
+### 4. 428 Precondition Required not in NENE2's error docs
+
+**Severity:** Low (documentation gap)
+
+RFC 6585 status codes (428, 429, 431, 511) are not mentioned in NENE2's Problem Details
+documentation or howto guides. A developer who doesn't know RFC 6585 would likely use
+`400 Bad Request` or `422 Unprocessable Entity` for "missing If-Match" — both semantically wrong.
+428 is the correct status: the request was well-formed, but a precondition (If-Match) was
+absent that the server requires.
+
+---
+
+## Results
+
+| Check | Result |
+|-------|--------|
+| PHPUnit tests | 15 tests, 30 assertions — OK |
+| PHPStan level 8 | No errors (first run) |
+| PHP-CS-Fixer | 0 files to fix |
+
+---
+
+## Developer Experience (DX) Review
+
+### 初心者・ロースキル観点での実装しやすさ
+
+**難易度: 高い（ETagを初めて実装する開発者には厳しい）**
+
+- ETag / If-Match / 412 / 428 はすべてHTTP仕様（RFC 9110 / RFC 6585）の知識が前提。ドキュメントなしにこれを実装させるのはハードルが高い。
+- `ConditionalGetHelper` を発見すると「書き込み側も同じようにサポートされているはず」と思ってしまう。実際には未サポートで、ギャップが大きい。
+- `If-Match: *` の wildcard 意味論はコードを読んでも発見できない — RFC を読む必要がある。
+- 一方、ルート定義・レスポンス返却・バリデーションエラーのパターンはFT82〜89で習得済みなら詰まらない。中盤以降は快適。
+
+### 使ってみた印象
+
+`ConditionalGetHelper` の存在がポジティブな発見だった。「NENE2はHTTPキャッシュ周りまで考えている」という印象を与える。ただしGET側だけで書き込み側がないため、「半分のツール」を見つけたような感覚。PSR-7の `.withHeader('ETag', $etag)` チェーンはシンプルで気持ちいい。
+
+### 楽しいか・気持ちいいか・快適か
+
+- **楽しい点**: ロストアップデート問題をテストで証明できるのは気持ちいい。`testLostUpdatePrevented()` が通った瞬間はフレームワークの力を感じた。
+- **不快な点**: `If-Match` ヘッダー解析、ETag文字列のパース（`"v3"` → `3`）、wildcard分岐を全部手書きしなければならず、「またゼロから書いた」感が残る。
+- **快適な点**: `ProblemDetailsResponseFactory::create()` で412も428も一貫して返せるのはよかった。
+
+### 簡単か
+
+簡単ではない。Happyパス（作成・取得・更新）は簡単だが、ETagの正確な実装（特にwildcard・TOCTOU・428）は上級者向け。
+
+### また使いたいか
+
+**はい** — ただしETag/If-Matchを使う場合は、フレームワークにヘルパーがあれば確実に使い直したい。`ConditionalGetHelper` と対になる `ConditionalWriteHelper` があれば、このトライアルはずっと快適だったはず。コアAPI（routing・JSON factory・problem details）の一貫性は高く評価できる。
+
+### 初心者に勧めたいか
+
+ETagなし（バージョン番号をJSONボディで受け取る方法）なら勧められる。HTTPヘッダー方式は中〜上級者向け。
+
+---
+
+## Notes
+
+- ETag format `"v{version}"` (integer-based) is simple and debuggable. Hash-based ETags (`md5($body)`) are more robust but harder to test predictably.
+- `ConditionalGetHelper` handles `If-None-Match` (read side). A `ConditionalWriteHelper` for `If-Match` (write side) would complete the pair.
+- The `WHERE id = ? AND version = ?` conditional UPDATE is the correct SQL-level lock guard — no extra SELECT needed if you accept that a 0-row UPDATE means "version mismatch or not found".
+- Distinguishing 404 from 412 requires a pre-check `findById()`, which introduces the TOCTOU window. Without serializable transactions, this is a known limitation.

--- a/docs/howto/add-optimistic-locking.md
+++ b/docs/howto/add-optimistic-locking.md
@@ -1,0 +1,151 @@
+# How to add optimistic concurrency control (ETag / If-Match)
+
+Optimistic locking prevents the **lost update problem**: two clients read the same resource,
+both modify it, and the second write silently overwrites the first.
+
+NENE2 ships `ConditionalWriteHelper` for the write side (PUT, PATCH, DELETE) and
+`ConditionalGetHelper` for the read side (GET → 304 Not Modified).
+
+---
+
+## 1. Add a version counter to the schema
+
+```sql
+CREATE TABLE documents (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    version    INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT    NOT NULL
+);
+```
+
+---
+
+## 2. Return an ETag on every GET and write response
+
+Use the version number as a simple, debuggable ETag:
+
+```php
+private function etag(int $version): string
+{
+    return '"v' . $version . '"';
+}
+
+// In GET handler:
+return $this->json->create($doc->toArray())
+    ->withHeader('ETag', $this->etag($doc->version));
+
+// In POST (create) handler:
+return $this->json->create($doc->toArray(), 201)
+    ->withHeader('ETag', $this->etag($doc->version));
+```
+
+---
+
+## 3. Check `If-Match` on PUT / PATCH / DELETE
+
+```php
+use Nene2\Http\ConditionalWriteHelper;
+
+private function update(ServerRequestInterface $request): ResponseInterface
+{
+    $id  = $this->resolveId($request);
+    $doc = $this->repo->findById($id);
+    if ($doc === null) {
+        return $this->problems->create($request, 'not-found', 'Not Found', 404, '');
+    }
+
+    $block = ConditionalWriteHelper::check($request, $this->problems, $this->etag($doc->version));
+    if ($block !== null) {
+        return $block; // 412 Precondition Failed or 428 Precondition Required
+    }
+
+    // ETag matched — safe to write
+    $updated = $this->repo->updateIfMatch($id, /* new values */, $doc->version);
+    if ($updated === null) {
+        // Concurrent modification after our check
+        return $this->problems->create($request, 'precondition-failed', 'Precondition Failed', 412, '');
+    }
+    return $this->json->create($updated->toArray())
+        ->withHeader('ETag', $this->etag($updated->version));
+}
+```
+
+### Status codes returned by `ConditionalWriteHelper::check()`
+
+| `If-Match` header | Server ETag | Result |
+|-------------------|-------------|--------|
+| absent | any | **428** Precondition Required (header is mandatory) |
+| `*` | any | **null** — pass (wildcard, any version) |
+| `"v3"` | `"v3"` | **null** — pass (exact match) |
+| `"v2"` | `"v3"` | **412** Precondition Failed (stale version) |
+
+To make `If-Match` optional, pass `require: false`:
+
+```php
+ConditionalWriteHelper::check($request, $this->problems, $etag, require: false);
+```
+
+---
+
+## 4. Use a conditional UPDATE in the repository
+
+```php
+public function updateIfMatch(int $id, string $title, int $expectedVersion): ?Document
+{
+    $newVer  = $expectedVersion + 1;
+    $now     = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d\TH:i:s\Z');
+    $updated = $this->db->execute(
+        'UPDATE documents SET title = ?, version = ?, updated_at = ? WHERE id = ? AND version = ?',
+        [$title, $newVer, $now, $id, $expectedVersion],
+    );
+
+    if ($updated === 0) {
+        return null; // version mismatch or not found
+    }
+    return new Document($id, $title, $newVer, $now);
+}
+```
+
+The `WHERE version = ?` clause is the database-level lock guard. If the row's version was
+already advanced by a concurrent writer, `execute()` returns `0` (no rows updated) and the
+caller can return a second 412 response.
+
+---
+
+## 5. Test the lost-update scenario
+
+```php
+public function testLostUpdatePrevented(): void
+{
+    $id = $this->decode($this->create('Original'))['id'];
+
+    // Alice reads version 1 and updates → version becomes 2
+    $this->req('PUT', '/documents/' . $id, ['title' => "Alice's edit"], '"v1"');
+
+    // Bob tries to update with stale v1 ETag → must fail
+    $bob = $this->req('PUT', '/documents/' . $id, ['title' => "Bob's edit"], '"v1"');
+    self::assertSame(412, $bob->getStatusCode());
+
+    // Alice's update is preserved
+    $final = $this->decode($this->req('GET', '/documents/' . $id));
+    self::assertSame("Alice's edit", $final['title']);
+    self::assertSame(2, $final['version']);
+}
+```
+
+---
+
+## Notes
+
+- **ETag format**: `"v{version}"` (integer-based) is simple and predictable in tests.
+  Content-hash ETags (`'"' . md5($body) . '"'`) are more robust for content-addressable resources
+  but harder to predict in tests without pre-computing the hash.
+- **Wildcard `If-Match: *`**: RFC 9110 defines `*` to mean "succeed if the resource has any
+  current representation" — i.e., it exists. Useful for "update-if-exists" without knowing
+  the version. The caller must still return 404 when the resource is absent.
+- **428 Precondition Required** (RFC 6585 §3): the correct status when `If-Match` is required
+  but absent. Use it instead of 400 or 422 — the request is well-formed; the precondition is missing.
+- **TOCTOU window**: the `findById()` + conditional UPDATE pattern has a brief race window on
+  multi-writer databases. Under SQLite's write serialization this is harmless. On PostgreSQL
+  under high concurrency, wrap both operations in a `SERIALIZABLE` transaction.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.23
+  version: 1.5.24
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.23';
+    public const string VERSION = '1.5.24';
 
     public function name(): string
     {

--- a/src/Http/ConditionalWriteHelper.php
+++ b/src/Http/ConditionalWriteHelper.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Evaluates the `If-Match` precondition for conditional writes (PUT, PATCH, DELETE).
+ *
+ * Call {@see check()} at the start of any write handler that supports optimistic locking.
+ * If it returns a response, send it immediately. If it returns `null`, the precondition passed
+ * and the write may proceed.
+ *
+ * ```php
+ * $etag = '"v' . $document->version . '"';
+ * $block = ConditionalWriteHelper::check($request, $problems, $etag);
+ * if ($block !== null) {
+ *     return $block; // 412 Precondition Failed or 428 Precondition Required
+ * }
+ * // safe to write — ETag matched
+ * ```
+ *
+ * **ETag format**: always pass a strong ETag with surrounding double quotes (e.g. `"v3"` or `"abc123"`).
+ * Weak ETags (`W/"..."`) are not compared.
+ *
+ * **`If-Match: *` wildcard**: passes unconditionally when the resource exists.
+ * The caller is responsible for returning 404 when the resource is absent.
+ *
+ * **`$require = false`**: when set, a missing `If-Match` header is allowed (no 428 returned).
+ * Useful when optimistic locking is optional rather than enforced.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class ConditionalWriteHelper
+{
+    /**
+     * Returns a 412 or 428 problem-details response when the `If-Match` precondition fails.
+     * Returns `null` when the precondition passes (write is safe to proceed).
+     *
+     * @param string $currentEtag Strong ETag of the current resource, with surrounding double quotes (e.g. `"v3"`)
+     * @param bool   $require     When `true` (default), an absent `If-Match` header returns 428.
+     *                            When `false`, an absent header is treated as a pass.
+     */
+    public static function check(
+        ServerRequestInterface $request,
+        ProblemDetailsResponseFactory $problems,
+        string $currentEtag,
+        bool $require = true,
+    ): ?ResponseInterface {
+        $ifMatch = $request->getHeaderLine('If-Match');
+
+        if ($ifMatch === '') {
+            if (!$require) {
+                return null;
+            }
+
+            return $problems->create(
+                $request,
+                'precondition-required',
+                'Precondition Required',
+                428,
+                'If-Match header is required. Fetch the current ETag and retry.',
+            );
+        }
+
+        // Wildcard: any existing version is acceptable; caller checks for 404.
+        if ($ifMatch === '*') {
+            return null;
+        }
+
+        if ($ifMatch === $currentEtag) {
+            return null;
+        }
+
+        return $problems->create(
+            $request,
+            'precondition-failed',
+            'Precondition Failed',
+            412,
+            'The supplied ETag does not match the current resource version. Fetch the latest ETag and retry.',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **FT90（locklog）発見の摩擦**: PUT/DELETE の楽観的ロックに必要な `If-Match` ヘルパーが存在せず、全部手書きが必要だった
- `ConditionalGetHelper`（GET → 304）と対になる `ConditionalWriteHelper`（PUT/DELETE → 412/428）を追加
- `docs/howto/add-optimistic-locking.md` 新規作成 — ETag パターン完全ガイド
- ADR 0009 公開 API 一覧更新
- v1.5.24 にバンプ

## Changes

- `src/Http/ConditionalWriteHelper.php` — 新規クラス
  - `check(request, problems, currentEtag, require)` — If-Match 評価、null でpass / 412・428 で返す
  - `If-Match: *` wildcard 対応
  - `require: false` でヘッダーを任意にできる
- `docs/howto/add-optimistic-locking.md` — 新規 howto（ETag設計・428 の使い所・TOCTOU 注記）
- ADR 0009 — ConditionalWriteHelper を公開 API 一覧に追加

## Validation

- `composer check` 全通過（PHPUnit / PHPStan level 8 / CS-Fixer / OpenAPI / MCP / バージョン整合）
- FT90（locklog）: 15 tests / 30 assertions — OK

## Related

Closes #674
Closes #675

Self-review: backend-api, docs-policy