### PR TITLE
feat(http): JSON_UNESCAPED_UNICODE・Unicode バリデーション how-to 追加 (FT93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.27] — 2026-05-20
+
+### Changed
+- `JsonResponseFactory::create()` and `createList()` now include `JSON_UNESCAPED_UNICODE` in the `json_encode` flags. Non-ASCII characters (Japanese, emoji, Arabic, etc.) are now emitted as literal UTF-8 in responses instead of `\uXXXX` escape sequences. Payload size for CJK-heavy responses is reduced by ~3×. (#681)
+
+### Added
+- `docs/howto/validate-unicode-input.md` — how-to guide for Unicode-aware input validation: `mb_strlen` vs `strlen`, null-byte rejection, grapheme clusters vs codepoints, and `JSON_UNESCAPED_UNICODE` behaviour. (#682)
+- `docs/field-trials/2026-05-field-trial-93.md` — FT93 report: unicodelog (Unicode/emoji/encoding boundary). (#681 #682)
+
+---
+
 ## [1.5.26] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-93.md
+++ b/docs/field-trials/2026-05-field-trial-93.md
@@ -1,0 +1,174 @@
+# Field Trial 93 — Unicode / Emoji / Encoding Boundary
+
+**Date:** 2026-05-20
+**Project:** `/home/xi/docker/NENE2-FT/unicodelog/`
+**NENE2 version:** 1.5.26
+**Theme:** Input boundary / encoding — Japanese, emoji, ZWJ sequences, Arabic RTL, null bytes, SQL-injection-style input, `mb_strlen` vs `strlen`, `JSON_UNESCAPED_UNICODE`
+
+---
+
+## What was built
+
+A multilingual user-profile API that accepts names, bios, and tags in any Unicode script. The API exercises:
+
+- Japanese (kanji, hiragana, katakana)
+- Emoji — single codepoint (🎉) and ZWJ sequences (👨‍👩‍👧 = U+1F468 U+200D U+1F469 U+200D U+1F467)
+- Arabic RTL text
+- Mixed scripts (Latin + CJK + Arabic)
+- Length validation using `mb_strlen('UTF-8')` — character count, not byte count
+- Null byte (`\x00`) rejection
+- SQL-injection-style strings stored safely via parameterized queries
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/profiles` | Create a profile |
+| GET | `/profiles` | List all profiles |
+| GET | `/profiles/{id}` | Get a profile |
+| PATCH | `/profiles/{id}` | Update a profile |
+| DELETE | `/profiles/{id}` | Delete a profile |
+
+### Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS profiles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    bio        TEXT    NOT NULL DEFAULT '',
+    tags       TEXT    NOT NULL DEFAULT '[]',
+    created_at TEXT    NOT NULL
+);
+```
+
+Tags are stored as a JSON array string inside a TEXT column.
+
+---
+
+## Frictions encountered
+
+### 1. `JsonResponseFactory` silently escapes non-ASCII to `\uXXXX` (高)
+
+**Symptom:** A response body containing `田中太郎` arrives as `"田中太郎"` in the raw HTTP body.
+
+`JsonResponseFactory::create()` calls:
+
+```php
+json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION)
+```
+
+`JSON_UNESCAPED_UNICODE` is absent. The result is valid JSON, but:
+
+- Increases payload size by ~3× for CJK characters (6 chars per `\uXXXX` vs 3 bytes UTF-8).
+- Harder to debug in logs or curl output.
+- Surprising to developers who expect literal UTF-8.
+
+**Workaround:** None at the call site. The JSON _decodes_ correctly, so API consumers that parse JSON see the right strings. But raw bytes differ from expectations.
+
+**Suggested fix:** Add `JSON_UNESCAPED_UNICODE` to `JsonResponseFactory`.
+
+---
+
+### 2. `mb_strlen` is not obvious as the correct validator (中)
+
+**Symptom:** A developer using `strlen()` for length validation silently breaks Unicode inputs.
+
+`strlen('あ') === 3` (bytes), `mb_strlen('あ', 'UTF-8') === 1` (character).
+
+For a 50-character name limit:
+- 50 Japanese characters = 150 bytes → `strlen` rejects it wrongly.
+- 50 emoji (each 4 bytes) = 200 bytes → `strlen` rejects it wrongly.
+
+NENE2 provides no built-in validation helper that wraps `mb_strlen`. The framework offers no guide or utility for Unicode-aware length constraints. Each developer must remember to use `mb_strlen($val, 'UTF-8')` explicitly.
+
+**Suggested fix:** Add a how-to guide covering Unicode-aware validation in NENE2.
+
+---
+
+### 3. ZWJ emoji sequences count as multiple codepoints (低)
+
+**Symptom:** `👨‍👩‍👧` (`\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}`) is rendered as one glyph but is 5 codepoints. `mb_strlen` counts 5, not 1.
+
+This is a standard Unicode segmentation issue, not a NENE2-specific problem, but worth documenting: if a "50 character" name limit means "50 grapheme clusters", PHP's `mb_strlen` gives the wrong answer. The `grapheme_strlen()` intl function gives the grapheme count.
+
+**Status:** Low friction; most use-cases are satisfied with codepoint counting. Document as a known trade-off in the how-to guide.
+
+---
+
+### 4. Null byte stored in SQLite without error (中)
+
+**Symptom:** SQLite TEXT columns accept null bytes. Without explicit validation, `"Alice\x00Bob"` is stored and retrieved. PHP string operations that use C-style null termination (none in modern PHP, but in some ext functions) could misbehave.
+
+NENE2 has no built-in null-byte stripping or rejection mechanism. Developers must add `str_contains($val, "\x00")` guards manually.
+
+**Suggested fix:** Document null-byte rejection in the Unicode validation how-to guide.
+
+---
+
+### 5. PHPStan false positive on `array_values(array_map(...))` (低)
+
+**Symptom:** PHPStan level 8 reports:
+
+```
+Parameter #1 $array (list<T>) of array_values is already a list, call has no effect.
+```
+
+This occurs when `fetchAll()` returns `array<int, array<string, mixed>>` but the PHPDoc says `list<>`. `array_map` over a `list` returns a `list`, so `array_values` is redundant. Harmless, but the warning is confusing.
+
+**Fix:** Remove the outer `array_values()` call. Note that this is a PHPStan inference issue, not a NENE2 bug.
+
+---
+
+## Test results
+
+22 tests, 50 assertions — all pass.
+
+Tested scenarios:
+- English, Japanese, emoji, ZWJ sequences, Arabic, mixed script profiles
+- mb_strlen boundary (50 chars exact, 51 chars rejected; 50 emoji codepoints accepted)
+- Null byte rejection in name, bio, and tags
+- Too-many-tags validation (max 10)
+- Per-tag length limit with Unicode tags
+- Non-string tag type rejection
+- SQL-injection strings stored safely
+- Raw JSON body contains `\uXXXX` but decoded values are correct
+- PATCH and DELETE with Unicode
+
+---
+
+## Developer Experience (DX) Review
+
+### 初心者・ロースキル観点での実装しやすさ
+
+難しかった。`mb_strlen` の使い方は知っていないと `strlen` で実装してしまい、日本語名が50文字なのに「文字数超過」と弾かれる見えにくいバグを作りこむ。フレームワーク側に「Unicode 対応長さチェック」のガイドや例がないので、初心者は気づけない。
+
+null バイト対策 (`str_contains($v, "\x00")`) も、NENE2 のドキュメントには登場しない「どこかで知っておくべき知識」。
+
+### 使ってみた印象
+
+ルーティング・DI・レスポンス生成のコアは非常に素直。`JsonRequestBodyParser::parse()` で body が配列で取れる点は良い。ただし `json_encode` に `JSON_UNESCAPED_UNICODE` がないせいで、ターミナルで `curl | cat` したときに文字化けして見えて、一瞬「バグ？」と思う。
+
+### 楽しいか・気持ちいいか・快適か
+
+ルーティングを書く部分は楽しい。`$router->post('/profiles', $this->createProfile(...))` のシンタックスは気持ちいい。バリデーションを自前で書かなければならない部分は機械的で退屈。
+
+emoji のラウンドトリップが問題なく通るのは小気味よく、「よし！」と思う瞬間があった。
+
+### 簡単か
+
+コアの組み立ては簡単。ただし Unicode 周りの地雷（`strlen` vs `mb_strlen`、null バイト、ZWJ）を踏む前提知識が必要で、初心者には「簡単ではない」。NENE2 のドキュメントに Unicode バリデーション how-to があれば大幅に改善する。
+
+### また使いたいか
+
+はい。PSR-7/15 に準拠していてテストが書きやすく、SQLite との組み合わせが手軽。
+
+### 初心者に勧めたいか
+
+コア部分（ルーティング・DI・DB）は勧めたい。ただし Unicode バリデーションについては「フレームワークが守ってくれない部分」として明示的に教育が必要。how-to ガイドが充実すれば推薦度は上がる。
+
+---
+
+## Issues / PRs
+
+- Issue: `JsonResponseFactory` に `JSON_UNESCAPED_UNICODE` を追加
+- Issue: Unicode バリデーション how-to ガイドの追加（`mb_strlen`・null バイト・grapheme cluster）

--- a/docs/howto/validate-unicode-input.md
+++ b/docs/howto/validate-unicode-input.md
@@ -1,0 +1,117 @@
+# How to validate Unicode input
+
+NENE2 stores and returns strings as UTF-8. This guide covers the pitfalls of Unicode-aware validation and how to handle them.
+
+## Use `mb_strlen` for character-count limits
+
+`strlen` counts bytes, not characters. Japanese, Arabic, and emoji use multiple bytes per character.
+
+```php
+strlen('あ')              // 3 (bytes)
+mb_strlen('あ', 'UTF-8') // 1 (character)
+
+strlen('🎉')              // 4 (bytes)
+mb_strlen('🎉', 'UTF-8') // 1 (character — one codepoint)
+```
+
+Always use `mb_strlen($value, 'UTF-8')` when enforcing a character limit:
+
+```php
+private const int NAME_MAX_CHARS = 50;
+
+if (mb_strlen($name, 'UTF-8') > self::NAME_MAX_CHARS) {
+    $errors[] = ['field' => 'name', 'code' => 'too_long',
+                 'message' => 'name must be at most ' . self::NAME_MAX_CHARS . ' characters.'];
+}
+```
+
+**Why `strlen` breaks:** A 50-character Japanese name is 150 bytes. `strlen(...) > 50` would reject it.
+
+## Reject null bytes explicitly
+
+SQLite TEXT columns accept null bytes (`\x00`). PHP string operations handle them too — but null bytes in user input are almost always injection attempts or encoding bugs. Reject them early:
+
+```php
+if (str_contains($name, "\x00")) {
+    $errors[] = ['field' => 'name', 'code' => 'invalid', 'message' => 'name must not contain null bytes.'];
+}
+```
+
+Apply this check to every string field before other validation (length, format, etc.).
+
+## Grapheme clusters vs codepoints
+
+`mb_strlen` counts Unicode _codepoints_. A visible glyph (grapheme cluster) can be multiple codepoints:
+
+| Input | Codepoints | `mb_strlen` | Glyphs |
+|-------|-----------|-------------|--------|
+| `é` (precomposed) | 1 | 1 | 1 |
+| `é` (e + combining accent) | 2 | 2 | 1 |
+| 👨‍👩‍👧 (ZWJ family) | 5 | 5 | 1 |
+
+For most use cases (usernames, bios), codepoint counting is fine. If you need to count visible characters, use `grapheme_strlen()` from the `intl` extension:
+
+```php
+grapheme_strlen('👨‍👩‍👧') // 1
+mb_strlen('👨‍👩‍👧', 'UTF-8') // 5
+```
+
+Choose the counting method that matches the user's expectation for your field.
+
+## JSON responses and non-ASCII characters
+
+`JsonResponseFactory` encodes responses with `JSON_UNESCAPED_UNICODE`, so non-ASCII characters appear as literal UTF-8 in the response body:
+
+```json
+{ "name": "田中太郎" }
+```
+
+If you are building a custom `json_encode` call elsewhere (e.g., storing tags as JSON in a TEXT column), add the same flag:
+
+```php
+$tagsJson = json_encode($tags, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+```
+
+Without `JSON_UNESCAPED_UNICODE`, the stored value would be `["タグ"]` instead of `["タグ"]`.
+
+## Complete validation example
+
+```php
+private const int NAME_MAX_CHARS = 50;
+
+private function validateName(string $raw): ?string
+{
+    if ($raw === '') {
+        return 'name is required.';
+    }
+    if (str_contains($raw, "\x00")) {
+        return 'name must not contain null bytes.';
+    }
+    if (mb_strlen($raw, 'UTF-8') > self::NAME_MAX_CHARS) {
+        return 'name must be at most ' . self::NAME_MAX_CHARS . ' characters.';
+    }
+    return null; // valid
+}
+```
+
+## Testing boundary values
+
+Always write tests for:
+
+- Exactly `MAX` characters (should pass) — use a Unicode character to verify byte/char difference:
+
+  ```php
+  $name50 = str_repeat('あ', 50); // 150 bytes, 50 chars — should pass
+  ```
+
+- `MAX + 1` characters (should fail):
+
+  ```php
+  $name51 = str_repeat('あ', 51); // should return 422 with too_long
+  ```
+
+- Null byte rejection:
+
+  ```php
+  "Valid\x00Name" // should return 422 with invalid
+  ```

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.26
+  version: 1.5.27
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.26';
+    public const string VERSION = '1.5.27';
 
     public function name(): string
     {

--- a/src/Http/JsonResponseFactory.php
+++ b/src/Http/JsonResponseFactory.php
@@ -28,7 +28,7 @@ final readonly class JsonResponseFactory
     public function create(array $data, int $status = 200, array $headers = []): ResponseInterface
     {
         $body = $this->streamFactory->createStream(
-            json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION)
+            json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_UNICODE)
         );
 
         $response = $this->responseFactory
@@ -54,7 +54,7 @@ final readonly class JsonResponseFactory
     public function createList(array $items, int $status = 200, array $headers = []): ResponseInterface
     {
         $body = $this->streamFactory->createStream(
-            json_encode($items, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION)
+            json_encode($items, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_UNICODE)
         );
 
         $response = $this->responseFactory


### PR DESCRIPTION
## Summary

- `JsonResponseFactory::create()` / `createList()` に `JSON_UNESCAPED_UNICODE` を追加。日本語・絵文字・アラビア語などの非ASCII文字がレスポンスで `\uXXXX` にエスケープされなくなった。CJK 文字のペイロードサイズが約 1/3 に削減される。
- `docs/howto/validate-unicode-input.md` を追加: `mb_strlen` vs `strlen`、null バイト拒否、grapheme cluster vs codepoint、`JSON_UNESCAPED_UNICODE` の挙動説明。
- FT93 フィールドトライアルレポート (`unicodelog`) を追加。

Closes #681
Closes #682

## Test plan

- [x] 341 PHPUnit テスト全通過
- [x] PHPStan level 8 エラーなし
- [x] PHP-CS-Fixer 変更なし
- [x] OpenAPI contract valid
- [x] MCP tool catalog valid
- [x] Version consistency OK: 1.5.27
- [x] FT93 22テスト全通過（日本語・絵文字・ZWJ・アラビア・null バイト・mb_strlen 境界値・SQLインジェクション文字列）

Self-review: backend-api, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)