### PR TITLE
feat(docs): Idempotency-Key パターン・CORS vs CSRF ガイド追加 v1.5.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.33] — 2026-05-21
+
+### Added
+- `docs/howto/idempotency.md` — Idempotency-Key pattern guide: header validation, replay with 200, race condition handling via `DatabaseConstraintException` + UNIQUE constraint, key generation guidance. (#699)
+- `docs/howto/csrf-and-json-api.md` — CORS vs CSRF guide: why CORS ≠ CSRF protection, JSON API preflight resistance, Bearer JWT immunity, SameSite cookies and Origin enforcement for cookie-based sessions. (#700)
+- `docs/field-trials/2026-05-field-trial-99.md` — FT99 report: csrflog (CSRF-like patterns / idempotency key). (#699 #700)
+
+---
+
 ## [1.5.32] — 2026-05-20
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-99.md
+++ b/docs/field-trials/2026-05-field-trial-99.md
@@ -1,0 +1,144 @@
+# Field Trial 99 — CSRF-like Patterns (Idempotency Key)
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/csrflog/`
+**NENE2 version:** 1.5.32
+**Theme:** CSRF 的なパターン — 冪等性トークン（Idempotency-Key）・二重送信防止・CORS ≠ CSRF 保護の検証
+
+---
+
+## What was built
+
+注文作成 API に `Idempotency-Key` ヘッダーを導入し、二重送信（ネットワークリトライによる重複注文）を防止するパターンを検証。NENE2 の CorsMiddleware が CSRF 保護として機能するかも確認した。
+
+---
+
+## Findings
+
+### 1. Idempotency-Key による二重送信防止は全て手実装が必要（中）
+
+NENE2 に冪等性サポートは組み込まれていない。`Idempotency-Key` ヘッダーの検証・ストレージ照合・リプレイ応答を全てアプリ層で実装する必要がある。
+
+実装パターン:
+
+```php
+// 1. ヘッダー取得と必須チェック
+$key = trim($request->getHeaderLine('Idempotency-Key'));
+if ($key === '') {
+    return $problems->create($request, 'missing-idempotency-key', ..., 422, ...);
+}
+
+// 2. 既存エントリ検索（DB の UNIQUE 制約と組み合わせ）
+$existing = $repo->findByIdempotencyKey($key);
+if ($existing !== null) {
+    return $json->create($existing->toArray(), 200); // リプレイ → 200
+}
+
+// 3. 作成（UNIQUE 違反でレースコンディション対応）
+try {
+    $order = $repo->create($key, ...);
+    return $json->create($order->toArray(), 201);
+} catch (DatabaseConstraintException) {
+    $existing = $repo->findByIdempotencyKey($key);
+    return $json->create($existing->toArray(), 200);
+}
+```
+
+**DX観点:** Stripe や GitHub など有名 API が採用するパターンだが、NENE2 はドキュメント・ヘルパーともに存在しない。「同じリクエストを2回送ったとき最初の結果が返る」という挙動を初心者が自力で設計するのは難しい。
+
+---
+
+### 2. リプレイ時はボディの内容を無視する（設計上の重要な決定）
+
+同一の `Idempotency-Key` で異なるボディ（量・価格変更）を送っても、最初の注文内容が返る。
+
+```
+POST /orders  Idempotency-Key: uuid-123  body: {item: "Widget", quantity: 1, price: 9.99}
+→ 201 Created  {id: 1, quantity: 1, ...}
+
+POST /orders  Idempotency-Key: uuid-123  body: {item: "Widget", quantity: 99, price: 0.01}
+→ 200 OK  {id: 1, quantity: 1, ...}  ← 元の注文が返る
+```
+
+これは意図した設計（キーが一致すれば同一リクエストとみなす）だが、ドキュメントなしでは初心者が「なぜ quantity が変わらないのか」と混乱する可能性がある。
+
+---
+
+### 3. CORS ≠ CSRF 保護（重要な誤解ポイント）（高）
+
+**「NENE2 に CORS の設定があるから CSRF は防げている」は誤り。**
+
+テスト確認:
+- `Origin: https://evil.example.com` を付けたリクエスト → **201 Created**（ブロックされない）
+- `Origin` ヘッダーなしのリクエスト（curl 等）→ **201 Created**（ブロックされない）
+
+NENE2 の `CorsMiddleware` は「ブラウザがレスポンスを読み取れるかどうか」を制御するだけ。攻撃者が `fetch()` や curl で `Origin` ヘッダーを偽装すれば、CORS は突破される。
+
+**JSON API が CSRF に比較的強い理由（設計上の保護）:**
+- `Content-Type: application/json` を要求するリクエストはブラウザの「シンプルリクエスト」にならない
+- プリフライト（OPTIONS）が必要になり、CORS allowlist で制御可能
+- しかし curl や fetch は `Content-Type: application/json` を自由に付けられる
+
+**真の CSRF 保護が必要な場合:**
+1. Bearer JWT（`Authorization` ヘッダー）— Cookie を使わないため CSRF 対象外
+2. `SameSite=Strict` Cookie + Origin ヘッダー検証
+3. アプリ層の Origin 強制ミドルウェア
+
+NENE2 は Bearer JWT 認証を標準提供しており、Cookie を使わない設計なら CSRF は本質的に問題にならない。ただし Cookie ベースの認証を使う場合は別途対策が必要。
+
+**DX観点 (初心者目線):** 「CORS を設定した = CSRF 対策が完了した」という誤解は非常によくある。NENE2 の howto に「JSON API と CSRF のリスクモデル」を明記することで、初心者が誤った安心感を持たずに済む。
+
+---
+
+### 4. `Idempotency-Key` ヘッダー名の大文字小文字（摩擦なし）
+
+PSR-7 はヘッダー名を case-insensitive で扱う。`getHeaderLine('Idempotency-Key')` は `idempotency-key` も `IDEMPOTENCY-KEY` も同じ値を返す。NENE2 の PSR-7 実装（Nyholm）も同様。
+
+---
+
+## Test results
+
+15 tests, 30 assertions — all pass.
+
+Key behaviors confirmed:
+- `Idempotency-Key` なし → 422
+- 同じキーを2回送信 → 1回目 201、2回目 200（同じ order ID）
+- 同じキーで body 変更 → 1回目の内容が保持される
+- 異なるキー → 別々の注文が作成される
+- `Origin: evil.example.com` → **ブロックされない**（CORS ≠ CSRF 保護を文書化）
+- `Origin` なし → ブロックされない（curl 等のアクセスも通る）
+
+---
+
+## Developer Experience (DX) Review
+
+### 初心者・ロースキル観点での実装しやすさ
+
+冪等性の概念自体は難しくないが、NENE2 にヘルパーがないため「どのヘッダーを使うか」「リプレイ時に何を返すか」「レースコンディションをどう扱うか」を全て自分で設計する必要がある。
+
+### 使ってみた印象
+
+`$request->getHeaderLine('Idempotency-Key')` でヘッダーが取れるのは直感的で良い。DB に UNIQUE 制約を付けてレースコンディション対応を `DatabaseConstraintException` でキャッチするパターンも綺麗にはまった。
+
+### 楽しいか・気持ちいいか・快適か
+
+冪等性トークンの動作を「同じキーを2回送ると同じ結果」というテストで確認できるのは面白い。CORS と CSRF の誤解を実験で確認できたのも学びになった。
+
+### 簡単か
+
+冪等性の実装は比較的単純。CSRF の考え方は CORS と混同しやすく、概念の整理が必要。
+
+### また使いたいか
+
+はい。冪等性トークンパターンは NENE2 の JSON API 設計と相性が良い。
+
+### 初心者に勧めたいか
+
+はい、ただし「CORS ≠ CSRF 保護」の誤解を解くドキュメントが必要。状態変更 API には `Idempotency-Key` を推奨するガイドがあれば、初心者でも安全な API を設計できる。
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/idempotency.md` — Idempotency-Key パターンの完全実装例（二重送信防止・リレースコンディション対応）
+- Issue: `docs/howto/csrf-and-json-api.md` — CORS ≠ CSRF 保護の明記・JSON API のリスクモデル・Bearer JWT の CSRF 免疫性

--- a/docs/howto/csrf-and-json-api.md
+++ b/docs/howto/csrf-and-json-api.md
@@ -1,0 +1,102 @@
+# CSRF and JSON APIs
+
+## CORS ≠ CSRF protection
+
+This is one of the most common security misconceptions in web API development.
+
+**CORS** (Cross-Origin Resource Sharing) controls whether a browser will let JavaScript on one origin *read the response* from another origin. The server adds `Access-Control-Allow-Origin` headers; the browser enforces the policy.
+
+**CSRF** (Cross-Site Request Forgery) is an attack where a malicious page tricks the victim's browser into sending a state-changing request to a trusted site — using the victim's session cookies.
+
+NENE2's `CorsMiddleware` handles CORS. It does **not** block requests from unknown origins. A request with `Origin: https://evil.example.com` passes through and reaches your handler unchanged — this is expected behavior. CORS is a browser safeguard that limits what *JavaScript can read*, not what the *server accepts*.
+
+```
+# These all reach your handler — CorsMiddleware does NOT block them
+curl -X POST https://api.example.com/orders \
+  -H "Origin: https://evil.example.com" \
+  -H "Content-Type: application/json" \
+  -d '{"item":"Widget","quantity":1}'
+
+curl -X POST https://api.example.com/orders \
+  -H "Content-Type: application/json" \
+  -d '{"item":"Widget","quantity":1}'
+# (no Origin header — e.g., server-to-server calls)
+```
+
+## Why JSON APIs are more resistant to CSRF than form-based APIs
+
+Classic CSRF exploits HTML forms (`<form method="POST">`). Browsers send form submissions with `Content-Type: application/x-www-form-urlencoded` or `multipart/form-data` — the browser will include session cookies automatically.
+
+A request with `Content-Type: application/json` is **not a "simple request"** under the CORS spec. The browser sends a preflight `OPTIONS` first. If your CORS configuration doesn't list the attacker's origin, the browser blocks the preflight — the actual request never arrives.
+
+However, **this only protects browser-based attacks**. A server or a `fetch()` call with explicit headers can send `Content-Type: application/json` to your API without restriction. CORS preflights are enforced by browsers, not servers.
+
+## The real protection: Bearer JWT
+
+NENE2's standard authentication uses Bearer JWTs in the `Authorization` header:
+
+```
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9...
+```
+
+CSRF attacks work by abusing cookies — the browser attaches them automatically to cross-site requests. The `Authorization` header is **never** sent automatically. A malicious page cannot include a victim's JWT because JavaScript on `https://evil.example.com` cannot read the token from `https://app.example.com`.
+
+If you use Bearer JWT authentication and never put tokens in cookies, you are not vulnerable to CSRF by design. No additional CSRF token or `SameSite` attribute is needed.
+
+## If you use cookie-based sessions
+
+If your application uses `Set-Cookie` for session management (instead of Bearer JWT), you need explicit CSRF protection:
+
+### Option 1: SameSite cookies (simplest)
+
+```php
+Set-Cookie: session=...; SameSite=Strict; Secure; HttpOnly
+```
+
+`SameSite=Strict` prevents the browser from including the cookie on cross-site requests. `SameSite=Lax` is also a reasonable default that still blocks cross-site `POST`.
+
+### Option 2: Origin header validation middleware
+
+Reject requests whose `Origin` doesn't match your allowlist:
+
+```php
+final class OriginEnforcementMiddleware implements MiddlewareInterface
+{
+    /** @param list<string> $allowedOrigins */
+    public function __construct(private readonly array $allowedOrigins) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $origin = $request->getHeaderLine('Origin');
+
+        // Non-browser calls (curl, server-to-server) have no Origin — allow them
+        if ($origin === '') {
+            return $handler->handle($request);
+        }
+
+        if (!in_array($origin, $this->allowedOrigins, strict: true)) {
+            // Return a 403 Problem Details response
+            // ...
+        }
+
+        return $handler->handle($request);
+    }
+}
+```
+
+Register it after CORS in the middleware stack (see CLAUDE.md section 5 for ordering).
+
+### Option 3: CSRF token
+
+Generate a per-session token, store it server-side, include it in forms as a hidden field, and verify it on every state-changing request. This is the traditional approach but adds complexity.
+
+## Summary
+
+| Scenario | CSRF risk | Recommended mitigation |
+|---|---|---|
+| Bearer JWT in `Authorization` header | None — header not sent automatically | No action needed |
+| Cookie session, SameSite=Strict | Very low | Keep `SameSite=Strict` |
+| Cookie session, no SameSite | High | Add `SameSite` or Origin enforcement |
+| API key in custom header | None — custom headers not sent automatically | No action needed |
+
+The simplest path: use NENE2's built-in Bearer JWT authentication and avoid cookie-based sessions for API endpoints.

--- a/docs/howto/idempotency.md
+++ b/docs/howto/idempotency.md
@@ -1,0 +1,131 @@
+# Idempotency-Key Pattern
+
+Prevent duplicate orders or resource creation caused by network retries by requiring clients to supply an `Idempotency-Key` header on every state-changing request.
+
+## Why it matters
+
+When a client sends `POST /orders` and the network drops before it receives a response, it will retry. Without idempotency, that retry creates a second order. With an `Idempotency-Key`, the server can detect the retry and return the original result instead of creating a duplicate.
+
+Stripe, GitHub, and many other production APIs use this exact pattern.
+
+## Database schema
+
+Add a `UNIQUE` constraint on the idempotency key column. This single constraint handles the race condition described below.
+
+```sql
+CREATE TABLE orders (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    idempotency_key  TEXT    NOT NULL UNIQUE,
+    item             TEXT    NOT NULL,
+    quantity         INTEGER NOT NULL,
+    total_price      REAL    NOT NULL,
+    created_at       TEXT    NOT NULL
+);
+```
+
+## Handler implementation
+
+```php
+// 1. Read and validate the header
+$key = trim($request->getHeaderLine('Idempotency-Key'));
+if ($key === '') {
+    return $problems->create(
+        $request,
+        'missing-idempotency-key',
+        'Idempotency-Key header is required for this endpoint.',
+        [],
+        422,
+    );
+}
+
+// 2. Check for an existing entry (replay path)
+$existing = $repo->findByIdempotencyKey($key);
+if ($existing !== null) {
+    return $json->create($existing->toArray(), 200); // replay — return original with 200
+}
+
+// 3. Validate the request body
+$body = json_decode((string) $request->getBody(), true);
+// ... validate fields ...
+
+// 4. Create — UNIQUE constraint handles the race condition
+try {
+    $order = $repo->create($key, $item, $quantity, $totalPrice);
+    return $json->create($order->toArray(), 201);
+} catch (DatabaseConstraintException) {
+    // Another request with the same key won the race — return its result
+    $existing = $repo->findByIdempotencyKey($key);
+    if ($existing !== null) {
+        return $json->create($existing->toArray(), 200);
+    }
+    return $problems->create($request, 'conflict', 'Conflict.', [], 409);
+}
+```
+
+## Repository
+
+```php
+public function findByIdempotencyKey(string $key): ?Order
+{
+    $row = $this->executor->fetchOne(
+        'SELECT * FROM orders WHERE idempotency_key = ?',
+        [$key],
+    );
+    return $row !== null ? Order::fromRow($row) : null;
+}
+
+public function create(string $key, string $item, int $quantity, float $totalPrice): Order
+{
+    // Throws DatabaseConstraintException on UNIQUE violation (race condition)
+    $this->executor->insert(
+        'INSERT INTO orders (idempotency_key, item, quantity, total_price, created_at) VALUES (?, ?, ?, ?, ?)',
+        [$key, $item, $quantity, $totalPrice, (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM)],
+    );
+    // ...
+}
+```
+
+## Key design decisions
+
+### Replay returns 200, not 201
+
+The second request is a replay, not a creation. Using `200 OK` tells the client "you've seen this before" without creating confusion about what was created.
+
+### Replay ignores the body
+
+If the client sends the same `Idempotency-Key` with a different body, the **original** result is returned. The server treats a matching key as proof that the request was already processed, regardless of what the body says.
+
+```
+POST /orders  Idempotency-Key: uuid-abc  body: {quantity: 1, price: 9.99}
+→ 201 Created  {id: 1, quantity: 1}
+
+POST /orders  Idempotency-Key: uuid-abc  body: {quantity: 99, price: 0.01}
+→ 200 OK  {id: 1, quantity: 1}   ← original order, body ignored
+```
+
+This is intentional. If the client wants to create a genuinely different resource, it must use a new key.
+
+### UNIQUE constraint as the race condition guard
+
+Two concurrent requests with the same key will race. The DB's `UNIQUE` constraint ensures only one insert succeeds. The loser catches `DatabaseConstraintException` and fetches the winner's row.
+
+## What clients should use as the key
+
+UUID v4 is the most common choice. The client generates the key before sending the request and stores it locally so it can retry with the same key if needed.
+
+```js
+// Client-side (JavaScript)
+const key = crypto.randomUUID();
+const response = await fetch('/orders', {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json',
+        'Idempotency-Key': key,
+    },
+    body: JSON.stringify({ item: 'Widget', quantity: 1, price: 9.99 }),
+});
+```
+
+## Reading the header
+
+PSR-7 header names are case-insensitive. `getHeaderLine('Idempotency-Key')`, `getHeaderLine('idempotency-key')`, and `getHeaderLine('IDEMPOTENCY-KEY')` all return the same value. NENE2 uses Nyholm/PSR-7 which implements this correctly.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.32
+  version: 1.5.33
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,10 +4,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.31`（2026-05-20 リリース済み）
+- Latest release: `v1.5.33`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
-## Recently Completed (FT ループ — v1.5.27 〜 v1.5.31)
+## Recently Completed (FT ループ — v1.5.27 〜 v1.5.33)
 
 | FT | テーマ | アプリ | テスト | リリース | 主要対応 |
 |---|---|---|---|---|---|
@@ -16,15 +16,17 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT95 | タイムゾーン敏感日付 | schedulelog | 19/19 | v1.5.29 | `QueryStringParser::parse()` 追加・handle-timezones.md |
 | FT96 | コンテントネゴシエーション | contentlog | 16/16 | v1.5.30 | content-negotiation.md（406 を返さない設計を明文化） |
 | FT97 | SQL インジェクション防御 | injectionlog | 19/19 | v1.5.31 | `Router::param()`・`QueryStringParser` デフォルト値引数・sql-injection.md |
+| FT98 | ファイルアップロード | uploadlog | 19/19 | v1.5.32 | file-upload.md（base64 オーバーヘッド・MIME 検出・パストラバーサル） |
+| FT99 | CSRF 的パターン・冪等性 | csrflog | 15/15 | v1.5.33 | idempotency.md・csrf-and-json-api.md（CORS ≠ CSRF 明文化） |
 
 ## 次のアクション
 
-- **FT98** — ファイルアップロード（MIME バリデーション・サイズ制限・パストラバーサルリスク）
+- **FT100** — 大量データ・ページネーション（実データ量でのパフォーマンス・カーソルベース）
   - FT ループが自動スケジュール中（ScheduleWakeup 設定済み）
 
 ## Open Issues
 
-なし（FT97 で起票した #691 / #692 / #693 は v1.5.31 で解消済み）
+なし（FT99 で起票した #699 / #700 は v1.5.33 で解消済み）
 
 ## Operating Notes
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.32';
+    public const string VERSION = '1.5.33';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/idempotency.md` を追加: Idempotency-Key による二重送信防止の完全実装例（FT99 から）
- `docs/howto/csrf-and-json-api.md` を追加: CORS ≠ CSRF 保護の明記・Bearer JWT 免疫性の説明
- `docs/field-trials/2026-05-field-trial-99.md` を追加: FT99 フィールドトライアルレポート
- バージョン 1.5.32 → 1.5.33

## Test plan

- [x] `composer check` — 341 tests, 860 assertions, PHPStan level 8, CS OK, OpenAPI valid, version consistency OK
- [x] FT99 プロジェクト: 15 tests, 30 assertions — all pass

## Self-review

Self-review: docs-policy, release-ci

Closes #699
Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)