### PR TITLE
docs(howto): API キー管理ガイドを追加 (FT117 — 脆弱性診断付き)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-117.md
+++ b/docs/field-trials/2026-05-field-trial-117.md
@@ -1,0 +1,116 @@
+# Field Trial Report — FT117: API Key Management (with Vulnerability Assessment)
+
+**Date**: 2026-05-21
+**Release**: v1.5.51
+**App**: `apikeylog` (`/home/xi/docker/NENE2-FT/apikeylog/`)
+**Tests**: 19/19 passed
+**PHPStan**: level 8, 0 errors
+**CS**: clean
+**Vulnerability Assessment**: 2 findings found and fixed before release
+
+## Theme
+
+Implement API key management in NENE2: key generation with type prefix, SHA-256 hash storage, scope-based authorization (read/write/admin hierarchy), key revocation, and key rotation.
+
+FT117 is the third FT in the FT115/FT116/FT117 cycle, triggering a mandatory vulnerability assessment.
+
+## Implementation patterns
+
+### Key format: `{type}_{base64url(32 random bytes)}`
+
+`random_bytes(32)` gives 256 bits of entropy. The type prefix (`nk`) makes keys identifiable in logs and code searches. The raw key is returned once at creation and never stored.
+
+### SHA-256 (not Argon2id) for API keys
+
+API keys are 256-bit random values — not dictionary words. Fast hashing is appropriate here; Argon2id overhead per request is unjustified, and brute-forcing 256-bit random values through SHA-256 is computationally infeasible regardless.
+
+### Prefix-based lookup + hash_equals() verification
+
+Authentication is a two-step process:
+1. DB lookup by `prefix` column (first 16 chars of the raw key) — O(1) with index
+2. `hash_equals()` timing-safe comparison of computed vs stored hash
+
+### Scope hierarchy via enum method
+
+`ApiKeyScope::allows(required)` encapsulates the hierarchy: admin ⊃ write ⊃ read. Endpoints call `requireScope()`, which returns either the authenticated `ApiKey` or an error response.
+
+### Rotation: create-first, then revoke
+
+Revoke-then-create is a lockout risk. Create-then-revoke means the worst failure mode is two temporarily active keys, which is observable and recoverable.
+
+## Vulnerability Assessment Findings
+
+### V1 — Critical: Prefix column always `'nk'` — full table scan on every auth
+
+**Root cause**: `extractPrefix()` split on `_` and returned `nk` for all keys. `WHERE prefix = 'nk'` returned every key in the database on every authentication request.
+
+**Impact**:
+- Performance: O(n) authentication scan — degrades with scale
+- DoS potential: any unauthenticated request triggers a full table scan
+- Timing channel: response time proportional to number of keys in DB
+
+**Fix**: Changed `extractPrefix()` to `substr($rawKey, 0, 16)`. First 16 chars of the key includes `nk_` plus 13 chars of the random part (78 bits of differentiation) — effectively unique per key, enabling O(1) index lookup.
+
+```php
+// Before (vulnerable)
+public function extractPrefix(string $rawKey): string
+{
+    $parts = explode('_', $rawKey, 2);
+    return $parts[0]; // always 'nk'
+}
+
+// After (fixed)
+public function extractPrefix(string $rawKey): string
+{
+    return substr($rawKey, 0, 16); // unique per key
+}
+```
+
+### V2 — Medium: `rotate()` not safe — revoke before create risks owner lockout
+
+**Root cause**: Original implementation revoked the old key first, then created the new key. If the CREATE INSERT fails (DB error, constraint violation), the old key is permanently revoked with no replacement.
+
+**Impact**: Owner permanently locked out if rotation fails mid-way. No recovery path without manual DB intervention.
+
+**Fix**: Reordered to create-first, revoke-after. If CREATE fails, old key remains active (no lockout). If REVOKE fails after CREATE succeeds, both keys briefly exist — operator can see this via list endpoint and manually revoke the old one.
+
+### V3 — Acceptable: SHA-256 without HMAC
+
+**Assessment**: Using `hash('sha256', $rawKey)` without a server-side HMAC secret means an attacker who obtains the DB can compute SHA-256 of candidate keys. However, with 256 bits of entropy per key, this is computationally infeasible. HMAC-SHA256 with a secret would provide defense-in-depth but the cost/benefit ratio is low for this key length. Rated Acceptable.
+
+### V4 — PASS: hash_equals() used throughout
+
+Timing-safe comparison is correctly applied. Using `===` would leak timing information revealing how many hash characters match, enabling prefix-based oracle attacks.
+
+### V5 — PASS: key_hash not in API responses
+
+`ApiKey::toArray()` omits `key_hash`. The raw key (`key`) only appears in `ApiKeyCreateResult::toArray()`, used exclusively by the create endpoint.
+
+### V6 — PASS: Scope enforcement
+
+`ApiKeyScope::allows()` correctly implements hierarchy. All three scope levels tested. Read key → 403 on write endpoint. Write key → 403 on admin endpoint. Admin key → 200 on all.
+
+### V7 — PASS: Ownership check on revoke/rotate
+
+Both operations verify `$key->ownerId !== $ownerId` and return `null` → `404` for unauthorized access. The 404 (rather than 403) prevents disclosure of whether a key ID exists at all.
+
+### V8 — PASS: Unified 401 for all authentication failures
+
+Missing key, invalid key, expired key, and revoked key all return `401` with the same message. No oracle for key state.
+
+## Test coverage (19 tests)
+
+| Category | Tests |
+|---|---|
+| Create key (defaults, missing owner, invalid scope, expiry, custom) | 4 |
+| List keys (isolation by owner, key_hash not exposed) | 2 |
+| Revoke (happy path, revoked key can't auth, wrong owner 404) | 3 |
+| Rotate (creates new + revokes old, already-revoked returns 404) | 2 |
+| Protected endpoints (read/write/admin scope enforcement) | 5 |
+| Error cases (missing header, invalid key, expired key) | 3 |
+
+## DX observations
+
+- The `prefix + hash_equals` pattern is well-understood in the API key ecosystem (GitHub, Stripe follow it) — easy to explain to implementers.
+- Returning `key_hash` in the domain object but omitting from `toArray()` requires discipline — easy to accidentally include it. An explicit exclusion list is safer than an inclusion list.
+- The scope hierarchy enum method (`allows()`) is cleaner than a switch in the handler — easy to extend with new scopes.

--- a/docs/howto/api-key-management.md
+++ b/docs/howto/api-key-management.md
@@ -1,0 +1,230 @@
+# API Key Management
+
+This guide covers implementing API key management in NENE2 applications: key generation, secure storage, scope-based authorization, revocation, and rotation.
+
+## Core design principles
+
+1. **Never store raw keys** — only SHA-256 hashes in the database.
+2. **Return the raw key once** — only at creation time, never again.
+3. **Prefix-based lookup, hash-based verification** — the prefix narrows the DB query; hash_equals() does the actual authentication.
+4. **Scope hierarchy** — admin ⊃ write ⊃ read; checked per endpoint.
+5. **Rotate safely** — create the new key before revoking the old one to prevent lockout.
+
+## Key format
+
+```
+nk_Vf3aB2cX9dJkQmHpNrTsUvWxYzAeBfCg
+^   ^----- 43 chars of base64url(32 random bytes) -----^
+|
+type prefix (identifiable in logs)
+```
+
+`random_bytes(32)` gives 256 bits of entropy. This is computationally infeasible to brute-force regardless of hash speed, so SHA-256 (fast, single-purpose) is appropriate — unlike passwords, API keys are not dictionary-attackable.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS api_keys (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id    INTEGER NOT NULL,
+    prefix      TEXT    NOT NULL,     -- first 16 chars of raw key (lookup index)
+    key_hash    TEXT    NOT NULL UNIQUE,
+    scope       TEXT    NOT NULL DEFAULT 'read',
+    description TEXT    NOT NULL DEFAULT '',
+    expires_at  TEXT,
+    revoked_at  TEXT,
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+```
+
+The `prefix` column stores the **first 16 characters of the raw key** (not the type prefix `nk`). This gives ~78 bits of differentiation, making each prefix effectively unique and enabling O(1) index lookup.
+
+**Critical**: Do NOT use the type prefix (`nk`) as the DB lookup prefix. All keys share the same type prefix, so `WHERE prefix = 'nk'` would scan the entire table — O(n) lookup and a timing channel proportional to the number of keys.
+
+## Key generation
+
+```php
+final class ApiKeyGenerator
+{
+    private const string PREFIX = 'nk';
+    private const int    BYTES  = 32;
+
+    public function generate(): string
+    {
+        $raw = random_bytes(self::BYTES);
+        return self::PREFIX . '_' . rtrim(strtr(base64_encode($raw), '+/', '-_'), '=');
+    }
+
+    public function hash(string $rawKey): string
+    {
+        return hash('sha256', $rawKey);
+    }
+
+    public function extractPrefix(string $rawKey): string
+    {
+        // First 16 chars of the full key — unique per key, safe to index
+        return substr($rawKey, 0, 16);
+    }
+
+    public function verify(string $rawKey, string $storedHash): bool
+    {
+        return hash_equals($storedHash, $this->hash($rawKey));
+    }
+}
+```
+
+`hash_equals()` is mandatory. Using `===` or `==` for hash comparison leaks timing information: a 64-char hex string compared with `===` exits on first mismatch, revealing how many leading characters match.
+
+## Authentication flow
+
+```php
+public function authenticate(string $rawKey, string $now): ?ApiKey
+{
+    $prefix = $this->generator->extractPrefix($rawKey);
+
+    $rows = $this->executor->fetchAll(
+        'SELECT * FROM api_keys WHERE prefix = ?',
+        [$prefix],
+    );
+
+    foreach ($rows as $row) {
+        $key = $this->hydrate($row);
+        if ($this->generator->verify($rawKey, $key->keyHash) && $key->isActive($now)) {
+            return $key;
+        }
+    }
+
+    return null;
+}
+```
+
+The two-step approach:
+1. Index lookup by prefix (fast DB query)
+2. `hash_equals()` verification against stored hash
+
+Return the same `null` and `401` for all failure cases (not found, wrong hash, expired, revoked) — callers must not distinguish between them.
+
+## Scope hierarchy
+
+```php
+enum ApiKeyScope: string
+{
+    case Read  = 'read';
+    case Write = 'write';
+    case Admin = 'admin';
+
+    public function allows(self $required): bool
+    {
+        return match ($required) {
+            self::Read  => true,
+            self::Write => $this === self::Write || $this === self::Admin,
+            self::Admin => $this === self::Admin,
+        };
+    }
+}
+```
+
+Enforce scope at the endpoint level:
+
+```php
+private function requireScope(ServerRequestInterface $request, ApiKeyScope $required): ApiKey|ResponseInterface
+{
+    $rawKey = $request->getHeaderLine('X-Api-Key');
+    if ($rawKey === '') {
+        return $this->problems->create($request, 'unauthorized', 'Missing X-Api-Key header.', 401, '');
+    }
+
+    $key = $this->repo->authenticate($rawKey, $now);
+    if ($key === null) {
+        return $this->problems->create($request, 'unauthorized', 'Invalid or expired API key.', 401, '');
+    }
+
+    if (!$key->scope->allows($required)) {
+        return $this->problems->create($request, 'forbidden', 'Insufficient scope.', 403, '');
+    }
+
+    return $key;
+}
+```
+
+Return `401` for unauthenticated, `403` for authenticated but insufficient scope — never leak whether the key exists.
+
+## Response filtering
+
+The `toArray()` method on `ApiKey` **must not** include `key_hash`. The raw key is only available via `ApiKeyCreateResult::toArray()` immediately after creation.
+
+```php
+// ApiKey::toArray() — safe to return from any endpoint
+public function toArray(): array
+{
+    return [
+        'id', 'owner_id', 'prefix', 'scope', 'description',
+        'expires_at', 'revoked_at', 'created_at', 'updated_at',
+        // key_hash is intentionally absent
+    ];
+}
+
+// ApiKeyCreateResult::toArray() — creation endpoint only
+public function toArray(): array
+{
+    return array_merge($this->key->toArray(), ['key' => $this->rawKey]);
+}
+```
+
+## Key rotation — safe ordering
+
+**Always create the new key before revoking the old one.**
+
+```php
+public function rotate(int $oldId, int $ownerId, string $now): ?ApiKeyCreateResult
+{
+    $old = $this->findById($oldId);
+    if ($old === null || $old->ownerId !== $ownerId || $old->isRevoked()) {
+        return null;
+    }
+
+    // Create first — if this fails, old key remains active (no lockout)
+    $result = $this->create($ownerId, $old->scope, $old->description, $now, $old->expiresAt);
+
+    // Revoke after — if this fails, both keys exist temporarily (recoverable via list)
+    $this->executor->execute(
+        'UPDATE api_keys SET revoked_at = ?, updated_at = ? WHERE id = ?',
+        [$now, $now, $oldId],
+    );
+
+    return $result;
+}
+```
+
+Revoke-then-create is dangerous: if CREATE fails after REVOKE, the owner is permanently locked out. The reverse (create-then-revoke) means the worst case is two active keys temporarily — observable and recoverable.
+
+## Expiry
+
+Store `expires_at` as an ISO datetime string. Check in `isActive()`:
+
+```php
+public function isActive(string $now): bool
+{
+    return !$this->isRevoked() && !$this->isExpired($now);
+}
+
+public function isExpired(string $now): bool
+{
+    return $this->expiresAt !== null && $this->expiresAt < $now;
+}
+```
+
+The authentication flow passes `$now` as a parameter, making the logic testable with fixed timestamps.
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Store raw key in DB | Full exposure on DB breach |
+| Use `===` for hash comparison | Timing attack leaks hash prefix length |
+| Use type prefix (`nk`) as DB lookup index | O(n) table scan; timing channel |
+| Return `key_hash` in list/detail responses | Offline dictionary attack on hashes |
+| Revoke old key before creating new key in rotation | Owner lockout on DB error |
+| Return different errors for "key not found" vs "key expired" | Oracle for key existence |
+| Log `X-Api-Key` header | Key leaks into log storage |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.50`（2026-05-21 リリース済み）
+- Latest release: `v1.5.51`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -32,10 +32,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT114 | 監査ログ（Audit Trail）| auditlog | 17/17 | v1.5.48 | audit-trail.md（監査はハンドラレイヤー・before/after スナップショット・immutable・JWT クレームからアクター取得・ORDER BY id DESC）脆弱性診断: ダミーハッシュ不正形式・所有権チェック漏れを修正 |
 | FT115 | API バージョニング | versionlog | 14/14 | v1.5.49 | api-versioning.md（URI プレフィックス・Deprecation/Sunset ヘッダー RFC 8594・toV1/toV2 変換・ストレージ共有） |
 | FT116 | バックグラウンドジョブキュー | queuelog | 27/27 | v1.5.50 | job-queue.md（優先度キュー・リトライロジックはリポジトリ層・retry_count/max_retries・idempotency_key UNIQUE 制約・max_retries=0 で即失敗） |
+| FT117 | API キー管理 | apikeylog | 19/19 | v1.5.51 | api-key-management.md（SHA-256 ハッシュ保存・prefix+hash_equals 2段階認証・スコープ階層・rotate は create-first・**脆弱性診断: prefix が常に 'nk' で全テーブルスキャン→修正・rotate 非アトミック→create-first に修正**） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT117 進行中・**FT117 で脆弱性診断**）
+- FT ループ継続中（FT118 以降・次の脆弱性診断は FT120）
 
 ## Open Issues
 


### PR DESCRIPTION
## Summary

- FT117 フィールドトライアル完走: API キー管理パターン（FT115/116/117 サイクル — 脆弱性診断実施）
- `docs/howto/api-key-management.md`: prefix+hash_equals 2段階認証・SHA-256ハッシュ保存・スコープ階層・create-first ローテーション
- `docs/field-trials/2026-05-field-trial-117.md`: 19/19 テスト・脆弱性診断 2 件発見修正

## Vulnerability Assessment Results

### [Critical — Fixed] Prefix column always 'nk' → full table scan on auth
- `extractPrefix()` returned `'nk'` for all keys → `WHERE prefix = 'nk'` scanned entire table
- Fixed: `substr($rawKey, 0, 16)` — first 16 chars are unique per key (~78 bits)

### [Medium — Fixed] rotate() revoke-then-create → owner lockout risk
- If CREATE fails after REVOKE, old key gone and no new key exists
- Fixed: create-first, then revoke — worst case is two temporarily active keys (recoverable)

## Test plan

- [x] 19 tests passing (`composer test`)
- [x] PHPStan level 8 clean (`composer analyse`)
- [x] CS fixer clean (`composer cs`)
- [x] Vulnerability findings fixed and verified

Closes #736

Self-review: docs-policy, middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)