### PR TITLE
docs(howto): jwt-authentication.md — BearerTokenMiddleware・LocalBearerTokenVerifier・alg:none (#722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.44] — 2026-05-21
+
+### Added
+- `docs/howto/jwt-authentication.md` — JWT 認証ガイド: `LocalBearerTokenVerifier` が Issuer/Verifier を兼ねる、`BearerTokenMiddleware` の3モード（`excludedPaths` / `protectedPaths` / `protectedPathPrefixes`）、`nene2.auth.claims` からのクレーム取得、`exp` は int 必須（文字列は有効期限チェックがスキップされる）、`alg: none` 攻撃拒否の解説、JWT シークレット環境変数管理、トークンリボーク設計、コードレビューチェックリスト。 (#722)
+- `docs/field-trials/2026-05-field-trial-110.md` — FT110 レポート: jwtlog（JWT 認証、14 tests / 53 assertions、6ペルソナ DX レビュー）。 (#722)
+
+---
+
 ## [1.5.43] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-110.md
+++ b/docs/field-trials/2026-05-field-trial-110.md
@@ -1,0 +1,250 @@
+# Field Trial 110 — JWT Authentication (BearerTokenMiddleware / LocalBearerTokenVerifier)
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/jwtlog/`
+**NENE2 version:** 1.5.43
+**Theme:** JWT 発行・検証・保護ルート — `LocalBearerTokenVerifier` による HMAC-HS256 JWT 発行・`BearerTokenMiddleware` による保護ルート、`alg: none` 攻撃拒否、有効期限検証、`nene2.auth.claims` request attribute からのクレーム取得。
+
+---
+
+## What was built
+
+JWT 認証 API を実装した。
+
+- `POST /auth/login` — メール + パスワードで認証し JWT トークンを返す。
+- `GET /auth/me` — Bearer トークン必須の保護ルート。クレームからユーザー情報を返す。
+
+---
+
+## Findings
+
+### 1. `LocalBearerTokenVerifier` は Issuer と Verifier を兼ねる（重要な発見）
+
+`LocalBearerTokenVerifier` は `TokenVerifierInterface` と `TokenIssuerInterface` の両方を実装している。インスタンスを一つ作れば JWT の発行・検証に使える:
+
+```php
+use Nene2\Auth\LocalBearerTokenVerifier;
+
+$verifier = new LocalBearerTokenVerifier($secret);
+
+// JWT 発行
+$token = $verifier->issue(['sub' => $user->id, 'email' => $user->email, 'exp' => time() + 3600]);
+
+// JWT 検証
+$claims = $verifier->verify($token); // TokenVerificationException if invalid
+```
+
+名前に "Verifier" とだけ付いているため "Issuer" でもあることが分かりにくい。PHPDoc を確認しないと見落とす。
+
+---
+
+### 2. `excludedPaths` vs `protectedPaths` vs `protectedPathPrefixes`（摩擦あり）
+
+`BearerTokenMiddleware` には3種類のパスマッチングモードがある。**`/auth/login` のような公開パスが少数のとき**は `excludedPaths` を使う（デフォルトは全保護）:
+
+```php
+// ❌ protectedPaths = [] は「全保護」ではなく「全公開」になる（空＝allowlist無効）
+$auth = new BearerTokenMiddleware($problems, $verifier, protectedPaths: []);
+
+// ❌ protectedPaths に /auth/me だけ書くと /auth/login も保護されてしまう
+$auth = new BearerTokenMiddleware($problems, $verifier, protectedPaths: ['/auth/me']);
+
+// ✅ 公開パスが少数 → excludedPaths でログインだけ除外
+$auth = new BearerTokenMiddleware($problems, $verifier, excludedPaths: ['/auth/login']);
+
+// ✅ 保護パスが少数 → protectedPaths で列挙
+$auth = new BearerTokenMiddleware($problems, $verifier, protectedPaths: ['/auth/me', '/admin/...']);
+
+// ✅ /me/* などダイナミックルート群 → protectedPathPrefixes
+$auth = new BearerTokenMiddleware($problems, $verifier, protectedPathPrefixes: ['/me/']);
+```
+
+優先順序: `protectedPaths` > `protectedPathPrefixes` > `excludedPaths` > 全保護（デフォルト）。
+
+---
+
+### 3. `nene2.auth.claims` request attribute からのクレーム取得
+
+`BearerTokenMiddleware` は検証済みクレームを以下の request attribute に格納する:
+
+```php
+// BearerTokenMiddleware が設定する属性
+$request->getAttribute('nene2.auth.credential_type'); // 'bearer'
+$request->getAttribute('nene2.auth.claims');           // array<string, mixed>
+
+// ハンドラー側での取得
+/** @var array<string, mixed>|null $claims */
+$claims = $request->getAttribute('nene2.auth.claims');
+$userId = $claims['sub'];   // subject (ユーザーID)
+$email  = $claims['email']; // カスタムクレーム
+```
+
+attribute 名は文字列定数として公開されていないため、PHPDoc か BearerTokenMiddleware のソースを読まないと分からない。
+
+---
+
+### 4. JWT クレームの `exp`/`iat`/`sub` は Unix タイムスタンプ（int）
+
+`LocalBearerTokenVerifier::verify()` は `exp` と `nbf` を int として比較する。文字列（ISO 8601 等）を渡しても検証は通るが、有効期限チェックが機能しない:
+
+```php
+// ❌ exp が文字列 — 型チェックで弾かれず、有効期限チェックが機能しない
+$token = $verifier->issue([
+    'sub' => $user->id,
+    'exp' => '2026-05-22T00:00:00Z',  // is_int() が false → チェックスキップ
+]);
+
+// ✅ exp は Unix タイムスタンプ（int）
+$token = $verifier->issue([
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'iat'   => time(),
+    'exp'   => time() + 3600,
+]);
+```
+
+---
+
+### 5. `alg: none` 攻撃は `LocalBearerTokenVerifier` が拒否する
+
+`LocalBearerTokenVerifier` はヘッダーの `alg` フィールドを確認し、`HS256` 以外は `TokenVerificationException` を throw する:
+
+```php
+// alg: none トークン（署名なし）を試みる
+$header  = base64_encode(json_encode(['typ' => 'JWT', 'alg' => 'none']));
+$payload = base64_encode(json_encode(['sub' => 1, 'exp' => time() + 3600]));
+$token   = rtrim(strtr($header, '+/', '-_'), '=') . '.' . rtrim(strtr($payload, '+/', '-_'), '=') . '.';
+
+// → TokenVerificationException: "Token algorithm must be HS256."
+$verifier->verify($token); // 401
+```
+
+JWT ライブラリの初期実装で `alg: none` 攻撃を許してしまうものが歴史的に多い。NENE2 の実装はこれを明示的に拒否する。
+
+---
+
+### 6. `WWW-Authenticate` ヘッダーの自動付与（RFC 6750）
+
+`BearerTokenMiddleware` は 401 レスポンスに `WWW-Authenticate: Bearer ...` ヘッダーを自動で付与する。クライアントが認証の仕組みを自動検出できるようになる:
+
+```
+WWW-Authenticate: Bearer realm="NENE2", error="missing_token", error_description="No Bearer token was provided."
+```
+
+自分で 401 を返すときにこのヘッダーを忘れがちだが、ミドルウェアが担うため実装側は意識しなくてよい。
+
+---
+
+### 7. `authMiddleware` パラメータ名（前回 FT107 の教訓の再確認）
+
+`RuntimeApplicationFactory` の named parameter は `authMiddleware:`（`middlewares:` や `middleware:` ではない）。`ThrottleMiddleware` 同様、PHPDoc を確認しないと間違えやすい:
+
+```php
+// ❌ 間違い
+new RuntimeApplicationFactory($psr17, $psr17, middlewares: [$authMiddleware]);
+
+// ✅ 正しい
+new RuntimeApplicationFactory($psr17, $psr17, authMiddleware: $authMiddleware);
+```
+
+---
+
+## Test results
+
+14 tests, 53 assertions — all pass.
+
+Key behaviors confirmed:
+- `POST /auth/login` 正しい認証 → 200、JWT トークン・`expires_at`・`token_type: Bearer`
+- JWT クレームに `sub`（int）、`email`、`iat`（int）、`exp`（int）が含まれる
+- JWT 有効期限が 1 時間後
+- 間違ったパスワード → 401
+- 存在しないメール → 401（404 ではない）
+- 必須フィールドなし → 400
+- 有効な JWT → `GET /auth/me` が 200
+- JWT なし → 401 + `WWW-Authenticate` ヘッダー
+- 署名改ざん JWT → 401
+- 期限切れ JWT → 401
+- `Bearer` スキーム以外（`Basic` 等） → 401
+- `alg: none` JWT → 401
+- `/auth/login` は認証不要（`excludedPaths` で除外）
+- `/auth/me` レスポンスに `password_hash` を含まない
+
+---
+
+## Developer Experience (DX) Review
+
+### ペルソナ1: 初心者（プログラミング歴1年・PHP 独学中）
+
+**JWT の概念自体が難しい:** ヘッダー・ペイロード・署名の3部構造、Base64URL エンコード、HMAC-HS256 署名、`exp`/`iat`/`sub` の意味を理解していない段階では何を作っているのか分からない。「なぜセッション Cookie ではなく JWT なのか」という根本的な疑問も出る。
+
+**`alg: none` 攻撃:** 攻撃の意味を理解できないため、「なぜわざわざこれを拒否するのか」が伝わらない。「署名なしのトークンを誰でも作れてしまう」という具体的なシナリオで説明が必要。
+
+**事故リスク:** 高。セッション + Cookie 方式とのトレードオフを理解せずに JWT を採用するリスクがある。
+
+---
+
+### ペルソナ2: ロースキル経験者（PHP 歴3〜4年・受託 Web 開発）
+
+**`exp` に文字列を渡す:** `'2026-06-01'` のような日付文字列を `exp` に渡しても PHP は型エラーを出さず、検証が静かにスキップされる。「有効期限を設定したつもりが機能していない」状態になりやすい。
+
+**`protectedPaths` の空配列誤解:** `protectedPaths: []` が「全保護なし（全公開）」ではなく「allowlist 無効（全保護）」だと理解しにくい。設定ミスでルート全体が保護されてしまうケースが想定される。
+
+**事故リスク:** 中〜高。`exp` の型チェックは静的解析でしか気づけない。
+
+---
+
+### ペルソナ3: フロントエンド寄り経験者（JS/TS 歴4年・フルスタック転向中）
+
+**クライアント側の JWT 保管:** `localStorage` に JWT を保存すると XSS で盗まれるリスクがある。`httpOnly Cookie` への保存が推奨されるが、その場合は CSRF 対策も必要になる。「なぜ Bearer トークンにしたのか」という設計判断を明文化することが重要。
+
+**`Authorization: Bearer` ヘッダー:** fetch API で `headers: { Authorization: 'Bearer ' + token }` を付ける実装は馴染みがあるが、スペースが必要なこと（`'Bearer' + token` ではなく `'Bearer ' + token`）で間違えるケースがある。
+
+**事故リスク:** 低〜中。クライアント側の JWT 保管が最大のリスク。
+
+---
+
+### ペルソナ4: バックエンド経験者（Laravel/Symfony 歴5年）
+
+**Laravel Sanctum/Passport との比較:** Laravel のトークン認証では `sanctum` や `passport` がトークン発行・検証・ブラックリストを提供する。NENE2 の `LocalBearerTokenVerifier` は開発・テスト向けで本番ではライブラリ実装（`firebase/php-jwt`・`lcobucci/jwt`）が必要な点を把握できる。
+
+**トークンリボーク:** JWT はステートレスなためリボークできない（有効期限まで使える）。ブラックリスト（Redis 等）との組み合わせが必要な場合は別途実装が必要。この設計上の制約を認識できる。
+
+**`LocalBearerTokenVerifier` の命名:** "Local" が「開発用・本番非推奨」を示すシグナルになっており、適切な設計。
+
+**事故リスク:** 低。ただしトークンリボークの欠如とシークレット管理に注意が必要。
+
+---
+
+### ペルソナ5: シニアエンジニア（設計・コードレビュー担当・10年超）
+
+**コードレビューポイント:**
+1. `exp` クレームが int（Unix タイムスタンプ）か（文字列は有効期限チェックが機能しない）
+2. シークレットが環境変数から読まれているか（ハードコード禁止）
+3. `LocalBearerTokenVerifier` を本番環境で使っていないか
+4. `alg` フィールドが HS256 固定で検証されているか（ライブラリ自前実装の場合）
+5. `nene2.auth.claims` の取得で null チェックをしているか
+6. トークンのレスポンスに `password_hash` 等の機密情報が含まれていないか
+7. `Authorization` ヘッダーがログに出力されていないか
+8. `excludedPaths` と `protectedPaths` の選択が意図通りか
+
+**トークン有効期限の選択:** 1 時間は一般的だが、要件次第。リフレッシュトークンパターンとのトレードオフも考慮する。
+
+---
+
+### ペルソナ6: 設計者・ポリシー照合（NENE2 設計ポリシー目線）
+
+**ポリシー整合:**
+- `BearerTokenMiddleware` が WWW-Authenticate ヘッダーを自動付与（RFC 6750 準拠）— 良い設計
+- `LocalBearerTokenVerifier` の命名が「本番非推奨」を明示している — 良い設計
+- `alg: none` 拒否が実装されている — 安全なデフォルト
+
+**設計上のギャップ:**
+1. `nene2.auth.claims` 属性名が文字列定数として公開されていない — 文字列を直接書く必要がある
+2. JWT 認証全体の howto が未作成
+3. `excludedPaths` / `protectedPaths` / `protectedPathPrefixes` の選択ガイドが howto に必要
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/jwt-authentication.md` — `LocalBearerTokenVerifier`・`BearerTokenMiddleware`・`excludedPaths` 設計・`nene2.auth.claims`・`exp` 型・`alg: none` 拒否・JWT シークレット環境変数

--- a/docs/howto/jwt-authentication.md
+++ b/docs/howto/jwt-authentication.md
@@ -1,0 +1,173 @@
+# How-To: JWT Authentication
+
+Issuing and verifying JWT Bearer tokens with `LocalBearerTokenVerifier` and `BearerTokenMiddleware`.
+
+---
+
+## Quick start
+
+```php
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+
+$secret   = getenv('NENE2_LOCAL_JWT_SECRET') ?: throw new \RuntimeException('JWT secret not set');
+$verifier = new LocalBearerTokenVerifier($secret);
+
+// Protect all paths except /auth/login
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier: $verifier,
+    excludedPaths: ['/auth/login'],
+);
+
+$app = (new RuntimeApplicationFactory($psr17, $psr17, authMiddleware: $authMiddleware, ...))->create();
+```
+
+---
+
+## Issuing tokens
+
+`LocalBearerTokenVerifier` implements both `TokenIssuerInterface` and `TokenVerifierInterface` — one instance handles both.
+
+```php
+$now   = time();
+$token = $verifier->issue([
+    'sub'   => $user->id,       // subject: user identifier (int or string)
+    'email' => $user->email,    // custom claim
+    'iat'   => $now,            // issued-at (Unix timestamp — int)
+    'exp'   => $now + 3600,     // expiry   (Unix timestamp — int, required for expiry to work)
+]);
+```
+
+**`exp` must be a Unix timestamp (int).** Passing a date string (`'2026-06-01'`) silently skips expiry enforcement because `LocalBearerTokenVerifier` checks `is_int($claims['exp'])` before comparing.
+
+---
+
+## Reading claims in a handler
+
+`BearerTokenMiddleware` stores decoded claims in the `nene2.auth.claims` request attribute after successful verification:
+
+```php
+private function me(ServerRequestInterface $request): ResponseInterface
+{
+    /** @var array<string, mixed>|null $claims */
+    $claims = $request->getAttribute('nene2.auth.claims');
+
+    // This null-guard should not trigger — the middleware already rejected missing tokens.
+    // Include it anyway for PHPStan level 8 and defensive clarity.
+    if (!is_array($claims)) {
+        return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401);
+    }
+
+    return $this->json->create([
+        'id'    => $claims['sub'],
+        'email' => $claims['email'],
+    ]);
+}
+```
+
+Also available: `$request->getAttribute('nene2.auth.credential_type')` returns `'bearer'`.
+
+---
+
+## Path protection modes
+
+`BearerTokenMiddleware` supports three modes — the first non-empty configuration wins:
+
+| Configuration | Behaviour | When to use |
+|---|---|---|
+| `protectedPaths: ['/me', '/admin']` | Only listed exact paths are protected | Public paths are the majority |
+| `protectedPathPrefixes: ['/api/']` | Paths starting with prefix are protected | Protecting a whole sub-tree |
+| `excludedPaths: ['/login', '/register']` | All paths except listed ones are protected | Public paths are the minority |
+| (default — all arrays empty) | Every path is protected | Fully private API |
+
+```php
+// ✅ /auth/login is public, everything else requires a token
+new BearerTokenMiddleware($problems, $verifier, excludedPaths: ['/auth/login']);
+
+// ✅ Only /auth/me is protected
+new BearerTokenMiddleware($problems, $verifier, protectedPaths: ['/auth/me']);
+
+// ✅ All /api/ paths are protected
+new BearerTokenMiddleware($problems, $verifier, protectedPathPrefixes: ['/api/']);
+
+// ⚠️  protectedPaths: [] is NOT "protect nothing" — it disables allowlist mode
+//     and falls through to the next mode (prefixes, then blocklist, then protect-all).
+```
+
+---
+
+## `alg: none` attack — already rejected
+
+`LocalBearerTokenVerifier` checks that `alg == 'HS256'` in the token header before verifying the signature. Any other algorithm — including `none` — throws `TokenVerificationException`:
+
+```
+Token algorithm must be HS256.
+```
+
+This prevents the classic `alg: none` bypass where an attacker crafts a header-less token with no signature. When implementing a custom verifier, always enforce the expected algorithm explicitly.
+
+---
+
+## Error responses
+
+`BearerTokenMiddleware` returns 401 Problem Details and automatically adds the `WWW-Authenticate` header (RFC 6750):
+
+```
+WWW-Authenticate: Bearer realm="NENE2", error="missing_token", error_description="No Bearer token was provided."
+```
+
+Possible `error` values: `missing_token` (no header), `invalid_token` (bad scheme, bad signature, expired, `nbf` in future, malformed).
+
+---
+
+## Secret management
+
+Never hardcode the JWT secret. Read it from an environment variable:
+
+```php
+// ❌ Hardcoded secret — committed to version control
+$verifier = new LocalBearerTokenVerifier('my-secret');
+
+// ✅ Environment variable
+$secret   = (string) (getenv('NENE2_LOCAL_JWT_SECRET') ?: throw new \RuntimeException('JWT secret not configured'));
+$verifier = new LocalBearerTokenVerifier($secret);
+```
+
+Use a strong random secret in all environments. For production, use a library-backed implementation (`firebase/php-jwt`, `lcobucci/jwt`) instead of `LocalBearerTokenVerifier` — the "Local" prefix signals its scope.
+
+---
+
+## Token revocation
+
+JWT is stateless — there is no built-in revocation. Tokens remain valid until `exp`. If you need immediate revocation (e.g., logout, password change):
+
+- Store a token blocklist in Redis with TTL matching `exp`
+- Or use short-lived tokens (15 minutes) with refresh tokens
+
+---
+
+## `authMiddleware` parameter name
+
+The `RuntimeApplicationFactory` named parameter is `authMiddleware:`, not `middlewares:` or `middleware:`:
+
+```php
+// ❌ Unknown named parameter $middlewares
+new RuntimeApplicationFactory($psr17, $psr17, middlewares: [$authMiddleware]);
+
+// ✅ Correct
+new RuntimeApplicationFactory($psr17, $psr17, authMiddleware: $authMiddleware);
+```
+
+---
+
+## Code review checklist
+
+- [ ] `exp` claim is a Unix timestamp (int), not a date string
+- [ ] JWT secret is read from an environment variable (not hardcoded)
+- [ ] `LocalBearerTokenVerifier` is not used in production (use a library implementation)
+- [ ] `nene2.auth.claims` attribute is null-checked before use
+- [ ] `excludedPaths` / `protectedPaths` mode choice matches intent
+- [ ] Token response does not contain `password_hash` or other secrets
+- [ ] `Authorization` header is not logged
+- [ ] 401 is returned for auth failures (not 404)

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.43
+  version: 1.5.44
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.43';
+    public const string VERSION = '1.5.44';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/jwt-authentication.md` を追加（FT110 jwtlog の実地検証から）
- `docs/field-trials/2026-05-field-trial-110.md` を追加（6ペルソナ DX レビュー含む）
- v1.5.44 にバンプ

カバーするトピック:
- `LocalBearerTokenVerifier` が Issuer/Verifier を兼ねる
- `BearerTokenMiddleware` の3パスマッチングモード（`excludedPaths` / `protectedPaths` / `protectedPathPrefixes`）
- `nene2.auth.claims` request attribute からのクレーム取得
- `exp` は Unix タイムスタンプ（int）必須
- `alg: none` 攻撃拒否の解説
- JWT シークレット環境変数管理・トークンリボーク設計

## Test plan

- [x] `composer check` — 341 tests, 860 assertions, PHPStan level 8, CS clean, OpenAPI valid, version 1.5.44 consistent
- [x] FT110 (jwtlog): 14 tests, 53 assertions — all pass

## Self-review: docs-policy

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)