### PR TITLE
docs(howto): 楽観的ロック（バージョンフィールド + 409 Conflict）howto 追加 (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.39] — 2026-05-21
+
+### Added
+- `docs/howto/optimistic-locking.md` — optimistic locking guide: lost-update problem scenario, version field schema, `WHERE version = ?` pattern with `execute()` affected-rows check, 0-rows disambiguation (not-found vs conflict), atomic `version = version + 1` in SQL, 409 response with `current_version`, client retry flow, optimistic vs pessimistic comparison table, code review checklist. (#712)
+- `docs/field-trials/2026-05-field-trial-105.md` — FT105 report: optlocklog (optimistic locking, 12 tests, 24 assertions, 6-persona DX review). (#712)
+
+---
+
 ## [1.5.38] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-105.md
+++ b/docs/field-trials/2026-05-field-trial-105.md
@@ -1,0 +1,196 @@
+# Field Trial 105 — Optimistic Locking (optlocklog)
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/optlocklog/`
+**NENE2 version:** 1.5.38
+**Theme:** 楽観的ロック（Optimistic Locking）— バージョンフィールドを使った競合する更新の検出と 409 Conflict 応答。`execute()` の戻り値（affected rows）でロック競合を判定するパターン。
+
+---
+
+## What was built
+
+記事の作成・取得・更新 API を実装した。更新 API は楽観的ロックを実装しており、クライアントが読み取ったバージョンと DB の現在バージョンが一致しない場合に 409 Conflict を返す。
+
+---
+
+## Findings
+
+### 1. `execute()` の戻り値で競合を検出（摩擦なし）
+
+楽観的ロックの核心は `WHERE id = ? AND version = ?` の UPDATE で affected rows を確認すること:
+
+```php
+$affected = $this->executor->execute(
+    'UPDATE articles SET title = ?, body = ?, version = version + 1, updated_at = ? WHERE id = ? AND version = ?',
+    [$title, $body, $now, $id, $expectedVersion],
+);
+
+if ($affected === 0) {
+    // 0 rows updated = either not found OR version conflict
+    $current = $this->findById($id);
+    if ($current === null) {
+        throw new \RuntimeException("Article {$id} does not exist.");
+    }
+    throw new ConflictException($id, $expectedVersion); // バージョン不一致
+}
+```
+
+`DatabaseQueryExecutorInterface::execute()` が affected rows 数を `int` で返すことが PHPDoc に明記されており、楽観的ロックパターンに自然に使える。
+
+**重要:** 0 rows の理由が「レコードなし」か「バージョン不一致」かを区別するため、追加の `findById()` が必要。これは2回のクエリになるが、競合パスのみで実行されるため通常は問題ない。
+
+---
+
+### 2. 「バージョンなし UPDATE」が起こす失われた更新（高リスク・最重要）
+
+楽観的ロックなしの危険なパターン:
+
+```php
+// ❌ バージョンチェックなし — 失われた更新が起きる
+$this->executor->execute(
+    'UPDATE articles SET title = ?, body = ? WHERE id = ?',
+    [$title, $body, $id],
+);
+```
+
+**シナリオ:**
+1. ユーザーA と ユーザーB が同時に記事を読む（どちらも version=1）
+2. ユーザーA が「タイトルを修正」して保存 → DB は version=1 のまま
+3. ユーザーB が「本文を修正」して保存 → ユーザーAの修正が上書きされる（消える）
+
+楽観的ロックがあれば:
+- ユーザーAの保存後、version=2 になる
+- ユーザーBが version=1 で保存しようとすると 409 → ユーザーBはリロードして再編集
+
+---
+
+### 3. 409 レスポンスに `current_version` を含める（UX 向上）
+
+クライアントが 409 を受け取った後、最新バージョンを知るために GET が不要になる:
+
+```php
+return $this->problems->create(
+    $request,
+    'conflict',
+    'Optimistic lock conflict.',
+    409,
+    $e->getMessage(),
+    $current !== null ? ['current_version' => $current->version] : [],
+);
+```
+
+テストで確認:
+
+```php
+$data = $this->json($conflictRes);
+$this->assertSame(2, $data['current_version']); // クライアントはこれを使って再試行できる
+```
+
+---
+
+### 4. `version` が文字列 `"1"` と整数 `1` の区別（PHPStan 貢献）
+
+JSON ボディで `"version": "1"`（文字列）と `"version": 1`（整数）は PHP の `is_int()` で区別できる:
+
+```php
+if (!is_int($body['version'])) {
+    return $this->problems->create(..., 400);
+}
+```
+
+`json_decode` で PHP は数値 JSON を `int` または `float` にデコードするため、クライアントが `"1"` を送ると `is_int()` が false になって 400 が返る。テストで確認済み。
+
+---
+
+## Test results
+
+12 tests, 24 assertions — all pass.
+
+Key behaviors confirmed:
+- 作成時の version は 1
+- 正常更新で version が 2、3 と順に増える
+- 同時書き込みで 2番目が 409 Conflict を受け取る
+- 409 後にリフェッチ＋再試行で成功する
+- 409 レスポンスに `current_version` が含まれる
+- 競合後もデータが勝者の内容で保持される
+- 存在しない記事への PATCH → 404
+- バージョンフィールドなし → 400
+- バージョンが文字列型 → 400
+- GET で現在状態を返す
+
+---
+
+## Developer Experience (DX) Review
+
+### ペルソナ1: 初心者（プログラミング歴1年・PHP 独学中）
+
+**楽観的ロックの概念理解:** 「悲観的ロック（SELECT FOR UPDATE）」と「楽観的ロック」の違いを知らないと、「なぜ UPDATE に WHERE version = ? を付けるのか」が謎に見える。「2人が同時に編集したらどうなるか」という問いから入れば理解しやすい。
+
+**affected rows の認識:** `execute()` が affected rows を返すことを活用する発想が出てこない可能性がある。更新が成功したかどうかは「例外が出なければ成功」と思いがちで、0 rows の確認が抜ける。
+
+**事故リスク:** 高。バージョンフィールドを追加し忘れる、または追加したが WHERE 句に含め忘れる（`UPDATE ... WHERE id = ?` だけにする）という事故が起きやすい。この場合コードは動くが競合が検出されない。
+
+---
+
+### ペルソナ2: ロースキル経験者（PHP 歴3〜4年・受託 Web 開発）
+
+**コピペ可能性:** `ArticleRepository::update()` のパターンをそのままコピーすれば動く。ただし「なぜ WHERE version = ? が必要か」を理解しないと、パフォーマンスチューニングで「不要な WHERE 句を削る」と間違えて削ってしまう。
+
+**暗黙の前提:** `execute()` が affected rows を返すことを知らない場合、`if ($affected === 0)` のチェックが「なぜ必要か」わからずコピーする。後から「エラーになることないし、削除しよう」となる可能性がある。
+
+**事故リスク:** 中。コピペで正しく動いても、機能追加時にパターンを崩しやすい。
+
+---
+
+### ペルソナ3: フロントエンド寄り経験者（JS/TS 歴4年・フルスタック転向中）
+
+**409 レスポンスの UX:** `current_version` が 409 に含まれているのは良い。クライアントは追加の GET なしに最新バージョンを知れる。ただし「何が競合したか」（タイトルか本文か）は分からない。マージ UI を実装するには全フィールドの比較が必要なため、クライアントは GET してから差分表示する必要がある。
+
+**`version` フィールドをフロントで管理する負担:** フロントは編集フォームに `version` を hidden field または state として持ち、更新リクエストに含める必要がある。これを忘れると 400 が返る。API のドキュメント（OpenAPI）に `version` が必須と明記されていることが重要。
+
+**再試行 UX:** `409` を受け取った後の UX 設計が難しい。「最新版を表示して再編集を促す」か「自動マージを試みる」かはドメインによる。NENE2 は競合を検出するだけで、マージは呼び出し元に委ねる設計が良い。
+
+---
+
+### ペルソナ4: バックエンド経験者（Laravel/Symfony 歴5年）
+
+**他フレームワークとの差異:** Laravel の Eloquent は `optimistic_lock` パッケージや `Model::lockForUpdate()` のような悲観的ロックを提供する。楽観的ロックを明示的に実装するには Eloquent のイベントフックや手動 SQL が必要。NENE2 の `execute()` は affected rows を返すという設計が楽観的ロックと相性が良く、明示的に実装しやすい。
+
+**`version = version + 1` のアトミック性:** SQL の `version = version + 1` はアトミックな操作なので、2つの UPDATE が同時に `version = 1` を読んでも、一方は WHERE version = 1 が true で成功し、もう一方は（先に更新されたため）WHERE version = 1 が false になって 0 rows になる。SELECT → 計算 → UPDATE のパターン（`$newVersion = $old + 1; UPDATE ... SET version = $newVersion`）はレースコンディションが残るため使わない。
+
+---
+
+### ペルソナ5: シニアエンジニア（設計・コードレビュー担当・10年超）
+
+**コードレビューポイント:**
+1. `WHERE id = ? AND version = ?` — バージョン条件が抜けていないか
+2. `execute()` の戻り値をチェックしているか（0 rows を無視していないか）
+3. 0 rows の理由を「not found」と「version conflict」で正しく区別しているか
+4. `version = version + 1` をアプリ側で計算していないか（競合の温床）
+5. 409 レスポンスに十分な情報が含まれているか
+
+**スケール時の問題:** SQLite の単一接続では実際の競合をテストできない。MySQL/PostgreSQL では複数接続から同時に UPDATE することで真の競合を再現できる。楽観的ロックはハイコンテンション環境では悲観的ロック（SELECT FOR UPDATE）より再試行コストが高くなる。コンフリクト率が高い場合は悲観的ロックの検討が必要。
+
+**`current_version` の情報漏洩リスク:** 409 に `current_version` を返すことは一般的に問題ないが、オブジェクトの存在を証明することになる。IDOR と組み合わせると「このIDのレコードが存在する」という情報になる。NENE2 では認証がある前提で設計されているため、通常は問題ない。
+
+---
+
+### ペルソナ6: 設計者・ポリシー照合（NENE2 設計ポリシー目線）
+
+**ポリシー整合:**
+- CLAUDE.md「フレームワークマジックでコントロールフローを隠さない」方針と整合: `WHERE version = ?` の仕組みが明示的
+- `execute()` → affected rows → `ConflictException` の流れが追いやすい
+- Problem Details (RFC 9457) 形式で 409 を返している（正しい HTTP セマンティクス）
+
+**`execute()` の PHPDoc 充実度:** `execute()` が affected rows を返すことは PHPDoc に書かれているが、楽観的ロックのユースケースが例示されていない。`execute()` の PHPDoc に「楽観的ロックパターンの例」を追加すると発見しやすくなる。
+
+**設計上のギャップ:**
+1. `execute()` の PHPDoc に楽観的ロックの例示が欲しい
+2. howto: `docs/howto/optimistic-locking.md` — バージョンフィールドパターン・失われた更新問題・409 応答設計・再試行パターン
+3. 0 rows の区別（not found vs conflict）は定型パターンなので howto に明示すべき
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/optimistic-locking.md` — バージョンフィールドパターン・失われた更新問題・409 応答設計・再試行フロー

--- a/docs/howto/optimistic-locking.md
+++ b/docs/howto/optimistic-locking.md
@@ -1,0 +1,177 @@
+# Optimistic Locking
+
+Optimistic locking prevents the **lost-update problem** — when two concurrent writers both read the same record, make independent changes, and the second writer silently overwrites the first writer's changes.
+
+Use optimistic locking when:
+- Conflicts are infrequent (most updates succeed)
+- You need non-blocking reads (no SELECT FOR UPDATE)
+- The record has a `version` or `updated_at` field to track its state
+
+## The Lost-Update Problem
+
+Without locking:
+
+```
+time | Writer A              | Writer B
+-----|----------------------|-------------------
+  1  | GET /articles/1      | GET /articles/1
+     | ← version: 1         | ← version: 1
+  2  | [edits title]        | [edits body]
+  3  | PATCH /articles/1    |
+     | title = "A's title"  |
+     | ← version: 1, 200 OK |
+  4  |                      | PATCH /articles/1
+     |                      | body = "B's body"
+     |                      | ← version: 1, 200 OK  ← A's title LOST
+```
+
+Writer B overwrites Writer A's title change because neither checked for concurrent modification.
+
+## Schema
+
+Add a `version` column that increments on every update:
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    version    INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT NOT NULL
+);
+```
+
+## Repository Implementation
+
+```php
+/**
+ * @throws ConflictException if another writer updated the record first
+ * @throws \RuntimeException if the article does not exist
+ */
+public function update(int $id, string $title, string $body, int $expectedVersion): Article
+{
+    $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+    // WHERE version = $expectedVersion is the optimistic lock check.
+    // If another writer has already incremented version, this UPDATE matches 0 rows.
+    $affected = $this->executor->execute(
+        'UPDATE articles SET title = ?, body = ?, version = version + 1, updated_at = ? WHERE id = ? AND version = ?',
+        [$title, $body, $now, $id, $expectedVersion],
+    );
+
+    if ($affected === 0) {
+        // 0 rows updated: either not found OR version conflict — distinguish them
+        $current = $this->findById($id);
+        if ($current === null) {
+            throw new \RuntimeException("Article {$id} does not exist.");
+        }
+        throw new ConflictException($id, $expectedVersion);
+    }
+
+    return new Article(id: $id, title: $title, body: $body, version: $expectedVersion + 1, updatedAt: $now);
+}
+```
+
+### Why `version = version + 1` in SQL (not in PHP)
+
+```php
+// ❌ Race condition: two writers both read version=1, both compute version=2
+$newVersion = $article->version + 1;
+$this->executor->execute('UPDATE ... SET version = ? ...', [$newVersion, $id, $expectedVersion]);
+
+// ✅ Atomic: the database increments — version is always correct
+$this->executor->execute('UPDATE ... SET version = version + 1 ...', [$id, $expectedVersion]);
+```
+
+The `WHERE version = $expectedVersion` check is the guard; `version = version + 1` ensures the new value is exactly one more than what passed the guard.
+
+## Controller Integration
+
+The client must read the current `version` and send it back with every update:
+
+```php
+private function update(ServerRequestInterface $request): ResponseInterface
+{
+    $id   = (int) Router::param($request, 'id');
+    $body = json_decode((string) $request->getBody(), true);
+
+    if (!is_array($body) || !is_int($body['version'] ?? null)) {
+        return $this->problems->create($request, 'invalid-body', 'version (int) is required.', 400);
+    }
+
+    try {
+        $article = $this->repo->update($id, $body['title'], $body['body'], $body['version']);
+        return $this->json->create($this->serialize($article));
+    } catch (ConflictException $e) {
+        $current = $this->repo->findById($id);
+        return $this->problems->create(
+            $request,
+            'conflict',
+            'Optimistic lock conflict.',
+            409,
+            $e->getMessage(),
+            $current !== null ? ['current_version' => $current->version] : [],
+        );
+    } catch (\RuntimeException) {
+        return $this->problems->create($request, 'not-found', 'Article not found.', 404);
+    }
+}
+```
+
+## Client Flow
+
+```
+POST /articles            → 201 { id: 1, version: 1, ... }
+GET /articles/1           → 200 { id: 1, version: 1, ... }
+
+PATCH /articles/1         → 200 { id: 1, version: 2, ... }
+  { title: "...", version: 1 }
+
+PATCH /articles/1         → 409 { type: "conflict", current_version: 2 }
+  { title: "...", version: 1 }   (stale version — conflict!)
+
+PATCH /articles/1         → 200 { id: 1, version: 3, ... }
+  { title: "...", version: 2 }   (re-fetch or use current_version from 409)
+```
+
+Including `current_version` in the 409 response lets the client retry without an extra GET.
+
+## Response Payload
+
+Always include `version` in every response so clients always have the latest value:
+
+```php
+/** @return array<string, mixed> */
+private function serialize(Article $article): array
+{
+    return [
+        'id'         => $article->id,
+        'title'      => $article->title,
+        'body'       => $article->body,
+        'version'    => $article->version,  // ← client needs this to send back
+        'updated_at' => $article->updatedAt,
+    ];
+}
+```
+
+## Optimistic vs Pessimistic Locking
+
+| | Optimistic | Pessimistic |
+|---|---|---|
+| Mechanism | `WHERE version = ?` + 0-rows check | `SELECT ... FOR UPDATE` |
+| Read blocking | None | Blocks other readers |
+| Conflict rate | Low (most updates succeed) | High contention OK |
+| Retry cost | Client retries on 409 | Waits for lock release |
+| SQLite support | ✅ | ❌ (not supported) |
+| Best for | Infrequent conflicts, UX-driven retries | High contention, must-succeed operations |
+
+## Code Review Checklist
+
+- [ ] UPDATE includes `AND version = ?` in the WHERE clause
+- [ ] `execute()` return value (affected rows) is checked — 0 means conflict or not found
+- [ ] 0-rows case distinguishes "not found" from "version conflict" (extra `findById` on conflict path)
+- [ ] `version = version + 1` is computed in SQL, not in PHP application code
+- [ ] Every response payload includes `version` so the client always has the latest
+- [ ] 409 response includes `current_version` for client retry without extra GET
+- [ ] `version` in request body is validated as `int`, not `string` (`is_int()` check)
+- [ ] Tests cover: successful update, successive updates, concurrent conflict, retry after conflict, 404, missing version

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.38
+  version: 1.5.39
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,10 +4,10 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.38`（2026-05-21 リリース済み）
+- Latest release: `v1.5.39`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
-## Recently Completed (FT ループ — v1.5.27 〜 v1.5.38)
+## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
 
 | FT | テーマ | アプリ | テスト | リリース | 主要対応 |
 |---|---|---|---|---|---|
@@ -20,6 +20,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT102 | DBトランザクション境界 | txlog | 11/11 | v1.5.36 | transactions.md（コールバック外インジェクト罠・pre-validation パターン） |
 | FT103 | マスアサインメント防御 | masslog | 14/14 | v1.5.37 | mass-assignment.md（DTO ホワイトリスト・権限フィールド隔離・レスポンス制御） |
 | FT104 | Webhook シグネチャ検証 | hmaclog | 13/13 | v1.5.38 | webhook-signature.md（hash_equals() vs ===・タイミング攻撃・リプレイ防止） |
+| FT105 | 楽観的ロック | optlocklog | 12/12 | v1.5.39 | optimistic-locking.md（失われた更新・WHERE version=?・409 応答設計） |
 
 ## 次のアクション
 
@@ -27,7 +28,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Open Issues
 
-なし（FT104 で起票した #710 は v1.5.38 で解消済み）
+なし（FT105 で起票した #712 は v1.5.39 で解消済み）
 
 ## Operating Notes
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.38';
+    public const string VERSION = '1.5.39';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/optimistic-locking.md` 新規追加 — 楽観的ロックパターン完全ガイド
- `docs/field-trials/2026-05-field-trial-105.md` — FT105 レポート（6ペルソナ DX レビュー）
- version 1.5.38 → 1.5.39

## 変更点

**optimistic-locking.md の内容:**
- 失われた更新問題のシナリオ（タイムライン形式で可視化）
- `WHERE id = ? AND version = ?` + `execute()` affected rows チェックパターン
- 0 rows 区別 — 「not found」と「version conflict」を分けて処理
- `version = version + 1` を SQL でアトミック実行する理由（PHP 計算は競合の温床）
- 409 レスポンスに `current_version` を含める UX 改善（追加 GET 不要）
- クライアント側リトライフロー
- 楽観的 vs 悲観的ロック比較表
- コードレビューチェックリスト

## 検証結果

- FT105: 12 tests, 24 assertions — all pass（CS・PHPStan・PHPUnit）
- NENE2 composer check: Version consistency OK: 1.5.39

## 関連

Closes #712

Self-review: docs-policy