### PR TITLE
docs: IDOR防止 howto（所有権強制・404-not-403）追加 (FT91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.25] — 2026-05-20
+
+### Added
+- `docs/howto/enforce-resource-ownership.md` — how-to guide for IDOR prevention: SQL-level ownership enforcement, 404-not-403 guidance, cross-tenant test patterns. (#677)
+- `docs/field-trials/2026-05-field-trial-91.md` — FT91 report: noteslog (personal notes with IDOR prevention). (#677)
+
+---
+
 ## [1.5.24] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-91.md
+++ b/docs/field-trials/2026-05-field-trial-91.md
@@ -1,0 +1,169 @@
+# Field Trial 91 — IDOR Prevention (Object-Level Authorization)
+
+**Date:** 2026-05-20
+**Project:** `/home/xi/docker/NENE2-FT/noteslog/`
+**NENE2 version:** 1.5.24
+**Theme:** Insecure Direct Object Reference (IDOR) prevention — enforcing resource ownership so users cannot read, modify, or delete each other's data
+
+---
+
+## What was built
+
+A personal notes API where each note has an `owner_id`. All write and read operations enforce ownership: a user can only access their own notes. Accessing another user's note returns 404 (not 403) to prevent information leakage.
+
+Authentication is simulated via an `X-Auth-User` header (stands in for real JWT auth in the FT context).
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/notes` | Create note (owner = authenticated user) |
+| GET | `/notes` | List own notes only |
+| GET | `/notes/{id}` | View note — 404 if not mine or not found |
+| PUT | `/notes/{id}` | Update note — 404 if not mine |
+| DELETE | `/notes/{id}` | Delete note — 404 if not mine |
+
+### Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id   TEXT    NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_notes_owner ON notes (owner_id);
+```
+
+---
+
+## Frictions found
+
+### 1. No ownership guard helper — boilerplate repeated in every handler
+
+**Severity:** High (DX friction, security-sensitive)
+
+NENE2 provides no abstraction for the "fetch resource and verify it belongs to the current user" pattern. Every handler that operates on an owned resource must:
+
+1. Extract the authenticated user (parsing header/attribute)
+2. Fetch the resource
+3. Compare `ownerId` to `authUser`
+4. Return 404 if mismatch (not 403 — see F-2)
+
+This pattern repeated 4 times (show, update, delete, list filter). Without a helper, each
+handler author must independently remember to enforce ownership — and the check is easy to forget.
+
+**Reproduction (the boilerplate pattern, repeated verbatim for each verb):**
+```php
+$authUser = trim($request->getHeaderLine('X-Auth-User'));
+if ($authUser === '') { return $this->unauthorized($request); }
+
+$id   = $this->resolveId($request);
+$note = $this->repo->findByIdAndOwner($id, $authUser);
+if ($note === null) { return $this->problems->create(..., 404); }
+// actual handler logic
+```
+
+**Alternative approach**: move ownership enforcement to the SQL layer (`WHERE id = ? AND owner_id = ?`) — this is what the FT does and it's elegant. But NENE2's docs and howtos don't describe this pattern anywhere.
+
+---
+
+### 2. 403 vs 404 — the IDOR information leakage decision is undocumented
+
+**Severity:** Medium (security design gap)
+
+OWASP recommends returning `404 Not Found` (not `403 Forbidden`) when a user accesses a resource that belongs to another user. A `403` confirms the resource exists — useful information for an attacker enumerating IDs.
+
+NENE2's Problem Details documentation does not mention this design consideration. A beginner
+would default to `403 Forbidden` (semantically "correct" but security-naive).
+
+The correct pattern: `findByIdAndOwner()` returns `null` for both "not found" and "wrong owner"
+— the caller cannot and should not distinguish the two cases.
+
+---
+
+### 3. No `X-Auth-User` / "current user" extraction utility in NENE2
+
+**Severity:** Low (minor DX friction)
+
+Every handler that needs the authenticated user must call:
+```php
+$authUser = trim($request->getHeaderLine('X-Auth-User'));
+```
+(or read from a request attribute set by `BearerTokenMiddleware`).
+
+There is no `AuthContext::fromRequest($request)` abstraction to DRY this up. In FTs using JWT
+auth (`BearerTokenMiddleware`), the pattern is `$request->getAttribute('nene2.auth.claims')['sub']`.
+In simpler FTs using API-key-style headers, it's manual header parsing.
+
+---
+
+### 4. PHPStan parse error on method chaining with `new` expression
+
+**Severity:** Low (PHPStan limitation)
+
+```php
+// This caused a PHPStan "syntax error" even though PHP 8.4 accepts it:
+return $this->json->create(new Note($id, $ownerId, $title, $body, $now)->toArray());
+
+// Fix: split to two lines
+$updated = new Note($id, $ownerId, $title, $body, $now);
+return $this->json->create($updated->toArray());
+```
+
+PHPStan 1.12.x does not always handle method calls on `new` expressions in certain contexts.
+This is a PHPStan issue, not a NENE2 issue, but it appears in FT projects regularly enough to
+be worth documenting.
+
+---
+
+## Results
+
+| Check | Result |
+|-------|--------|
+| PHPUnit tests | 15 tests, 31 assertions — OK |
+| PHPStan level 8 | 1 error (new expression method chain) → fixed → 0 errors |
+| PHP-CS-Fixer | 0 files to fix |
+
+---
+
+## Developer Experience (DX) Review
+
+### 初心者・ロースキル観点での実装しやすさ
+
+**難易度: 低〜中（パターン自体は単純、セキュリティ設計知識が必要）**
+
+- CRUD実装は問題なし。NENE2のJSON・Problem Details・ルーティングAPIは直感的。
+- 「IDORとは何か、なぜ危険か」を知らない初心者は、そもそもこの問題を意識しない。NENE2にヘルプがない以上、セキュリティ知識が前提になってしまう。
+- `WHERE id = ? AND owner_id = ?` というSQL側での所有権強制のパターンは、一度習得すれば明快で覚えやすい。
+
+### 使ってみた印象
+
+ルーティング・レスポンス生成はスムーズで、FT82〜90で培ったパターンが活きる。しかしIDOR対策はフレームワーク側のガイドが何もなく、「自力で気づいてください」状態。他のフレームワーク（Laravel/Symfony）でもこの問題は同様に難しいが、少なくともドキュメントや認可ライブラリが存在する。
+
+### 楽しいか・気持ちいいか・快適か
+
+- **楽しい点**: クロステナントアクセスをテストで明示的に証明できるのは気持ちいい。`testCannotReadAnotherUsersNote()` が通った瞬間、「このAPIは安全だ」という達成感がある。
+- **不快な点**: 同じ `resolveAuthUser()` 呼び出しを5つのハンドラーに書く繰り返しが煩わしい。フレームワーク側でこれをインターセプトする仕組みがあれば。
+- **快適な点**: `WHERE id = ? AND owner_id = ?` パターンはSQL側で完結するため、アプリ側のロジックがシンプルになる。
+
+### 簡単か
+
+パターン自体（`findByIdAndOwner`）は簡単。難しいのは「なぜ403でなく404を返すか」というセキュリティ設計の判断。知らなければ間違える。
+
+### また使いたいか
+
+**はい** — ルーティング・バリデーション・レスポンス生成の一貫性は高い。IDORパターンのベストプラクティスがドキュメントに記載されれば、より自信を持って使える。
+
+### 初心者に勧めたいか
+
+基本CRUD部分は勧められる。セキュリティ（IDOR）部分は中級者向けとして位置づけ、howtoで誘導すべき。
+
+---
+
+## Notes
+
+- SQL側での所有権強制（`WHERE id = ? AND owner_id = ?`）はアプリ側のif分岐より安全 — コードパスを誤って通り抜けることがない。
+- `findByIdAndOwner()` が「存在しない」と「所有者が違う」の両方で `null` を返すのがポイント。呼び出し側がこの2ケースを区別できないようにすることで、誤った分岐が書けなくなる。
+- テナント分離の確認は `testListDoesNotLeakOtherTenantNotes()` のように複数ユーザーのデータをセットアップしてから検証するのが最も確実。

--- a/docs/howto/enforce-resource-ownership.md
+++ b/docs/howto/enforce-resource-ownership.md
@@ -1,0 +1,155 @@
+# How to enforce resource ownership (IDOR prevention)
+
+Insecure Direct Object Reference (IDOR) is the #1 API vulnerability (OWASP API Security Top 10).
+It occurs when a user can access or modify another user's resources by guessing or enumerating IDs.
+
+NENE2 provides no automatic ownership enforcement — every repository and handler must implement
+it explicitly. This guide shows the recommended patterns.
+
+---
+
+## 1. The core rule: 404, not 403
+
+When a user accesses a resource that belongs to another user, return `404 Not Found` — **not** `403 Forbidden`.
+
+- **403** tells the attacker: "this resource exists, but you can't access it." — information leak
+- **404** tells the attacker: "this resource does not exist." — no confirmation
+
+```php
+// WRONG — leaks existence
+if ($note->ownerId !== $authUserId) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403, '');
+}
+
+// CORRECT — reveals nothing
+if ($note === null) {
+    return $this->problems->create($request, 'not-found', 'Not Found', 404, '');
+}
+```
+
+The practical way to achieve this: make the repository **unable to return a resource that doesn't
+belong to the caller** — see the next section.
+
+---
+
+## 2. Enforce ownership at the SQL level
+
+The safest pattern is to include `owner_id` in every query. The method literally cannot return
+another user's data, regardless of how the caller uses the result.
+
+```php
+public function findByIdAndOwner(int $id, string $ownerId): ?Resource
+{
+    $row = $this->db->fetchOne(
+        'SELECT * FROM resources WHERE id = ? AND owner_id = ?',
+        [$id, $ownerId],
+    );
+    return $row !== null ? $this->hydrate($row) : null;
+}
+
+public function update(int $id, string $ownerId, string $newValue): bool
+{
+    $updated = $this->db->execute(
+        'UPDATE resources SET value = ? WHERE id = ? AND owner_id = ?',
+        [$newValue, $id, $ownerId],
+    );
+    return $updated > 0;
+}
+
+public function delete(int $id, string $ownerId): bool
+{
+    return $this->db->execute(
+        'DELETE FROM resources WHERE id = ? AND owner_id = ?',
+        [$id, $ownerId],
+    ) > 0;
+}
+```
+
+**Why SQL-level is better than application-level:**
+- An app-level check can be bypassed if a developer forgets to call it
+- A SQL-level check cannot be skipped — the wrong-owner row will simply not be returned
+- Returning `null` for "not found" and "wrong owner" prevents the caller from accidentally branching on a case they shouldn't know about
+
+---
+
+## 3. Handler pattern
+
+```php
+private function show(ServerRequestInterface $request): ResponseInterface
+{
+    $authUserId = $this->resolveAuthUser($request);
+    if ($authUserId === null) {
+        return $this->unauthorized($request);
+    }
+
+    $id       = $this->resolveId($request);
+    $resource = $this->repo->findByIdAndOwner($id, $authUserId);
+
+    if ($resource === null) {
+        // 404 covers both "not found" and "belongs to another user"
+        return $this->problems->create($request, 'not-found', 'Not Found', 404, '');
+    }
+
+    return $this->json->create($resource->toArray());
+}
+```
+
+---
+
+## 4. Listing: filter by owner in the query
+
+```php
+public function listByOwner(string $ownerId): array
+{
+    return $this->db->fetchAll(
+        'SELECT * FROM resources WHERE owner_id = ? ORDER BY id DESC',
+        [$ownerId],
+    );
+}
+```
+
+Never fetch all rows and filter in PHP. It leaks other users' data if filtering logic is wrong
+and is also an N+1 problem.
+
+---
+
+## 5. Test cross-owner access explicitly
+
+Add dedicated tests that verify IDOR is prevented:
+
+```php
+public function testCannotReadAnotherUsersResource(): void
+{
+    $bobId = $this->decode($this->create('bob', 'Bob content'))['id'];
+
+    // Alice tries to read Bob's resource — must get 404
+    $res = $this->request('GET', '/resources/' . $bobId, authUser: 'alice');
+    self::assertSame(404, $res->getStatusCode());
+    // Specifically not 403 — which would leak the resource's existence
+    self::assertNotSame(403, $res->getStatusCode());
+}
+
+public function testListDoesNotLeakCrossTenantData(): void
+{
+    $this->create('alice', 'Alice content');
+    $this->create('bob', 'Bob content');
+
+    $aliceList = $this->decode($this->request('GET', '/resources', authUser: 'alice'));
+    $titles    = array_column($aliceList['items'], 'content');
+
+    self::assertNotContains('Bob content', $titles);
+}
+```
+
+---
+
+## Notes
+
+- **Why 404 feels wrong**: Returning 404 for a resource you can see in the URL feels "dishonest".
+  It is — but OWASP explicitly recommends it to prevent ID enumeration attacks. The tradeoff
+  is accepted security practice.
+- **Admin bypass**: If you have admin routes that can see any resource, keep those on a separate
+  path prefix with a separate ownership check (or no check). Don't complicate the ownership
+  methods with "is admin" flags.
+- **Database schema**: always add an index on `owner_id` (and on `(owner_id, id)` for compound
+  lookups). Without an index, every per-user query is a full table scan.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.24
+  version: 1.5.25
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.24';
+    public const string VERSION = '1.5.25';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

FT91（noteslog: 個人ノートAPI）でIDOR（Insecure Direct Object Reference）防止を実装した際、ベストプラクティスがNENE2にまったくドキュメントされていないことが判明。

- `docs/howto/enforce-resource-ownership.md` 新規作成
  - SQL側での所有権強制パターン（`WHERE id = ? AND owner_id = ?`）
  - OWASPが推奨する「403ではなく404を返す」理由の説明
  - クロステナントアクセス防止のテスト例（`testCannotReadAnotherUsersResource`）
  - 管理者バイパス・インデックス設計の注意

## Validation

- `composer check` 全通過
- FT91 noteslog: 15 tests / 31 assertions — OK

## Related

Closes #677

Self-review: docs-policy