### PR TITLE
docs: JWT Refresh Token Rotation ガイドを追加 v1.5.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.47] — 2026-05-21
+
+### Added
+- `docs/howto/refresh-token-rotation.md` — Refresh Token Rotation ガイド: リフレッシュトークンのハッシュ保存（SHA-256、生値は DB に入れない）、ローテーション（使用後即 `revoke()`）、リプレイ攻撃検知（失効済みトークン再利用時に `revokeAllForUser()`）、ログアウトは必ず 204（情報漏洩防止）、`jti` クレームによるアクセストークンのユニーク性保証、アクセストークン（短命・stateless）とリフレッシュトークン（長命・DB管理）の分離。 (#728)
+- `docs/field-trials/2026-05-field-trial-113.md` — FT113 レポート: refreshlog（JWT Refresh Token Rotation、15 tests / 63 assertions、6ペルソナ DX レビュー）。 (#728)
+
+---
+
 ## [1.5.46] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-113.md
+++ b/docs/field-trials/2026-05-field-trial-113.md
@@ -1,0 +1,238 @@
+# Field Trial 113 — JWT Refresh Token Rotation
+
+**Date:** 2026-05-21
+**Project:** `/home/xi/docker/NENE2-FT/refreshlog/`
+**NENE2 version:** 1.5.46
+**Theme:** JWT Refresh Token Rotation — アクセストークン短命化（5分）・リフレッシュトークンのハッシュ保存・ローテーション（使用後即失効）・リプレイ攻撃検知（失効済みトークン再利用時に全トークン失効）・ログアウトは必ず 204（トークン有効性を漏らさない）・`jti` クレームによるアクセストークンのユニーク性保証。
+
+---
+
+## What was built
+
+アクセストークン（短命）＋リフレッシュトークン（長命・DB管理）による認証フローを実装した。
+
+- `POST /auth/login` — アクセストークン（5分）＋リフレッシュトークン（7日）を返す
+- `POST /auth/refresh` — リフレッシュトークンを受け取り新しいトークンペアを返す（ローテーション）
+- `POST /auth/logout` — リフレッシュトークンを失効させる（必ず 204）
+- `GET /auth/me` — アクセストークンで保護されたエンドポイント
+
+---
+
+## Findings
+
+### 1. リフレッシュトークンはハッシュして保存する（生値は DB に入れない）
+
+リフレッシュトークンを生値で DB に保存すると、DB が漏洩した瞬間に全ユーザーのセッションが乗っ取られる:
+
+```php
+// ❌ 生値を保存すると DB 漏洩 = 全セッション乗っ取り
+$raw = bin2hex(random_bytes(32));
+$this->executor->insert(
+    'INSERT INTO refresh_tokens (user_id, token) VALUES (?, ?)',
+    [$userId, $raw],  // 生値を保存している
+);
+
+// ✅ SHA-256 ハッシュを保存し、クライアントには生値のみ返す
+$raw  = bin2hex(random_bytes(32));
+$hash = hash('sha256', $raw);
+$this->executor->insert(
+    'INSERT INTO refresh_tokens (user_id, token_hash) VALUES (?, ?)',
+    [$userId, $hash],  // ハッシュのみ保存
+);
+return $raw;  // クライアントには生値を返す
+```
+
+検証時はクライアントから受け取った生値を SHA-256 でハッシュしてから DB と照合する:
+
+```php
+public function findByRaw(string $raw): ?RefreshToken
+{
+    $hash = hash('sha256', $raw);
+    $row  = $this->executor->fetchOne(
+        'SELECT ... FROM refresh_tokens WHERE token_hash = ?',
+        [$hash],
+    );
+    // ...
+}
+```
+
+---
+
+### 2. ローテーション: 使用と同時に旧トークンを失効させる
+
+リフレッシュトークンを使ったら**即座に失効**させる。使用後も有効なままだと、盗まれたトークンが使い放題になる:
+
+```php
+// Rotation: revoke the old token before issuing a new one
+$this->refreshTokens->revoke($stored->id);
+
+return $this->json->create($this->issueTokenPair($user));
+```
+
+ローテーション後に古いトークンを再度使おうとすると 401 が返る。
+
+---
+
+### 3. リプレイ攻撃検知: 失効済みトークンが再利用されたら全トークンを失効させる
+
+正規ユーザーが既にローテーション済みのトークンを再利用してきた場合、それは攻撃者がそのトークンを盗んで使い回しているサインかもしれない。全トークンを失効させて強制再ログインを要求する:
+
+```php
+if ($stored === null || !$stored->isValid()) {
+    // 失効済みトークンが届いた = 盗まれた可能性がある
+    if ($stored !== null && $stored->revoked) {
+        $this->refreshTokens->revokeAllForUser($stored->userId);
+    }
+
+    return $this->problems->create(
+        $request,
+        'invalid-refresh-token',
+        'Invalid or Expired Refresh Token',
+        401,
+        'The refresh token is invalid, expired, or has already been used.',
+    );
+}
+```
+
+---
+
+### 4. ログアウトは必ず 204 を返す（有効性を漏らさない）
+
+ログアウトエンドポイントがトークンの有無や有効性によって異なるステータスを返すと、攻撃者がトークンの有効性を探れる:
+
+```php
+// ❌ トークンが有効かどうかを漏らす
+$stored = $this->refreshTokens->findByRaw($token);
+if ($stored === null) {
+    return $this->problems->create(..., 401);  // "このトークンは無効" と教えている
+}
+
+// ✅ 常に 204 を返す — トークン有効性を漏らさない
+$stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+if ($stored !== null && !$stored->revoked) {
+    $this->refreshTokens->revoke($stored->id);
+}
+return $this->json->createEmpty(204);  // 常に 204
+```
+
+---
+
+### 5. `jti` クレームでアクセストークンをユニークにする
+
+アクセストークンの TTL を短く設定していても、同じユーザーに対して同じ秒内にトークンを2回発行すると、全クレームが同一なので JWT が一致してしまう。`jti`（JWT ID）クレームを追加することでユニーク性を保証する:
+
+```php
+$accessToken = $this->issuer->issue([
+    'jti'   => bin2hex(random_bytes(8)),  // ユニーク ID
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'iat'   => $now,
+    'exp'   => $now + self::ACCESS_TOKEN_TTL_SECONDS,
+]);
+```
+
+`jti` は将来のトークンブロックリスト実装（アクセストークンの即時失効）の起点にもなる。
+
+---
+
+### 6. アクセストークン（短命）とリフレッシュトークン（長命）の分離
+
+```
+アクセストークン: 5分（300秒）— JWT、stateless、DB参照不要
+リフレッシュトークン: 7日 — 生値はクライアントのみ、DB にはハッシュ、ローテーション管理
+```
+
+アクセストークンが短命なので、漏洩しても5分で無効になる。リフレッシュトークンはローテーションで管理するため、使い回しが検知できる。
+
+---
+
+## Test results
+
+15 tests, 63 assertions — all pass.
+
+Key behaviors confirmed:
+- ログインで access_token と refresh_token の両方が返る（`expires_in: 300`）
+- アクセストークンで保護エンドポイントにアクセスできる
+- リフレッシュで新しいトークンペアが返る（旧トークンとは異なる）
+- 新しいアクセストークンで保護エンドポイントにアクセスできる
+- ローテーション後に旧リフレッシュトークンは 401
+- 失効済みトークン再利用時に全トークン失効（新トークンも無効化）
+- ログアウト後にリフレッシュトークンが 401
+- ログアウトは無効なトークンでも 204（情報漏洩なし）
+- リフレッシュトークンは 64 文字の hex 文字列（raw, 32バイト）
+- 認証なしで `/auth/me` → 401
+
+---
+
+## Developer Experience (DX) Review
+
+### ペルソナ1: 初心者（プログラミング歴1.5年・PHP 独学・女性・バックエンド志望）
+
+**「アクセストークンとリフレッシュトークンって何が違うの？」:** JWT を1種類しか知らない段階では、なぜ2種類のトークンが必要なのかが分からない。「短命 JWT を毎回発行すれば良いのでは？」と思うが、そうすると毎回ログインを要求することになる。「ユーザーが30日ログインを保持したい」というユースケースで初めて必要性を理解できる。
+
+**「トークンを DB に保存するのが嫌だ」:** JWT の「stateless」という言葉を覚えた直後だと、リフレッシュトークンを DB に保存することに違和感を覚える。「DB に保存するなら JWT の意味がない」という誤解が生まれやすい。アクセストークンは stateless、リフレッシュトークンは stateful という分離が鍵。
+
+**事故リスク:** 高。リフレッシュトークンを生値で保存する実装が多い。
+
+---
+
+### ペルソナ2: ロースキル経験者（PHP 歴4年・受託 Web 開発・男性・SES）
+
+**「ハッシュ化すれば良いってことはハッシュ化しなくていいのでは？」:** bcrypt でのパスワードハッシュは知っていても、リフレッシュトークンに SHA-256 を使うという発想がない。「トークンは長いから大丈夫では？」という考え方になりがち。DB 漏洩シナリオが腹落ちすると理解できる。
+
+**「ローテーションは実装コストが高い」:** 旧トークンを失効させながら新トークンを発行する実装は、单純な CRUD より複雑。「毎回ローテーションするんですか？それ必要ですか？」という疑問が出やすい。セッション固定攻撃のリスクで説明すると納得しやすい。
+
+**事故リスク:** 高。ローテーションなし・生値保存の実装が起きやすい。
+
+---
+
+### ペルソナ3: フロントエンド寄り経験者（React/TS 歴4年・フルスタック転向中・ノンバイナリ）
+
+**「リフレッシュトークンをどこに保存すれば良い？」:** フロントエンド目線では、localStorage vs cookie (httpOnly) の議論が重要。サーバーの実装だけでなく、「クライアントでどう管理するか」のガイドが欲しい。httpOnly cookie なら JavaScript からアクセスできないので XSS に強いが、CSRF への対策が必要になる。
+
+**「レース条件はどうする？」:** 複数タブで同時にリフレッシュリクエストが飛んだ場合、最初の1つが成功して残りが 401 になる問題。フロントエンドでのトークン更新のシリアライズ（1つのリフレッシュリクエストを待って他を待機させる）が必要になる。
+
+**事故リスク:** 中。フロント側のトークン管理が問題になりやすい。
+
+---
+
+### ペルソナ4: バックエンド経験者（Laravel 歴6年・男性・リードエンジニア）
+
+**「Laravel Sanctum との比較」:** Laravel Sanctum は SPA 認証としてリフレッシュトークンパターンを提供しているが、NENE2 では手動実装。Sanctum の `PersonalAccessToken` は DB に保存して失効管理も内蔵されている。NENE2 の「フレームワークマジックなし」の哲学と整合しているが、実装コストはある。
+
+**「リプレイ攻撃検知の実装は正しいか？」:** `revokeAllForUser()` は効果的だが、正規ユーザーも影響を受ける。「Token Family」（ローテーションの系譜）で部分失効するアプローチもある。トレードオフの議論ができる経験者。
+
+**事故リスク:** 低（経験者はパターンを知っている）。ただし `revokeAllForUser()` の影響範囲をレビューすべき。
+
+---
+
+### ペルソナ5: シニアエンジニア（設計・コードレビュー担当・女性・12年）
+
+**コードレビューポイント:**
+1. リフレッシュトークンが生値で DB に保存されていないか（`token_hash` を確認）
+2. ローテーション実装: `revoke()` が `issueTokenPair()` の前に呼ばれているか
+3. 失効済みトークン再利用時の `revokeAllForUser()` が実装されているか
+4. ログアウトが常に 204 を返しているか（条件分岐で 401 を返していないか）
+5. `jti` クレームが含まれているか（アクセストークンのユニーク性）
+6. アクセストークン TTL が短いか（数分〜数十分が適切）
+
+**テスト必須:** `testRefreshTokenReuseRevokesAllUserTokens()` — リプレイ攻撃検知の動作確認。
+
+---
+
+### ペルソナ6: 設計者・ポリシー照合（NENE2 設計ポリシー目線）
+
+**ポリシー整合:**
+- リフレッシュトークンのハッシュ保存は良い設計（DB 漏洩耐性）
+- `createEmpty(204)` の使用は正しい（`create(null, 204)` は型エラー）
+- `jti` クレームによるユニーク性保証はトークン追跡の起点として良い
+
+**設計上のギャップ:**
+1. Refresh Token Rotation howto が未作成
+2. アクセストークンと `jti` によるトークンブロックリスト（即時失効）パターンが未文書
+
+---
+
+## Issues / PRs
+
+- Issue: `docs/howto/refresh-token-rotation.md` — リフレッシュトークンのハッシュ保存・ローテーション・リプレイ攻撃検知・ログアウトの情報漏洩防止・`jti` クレーム

--- a/docs/howto/refresh-token-rotation.md
+++ b/docs/howto/refresh-token-rotation.md
@@ -1,0 +1,261 @@
+# How-To: JWT Refresh Token Rotation
+
+This guide covers implementing short-lived access tokens combined with long-lived refresh
+tokens. The key property is **rotation**: every use of a refresh token immediately revokes
+it and issues a new one. A reused (already-revoked) refresh token triggers revocation of all
+tokens for that user.
+
+---
+
+## Why two tokens?
+
+| Token | TTL | Storage | Purpose |
+|---|---|---|---|
+| Access token | 5 min | Client memory | Authenticates API requests (stateless, no DB lookup) |
+| Refresh token | 7 days | DB (hashed) | Issues new access tokens; managed via rotation |
+
+A short-lived access token limits the damage if it leaks — it expires in minutes. The
+refresh token extends the session without requiring re-login, but it is revocable because
+it lives in the database.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE refresh_tokens (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id),
+    token_hash TEXT    NOT NULL UNIQUE,  -- SHA-256 hash; never the raw value
+    expires_at TEXT    NOT NULL,
+    revoked    INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+```
+
+`token_hash` — always store the hash, never the raw token. If the DB leaks,
+hashed tokens cannot be used directly.
+
+---
+
+## Issuing tokens
+
+### Access token: add `jti` for uniqueness
+
+Without `jti`, two tokens issued in the same second for the same user are identical —
+their payloads are byte-for-byte equal. `jti` (JWT ID) guarantees each token is unique
+and is the foundation for future access-token blocklists:
+
+```php
+$accessToken = $this->issuer->issue([
+    'jti'   => bin2hex(random_bytes(8)),  // unique per issuance
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'iat'   => time(),
+    'exp'   => time() + 300,  // 5 minutes
+]);
+```
+
+### Refresh token: store the hash, return the raw value
+
+```php
+public function issue(int $userId): string
+{
+    $raw       = bin2hex(random_bytes(32));  // 256-bit random token
+    $hash      = hash('sha256', $raw);       // store only this
+    $expiresAt = (new \DateTimeImmutable())->modify('+7 days')->format('Y-m-d\TH:i:s\Z');
+    $createdAt = (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+
+    $this->executor->insert(
+        'INSERT INTO refresh_tokens (user_id, token_hash, expires_at, revoked, created_at)
+         VALUES (?, ?, ?, 0, ?)',
+        [$userId, $hash, $expiresAt, $createdAt],
+    );
+
+    return $raw;  // the client receives this; the DB never stores it
+}
+```
+
+To look up a token from a client-supplied value:
+
+```php
+public function findByRaw(string $raw): ?RefreshToken
+{
+    $hash = hash('sha256', $raw);
+
+    $row = $this->executor->fetchOne(
+        'SELECT ... FROM refresh_tokens WHERE token_hash = ?',
+        [$hash],
+    );
+    // ...
+}
+```
+
+---
+
+## Token rotation
+
+Every refresh request must revoke the old token before issuing a new one:
+
+```php
+private function refresh(ServerRequestInterface $request): ResponseInterface
+{
+    // ... parse body, find stored token ...
+
+    if ($stored === null || !$stored->isValid()) {
+        // Reuse of a revoked token is a potential replay attack —
+        // revoke all tokens for the user to force re-authentication.
+        if ($stored !== null && $stored->revoked) {
+            $this->refreshTokens->revokeAllForUser($stored->userId);
+        }
+
+        return $this->problems->create(
+            $request,
+            'invalid-refresh-token',
+            'Invalid or Expired Refresh Token',
+            401,
+            'The refresh token is invalid, expired, or has already been used.',
+        );
+    }
+
+    $user = $this->users->findById($stored->userId);
+
+    // Rotation: revoke old token first, then issue new pair
+    $this->refreshTokens->revoke($stored->id);
+
+    return $this->json->create($this->issueTokenPair($user));
+}
+```
+
+**Reuse detection**: if a revoked refresh token arrives at the `/auth/refresh` endpoint,
+it means either the user is replaying an old token (unusual) or an attacker stole it.
+`revokeAllForUser()` forces every session to re-authenticate, limiting the blast radius.
+
+---
+
+## Logout: always return 204
+
+Never return different status codes depending on whether the refresh token was valid.
+Doing so lets an attacker probe whether a token is still active:
+
+```php
+private function logout(ServerRequestInterface $request): ResponseInterface
+{
+    // ... parse body ...
+
+    $stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+
+    if ($stored !== null && !$stored->revoked) {
+        $this->refreshTokens->revoke($stored->id);
+    }
+
+    // Always 204 — never leak whether the token was valid or not
+    return $this->json->createEmpty(204);
+}
+```
+
+This also means double-logout (calling logout twice with the same token) returns 204 both
+times — the client can always call logout safely without worrying about the token's state.
+
+---
+
+## Validity check on the RefreshToken entity
+
+```php
+public function isValid(): bool
+{
+    if ($this->revoked) {
+        return false;
+    }
+
+    return $this->expiresAt > (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+}
+```
+
+String comparison works for ISO-8601 dates sorted lexicographically. If you store
+timestamps as Unix integers, compare with `time()` instead.
+
+---
+
+## BearerTokenMiddleware: exclude refresh/logout paths
+
+The refresh and logout endpoints receive a refresh token in the body, not a Bearer access
+token in the Authorization header. Exclude them from `BearerTokenMiddleware`:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier: $verifier,
+    excludedPaths: ['/auth/login', '/auth/refresh', '/auth/logout'],
+);
+```
+
+The `/auth/me` endpoint (and any other protected path) stays protected by the middleware.
+
+---
+
+## Response shape
+
+```json
+{
+  "access_token":  "eyJhbGci...",
+  "token_type":    "Bearer",
+  "expires_in":    300,
+  "refresh_token": "a3f92c..."
+}
+```
+
+`expires_in` (seconds) lets the client schedule a proactive refresh before the access
+token expires, avoiding a failed request followed by a refresh.
+
+---
+
+## Code-review checklist
+
+1. `token_hash` column stores `hash('sha256', $raw)` — never the raw value
+2. `revoke()` is called before `issueTokenPair()` in the refresh handler
+3. Revoked-token reuse triggers `revokeAllForUser()` (not just a 401)
+4. Logout always returns 204 — no conditional 401/404
+5. Access token TTL is short (≤ 15 minutes)
+6. `jti` claim is present in access tokens
+7. Tests cover cross-token-rotation (old token invalid after refresh) and reuse detection
+
+---
+
+## Testing rotation and reuse detection
+
+```php
+public function testRefreshTokenRotation_OldTokenIsInvalidAfterRefresh(): void
+{
+    $tokens = $this->login();
+
+    $this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]);
+
+    // Old token must be rejected
+    $res = $this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]);
+    $this->assertSame(401, $res->getStatusCode());
+}
+
+public function testRefreshTokenReuseRevokesAllUserTokens(): void
+{
+    $tokens = $this->login();
+
+    // Rotate once — old token is now revoked
+    $newTokens = $this->json($this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]));
+
+    // Attacker replays the old (revoked) refresh token — triggers revokeAllForUser()
+    $this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]);
+
+    // The newly issued refresh token is now also revoked
+    $res = $this->post('/auth/refresh', ['refresh_token' => (string) $newTokens['refresh_token']]);
+    $this->assertSame(401, $res->getStatusCode());
+}
+```
+
+---
+
+## See also
+
+- `docs/howto/jwt-authentication.md` — JWT issuance, BearerTokenMiddleware, `nene2.auth.claims`
+- `docs/howto/password-hashing.md` — Argon2id, dummy hash pattern for user enumeration prevention
+- `docs/field-trials/2026-05-field-trial-113.md` — Refresh token rotation field trial

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.46
+  version: 1.5.47
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.46';
+    public const string VERSION = '1.5.47';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/refresh-token-rotation.md` 追加 — FT113（refreshlog）で検証した Refresh Token Rotation パターンを網羅
- `docs/field-trials/2026-05-field-trial-113.md` 追加 — 15 tests / 63 assertions
- v1.5.47 バンプ

## 内容

1. **リフレッシュトークンはハッシュして保存**（SHA-256、生値は DB に入れない）
2. **ローテーション**: 使用後即 `revoke()` → 新トークン発行
3. **リプレイ攻撃検知**: 失効済みトークン再利用時に `revokeAllForUser()`
4. **ログアウトは必ず 204**（有効・無効にかかわらず）
5. **`jti` クレームでアクセストークンのユニーク性を保証**
6. アクセストークン（5分・stateless）とリフレッシュトークン（7日・DB管理）の分離解説

## Test plan

- [x] `composer check` — PHPStan level 8 / CS / OpenAPI / MCP / version 全 OK
- [x] FT113 refreshlog: 15 tests / 63 assertions all pass

Self-review: docs-policy

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)