### PR TITLE
feat(http,routing): QueryStringParser デフォルト値・Router::param() ヘルパー・SQLインジェクション howto (#691 #692 #693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.31] — 2026-05-20
+
+### Added
+- `Router::param(ServerRequestInterface $request, string $key): ?string` — static helper to read a single route path parameter without the two-step `getAttribute(Router::PARAMETERS_ATTRIBUTE)` boilerplate. (#693)
+- `QueryStringParser::string()` — optional `$default` third argument; returns `$default` (instead of `null`) when the key is absent or empty. Backwards-compatible. (#692)
+- `QueryStringParser::int()` — optional `$default` third argument; same pattern. (#692)
+- `docs/howto/sql-injection.md` — SQL injection defense guide: LIKE parameterization, ORDER BY whitelist requirement, IN clause with variable-length placeholders. (#691)
+- `docs/field-trials/2026-05-field-trial-97.md` — FT97 report: injectionlog (SQL injection defense). (#691)
+
+---
+
 ## [1.5.30] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-97.md
+++ b/docs/field-trials/2026-05-field-trial-97.md
@@ -1,0 +1,151 @@
+# Field Trial 97 — SQL Injection Defense
+
+**Date:** 2026-05-20
+**Project:** `/home/xi/docker/NENE2-FT/injectionlog/`
+**NENE2 version:** 1.5.30
+**Theme:** SQL injection — parameterized queries, LIKE injection, ORDER BY injection, path parameter coercion
+
+---
+
+## What was built
+
+A product search API (`GET /products?q=...&sort=...&order=...`) used as a test harness for SQL injection defense. Tests send classic injection payloads (tautology, DROP TABLE, UNION SELECT, ORDER BY injection) and verify that NENE2's parameterized query layer neutralizes them.
+
+---
+
+## Findings
+
+### 1. NENE2's `fetchAll()` / `fetchOne()` / `insert()` use PDO prepared statements — safe by default (摩擦なし)
+
+All DB methods accept `array $parameters` and bind values via PDO. This means any user input passed through these methods is automatically parameterized — no string interpolation occurs.
+
+```php
+// Safe: parameterized LIKE — wildcard in SQL literal, value bound separately
+$rows = $this->db->fetchAll(
+    "SELECT * FROM products WHERE name LIKE '%' || ? || '%'",
+    [$userInput],
+);
+```
+
+Classic tautology `' OR '1'='1`, DROP TABLE, and UNION SELECT payloads all became literal search strings — 0 matches, table intact.
+
+**DX観点:** 「デフォルトで安全」なのは非常に良い。初心者が `fetchAll()` を使っていれば、特別なことをしなくてもSQLインジェクションは防げる。
+
+---
+
+### 2. ORDER BY column cannot be parameterized — requires explicit whitelist (高: 重要な設計判断)
+
+**Symptom:** `ORDER BY ?` does not work in SQL — column names are SQL structure, not values, and PDO cannot bind them as parameters. A developer who naively tries to pass `sort` from query string directly into an `ORDER BY` clause creates an injection vector.
+
+**Example of the footgun:**
+```php
+// UNSAFE — if $sortField comes from user input:
+$sql = "SELECT * FROM products ORDER BY {$sortField} ASC";
+$this->db->fetchAll($sql);
+```
+
+**Correct approach — whitelist validation:**
+```php
+private const array ALLOWED_SORT_FIELDS = ['id', 'name', 'category', 'price'];
+
+if (!in_array($sortField, self::ALLOWED_SORT_FIELDS, true)) {
+    throw new InvalidSortFieldException("...");
+}
+// Only after validation:
+$sql = "SELECT * FROM products ORDER BY {$sortField} {$sortDir}";
+```
+
+NENE2's `execute()` / `fetchAll()` have no mechanism to prevent raw interpolation — this is entirely up to the developer.
+
+**DX観点 (初心者目線):** `QueryStringParser::string($request, 'sort')` で取得した値をそのまま `ORDER BY` に入れてしまう初心者は多い。NENE2 は「ORDER BY にパラメーターを使えない」という事実を警告する仕組みがない。Howto ドキュメントで明示しないと、初心者が脆弱なコードを書く可能性が高い。
+
+---
+
+### 3. `QueryStringParser::string()` returns `?string` — no default value argument (中)
+
+**Symptom:** `QueryStringParser::string($request, 'sort', 'id')` のように第3引数でデフォルト値を渡そうとすると、引数が存在しないため PHP エラーになる。
+
+```php
+// BROKEN — no 3rd argument:
+$sort = QueryStringParser::string($request, 'sort', 'id');
+
+// Correct:
+$sort = QueryStringParser::string($request, 'sort') ?? 'id';
+```
+
+`JsonRequestBodyParser::parse()` はフォールバックを返すが、`QueryStringParser::string()` は `null` を返す。デフォルト値を第3引数で渡せる設計の方がより一貫性がある。
+
+**DX観点:** 「デフォルト値を渡したい」という自然な使い方が2ステップ（取得→`?? 'default'`）になる。引数でデフォルトを渡せると書き方が一行で完結して気持ちいい。
+
+---
+
+### 4. Route parameters are in `nene2.route.parameters` attribute — not directly accessible (中)
+
+**Symptom:** `$request->getAttribute('id')` returns null. Path params must be read via:
+
+```php
+$params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+$id     = (int) ($params['id'] ?? 0);
+```
+
+The constant `Router::PARAMETERS_ATTRIBUTE = 'nene2.route.parameters'` is stable API but the two-step access is non-obvious. FT94 authlog already hit this footgun.
+
+**DX観点:** 毎回 `(array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE)['id']` を書くのは冗長。`Router::param($request, 'id')` のようなヘルパーがあると嬉しい。
+
+---
+
+### 5. ORDER direction injection is neutralized by normalization (摩擦なし)
+
+Even if a user sends `?order=ASC; DROP TABLE products; --`, the repository normalizes the direction with `strtolower($sortDir) === 'desc' ? 'DESC' : 'ASC'` — any string that isn't `desc` becomes `ASC`. No injection possible through the direction parameter.
+
+---
+
+## Test results
+
+19 tests, 45 assertions — all pass.
+
+Key behaviors confirmed:
+- Tautology injection `' OR '1'='1` → 0 results (literal string search)
+- DROP TABLE injection → table survives, 0 results
+- UNION SELECT injection → no injected rows in result
+- ORDER BY whitelisted field → works correctly
+- ORDER BY injection payload → 400 `invalid-sort-field`
+- Order direction injection → normalized to `ASC`, table intact
+- SQL injection in POST body name/description → stored as literal string, table intact
+- `(int)` coercion of path `{id}` parameter → prevents numeric injection
+
+---
+
+## Developer Experience (DX) Review
+
+### 初心者・ロースキル観点での実装しやすさ
+
+NENE2 の DB 層はデフォルトで安全（全メソッドがパラメーター化クエリを使う）なため、`fetchAll()` / `insert()` を正しく使えばインジェクションは防げる。ただし ORDER BY の扱いは NENE2 が直接ガードしてくれるわけではなく、初心者がホワイトリスト検証を「知っていなければ危険」な設計上の空白がある。
+
+### 使ってみた印象
+
+PDO ベースのパラメーター化は当然の正解だが、`LIKE '%' || ? || '%'` という書き方は SQL 方言依存で初見では「これで合ってる？」と不安になる。動作確認できれば問題ないが、ドキュメント例がほしい。
+
+### 楽しいか・気持ちいいか・快適か
+
+SQLインジェクションペイロードをテストとして書いて「ちゃんと0件が返ってくる」を確認するのは、セキュリティ検証として爽快感がある。NENE2 が守ってくれている安心感を実感できる。
+
+### 簡単か
+
+基本的なCRUDと検索は簡単。困ったのは ORDER BY のホワイトリスト必須という暗黙の知識と、`QueryStringParser::string()` のデフォルト値引数がないこと。
+
+### また使いたいか
+
+はい。デフォルト安全な DB 層は非常に信頼できる。ORDER BY の扱いを howto で明示してくれれば完璧。
+
+### 初心者に勧めたいか
+
+はい、ただし「ORDER BY にユーザー入力を直接入れてはいけない・ホワイトリスト必須」という点を howto に明示すること。現状その警告がドキュメントにないため、初心者が脆弱なコードを書くリスクがある。
+
+---
+
+## Issues / PRs
+
+- Issue: ORDER BY injection footgun を howto で説明（ホワイトリスト必須の理由と実装例）
+- Issue: `QueryStringParser::string()` にデフォルト値引数を追加（`?? 'default'` 二段構えをなくす）
+- Issue: `Router::param($request, 'key')` ヘルパーメソッド追加（路由パラメーター取得の簡略化）

--- a/docs/howto/sql-injection.md
+++ b/docs/howto/sql-injection.md
@@ -1,0 +1,81 @@
+# SQL injection defense
+
+NENE2's database methods (`execute`, `insert`, `fetchOne`, `fetchAll`) use PDO prepared statements internally. Any value passed in the `$parameters` array is bound as a PDO parameter — never interpolated into the SQL string.
+
+## Safe by default: value parameters
+
+```php
+// All values go through PDO binding — injection-safe regardless of content
+$product = $this->db->fetchOne(
+    'SELECT * FROM products WHERE id = ?',
+    [$userId],
+);
+
+// LIKE search — wildcard in SQL literal, value bound separately
+$rows = $this->db->fetchAll(
+    "SELECT * FROM products WHERE name LIKE '%' || ? || '%'",
+    [$searchQuery],
+);
+```
+
+Classic payloads (`' OR '1'='1`, `'; DROP TABLE products; --`, `UNION SELECT ...`) become literal search strings because PDO never interpolates them into SQL.
+
+## The ORDER BY footgun — whitelist required
+
+**PDO cannot parameterize column names or SQL structural elements.** `ORDER BY ?` does not work — it binds a literal string value, not a column reference.
+
+If a developer puts user input directly into `ORDER BY`, it becomes an injection vector:
+
+```php
+// UNSAFE — never do this
+$sort = QueryStringParser::string($request, 'sort') ?? 'id';
+$rows = $this->db->fetchAll("SELECT * FROM products ORDER BY {$sort} ASC");
+// ?sort=id;+DROP+TABLE+products;+-- executes the DROP
+```
+
+**Always validate against an explicit whitelist before interpolating column names:**
+
+```php
+private const array ALLOWED_SORT_FIELDS = ['id', 'name', 'price', 'created_at'];
+
+public function list(string $sortField, string $sortDir): array
+{
+    if (!in_array($sortField, self::ALLOWED_SORT_FIELDS, true)) {
+        throw new InvalidSortFieldException("Invalid sort field: {$sortField}");
+    }
+
+    // Only ASC or DESC — normalize, never interpolate raw user input
+    $dir  = strtolower($sortDir) === 'desc' ? 'DESC' : 'ASC';
+    $rows = $this->db->fetchAll(
+        "SELECT * FROM products ORDER BY {$sortField} {$dir}",
+    );
+
+    return $rows;
+}
+```
+
+The same principle applies to any SQL structural element: table names, column names in `GROUP BY`, `HAVING`, `INSERT INTO ... (col1, col2)` — none of these can be bound as PDO parameters. Whitelist-validate before interpolating.
+
+## IN clause with variable length
+
+PDO does not support binding a variable-length list directly. Build the placeholder list explicitly:
+
+```php
+$ids          = [1, 2, 3];
+$placeholders = implode(', ', array_fill(0, count($ids), '?'));
+$rows         = $this->db->fetchAll(
+    "SELECT * FROM products WHERE id IN ({$placeholders})",
+    $ids,
+);
+```
+
+## Summary
+
+| Input type | Safe method |
+|---|---|
+| Filter value (`WHERE col = ?`) | `?` placeholder in `$parameters` |
+| LIKE value | `'%' \|\| ? \|\| '%'` — value in `$parameters` |
+| ORDER BY column | Whitelist `in_array` + interpolate only after passing |
+| ORDER direction | Normalize to literal `'ASC'` or `'DESC'` |
+| IN list | Build `?` placeholders from `count()`, spread array as params |
+| Table/column name | Whitelist only — never accept from user input |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.30
+  version: 1.5.31
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.30';
+    public const string VERSION = '1.5.31';
 
     public function name(): string
     {

--- a/src/Http/QueryStringParser.php
+++ b/src/Http/QueryStringParser.php
@@ -14,12 +14,14 @@ use Psr\Http\Message\ServerRequestInterface;
  * absent or empty-string values.
  *
  * Usage:
- *   $all      = QueryStringParser::parse($request);                  // array<string, mixed> — all params
- *   $category = QueryStringParser::string($request, 'category');     // ?string
- *   $page     = QueryStringParser::int($request, 'page');            // ?int
- *   $isRead   = QueryStringParser::bool($request, 'is_read');        // ?bool (null when absent)
- *   $tags     = QueryStringParser::commaSeparated($request, 'tags'); // list<string>|null
- *   $tags     = QueryStringParser::array($request, 'tags');         // list<string>|null — ?tags[]=php&tags[]=api
+ *   $all      = QueryStringParser::parse($request);                      // array<string, mixed> — all params
+ *   $category = QueryStringParser::string($request, 'category');         // ?string
+ *   $category = QueryStringParser::string($request, 'category', 'all');  // string with default
+ *   $page     = QueryStringParser::int($request, 'page');                // ?int
+ *   $page     = QueryStringParser::int($request, 'page', 1);             // int with default
+ *   $isRead   = QueryStringParser::bool($request, 'is_read');            // ?bool (null when absent)
+ *   $tags     = QueryStringParser::commaSeparated($request, 'tags');     // list<string>|null
+ *   $tags     = QueryStringParser::array($request, 'tags');              // list<string>|null — ?tags[]=php&tags[]=api
  *
  * Part of the public API stability guarantee (see ADR 0009).
  */
@@ -39,34 +41,40 @@ final class QueryStringParser
     }
 
     /**
-     * Returns the raw string value for a query parameter, or null when the key is
+     * Returns the raw string value for a query parameter, or `$default` when the key is
      * absent or the value is an empty string.
+     *
+     * When `$default` is omitted (null), the return type is `?string`.
+     * When `$default` is a non-null string, the return type is `string`.
      */
-    public static function string(ServerRequestInterface $request, string $key): ?string
+    public static function string(ServerRequestInterface $request, string $key, ?string $default = null): ?string
     {
         $params = $request->getQueryParams();
 
         if (!isset($params[$key]) || !is_string($params[$key]) || $params[$key] === '') {
-            return null;
+            return $default;
         }
 
         return $params[$key];
     }
 
     /**
-     * Returns the integer value for a query parameter, or null when the key is
+     * Returns the integer value for a query parameter, or `$default` when the key is
      * absent, empty, or not a valid integer string.
+     *
+     * When `$default` is omitted (null), the return type is `?int`.
+     * When `$default` is a non-null int, the return type is `int`.
      */
-    public static function int(ServerRequestInterface $request, string $key): ?int
+    public static function int(ServerRequestInterface $request, string $key, ?int $default = null): ?int
     {
         $raw = self::string($request, $key);
 
         if ($raw === null) {
-            return null;
+            return $default;
         }
 
         if (!ctype_digit(ltrim($raw, '-')) || $raw === '-') {
-            return null;
+            return $default;
         }
 
         return (int) $raw;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -71,6 +71,34 @@ final class Router implements RequestHandlerInterface
         return $this->add('DELETE', $path, $handler);
     }
 
+    /**
+     * Returns a single route path parameter by name, or null when the key is absent.
+     *
+     * Shorthand for `(array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE)` followed
+     * by key access. Eliminates the common two-step boilerplate in route handlers.
+     *
+     * ```php
+     * // Before:
+     * $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+     * $id     = (int) ($params['id'] ?? 0);
+     *
+     * // After:
+     * $id = (int) Router::param($request, 'id');
+     * ```
+     */
+    public static function param(ServerRequestInterface $request, string $key): ?string
+    {
+        $params = $request->getAttribute(self::PARAMETERS_ATTRIBUTE);
+
+        if (!is_array($params)) {
+            return null;
+        }
+
+        $value = $params[$key] ?? null;
+
+        return is_string($value) ? $value : null;
+    }
+
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         if (!$this->sorted) {


### PR DESCRIPTION
## Summary

- `Router::param(ServerRequestInterface $request, string $key): ?string` — ルートパラメーター取得を1行化する静的ヘルパー（FT94, FT97 で繰り返し発生した2ステップ定型文を解消）
- `QueryStringParser::string/int()` — 第3引数 `$default` 追加（後方互換。`?? 'fallback'` の2ステップ書き方が不要になる）
- `docs/howto/sql-injection.md` — ORDER BY ホワイトリスト必須・LIKE 安全パターン・IN 句を実装例付きで文書化

## Test plan

- [x] `composer check` 全通過（341 tests, 860 assertions）
- [x] PHPStan level 8 エラーなし
- [x] FT97 injectionlog: 19 tests, 45 assertions — SQLインジェクションペイロード検証済み
- [x] Version consistency OK: 1.5.31

## Self-review

`backend-api`, `docs-policy`

Closes #691
Closes #692
Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)