### PR TITLE
docs(howto): ソフトデリート howto 追加・v1.5.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.42] — 2026-05-21
+
+### Added
+- `docs/howto/soft-delete.md` — soft delete guide: `deleted_at` schema pattern, critical `WHERE deleted_at IS NULL` filter (missing it leaks deleted data), `$includeTrashed = false` default, `purge()` guard (trash-first requirement), `insert()` vs `execute()` + `lastInsertId()`, REST semantics note, foreign key considerations, code review checklist. (#718)
+- `docs/field-trials/2026-05-field-trial-108.md` — FT108 report: softdeletelog (soft delete, 18 tests, 30 assertions, 6-persona DX review). (#718)
+
+---
+
 ## [1.5.41] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-108.md
+++ b/docs/field-trials/2026-05-field-trial-108.md
@@ -1,0 +1,214 @@
+# Field Trial 108 — Soft Delete (Logical Deletion)
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/softdeletelog/`
+**NENE2 version:** 1.5.41
+**Theme:** ソフトデリート（論理削除）— `deleted_at` フィールドによる論理削除・ゴミ箱エンドポイント・復元・物理削除。`WHERE deleted_at IS NULL` が抜けると削除済みデータが漏洩するセキュリティリスク。
+
+---
+
+## What was built
+
+ノートの CRUD + ソフトデリート API を実装した。
+
+- `POST /notes` — 作成
+- `GET /notes` — アクティブなノート一覧（`deleted_at IS NULL`）
+- `GET /notes/trash` — 削除済みノート一覧
+- `GET /notes/{id}` — 取得（削除済みは 404）
+- `DELETE /notes/{id}` — ソフトデリート（`deleted_at = now()`）
+- `POST /notes/{id}/restore` — 復元（`deleted_at = NULL`）
+- `DELETE /notes/{id}/purge` — 物理削除（トラッシュから完全削除）
+
+---
+
+## Findings
+
+### 1. `WHERE deleted_at IS NULL` の書き忘れ（最重要・高リスク）
+
+ソフトデリートの最大の落とし穴は、クエリに `WHERE deleted_at IS NULL` を書き忘れること:
+
+```php
+// ❌ 削除済みレコードが返る — データ漏洩
+$rows = $this->executor->fetchAll('SELECT * FROM notes WHERE id = ?', [$id]);
+
+// ✅ 削除済みを除外
+$rows = $this->executor->fetchAll(
+    'SELECT * FROM notes WHERE id = ? AND deleted_at IS NULL',
+    [$id],
+);
+```
+
+コードは動作するが、削除済みのはずのデータが API レスポンスに含まれる。認証済みシステムでも IDOR に繋がるリスクがある（他ユーザーの削除済みデータが見える）。
+
+---
+
+### 2. `includeTrashed` フラグで意図を明示
+
+復元・物理削除ではトラッシュ内のレコードを操作する必要があるため、明示的な `$includeTrashed = false` フラグを使う:
+
+```php
+public function findById(int $id, bool $includeTrashed = false): ?Note
+{
+    $sql = $includeTrashed
+        ? 'SELECT * FROM notes WHERE id = ?'
+        : 'SELECT * FROM notes WHERE id = ? AND deleted_at IS NULL';
+    // ...
+}
+
+// 使い方
+$this->findById($id);                       // アクティブのみ
+$this->findById($id, includeTrashed: true); // トラッシュも含む
+```
+
+デフォルトが `false`（除外）なのは「うっかり削除済みを返してしまう」事故を防ぐ設計として重要。
+
+---
+
+### 3. 物理削除はトラッシュ内のみ許可（purge のガード）
+
+`purge` が「アクティブなレコードの物理削除」を許可しないようにガードが必要:
+
+```php
+public function purge(int $id): bool
+{
+    $note = $this->findById($id, includeTrashed: true);
+    // トラッシュに入っていない（アクティブ or 存在しない）場合は拒否
+    if ($note === null || !$note->isDeleted()) {
+        return false;
+    }
+    $this->executor->execute('DELETE FROM notes WHERE id = ?', [$id]);
+    return true;
+}
+```
+
+このガードがないと、ソフトデリートを経由せずに物理削除ができてしまう（監査ログが残らない）。
+
+---
+
+### 4. `execute()` + `lastInsertId()` vs `insert()` の混乱（摩擦）
+
+最初の実装で `execute()` + `lastInsertId()` を使ってしまった。正しいイディオムは `insert()`:
+
+```php
+// ❌ 2回呼ぶ（冗長、後から lastInsertId() を呼ぶ順序に依存）
+$this->executor->execute('INSERT INTO ...', [...]);
+$id = (int) $this->executor->lastInsertId();
+
+// ✅ insert() は affected rows ではなく insert id を返す
+$id = $this->executor->insert('INSERT INTO ...', [...]);
+```
+
+PHPDoc に「`execute()` followed by `lastInsertId()` と等価」と書かれているが、`insert()` の存在に気付かずに長パターンを使ってしまうことがある。
+
+---
+
+### 5. `Router::PARAMETERS_ATTRIBUTE` vs `Router::param()` の変遷
+
+古いバージョン（v1.5.20）では `Router::param()` が存在せず、`Router::PARAMETERS_ATTRIBUTE` を使った:
+
+```php
+// 旧パターン（v1.5.20 以前）
+$params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+$id     = (int) ($params['id'] ?? 0);
+
+// 新パターン（v1.5.31+）
+$id = (int) Router::param($request, 'id');
+```
+
+NENE2 のバージョンアップで `Router::param()` が追加されたが、旧パターンで書いた後にアップグレードしても動作は変わらない。ただし `Router::param()` の方が意図が明確でコードが短い。howto やサンプルを古いパターンで書くと、新バージョンの便利メソッドが伝わらない。
+
+---
+
+## Test results
+
+18 tests, 30 assertions — all pass.
+
+Key behaviors confirmed:
+- POST → 201、アクティブ一覧に表示
+- GET /notes — `deleted_at IS NULL` のみ返す
+- GET /notes/trash — `deleted_at IS NOT NULL` のみ返す
+- GET /notes/{id} — 削除済みは 404
+- DELETE → `deleted_at` にタイムスタンプ設定、一覧から消える
+- 既に削除済みの DELETE → 404
+- POST /{id}/restore → `deleted_at = NULL`、一覧に戻る
+- アクティブなノートの restore → 404
+- DELETE /{id}/purge → トラッシュから完全削除
+- 物理削除後の GET → どこからも見つからない
+- アクティブなノートの purge → 404
+- title なしの POST → 422
+
+---
+
+## Developer Experience (DX) Review
+
+### ペルソナ1: 初心者（プログラミング歴1.5年・PHP 独学・女性・バックエンド志望）
+
+**`WHERE deleted_at IS NULL` の忘れ:** 「削除したのになぜ出てくるのか」が分からず、デバッグに時間がかかる。`SELECT *` + 後で PHP 側でフィルタリング、という誤った実装に走る可能性がある。
+
+**ソフトデリートとハードデリートの違い:** 「なぜ DELETE しないのか」の理由（監査ログ・データ復元・参照整合性）が理解できると、`deleted_at` パターンの意味が分かる。理由を知らないまま実装すると、後から「削除フラグをどうせ使わないから消そう」となる。
+
+**事故リスク:** 高。`findById()` に `deleted_at IS NULL` を入れ忘れた場合、テストで気付きにくい（テストが削除後の取得を試みていなければ）。
+
+---
+
+### ペルソナ2: ロースキル経験者（PHP 歴4年・受託 Web 開発・男性・SES）
+
+**コピペ可能性:** `SqliteNoteRepository` のパターンをそのままコピーすれば動く。ただし「`findById()` の `WHERE deleted_at IS NULL` を消したらどうなるか」を理解していないと、パフォーマンスチューニング時に「不要な条件を削る」という誤操作が起きる。
+
+**`insert()` vs `execute()` + `lastInsertId()`:** PHP/PDO に慣れていると `lastInsertId()` を呼ぶパターンに馴染みがある。`insert()` の存在を知らずに長いパターンを使ってしまう。
+
+**事故リスク:** 中。コピペで正しく動いても、機能追加時にパターンを崩しやすい。
+
+---
+
+### ペルソナ3: フロントエンド寄り経験者（React/TS 歴4年・フルスタック転向中・ノンバイナリ）
+
+**ゴミ箱 UI:** `GET /notes/trash` でトラッシュ一覧を取得して「ごみ箱を空にする」「復元」ボタンを実装するのは直感的。`deleted_at` フィールドが null か非 null かで表示を切り替える UI は実装しやすい。
+
+**`DELETE /notes/{id}` の意味:** HTTP の `DELETE` がソフトデリート（完全削除ではない）なのは、REST セマンティクスと若干乖離する。「`DELETE` を呼んだのにデータが残る」という驚きがある。設計によっては `POST /notes/{id}/trash` の方が明示的かもしれない。
+
+**事故リスク:** 低。ただし「DELETE = 完全削除」という思い込みで UI を設計しないよう注意。
+
+---
+
+### ペルソナ4: バックエンド経験者（Laravel 歴6年・男性・リードエンジニア）
+
+**Eloquent との差異:** Laravel の `SoftDeletes` trait は `deleted_at` カラムを自動で管理し、クエリスコープも自動適用される。NENE2 では明示的に `WHERE deleted_at IS NULL` を書く必要がある。「フレームワークマジックで隠さない」方針と整合しているが、書き忘れリスクが高い。
+
+**`$includeTrashed` フラグ:** Eloquent の `withTrashed()` に相当する。Laravel は Eloquent モデルに自動でスコープを掛けるが、NENE2 は明示的なフラグ。どちらも正しい設計だが、デフォルトが「除外」というのは同じ。
+
+**物理削除のガード:** Eloquent の `forceDelete()` はソフトデリート済みでも実行できる（ガードなし）。NENE2 の FT 実装は「トラッシュに入っていないと物理削除できない」という追加のガードを設けており、監査証跡の観点では safer。
+
+**事故リスク:** 低。
+
+---
+
+### ペルソナ5: シニアエンジニア（設計・コードレビュー担当・女性・12年）
+
+**コードレビューポイント:**
+1. すべての SELECT/UPDATE/DELETE クエリに `WHERE deleted_at IS NULL` が必要か確認
+2. `findById()` のデフォルトが `includeTrashed = false` になっているか
+3. `purge()` が「アクティブなレコードを物理削除できない」ようにガードしているか
+4. レスポンスに `deleted_at` が含まれているか（null か非 null でクライアントが状態を判別できる）
+5. 全文検索・JOIN・集計クエリにも `deleted_at IS NULL` が付いているか（特に JOIN 先が見落としやすい）
+
+**外部キー制約とソフトデリート:** 削除済みレコードを参照する外部キーが残っていると参照整合性の問題が起きる。物理削除前にすべての参照先を確認するか、カスケードソフトデリート戦略が必要。
+
+---
+
+### ペルソナ6: 設計者・ポリシー照合（NENE2 設計ポリシー目線）
+
+**ポリシー整合:**
+- `findById()` の `$includeTrashed = false` デフォルトは「明示的」で「フレームワークマジックなし」方針と整合
+- `isDeleted()` メソッドを `Note` に持たせることでビジネスルールがドメインに閉じている
+
+**設計上のギャップ:**
+1. `insert()` vs `execute()` + `lastInsertId()` の使い分けが howto に未記載
+2. `WHERE deleted_at IS NULL` 忘れのリスクを howto のチェックリストに明記すること
+3. `GET /notes/trash` vs `GET /notes?include_deleted=true` の設計選択基準が不明確
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/soft-delete.md` — deleted_at パターン・includeTrashed フラグ・WHERE deleted_at IS NULL 忘れリスク・purge ガード・ REST セマンティクスの考慮・チェックリスト

--- a/docs/howto/soft-delete.md
+++ b/docs/howto/soft-delete.md
@@ -1,0 +1,192 @@
+# Soft Delete (Logical Deletion)
+
+Soft delete keeps a record in the database but marks it as deleted by setting a `deleted_at` timestamp. This enables:
+- Undo / restore functionality
+- Audit trails (who deleted what, when)
+- Referential integrity (records can still be referenced until purged)
+
+## Schema
+
+Add a `deleted_at` column that is `NULL` for active records and a timestamp for deleted records:
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT NULL          -- NULL = active, timestamp = deleted
+);
+```
+
+## The Critical Rule: Always Filter deleted_at
+
+**Every query that should return only active records must include `AND deleted_at IS NULL`.** Missing this filter is the most common mistake — the code works but deleted data leaks into API responses.
+
+```php
+// ❌ Missing filter — returns deleted records too
+$rows = $this->executor->fetchAll('SELECT * FROM articles WHERE id = ?', [$id]);
+
+// ✅ Exclude deleted
+$rows = $this->executor->fetchAll(
+    'SELECT * FROM articles WHERE id = ? AND deleted_at IS NULL',
+    [$id],
+);
+```
+
+This applies to every query: `findById`, `findAll`, `findByUser`, pagination queries, and JOIN targets.
+
+## Entity
+
+```php
+final readonly class Article
+{
+    public function __construct(
+        public int $id,
+        public string $title,
+        public string $body,
+        public string $createdAt,
+        public string $updatedAt,
+        public ?string $deletedAt,
+    ) {
+    }
+
+    public function isDeleted(): bool
+    {
+        return $this->deletedAt !== null;
+    }
+}
+```
+
+## Repository Pattern
+
+Use an `$includeTrashed = false` flag. The default of `false` means callers must explicitly opt in to see deleted records, which prevents accidental leakage:
+
+```php
+final class ArticleRepository
+{
+    public function findById(int $id, bool $includeTrashed = false): ?Article
+    {
+        $sql = $includeTrashed
+            ? 'SELECT * FROM articles WHERE id = ?'
+            : 'SELECT * FROM articles WHERE id = ? AND deleted_at IS NULL';
+
+        $row = $this->executor->fetchOne($sql, [$id]);
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    /** @return list<Article> */
+    public function findActive(): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT * FROM articles WHERE deleted_at IS NULL ORDER BY created_at DESC',
+        );
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    /** @return list<Article> */
+    public function findTrashed(): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT * FROM articles WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC',
+        );
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function softDelete(int $id): ?Article
+    {
+        $article = $this->findById($id); // active only
+        if ($article === null) {
+            return null;
+        }
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $this->executor->execute('UPDATE articles SET deleted_at = ? WHERE id = ?', [$now, $id]);
+        return new Article($article->id, $article->title, $article->body, $article->createdAt, $article->updatedAt, $now);
+    }
+
+    public function restore(int $id): ?Article
+    {
+        $article = $this->findById($id, includeTrashed: true);
+        if ($article === null || !$article->isDeleted()) {
+            return null; // not found, or not in trash
+        }
+        $this->executor->execute('UPDATE articles SET deleted_at = NULL WHERE id = ?', [$id]);
+        return new Article($article->id, $article->title, $article->body, $article->createdAt, $article->updatedAt, null);
+    }
+
+    /** Permanently delete — only allowed from trash. */
+    public function purge(int $id): bool
+    {
+        $article = $this->findById($id, includeTrashed: true);
+        if ($article === null || !$article->isDeleted()) {
+            return false; // guard: must be in trash first
+        }
+        $this->executor->execute('DELETE FROM articles WHERE id = ?', [$id]);
+        return true;
+    }
+}
+```
+
+### Use `insert()` for INSERT
+
+When creating records, use `insert()` (not `execute()` + `lastInsertId()`):
+
+```php
+// ❌ Two calls
+$this->executor->execute('INSERT INTO articles ...', [...]);
+$id = $this->executor->lastInsertId();
+
+// ✅ One call — returns the inserted row ID
+$id = $this->executor->insert('INSERT INTO articles ...', [...]);
+```
+
+## Endpoints
+
+A typical soft-delete API:
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/articles` | Create |
+| `GET` | `/articles` | Active records only |
+| `GET` | `/articles/trash` | Deleted records only |
+| `GET` | `/articles/{id}` | Get one (404 if deleted) |
+| `DELETE` | `/articles/{id}` | Soft delete → 404 if already deleted |
+| `POST` | `/articles/{id}/restore` | Restore → 404 if not in trash |
+| `DELETE` | `/articles/{id}/purge` | Hard delete → 404 if not in trash |
+
+**Note on REST semantics:** `DELETE /articles/{id}` behaves as a soft delete, not a permanent removal. If this surprises clients, document it clearly in the OpenAPI spec, or use `POST /articles/{id}/trash` for the soft-delete action.
+
+## Always Include `deleted_at` in Responses
+
+Include `deleted_at` in every response so clients can determine resource state without extra requests:
+
+```php
+return $this->json->create([
+    'id'         => $article->id,
+    'title'      => $article->title,
+    'body'       => $article->body,
+    'created_at' => $article->createdAt,
+    'updated_at' => $article->updatedAt,
+    'deleted_at' => $article->deletedAt, // null = active; timestamp = deleted
+]);
+```
+
+## Foreign Keys and Soft Delete
+
+When other tables reference a soft-deleted record:
+- Soft deletion does not break foreign key constraints — the row still exists
+- Hard delete (purge) can violate constraints if referencing rows exist
+- Before purging, check for dependent records or cascade soft delete to dependents
+
+## Code Review Checklist
+
+- [ ] Every query for active records includes `AND deleted_at IS NULL`
+- [ ] `findById()` default is `$includeTrashed = false` — callers explicitly opt in
+- [ ] `purge()` guards against hard-deleting active records (`isDeleted()` check)
+- [ ] `restore()` returns `null` (→ 404) when the record is not in trash
+- [ ] JOIN queries on soft-deleted tables also filter `deleted_at IS NULL` on the joined table
+- [ ] `deleted_at` is included in API responses so clients can determine state
+- [ ] `DELETE /articles/{id}` behavior (soft vs hard) is documented in OpenAPI
+- [ ] Tests cover: delete → 404 on GET, list excludes deleted, restore → visible again, purge → gone everywhere, double-delete → 404, purge active → 404
+- [ ] `insert()` is used for INSERT (not `execute()` + `lastInsertId()`)

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.41
+  version: 1.5.42
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.41';
+    public const string VERSION = '1.5.42';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/soft-delete.md` 新規追加 — deleted_at パターン・WHERE漏れリスク・includeTrashed フラグ・purge ガード・コードレビューチェックリスト
- `docs/field-trials/2026-05-field-trial-108.md` 新規追加 — FT108 softdeletelog レポート（18 tests, 30 assertions, 6ペルソナ DX レビュー）
- v1.5.41 → v1.5.42

Closes #718

## Test plan

- [x] `composer check` 通過
- [x] FT108 softdeletelog: 18 tests, 30 assertions — all pass

## Self-review: docs-policy