### PR TITLE
feat(ft130): 通知インボックス実装 (v1.5.64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.64] — 2026-05-21
+
+### Added
+- `docs/howto/notification-inbox.md` — 通知インボックスガイド: `read_at` nullable パターン・冪等マーク・クロスユーザー 404・`ORDER BY id DESC`・bulk mark-as-read。 (#764)
+- `docs/field-trials/2026-05-field-trial-130.md` — FT130 レポート: notificationlog（通知インボックス、23 tests）。 (#764)
+
+---
+
 ## [1.5.63] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-130.md
+++ b/docs/field-trials/2026-05-field-trial-130.md
@@ -1,0 +1,83 @@
+# Field Trial 130 — Notification Inbox
+
+**Date**: 2026-05-21
+**Version**: v1.5.64
+**Project**: `notificationlog`
+**Theme**: User notification inbox with read/unread state tracking
+
+## Summary
+
+Implemented a notification inbox API covering push delivery, unread filtering, single mark-as-read, bulk mark-as-read, and unread count. 23 tests, all passing. No special assessments this round.
+
+## What Was Built
+
+- `POST /users` — create a user
+- `POST /users/{userId}/notifications` — push a notification to a user
+- `GET /users/{userId}/notifications` — list notifications (newest-first; `?unread=true` for unread only)
+- `GET /users/{userId}/notifications/unread-count` — badge counter
+- `PATCH /users/{userId}/notifications/{id}/read` — idempotent single mark-as-read
+- `POST /users/{userId}/notifications/read-all` — bulk mark-as-read
+
+Key design decisions:
+- `read_at` nullable timestamp instead of `is_read` boolean — preserves when it was read
+- `ORDER BY id DESC` not `created_at DESC` — stable sort for same-timestamp events
+- Cross-user 404 (not 403) — prevents notification ID enumeration
+- Idempotent single read: checks `isRead()` before UPDATE, preserving original `read_at`
+- Bulk read uses `WHERE read_at IS NULL` — idempotent, skips already-read rows
+
+## Test Results
+
+| Suite | Tests | Result |
+|---|---|---|
+| NotificationTest (SQLite) | 23/23 | PASS |
+
+```
+OK (23 tests, 65 assertions)
+```
+
+## Implementation Notes
+
+The `read_at IS NULL` pattern is idiomatic SQL for tracking boolean state that also needs an audit timestamp. It eliminates a separate `updated_at` column for the read event and makes `WHERE read_at IS NULL` indexable. The unread count is included in list responses to avoid extra round-trips for badge UI updates.
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 歴 6 ヶ月、フレームワーク初経験）
+
+**印象**: `read_at IS NULL = 未読` というパターンが直感的だった。boolean の `is_read` カラムより「いつ読んだか」まで記録できることに気づいてから腑に落ちた。`ORDER BY id DESC` の理由（同一タイムスタンプ問題）はコメントがあれば助かった。`JsonRequestBodyParser::parse()` を毎ハンドラに書く必要があるのは最初に驚いたが、howto を読んで「ミドルウェアではなく明示呼び出し」と分かれば問題ない。
+
+**摩擦点**: PHP の `[]` が `json_encode` で `"[]"` になり JSON オブジェクトと混在する罠に引っかかった（テストで 400 が返ってきた）。
+
+### Persona 2 — Laravel 経験者（NENE2 移行中）
+
+**印象**: `nullable read_at` カラムは Eloquent でも同じ設計をするので自然。`markAllAsRead` が `WHERE read_at IS NULL` で冪等になっているのは良い。リポジトリパターンが薄く、クエリが透けて見えるのは Laravel の `Eloquent` に慣れていると最初は冗長に見えるが、テストで差し替えられる構造は好ましい。
+
+**摩擦点**: `Router::PARAMETERS_ATTRIBUTE` を毎回書くのは Laravel の `$request->route('userId')` より煩雑。慣れれば許容範囲。
+
+### Persona 3 — フロントエンドエンジニア（API 消費側、React 開発者）
+
+**印象**: レスポンスに `unread_count` が含まれているのは嬉しい。バッジを更新するために別途 GET を叩かなくていい。`read` boolean フィールドがレスポンスにあるので、`read_at` を自分でチェックしなくていい。`PATCH /…/read` の冪等性が保証されているのでリトライ安全。
+
+**摩擦点**: `PATCH` メソッドをサポートしないプロキシ環境だと `/read-all` の `POST` は通るのに単体読了が詰まる可能性がある。`POST /…/read` の別名があれば安心。
+
+### Persona 4 — セキュリティエンジニア
+
+**印象**: 他ユーザーの通知を既読にしようとすると 404 が返るのは適切（403 だと ID の存在が確認できてしまう）。`user_id` をすべてのクエリで絞り込んでいる。所有権チェックがリポジトリではなくハンドラ層で行われているのは意図的で正しい（ビジネスルール＝ハンドラ層の原則）。
+
+**摩擦点**: 通知の `body` フィールドにサーバー側で生成された HTML が入りうるケースでは XSS リスクがあるが、今回の設計は JSON API なのでフロントがエスケープする責任。API ドキュメントに明記すべき点。
+
+### Persona 5 — DevOps / SRE エンジニア
+
+**印象**: SQLite で動くため開発環境のセットアップが軽い。`countUnread` が `COUNT(*)` ベースなので大量通知でも O(n) スキャンになりうる。本番では `(user_id, read_at)` の複合インデックスが必要。リストが `ORDER BY id DESC` で最新先頭なので、ページネーション追加時も OFFSET ではなくカーソルを `id < ?` で実装しやすい。
+
+**摩擦点**: 現在の実装にページネーションがないため、ユーザーの通知が増えると全件返す。本番投入前に `LIMIT/OFFSET` またはカーソルの追加が必要。
+
+### Persona 6 — テックリード（コードレビュー担当）
+
+**印象**: `markAsRead` の `isRead()` 事前チェックが `read_at` の上書きを防いでいる点が丁寧。`markAllAsRead` が残余件数を返すのは API 設計として自然（クライアントが 0 を確認できる）。ハンドラが薄く、ロジックがリポジトリに集約されている。PHPStan level 8 / PHP-CS-Fixer 通過。
+
+**改善提案**: `findByUserId` の `?bool $unreadOnly` パラメータは nullable boolean より enum（`FilterMode::ALL / UNREAD_ONLY`）の方が将来の拡張に強い（既読のみフィルターなど）。現時点では過剰設計なので今のままで良い。
+
+## Howto Coverage
+
+- `docs/howto/notification-inbox.md` 追加
+- `read_at IS NULL` パターン、冪等マーク、クロスユーザー 404、`ORDER BY id DESC` の理由を文書化

--- a/docs/howto/notification-inbox.md
+++ b/docs/howto/notification-inbox.md
@@ -1,0 +1,182 @@
+# Notification Inbox
+
+Deliver notifications to users and let them track read/unread status. State is stored as a `read_at` timestamp — `NULL` means unread, a timestamp means read.
+
+## Overview
+
+A notification inbox consists of:
+- **Create**: push a notification to a user
+- **List**: retrieve all notifications (optionally filter to unread only)
+- **Mark as read**: set `read_at` on a single notification (idempotent)
+- **Bulk mark as read**: set `read_at` on all unread notifications for a user
+- **Unread count**: cheap badge counter
+
+Notifications are never deleted — they are permanent records of what was communicated to the user.
+
+## Database Schema
+
+```sql
+CREATE TABLE notifications (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    read_at    TEXT    DEFAULT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`read_at IS NULL` means unread. `read_at IS NOT NULL` means read. No boolean column is needed — the timestamp is the state.
+
+## Read State Pattern
+
+Use a single nullable `read_at` column instead of a boolean `is_read`. This gives you:
+
+- **When it was read** (useful for analytics)
+- **Idempotent update**: `UPDATE ... WHERE read_at IS NULL` is safe to call multiple times
+- **Cheap unread count**: `SELECT COUNT(*) WHERE read_at IS NULL`
+
+```php
+public function isRead(): bool
+{
+    return $this->readAt !== null;
+}
+```
+
+## Appending a Notification
+
+Notifications are written by the server (admin, system event) and pushed to a user:
+
+```php
+public function create(int $userId, string $title, string $body, string $now): Notification
+{
+    $this->executor->execute(
+        'INSERT INTO notifications (user_id, title, body, read_at, created_at) VALUES (?, ?, ?, NULL, ?)',
+        [$userId, $title, $body, $now],
+    );
+
+    $id = (int) $this->executor->lastInsertId();
+
+    return new Notification($id, $userId, $title, $body, null, $now);
+}
+```
+
+`read_at` is always `NULL` on insert — a new notification is always unread.
+
+## Listing Notifications
+
+Return notifications newest-first. Include the unread count in the response so clients can update badge UI without a separate request:
+
+```php
+public function findByUserId(int $userId, ?bool $unreadOnly = null): array
+{
+    if ($unreadOnly === true) {
+        $rows = $this->executor->fetchAll(
+            'SELECT * FROM notifications WHERE user_id = ? AND read_at IS NULL ORDER BY id DESC',
+            [$userId],
+        );
+    } else {
+        $rows = $this->executor->fetchAll(
+            'SELECT * FROM notifications WHERE user_id = ? ORDER BY id DESC',
+            [$userId],
+        );
+    }
+    ...
+}
+```
+
+`ORDER BY id DESC` (not `created_at DESC`) — insertion order is stable; two notifications with the same timestamp keep a deterministic order.
+
+## Mark as Read (Single, Idempotent)
+
+```php
+public function markAsRead(int $id, string $now): ?Notification
+{
+    $existing = $this->findById($id);
+
+    if ($existing === null) {
+        return null;
+    }
+
+    if ($existing->isRead()) {
+        return $existing;  // already read — no UPDATE, preserve original read_at
+    }
+
+    $this->executor->execute(
+        'UPDATE notifications SET read_at = ? WHERE id = ?',
+        [$now, $id],
+    );
+
+    return $this->findById($id);
+}
+```
+
+Check `isRead()` before updating so `read_at` is never overwritten. A second PATCH call returns the same `read_at` value as the first.
+
+## Bulk Mark as Read
+
+```php
+public function markAllAsRead(int $userId, string $now): int
+{
+    $this->executor->execute(
+        'UPDATE notifications SET read_at = ? WHERE user_id = ? AND read_at IS NULL',
+        [$now, $userId],
+    );
+
+    return $this->countUnread($userId);
+}
+```
+
+`WHERE read_at IS NULL` makes the bulk update idempotent — already-read notifications keep their original `read_at`. Returns the remaining unread count (should be 0).
+
+## Cross-User Ownership Check
+
+When marking a single notification as read, verify the notification belongs to the requesting user:
+
+```php
+$notification = $this->repo->findById($id);
+
+if ($notification === null || $notification->userId !== $userId) {
+    return $this->responseFactory->create(['error' => 'notification not found'], 404);
+}
+```
+
+Return 404 (not 403) — this prevents enumeration of notification IDs belonging to other users.
+
+## Unread Count
+
+A lightweight endpoint for badge counters — no need to load all notifications:
+
+```php
+public function countUnread(int $userId): int
+{
+    $row = $this->executor->fetchOne(
+        'SELECT COUNT(*) as cnt FROM notifications WHERE user_id = ? AND read_at IS NULL',
+        [$userId],
+    );
+    ...
+}
+```
+
+Include this count in list responses as well so clients can keep badges in sync without extra round-trips.
+
+## Security Properties
+
+| Property | Implementation |
+|---|---|
+| User isolation | All queries filter by `user_id` |
+| Cross-user read attempt | Returns 404 — prevents notification ID enumeration |
+| Idempotent mark-as-read | Checks `isRead()` before UPDATE; `read_at` never overwritten |
+| Bulk update safety | `WHERE read_at IS NULL` — only unread rows are touched |
+
+## Route Summary
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/users` | Create a user |
+| `POST` | `/users/{userId}/notifications` | Push a notification to a user |
+| `GET` | `/users/{userId}/notifications` | List all notifications (`?unread=true` for unread only) |
+| `GET` | `/users/{userId}/notifications/unread-count` | Get unread badge count |
+| `PATCH` | `/users/{userId}/notifications/{id}/read` | Mark a single notification as read |
+| `POST` | `/users/{userId}/notifications/read-all` | Mark all notifications as read |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.63
+  version: 1.5.64
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.63`（2026-05-21 リリース済み）
+- Latest release: `v1.5.64`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -45,10 +45,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT127 | スレッドコメント | commentlog | 20/20 | v1.5.61 | threaded-comments.md（parent_id 自己参照・depth 非正規化・MAX_DEPTH=3・ソフトデリート子保持・2パスツリー組み立て・PHPStan-safe） |
 | FT128 | アカウントロックアウト | lockoutlog | 32/32 | v1.5.62 | account-lockout.md（per-account 失敗カウント・locked_until・423・ユーザー列挙防止・MySQL スキーマ）**クラッカー攻撃試験: 12 攻撃すべて耐久** / **MySQL 統合テスト初導入: 5テスト** |
 | FT129 | イベントソーシング（基本） | eventsourcelog | 17/17 | v1.5.63 | event-sourcing.md（append-only イベントログ・リプレイ・ORDER BY id ASC）**脆弱性診断: VULN-A 整数オーバーフロー（is_int + 上限 1e9）修正** |
+| FT130 | 通知インボックス | notificationlog | 23/23 | v1.5.64 | notification-inbox.md（read_at nullable・冪等マーク・クロスユーザー 404・bulk read-all） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT130 以降・次のクラッカー攻撃試験は FT132・次の脆弱性診断は FT132・次の MySQL テストは FT133）
+- FT ループ継続中（FT131 以降・次のクラッカー攻撃試験は FT132・次の脆弱性診断は FT132・次の MySQL テストは FT133）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.63';
+    public const string VERSION = '1.5.64';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT130 — 通知インボックス（notificationlog）

- `read_at` nullable timestamp で既読/未読状態を管理（boolean カラム不要）
- 単一・一括既読マーク（両方冪等）
- 未読カウントをリストレスポンスに同梱（バッジ更新に余分な round-trip 不要）
- クロスユーザー所有権チェックで 404 を返し、通知 ID の列挙を防止

## 変更点

- `docs/howto/notification-inbox.md` 新規追加
- `docs/field-trials/2026-05-field-trial-130.md` 新規追加（6ペルソナ DX レビュー含む）
- `CHANGELOG.md` v1.5.64 エントリ追加
- `src/FrameworkInfo.php` VERSION → 1.5.64
- `docs/openapi/openapi.yaml` version → 1.5.64
- `docs/todo/current.md` FT130 完了記録

## テスト結果

- 23/23 tests PASS（SQLite）
- PHPStan level 8 クリア
- PHP-CS-Fixer クリア

## Self-review

Self-review: backend-api, docs-policy

Closes #764