### PR TITLE
docs(howto): コンテントネゴシエーション挙動ドキュメント追加 (FT96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.30] — 2026-05-20
+
+### Added
+- `docs/howto/content-negotiation.md` — documents NENE2's JSON-only response design (no 406), `JsonRequestBodyParser` Content-Type behavior, and a custom middleware pattern for 406/415 enforcement. (#689)
+- `docs/field-trials/2026-05-field-trial-96.md` — FT96 report: contentlog (content negotiation / Accept header). (#689)
+
+---
+
 ## [1.5.29] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-96.md
+++ b/docs/field-trials/2026-05-field-trial-96.md
@@ -1,0 +1,132 @@
+# Field Trial 96 — Content Negotiation (Accept Header)
+
+**Date:** 2026-05-20
+**Project:** `/home/xi/docker/NENE2-FT/contentlog/`
+**NENE2 version:** 1.5.29
+**Theme:** Content negotiation — Accept header behavior, response Content-Type consistency, request Content-Type enforcement (or lack thereof)
+
+---
+
+## What was built
+
+A minimal articles CRUD API used as a test harness for content negotiation behavior. All tests examine how NENE2 handles `Accept` headers, error response types, and request body `Content-Type` variations.
+
+---
+
+## Findings
+
+### 1. NENE2 ignores the `Accept` header — always returns JSON (設計上の選択)
+
+NENE2 does not implement content negotiation. Regardless of what the `Accept` header contains, all responses are `Content-Type: application/json; charset=utf-8`.
+
+| Accept header sent | Response Content-Type |
+|---|---|
+| (none) | `application/json; charset=utf-8` |
+| `application/json` | `application/json; charset=utf-8` |
+| `*/*` | `application/json; charset=utf-8` |
+| `text/html` | `application/json; charset=utf-8` |
+| `application/xml` | `application/json; charset=utf-8` |
+| `text/html;q=1.0, application/json;q=0.9` | `application/json; charset=utf-8` |
+
+RFC 7231 §6.5.6 states that a server "SHOULD" return `406 Not Acceptable` when the Accept header lists no acceptable types. NENE2 does not follow this — it always returns JSON.
+
+**This is correct for a JSON-first API** and is a deliberate design choice, but it is undocumented.
+
+**DX観点 (初心者目線):** NENE2 が「JSON のみ返す」と明示されていないと、初心者は Accept ヘッダーを試して「なぜ 406 にならないのか」と混乱する可能性がある。明確なドキュメントがあれば問題なし。
+
+---
+
+### 2. Error responses use `application/problem+json` correctly (摩擦なし)
+
+All error responses — 404, 405, 422, 500 — use `Content-Type: application/problem+json`. This is consistent regardless of what `Accept` header the client sends.
+
+```
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+```
+
+This is RFC 9457 compliant and works well.
+
+---
+
+### 3. `JsonRequestBodyParser` does not enforce `Content-Type: application/json` on requests (中)
+
+**Symptom:** A request with `Content-Type: application/x-www-form-urlencoded` and form-encoded body results in a 400 Bad Request (JSON parse failure), not a clean 415 Unsupported Media Type.
+
+**More surprising:** A request with no `Content-Type` header and a valid JSON body is parsed correctly:
+
+```php
+// No Content-Type header set
+$req = new ServerRequest('POST', '/articles');
+$req->withBody('{"title":"Hello"}');
+// → JsonRequestBodyParser parses successfully → 201 Created
+```
+
+`JsonRequestBodyParser::parse()` calls `json_decode()` unconditionally without checking whether the request's `Content-Type` is `application/json`. This means:
+- Form-encoded bodies get 400 (JSON decode fails)
+- Raw JSON bodies succeed even without the header
+
+For a JSON API this is arguably correct (liberal input policy), but there is no way to return 415 Unsupported Media Type via NENE2's built-in tooling.
+
+**DX観点:** 初心者が「Content-Type を付け忘れた JSON リクエスト」を送っても動いてしまう — これは問題にならないことが多いが、デバッグ時に驚く。「Content-Type が必要」という明示的なエラーが出ない。
+
+---
+
+### 4. `405 Method Not Allowed` is returned correctly (摩擦なし)
+
+`DELETE /articles` (no such route defined, but GET and POST exist) returns 405. The router correctly distinguishes "no route at all" (404) from "route exists but wrong method" (405).
+
+---
+
+## Test results
+
+16 tests, 28 assertions — all pass.
+
+Key behaviors confirmed:
+- No Accept header → 200 JSON
+- `Accept: application/json` → 200 JSON
+- `Accept: */*` → 200 JSON
+- `Accept: text/html` → 200 JSON (no 406)
+- `Accept: text/html;q=1.0, application/json;q=0.9` → 200 JSON (no 406)
+- 404 → `application/problem+json`
+- 422 → `application/problem+json`
+- 404 with `Accept: text/html` → `application/problem+json`
+- Form-encoded body → 400/415/422
+- JSON body without Content-Type → 201 (success)
+- Unknown route → 404 problem+json
+- Wrong method → 405
+
+---
+
+## Developer Experience (DX) Review
+
+### 初心者・ロースキル観点での実装しやすさ
+
+テーマ自体は複雑だが、「NENE2 が Accept ヘッダーを無視する」という事実さえ知っていれば実装は簡単。ドキュメントに明記されれば初心者も混乱しない。
+
+### 使ってみた印象
+
+エラーレスポンスが `application/problem+json` で統一されていて安心感がある。406 を心配せず「JSON を返す」と割り切れるのはシンプルで良い。
+
+### 楽しいか・気持ちいいか・快適か
+
+コンテントネゴシエーションは実装が面倒な分野なので、NENE2 が「JSON のみ」に割り切っているのは快適。自前の `Accept` ヘッダーパーサーを書かなくていい。
+
+### 簡単か
+
+はい。このテーマでは NENE2 がほぼ透過的に動いた。唯一の複雑さは「`JsonRequestBodyParser` が `Content-Type` を無視する」という挙動の把握。
+
+### また使いたいか
+
+はい。JSON-only なユースケースでは NENE2 の設計はシンプルで嬉しい。
+
+### 初心者に勧めたいか
+
+はい、ただし「NENE2 は 406 を返さない」「Content-Type なしの JSON でも動く」という挙動をドキュメントで明示すると推薦度が上がる。
+
+---
+
+## Issues / PRs
+
+- Issue: Accept ヘッダー無視の設計決定をドキュメント化（README / CLAUDE.md / ADR）
+- Issue: `JsonRequestBodyParser` の Content-Type チェック非実施を howto で説明（415 を返したい場合のミドルウェア例）

--- a/docs/howto/content-negotiation.md
+++ b/docs/howto/content-negotiation.md
@@ -1,0 +1,90 @@
+# Content negotiation
+
+NENE2 is a JSON-first framework. It does not implement content negotiation — all responses use `application/json` (or `application/problem+json` for errors) regardless of what the client sends in the `Accept` header.
+
+## What NENE2 does
+
+| Client sends | Server returns |
+|---|---|
+| No `Accept` header | `application/json; charset=utf-8` |
+| `Accept: application/json` | `application/json; charset=utf-8` |
+| `Accept: */*` | `application/json; charset=utf-8` |
+| `Accept: text/html` | `application/json; charset=utf-8` |
+| `Accept: application/xml` | `application/json; charset=utf-8` |
+| `Accept: text/html;q=1.0, application/json;q=0.9` | `application/json; charset=utf-8` |
+
+**NENE2 never returns `406 Not Acceptable`.** RFC 7231 §6.5.6 says the server SHOULD return 406 when no acceptable type is available, but this is a SHOULD (not MUST). For a JSON-only API server, always returning JSON is the simplest and most common choice.
+
+Error responses use `application/problem+json` (RFC 9457) regardless of `Accept`:
+
+```
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+```
+
+## Request body Content-Type
+
+`JsonRequestBodyParser::parse()` does not check the `Content-Type` header on the incoming request. It attempts to JSON-decode the body unconditionally:
+
+```php
+// All three reach JsonRequestBodyParser::parse() identically:
+// Content-Type: application/json → works
+// Content-Type: application/x-www-form-urlencoded → 400 (JSON parse fails on form body)
+// (no Content-Type) + JSON body → works
+```
+
+This means:
+- A valid JSON body without `Content-Type` is accepted — liberal input policy.
+- A form-encoded body (`name=Alice&age=30`) results in a 400 Bad Request (JSON parse failure), not a 415 Unsupported Media Type.
+
+## If you need 406 or 415 responses
+
+Add a middleware that inspects the `Accept` and `Content-Type` headers before the route handler:
+
+```php
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class JsonOnlyMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problems,
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        // Enforce JSON-only Accept (optional — most clients send */* or application/json)
+        $accept = $request->getHeaderLine('Accept');
+        if ($accept !== '' && $accept !== '*/*' && !str_contains($accept, 'application/json')) {
+            return $this->problems->create($request, 'not-acceptable', 'Not Acceptable', 406,
+                'This API only produces application/json.');
+        }
+
+        // Enforce JSON Content-Type on state-changing requests
+        $method      = strtoupper($request->getMethod());
+        $contentType = $request->getHeaderLine('Content-Type');
+        if (in_array($method, ['POST', 'PUT', 'PATCH'], true)
+            && $contentType !== ''
+            && !str_contains($contentType, 'application/json')
+        ) {
+            return $this->problems->create($request, 'unsupported-media-type', 'Unsupported Media Type', 415,
+                'This API only accepts application/json request bodies.');
+        }
+
+        return $handler->handle($request);
+    }
+}
+```
+
+Wire it via `RuntimeApplicationFactory`:
+
+```php
+new RuntimeApplicationFactory(
+    ...,
+    authMiddleware: new JsonOnlyMiddleware($problems),
+);
+```
+
+> **Note:** `authMiddleware` is evaluated before routing. Place content-type enforcement here if you want it applied globally.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.29
+  version: 1.5.30
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.29';
+    public const string VERSION = '1.5.30';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/content-negotiation.md` を追加: NENE2 の Accept ヘッダー無視設計・JsonRequestBodyParser の Content-Type 非チェック・406/415 カスタムミドルウェアパターン。
- FT96 フィールドトライアルレポート（contentlog — コンテントネゴシエーション）を追加。

Closes #689

## Test plan

- [x] 341 PHPUnit テスト全通過
- [x] PHPStan level 8 エラーなし
- [x] Version consistency OK: 1.5.30
- [x] FT96 16テスト全通過（Accept header 各種、error response content-type、form body 処理、405）

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)