### PR TITLE
docs(howto): バックグラウンドジョブキューガイドを追加 (FT116)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-116.md
+++ b/docs/field-trials/2026-05-field-trial-116.md
@@ -1,0 +1,79 @@
+# Field Trial Report — FT116: Background Job Queue with Retry and Idempotency
+
+**Date**: 2026-05-21
+**Release**: v1.5.50
+**App**: `queuelog` (`/home/xi/docker/NENE2-FT/queuelog/`)
+**Tests**: 27/27 passed
+**PHPStan**: level 8, 0 errors
+**CS**: clean
+
+## Theme
+
+Implement a persistent background job queue using NENE2's database layer. The trial focused on three patterns:
+
+1. **Priority queue** — claim highest-priority pending job (priority DESC, FIFO within tier)
+2. **Automatic retry** — fail with retry_count < max_retries requeues to pending; exhausted retries transition to failed
+3. **Idempotent job creation** — `idempotency_key` prevents duplicate jobs under retry/concurrent POST
+
+## Schema additions to existing FT65 foundation
+
+The `queuelog` project reused the FT65 job queue foundation (claim/complete/fail cycle, priority enum) and added:
+
+```sql
+retry_count     INTEGER NOT NULL DEFAULT 0,
+max_retries     INTEGER NOT NULL DEFAULT 3,
+idempotency_key TEXT    UNIQUE,
+```
+
+The `UNIQUE` constraint on `idempotency_key` is enforced at the database level, not only in application code, to prevent race conditions under concurrent requests.
+
+## Key implementation decisions
+
+### Retry logic belongs in the repository
+
+The check `retry_count < max_retries` is a data-layer invariant. Placing it in `SqliteJobRepository::fail()` keeps workers stateless and prevents drift from multiple implementations:
+
+```php
+if ($job->retryCount < $job->maxRetries) {
+    // requeue: increment retry_count, reset to pending, clear worker assignment
+} else {
+    // permanent failure
+}
+```
+
+The `error` field is updated on every failure, including requeues, providing a diagnostic trail.
+
+### Idempotency: check first, catch never
+
+The application layer checks for an existing job by key before attempting INSERT. The DB UNIQUE constraint catches concurrent races but should not be the primary code path — exceptions from constraint violations are harder to distinguish from other DB errors and produce inconsistent HTTP responses if not handled explicitly.
+
+### max_retries=0 for non-retryable jobs
+
+Jobs where replay would cause harm (payments, external webhooks) can be created with `max_retries: 0`. The first `fail` call immediately sets status to `failed`.
+
+## Test coverage (27 tests)
+
+| Category | Tests |
+|---|---|
+| Job creation (defaults, payload, validation) | 5 |
+| Get / List / Filter by status | 4 |
+| Claim (priority, claimed_at, no-pending, missing worker_id) | 4 |
+| Complete (happy path, 409 on non-running, cannot re-claim) | 3 |
+| Fail (409 on non-running) | 1 |
+| Retry: requeue on fail with retries remaining | 1 |
+| Retry: requeued job can be claimed again | 1 |
+| Retry: exhausts retries → failed | 1 |
+| Retry: max_retries=0 → immediate fail | 1 |
+| Idempotency: duplicate key returns existing | 1 |
+| Idempotency: key stored and returned | 1 |
+| Idempotency: different keys create separate jobs | 1 |
+| Priority: FIFO within same priority | 1 |
+| Priority: critical beats high | 1 |
+| Custom max_retries | 1 |
+
+## DX observations
+
+- The claim/complete/fail API maps directly to worker loop logic — easy to reason about.
+- Returning the job object from every state-transition endpoint (including fail/requeue) lets callers inspect the new state without a separate GET.
+- `max_retries` configurable per job type is more flexible than a global default.
+- Stalled job detection (running + claimed_at timeout) is a natural next concern not covered in this trial.

