### PR TITLE
feat(docs): ネスト JSON バリデーションガイド追加 v1.5.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.35] — 2026-05-21
+
+### Added
+- `docs/howto/nested-json-validation.md` — nested JSON validation guide: dot-notation error paths, collect-all-errors pattern, PHPStan discriminated-union workaround (`@var` annotation), `array_is_list()` usage, JSON numeric type handling. (#704)
+- `docs/field-trials/2026-05-field-trial-101.md` — FT101 report: nestedlog (nested JSON validation with structured error paths). (#704)
+
+---
+
 ## [1.5.34] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-101.md
+++ b/docs/field-trials/2026-05-field-trial-101.md
@@ -1,0 +1,182 @@
+# Field Trial 101 — Nested JSON Input Validation
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/nestedlog/`
+**NENE2 version:** 1.5.34
+**Theme:** ネストした JSON バリデーション — 配列内オブジェクトのバリデーション・ドット記法エラーパス（`items.0.quantity`）・全エラー収集（fail-fast でない）
+
+---
+
+## What was built
+
+注文（Order）に複数の明細（items）を持つ API を実装し、ネストした JSON のバリデーションを検証した。顧客名・明細配列・各明細内の product_id / quantity / unit_price を全て検証し、エラーを `items.0.quantity` のようなドット記法パスで返す。fail-fast ではなく全エラーを一括返却する。
+
+---
+
+## Findings
+
+### 1. NENE2 にネスト JSON バリデーターは存在しない（高）
+
+NENE2 は単純なフラットフィールドのバリデーションには何も提供しておらず、ネストした配列のバリデーションは完全に手実装が必要。
+
+実装した `OrderValidator` の要点:
+
+```php
+// 配列の各要素を index 付きでバリデート
+foreach ($body['items'] as $i => $item) {
+    $prefix = "items.{$i}";
+
+    if (!is_array($item)) {
+        $errors[] = ['field' => $prefix, 'code' => 'must-be-object', ...];
+        continue;
+    }
+
+    if (!isset($item['product_id']) || !is_int($item['product_id'])) {
+        $errors[] = ['field' => "{$prefix}.product_id", 'code' => 'required', ...];
+    } elseif ($item['product_id'] < 1) {
+        $errors[] = ['field' => "{$prefix}.product_id", 'code' => 'min-value', ...];
+    }
+    // ... quantity, unit_price ...
+}
+```
+
+**DX観点:** Symfony Validator や Laravel では `items.*.quantity` のような記法で一行で書けるが、NENE2 では `foreach` + 文字列連結で手書きする。慣れれば予測可能だが、初心者には「エラーパスをどう設計するか」が自明でない。
+
+---
+
+### 2. PHPStan level 8 — 判別共用体の絞り込みが必要（摩擦あり・中）
+
+`OrderValidator::validate()` は成功時と失敗時で異なる shape を返す:
+
+```php
+// 成功: {errors: [], customer: string, note: string, items: list<...>}
+// 失敗: {errors: list<error>}  ← customer/note/items なし
+```
+
+`if ($result['errors'] !== []) { return; }` で早期リターンした後も、PHPStan は `$result['customer']` が存在するか分からない（`offsetAccess.notFound`）。
+
+**修正:** `@var` アノテーションで型を上書きする:
+
+```php
+if ($result['errors'] !== []) {
+    return $this->problems->create(...);
+}
+
+/** @var array{customer: string, note: string, items: list<...>} $valid */
+$valid = $result;
+$order = $this->repo->create($valid['customer'], $valid['note'], $valid['items']);
+```
+
+**DX観点:** PHPStan の型推論は正しいが、この回避パターンを知っていないと詰まる。NENE2 が Validator インターフェースや DTO を提供すれば不要なボイラープレートが消える。
+
+---
+
+### 3. エラーを一括返却するパターン（fail-fast でない）
+
+fail-fast（最初のエラーで即返す）は実装が簡単だが UX が悪い。ユーザーは何度もリクエストを送り直す必要がある。
+
+全エラー収集パターン:
+
+```php
+$errors = [];
+// ... 全フィールドをチェック ...
+if ($errors !== []) {
+    return $this->problems->create(..., ['errors' => $errors]);
+}
+```
+
+NENE2 は `extensions` 配列に `errors` を入れるパターン（Problem Details RFC 9457 準拠）。これで全エラーが一括返却される:
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation failed.",
+  "status": 422,
+  "errors": [
+    {"field": "customer", "code": "required", "message": "Customer name is required."},
+    {"field": "items.0.quantity", "code": "min-value", "message": "items.0.quantity must be ≥ 1."},
+    {"field": "items.1.unit_price", "code": "min-value", "message": "items.1.unit_price must be > 0."}
+  ]
+}
+```
+
+---
+
+### 4. `unit_price` の型 — JSON の数値は int/float 両方（摩擦なし）
+
+JSON の `9.99` は PHP で `float`、`10` は `int` になる。どちらも許容するため `is_int($v) || is_float($v)` でチェックする:
+
+```php
+$rawPrice = $item['unit_price'] ?? null;
+if (!is_int($rawPrice) && !is_float($rawPrice)) {
+    $errors[] = [...]; // 文字列・null・bool はエラー
+}
+```
+
+`0` (int) も `0.0` (float) も「価格なし」としてエラーにする。PHPStan の型推論が `is_int || is_float` パターンを正しく理解するので摩擦なし。
+
+---
+
+### 5. `array_is_list()` (PHP 8.1+) が便利
+
+`$body['items']` が `{"0": ...}` のような連想配列でないことを確認するのに `array_is_list()` が使える:
+
+```php
+} elseif (!is_array($body['items']) || array_is_list($body['items']) === false) {
+    $errors[] = ['field' => 'items', 'code' => 'must-be-array', ...];
+```
+
+PHP 8.1 以降で使えるが、NENE2 が PHP 8.4 要件なので問題なし。
+
+---
+
+## Test results
+
+19 tests, 43 assertions — all pass.
+
+Key behaviors confirmed:
+- 有効な注文が 201 で作成される（複数明細・合計金額計算）
+- GET /orders/{id} で明細付きで取得できる
+- 顧客名: 必須・空白のみ・200字超過
+- items: 必須・空配列
+- items.0.product_id: 整数でない・0以下
+- items.1.product_id: 負の値
+- items.0.quantity: 0・欠損
+- items.0/1.unit_price: 負・欠損・ゼロ
+- 複数アイテムの複数エラーが一括返却される
+- トップレベル + ネストエラーが一括返却される
+- エラーコード (`min-value` 等) が含まれる
+
+---
+
+## Developer Experience (DX) Review
+
+### 初心者・ロースキル観点での実装しやすさ
+
+ネスト JSON バリデーションは概念自体は難しくないが、「エラーパスをどう設計するか」「fail-fast か全収集か」「型チェックをどう書くか」を全て自分で決める必要がある。NENE2 にガイドラインがなく、初心者は各自で異なる実装をする可能性が高い。
+
+### 使ってみた印象
+
+`foreach` + `$prefix = "items.{$i}"` のパターンは直感的で書きやすい。Problem Details の `extensions` に `errors` 配列を入れるのも一貫性があって良い。
+
+### 楽しいか・気持ちいいか・快適か
+
+「同じエラーフォーマットで複数階層のフィールドが返せる」のは気持ちいい。`items.0.product_id` のようなパスをテストで確認するのも明確で楽しい。
+
+### 簡単か
+
+フラットなバリデーションより複雑だが、パターン化されているので慣れれば速い。PHPStan の判別共用体エラーでは詰まった。
+
+### また使いたいか
+
+はい。このパターンをコピーして使い回せる。
+
+### 初心者に勧めたいか
+
+はい、ただし「エラーパス設計」と「全エラー収集パターン」のサンプルコードが必要。判別共用体の PHPStan 回避パターン（`@var` アノテーション）も文書化が必要。
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/nested-json-validation.md` — ネスト JSON バリデーションガイド: エラーパスのドット記法・fail-fast vs 全収集・PHPStan の判別共用体絞り込み・unit_price の型チェック

--- a/docs/howto/nested-json-validation.md
+++ b/docs/howto/nested-json-validation.md
@@ -1,0 +1,208 @@
+# Nested JSON Validation
+
+NENE2 does not include a recursive validator. When a request body contains arrays of objects — for example, an order with line items — you validate it yourself with a `foreach` loop and accumulate errors in a structured list.
+
+## Error path convention
+
+Use dot notation with 0-based integer indexes for array elements:
+
+| Path | Meaning |
+|---|---|
+| `customer` | Top-level field |
+| `items` | The array itself (e.g., missing or empty) |
+| `items.0.quantity` | `quantity` in the first item |
+| `items.2.unit_price` | `unit_price` in the third item |
+
+This format is readable, easy to generate, and easy for clients to map back to their form fields.
+
+## Validator class
+
+Put all validation logic in a dedicated class. Keep the route handler thin — it only calls the validator and maps the result to a response.
+
+```php
+final class OrderValidator
+{
+    /**
+     * @param mixed $body
+     * @return array{errors: list<array{field: string, code: string, message: string}>}
+     *       | array{errors: list<array{field: string, code: string, message: string}>, customer: string, note: string, items: list<array{product_id: int, quantity: int, unit_price: float}>}
+     */
+    public function validate(mixed $body): array
+    {
+        if (!is_array($body)) {
+            return ['errors' => [['field' => '', 'code' => 'invalid-body', 'message' => 'Request body must be a JSON object.']]];
+        }
+
+        $errors = [];
+
+        // --- top-level ---
+        $customer = isset($body['customer']) && is_string($body['customer']) ? trim($body['customer']) : '';
+        if ($customer === '') {
+            $errors[] = ['field' => 'customer', 'code' => 'required', 'message' => 'Customer name is required.'];
+        } elseif (strlen($customer) > 200) {
+            $errors[] = ['field' => 'customer', 'code' => 'too-long', 'message' => 'Customer name must not exceed 200 characters.'];
+        }
+
+        // --- items array ---
+        if (!isset($body['items'])) {
+            $errors[] = ['field' => 'items', 'code' => 'required', 'message' => 'items is required.'];
+        } elseif (!is_array($body['items']) || !array_is_list($body['items'])) {
+            $errors[] = ['field' => 'items', 'code' => 'must-be-array', 'message' => 'items must be an array.'];
+        } elseif (count($body['items']) === 0) {
+            $errors[] = ['field' => 'items', 'code' => 'min-items', 'message' => 'Order must contain at least one item.'];
+        } elseif (count($body['items']) > 50) {
+            $errors[] = ['field' => 'items', 'code' => 'max-items', 'message' => 'Order may not contain more than 50 items.'];
+        } else {
+            // --- per-item validation ---
+            foreach ($body['items'] as $i => $item) {
+                $prefix = "items.{$i}"; // dot-notation path prefix
+
+                if (!is_array($item)) {
+                    $errors[] = ['field' => $prefix, 'code' => 'must-be-object', 'message' => "{$prefix} must be an object."];
+                    continue; // skip field checks — no point if the item itself is wrong
+                }
+
+                // product_id: required integer ≥ 1
+                if (!isset($item['product_id']) || !is_int($item['product_id'])) {
+                    $errors[] = ['field' => "{$prefix}.product_id", 'code' => 'required', 'message' => "{$prefix}.product_id must be an integer."];
+                } elseif ($item['product_id'] < 1) {
+                    $errors[] = ['field' => "{$prefix}.product_id", 'code' => 'min-value', 'message' => "{$prefix}.product_id must be ≥ 1."];
+                }
+
+                // quantity: required integer 1–9999
+                if (!isset($item['quantity']) || !is_int($item['quantity'])) {
+                    $errors[] = ['field' => "{$prefix}.quantity", 'code' => 'required', 'message' => "{$prefix}.quantity must be an integer."];
+                } elseif ($item['quantity'] < 1) {
+                    $errors[] = ['field' => "{$prefix}.quantity", 'code' => 'min-value', 'message' => "{$prefix}.quantity must be ≥ 1."];
+                } elseif ($item['quantity'] > 9999) {
+                    $errors[] = ['field' => "{$prefix}.quantity", 'code' => 'max-value', 'message' => "{$prefix}.quantity must be ≤ 9999."];
+                }
+
+                // unit_price: required number > 0 (JSON gives int OR float)
+                $rawPrice = $item['unit_price'] ?? null;
+                if (!is_int($rawPrice) && !is_float($rawPrice)) {
+                    $errors[] = ['field' => "{$prefix}.unit_price", 'code' => 'required', 'message' => "{$prefix}.unit_price must be a number."];
+                } elseif ($rawPrice <= 0) {
+                    $errors[] = ['field' => "{$prefix}.unit_price", 'code' => 'min-value', 'message' => "{$prefix}.unit_price must be > 0."];
+                }
+            }
+        }
+
+        if ($errors !== []) {
+            return ['errors' => $errors];
+        }
+
+        return [
+            'errors'   => [],
+            'customer' => $customer,
+            'note'     => isset($body['note']) && is_string($body['note']) ? trim($body['note']) : '',
+            'items'    => array_map(
+                static fn (array $item) => [
+                    'product_id' => (int) $item['product_id'],
+                    'quantity'   => (int) $item['quantity'],
+                    'unit_price' => (float) ($item['unit_price'] ?? 0),
+                ],
+                (array) $body['items'],
+            ),
+        ];
+    }
+}
+```
+
+## Route handler
+
+```php
+private function createOrder(ServerRequestInterface $request): ResponseInterface
+{
+    $body   = json_decode((string) $request->getBody(), true);
+    $result = $this->validator->validate($body);
+
+    if ($result['errors'] !== []) {
+        return $this->problems->create(
+            $request,
+            'validation-failed',
+            'Validation failed.',
+            422,
+            null,
+            ['errors' => $result['errors']],
+        );
+    }
+
+    // PHPStan level 8: the union type doesn't narrow automatically after the early return.
+    // Use a @var annotation to tell PHPStan which shape remains.
+    /** @var array{customer: string, note: string, items: list<array{product_id: int, quantity: int, unit_price: float}>} $valid */
+    $valid = $result;
+    $order = $this->repo->create($valid['customer'], $valid['note'], $valid['items']);
+    return $this->json->create($order->toArray(), 201);
+}
+```
+
+## Error response shape
+
+All errors are collected before returning — clients get everything wrong in a single response:
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "title": "Validation failed.",
+  "status": 422,
+  "instance": "/orders",
+  "errors": [
+    {
+      "field": "customer",
+      "code": "required",
+      "message": "Customer name is required."
+    },
+    {
+      "field": "items.0.quantity",
+      "code": "min-value",
+      "message": "items.0.quantity must be ≥ 1."
+    },
+    {
+      "field": "items.2.unit_price",
+      "code": "required",
+      "message": "items.2.unit_price must be a number."
+    }
+  ]
+}
+```
+
+## Design decisions
+
+### Collect all errors, not fail-fast
+
+Fail-fast (return on the first error) is simpler to implement but forces clients to iterate: fix one error, submit, discover the next, and so on. Collecting all errors in a single pass means one round-trip for the client to fix everything.
+
+The tradeoff: if item `0` itself is not an object, skip the field checks for that item with `continue` — there is nothing useful to report inside a non-object.
+
+### Numeric keys in paths
+
+Use `0`-based integer indexes matching the array position: `items.0`, `items.1`. Avoid brackets (`items[0]`) — dot notation is simpler to generate and parse, and many client-side validation libraries support it.
+
+### PHPStan and discriminated unions
+
+When a function returns a union of shapes (one with extra keys on success, one without on error), PHPStan level 8 does not automatically narrow after an early return. Use a `@var` annotation at the call site to assert the narrower type:
+
+```php
+/** @var array{customer: string, ...} $valid */
+$valid = $result;
+```
+
+This is the recommended workaround until PHPStan adds full control-flow narrowing for array shapes.
+
+### `array_is_list()` vs `is_array()`
+
+`is_array()` alone accepts `{"0": "x", "1": "y"}` — a JSON object with numeric string keys — as an array. `array_is_list()` additionally requires 0-based sequential integer keys, rejecting associative arrays disguised as lists.
+
+### Numeric types in JSON
+
+JSON has one number type. PHP's `json_decode` maps integers to `int` and decimals to `float`. To accept both for a price field:
+
+```php
+$rawPrice = $item['unit_price'] ?? null;
+if (!is_int($rawPrice) && !is_float($rawPrice)) {
+    // reject strings, booleans, null
+}
+```
+
+Never use `is_numeric()` here — it accepts `"9.99"` (a string), which would pass but is semantically wrong.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.34
+  version: 1.5.35
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,21 +4,20 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.34`（2026-05-21 リリース済み）
+- Latest release: `v1.5.35`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
-## Recently Completed (FT ループ — v1.5.27 〜 v1.5.34)
+## Recently Completed (FT ループ — v1.5.27 〜 v1.5.35)
 
 | FT | テーマ | アプリ | テスト | リリース | 主要対応 |
 |---|---|---|---|---|---|
-| FT93 | Unicode / 絵文字入力 | unicodelog | 22/22 | v1.5.27 | `JSON_UNESCAPED_UNICODE` 追加・validate-unicode-input.md |
-| FT94 | JWT 認証エッジケース | authlog | 18/18 | v1.5.28 | `authMiddleware` 命名 howto・`exp` 推奨明記 |
 | FT95 | タイムゾーン敏感日付 | schedulelog | 19/19 | v1.5.29 | `QueryStringParser::parse()` 追加・handle-timezones.md |
 | FT96 | コンテントネゴシエーション | contentlog | 16/16 | v1.5.30 | content-negotiation.md（406 を返さない設計を明文化） |
 | FT97 | SQL インジェクション防御 | injectionlog | 19/19 | v1.5.31 | `Router::param()`・`QueryStringParser` デフォルト値引数・sql-injection.md |
 | FT98 | ファイルアップロード | uploadlog | 19/19 | v1.5.32 | file-upload.md（base64 オーバーヘッド・MIME 検出・パストラバーサル） |
 | FT99 | CSRF 的パターン・冪等性 | csrflog | 15/15 | v1.5.33 | idempotency.md・csrf-and-json-api.md（CORS ≠ CSRF 明文化） |
 | FT100 | OFFSET vs カーソルページネーション | pagelog | 15/15 | v1.5.34 | pagination.md（fetch+1・パフォーマンス比較・選択基準） |
+| FT101 | ネスト JSON バリデーション | nestedlog | 19/19 | v1.5.35 | nested-json-validation.md（ドット記法・全収集・PHPStan 判別共用体） |
 
 ## 次のアクション
 
@@ -26,7 +25,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Open Issues
 
-なし（FT100 で起票した #702 は v1.5.34 で解消済み）
+なし（FT101 で起票した #704 は v1.5.35 で解消済み）
 
 ## Operating Notes
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.34';
+    public const string VERSION = '1.5.35';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/nested-json-validation.md` を追加: ドット記法エラーパス・全エラー収集・PHPStan 判別共用体回避・array_is_list() 活用・JSON 数値型処理
- `docs/field-trials/2026-05-field-trial-101.md` を追加: FT101 レポート
- バージョン 1.5.34 → 1.5.35

## Test plan

- [x] `composer check` — 341 tests, 860 assertions, PHPStan level 8, CS OK, OpenAPI valid, version consistency OK
- [x] FT101 プロジェクト: 19 tests, 43 assertions — all pass

## Self-review

Self-review: docs-policy, release-ci

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)