### PR TITLE
feat(ft132): プロフィール管理 + クラッカー攻撃試験 + 脆弱性診断 (v1.5.66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.66] — 2026-05-21
+
+### Added
+- `docs/howto/user-profile-management.md` — プロフィール管理ガイド: avatar_url https 強制・DatabaseConstraintException catch・mb_strlen・X-User-Id 所有権チェック。 (#768)
+- `docs/field-trials/2026-05-field-trial-132.md` — FT132 レポート: profilelog（プロフィール管理、32 tests = 20 正常 + 12 攻撃）**クラッカー攻撃試験: 12 攻撃全耐久** / **脆弱性診断: VULN-A 重複メール 500 → 409 修正**。 (#768)
+
+---
+
 ## [1.5.65] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-132.md
+++ b/docs/field-trials/2026-05-field-trial-132.md
@@ -1,0 +1,129 @@
+# Field Trial 132 — User Profile Management
+
+**Date**: 2026-05-21
+**Version**: v1.5.66
+**Project**: `profilelog`
+**Theme**: User profile CRUD with ownership enforcement
+**Special**: Cracker Attack Test (12 attacks) + Vulnerability Assessment
+
+## Summary
+
+Implemented a user profile management API with email-based user registration, profile creation/update, and ownership enforcement via `X-User-Id` header. 32 tests total (20 normal + 12 attack), all passing.
+
+Vulnerability assessment found 1 issue (VULN-A), fixed before release.
+
+## What Was Built
+
+- `POST /users` — register user (email validated, 409 on duplicate)
+- `POST /users/{userId}/profile` — create profile (409 if already exists)
+- `GET /users/{userId}/profile` — get profile
+- `PUT /users/{userId}/profile` — update profile (ownership via `X-User-Id`)
+
+Key design decisions:
+- Avatar URL validated: `https://` only (blocks `javascript:`, `data:`, `http://`, `file://`)
+- Field limits: bio 500 chars, display_name 100 chars, avatar_url 2048 chars
+- `mb_strlen()` for multibyte correctness
+- `UNIQUE (user_id)` on profiles enforces one-profile-per-user at DB level
+- `DatabaseConstraintException` caught for duplicate email → 409 (not 500)
+- Ownership check: `X-User-Id` header resolves to 0 when missing/non-numeric
+
+## Test Results
+
+| Suite | Tests | Result |
+|---|---|---|
+| ProfileTest (SQLite) | 20/20 | PASS |
+| AttackTest (SQLite) | 12/12 | PASS |
+| **Total** | **32/32** | **PASS** |
+
+```
+OK (32 tests, 62 assertions)
+```
+
+## Vulnerability Assessment
+
+### VULN-A: Duplicate email causes unhandled DatabaseConstraintException → 500
+
+**Severity**: Medium  
+**Location**: `RouteRegistrar::createUser()`
+
+**Description**: The `users` table has a `UNIQUE` constraint on `email`. When a duplicate email was submitted, `PdoDatabaseQueryExecutor` threw `DatabaseConstraintException` which was not caught by the handler. This caused a 500 response that could expose internal error details.
+
+**Fix applied**:
+```php
+try {
+    $userId = $this->repo->createUser($email, $now);
+} catch (DatabaseConstraintException) {
+    return $this->responseFactory->create(['error' => 'email already registered'], 409);
+}
+```
+
+**Verification**: `testCreateUserDuplicateEmailReturns409()` confirms 409 is returned.
+
+### Design Limitation: X-User-Id header is unauthenticated
+
+**Severity**: By design (FT scope)  
+**Description**: The `X-User-Id` header used for ownership verification has no cryptographic backing. A client can set it to any user ID. This is documented as a known limitation — in production, this would be replaced by a JWT claim (see FT110, FT111).
+
+**No fix**: Within FT scope, the ownership logic is correct. The missing piece is JWT authentication as the source of the actor ID.
+
+## Cracker Attack Test Results
+
+| # | Attack | Input | Expected | Result |
+|---|---|---|---|---|
+| ATTACK-01 | IDOR: update without auth | `PUT` with no `X-User-Id` | 403 | ✅ PASS |
+| ATTACK-02 | IDOR: forge wrong user ID | `X-User-Id: <attacker_id>` for victim's profile | 403 | ✅ PASS |
+| ATTACK-03 | XSS: `javascript:` URI in avatar | `"avatar_url": "javascript:alert(1)"` | 422 | ✅ PASS |
+| ATTACK-04 | Data URI injection | `"avatar_url": "data:text/html,<script>..."` | 422 | ✅ PASS |
+| ATTACK-05 | HTTP (non-HTTPS) avatar | `"avatar_url": "http://internal/secret"` | 422 | ✅ PASS |
+| ATTACK-06 | DoS: 100KB bio | `"bio": "A" × 100,000` | 422 | ✅ PASS |
+| ATTACK-07 | SQL injection in display_name | `"'; DROP TABLE profiles; --"` | 201 (stored safely) | ✅ PASS |
+| ATTACK-08 | XSS payload in bio | `<script>...</script>` | 201 (API stores text; client renders safely) | ✅ PASS |
+| ATTACK-09 | Negative user ID | `/users/-1/profile` | 404 | ✅ PASS |
+| ATTACK-10 | Zero user ID | `/users/0/profile` | 404 | ✅ PASS |
+| ATTACK-11 | Huge integer user ID | `/users/999999999999999999/profile` | 404/400 | ✅ PASS |
+| ATTACK-12 | Non-numeric X-User-Id | `X-User-Id: admin` | 403 | ✅ PASS |
+
+**全 12 攻撃耐久**
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 歴 6 ヶ月）
+
+**印象**: メールの UNIQUE 制約違反が 500 になる落とし穴は最初気づかなかった。`DatabaseConstraintException` を catch するパターンを howto で見て初めて理解できた。`isValidAvatarUrl()` の `str_starts_with('https://')` チェックが「なぜ FILTER_VALIDATE_URL だけではダメか」の理由（`javascript:` が valid URL として通る）を知れて勉強になった。
+
+**摩擦点**: `X-User-Id` ヘッダーが「本番では JWT にすべき」という前提が分かりにくい。コメントや howto の注記で補完して良かった。
+
+### Persona 2 — Laravel 経験者
+
+**印象**: Eloquent の `firstOrCreate` のような高レベル抽象がないため、「プロフィールが存在するか確認してから INSERT」というロジックを明示的に書く必要がある。冗長に見えるが、レース条件の挙動が予測しやすい。`DatabaseConstraintException` のキャッチは Laravel の `QueryException` キャッチと同等のパターン。
+
+**摩擦点**: Eloquent なら `$user->profile()->updateOrCreate(...)` で済む部分が 3 ハンドラに分かれる。設計の意図は明確なので許容範囲。
+
+### Persona 3 — フロントエンドエンジニア（React 開発者）
+
+**印象**: 409 で「既に存在する」を返してくれるのでフォーム側で分岐しやすい。`GET /users/{userId}/profile` が 404 を返すとき「ユーザーが存在しない」か「プロフィールが未作成」か区別できないが、エラーメッセージに `'profile not found'` vs `'user not found'` が入っているので判別できる。
+
+**摩擦点**: プロフィール画像の URL を `https://` に限定するのはフロントでも同様のバリデーションをしているが、両方に制約があることで UX が二重チェックになる。バランスは適切だと思う。
+
+### Persona 4 — セキュリティエンジニア
+
+**印象**: `javascript:` と `data:` の URI スキームを `str_starts_with('https://')` で防いでいるのは正しいアプローチ。FILTER_VALIDATE_URL だけでは `javascript:alert(1)` が通るため、スキーム固定チェックが必須。SQL インジェクションはパラメータ化クエリで防いでいる（ATTACK-07 で確認）。`DatabaseConstraintException` を catch して 409 を返すことでスタックトレースが漏れない。
+
+**残留リスク**: `X-User-Id` 認証なし。本番投入前に JWT 認証（FT110）との統合が必要。bio の XSS（ATTACK-08）はサーバー側では JSON テキストとして格納しており、フロントの責任とする設計は適切だが、API ドキュメントに明記すべき。
+
+### Persona 5 — DevOps / SRE エンジニア
+
+**印象**: `UNIQUE (user_id)` インデックスが自動で作成されるためプロフィール取得が高速。メールの UNIQUE インデックスも同様。現在は SQLite だが、MySQL 移行時も同じスキーマが動作する（`AUTOINCREMENT` → `AUTO_INCREMENT` の差分のみ）。
+
+**摩擦点**: プロフィールの `updated_at` はアプリ側で `date('Y-m-d H:i:s')` を使っているため、サーバー時刻依存。高トラフィックや複数サーバー環境では DB 側の `NOW()` を使う方が安全。
+
+### Persona 6 — テックリード（コードレビュー担当）
+
+**印象**: `extractProfileFields()` で共通バリデーションを切り出しているため、create と update で同じ制約が保証されている。`isValidAvatarUrl()` が private で RouteRegistrar に閉じているのは適切（ビジネスルール）。`DatabaseConstraintException` catch は早期リリースで抜けやすい穴で、今回の脆弱性診断で発見・修正されたのは良いサイクル。PHPStan level 8 / PHP-CS-Fixer 通過。
+
+**改善提案**: `resolveActorId()` を抽象化して将来の JWT 認証切り替えを容易にすることができる。現時点では 1 メソッドで十分。
+
+## Howto Coverage
+
+- `docs/howto/user-profile-management.md` 追加
+- `DatabaseConstraintException` catch パターン、avatar_url https 強制、mb_strlen、X-User-Id 所有権チェックを文書化

--- a/docs/howto/user-profile-management.md
+++ b/docs/howto/user-profile-management.md
@@ -1,0 +1,136 @@
+# User Profile Management
+
+Store and update user-facing profile data: display name, bio, and avatar URL. Profile creation is separate from user creation — users exist first, then a profile is created once and updated in place.
+
+## Overview
+
+A profile management API involves:
+- **Create user** — email-based user registration (one profile per user)
+- **Create profile** — initial profile setup (idempotent-resistant: 409 if already exists)
+- **Get profile** — retrieve current profile data
+- **Update profile** — replace profile fields (ownership enforced)
+
+## Database Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    email      TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE profiles (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL UNIQUE,
+    display_name TEXT    NOT NULL DEFAULT '',
+    bio          TEXT    NOT NULL DEFAULT '',
+    avatar_url   TEXT    NOT NULL DEFAULT '',
+    updated_at   TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`UNIQUE` on `user_id` enforces one profile per user at the DB level.
+
+## Handling Duplicate Email
+
+Catch `DatabaseConstraintException` to return 409 instead of leaking a 500:
+
+```php
+try {
+    $userId = $this->repo->createUser($email, $now);
+} catch (DatabaseConstraintException) {
+    return $this->responseFactory->create(['error' => 'email already registered'], 409);
+}
+```
+
+Without this catch, a duplicate email causes an unhandled exception that exposes internal error details to the client.
+
+## Avatar URL Validation
+
+Only allow `https://` URLs to prevent `javascript:`, `data:`, `file://`, and `http://` schemes:
+
+```php
+private function isValidAvatarUrl(string $url): bool
+{
+    if (mb_strlen($url) > UserProfile::MAX_AVATAR_URL_LENGTH) {
+        return false;
+    }
+
+    // Only https — blocks javascript:, data:, file://, ftp://, http://
+    if (!str_starts_with($url, 'https://')) {
+        return false;
+    }
+
+    return filter_var($url, FILTER_VALIDATE_URL) !== false;
+}
+```
+
+Empty string is allowed (no avatar set). The `MAX_AVATAR_URL_LENGTH = 2048` limit prevents storage abuse.
+
+## Field Length Limits
+
+Define limits as constants on the value object for a single source of truth:
+
+```php
+final readonly class UserProfile
+{
+    public const int MAX_BIO_LENGTH          = 500;
+    public const int MAX_DISPLAY_NAME_LENGTH = 100;
+    public const int MAX_AVATAR_URL_LENGTH   = 2048;
+    ...
+}
+```
+
+Use `mb_strlen()` not `strlen()` for multibyte (UTF-8) correctness.
+
+## Ownership Check
+
+The `PUT /users/{userId}/profile` endpoint uses an `X-User-Id` header to identify the requesting actor. In production, replace this with a JWT claim:
+
+```php
+private function resolveActorId(ServerRequestInterface $request): int
+{
+    $header = $request->getHeaderLine('X-User-Id');
+    return is_numeric($header) ? (int) $header : 0;
+}
+
+// In the handler:
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+Non-numeric or missing header resolves to `0`, which never matches a real user ID → 403.
+
+## Duplicate Profile Prevention
+
+Check for existing profile before inserting and return 409:
+
+```php
+if ($this->repo->findByUserId($userId) !== null) {
+    return $this->responseFactory->create(['error' => 'profile already exists'], 409);
+}
+```
+
+This prevents a second `POST /users/{userId}/profile` from overwriting an existing profile silently.
+
+## Security Properties
+
+| Property | Implementation |
+|---|---|
+| Duplicate email | `DatabaseConstraintException` caught → 409 (no stack trace leaked) |
+| avatar_url scheme | `str_starts_with('https://')` blocks all non-https schemes |
+| avatar_url length | `MAX_AVATAR_URL_LENGTH = 2048` |
+| bio length | `MAX_BIO_LENGTH = 500` with `mb_strlen()` |
+| Ownership | `X-User-Id` header (replace with JWT claim in production) |
+| One profile per user | `UNIQUE (user_id)` DB constraint + 409 check in handler |
+
+## Route Summary
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/users` | Register a user (email, 409 on duplicate) |
+| `POST` | `/users/{userId}/profile` | Create profile (409 if already exists) |
+| `GET` | `/users/{userId}/profile` | Get profile |
+| `PUT` | `/users/{userId}/profile` | Update profile (requires `X-User-Id` header) |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.65
+  version: 1.5.66
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.65`（2026-05-21 リリース済み）
+- Latest release: `v1.5.66`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -47,10 +47,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT129 | イベントソーシング（基本） | eventsourcelog | 17/17 | v1.5.63 | event-sourcing.md（append-only イベントログ・リプレイ・ORDER BY id ASC）**脆弱性診断: VULN-A 整数オーバーフロー（is_int + 上限 1e9）修正** |
 | FT130 | 通知インボックス | notificationlog | 23/23 | v1.5.64 | notification-inbox.md（read_at nullable・冪等マーク・クロスユーザー 404・bulk read-all） |
 | FT131 | コメント投票 | votelog | 20/20 | v1.5.65 | voting-system.md（upvote/downvote toggle・VoteDirection enum・UNIQUE 制約・スコア同梱） |
+| FT132 | プロフィール管理 | profilelog | 32/32 | v1.5.66 | user-profile-management.md（avatar_url https 強制・DatabaseConstraintException 409・mb_strlen・X-User-Id 所有権）**クラッカー攻撃試験: 12 攻撃全耐久** / **脆弱性診断: VULN-A 重複メール 500 → 409** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT132 以降・次のクラッカー攻撃試験は FT132・次の脆弱性診断は FT132・次の MySQL テストは FT133）
+- FT ループ継続中（FT133 以降・次のクラッカー攻撃試験は FT136・次の脆弱性診断は FT135・次の MySQL テストは FT133）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.65';
+    public const string VERSION = '1.5.66';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT132 — プロフィール管理（profilelog）+ クラッカー攻撃試験 + 脆弱性診断

- プロフィール CRUD（bio・avatar_url・display_name）
- avatar_url: `https://` のみ許可（`javascript:`, `data:`, `http://` を拒否）
- 所有権チェック: `X-User-Id` ヘッダー（本番は JWT クレームに置換）
- VULN-A 修正: 重複メールで `DatabaseConstraintException` uncaught → 500 → 409 に修正

## クラッカー攻撃試験

12 攻撃すべて耐久（IDOR・XSS URI・http URL・DoS・SQLインジェクション・型混乱）

## 脆弱性診断

VULN-A: `DatabaseConstraintException` を catch して 409 を返すよう修正

## テスト結果

- 32/32 tests PASS（20 正常 + 12 攻撃）
- PHPStan level 8 クリア
- PHP-CS-Fixer クリア

## Self-review

Self-review: backend-api, middleware-security, docs-policy

Closes #768