### PR TITLE
feat(howto): FT121 フィーチャーフラグ (#744)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-121.md
+++ b/docs/field-trials/2026-05-field-trial-121.md
@@ -1,0 +1,64 @@
+# Field Trial Report — FT121: Feature Flags
+
+**Date**: 2026-05-21
+**Release**: v1.5.55
+**App**: `featureflaglog` (`/home/xi/docker/NENE2-FT/featureflaglog/`)
+**Tests**: 21/21 passed
+**PHPStan**: level 8, 0 errors
+**CS**: clean
+
+## Theme
+
+Implement a DB-backed feature flag system with global enable/disable, rollout percentage, and per-user/tenant targeting with override priority.
+
+## Core design
+
+### Evaluation priority chain
+
+Priority (highest wins):
+1. User-level target override (`enabled = true/false`)
+2. Tenant-level target override
+3. `globally_enabled = 1`
+4. `rollout_pct > 0` with deterministic hash bucket
+5. Default: `false`
+
+User-level targets act as both early-access grants and kill switches — `enabled = false` blocks a specific user even when the flag is globally on.
+
+### Rollout percentage — deterministic bucket
+
+```php
+$bucket = abs(crc32($userId . '.' . $flag->name)) % 100;
+return $bucket < $flag->rolloutPct;
+```
+
+Stable per (user, flag) pair. The flag name is included in the hash seed so different flags roll out to different users at the same percentage.
+
+### Schema
+
+Two tables: `feature_flags` (name UNIQUE, globally_enabled, rollout_pct) and `flag_targets` (UNIQUE on flag_id + target_type + target_id).
+
+## Test coverage (21 tests)
+
+| Category | Tests |
+|---|---|
+| Create flag (valid, missing name, duplicate) | 3 |
+| Get flag (found, not found) | 2 |
+| Toggle globally_enabled (on, off) | 2 |
+| Set rollout_pct (valid, out-of-range) | 2 |
+| Upsert target (user target, invalid type) | 2 |
+| Delete target | 1 |
+| Evaluate: disabled flag → false | 1 |
+| Evaluate: globally enabled → true | 1 |
+| Evaluate: user target overrides global disable | 1 |
+| Evaluate: user kill switch overrides global enable | 1 |
+| Evaluate: tenant target applied | 1 |
+| Evaluate: rollout 100% → true | 1 |
+| Evaluate: rollout 0% → false | 1 |
+| Evaluate: missing user_id → 422 | 1 |
+| Evaluate: non-existent flag → 404 | 1 |
+
+## DX observations
+
+- Separating `globally_enabled` and `rollout_pct` into distinct fields keeps the evaluation logic explicit — no overloaded semantics.
+- Upsert pattern for targets avoids client-side check-then-set races and keeps the API idempotent.
+- The `FlagEvaluator` class is pure (no DB, no HTTP) and independently testable, though this FT tested it through the full HTTP stack.

--- a/docs/howto/feature-flags.md
+++ b/docs/howto/feature-flags.md
@@ -1,0 +1,143 @@
+# Feature Flags
+
+Feature flags let you toggle functionality at runtime without deploying code. The core decisions are: where to store state (DB vs config), how to evaluate priority when multiple rules apply, and how to handle rollout percentages without per-user tracking.
+
+## Core components
+
+- **Feature flag registry**: one row per flag with a name, global on/off switch, and rollout percentage.
+- **Flag targets**: per-user or per-tenant overrides that win over the global state.
+- **Evaluator**: applies the priority chain and returns a boolean for a given user.
+
+## Schema
+
+```sql
+CREATE TABLE feature_flags (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    name             TEXT    NOT NULL UNIQUE,
+    description      TEXT    NOT NULL DEFAULT '',
+    globally_enabled INTEGER NOT NULL DEFAULT 0,
+    rollout_pct      INTEGER NOT NULL DEFAULT 0,  -- 0-100
+    created_at       TEXT    NOT NULL
+);
+
+CREATE TABLE flag_targets (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    flag_id     INTEGER NOT NULL,
+    target_type TEXT    NOT NULL,  -- 'user' | 'tenant'
+    target_id   TEXT    NOT NULL,
+    enabled     INTEGER NOT NULL DEFAULT 1,
+    UNIQUE (flag_id, target_type, target_id),
+    FOREIGN KEY (flag_id) REFERENCES feature_flags(id)
+);
+```
+
+## Evaluation priority
+
+```php
+final readonly class FlagEvaluator
+{
+    /** @param FlagTarget[] $targets */
+    public function evaluate(FeatureFlag $flag, array $targets, string $userId, ?string $tenantId): bool
+    {
+        // 1. Explicit user-level target wins first
+        foreach ($targets as $target) {
+            if ($target->targetType === 'user' && $target->targetId === $userId) {
+                return $target->enabled;
+            }
+        }
+
+        // 2. Tenant-level target
+        if ($tenantId !== null) {
+            foreach ($targets as $target) {
+                if ($target->targetType === 'tenant' && $target->targetId === $tenantId) {
+                    return $target->enabled;
+                }
+            }
+        }
+
+        // 3. Global switch
+        if ($flag->globallyEnabled) {
+            return true;
+        }
+
+        // 4. Rollout percentage: deterministic bucket via crc32 hash
+        if ($flag->rolloutPct > 0) {
+            $bucket = abs(crc32($userId . '.' . $flag->name)) % 100;
+            return $bucket < $flag->rolloutPct;
+        }
+
+        // 5. Default off
+        return false;
+    }
+}
+```
+
+Priority order (highest wins):
+1. User-level target (`target_type = 'user'`)
+2. Tenant-level target (`target_type = 'tenant'`)
+3. `globally_enabled = 1`
+4. `rollout_pct > 0` with hash-based bucket
+5. `false`
+
+## Rollout percentage — deterministic bucket
+
+`crc32($userId . '.' . $flagName) % 100` produces a stable bucket per (user, flag) pair. The same user always lands in the same bucket, so their experience is consistent across requests. Appending the flag name prevents all flags from rolling out to the same users at `pct = 10`.
+
+Important: `crc32()` can return negative values on 64-bit systems — use `abs()`.
+
+## Targets as overrides
+
+A target with `enabled = false` is a kill switch: it disables the flag for that user or tenant even when `globally_enabled = 1`. This is the canonical way to exclude a specific user from a rollout.
+
+```php
+// User-level kill switch (overrides global enable)
+$repo->upsertTarget($flag->id, 'user', 'problem-user', false);
+
+// Tenant early-access (overrides global disable)
+$repo->upsertTarget($flag->id, 'tenant', 'beta-tenant', true);
+```
+
+## Upsert pattern for targets
+
+Targets use `INSERT OR REPLACE` / upsert semantics — calling the same endpoint twice with different `enabled` values updates the existing row rather than creating a duplicate:
+
+```php
+$existing = $this->executor->fetchOne(
+    'SELECT * FROM flag_targets WHERE flag_id = ? AND target_type = ? AND target_id = ?',
+    [$flagId, $targetType, $targetId],
+);
+
+if ($existing !== null) {
+    $this->executor->execute('UPDATE flag_targets SET enabled = ? WHERE id = ?', ...);
+} else {
+    $this->executor->execute('INSERT INTO flag_targets ...', ...);
+}
+```
+
+The UNIQUE constraint on `(flag_id, target_type, target_id)` enforces that there is at most one override per (flag, target) pair.
+
+## Conflict response for duplicate flag names
+
+`feature_flags.name` has a UNIQUE constraint. On duplicate creation, the DB throws a `RuntimeException`. Catch it and return 409 Conflict rather than 500:
+
+```php
+try {
+    $this->executor->execute('INSERT INTO feature_flags ...', [...]);
+} catch (\RuntimeException) {
+    return null; // caller maps null → 409
+}
+```
+
+## Design decisions
+
+**Why DB-backed rather than config-file?**
+Config files require a deploy to change a flag. DB-backed flags can be toggled live without touching code or restarting processes.
+
+**Why deterministic hash for rollout rather than random?**
+Random selection means the same user flips between enabled/disabled across requests. A stable hash gives each user a consistent experience for the lifetime of the flag.
+
+**Why allow `enabled = false` targets?**
+A flag system without kill switches is incomplete. `enabled = false` is the safest way to exclude a user from a rollout that is already globally enabled — no code change, no deploy.
+
+**Why separate `globally_enabled` and `rollout_pct`?**
+`globally_enabled = 1` is an explicit all-or-nothing switch. `rollout_pct` is for gradual exposure. Keeping them separate avoids overloading one field with two different meanings.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.54`（2026-05-21 リリース済み）
+- Latest release: `v1.5.55`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -36,10 +36,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT118 | 署名付き URL | signedlog | 17/17 | v1.5.52 | signed-urls.md（HMAC-SHA256 トークン・hash_equals 必須・410 Gone vs 401 設計・stateless 検証・secret rotation パターン） |
 | FT119 | サーキットブレーカー | circuitlog | 15/15 | v1.5.53 | circuit-breaker.md（3状態遷移・lazy Half-Open・DB 永続化・連続失敗カウント・503 応答） |
 | FT120 | アウトバウンド Webhook 配信 | webhookdeliverylog | 31/31 | v1.5.54 | webhook-delivery.md（SSRF URL 検証・timestamp 付き HMAC・secret ハッシュ保存・リトライ）**脆弱性診断: null safety 修正** ／ **クラッカー攻撃試験: 16 攻撃すべて耐久** |
+| FT121 | フィーチャーフラグ | featureflaglog | 21/21 | v1.5.55 | feature-flags.md（評価優先順位・rollout_pct crc32 バケット・ターゲット upsert・kill switch パターン） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT121 以降・次の脆弱性診断は FT123・次のクラッカー攻撃試験は FT124）
+- FT ループ継続中（FT122 以降・次の脆弱性診断は FT123・次のクラッカー攻撃試験は FT124）
 
 ## Open Issues
 


### PR DESCRIPTION
## Summary

- FT121: DB バックドフィーチャーフラグシステム (`featureflaglog`) を実装
- 評価優先順位: ユーザーターゲット → テナントターゲット → globally_enabled → rollout_pct → false
- crc32 ハッシュによる決定論的ロールアウトバケット（`abs(crc32($userId . '.' . $flagName)) % 100`）
- kill switch パターン: `enabled = false` のターゲットでグローバル有効フラグも個別ブロック可能
- 21 テスト / PHPStan level 8 / CS クリーン → v1.5.55 リリース予定

## Test plan

- [x] 21/21 テスト通過
- [x] PHPStan level 8: 0 errors
- [x] PHP-CS-Fixer: clean

Closes #744

Self-review: docs-policy