### PR TITLE
docs(howto): レートリミット howto 追加・v1.5.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.41] — 2026-05-21
+
+### Added
+- `docs/howto/rate-limiting.md` — rate limiting guide: `ThrottleMiddleware` setup (`throttleMiddleware` named parameter), `X-RateLimit-*` headers, 429 response format, IP-based vs custom `keyExtractor` (user, API key), reverse proxy `REMOTE_ADDR` warning (`X-Forwarded-For` trust), `InMemoryRateLimitStorage` production restriction, Redis `RateLimitStorageInterface` implementation pattern, fixed-window burst problem, client retry pattern, code review checklist. (#716)
+- `docs/field-trials/2026-05-field-trial-107.md` — FT107 report: throttlelog (rate limiting, 9 tests, 33 assertions, 6-persona DX review). (#716)
+
+---
+
 ## [1.5.40] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-107.md
+++ b/docs/field-trials/2026-05-field-trial-107.md
@@ -1,0 +1,200 @@
+# Field Trial 107 — Rate Limiting (ThrottleMiddleware)
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/throttlelog/`
+**NENE2 version:** 1.5.40
+**Theme:** レートリミット — `ThrottleMiddleware` による固定ウィンドウ制限、`X-RateLimit-Limit/Remaining/Reset` ヘッダー、429 Too Many Requests、IP ベース vs カスタム keyExtractor（認証ユーザー・API キー）、プロダクション要件（共有ストレージ）。
+
+---
+
+## What was built
+
+ノート API（GET /notes・POST /notes）に `ThrottleMiddleware` を組み込み、レートリミットの挙動を検証した。
+
+---
+
+## Findings
+
+### 1. `throttleMiddleware:` パラメータ名がドキュメントに明記されていない（摩擦あり）
+
+`RuntimeApplicationFactory` には `$middlewares` ではなく `$throttleMiddleware` という専用パラメータがある。PHP の名前付き引数で渡すとき `middlewares:` と書くとエラーになる:
+
+```php
+// ❌ パラメータ名が違う — エラー
+new RuntimeApplicationFactory($psr17, $psr17, middlewares: [$throttle], ...);
+
+// ✅ 正しい専用パラメータ
+new RuntimeApplicationFactory($psr17, $psr17, throttleMiddleware: $throttle, ...);
+```
+
+`composer install` して `vendor/hideyukimori/nene2/src/Http/RuntimeApplicationFactory.php` を確認するか、IDE の補完を使えば分かるが、howto や README に記載がなければ初見では気付けない。
+
+---
+
+### 2. `InMemoryRateLimitStorage` の「プロセス間共有なし」警告
+
+PHPDoc に明記されているが、初心者がコピペすると本番環境でも `InMemoryRateLimitStorage` を使ってしまう:
+
+```php
+// ⚠️ 本番では使えない — PHP-FPM ワーカー間で状態が共有されない
+$storage = new InMemoryRateLimitStorage();
+
+// ✅ 本番では Redis / Memcached / DB 実装を注入する
+$storage = new RedisRateLimitStorage($redisClient);
+```
+
+`RateLimitStorageInterface` を実装すれば任意のバックエンドを使える設計は正しい。ただし NENE2 は Redis 実装を同梱していないため、プロダクション利用者が自前で実装する必要がある。
+
+---
+
+### 3. リバースプロキシ背後では `REMOTE_ADDR` が信頼できない
+
+デフォルトの keyExtractor は `REMOTE_ADDR` を使うが、リバースプロキシ背後ではプロキシの IP になる:
+
+```php
+// ❌ すべてのクライアントが同じバケットを共有してしまう
+$throttle = new ThrottleMiddleware($problems, $storage, limit: 60);
+
+// ✅ X-Forwarded-For を信頼する場合（プロキシが制御下にある場合のみ）
+$throttle = new ThrottleMiddleware(
+    $problems,
+    $storage,
+    keyExtractor: static fn ($r): string
+        => $r->getHeaderLine('X-Forwarded-For') ?: $r->getServerParams()['REMOTE_ADDR'] ?? 'unknown',
+);
+```
+
+PHPDoc にこの警告が書かれているが、実際に問題が起きるまで気付かないケースが多い。
+
+---
+
+### 4. カスタム keyExtractor で認証ユーザーベース制限
+
+IP ではなく認証ユーザー（または API キー）単位で制限できる:
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problems,
+    $storage,
+    limit: 100,
+    windowSeconds: 3600,
+    keyExtractor: static fn ($r): string => 'user:' . ($r->getAttribute('user_id') ?? 'anonymous'),
+);
+```
+
+これにより:
+- 同一 IP から複数ユーザーが接続する環境（オフィス NAT）で公平な制限が可能
+- 認証されていないリクエストは `anonymous` バケットに入り、より厳しく制限できる
+
+---
+
+### 5. 固定ウィンドウアルゴリズムの境界問題
+
+固定ウィンドウは「ウィンドウ境界前後の集中リクエスト」に弱い:
+
+```
+制限: 100 req/分
+ウィンドウ: :00〜:59
+
+:59 に 100 req → 制限に達する
+:00 に 100 req → 新しいウィンドウ、また 100 req 許可
+
+→ 2秒間に 200 req が通ることになる
+```
+
+スライディングウィンドウや Token Bucket アルゴリズムならこの問題は発生しない。`ThrottleMiddleware` は固定ウィンドウのため、高精度な制限が必要な場合は注意が必要。
+
+---
+
+## Test results
+
+9 tests, 33 assertions — all pass.
+
+Key behaviors confirmed:
+- 200 レスポンスに `X-RateLimit-Limit`/`Remaining`/`Reset` が付く
+- リクエストごとに `X-RateLimit-Remaining` が減る
+- 制限超過で 429 + `Retry-After` ヘッダー
+- 429 レスポンスは Problem Details 形式（`too-many-requests` タイプ）
+- 異なる IP は別バケット
+- カスタム keyExtractor（API キーベース）で別バケット
+- GET と POST は同じバケットからカウント
+- `X-RateLimit-Reset` は Unix タイムスタンプ
+- 制限内のリクエストは正常に通る
+
+---
+
+## Developer Experience (DX) Review
+
+### ペルソナ1: 初心者（プログラミング歴1.5年・PHP 独学・女性・バックエンド志望）
+
+**概念理解:** レートリミットの目的（ブルートフォース防止・DDoS 軽減・公平利用）は理解しやすい。「1分間に何回まで」という制限は直感的。
+
+**`InMemoryRateLimitStorage` の落とし穴:** 「動いた！」で満足してしまい、本番環境でも使い続けるリスクが高い。PHP-FPM の複数プロセスで状態が共有されない問題は、開発環境では再現しにくい。「本番では Redis が必要」という注記を howto に大きく書く必要がある。
+
+**`throttleMiddleware:` パラメータ名:** IDE 補完なしでは判断できない。howto にコピペできるサンプルコードがあれば迷わない。
+
+**事故リスク:** 高。`InMemoryRateLimitStorage` を本番で使うのは「一見動く」サイレントバグ。
+
+---
+
+### ペルソナ2: ロースキル経験者（PHP 歴4年・受託 Web 開発・男性・SES）
+
+**コピペ可能性:** `ThrottleMiddleware` の基本使用法は引数が明確でコピペしやすい。`$storage = new InMemoryRateLimitStorage()` を本番でそのまま使うパターンには要注意。
+
+**リバースプロキシ問題:** Nginx 背後でのデプロイが多いため、`REMOTE_ADDR` がプロキシの IP になる問題に直面する可能性が高い。「なぜ全員が同じ制限を共有するのか」のデバッグが難しい。
+
+**事故リスク:** 中〜高。リバースプロキシ設定ミスはプロダクションの問題として表面化する。
+
+---
+
+### ペルソナ3: フロントエンド寄り経験者（React/TS 歴4年・フルスタック転向中・ノンバイナリ）
+
+**クライアントサイドの対応:** 429 レスポンスを受け取った場合の `Retry-After` ヘッダーを使った再試行ロジックは実装しやすい。`X-RateLimit-Remaining` を監視してリクエストを間引くパターンも理解できる。
+
+**API キーベース制限:** カスタム keyExtractor の存在は嬉しい設計。フロントからは `X-Api-Key` ヘッダーを送るだけでよい。
+
+**事故リスク:** 低。クライアント側の 429 対応は一般的なパターン。
+
+---
+
+### ペルソナ4: バックエンド経験者（Laravel 歴6年・男性・リードエンジニア）
+
+**他フレームワークとの差異:** Laravel の `throttle` ミドルウェアは Redis をデフォルトで使い、キャッシュドライバーを通じて設定する。NENE2 の `RateLimitStorageInterface` は明示的な DI だが、Redis 実装を自分で書く必要がある。
+
+**固定ウィンドウの弱点:** Laravel の ThrottleRequests は固定ウィンドウ + プロバイダー差し替えで Redis Sliding Window も選べる。NENE2 は固定ウィンドウのみ。
+
+**`keyExtractor` の型安全性:** `\Closure(ServerRequestInterface): string` という型付きクロージャは正確で良い。PHPStan でも問題なく解析される。
+
+**事故リスク:** 低。ただしプロダクション用の Redis 実装が未同梱なのは不便。
+
+---
+
+### ペルソナ5: シニアエンジニア（設計・コードレビュー担当・女性・12年）
+
+**コードレビューポイント:**
+1. `InMemoryRateLimitStorage` を本番コードで使っていないか
+2. `REMOTE_ADDR` がリバースプロキシ背後で正しいか
+3. `keyExtractor` が認証済みユーザー単位でキーを生成しているか（IP 単位だと公平性の問題がある）
+4. `windowSeconds` と `limit` の値がユースケースに合っているか（ログインは厳しく、GET は緩く、など）
+5. `X-Forwarded-For` を信頼する場合、プロキシが信頼できる経路にあるか
+
+**スケール時の問題:** 固定ウィンドウのバースト問題は高トラフィック環境で顕在化する。必要なら Token Bucket/Sliding Window の実装を注入する設計にすることを検討。
+
+---
+
+### ペルソナ6: 設計者・ポリシー照合（NENE2 設計ポリシー目線）
+
+**ポリシー整合:**
+- `RateLimitStorageInterface` を使った DI は「フレームワークマジックでコントロールフローを隠さない」方針と整合
+- `ThrottleMiddleware` を `RuntimeApplicationFactory` の専用パラメータで受け取る設計は明示的
+
+**設計上のギャップ:**
+1. `throttleMiddleware:` パラメータ名が howto に未記載 → サンプルコードで補完
+2. プロダクション用 Redis 実装が未同梱 → `RateLimitStorageInterface` の実装例を howto に示す
+3. 固定ウィンドウアルゴリズムのバースト問題の説明が不足
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/rate-limiting.md` — ThrottleMiddleware の使い方・InMemoryRateLimitStorage の本番制限・リバースプロキシ設定・カスタム keyExtractor・固定ウィンドウの弱点

--- a/docs/howto/rate-limiting.md
+++ b/docs/howto/rate-limiting.md
@@ -1,0 +1,182 @@
+# Rate Limiting
+
+`ThrottleMiddleware` enforces a fixed-window rate limit on all requests. It adds `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers to every response, and returns a `429 Too Many Requests` Problem Details response when the limit is exceeded.
+
+## Basic Setup
+
+Pass `ThrottleMiddleware` to `RuntimeApplicationFactory` via the `throttleMiddleware` parameter:
+
+```php
+use Nene2\Middleware\InMemoryRateLimitStorage;
+use Nene2\Middleware\ThrottleMiddleware;
+
+$storage  = new InMemoryRateLimitStorage(); // local/test only — see "Production" below
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    limit:         60,   // requests allowed per window
+    windowSeconds: 60,   // window duration in seconds
+);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    throttleMiddleware: $throttle, // ← named parameter, not "middlewares"
+    routeRegistrars: [...],
+))->create();
+```
+
+The named parameter is `throttleMiddleware`, not `middlewares` — `RuntimeApplicationFactory` has a dedicated slot for this middleware that positions it correctly in the pipeline (after authentication, so per-user limits are possible).
+
+## Response Headers
+
+Every response includes rate limit state:
+
+```http
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 42
+X-RateLimit-Reset: 1716292860
+```
+
+When the limit is exceeded:
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 18
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1716292860
+Content-Type: application/problem+json
+
+{
+  "type": "https://nene2.dev/problems/too-many-requests",
+  "title": "Too Many Requests",
+  "status": 429,
+  "detail": "Rate limit of 60 requests per 60 seconds exceeded. Try again in 18 seconds."
+}
+```
+
+## Rate Limit Keys
+
+### Default: IP-based (REMOTE_ADDR)
+
+By default the key is `ip:<REMOTE_ADDR>`. Every client IP gets its own bucket.
+
+### Custom: Authenticated user
+
+After authentication middleware has set a user attribute, key by user ID:
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    limit:        100,
+    windowSeconds: 3600,
+    keyExtractor: static fn (ServerRequestInterface $r): string
+        => 'user:' . ($r->getAttribute('user_id') ?? 'anonymous'),
+);
+```
+
+This prevents shared-IP environments (office NAT) from unfairly sharing one bucket, and lets you apply tighter limits to unauthenticated requests.
+
+### Custom: API key header
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    keyExtractor: static fn (ServerRequestInterface $r): string
+        => 'apikey:' . ($r->getHeaderLine('X-Api-Key') ?: 'anonymous'),
+);
+```
+
+## Reverse Proxy / Load Balancer Warning
+
+Behind a reverse proxy, `REMOTE_ADDR` is the proxy's IP — all real clients share a single bucket. Fix this by reading a trusted forwarded-IP header:
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    keyExtractor: static fn (ServerRequestInterface $r): string
+        => $r->getHeaderLine('X-Forwarded-For') ?: $r->getServerParams()['REMOTE_ADDR'] ?? 'unknown',
+);
+```
+
+**Only trust `X-Forwarded-For` when your proxy is under your control and sets it reliably.** An attacker can spoof this header if traffic reaches the application directly without passing through the proxy.
+
+## Production: Use Shared Storage
+
+`InMemoryRateLimitStorage` holds counters in a plain PHP array. PHP-FPM runs multiple worker processes; **each worker has its own array, so counters are not shared**. In production, 10 workers with a limit of 60 means a real limit of ~600.
+
+For production, implement `RateLimitStorageInterface` backed by a shared store:
+
+```php
+use Nene2\Middleware\RateLimitStorageInterface;
+
+final class RedisRateLimitStorage implements RateLimitStorageInterface
+{
+    public function __construct(private \Redis $redis) {}
+
+    public function hit(string $key, int $windowSeconds): array
+    {
+        $count = $this->redis->incr($key);
+        if ($count === 1) {
+            $this->redis->expire($key, $windowSeconds);
+        }
+        $ttl     = max(0, $this->redis->ttl($key));
+        $resetAt = time() + $ttl;
+
+        return ['count' => $count, 'reset_at' => $resetAt];
+    }
+}
+```
+
+Then inject it:
+
+```php
+$throttle = new ThrottleMiddleware($problemDetails, new RedisRateLimitStorage($redis), limit: 60);
+```
+
+## Fixed-Window Burst Problem
+
+`ThrottleMiddleware` uses a fixed-window algorithm. Clients can double the effective rate by sending requests at the boundary of two windows:
+
+```
+Limit: 100 req/min, Window: :00–:59
+
+:59 — 100 requests → hits the limit
+:00 — 100 requests → new window, all pass
+
+Result: 200 requests in ~2 seconds
+```
+
+If this is a concern, implement a sliding-window or token-bucket algorithm in your `RateLimitStorageInterface` implementation. The interface and middleware are algorithm-agnostic.
+
+## Per-Route Limits
+
+`RuntimeApplicationFactory` supports one `ThrottleMiddleware` instance applied globally. For per-route limits with different settings, apply `ThrottleMiddleware` as a route-level middleware manually by wrapping individual handlers.
+
+## Client Retry Pattern
+
+```typescript
+async function fetchWithRetry(url: string, options: RequestInit): Promise<Response> {
+    const res = await fetch(url, options);
+    if (res.status === 429) {
+        const retryAfter = parseInt(res.headers.get('Retry-After') ?? '5', 10);
+        await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+        return fetch(url, options); // one retry
+    }
+    return res;
+}
+```
+
+## Code Review Checklist
+
+- [ ] `InMemoryRateLimitStorage` is NOT used in production code
+- [ ] Shared storage (Redis, Memcached, or database-backed) is injected via `RateLimitStorageInterface` in production
+- [ ] `keyExtractor` uses the correct granularity: IP, user, or API key (not always `REMOTE_ADDR`)
+- [ ] Behind a reverse proxy: `X-Forwarded-For` is read only from a trusted proxy, not from arbitrary client headers
+- [ ] `limit` and `windowSeconds` are appropriate for the endpoint's expected traffic (login endpoints: stricter; read-only APIs: more lenient)
+- [ ] The `throttleMiddleware` named parameter (not `middlewares`) is used with `RuntimeApplicationFactory`
+- [ ] Tests use `InMemoryRateLimitStorage` and a low `limit` (e.g. 3) to verify 429 behavior without sleeping

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.40
+  version: 1.5.41
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.40';
+    public const string VERSION = '1.5.41';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/rate-limiting.md` 新規追加 — ThrottleMiddleware の使い方・InMemoryRateLimitStorage 本番制限・リバースプロキシ設定・カスタム keyExtractor・固定ウィンドウの弱点
- `docs/field-trials/2026-05-field-trial-107.md` 新規追加 — FT107 throttlelog レポート（9 tests, 33 assertions, 6ペルソナ DX レビュー）
- v1.5.40 → v1.5.41

Closes #716

## Test plan

- [x] `composer check` 通過（PHPStan level 8・CS Fixer・PHPUnit・OpenAPI・MCP・バージョン整合）
- [x] FT107 throttlelog: 9 tests, 33 assertions — all pass
- [x] NENE2 全テスト通過

## Self-review: docs-policy