--- a/docs/howto/job-queue.md
+++ b/docs/howto/job-queue.md
@@ -1,0 +1,172 @@
+# Background Job Queue with Retry and Idempotency
+
+This guide covers implementing a persistent background job queue in NENE2 applications. The pattern supports priority queues, automatic retry with backoff counters, and idempotent job creation.
+
+## Core concepts
+
+A job queue decouples work from HTTP request cycles. The HTTP handler enqueues a job and returns immediately; a separate worker process claims and executes jobs.
+
+Key states: `pending` → `running` → `completed` or `failed` (with automatic requeue when retries remain).
+
+## Schema design
+
+```sql
+CREATE TABLE IF NOT EXISTS jobs (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    type            TEXT    NOT NULL,
+    payload         TEXT    NOT NULL DEFAULT '{}',
+    priority        INTEGER NOT NULL DEFAULT 0,
+    status          TEXT    NOT NULL DEFAULT 'pending',
+    retry_count     INTEGER NOT NULL DEFAULT 0,
+    max_retries     INTEGER NOT NULL DEFAULT 3,
+    idempotency_key TEXT    UNIQUE,
+    claimed_at      TEXT,
+    worker_id       TEXT,
+    error           TEXT,
+    created_at      TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL
+);
+```
+
+`idempotency_key UNIQUE` is enforced at the database level, not just application level. This prevents races where two concurrent HTTP requests both pass the application-layer check and both attempt INSERT.
+
+## Job lifecycle
+
+```
+POST /jobs                  → pending (retry_count=0)
+POST /jobs/claim            → running (worker_id, claimed_at set)
+POST /jobs/{id}/complete    → completed
+POST /jobs/{id}/fail        → pending (retry_count+1) if retries remain
+                            → failed if retry_count >= max_retries
+```
+
+## Retry logic
+
+When a worker calls `fail`, the repository decides whether to requeue or permanently fail:
+
+```php
+public function fail(int $id, string $error, string $now): ?Job
+{
+    $job = $this->findById($id);
+    if ($job === null || $job->status !== JobStatus::Running) {
+        return null;
+    }
+
+    if ($job->retryCount < $job->maxRetries) {
+        $this->executor->execute(
+            "UPDATE jobs SET status = 'pending', retry_count = retry_count + 1,
+             error = ?, claimed_at = NULL, worker_id = NULL, updated_at = ? WHERE id = ?",
+            [$error, $now, $id],
+        );
+    } else {
+        $this->executor->execute(
+            "UPDATE jobs SET status = 'failed', error = ?, updated_at = ? WHERE id = ?",
+            [$error, $now, $id],
+        );
+    }
+
+    return $this->findById($id);
+}
+```
+
+The `error` field stores the **most recent** failure reason even on requeue, giving operators a diagnostic trail on the job record.
+
+## Idempotency
+
+Pass an `idempotency_key` when creating a job to make the operation safe to retry from the HTTP client:
+
+```http
+POST /jobs
+Content-Type: application/json
+
+{
+  "type": "send-invoice",
+  "payload": {"invoice_id": 42},
+  "idempotency_key": "invoice-42-send-2026-05"
+}
+```
+
+- First call: `201 Created` — job is created.
+- Subsequent calls with same key: `200 OK` — existing job returned, no duplicate created.
+
+The database `UNIQUE` constraint on `idempotency_key` is the safety net. Check at the application layer first to avoid relying on exception handling as the primary code path:
+
+```php
+if ($idempotencyKey !== null) {
+    $existing = $this->repo->findByIdempotencyKey($idempotencyKey);
+    if ($existing !== null) {
+        return $this->json->create($existing->toArray(), 200);
+    }
+}
+$job = $this->repo->create(..., $idempotencyKey, $maxRetries);
+return $this->json->create($job->toArray(), 201);
+```
+
+## Priority queue
+
+Jobs are claimed by priority DESC, then created_at ASC (FIFO within a tier):
+
+```sql
+SELECT * FROM jobs
+WHERE status = 'pending'
+ORDER BY priority DESC, created_at ASC
+LIMIT 1
+```
+
+Priority levels (integer values stored, human labels exposed):
+
+| Label    | Value |
+|----------|-------|
+| low      | 0     |
+| medium   | 10    |
+| high     | 20    |
+| critical | 30    |
+
+## Worker pattern
+
+Workers are stateless processes that loop: claim → execute → complete or fail.
+
+```
+loop:
+  job = POST /jobs/claim { worker_id: "worker-1" }
+  if job is null → sleep, continue
+
+  try:
+    execute(job.type, job.payload)
+    POST /jobs/{job.id}/complete {}
+  catch error:
+    POST /jobs/{job.id}/fail { error: error.message }
+```
+
+Workers identify themselves with `worker_id` so operators can see which worker holds a job and diagnose stalled workers.
+
+## Stalled job detection
+
+Jobs in `running` status with a `claimed_at` timestamp older than a threshold are stalled (worker crashed). A maintenance process should detect and requeue them:
+
+```sql
+UPDATE jobs
+SET status = 'pending', retry_count = retry_count + 1,
+    claimed_at = NULL, worker_id = NULL, updated_at = ?
+WHERE status = 'running'
+  AND claimed_at < ?             -- older than timeout threshold
+  AND retry_count < max_retries
+```
+
+## max_retries=0 for non-retryable jobs
+
+Some jobs must not be retried (e.g., payments, external webhooks where replay would cause harm). Set `max_retries: 0` when creating:
+
+```json
+{ "type": "charge-card", "max_retries": 0, "idempotency_key": "charge-order-99" }
+```
+
+The first `fail` call immediately transitions the job to `failed`.
+
+## Design decisions
+
+**Why retry logic in the repository, not the worker?** The decision to requeue is a data-layer invariant (retry_count < max_retries), not business logic. Placing it in the repository keeps workers simple and prevents inconsistency from workers that implement the check differently.
+
+**Why UNIQUE constraint on idempotency_key at DB level?** Application-level checks have race conditions under concurrent requests. The DB constraint is the authoritative guard; the application-layer check is an optimization to avoid relying on exception handling.
+
+**Why store priority as an integer?** Allows adding intermediate priority levels later without schema changes. The human-readable label is derived, not stored.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.49`（2026-05-21 リリース済み）
+- Latest release: `v1.5.50`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -31,10 +31,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT113 | JWT Refresh Token Rotation | refreshlog | 15/15 | v1.5.47 | refresh-token-rotation.md（リフレッシュトークンをハッシュ保存・ローテーション・リプレイ攻撃検知・ログアウト常に 204・jti クレーム） |
 | FT114 | 監査ログ（Audit Trail）| auditlog | 17/17 | v1.5.48 | audit-trail.md（監査はハンドラレイヤー・before/after スナップショット・immutable・JWT クレームからアクター取得・ORDER BY id DESC）脆弱性診断: ダミーハッシュ不正形式・所有権チェック漏れを修正 |
 | FT115 | API バージョニング | versionlog | 14/14 | v1.5.49 | api-versioning.md（URI プレフィックス・Deprecation/Sunset ヘッダー RFC 8594・toV1/toV2 変換・ストレージ共有） |
+| FT116 | バックグラウンドジョブキュー | queuelog | 27/27 | v1.5.50 | job-queue.md（優先度キュー・リトライロジックはリポジトリ層・retry_count/max_retries・idempotency_key UNIQUE 制約・max_retries=0 で即失敗） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT116 進行中・FT117 で脆弱性診断）
+- FT ループ継続中（FT117 進行中・**FT117 で脆弱性診断**）
 
 ## Open Issues
 


### PR DESCRIPTION
## Summary

- FT116 フィールドトライアル完走: バックグラウンドジョブキューの Retry + Idempotency パターン
- `docs/howto/job-queue.md`: 優先度キュー・リトライロジック・idempotency_key 設計ガイド
- `docs/field-trials/2026-05-field-trial-116.md`: 27/27 テスト・PHPStan level 8 クリーン

## Key patterns documented

- リトライロジックはリポジトリ層（`retry_count < max_retries` で requeue、それ以上で failed）
- `idempotency_key UNIQUE` は DB 制約でレース防止、アプリ層は先行チェックで最適化
- `max_retries=0` で非リトライジョブ（決済・外部 Webhook）の即時失敗

## Test plan

- [x] 27 tests passing (`composer test`)
- [x] PHPStan level 8 clean (`composer analyse`)
- [x] CS fixer clean (`composer cs`)

Closes #734

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)