### PR TITLE
docs(howto): rbac.md — JWT クレームロール・requireRole・401 vs 403・createEmpty (#724)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.45] — 2026-05-21
+
+### Added
+- `docs/howto/rbac.md` — RBAC ガイド: JWT クレームへのロール埋め込み（DB 毎回参照とのトレードオフ）、`requireAuth()` / `requireRole()` ヘルパーパターン、401 vs 403 の正しい使い分け、`BearerTokenMiddleware` が HTTP メソッドを区別しない制限と手動検証回避策、`Role` enum / `tryFrom()` 型安全デコード、`createEmpty(204)` の正しい使い方。 (#724)
+- `docs/field-trials/2026-05-field-trial-111.md` — FT111 レポート: rbaclog（RBAC、14 tests / 48 assertions、6ペルソナ DX レビュー）。 (#724)
+
+---
+
 ## [1.5.44] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-111.md
+++ b/docs/field-trials/2026-05-field-trial-111.md
@@ -1,0 +1,238 @@
+# Field Trial 111 — RBAC (Role-Based Access Control)
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/rbaclog/`
+**NENE2 version:** 1.5.44
+**Theme:** ロールベースアクセス制御 — JWT クレームに `role` を含める、ハンドラーでの権限チェック、401 Unauthorized vs 403 Forbidden の正しい使い分け、`BearerTokenMiddleware` の HTTP メソッド別ルーティング制限、`createEmpty()` を使った 204 レスポンス。
+
+---
+
+## What was built
+
+RBAC 付きブログ API を実装した。
+
+- `POST /auth/login` — JWT を返す（クレームに `role` を含む）
+- `GET /posts` — 公開（認証不要）
+- `POST /posts` — 認証済みユーザーのみ（`user` or `admin`）
+- `DELETE /posts/{id}` — 管理者のみ（`admin`）
+
+---
+
+## Findings
+
+### 1. JWT クレームにロールを含める（重要なアーキテクチャ決定）
+
+ロールを DB から毎リクエスト取得する設計と、JWT クレームに含める設計の2択がある:
+
+```php
+// ❌ DB 毎回参照 — 認証のたびにクエリが走る
+$user = $this->users->findById((int) $claims['sub']);
+if ($user->role !== Role::Admin) { ... }
+
+// ✅ JWT クレームにロールを含める — 追加 DB クエリなし
+$token = $this->issuer->issue([
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'role'  => $user->role->value,  // 'user' or 'admin'
+    'iat'   => time(),
+    'exp'   => time() + 3600,
+]);
+
+// ハンドラーでの検証
+$role = Role::tryFrom((string) ($claims['role'] ?? ''));
+if ($role !== Role::Admin) { return 403; }
+```
+
+トレードオフ: JWT はロール変更を即座に反映しない（トークン有効期限まで古いロールのまま）。高セキュリティ要件では DB 確認を組み合わせる。
+
+---
+
+### 2. `BearerTokenMiddleware` はパスのみで保護を決定する（HTTP メソッドを区別しない）
+
+`GET /posts`（公開）と `POST /posts`（認証必須）が同じパス `/posts` に存在する場合、`BearerTokenMiddleware` はこれを区別できない:
+
+```php
+// ❌ /posts を excludedPaths に入れると POST /posts も公開になる
+$auth = new BearerTokenMiddleware($problems, $verifier, excludedPaths: ['/auth/login', '/posts']);
+// → POST /posts に認証トークンを送っても nene2.auth.claims は設定されない
+```
+
+回避策1（推奨）: **同じパスで公開・保護メソッドが混在するときはハンドラーで手動検証する**:
+
+```php
+// ハンドラーが TokenVerifierInterface を受け取り、手動で検証する
+private function requireAuth(ServerRequestInterface $request): array|ResponseInterface
+{
+    // 保護パスなら middleware が設定済み
+    $claims = $request->getAttribute('nene2.auth.claims');
+    if (is_array($claims)) {
+        return $claims;
+    }
+
+    // 公開パスで除外された場合 — Authorization ヘッダーを手動で検証
+    $authorization = $request->getHeaderLine('Authorization');
+    if ($authorization === '' || !str_starts_with($authorization, 'Bearer ')) {
+        return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401, '...');
+    }
+
+    try {
+        return $this->verifier->verify(substr($authorization, 7));
+    } catch (TokenVerificationException) {
+        return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401, '...');
+    }
+}
+```
+
+回避策2: パスを分離する（例: `GET /public/posts` と `POST /posts`）。
+
+---
+
+### 3. 401 Unauthorized vs 403 Forbidden — 混同しやすい
+
+```php
+// ❌ 認証済みユーザーに 401 を返すのは誤り
+if ($role !== Role::Admin) {
+    return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401, '...');
+}
+
+// ✅ 認証済みだが権限不足 → 403 Forbidden
+// ✅ 未認証（トークンなし・無効） → 401 Unauthorized
+if ($role !== Role::Admin) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+        "This action requires the 'admin' role.");
+}
+```
+
+| 状況 | 正しい HTTP ステータス |
+|---|---|
+| トークンなし・期限切れ・署名無効 | 401 Unauthorized |
+| 認証済みだがロール不足 | 403 Forbidden |
+| リソースが存在しない | 404 Not Found |
+
+---
+
+### 4. 204 No Content には `createEmpty()` を使う（摩擦あり）
+
+`JsonResponseFactory::create()` の第1引数は `array` 型。`null` や空配列を渡すと型エラーまたは意図しない空 JSON になる:
+
+```php
+// ❌ 型エラー — create() は array 必須
+return $this->json->create(null, 204);
+
+// ❌ 空の JSON オブジェクト {} が返る（204 は body を持たないべき）
+return $this->json->create([], 204);
+
+// ✅ 空レスポンス専用メソッドを使う
+return $this->json->createEmpty(204);
+```
+
+---
+
+### 5. `Role::tryFrom()` でクレームの型安全なデコード
+
+クレームの `role` フィールドは `mixed` 型のため、キャストしてから `tryFrom()` を使う:
+
+```php
+// ❌ $claims['role'] は mixed — 直接 Role::from() はエラーリスク
+$role = Role::from($claims['role']);
+
+// ✅ キャストしてから tryFrom — 未知の値は null になる
+$role = Role::tryFrom((string) ($claims['role'] ?? ''));
+if ($role !== Role::Admin) {
+    return 403;
+}
+```
+
+---
+
+## Test results
+
+14 tests, 48 assertions — all pass.
+
+Key behaviors confirmed:
+- ログイン JWT クレームに `role` フィールドが含まれる（`user` / `admin`）
+- `GET /posts` — 認証なしで公開
+- `POST /posts` — 認証必須（`user` も `admin` も可能）
+- `POST /posts` — 認証なしで 401
+- `DELETE /posts/{id}` — admin のみ成功 → 204
+- `DELETE /posts/{id}` — user ロールで 403（401 ではない）
+- `DELETE /posts/{id}` — 認証なしで 401（403 ではない）
+- 期限切れトークンで `DELETE` → 401
+- 存在しない投稿の `DELETE` → 404
+
+---
+
+## Developer Experience (DX) Review
+
+### ペルソナ1: 初心者（プログラミング歴1年・PHP 独学中）
+
+**「認証」と「認可」の違いが分からない:** 「ログインしているかどうか」（認証）と「権限があるかどうか」（認可）の区別が初心者には曖昧。401 と 403 の違いも「両方 "認証系エラー" じゃないの？」となりやすい。「警備員に IDカードを見せる（認証）」と「その部屋に入る権限があるか確認する（認可）」の比喩で説明すると伝わりやすい。
+
+**事故リスク:** 高。全てのエラーを 401 で返してしまうケースが非常に多い。
+
+---
+
+### ペルソナ2: ロースキル経験者（PHP 歴3〜4年・受託 Web 開発）
+
+**`create(null, 204)` の落とし穴:** 「null を渡せば空だろう」と考えて `JsonResponseFactory::create(null, 204)` を書いてしまう。型エラーまたは 500 になって初めて気づく。`createEmpty()` の存在を知らない。
+
+**JWT ロールのキャッシュ問題:** 「ユーザーのロールを admin に変更したのに API が反映されない」というバグレポートが来るケースが想定される。JWT の有効期限とロール更新の同期を設計段階で決めておく必要がある。
+
+**事故リスク:** 中。`create(null, ...)` の型エラーと JWT ロールキャッシュが主なリスク。
+
+---
+
+### ペルソナ3: フロントエンド寄り経験者（JS/TS 歴4年・フルスタック転向中）
+
+**クライアント側でのロール表示:** JWT のペイロードは Base64 デコードで読めるため（署名は検証できないが内容は見える）、クライアント側でロールを表示する実装は可能。ただし **アクセス制御はサーバー側で必ず行う** — クライアントのデコードは UI 表示用のみ。
+
+**403 vs 401 のクライアント側ハンドリング:** 401 は「ログインページへリダイレクト」、403 は「権限不足のエラー表示」と異なる UI フローになる。サーバーが正しい HTTP ステータスを返すことでクライアントのロジックが正しく書ける。
+
+**事故リスク:** 低〜中。クライアント側のロールチェックをサーバー側チェックの代わりにしてしまうリスクがある。
+
+---
+
+### ペルソナ4: バックエンド経験者（Laravel/Symfony 歴5年）
+
+**Laravel Gate / Policy との比較:** Laravel の `$this->authorize('delete', $post)` に相当する仕組みを NENE2 では手動実装する。`Gate` のような共通抽象は NENE2 に存在しない — フレームワークマジックなしが哲学。`requireRole()` ヘルパーパターンが同等の役割を果たす。
+
+**JWT ロール vs DB ロール:** JWT ロールは即座に反映されないため、高セキュリティ要件（医療・金融）では `findById($claims['sub'])` で DB のロールを毎回確認する方が安全。パフォーマンスと一貫性のトレードオフ。
+
+**`BearerTokenMiddleware` のメソッド非区別:** Laravel Route Middleware は HTTP メソッドごとに適用できる（`Route::post(...)->middleware('auth')`）。NENE2 の `BearerTokenMiddleware` にはこの仕組みがない — ハンドラー手動検証か URL 分離が必要な点が摩擦。
+
+**事故リスク:** 低。JWT ロールキャッシュの設計判断が最大の考慮点。
+
+---
+
+### ペルソナ5: シニアエンジニア（設計・コードレビュー担当・10年超）
+
+**コードレビューポイント:**
+1. `role` クレームが `Role::tryFrom()` で安全にデコードされているか（`Role::from()` は例外リスク）
+2. 403 と 401 が正しく区別されているか
+3. JWT ロールキャッシュの有効期限設計が明示されているか（ロール変更の即時反映が必要か）
+4. `createEmpty(204)` を使っているか（`create(null, 204)` ではなく）
+5. `BearerTokenMiddleware` の除外パス設計が意図通りか（POST が意図せず公開になっていないか）
+6. ロールチェックが全ての保護エンドポイントで実施されているか（チェック漏れのエンドポイント）
+
+**セキュリティ上の観点:** ロール変更後のトークン無効化戦略がないと、昇格したロールも降格したロールも有効期限まで有効になる。短い有効期限か、リフレッシュトークンによる定期的な再発行が推奨。
+
+---
+
+### ペルソナ6: 設計者・ポリシー照合（NENE2 設計ポリシー目線）
+
+**ポリシー整合:**
+- `requireRole()` → `requireAuth()` という委譲パターンはフレームワークマジックなしで明示的 — 良い設計
+- `Role` enum を使うことで型安全なロールチェック — 設計ポリシーと整合
+- 403 と 401 の正しい区別 — RFC 7231 準拠
+
+**設計上のギャップ:**
+1. `BearerTokenMiddleware` が HTTP メソッドを区別しない制限が howto に未記載
+2. `JsonResponseFactory::createEmpty()` の使いどころが howto に未記載
+3. RBAC 全体の howto が未作成
+4. `Role` enum パターンと `tryFrom()` の推奨が未文書
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/rbac.md` — JWT クレームへのロール埋め込み・`requireRole()` パターン・401 vs 403・`BearerTokenMiddleware` のメソッド非区別・`createEmpty()` 204 レスポンス

