### PR TITLE
feat(ft133): ブックマークシステム + MySQL 統合テスト (v1.5.67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.67] — 2026-05-21
+
+### Added
+- `docs/howto/bookmark-system.md` — ブックマークシステムガイド: 冪等 add・DatabaseConstraintException catch・コレクションフィルタ・204 vs 404・MySQL スキーマ差分。 (#770)
+- `docs/field-trials/2026-05-field-trial-133.md` — FT133 レポート: bookmarklog（ブックマーク、22 tests = 17 SQLite + 5 MySQL）**MySQL 統合テスト: 5テスト**。 (#770)
+
+---
+
 ## [1.5.66] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-133.md
+++ b/docs/field-trials/2026-05-field-trial-133.md
@@ -1,0 +1,99 @@
+# Field Trial 133 — Bookmark System
+
+**Date**: 2026-05-21
+**Version**: v1.5.67
+**Project**: `bookmarklog`
+**Theme**: User bookmark management with collection grouping
+**Special**: MySQL Integration Tests (5 tests)
+
+## Summary
+
+Implemented a bookmark system covering add (idempotent), remove, list, count, and single-bookmark lookup. Collections allow grouping bookmarks by category. 22 tests total (17 SQLite + 5 MySQL), all passing.
+
+## What Was Built
+
+- `POST /users` — create a user
+- `POST /items` — create a bookmarkable item
+- `POST /users/{userId}/bookmarks` — add bookmark (idempotent; returns existing if already bookmarked)
+- `DELETE /users/{userId}/bookmarks/{itemId}` — remove bookmark (204) or 404 if not found
+- `GET /users/{userId}/bookmarks` — list all bookmarks (`?collection=` filter)
+- `GET /users/{userId}/bookmarks/count` — total count
+- `GET /users/{userId}/bookmarks/{itemId}` — check if specific item is bookmarked
+
+Key design decisions:
+- `UNIQUE (user_id, item_id)` at DB level — one bookmark per user per item
+- Idempotent add: check-then-insert with `DatabaseConstraintException` catch for race conditions
+- `collection = 'default'` fallback when not specified
+- Remove returns 204 (deleted) or 404 (not found) — not silently 204 always
+- `ORDER BY id DESC` for newest-first listing
+
+## Test Results
+
+| Suite | Tests | Result |
+|---|---|---|
+| BookmarkTest (SQLite) | 17/17 | PASS |
+| MysqlBookmarkTest (MySQL) | 5/5 | PASS |
+| **Total** | **22/22** | **PASS** |
+
+```
+OK (22 tests, 88 assertions)
+```
+
+MySQL run command:
+```bash
+docker run --rm --network nene2-ft_default \
+  -v /path/to/bookmarklog:/app -w /app \
+  -e MYSQL_HOST=mysql -e MYSQL_PORT=3306 -e MYSQL_DATABASE=ft_test \
+  -e MYSQL_USER=ft_user -e MYSQL_PASSWORD=ft_pass \
+  nene2-app composer test
+```
+
+## MySQL Integration Notes
+
+- `SET FOREIGN_KEY_CHECKS = 0` before DROP TABLE — avoids FK dependency order issues with InnoDB
+- `schema.mysql.sql` separate from `schema.sql` — MySQL requires `ENGINE=InnoDB`, `AUTO_INCREMENT`, `VARCHAR` instead of `TEXT`, named `UNIQUE KEY`
+- Tests use the shared `ft_test` database (ft_user lacks CREATE DATABASE privilege)
+- setUp/tearDown recreate tables for isolation — no test data bleeds across test cases
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 歴 6 ヶ月）
+
+**印象**: ブックマーク追加が冪等なので、フロントエンドからリトライしても大丈夫という安心感がある。`DELETE` で 204 を返すパターンが「成功だけど返すものがない」と直感的に理解できた。コレクション機能がクエリパラメータ 1 つで実現できるシンプルさが好印象。
+
+**摩擦点**: 「冪等性」という概念を最初に理解するのに時間がかかった。`DatabaseConstraintException` のキャッチが「レースコンディション対策」だと気づくには howto の説明が必要。
+
+### Persona 2 — Laravel 経験者
+
+**印象**: `UNIQUE (user_id, item_id)` 制約はEloquent の `unique` バリデーションルールと同じ思想。`firstOrCreate` 相当のロジックを手書きしている部分はボイラープレートだが、競合時の挙動が明示的で分かりやすい。`createEmpty(204)` が便利。
+
+**摩擦点**: コレクション名を変更する（ブックマーク済みアイテムをコレクション間で移動する）エンドポイントが欲しい場合、現在の設計では DELETE + POST が必要。PATCH エンドポイントを追加する余地がある。
+
+### Persona 3 — フロントエンドエンジニア（React 開発者）
+
+**印象**: `GET /users/{userId}/bookmarks/count` があるのでバッジ表示が楽。リストレスポンスに `count` が含まれているのも便利（バッジと一覧を同時に更新できる）。`GET /users/{userId}/bookmarks/{itemId}` でアイテムがブックマーク済みかどうかを確認できるのでハートアイコンの初期状態表示に使える。
+
+**摩擦点**: コレクション一覧（どんなコレクション名があるか）を取得するエンドポイントがないため、コレクション管理 UI を作るときに別途実装が必要。現 FT スコープでは適切。
+
+### Persona 4 — セキュリティエンジニア
+
+**印象**: 全クエリが `user_id` でフィルタリングされている。`find()` でクロスユーザーアクセスは不可能。`DatabaseConstraintException` のキャッチで constraint 違反が 500 にならない。`remove()` の rowCount チェックで「削除できたか」を明示的に確認している。
+
+**改善点**: `addBookmark` ハンドラでアクターの確認がない（誰でも任意ユーザーにブックマークを追加できる）。本番では JWT クレームでユーザー ID を確認する必要がある（FT132 の `X-User-Id` パターンと同様）。
+
+### Persona 5 — DevOps / SRE エンジニア
+
+**印象**: MySQL 統合テストで FK 制約の DROP 順序問題を `SET FOREIGN_KEY_CHECKS = 0` で解決しているのは実践的。`schema.mysql.sql` と `schema.sql` を分離したことで SQLite（開発）・MySQL（本番）の両方に対応できる。`UNIQUE KEY uq_user_item` のインデックスが `(user_id, item_id)` クエリを高速化。
+
+**摩擦点**: コレクション列に `VARCHAR(100)` で制限しているが、アプリ側で長さ検証をしていない。MySQL では切り捨てなしにエラーになるため、API 側で 100 文字制限を追加すべき（今回 FT スコープ外）。
+
+### Persona 6 — テックリード（コードレビュー担当）
+
+**印象**: 冪等性の実装がチェック→インサート→例外キャッチの 3 段階になっており、ロジックが完全にレポジトリに閉じている。`AppFactory` が SQLite と MySQL で同一のビジネスロジックを共有するように `buildApp()` を切り出しているのは良い設計。MySQL テストが `setUp`/`tearDown` で完全に分離されており、他のテストに影響しない。
+
+**改善提案**: コレクション名の最大長バリデーションと、コレクション名に使用できる文字の制約（スラッシュ等）を追加すると堅牢になる。現在の FT スコープでは問題ない。
+
+## Howto Coverage
+
+- `docs/howto/bookmark-system.md` 追加
+- 冪等 add パターン、`DatabaseConstraintException` catch、MySQL スキーマ差分、`SET FOREIGN_KEY_CHECKS` パターン、204 vs 404 を文書化

--- a/docs/howto/bookmark-system.md
+++ b/docs/howto/bookmark-system.md
@@ -1,0 +1,166 @@
+# Bookmark System
+
+Allow users to save items into named collections. Bookmarking is idempotent — bookmarking the same item twice returns the existing bookmark without error.
+
+## Overview
+
+A bookmark system involves:
+- **Add bookmark** — save an item to a user's collection (idempotent)
+- **Remove bookmark** — delete a saved bookmark (404 if not found)
+- **List bookmarks** — all bookmarks for a user, optionally filtered by collection
+- **Count bookmarks** — lightweight badge counter
+- **Get bookmark** — check whether a specific item is bookmarked
+
+## Database Schema
+
+```sql
+CREATE TABLE bookmarks (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    collection TEXT    NOT NULL DEFAULT 'default',
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+```
+
+`UNIQUE (user_id, item_id)` enforces one bookmark per user per item. The `collection` field groups bookmarks into named categories with `'default'` as the fallback.
+
+## Idempotent Add
+
+Check for an existing bookmark before inserting. On conflict (race condition), catch `DatabaseConstraintException` and return the existing record:
+
+```php
+public function add(int $userId, int $itemId, string $collection, string $now): Bookmark
+{
+    $existing = $this->find($userId, $itemId);
+
+    if ($existing !== null) {
+        return $existing;  // already bookmarked — not an error
+    }
+
+    try {
+        $this->executor->execute(
+            'INSERT INTO bookmarks (user_id, item_id, collection, created_at) VALUES (?, ?, ?, ?)',
+            [$userId, $itemId, $collection, $now],
+        );
+    } catch (DatabaseConstraintException) {
+        // Race condition — another request won; return the existing bookmark
+        $found = $this->find($userId, $itemId);
+        if ($found !== null) {
+            return $found;
+        }
+    }
+
+    $id = (int) $this->executor->lastInsertId();
+    return new Bookmark($id, $userId, $itemId, $collection, $now);
+}
+```
+
+The check-then-insert pattern handles the common case efficiently. The `DatabaseConstraintException` catch handles the race condition under concurrent requests.
+
+## Collection Filtering
+
+Use an optional `collection` query parameter to filter bookmarks:
+
+```php
+// GET /users/{userId}/bookmarks?collection=reading
+$collection = isset($query['collection']) && $query['collection'] !== ''
+    ? $query['collection'] : null;
+
+$items = $this->repo->listByUser($userId, $collection);
+```
+
+`null` collection returns all bookmarks; a non-empty string filters to that collection.
+
+## Remove Returns 204 vs 404
+
+- `204 No Content` — bookmark existed and was deleted
+- `404 Not Found` — bookmark did not exist
+
+```php
+$removed = $this->repo->remove($userId, $itemId);
+
+if (!$removed) {
+    return $this->responseFactory->create(['error' => 'bookmark not found'], 404);
+}
+
+return $this->responseFactory->createEmpty(204);
+```
+
+`execute()` returns the affected row count — zero means no bookmark was found.
+
+## MySQL Schema
+
+MySQL requires explicit `ENGINE=InnoDB` and `AUTO_INCREMENT` syntax:
+
+```sql
+CREATE TABLE bookmarks (
+    id         INT          NOT NULL AUTO_INCREMENT,
+    user_id    INT          NOT NULL,
+    item_id    INT          NOT NULL,
+    collection VARCHAR(100) NOT NULL DEFAULT 'default',
+    created_at DATETIME     NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_item (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+For MySQL integration tests, `SET FOREIGN_KEY_CHECKS = 0` before dropping tables to avoid FK dependency order issues.
+
+## MySQL Integration Test Pattern
+
+```php
+protected function setUp(): void
+{
+    $host = (string) (getenv('MYSQL_HOST') ?: '');
+    if ($host === '') {
+        self::markTestSkipped('MYSQL_HOST not set — skipping MySQL integration tests');
+    }
+    ...
+    $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+    $this->pdo->exec('DROP TABLE IF EXISTS bookmarks');
+    $this->pdo->exec('DROP TABLE IF EXISTS items');
+    $this->pdo->exec('DROP TABLE IF EXISTS users');
+    $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+
+    $schema = (string) file_get_contents('.../database/schema.mysql.sql');
+    $this->pdo->exec($schema);
+}
+
+protected function tearDown(): void
+{
+    if ($this->mysqlEnabled && $this->pdo !== null) {
+        $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+        $this->pdo->exec('DROP TABLE IF EXISTS bookmarks');
+        $this->pdo->exec('DROP TABLE IF EXISTS items');
+        $this->pdo->exec('DROP TABLE IF EXISTS users');
+        $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+    }
+}
+```
+
+## Security Properties
+
+| Property | Implementation |
+|---|---|
+| One bookmark per user per item | `UNIQUE (user_id, item_id)` DB constraint |
+| Race condition on add | `DatabaseConstraintException` catch → return existing |
+| User isolation | All queries filter by `user_id` |
+| Remove non-existent | Returns 404 (not silent) |
+
+## Route Summary
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/users` | Create a user |
+| `POST` | `/items` | Create an item |
+| `POST` | `/users/{userId}/bookmarks` | Add bookmark (idempotent) |
+| `DELETE` | `/users/{userId}/bookmarks/{itemId}` | Remove bookmark (204 or 404) |
+| `GET` | `/users/{userId}/bookmarks` | List bookmarks (`?collection=` filter) |
+| `GET` | `/users/{userId}/bookmarks/count` | Total bookmark count |
+| `GET` | `/users/{userId}/bookmarks/{itemId}` | Get single bookmark status |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.66
+  version: 1.5.67
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.66`（2026-05-21 リリース済み）
+- Latest release: `v1.5.67`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -48,10 +48,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT130 | 通知インボックス | notificationlog | 23/23 | v1.5.64 | notification-inbox.md（read_at nullable・冪等マーク・クロスユーザー 404・bulk read-all） |
 | FT131 | コメント投票 | votelog | 20/20 | v1.5.65 | voting-system.md（upvote/downvote toggle・VoteDirection enum・UNIQUE 制約・スコア同梱） |
 | FT132 | プロフィール管理 | profilelog | 32/32 | v1.5.66 | user-profile-management.md（avatar_url https 強制・DatabaseConstraintException 409・mb_strlen・X-User-Id 所有権）**クラッカー攻撃試験: 12 攻撃全耐久** / **脆弱性診断: VULN-A 重複メール 500 → 409** |
+| FT133 | ブックマーク | bookmarklog | 22/22 | v1.5.67 | bookmark-system.md（冪等 add・DatabaseConstraintException catch・コレクションフィルタ・204 vs 404）**MySQL 統合テスト: 5テスト** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT133 以降・次のクラッカー攻撃試験は FT136・次の脆弱性診断は FT135・次の MySQL テストは FT133）
+- FT ループ継続中（FT134 以降・次のクラッカー攻撃試験は FT136・次の脆弱性診断は FT135・次の MySQL テストは FT138）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.66';
+    public const string VERSION = '1.5.67';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT133 — ブックマークシステム（bookmarklog）+ MySQL 統合テスト

- ブックマーク追加（冪等）・削除・一覧・カウント・単一取得
- コレクション名でグループ化（`?collection=` フィルタ）
- `DatabaseConstraintException` catch でレースコンディション対応
- MySQL 統合テスト 5 本（`SET FOREIGN_KEY_CHECKS=0` で FK DROP 問題を解決）

## テスト結果

- 22/22 tests PASS（17 SQLite + 5 MySQL）
- PHPStan level 8 クリア
- PHP-CS-Fixer クリア

## Self-review

Self-review: backend-api, database, docs-policy

Closes #770