### PR TITLE
docs(howto): サーキットブレーカーガイドを追加 (FT119)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-119.md
+++ b/docs/field-trials/2026-05-field-trial-119.md
@@ -1,0 +1,61 @@
+# Field Trial Report — FT119: Circuit Breaker Pattern
+
+**Date**: 2026-05-21
+**Release**: v1.5.53
+**App**: `circuitlog` (`/home/xi/docker/NENE2-FT/circuitlog/`)
+**Tests**: 15/15 passed
+**PHPStan**: level 8, 0 errors
+**CS**: clean
+
+## Theme
+
+Implement the circuit breaker pattern with three-state transitions (Closed → Open → Half-Open → Closed), configurable failure threshold, and timeout-based recovery. State is persisted in SQLite to survive restarts and share across workers.
+
+## State machine
+
+```
+Closed ──(failures >= threshold)──▶ Open ──(open_until elapsed)──▶ Half-Open
+  ▲                                                                      │
+  └───────────────────(success)────────────────────────────────────────┘
+Half-Open ──(any failure)──▶ Open
+```
+
+## Key decisions
+
+### Lazy Half-Open transition
+
+`maybeTransitionToHalfOpen()` is called on every request before the `isCallAllowed()` check. This avoids background timers or scheduled jobs — the transition happens naturally when traffic arrives after the timeout. For low-traffic services, this means the recovery probe is slightly delayed until the next request arrives, which is acceptable in practice.
+
+### DB-backed state for consistency
+
+In-memory state would be reset on PHP-FPM worker restart and wouldn't be shared between workers. DB state is consistent at the cost of one additional query per protected call. For very high throughput, Redis with atomic commands (INCR, SET NX) would be preferable.
+
+### "Consecutive failures" not "failure rate"
+
+`failure_count` resets to 0 on any success. This is simpler than a sliding window rate calculation and works well for services that are either working or not. A sliding window (e.g., >50% failures in 60 seconds) would be more appropriate for services with intermittent partial degradation.
+
+### 503 on Open circuit
+
+The call endpoint returns `503 Service Unavailable` with the circuit state and `open_until` when the circuit is open. This gives clients and upstream load balancers enough context to implement backoff.
+
+## Test coverage (15 tests)
+
+| Category | Tests |
+|---|---|
+| Initial state (new circuit starts Closed) | 1 |
+| Closed → Open after threshold failures | 2 |
+| Failures below threshold stay Closed | 1 |
+| Success resets failure count | 1 |
+| Open → Half-Open after timeout | 2 |
+| Half-Open success → Closed | 1 |
+| Half-Open failure → Open | 1 |
+| GET /circuits/{name} (404, state) | 2 |
+| Reset | 1 |
+| Circuits isolated by name | 1 |
+| open_until in response, last_failure_at | 2 |
+
+## DX observations
+
+- The three-state enum makes transitions self-documenting; adding a fourth state (e.g., `forced_open`) would be a clean extension.
+- Passing `$now` as a string parameter to all repository methods makes temporal transitions fully testable without `sleep()`.
+- The `isCallAllowed()` method on the record object keeps the Open check logic co-located with the state definition.

