### PR TITLE
feat(ft131): コメント投票システム実装 (v1.5.65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.65] — 2026-05-21
+
+### Added
+- `docs/howto/voting-system.md` — 投票システムガイド: upvote/downvote トグル・VoteDirection enum・UNIQUE 制約・スコア同梱・ユーザー投票状態取得。 (#766)
+- `docs/field-trials/2026-05-field-trial-131.md` — FT131 レポート: votelog（投票システム、20 tests）。 (#766)
+
+---
+
 ## [1.5.64] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-131.md
+++ b/docs/field-trials/2026-05-field-trial-131.md
@@ -1,0 +1,83 @@
+# Field Trial 131 — Voting System
+
+**Date**: 2026-05-21
+**Version**: v1.5.65
+**Project**: `votelog`
+**Theme**: Upvote/downvote with toggle, score, and per-user vote state
+
+## Summary
+
+Implemented a voting system covering cast/toggle/switch, score retrieval, and current vote state. 20 tests, all passing. No special assessments this round.
+
+## What Was Built
+
+- `POST /users` — create a user
+- `POST /items` — create a votable item
+- `POST /items/{itemId}/vote` — cast, switch, or toggle a vote
+- `GET /items/{itemId}/score` — upvotes, downvotes, score
+- `GET /items/{itemId}/vote/{userId}` — user's current vote state
+
+Key design decisions:
+- `UNIQUE (user_id, item_id)` enforces one-vote-per-user at DB level
+- `CHECK (direction IN ('up', 'down'))` prevents invalid values at DB level
+- `VoteDirection` backed enum — `tryFrom()` for clean 422 on invalid input
+- Toggle logic in repository: same direction → DELETE, opposite → UPDATE, new → INSERT
+- Score included in vote response — no separate round-trip needed for counter refresh
+- `?VoteDirection` return from `castVote()` encodes removed state as `null`
+
+## Test Results
+
+| Suite | Tests | Result |
+|---|---|---|
+| VoteTest (SQLite) | 20/20 | PASS |
+
+```
+OK (20 tests, 78 assertions)
+```
+
+## Implementation Notes
+
+The toggle pattern (same direction → remove) is idiomatic for voting UIs: users expect clicking the already-active vote button to deactivate it. A single `castVote()` entry point covers all three state transitions (no vote → vote, vote → no vote, up → down) which keeps the handler thin. The UNIQUE constraint prevents race conditions at the DB level, though concurrent toggle scenarios may need optimistic locking in high-traffic contexts.
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 歴 6 ヶ月）
+
+**印象**: `VoteDirection` enum を使うことで「up か down しか入れられない」という制約が型で見えるのは分かりやすかった。`tryFrom()` が null を返すパターンを初めて見たが、`VoteDirection::tryFrom($dirStr) ?? null` で 422 を返す流れはシンプルで理解できた。スコアが投票レスポンスに含まれているのは「一石二鳥」で便利だと感じた。
+
+**摩擦点**: 「トグル」という概念（同じ方向に 2 回投票 → 取消）がドキュメントに明記されていないと実装時に迷う。howto に記載して良かった。
+
+### Persona 2 — Laravel 経験者
+
+**印象**: Eloquent の `updateOrCreate` に相当するロジックを手書きしているが、明示的な SELECT → DELETE/UPDATE/INSERT の 3 分岐は Eloquent より読みやすい。`UNIQUE` 制約とアプリケーション側の一票制御が二重になっているのはフェイルセーフとして好ましい。
+
+**摩擦点**: Laravel なら `Vote::updateOrCreate(['user_id' => $userId, 'item_id' => $itemId], ['direction' => $direction])` で済む。ボイラープレートが増えるが、その分ロジックが追いやすい。慣れれば問題ない。
+
+### Persona 3 — フロントエンドエンジニア（React 開発者）
+
+**印象**: 投票レスポンスにスコアが入っているので、ボタンクリックで即座に UI のカウンターを更新できる。`vote: null` で「投票なし」を表現しているので三項演算子 `vote === 'up' ? activeStyle : defaultStyle` で直接使える。`GET /items/{itemId}/vote/{userId}` で初期表示時のボタン状態を取得できるのも良い。
+
+**摩擦点**: 楽観的更新（optimistic update）でトグルを先に描画してから API を叩く実装では、失敗時のロールバックが必要になる。API レスポンスに `previous_vote` フィールドがあるとロールバックが楽になる。
+
+### Persona 4 — セキュリティエンジニア
+
+**印象**: `CHECK (direction IN ('up', 'down'))` の DB レベル制約と `VoteDirection::tryFrom()` のアプリレベル制約が二重になっている。`UNIQUE (user_id, item_id)` で DB レベルの一票制御も確保されている。ユーザー/アイテム存在確認を `findUserById` / `findItemById` で行い 404 を返している。存在確認はタイミング攻撃の余地が小さい（boolean 返却、一定処理）。
+
+**改善点**: 現在の設計では誰でも任意ユーザーの代わりに投票できる（認証なし）。実運用では JWT クレームからユーザー ID を取得し、`user_id` の詐称を防ぐ必要がある。FT としてのスコープは適切。
+
+### Persona 5 — DevOps / SRE エンジニア
+
+**印象**: `UNIQUE (user_id, item_id)` インデックスが自動で作成されるため、特定ユーザーの特定アイテムへの投票取得が高速。スコア計算が 2 回の COUNT クエリで済む（GROUP BY より単純で最適化しやすい）。アイテムが増えた場合は `(item_id, direction)` の複合インデックスが有効。
+
+**摩擦点**: 現在の実装では高頻度な投票切り替えで UPDATE が走り続ける。レート制限（FT107）と組み合わせると安定する。
+
+### Persona 6 — テックリード（コードレビュー担当）
+
+**印象**: `castVote()` の 3 分岐（DELETE / UPDATE / INSERT）がレポジトリ内に完結しており、ハンドラが薄い。`?VoteDirection` 戻り値で「投票済み/取消」を型で表現しているのは設計として明快。enum の使用が PHP 8.1+ のベストプラクティスに沿っている。PHPStan level 8 / PHP-CS-Fixer 通過。
+
+**改善提案**: `getScore()` が 2 本の SELECT になっているが、`SELECT direction, COUNT(*) as cnt FROM votes WHERE item_id = ? GROUP BY direction` の 1 本にまとめるとパフォーマンスが向上する。現在の件数規模では問題ないが、スケール時に検討すべき。
+
+## Howto Coverage
+
+- `docs/howto/voting-system.md` 追加
+- トグル/スイッチロジック、enum による型安全、スコアの同梱、UNIQUE 制約の役割を文書化

--- a/docs/howto/voting-system.md
+++ b/docs/howto/voting-system.md
@@ -1,0 +1,149 @@
+# Voting System (Upvote / Downvote)
+
+Allow users to upvote or downvote items. Each user can cast at most one vote per item. Voting in the same direction twice toggles the vote off. Voting in the opposite direction switches the vote.
+
+## Overview
+
+A voting system involves:
+- **Cast vote**: upvote or downvote an item
+- **Toggle**: casting the same direction twice removes the vote
+- **Switch**: casting the opposite direction replaces the current vote
+- **Score**: upvotes − downvotes, returned with every vote response
+- **Current vote**: retrieve a user's current vote for an item (for UI highlighting)
+
+## Database Schema
+
+```sql
+CREATE TABLE votes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    direction  TEXT    NOT NULL CHECK (direction IN ('up', 'down')),
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+```
+
+The `UNIQUE (user_id, item_id)` constraint enforces one vote per user per item at the database level. `CHECK (direction IN ('up', 'down'))` prevents invalid values even if application-level validation is bypassed.
+
+## Direction as Enum
+
+Use a backed enum to prevent invalid direction values reaching the repository:
+
+```php
+enum VoteDirection: string
+{
+    case Up   = 'up';
+    case Down = 'down';
+}
+```
+
+Parse with `VoteDirection::tryFrom($dirStr)` — returns `null` for invalid input, enabling clean 422 handling without a match/switch.
+
+## Toggle and Switch Logic
+
+All three cases (toggle off, switch direction, new vote) are handled in the repository:
+
+```php
+public function castVote(int $userId, int $itemId, VoteDirection $direction, string $now): ?VoteDirection
+{
+    $current = $this->getCurrentVote($userId, $itemId);
+
+    if ($current === $direction) {
+        // same direction → toggle off
+        $this->executor->execute(
+            'DELETE FROM votes WHERE user_id = ? AND item_id = ?',
+            [$userId, $itemId],
+        );
+        return null;
+    }
+
+    if ($current !== null) {
+        // different direction → switch
+        $this->executor->execute(
+            'UPDATE votes SET direction = ?, created_at = ? WHERE user_id = ? AND item_id = ?',
+            [$direction->value, $now, $userId, $itemId],
+        );
+    } else {
+        // no existing vote → insert
+        $this->executor->execute(
+            'INSERT INTO votes (user_id, item_id, direction, created_at) VALUES (?, ?, ?, ?)',
+            [$userId, $itemId, $direction->value, $now],
+        );
+    }
+
+    return $direction;
+}
+```
+
+The return value `?VoteDirection` lets the handler know whether the vote is now set (`'up'`/`'down'`) or removed (`null`).
+
+## Returning Score with Every Vote
+
+Include the updated score in the vote response so clients can refresh counters without a separate GET:
+
+```php
+$result = $this->repo->castVote($userId, $itemId, $direction, $now);
+$score  = $this->repo->getScore($itemId);
+
+return $this->responseFactory->create([
+    'user_id' => $userId,
+    'item_id' => $itemId,
+    'vote'    => $result !== null ? $result->value : null,
+    'score'   => $score->toArray(),
+]);
+```
+
+## Score Computation
+
+Separate COUNT queries per direction are simpler and more readable than a single GROUP BY:
+
+```php
+public function getScore(int $itemId): ItemScore
+{
+    $upRow = $this->executor->fetchOne(
+        "SELECT COUNT(*) as cnt FROM votes WHERE item_id = ? AND direction = 'up'",
+        [$itemId],
+    );
+    $downRow = $this->executor->fetchOne(
+        "SELECT COUNT(*) as cnt FROM votes WHERE item_id = ? AND direction = 'down'",
+        [$itemId],
+    );
+    ...
+}
+```
+
+`score = upvotes - downvotes`. Zero is the initial state before any votes are cast.
+
+## User Vote State
+
+A separate endpoint lets the UI show which direction the current user voted (for button highlighting):
+
+```php
+// GET /items/{itemId}/vote/{userId}
+$current = $this->repo->getCurrentVote($userId, $itemId);
+return ['vote' => $current !== null ? $current->value : null];
+```
+
+Returns `null` when the user has not voted (or toggled their vote off).
+
+## Security Properties
+
+| Property | Implementation |
+|---|---|
+| One vote per user per item | `UNIQUE (user_id, item_id)` DB constraint |
+| Invalid direction rejected | `CHECK (direction IN ('up', 'down'))` + `VoteDirection::tryFrom()` |
+| Unknown user/item | Returns 404 — no leaking of resource existence |
+| Toggle safety | Checks current vote before DELETE/UPDATE |
+
+## Route Summary
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/users` | Create a user |
+| `POST` | `/items` | Create an item |
+| `POST` | `/items/{itemId}/vote` | Cast, switch, or toggle a vote |
+| `GET` | `/items/{itemId}/score` | Get upvotes, downvotes, and score |
+| `GET` | `/items/{itemId}/vote/{userId}` | Get a user's current vote for an item |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.64
+  version: 1.5.65
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.64`（2026-05-21 リリース済み）
+- Latest release: `v1.5.65`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -46,10 +46,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT128 | アカウントロックアウト | lockoutlog | 32/32 | v1.5.62 | account-lockout.md（per-account 失敗カウント・locked_until・423・ユーザー列挙防止・MySQL スキーマ）**クラッカー攻撃試験: 12 攻撃すべて耐久** / **MySQL 統合テスト初導入: 5テスト** |
 | FT129 | イベントソーシング（基本） | eventsourcelog | 17/17 | v1.5.63 | event-sourcing.md（append-only イベントログ・リプレイ・ORDER BY id ASC）**脆弱性診断: VULN-A 整数オーバーフロー（is_int + 上限 1e9）修正** |
 | FT130 | 通知インボックス | notificationlog | 23/23 | v1.5.64 | notification-inbox.md（read_at nullable・冪等マーク・クロスユーザー 404・bulk read-all） |
+| FT131 | コメント投票 | votelog | 20/20 | v1.5.65 | voting-system.md（upvote/downvote toggle・VoteDirection enum・UNIQUE 制約・スコア同梱） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT131 以降・次のクラッカー攻撃試験は FT132・次の脆弱性診断は FT132・次の MySQL テストは FT133）
+- FT ループ継続中（FT132 以降・次のクラッカー攻撃試験は FT132・次の脆弱性診断は FT132・次の MySQL テストは FT133）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.64';
+    public const string VERSION = '1.5.65';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT131 — 投票システム（votelog）

- upvote / downvote
- トグル: 同方向に再投票で取消
- スイッチ: 逆方向に投票で上書き
- スコア（upvotes − downvotes）を投票レスポンスに同梱
- ユーザー別現在投票状態の取得

## 変更点

- `docs/howto/voting-system.md` 新規追加
- `docs/field-trials/2026-05-field-trial-131.md` 新規追加（6ペルソナ DX レビュー含む）
- `CHANGELOG.md` v1.5.65 エントリ追加
- `src/FrameworkInfo.php` VERSION → 1.5.65
- `docs/openapi/openapi.yaml` version → 1.5.65
- `docs/todo/current.md` FT131 完了記録

## テスト結果

- 20/20 tests PASS（SQLite）
- PHPStan level 8 クリア
- PHP-CS-Fixer クリア

## Self-review

Self-review: backend-api, docs-policy

Closes #766