--- a/docs/howto/rbac.md
+++ b/docs/howto/rbac.md
@@ -1,0 +1,233 @@
+# How-To: Role-Based Access Control (RBAC)
+
+Implementing role-based access control with JWT claims and `BearerTokenMiddleware`.
+
+---
+
+## Quick start
+
+```php
+// 1. Include role in the JWT on login
+$token = $issuer->issue([
+    'sub'  => $user->id,
+    'role' => $user->role->value,  // 'user' or 'admin'
+    'exp'  => time() + 3600,
+]);
+
+// 2. Check the role in the handler
+/** @var array<string, mixed>|null $claims */
+$claims     = $request->getAttribute('nene2.auth.claims');
+$actualRole = Role::tryFrom((string) ($claims['role'] ?? ''));
+
+if ($actualRole !== Role::Admin) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+        "This action requires the 'admin' role.");
+}
+```
+
+---
+
+## Embedding roles in JWT claims
+
+**Two approaches:**
+
+| Approach | Pro | Con |
+|---|---|---|
+| Role in JWT claims | No DB query per request | Role changes take effect only after token expires |
+| DB lookup per request | Immediate role changes | Extra query on every authenticated request |
+
+For most applications the JWT approach is appropriate. For high-security contexts (medical, financial, admin privilege revocation) add a DB lookup on sensitive operations.
+
+```php
+// Login — embed role in claims
+$token = $issuer->issue([
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'role'  => $user->role->value,   // string: 'user' | 'admin'
+    'iat'   => time(),
+    'exp'   => time() + 3600,
+]);
+```
+
+---
+
+## 401 Unauthorized vs 403 Forbidden
+
+This distinction matters for client error handling (401 → redirect to login, 403 → show permission error):
+
+| Situation | Status |
+|---|---|
+| No token / expired / invalid signature | **401** Unauthorized |
+| Valid token but insufficient role | **403** Forbidden |
+| Resource not found | **404** Not Found |
+
+```php
+// ❌ Wrong — authenticated user gets 401 (implies "not logged in")
+if ($role !== Role::Admin) {
+    return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401, '...');
+}
+
+// ✅ Correct — authenticated but lacks permission
+if ($role !== Role::Admin) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+        "This action requires the 'admin' role.");
+}
+```
+
+---
+
+## `requireAuth()` / `requireRole()` pattern
+
+A reusable helper pair in the route registrar:
+
+```php
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+
+final class RouteRegistrar
+{
+    public function __construct(
+        private readonly TokenVerifierInterface $verifier,
+        // ... other deps
+    ) {}
+
+    /**
+     * Returns claims on success or a 401 ResponseInterface.
+     * Checks middleware attribute first; falls back to manual verification
+     * for paths excluded from BearerTokenMiddleware.
+     *
+     * @return array<string, mixed>|ResponseInterface
+     */
+    private function requireAuth(ServerRequestInterface $request): array|ResponseInterface
+    {
+        /** @var array<string, mixed>|null $claims */
+        $claims = $request->getAttribute('nene2.auth.claims');
+
+        if (is_array($claims)) {
+            return $claims;
+        }
+
+        $authorization = $request->getHeaderLine('Authorization');
+
+        if ($authorization === '' || !str_starts_with($authorization, 'Bearer ')) {
+            return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401,
+                'Authentication required.');
+        }
+
+        try {
+            return $this->verifier->verify(substr($authorization, 7));
+        } catch (TokenVerificationException) {
+            return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401,
+                'Token is invalid or expired.');
+        }
+    }
+
+    /**
+     * Returns claims if the user has the required role, or a 401/403 ResponseInterface.
+     *
+     * @return array<string, mixed>|ResponseInterface
+     */
+    private function requireRole(ServerRequestInterface $request, Role $required): array|ResponseInterface
+    {
+        $claims = $this->requireAuth($request);
+
+        if ($claims instanceof ResponseInterface) {
+            return $claims;
+        }
+
+        $actualRole = Role::tryFrom((string) ($claims['role'] ?? ''));
+
+        if ($actualRole !== $required) {
+            return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+                "This action requires the '{$required->value}' role.");
+        }
+
+        return $claims;
+    }
+}
+```
+
+Usage in handlers:
+
+```php
+private function deletePost(ServerRequestInterface $request): ResponseInterface
+{
+    $claims = $this->requireRole($request, Role::Admin);
+    if ($claims instanceof ResponseInterface) {
+        return $claims;  // 401 or 403
+    }
+    // $claims is now a verified admin's JWT payload
+}
+```
+
+---
+
+## `BearerTokenMiddleware` does not differentiate by HTTP method
+
+`BearerTokenMiddleware` uses the request path, not the HTTP method, to decide whether authentication is required. When `GET /posts` (public) and `POST /posts` (auth-required) share the same path, exclude `/posts` from the middleware and verify the token manually in the handler:
+
+```php
+// Middleware: exclude /posts entirely (covers both GET and POST)
+$auth = new BearerTokenMiddleware($problems, $verifier, excludedPaths: ['/auth/login', '/posts']);
+
+// For DELETE /posts/{id} (path /posts/1, /posts/2 etc.) — NOT in excludedPaths → middleware protects it.
+// For POST /posts (path /posts) — excluded → handler must call requireAuth() manually.
+```
+
+The `requireAuth()` helper above handles this transparently: it reads `nene2.auth.claims` from the middleware attribute if present, and falls back to parsing the `Authorization` header directly if not.
+
+**Alternative**: use distinct path prefixes to avoid the ambiguity entirely:
+- `GET /public/posts` — no auth
+- `POST /posts` — auth required (middleware can protect `/posts` without conflict)
+
+---
+
+## `Role` enum pattern
+
+Use a backed enum for type-safe role handling:
+
+```php
+enum Role: string
+{
+    case User  = 'user';
+    case Admin = 'admin';
+}
+
+// ❌ Role::from() throws on unknown values
+$role = Role::from($claims['role']);  // UnhandledMatchError if 'superuser' or ''
+
+// ✅ Role::tryFrom() returns null for unknown values
+$role = Role::tryFrom((string) ($claims['role'] ?? ''));
+if ($role === null || $role !== Role::Admin) {
+    return 403;
+}
+```
+
+---
+
+## 204 No Content — use `createEmpty()`
+
+`JsonResponseFactory::create()` requires an `array` argument. For 204 responses with no body, use `createEmpty()`:
+
+```php
+// ❌ Type error — create() does not accept null
+return $this->json->create(null, 204);
+
+// ❌ Returns empty JSON object {} (body should be absent for 204)
+return $this->json->create([], 204);
+
+// ✅ Correct — no body, correct status
+return $this->json->createEmpty(204);
+```
+
+---
+
+## Code review checklist
+
+- [ ] `role` claim is decoded with `Role::tryFrom()` (not `Role::from()` — throws on unknown values)
+- [ ] 403 is returned for insufficient permissions, 401 for unauthenticated (not both as 401)
+- [ ] `requireRole()` also calls `requireAuth()` — no duplicate auth checks needed
+- [ ] `BearerTokenMiddleware` exclusion is understood: excluded paths bypass claims attribute
+- [ ] Handlers on excluded paths call `requireAuth()` with manual token verification
+- [ ] 204 responses use `createEmpty(204)` not `create(null, 204)`
+- [ ] JWT role caching is understood: role changes take effect only after token expiry

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.44
+  version: 1.5.45
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.44';
+    public const string VERSION = '1.5.45';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/rbac.md` を追加（FT111 rbaclog の実地検証から）
- `docs/field-trials/2026-05-field-trial-111.md` を追加（6ペルソナ DX レビュー含む）
- v1.5.45 にバンプ

カバーするトピック:
- JWT クレームへのロール埋め込みと DB 毎回参照のトレードオフ
- `requireAuth()` / `requireRole()` ヘルパーパターン
- 401 vs 403 の正しい使い分け
- `BearerTokenMiddleware` の HTTP メソッド非区別制限と手動検証回避策
- `Role::tryFrom()` 型安全デコード
- `createEmpty(204)` の正しい使い方

## Test plan

- [x] `composer check` — 341 tests, 860 assertions, PHPStan level 8, CS clean, OpenAPI valid, version 1.5.45 consistent
- [x] FT111 (rbaclog): 14 tests, 48 assertions — all pass

## Self-review: docs-policy

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)