--- a/docs/howto/circuit-breaker.md
+++ b/docs/howto/circuit-breaker.md
@@ -1,0 +1,124 @@
+# Circuit Breaker
+
+The circuit breaker pattern prevents cascading failures when calling external services. Instead of letting slow or failed calls pile up, the circuit trips open and immediately rejects calls until the dependency recovers.
+
+## Three states
+
+```
+Closed ──(N consecutive failures)──▶ Open ──(timeout elapsed)──▶ Half-Open
+  ▲                                                                    │
+  └──────────────────(success)────────────────────────────────────────┘
+  Half-Open ──(failure)──▶ Open
+```
+
+| State | Behavior |
+|---|---|
+| **Closed** | Normal — calls pass through. Failure count increments on each error. |
+| **Open** | Calls immediately rejected with 503. Opens for `timeout_seconds` after `failure_threshold` consecutive failures. |
+| **Half-Open** | Single probe call allowed. Success → Closed (reset). Failure → Open again. |
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS circuits (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    name              TEXT    NOT NULL UNIQUE,
+    state             TEXT    NOT NULL DEFAULT 'closed',
+    failure_count     INTEGER NOT NULL DEFAULT 0,
+    failure_threshold INTEGER NOT NULL DEFAULT 5,
+    open_until        TEXT,
+    half_open_at      TEXT,
+    last_failure_at   TEXT,
+    updated_at        TEXT    NOT NULL
+);
+```
+
+The circuit name is typically the external service identifier (e.g., `payment-gateway`, `email-svc`). Multiple independent circuits can coexist.
+
+## Recording outcomes
+
+```php
+// After a successful call to the external service:
+$this->repo->recordSuccess($circuitName, $now);
+
+// After a failed call:
+$this->repo->recordFailure($circuitName, $now, timeoutSeconds: 30);
+```
+
+`recordFailure()` decides the transition:
+- If `failure_count + 1 >= failure_threshold` → set state to `open`, compute `open_until = now + timeout`.
+- If still below threshold → increment `failure_count`, stay `closed`.
+- If in `half_open` state → any failure immediately reopens.
+
+## Checking if a call is allowed
+
+```php
+$circuit = $this->repo->maybeTransitionToHalfOpen($name, $now);
+
+if (!$circuit->isCallAllowed($now)) {
+    // Return 503 immediately — don't call the external service
+    return $problems->create($request, 'service-unavailable', 'Circuit is open.', 503);
+}
+
+// Attempt the call...
+```
+
+Call `maybeTransitionToHalfOpen()` before the `isCallAllowed()` check on every request. This transitions `Open → Half-Open` once `open_until` has passed, allowing the probe call through.
+
+```php
+public function isCallAllowed(string $now): bool
+{
+    return match ($this->state) {
+        CircuitState::Closed   => true,
+        CircuitState::Open     => $now >= ($this->openUntil ?? ''),
+        CircuitState::HalfOpen => true,
+    };
+}
+```
+
+## Half-Open timing
+
+The `Open → Half-Open` transition is lazy: it happens the next time `maybeTransitionToHalfOpen()` is called after `open_until` has elapsed. This is intentional — it avoids background timers and keeps state changes tied to incoming requests.
+
+## Failure threshold and timeout tuning
+
+| Dependency type | Recommended threshold | Recommended timeout |
+|---|---|---|
+| Database (critical) | 3–5 | 10–30s |
+| External API | 5–10 | 30–60s |
+| Non-critical service | 10–20 | 60–120s |
+
+Higher thresholds reduce false positives (temporary blips). Longer timeouts give dependencies more recovery time but extend customer-visible degradation.
+
+## Multiple circuits per service
+
+Use distinct circuit names for distinct failure domains:
+
+```
+payment-gateway/charge
+payment-gateway/refund
+email-svc/transactional
+email-svc/marketing
+```
+
+This prevents a failure in the refund endpoint from blocking charge attempts.
+
+## Response when circuit is Open
+
+Return `503 Service Unavailable` with a `Retry-After` header pointing to `open_until`:
+
+```php
+return $problems->create($request, 'service-unavailable', 'Circuit is open.', 503, null, [
+    'open_until' => $circuit->openUntil,
+]);
+```
+
+Clients and load balancers that respect `503` can stop routing to this instance while the circuit is open.
+
+## Design decisions
+
+**Why DB-backed state instead of in-memory?** In-memory state is lost on restart and doesn't share across PHP-FPM workers. DB state is consistent across all workers and survives restarts, at the cost of one extra DB query per protected call. For high-throughput paths, consider Redis with atomic increment operations.
+
+**Why lazy Half-Open transition?** Proactive background transitions require a scheduler or daemon. Lazy transitions are simpler, stateless from the scheduler's perspective, and sufficient for most web APIs where request volume ensures the check runs promptly.
+
+**Why `failure_count` resets on any success?** This is "consecutive failures" semantics. An alternative is "failure rate over a sliding window" (e.g., >50% failures in the last 60 seconds). The sliding window is more accurate for services with low but steady traffic; consecutive failures is simpler and sufficient for services that are either up or down.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.52`（2026-05-21 リリース済み）
+- Latest release: `v1.5.53`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -34,10 +34,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT116 | バックグラウンドジョブキュー | queuelog | 27/27 | v1.5.50 | job-queue.md（優先度キュー・リトライロジックはリポジトリ層・retry_count/max_retries・idempotency_key UNIQUE 制約・max_retries=0 で即失敗） |
 | FT117 | API キー管理 | apikeylog | 19/19 | v1.5.51 | api-key-management.md（SHA-256 ハッシュ保存・prefix+hash_equals 2段階認証・スコープ階層・rotate は create-first・**脆弱性診断: prefix が常に 'nk' で全テーブルスキャン→修正・rotate 非アトミック→create-first に修正**） |
 | FT118 | 署名付き URL | signedlog | 17/17 | v1.5.52 | signed-urls.md（HMAC-SHA256 トークン・hash_equals 必須・410 Gone vs 401 設計・stateless 検証・secret rotation パターン） |
+| FT119 | サーキットブレーカー | circuitlog | 15/15 | v1.5.53 | circuit-breaker.md（3状態遷移・lazy Half-Open・DB 永続化・連続失敗カウント・503 応答） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT119 以降・次の脆弱性診断は FT120）
+- FT ループ継続中（FT120 進行中・**FT120 で脆弱性診断**）
 
 ## Open Issues
 


### PR DESCRIPTION
## Summary

- FT119 フィールドトライアル完走: サーキットブレーカーパターン
- `docs/howto/circuit-breaker.md`: 3状態遷移・lazy Half-Open・DB永続化・チューニングガイド
- `docs/field-trials/2026-05-field-trial-119.md`: 15/15 テスト

## Test plan

- [x] 15 tests passing
- [x] PHPStan level 8 clean
- [x] CS fixer clean

Closes #740

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)