### PR TITLE
docs(howto): マスアサインメント防御 DTO ホワイトリストパターン howto 追加 (#708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.37] — 2026-05-21
+
+### Added
+- `docs/howto/mass-assignment.md` — mass assignment defence guide: explicit DTO whitelist pattern, attack scenarios (role escalation, is_active tampering, id/timestamp forgery), response field control, trusted-internal-service DTO pattern, `create()` vs `createList()` distinction, code review checklist. (#708)
+- `docs/field-trials/2026-05-field-trial-103.md` — FT103 report: masslog (mass assignment defence, 14 tests, 39 assertions, 6-persona DX review). (#708)
+
+---
+
 ## [1.5.36] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-103.md
+++ b/docs/field-trials/2026-05-field-trial-103.md
@@ -1,0 +1,218 @@
+# Field Trial 103 — Mass Assignment Defence (masslog)
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/masslog/`
+**NENE2 version:** 1.5.36
+**Theme:** マスアサインメント防御 — ユーザー登録 API で `role=admin` や `is_active=false` をリクエストボディに混入されても永続化されないことを、明示的 DTO ホワイトリストパターンで保証する。
+
+---
+
+## What was built
+
+ユーザー登録・一覧取得 API を実装した。攻撃者がリクエストボディに `role`, `is_active`, `id`, `created_at` などのフィールドを混入しても、サーバー側の DTO（`CreateUserInput`）が `name` と `email` のみを受け取るため、権限昇格やデータ改ざんが起きないことを確認した。
+
+---
+
+## Findings
+
+### 1. 明示的 DTO がマスアサインメント防御の核心（摩擦なし）
+
+```php
+// ✅ CreateUserInput は name と email しか持たない
+final readonly class CreateUserInput
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+    ) {}
+}
+```
+
+コントローラーで `$body` 全体を渡さず、ホワイトリストされたフィールドだけを DTO に詰める:
+
+```php
+// role・is_active は明示的に除外 — extra fields are silently ignored
+$input = new CreateUserInput(
+    name:  trim((string) $body['name']),
+    email: strtolower(trim((string) $body['email'])),
+);
+```
+
+リポジトリは DTO のフィールドのみを使って INSERT するため、`role` は常に `'user'`、`is_active` は常に `1` が永続化される。
+
+攻撃シナリオの確認:
+
+```php
+// ❌ 攻撃者の試み
+$res = $this->post('/users', [
+    'name'       => 'Attacker',
+    'email'      => 'attacker@example.com',
+    'role'       => 'admin',    // ← 無視される
+    'is_active'  => false,      // ← 無視される
+    'created_at' => '2000-01-01 00:00:00', // ← 無視される
+    'id'         => 9999,       // ← 無視される
+]);
+
+assertSame('user', $data['role']); // ✅ 防御成功
+```
+
+---
+
+### 2. 「配列まるごと渡し」は脆弱パターン（高リスク）
+
+フレームワークが薄い場合、初心者がよく書く危険なパターン:
+
+```php
+// ❌ $body をそのまま INSERT に使う
+$this->executor->insert(
+    'INSERT INTO users (name, email, role, is_active) VALUES (:name, :email, :role, :is_active)',
+    $body, // ← role=admin が混入してしまう
+);
+```
+
+または ORM の mass assignment:
+
+```php
+// ❌ Laravel 風の危険パターン（NENE2 にはないが、初心者が真似しがち）
+User::create($request->all()); // role, is_active が全部入る
+```
+
+NENE2 は薄いフレームワークで `create($body)` のようなマジックメソッドを持たないため、この罠は踏みにくい。しかしクエリに `$body` を直接渡せば同じ問題が起きる。
+
+---
+
+### 3. `JsonResponseFactory::createList()` の発見（摩擦あり・低）
+
+最初 `$this->json->create(array_map(...))` でリスト形式の配列を渡したところ PHPStan level 8 が `argument.type` エラーを出した。`create()` は `array<string, mixed>` を期待するが、`array_map` の結果は `list<array<...>>` になるため型が合わない。
+
+`createList()` メソッドが存在することを発見して解決:
+
+```php
+// ✅ リスト（JSON 配列）は createList()
+return $this->json->createList(array_map(fn (User $u) => [...], $users));
+
+// create() は JSON オブジェクト専用
+return $this->json->create(['id' => $user->id, ...], 201);
+```
+
+**DX観点:** `create()` と `createList()` の使い分けは PHPDoc には書いてあるが、エラーメッセージだけ見ると「型が合わない」という情報しか得られない。初心者は `create()` だけあれば良いと思い込みやすい。
+
+---
+
+### 4. レスポンスフィールドの明示的制御（情報漏洩防止）
+
+DB カラムが増えても、レスポンスに含めるフィールドを明示的にマッピングすることで、意図しないカラムの露出を防ぐ:
+
+```php
+// ✅ 返すフィールドを明示的に列挙
+return $this->json->create([
+    'id'         => $user->id,
+    'name'       => $user->name,
+    'email'      => $user->email,
+    'role'       => $user->role,
+    'is_active'  => $user->isActive,
+    'created_at' => $user->createdAt,
+    // password_hash は含めない — 明示的な除外
+], 201);
+```
+
+テストで確認:
+
+```php
+$this->assertArrayNotHasKey('password_hash', $data);
+$this->assertArrayNotHasKey('deleted_at', $data);
+```
+
+---
+
+## Test results
+
+14 tests, 39 assertions — all pass.
+
+Key behaviors confirmed:
+- 正常なユーザー作成（role は常に `user`）
+- `role=admin` をリクエストに含めても無視される
+- `is_active=false` をリクエストに含めても無視される
+- 複数の不正フィールド（`role`, `is_active`, `id`, `created_at`）が全て無視される
+- 既存の管理者ユーザーは API 経由で変更されない
+- バリデーション: name 必須、email 必須・形式検証、空 name 拒否
+- 非 JSON オブジェクトボディ（400）
+- email の小文字正規化
+- 一覧取得（全ユーザーが `role=user`）
+- レスポンスフィールドに内部フィールドが含まれないこと
+
+---
+
+## Developer Experience (DX) Review
+
+### ペルソナ1: 初心者（プログラミング歴1.5年・PHP 独学・女性・バックエンド志望）
+
+**マスアサインメントの概念理解:** 「なぜリクエストのフィールドをそのまま DB に入れてはいけないのか」を最初から知っている初心者は少ない。自分でフォームから送ったデータを INSERT するのが「普通」と思っている。この脆弱性を認識するには「攻撃者の視点」を持つ必要があり、経験が浅いと気づきにくい。
+
+**NENE2 での安全性:** NENE2 が薄いフレームワークであることで逆に安全。`User::create($request->all())` のようなマジックがないため、「`$body` をそのまま使うと危ない」を意識せずとも、DTO に詰め替える工程を踏まざるを得ない。ただし「なぜ DTO に詰め替えるのか」の理由を理解せずにコピペすると、後で `$body['role'] ??  'user'` のような迂回コードを書いてしまう危険がある。
+
+**事故リスク:** 中。NENE2 のパターンを踏んでいれば安全だが、`$body` を直接 SQL パラメータに渡す誘惑がある。
+
+---
+
+### ペルソナ2: ロースキル経験者（PHP 歴4年・受託 Web 開発・男性・SES）
+
+**コピペ可能性:** `CreateUserInput` パターンをコピーして使える。ただし「このフィールドしか受け取らない」という意図を理解していないと、新しいフィールドを追加するとき（例: `bio` フィールド）に `CreateUserInput` ではなく `$body['bio']` から直接取ることで「慣れてきたら省略」してしまう可能性がある。
+
+**他フレームワークの影響:** Laravel や CakePHP の ORM に慣れていると、`$model->fill($request->all())` が頭にある。NENE2 にはそれがないが、「こっちのほうが手間が少なくて良いな」と感じて近似するコードを書く。
+
+**事故リスク:** 中〜高。特に「レガシーコードに機能を追加するとき」にパターンを崩しやすい。
+
+---
+
+### ペルソナ3: フロントエンド寄り経験者（React/TS 歴4年・フルスタック転向中・ノンバイナリ）
+
+**API 設計の観点:** フロントから「余分なフィールドを送っても無視してくれる API」は扱いやすいが、「どのフィールドが有効か」の定義がドキュメントに書かれていないと混乱する。OpenAPI スキーマで `additionalProperties: false` を設定してリクエストスキーマを明示するのが最善。
+
+**エラーレスポンスの質:** バリデーションエラーの Problem Details は十分。ただし「なぜ role フィールドが無効なのか」のフィードバックが 422 ではなく「単に無視される」ことは、フロントエンド開発者には不透明に感じられる（デバッグ時に「なんで設定したのに反映されないの？」となる）。
+
+**TS の比較:** TypeScript では入力の型を厳密に定義するため、余分なフィールドを送る機会が少ない。しかしバックエンドが型チェックなしで受けると危険。
+
+---
+
+### ペルソナ4: バックエンド経験者（Laravel 歴6年・男性・リードエンジニア）
+
+**他フレームワークとの差異:** Laravel では `$fillable` / `$guarded` プロパティがマスアサインメント防御の仕組みとして提供されている。NENE2 にはそれがなく、DTO パターンが代替となる。DTO パターンのほうが型安全で明示的だが、フィールドが増えるたびに DTO も更新する必要があり、コード量が増える。
+
+`protected $guarded = [];`（全フィールド許可）のような「緩い設定」を NENE2 では書けないため、逆に安全。
+
+**PHPStan との組み合わせ:** `CreateUserInput` が readonly プロパティで構成されているため、PHPStan level 8 が型安全を保証する。`$body['role']` を DTO に渡しそうになったとき、型エラーで気づける（`string|null` を `string` に渡せない等）。
+
+**チームでの安全な共有:** DTO パターンを「コーディング規約」として定義すれば、コードレビューで「`$body` を直接渡していないか」をチェックするルールを追加できる。
+
+---
+
+### ペルソナ5: シニアエンジニア（設計・コードレビュー担当・女性・12年）
+
+**セキュリティ事故リスク評価:** マスアサインメントは OWASP Top 10（A04: インセキュアデザイン）に関連する。特に `role` フィールドの権限昇格は直接的なセキュリティインシデントにつながる（EC サイトで `is_admin=true` を付けて無制限注文するなど）。
+
+NENE2 の薄い設計はここで有利。`create($body)` のような便利メソッドが存在しないため、初学者でも「どのフィールドを INSERT するか」を明示せざるを得ない。
+
+**スケール時の問題:** マイクロサービス間で内部 API を呼ぶとき、信頼されたサービスからは `role` を設定できる必要がある。その場合のパターン（`AdminCreateUserInput` のような別DTO）が howto にあると良い。
+
+**コードレビューチェックポイント:** `$body` が直接 `execute()` や `insert()` のパラメータに渡されていないか、`$body[$key]` が DTO を経由せず直接使われていないか、を確認する。
+
+---
+
+### ペルソナ6: 設計者・ポリシー照合（NENE2 設計ポリシー目線）
+
+**ポリシー整合:**
+- `DatabaseQueryExecutorInterface::insert()` / `execute()` に `array $params` を渡す設計は、パラメータをどう構築するかをコード側に委ねる — マスアサインメント防御をフレームワークが強制しない代わりに、DTO パターンで補う
+- CLAUDE.md「フレームワークマジックでコントロールフローを隠さない」方針と整合: マスアサインメントの防御を明示的にするのが NENE2 の哲学に沿っている
+- CLAUDE.md「境界で array のままにせず DTO / value object を使う」— `CreateUserInput` は正しいパターン
+
+**設計上のギャップ:**
+1. `JsonResponseFactory::create()` と `createList()` の使い分けが PHPDoc にあるが、エラーメッセージからは発見しにくい — 型エラーが出た時に「`createList()` がある」と知るまでに時間がかかる
+2. `additionalProperties: false` の OpenAPI スキーマを合わせて定義すると、フロントエンドとのコントラクトが明確になる（今回の FT では OpenAPI は実装していない）
+3. howto: `docs/howto/mass-assignment.md` — DTO ホワイトリストパターン・「配列まるごと渡し」の危険・信頼済みサービス向けの別 DTO パターン
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/mass-assignment.md` — DTO ホワイトリストパターン・権限フィールドの隔離・レスポンスフィールドの明示的制御

--- a/docs/howto/mass-assignment.md
+++ b/docs/howto/mass-assignment.md
@@ -1,0 +1,148 @@
+# Mass Assignment Defence
+
+Mass assignment is a vulnerability where an attacker adds extra fields to a request body — such as `role=admin` or `is_active=false` — and the server persists them without intending to.
+
+NENE2 has no `create($body)` magic method that would make this easy to trigger accidentally. Even so, the DTO whitelist pattern is the correct and explicit defence.
+
+## The Vulnerability
+
+```php
+// ❌ Dangerous: $body passed directly to INSERT
+$body = json_decode((string) $request->getBody(), true);
+
+$this->executor->insert(
+    'INSERT INTO users (name, email, role, is_active) VALUES (?, ?, ?, ?)',
+    [$body['name'], $body['email'], $body['role'] ?? 'user', $body['is_active'] ?? 1],
+);
+```
+
+An attacker sends:
+
+```json
+{
+  "name": "Attacker",
+  "email": "attacker@example.com",
+  "role": "admin"
+}
+```
+
+Because `$body['role']` is read from the request, the attacker receives `role=admin` in the database.
+
+## The Defence: Explicit DTO Whitelist
+
+Define a DTO that only contains the fields a user is allowed to supply:
+
+```php
+/**
+ * Only name and email are accepted from user input.
+ * role and is_active are set by server-side logic, never from the request.
+ */
+final readonly class CreateUserInput
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+    ) {}
+}
+```
+
+In the controller, map only the allowed fields to the DTO:
+
+```php
+// ✅ Extra fields (role, is_active, id, created_at) are never read from $body
+$input = new CreateUserInput(
+    name:  trim((string) $body['name']),
+    email: strtolower(trim((string) $body['email'])),
+);
+
+$user = $this->repo->create($input);
+```
+
+In the repository, use the DTO properties directly:
+
+```php
+public function create(CreateUserInput $input): User
+{
+    $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+    $id = $this->executor->insert(
+        'INSERT INTO users (name, email, role, is_active, created_at) VALUES (?, ?, ?, ?, ?)',
+        [$input->name, $input->email, 'user', 1, $now], // role and is_active are hardcoded
+    );
+    // ...
+}
+```
+
+Even if the attacker sends `role=admin`, `$input` only has `name` and `email` — the extra field never reaches the INSERT.
+
+## Attack Scenarios Covered
+
+| Field | Attack intent | Defence |
+|-------|---------------|---------|
+| `role=admin` | Privilege escalation | `role` is not in `CreateUserInput`; always set to `'user'` in repository |
+| `is_active=false` | Create disabled account or lock a user | `is_active` not in DTO; always set to `1` |
+| `id=9999` | Override primary key | `id` not in DTO; auto-assigned by SQLite |
+| `created_at=2000-01-01` | Forge audit timestamp | `created_at` not in DTO; always set to current time |
+
+## Response Field Control
+
+The defence extends to the response: never return DB rows directly. Explicitly map what to include:
+
+```php
+return $this->json->create([
+    'id'         => $user->id,
+    'name'       => $user->name,
+    'email'      => $user->email,
+    'role'       => $user->role,
+    'is_active'  => $user->isActive,
+    'created_at' => $user->createdAt,
+    // password_hash intentionally excluded
+    // deleted_at intentionally excluded
+], 201);
+```
+
+Test for the absence of sensitive fields:
+
+```php
+$this->assertArrayNotHasKey('password_hash', $data);
+$this->assertArrayNotHasKey('deleted_at', $data);
+```
+
+## Trusted Internal Services
+
+When an internal service needs to create an admin user (e.g., a provisioning service), use a separate DTO:
+
+```php
+final readonly class AdminCreateUserInput
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+        public string $role,   // allowed for internal callers only
+        public bool $isActive,
+    ) {}
+}
+```
+
+Call this DTO only from code paths that have already verified the caller's identity (e.g., machine API key, internal service auth). Never expose a public HTTP endpoint that accepts `AdminCreateUserInput` directly.
+
+## `create()` vs `createList()` for Responses
+
+When returning a list, use `createList()` instead of `create()`:
+
+```php
+// ✅ Top-level JSON array
+return $this->json->createList(array_map(fn (User $u) => [...], $users));
+
+// ✅ Top-level JSON object
+return $this->json->create(['id' => $user->id, ...], 201);
+```
+
+`create()` expects `array<string, mixed>` (an object). Passing `array_map()` output directly to `create()` causes a PHPStan level 8 type error because `array_map` returns a `list<T>`.
+
+## Code Review Checklist
+
+- [ ] Request body fields are mapped to a DTO before being passed to the repository
+- [ ] DTO only contains fields the user is allowed to supply
+- [ ] Server-controlled fields (`role`, `is_active`, timestamps, primary keys) are set in the repository, not read from `$body`
+- [ ] Response explicitly lists returned fields; no wildcard `SELECT *` or direct row-to-JSON serialization
+- [ ] Tests verify that extra request fields are ignored and do not affect the persisted value

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.36
+  version: 1.5.37
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,10 +4,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.36`（2026-05-21 リリース済み）
+- Latest release: `v1.5.37`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
-## Recently Completed (FT ループ — v1.5.27 〜 v1.5.36)
+## Recently Completed (FT ループ — v1.5.27 〜 v1.5.37)
 
 | FT | テーマ | アプリ | テスト | リリース | 主要対応 |
 |---|---|---|---|---|---|
@@ -18,6 +18,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT100 | OFFSET vs カーソルページネーション | pagelog | 15/15 | v1.5.34 | pagination.md（fetch+1・パフォーマンス比較・選択基準） |
 | FT101 | ネスト JSON バリデーション | nestedlog | 19/19 | v1.5.35 | nested-json-validation.md（ドット記法・全収集・PHPStan 判別共用体） |
 | FT102 | DBトランザクション境界 | txlog | 11/11 | v1.5.36 | transactions.md（コールバック外インジェクト罠・pre-validation パターン） |
+| FT103 | マスアサインメント防御 | masslog | 14/14 | v1.5.37 | mass-assignment.md（DTO ホワイトリスト・権限フィールド隔離・レスポンス制御） |
 
 ## 次のアクション
 
@@ -25,7 +26,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Open Issues
 
-なし（FT102 で起票した #706 は v1.5.36 で解消済み）
+なし（FT103 で起票した #708 は v1.5.37 で解消済み）
 
 ## Operating Notes
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.36';
+    public const string VERSION = '1.5.37';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/mass-assignment.md` 新規追加 — DTO ホワイトリストによるマスアサインメント防御
- `docs/field-trials/2026-05-field-trial-103.md` — FT103 レポート（6ペルソナ DX レビュー）
- version 1.5.36 → 1.5.37

## 変更点

**mass-assignment.md の内容:**
- 脆弱パターン（`$body` をそのまま INSERT に使う危険性）
- 正しいパターン（`CreateUserInput` DTO でホワイトリストを明示）
- 攻撃シナリオ対応表（role 昇格・is_active 改ざん・id/timestamp 偽造）
- レスポンスフィールドの明示的制御（内部フィールド漏洩防止）
- 信頼済み内部サービス向けの別 DTO パターン（`AdminCreateUserInput`）
- `create()` vs `createList()` の使い分け（PHPStan 型エラーの回避）
- コードレビューチェックリスト

## 検証結果

- PHPStan level 8: OK, CS: OK, Version 1.5.37: OK

## 関連

Closes #708

Self-review: docs-policy