### PR TITLE
feat(http): QueryStringParser::parse() 追加・タイムゾーン howto 追加 (FT95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.29] — 2026-05-20
+
+### Added
+- `QueryStringParser::parse()` — returns `array<string, mixed>` (alias for `$request->getQueryParams()`). Mirrors the `JsonRequestBodyParser::parse()` discovery pattern so developers can find the method without knowing the typed-accessor API upfront. (#686)
+- `docs/howto/handle-timezones.md` — timezone handling guide: always explicit UTC on `now`, IANA validation with `listIdentifiers()`, `createFromFormat` for strict parsing, DST ambiguous-time behavior (PHP takes first occurrence), local→UTC conversion pattern. (#687)
+- `docs/field-trials/2026-05-field-trial-95.md` — FT95 report: schedulelog (timezone-sensitive scheduling). (#686 #687)
+- `QueryStringParser` added to the public API stability guarantee (ADR 0009). (#686)
+
+---
+
 ## [1.5.28] — 2026-05-20
 
 ### Added

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -53,7 +53,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | Namespace | Key public surfaces |
 |-----------|---------------------|
 | `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `patch`, `delete`, `handle`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
-| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException`, `PaginationQuery`, `PaginationQueryParser`, `ConditionalGetHelper`, `ConditionalWriteHelper` |
+| `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException`, `PaginationQuery`, `PaginationQueryParser`, `QueryStringParser`, `ConditionalGetHelper`, `ConditionalWriteHelper` |
 | `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
 | `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException`, `DatabaseConstraintException` |

--- a/docs/field-trials/2026-05-field-trial-95.md
+++ b/docs/field-trials/2026-05-field-trial-95.md
@@ -1,0 +1,165 @@
+# Field Trial 95 — Timezone-Sensitive Scheduling
+
+**Date:** 2026-05-20
+**Project:** `/home/xi/docker/NENE2-FT/schedulelog/`
+**NENE2 version:** 1.5.28
+**Theme:** Timezone-aware event scheduling — IANA timezone validation, local→UTC conversion, DST handling, multi-timezone list view
+
+---
+
+## What was built
+
+An event scheduling API where events are stored with both a UTC timestamp and the original local time. Input is a local datetime string (`YYYY-MM-DDTHH:mm:ss`) plus an IANA timezone name. The API converts to UTC on create and can re-express stored UTC times in any requested timezone on list.
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/events` | Create event (title, timezone, start) |
+| GET | `/events` | List events ordered by UTC; optional `?timezone=X` for local-time view |
+| GET | `/events/{id}` | Get single event |
+
+### Domain layer
+
+- `TimezoneConverter` — static helpers: `localToUtc()`, `utcToLocal()`, `formatUtc()`, `formatLocal()`
+- `InvalidTimezoneException` — thrown for unknown IANA identifiers
+- IANA validation: `\DateTimeZone::listIdentifiers()` + explicit membership check (PHP's `DateTimeZone` constructor silently accepts some abbreviations not in the canonical list)
+
+---
+
+## Frictions encountered
+
+### 1. `QueryStringParser::parse()` doesn't exist — correct API is `QueryStringParser::string()` (高)
+
+**Symptom:** `Error: Call to undefined method Nene2\Http\QueryStringParser::parse()` at runtime — all list endpoints return 500.
+
+Natural reflex after `JsonRequestBodyParser::parse($request)` is to call `QueryStringParser::parse($request)`. But these two classes have completely different APIs:
+
+```php
+// JsonRequestBodyParser — returns whole array:
+$body = JsonRequestBodyParser::parse($request);
+
+// QueryStringParser — per-parameter typed accessors:
+$tz = QueryStringParser::string($request, 'timezone'); // returns ?string
+```
+
+`QueryStringParser` has no `parse()` method. Developers who infer the API from `JsonRequestBodyParser` hit a fatal error. The inconsistency between the two parsers is a real trap for beginners.
+
+**Workaround used:** `$request->getQueryParams()` directly.
+
+**Suggested fix:** Add `QueryStringParser::parse()` that returns `array<string, mixed>` as an alias for `$request->getQueryParams()`, or document the API inconsistency clearly in the how-to guide.
+
+**DX観点 (初心者目線):** 同じ `Parser` という名前でも API が全く違い、既存のパターンを真似すると実行時エラー。型エラーでなく「メソッドが存在しない」エラーなので静的解析でのみ発見可能。初心者に優しくない設計。
+
+---
+
+### 2. PHP の `DateTimeZone` は "EST" を黙って受け入れる（中）
+
+**Symptom:** `new DateTimeZone('EST')` は例外を投げない。しかし `DateTimeZone::listIdentifiers()` に "EST" は含まれない。
+
+```php
+new DateTimeZone('EST');         // succeeds! No exception
+in_array('EST', DateTimeZone::listIdentifiers(), true); // false
+```
+
+"EST"（東部標準時の略称）はPHPで有効な timezone 文字列として扱われるが、IANA 識別子（`America/New_York` など）ではない。コンストラクタで例外が出ないため、バリデーションに `try/catch (Exception)` だけを使うと不正な略称が通過してしまう。
+
+**Fix:** `\DateTimeZone::listIdentifiers()` による明示的なメンバシップチェックが必須。
+
+**DX観点:** PHP のドキュメントを読んだだけでは気づきにくい落とし穴。NENE2 のガイドに「IANA 識別子の検証は listIdentifiers() で確認せよ」と明記すべき。
+
+---
+
+### 3. DST 境界のあいまい時刻 — PHP は夏時間（最初の出現）を選ぶ（低）
+
+**Symptom:** 2026年11月1日 01:30 AM America/New_York は DST 切り替え後のあいまい時刻。
+- EDT (UTC-4) の 01:30 → 05:30 UTC（切り替え前・夏時間）
+- EST (UTC-5) の 01:30 → 06:30 UTC（切り替え後・冬時間）
+
+PHP は `DateTimeImmutable::createFromFormat()` でこの時刻を **最初の出現（EDT = UTC-4）** として解釈する。
+
+```php
+// Nov 1 2026 01:30 AM → PHP returns 05:30 UTC (not 06:30)
+```
+
+これは IANA の仕様（最初の出現）に一致するが、「折り返し時刻を冬時間として扱うべき」という期待を持つ開発者は驚く。
+
+**Status:** 回避策不要だが、ドキュメントで「PHP は最初の出現を選ぶ」と明記する価値あり。
+
+---
+
+### 4. `new DateTimeImmutable()` のデフォルトタイムゾーンはサーバー設定依存（中）
+
+**Symptom:** `new DateTimeImmutable('now')` はサーバーの `date.timezone` ini 設定に依存する。
+
+テスト環境と本番で `date.timezone` が異なると、暗黙の「now」が異なる。
+
+**Fix:** `new DateTimeImmutable('now', new DateTimeZone('UTC'))` で常にタイムゾーンを明示する。
+
+**DX観点:** この落とし穴は有名だが、NENE2 の how-to で「`now` には明示的に UTC を渡せ」と書いてあると初心者が助かる。
+
+---
+
+## Test results
+
+19 tests, 39 assertions — all pass.
+
+Tested scenarios:
+- Tokyo (JST=UTC+9): 10:00 → 01:00 UTC
+- New York summer (EDT=UTC-4): 09:00 → 13:00 UTC
+- London summer (BST=UTC+1): 12:00 → 11:00 UTC
+- London winter (GMT=UTC+0): 12:00 → 12:00 UTC
+- UTC timezone: no conversion
+- DST fall-back 01:30 AM → PHP uses summer time (05:30 UTC)
+- Invalid timezone name → 422
+- Timezone abbreviation "EST" (not IANA) → 422
+- Invalid datetime format → 422
+- Date-only string → 422
+- ISO8601 with offset → 422 (format mismatch)
+- Missing required fields → 422
+- List ordered by UTC (multi-timezone)
+- List with requested-timezone conversion (01:00 UTC → 03:00 CEST)
+- GET by ID
+- 404 for missing event
+- Same wall-clock time in different timezones = different UTC (naive assumption footgun)
+
+---
+
+## Developer Experience (DX) Review
+
+### 初心者・ロースキル観点での実装しやすさ
+
+難しかった。`TimezoneConverter` を自前で書く必要があり、PHP の DateTimeZone の落とし穴（EST の黙認、listIdentifiers() の必要性、now のデフォルト TZ）を知っていないと正しく実装できない。NENE2 がタイムゾーン変換のユーティリティを提供していれば大幅に楽になる。
+
+`QueryStringParser` の API 不一致（`parse()` がない）も初心者の大きな落とし穴。
+
+### 使ってみた印象
+
+コアのルーティング・DI・DB は快適。タイムゾーン変換の自前実装に多くの時間を使った。もし NENE2 が `TimezoneHelper::localToUtc()` 的なユーティリティを提供していたら、FT の本筋に集中できた。
+
+`QueryStringParser::string($request, 'key')` の API に慣れると使いやすいが、初見では `parse()` を探してしまう。
+
+### 楽しいか・気持ちいいか・快適か
+
+タイムゾーン変換のテストは「日本の 10:00 が UTC では 01:00 になる」を確認する瞬間が楽しい。多タイムゾーンのイベントを一覧して UTC 順にソートされるのを見ると、正しく動いている実感がある。
+
+DST のテスト（あいまい時刻）は少し不安になる — 「PHP はどちらを選ぶのか？」を確かめる過程は面白いが不確実性がある。
+
+### 簡単か
+
+タイムゾーン分野自体は難しい（PHP・IANA・DST の知識が必要）。NENE2 は邪魔をせず、PSR-7 リクエストから値を取り出して変換→保存→返す流れは明快。難しさの 80% は PHP/タイムゾーン知識であり、フレームワーク由来の難しさは `QueryStringParser` の API 差異のみ。
+
+### また使いたいか
+
+はい。難しいドメインでも NENE2 が DB・HTTP まわりをきれいに処理してくれるので、ビジネスロジックに集中できた。
+
+### 初心者に勧めたいか
+
+タイムゾーン操作は「PHP 力」が必要なテーマなので万人に勧めるのは難しい。ただし NENE2 の部分はシンプルで、`QueryStringParser` の API 差異さえドキュメント化されれば推薦度は上がる。
+
+---
+
+## Issues / PRs
+
+- Issue: `QueryStringParser` に `parse()` メソッド追加、または `JsonRequestBodyParser` との API 一貫性ドキュメント化
+- Issue: タイムゾーン処理 how-to ガイド追加（IANA 検証・DST・`now` に UTC 明示）

--- a/docs/howto/handle-timezones.md
+++ b/docs/howto/handle-timezones.md
@@ -1,0 +1,134 @@
+# How to handle timezones
+
+PHP's timezone handling has several silent failure modes. This guide covers the patterns and pitfalls encountered in real NENE2 field trials.
+
+## Always specify the timezone when creating `DateTimeImmutable`
+
+`new DateTimeImmutable('now')` uses the server's `date.timezone` ini setting, which differs between environments. Always pass `UTC` explicitly for server-side timestamps:
+
+```php
+// Fragile — depends on server's date.timezone
+$now = new \DateTimeImmutable('now');
+
+// Correct — always UTC
+$now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+```
+
+For stored timestamps, format as ISO8601 UTC:
+
+```php
+$now->format('Y-m-d\TH:i:s\Z') // → "2026-05-20T15:00:00Z"
+```
+
+## Validate IANA timezone identifiers explicitly
+
+PHP's `DateTimeZone` constructor accepts timezone abbreviations like `"EST"` without throwing an exception, but they are not canonical IANA identifiers. `"America/New_York"` is the correct IANA form.
+
+```php
+// This succeeds — but "EST" is not an IANA identifier
+$tz = new \DateTimeZone('EST'); // no exception!
+
+// Correct validation:
+try {
+    $tz = new \DateTimeZone($input);
+} catch (\Exception) {
+    throw new InvalidTimezoneException("Unknown timezone: $input");
+}
+
+// Additional membership check for non-IANA abbreviations:
+if (!in_array($input, \DateTimeZone::listIdentifiers(), true)) {
+    throw new InvalidTimezoneException("Unknown timezone: $input");
+}
+```
+
+Without the `listIdentifiers()` check, `"EST"`, `"PST"`, and similar abbreviations pass silently.
+
+## Parse local datetime strings with `createFromFormat`
+
+When accepting a local datetime from user input (without timezone offset), use `createFromFormat` with the explicit format and timezone:
+
+```php
+$tz    = new \DateTimeZone('Asia/Tokyo');
+$local = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', '2026-06-01T10:00:00', $tz);
+
+if ($local === false) {
+    // Invalid format — '2026/06/01 10:00', '2026-06-01', etc. all return false
+    throw new \InvalidArgumentException('Invalid datetime format. Expected YYYY-MM-DDTHH:mm:ss.');
+}
+```
+
+Prefer `createFromFormat` over `new DateTimeImmutable($str, $tz)` — the constructor is lenient and accepts many formats silently.
+
+## Convert local time to UTC for storage
+
+```php
+$utc = $local->setTimezone(new \DateTimeZone('UTC'));
+// Store as: $utc->format('Y-m-d\TH:i:s\Z')
+```
+
+Always store UTC in the database. Store the original timezone name alongside it so you can reconstruct the local time on retrieval.
+
+## DST transition: ambiguous wall-clock times
+
+During "fall back" transitions (e.g., `America/New_York` on the first Sunday of November), some wall-clock times occur twice:
+
+- `2026-11-01 01:30 AM` exists in both EDT (UTC-4) and EST (UTC-5)
+
+PHP resolves the ambiguity by choosing the **first occurrence** (summer/DST time):
+
+```php
+$dt = \DateTimeImmutable::createFromFormat(
+    'Y-m-d\TH:i:s',
+    '2026-11-01T01:30:00',
+    new \DateTimeZone('America/New_York'),
+);
+// → 05:30 UTC (EDT = UTC-4), not 06:30 UTC (EST = UTC-5)
+```
+
+This matches the IANA standard. If your application needs to distinguish the two occurrences (e.g., for calendar systems), you must handle this at the application level — PHP does not expose an API for selecting the second occurrence.
+
+## Complete local→UTC conversion pattern
+
+```php
+use Schedule\Event\InvalidTimezoneException;
+
+function localToUtc(string $localDatetime, string $ianaTimezone): \DateTimeImmutable
+{
+    try {
+        $tz = new \DateTimeZone($ianaTimezone);
+    } catch (\Exception) {
+        throw new InvalidTimezoneException("Unknown timezone: $ianaTimezone");
+    }
+
+    // Reject non-IANA abbreviations (e.g. "EST")
+    if (!in_array($ianaTimezone, \DateTimeZone::listIdentifiers(), true)) {
+        throw new InvalidTimezoneException("Unknown timezone: $ianaTimezone");
+    }
+
+    $local = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $localDatetime, $tz);
+
+    if ($local === false) {
+        throw new \InvalidArgumentException("Cannot parse datetime: $localDatetime");
+    }
+
+    return $local->setTimezone(new \DateTimeZone('UTC'));
+}
+```
+
+## Multi-timezone list queries
+
+When listing events stored in UTC, convert to a viewer's timezone on the way out:
+
+```php
+$viewTz = QueryStringParser::string($request, 'timezone');
+
+if ($viewTz !== null) {
+    try {
+        $tz    = new \DateTimeZone($viewTz);
+        $local = (new \DateTimeImmutable($event->startUtc, new \DateTimeZone('UTC')))->setTimezone($tz);
+        $data['start_local'] = $local->format('Y-m-d\TH:i:s');
+    } catch (\Exception) {
+        // Invalid requested timezone — silently omit the conversion
+    }
+}
+```

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.28
+  version: 1.5.29
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.28';
+    public const string VERSION = '1.5.29';
 
     public function name(): string
     {

--- a/src/Http/QueryStringParser.php
+++ b/src/Http/QueryStringParser.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * absent or empty-string values.
  *
  * Usage:
+ *   $all      = QueryStringParser::parse($request);                  // array<string, mixed> — all params
  *   $category = QueryStringParser::string($request, 'category');     // ?string
  *   $page     = QueryStringParser::int($request, 'page');            // ?int
  *   $isRead   = QueryStringParser::bool($request, 'is_read');        // ?bool (null when absent)
@@ -24,6 +25,19 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 final class QueryStringParser
 {
+    /**
+     * Returns all query parameters as a raw array — equivalent to `$request->getQueryParams()`.
+     *
+     * Mirrors the `JsonRequestBodyParser::parse()` API for discoverability.
+     * Use the typed accessor methods (`string`, `int`, `bool`) for validated access to individual keys.
+     *
+     * @return array<string, mixed>
+     */
+    public static function parse(ServerRequestInterface $request): array
+    {
+        return $request->getQueryParams();
+    }
+
     /**
      * Returns the raw string value for a query parameter, or null when the key is
      * absent or the value is an empty string.


### PR DESCRIPTION
## Summary

- `QueryStringParser::parse()` を追加: `JsonRequestBodyParser::parse()` との API 対称性を実現。`getQueryParams()` のラッパー。
- `docs/howto/handle-timezones.md` を追加: IANA 識別子の検証 (`listIdentifiers()`)・`createFromFormat` 厳密パース・DST あいまい時刻の PHP 動作・UTC 明示パターン。
- FT95 フィールドトライアルレポート（schedulelog — タイムゾーン敏感スケジューリング）を追加。
- ADR 0009 に `QueryStringParser` を安定 API として追記。

Closes #686
Closes #687

## Test plan

- [x] 341 PHPUnit テスト全通過
- [x] PHPStan level 8 エラーなし
- [x] PHP-CS-Fixer 変更なし
- [x] Version consistency OK: 1.5.29
- [x] FT95 19テスト全通過（JST・EDT・BST・GMT・UTC変換、DST fall-back、無効TZ、日時フォーマット検証）

Self-review: backend-api, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)