### PR TITLE
docs(howto): transactional() スコープ罠・pre-validation パターンの howto 追加 (#706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.36] — 2026-05-21
+
+### Added
+- `docs/howto/transactions.md` — `DatabaseTransactionManagerInterface::transactional()` guide: correct callback-scoped executor pattern, injected-repository trap (silent rollback failure), pre-validation + atomic operation pattern, rollback testing, Laravel vs NENE2 connection model comparison. (#706)
+- `docs/field-trials/2026-05-field-trial-102.md` — FT102 report: txlog (database transaction boundaries, rollback correctness, 6-persona DX review). (#706)
+
+---
+
 ## [1.5.35] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-102.md
+++ b/docs/field-trials/2026-05-field-trial-102.md
@@ -1,0 +1,209 @@
+# Field Trial 102 — Database Transaction Boundaries (txlog)
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/txlog/`
+**NENE2 version:** 1.5.35
+**Theme:** データベーストランザクション境界 — `DatabaseTransactionManagerInterface::transactional()` を使った原子的な在庫減算 + 注文作成。ロールバック正確性と「インジェクト済みリポジトリ」の罠を検証。
+
+---
+
+## What was built
+
+注文が在庫を原子的に減算する API を実装した。複数商品の注文で1つでも在庫不足があれば、それまでの全減算がロールバックされる。`DatabaseTransactionManagerInterface::transactional()` の正しい使い方と、初心者が踏みやすい罠（コールバック外でインジェクトされたリポジトリはトランザクション外で動く）を検証した。
+
+---
+
+## Findings
+
+### 1. `transactional()` のコールバックスコープルール — 最重要の罠（高）
+
+`DatabaseTransactionManagerInterface::transactional()` の PHPDoc に重要な注意書きがある:
+
+> Repositories injected at construction time use a different connection and execute outside the transaction — rollbacks will not undo their changes.
+
+**正しいパターン（コールバック内でリポジトリをインスタンス化）:**
+
+```php
+public function placeOrder(array $items): int
+{
+    return $this->tx->transactional(function ($executor) use ($items): int {
+        // コールバック内で $executor を使ってリポジトリを作る — これがトランザクション境界内
+        $inventory = new InventoryRepository($executor);
+        $orders    = new OrderRepository($executor);
+
+        foreach ($items as $item) {
+            $inventory->decrement($item['product_id'], $item['quantity']); // 例外 → ロールバック
+        }
+        return $orders->create($items);
+    });
+}
+```
+
+**誤ったパターン（コンストラクタでインジェクトしたリポジトリをコールバック内で使う）:**
+
+```php
+// ❌ これはロールバックされない
+public function __construct(
+    private readonly InventoryRepository $inventory,  // 別コネクション
+    private readonly OrderRepository $orders,         // 別コネクション
+    private readonly DatabaseTransactionManagerInterface $tx,
+) {}
+
+public function placeOrder(array $items): int
+{
+    return $this->tx->transactional(function ($executor) use ($items): int {
+        foreach ($items as $item) {
+            $this->inventory->decrement(...); // ← 別コネクション、トランザクション外！
+        }
+        return $this->orders->create($items); // ← 同じく外
+        // 例外が発生しても $this->inventory の変更は戻らない
+    });
+}
+```
+
+**DX観点:** PHPDoc に書いてあるが、初心者は DI コンテナで全てをインジェクトするのが「正しい設計」と思い込む。この罠を踏むと「トランザクション使ったのに在庫が戻らない」という謎のバグになる。
+
+---
+
+### 2. ロールバック正確性の確認（摩擦なし）
+
+「最後のアイテムが在庫不足」のケースで、先に処理した商品の在庫がロールバックされることをテストで確認:
+
+```php
+$this->inventory->seed(1, 'Widget', 10);
+$this->inventory->seed(2, 'Gadget', 1);
+
+// Widget の減算は成功するが、Gadget が在庫不足で例外 → 全ロールバック
+$res = $this->post('/orders', ['items' => [
+    ['product_id' => 1, 'quantity' => 3],   // 成功するはずだった
+    ['product_id' => 2, 'quantity' => 5],   // 在庫1しかない → 例外
+]]);
+
+assertSame(422, $res->getStatusCode());
+assertSame(10, $this->inventory->getStock(1)); // Widget は元の10のまま ← ロールバック確認
+assertSame(0, $this->orders->count());          // 注文も作成されていない
+```
+
+NENE2 の `transactional()` は `Throwable` をキャッチしてロールバック後に rethrow するので、正しいパターンで使えばロールバックは確実。
+
+---
+
+### 3. SQLite の CHECK 制約 vs アプリ層チェック
+
+スキーマに `stock INTEGER NOT NULL CHECK (stock >= 0)` を設定。アプリ層でも在庫チェックをしているが、DB レベルの制約が二重安全網になる。
+
+```sql
+CREATE TABLE inventory (
+    product_id   INTEGER PRIMARY KEY,
+    stock        INTEGER NOT NULL CHECK (stock >= 0)
+);
+```
+
+アプリ層で先にチェックしているため、通常は CHECK 制約は発火しない。ただし並行リクエストでのレースコンディション（チェック後に別トランザクションが減算）では CHECK 制約が最後の防壁になる。今回の FT は SQLite 単一接続なので並行性は検証対象外。
+
+---
+
+### 4. `PdoDatabaseTransactionManager` の可視性（摩擦あり・低）
+
+`PdoDatabaseTransactionManager` クラスに `@internal` タグがついている。インターフェースは公開 API だが、実装クラスを直接テストコードで `new PdoDatabaseTransactionManager($factory)` とインスタンス化するのは内部実装に依存することになる。
+
+FT では直接インスタンス化を使ったが、本番コードでは DI コンテナ経由でインターフェースを受け取るのが正しい。
+
+---
+
+## Test results
+
+11 tests, 25 assertions — all pass.
+
+Key behaviors confirmed:
+- 成功注文: 全商品の在庫が正確に減算される
+- 最後のアイテムが在庫不足 → 全ロールバック (Widget 在庫が元の値に戻る)
+- 最初のアイテムが在庫不足 → 即ロールバック (後続商品も変化なし)
+- 無関係な商品の在庫は影響を受けない
+- 連続した複数注文は正しく蓄積される
+- 在庫ちょうど注文（境界値）
+- 在庫+1の注文は拒否（境界値）
+- バリデーションエラー（items なし・構造不正・quantity = 0）
+
+---
+
+## Developer Experience (DX) Review
+
+### ペルソナ1: 初心者（プログラミング歴1.5年・PHP 独学・女性・バックエンド志望）
+
+ドキュメントを読みながら実装する段階。DI の概念は理解しているが「なぜコールバック内でリポジトリを new するのか」が腑に落ちない可能性が高い。
+
+**ドキュメント理解:** `transactional()` のシグネチャとコメントを読んで理解できるかは怪しい。「別コネクション」という概念は DB の内部に踏み込んだ知識が必要で、初心者には抽象度が高い。サンプルコードで「こう書くと動かない」「こう書けば動く」を並べて見せれば理解できる。
+
+**事故リスク:** 高い。インジェクトしたリポジトリをコールバック内で使うのが「普通の DI の使い方」に見えるため、罠にはまりやすい。ロールバックが効いていないバグはテストで再現しにくく（単体テストでは検出不能）、発見が遅れる。
+
+**規約の使いやすさ:** `transactional()` のコールバック引数 `$executor` から自分でリポジトリを new するパターンは、一度理解すれば機械的に書けるが、最初に「なぜ？」を解決するまでが険しい。
+
+---
+
+### ペルソナ2: ロースキル経験者（PHP 歴4年・受託 Web 開発・男性・SES）
+
+既存プロジェクトのコードをコピーして使うスタイル。DI コンテナに慣れているが深くは理解していない。
+
+**コピペ可能性:** howto にサンプルコードがあれば `OrderService` のパターンをそのままコピーして使える。ただし「このプロジェクトではコールバックに書いてあるから」という理由でコピーするため、why を理解していない。次回新機能を足すとき（例：メールを送る処理を足す）に誤ったパターンで拡張する危険性がある。
+
+**セキュリティ的な罠:** 直接的なセキュリティリスクではないが、「在庫が二重減算される」「注文が作成されたのに在庫が戻らない」という金銭的な事故につながりうる。EC サイトで踏むと深刻。
+
+**事故リスク:** 中。コピペで正しく書けても、後から「外側にあったからここに書いても同じだろう」と`$this->repo->...`に変えてしまう可能性がある。
+
+---
+
+### ペルソナ3: フロントエンド寄り経験者（React/TS 歴4年・フルスタック転向中・ノンバイナリ）
+
+API クライアントとして使う側でもあり、API のエラーレスポンスの質を気にする。
+
+**エラーレスポンスの質:** 在庫不足の `422 insufficient-stock` は Problem Details 形式で返るため、フロントから `error.type` で分岐できる。`detail` に「どの商品の在庫が何個不足しているか」が入るのも良い。ただし複数商品が同時に不足している場合、最初に失敗した商品しか報告されない（fail-fast になっている）。全商品の在庫不足を一括チェックするパターンのほうがフロントの UX は良い。
+
+**PHP 固有の学習コスト:** `transactional()` のコールバックスコープは JavaScript の Promise チェーンに近い感覚で理解できる。ただし「PDO コネクション」という概念はフロントエンド出身者には馴染みが薄い。
+
+---
+
+### ペルソナ4: バックエンド経験者（Laravel 歴6年・男性・リードエンジニア）
+
+Laravel の `DB::transaction()` と比較しながら NENE2 を評価する。
+
+**他フレームワークとの差異:**
+Laravel では `DB::transaction(function () { $this->inventoryRepo->decrement(...); })` のようにインジェクト済みモデルをそのまま使える。NENE2 では「コールバック内でリポジトリを new する」という違いがある。Laravel は内部でコネクションを共有しているため機能するが、NENE2 の `PdoConnectionFactory` はリクエストごとに新しいコネクションを返す設計（テストでも毎回インスタンス化）のため、コールバック内での new が必要になる。
+
+この差異を知らずに Laravel 感覚で実装するとサイレントに壊れる。PHPStan でも検出できない（型エラーではなく設計上の罠）。
+
+**NENE2 の薄さ評価:** `transactional()` のシンプルな API は好ましい。ただしコールバックの「スコープルール」のドキュメントが interface のコメントだけでは発見しにくい。howto があれば許容範囲。
+
+---
+
+### ペルソナ5: シニアエンジニア（設計・コードレビュー担当・女性・12年）
+
+チームで NENE2 を使う場合のリスクを評価する。
+
+**セキュリティ事故リスク:** トランザクション外での在庫更新は金銭的損害に直結する（EC サイトでの在庫マイナス・重複注文）。「動くけど間違っている」コードが混入するリスクが高い。コードレビューで毎回チェックするより、`transactional()` が自動でスコープを強制するような API 設計（例: リポジトリファクトリをコールバック引数として渡す）のほうが安全。
+
+**スケール時の問題:** 単一 SQLite コネクションでは問題が顕在化しにくいが、MySQL/PostgreSQL でコネクションプールを使う環境では「どのコネクションのトランザクションか」が更に重要になる。
+
+**チームでの安全な共有:** パターンが一度確立されれば linter や PHPStan でガードするルールを追加できる。しかし NENE2 のデフォルト tooling ではルール追加が必要（カスタム PHPStan ルール等）。howto + コードテンプレートで補うのが現実的。
+
+---
+
+### ペルソナ6: 設計者・ポリシー照合（NENE2 設計ポリシー目線）
+
+**ポリシー整合:**
+- `DatabaseTransactionManagerInterface` は公開 API（ADR 0009 対象）として正しく設計されている
+- `PdoDatabaseTransactionManager` が `@internal` なのは適切
+- CLAUDE.md の「フレームワークマジックでコントロールフローを隠さない」方針と整合: transactional() のスコープルールは明示的だが、**明示性が高すぎて罠になっている**
+
+**「初心者でも安全な API が設計できるか」達成度:** 低〜中。`transactional()` の API 自体はシンプルだが、スコープルールが interface コメントにしか書かれていない。howto で補えば中程度まで上がる。
+
+**設計上の負債・ギャップ:**
+1. コールバック内でリポジトリを new する必要があるため、単一責任が崩れやすい（サービスがリポジトリの具体クラスを知る必要がある）
+2. `transactional()` を呼ぶ前に全在庫を事前チェックして fail-fast する「pre-validation + atomic decrement」パターンのほうが UX が良い（今回の実装は fail-fast だが複数アイテムの全エラー収集ではない）
+3. howto: `docs/howto/transactions.md` — スコープルールの罠・正しいパターン・pre-validation パターンを追加すべき
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/transactions.md` — `transactional()` の正しい使い方・スコープルールの罠（インジェクトリポジトリはトランザクション外）・pre-validation + atomic operation パターン

--- a/docs/howto/transactions.md
+++ b/docs/howto/transactions.md
@@ -1,0 +1,151 @@
+# Database Transactions
+
+Use `DatabaseTransactionManagerInterface::transactional()` for atomic multi-step operations.
+If any step throws, all changes in the callback are rolled back automatically.
+
+## The Critical Rule: Instantiate Repositories Inside the Callback
+
+> **Warning:** Repositories injected at construction time use a *different* PDO connection and execute **outside the transaction**. Rollbacks will not undo their changes.
+
+`PdoConnectionFactory` creates a new connection each time it is called. When `transactional()` opens a transaction, it opens it on a *new* connection. Any repository that was created before this call (e.g., injected via constructor DI) holds a different connection — one that is not part of the transaction.
+
+### Correct pattern
+
+```php
+final class OrderService
+{
+    public function __construct(
+        private readonly DatabaseTransactionManagerInterface $tx,
+    ) {}
+
+    public function placeOrder(array $items): int
+    {
+        return $this->tx->transactional(function ($executor) use ($items): int {
+            // ✅ Instantiate repositories INSIDE the callback with the tx-scoped executor
+            $inventory = new InventoryRepository($executor);
+            $orders    = new OrderRepository($executor);
+
+            foreach ($items as $item) {
+                // throws InsufficientStockException → rollback triggered automatically
+                $inventory->decrement($item['product_id'], $item['quantity']);
+            }
+
+            return $orders->create($items);
+        });
+    }
+}
+```
+
+### Wrong pattern (changes NOT rolled back)
+
+```php
+// ❌ These repos hold a different connection — not part of the transaction
+public function __construct(
+    private readonly InventoryRepository $inventory,
+    private readonly OrderRepository $orders,
+    private readonly DatabaseTransactionManagerInterface $tx,
+) {}
+
+public function placeOrder(array $items): int
+{
+    return $this->tx->transactional(function ($executor) use ($items): int {
+        foreach ($items as $item) {
+            $this->inventory->decrement(...); // ← different connection, outside transaction!
+        }
+        return $this->orders->create($items); // ← same problem
+        // If an exception is thrown, $this->inventory changes are NOT undone
+    });
+}
+```
+
+This is a silent failure: the code compiles, PHPStan cannot detect it, and tests may pass unless they specifically verify rollback behavior.
+
+---
+
+## Rollback Behavior
+
+`transactional()` catches `Throwable`, rolls back, then re-throws. The caller receives the original exception.
+
+```php
+try {
+    $this->orderService->placeOrder($items);
+} catch (InsufficientStockException $e) {
+    // All inventory decrements from this call are undone
+    // No order was created
+}
+```
+
+---
+
+## Pre-Validation + Atomic Operation Pattern
+
+The fail-fast pattern above stops at the first out-of-stock item, leaving the client unaware of other failures.
+When UX matters, collect all errors first, then execute atomically:
+
+```php
+public function placeOrder(array $items): int
+{
+    // Phase 1: validate all items outside the transaction (read-only)
+    $errors = [];
+    foreach ($items as $item) {
+        $stock = $this->getStockSnapshot($item['product_id']);
+        if ($stock < $item['quantity']) {
+            $errors[] = [
+                'product_id' => $item['product_id'],
+                'requested'  => $item['quantity'],
+                'available'  => $stock,
+            ];
+        }
+    }
+
+    if ($errors !== []) {
+        throw new InsufficientStockException($errors);
+    }
+
+    // Phase 2: atomic decrement — still use the tx-scoped executor inside
+    return $this->tx->transactional(function ($executor) use ($items): int {
+        $inventory = new InventoryRepository($executor);
+        $orders    = new OrderRepository($executor);
+
+        foreach ($items as $item) {
+            // DB CHECK constraint is the final safety net for races
+            $inventory->decrement($item['product_id'], $item['quantity']);
+        }
+
+        return $orders->create($items);
+    });
+}
+```
+
+**Trade-offs:**
+- The read in Phase 1 is not part of the transaction, so a concurrent request may deplete stock between Phase 1 and Phase 2. The database `CHECK (stock >= 0)` constraint (or `decrement()` throwing on negative stock) catches this race.
+- For most applications this is acceptable. For strict correctness, use `SELECT ... FOR UPDATE` or a serializable isolation level (not available in SQLite).
+
+---
+
+## Testing Rollback Correctness
+
+Always verify that inventory is unchanged after a failed order:
+
+```php
+$this->inventory->seed(1, 'Widget', 10);
+$this->inventory->seed(2, 'Gadget', 1);
+
+// Widget decrement would succeed, but Gadget fails → both must roll back
+$res = $this->post('/orders', ['items' => [
+    ['product_id' => 1, 'quantity' => 3],
+    ['product_id' => 2, 'quantity' => 5], // only 1 in stock
+]]);
+
+assertSame(422, $res->getStatusCode());
+assertSame(10, $this->inventory->getStock(1), 'Widget must be rolled back to 10');
+assertSame(0, $this->orders->count(), 'No order created');
+```
+
+Unit tests that mock repositories cannot catch this class of bug — only integration tests that share the same SQLite/MySQL connection can verify rollback correctness.
+
+---
+
+## Laravel vs NENE2
+
+Laravel's `DB::transaction()` works with injected models because it transparently shares one connection across the request. NENE2's `PdoConnectionFactory` returns a new connection on each call — a deliberate design choice for testability and explicit connection control. The consequence is that the callback-scoped executor pattern is **required** in NENE2.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.35
+  version: 1.5.36
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,20 +4,20 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.35`（2026-05-21 リリース済み）
+- Latest release: `v1.5.36`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
-## Recently Completed (FT ループ — v1.5.27 〜 v1.5.35)
+## Recently Completed (FT ループ — v1.5.27 〜 v1.5.36)
 
 | FT | テーマ | アプリ | テスト | リリース | 主要対応 |
 |---|---|---|---|---|---|
-| FT95 | タイムゾーン敏感日付 | schedulelog | 19/19 | v1.5.29 | `QueryStringParser::parse()` 追加・handle-timezones.md |
 | FT96 | コンテントネゴシエーション | contentlog | 16/16 | v1.5.30 | content-negotiation.md（406 を返さない設計を明文化） |
 | FT97 | SQL インジェクション防御 | injectionlog | 19/19 | v1.5.31 | `Router::param()`・`QueryStringParser` デフォルト値引数・sql-injection.md |
 | FT98 | ファイルアップロード | uploadlog | 19/19 | v1.5.32 | file-upload.md（base64 オーバーヘッド・MIME 検出・パストラバーサル） |
 | FT99 | CSRF 的パターン・冪等性 | csrflog | 15/15 | v1.5.33 | idempotency.md・csrf-and-json-api.md（CORS ≠ CSRF 明文化） |
 | FT100 | OFFSET vs カーソルページネーション | pagelog | 15/15 | v1.5.34 | pagination.md（fetch+1・パフォーマンス比較・選択基準） |
 | FT101 | ネスト JSON バリデーション | nestedlog | 19/19 | v1.5.35 | nested-json-validation.md（ドット記法・全収集・PHPStan 判別共用体） |
+| FT102 | DBトランザクション境界 | txlog | 11/11 | v1.5.36 | transactions.md（コールバック外インジェクト罠・pre-validation パターン） |
 
 ## 次のアクション
 
@@ -25,7 +25,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Open Issues
 
-なし（FT101 で起票した #704 は v1.5.35 で解消済み）
+なし（FT102 で起票した #706 は v1.5.36 で解消済み）
 
 ## Operating Notes
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.35';
+    public const string VERSION = '1.5.36';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/transactions.md` 新規追加 — `DatabaseTransactionManagerInterface::transactional()` の正しい使い方
- `docs/field-trials/2026-05-field-trial-102.md` — FT102 レポート（DB トランザクション境界、6ペルソナ DX レビュー）
- version 1.5.35 → 1.5.36

## 変更点

**transactions.md の内容:**
- コールバック内で `$executor` を渡してリポジトリをインスタンス化する正しいパターン
- コンストラクタインジェクト済みリポジトリがトランザクション外になる罠（ロールバックされない・PHPStan 検出不能）
- pre-validation + atomic operation パターン（全在庫を先にチェック → フロント UX 改善）
- ロールバック正確性テストのサンプルコード
- Laravel `DB::transaction()` との接続モデルの差異解説

## 検証結果

- PHPStan level 8: OK（0 errors, 195 files）
- PHP-CS-Fixer: 0 files to fix
- OpenAPI contract: valid
- MCP tool catalog: valid
- Version consistency: 1.5.36 OK

## 関連

Closes #706

Self-review: docs-policy