### PR TITLE
docs(howto): アクセストークン管理ガイドを追加 (#776)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.70] — 2026-05-21
+
+### Added
+- `docs/howto/access-token-management.md` — アクセストークン管理ガイド: SHA-256 ハッシュ保存・TokenScope enum・二重所有権チェック・revoke 409・verify 常に 200・isset+null PHPStan 注意点。 (#776)
+- `docs/field-trials/2026-05-field-trial-136.md` — FT136 レポート: tokenlog（アクセストークン、29 tests = 17 正常 + 12 攻撃）**クラッカー攻撃試験: 12 攻撃全耐久（ATK-04 二重 IDOR を確認）**。 (#776)
+
+---
+
 ## [1.5.69] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-136.md
+++ b/docs/field-trials/2026-05-field-trial-136.md
@@ -1,0 +1,183 @@
+# Field Trial 136 — Access Token Management (tokenlog)
+
+**Date**: 2026-05-21  
+**Theme**: パーソナルアクセストークン管理 — 発行・一覧・失効・検証  
+**Project**: `NENE2-FT/tokenlog/`  
+**NENE2 version**: ^1.5 (released as v1.5.70)  
+**Issue**: #776  
+**Special**: クラッカー攻撃試験（4FT ごとの試験対象 — FT136）
+
+---
+
+## Overview
+
+This trial implements a personal access token (PAT) system where users issue tokens with scopes (`read`/`write`/`admin`), list their active/revoked tokens, and revoke individual tokens. A public verify endpoint returns valid/invalid status without revealing token existence for unknown tokens.
+
+---
+
+## Implementation Summary
+
+### Schema
+
+Two tables: `users` and `tokens`. Tokens store only the SHA-256 hash of the raw token; the raw value is never persisted.
+
+- `token_hash TEXT NOT NULL UNIQUE` — prevents hash collisions
+- `revoked_at TEXT` — nullable; NULL = active
+- `CHECK (scope IN ('read', 'write', 'admin'))` — DB-level scope constraint
+
+### API
+
+| Method | Path                               | Status codes      |
+|--------|------------------------------------|-------------------|
+| POST   | `/users`                           | 201, 422          |
+| POST   | `/users/{userId}/tokens`           | 201, 403, 404, 422 |
+| GET    | `/users/{userId}/tokens`           | 200, 403, 404     |
+| DELETE | `/users/{userId}/tokens/{tokenId}` | 204, 403, 404, 409 |
+| POST   | `/tokens/verify`                   | 200, 422          |
+
+### Key design choices
+
+**Token hashing** — `bin2hex(random_bytes(32))` generates the 64-character raw token. Only `hash('sha256', $raw)` is stored. The raw token is returned once at issue time and cannot be recovered.
+
+**TokenScope enum** — `TokenScope::tryFrom($value)` validates scope before DB insertion. Invalid scopes → 422.
+
+**Verify always returns 200** — Unknown and revoked tokens both return `{ "valid": false }` with 200 OK, not 404. This prevents token existence enumeration.
+
+**409 for double-revoke** — `UPDATE ... WHERE revoked_at IS NULL` is a no-op for already-revoked tokens. The handler maps 0 affected rows → 409 Conflict.
+
+**Double ownership check on revoke** — First check: actor matches the userId in the URL. Second check: the tokenId's `user_id` matches userId. This closes ATK-04 (Bob using his own userId path to revoke Alice's token ID).
+
+---
+
+## Bug Found and Fixed
+
+**PHPStan level 8: redundant null comparison after isset()**
+
+Initial code used `isset($arr['revoked_at']) && $arr['revoked_at'] !== null` in hydration methods. PHPStan level 8 correctly identifies that after `isset()` returns true, null is already eliminated from the type — `!== null` is always true.
+
+**Fix**: Changed all nullable timestamp checks to `isset($arr['revoked_at'])` alone.
+
+---
+
+## Test Results
+
+```
+29 tests, 70 assertions — all pass
+17 normal tests + 12 attack tests
+```
+
+---
+
+## Cracker Attack Test (FT136)
+
+### Methodology
+
+Twelve adversarial tests in `tests/Token/AttackTest.php`. Each test sends a crafted request representing a realistic attack vector.
+
+### Findings
+
+| ID | Attack | Description | Expected | Result |
+|----|--------|-------------|----------|--------|
+| ATK-01 | IDOR | Issue token for another user | 403 | **Pass** |
+| ATK-02 | IDOR | List another user's tokens | 403 | **Pass** |
+| ATK-03 | IDOR | Revoke token via victim's path | 403 | **Pass** |
+| ATK-04 | IDOR | Revoke victim's token via attacker's own path | 403 | **Pass** |
+| ATK-05 | Scope escalation | Use `superuser` scope | 422 | **Pass** |
+| ATK-06 | Token replay | Use revoked token for verify | valid=false | **Pass** |
+| ATK-07 | Brute-force | Random 64-char token | valid=false | **Pass** |
+| ATK-08 | SQL injection | `' OR '1'='1` in verify body | valid=false | **Pass** |
+| ATK-09 | Header injection | `X-User-Id: admin` | not 201 | **Pass** |
+| ATK-10 | Path injection | Negative user ID | 404 | **Pass** |
+| ATK-11 | Resource exhaustion | 10KB scope string | 422 | **Pass** |
+| ATK-12 | Empty input | Whitespace-only token | 422 | **Pass** |
+
+**Overall: No vulnerabilities found.** All 12 attack tests pass without code changes.
+
+### Notable findings
+
+- **ATK-04 (double IDOR)**: This is the most subtle attack — an attacker uses their own `userId` in the URL path but supplies another user's `tokenId`. The system correctly rejects this via the second ownership check (`token['user_id'] !== $userId`).
+- **ATK-08 (SQL injection)**: `' OR '1'='1` is hashed with SHA-256 before the DB query — the resulting hash is unlikely to match any stored token. Prepared statements provide the primary protection.
+- **ATK-11 (10KB scope)**: `TokenScope::tryFrom()` returns `null` for any string not exactly matching 'read', 'write', or 'admin' — length doesn't matter; unknown values are always rejected.
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1: Junko — Junior PHP Developer (2 years experience)
+
+*"I learned that tokens should never be stored in plaintext — use SHA-256 hash. The howto makes this clear. The 'return token once at issue time' pattern is a concept I hadn't seen before. I also tripped on `isset($x) && $x !== null` — I thought that was more explicit, but PHPStan said it was redundant. Now I understand."*
+
+**Rating**: ★★★★☆ (4/5)  
+**Learning**: One-time token return pattern, PHPStan null-after-isset semantics
+
+---
+
+### Persona 2: Tariq — Mid-level Backend Developer (5 years, first time with NENE2)
+
+*"The double ownership check on revoke (URL user match + token user match) is exactly right. I've seen APIs that only check the URL and have ATK-04 style bugs. The 409 for double-revoke is clean — better than silently returning 204 again. TokenScope enum makes the API self-documenting."*
+
+**Rating**: ★★★★★ (5/5)  
+**Highlight**: Double ownership check is a pattern I'll reuse
+
+---
+
+### Persona 3: Priya — Senior Developer / Tech Lead
+
+*"SHA-256 is fast — a motivated attacker with a leaked DB can brute-force common tokens quickly. Production should use Argon2id or bcrypt for token hashing, or use opaque tokens long enough (256 bits) that brute-force is impractical. For a FT, SHA-256 is fine. I also note `bin2hex(random_bytes(32))` generates 256 bits of entropy — good."*
+
+**Rating**: ★★★★☆ (4/5)  
+**Note**: SHA-256 for token hashing is acceptable; production may want Argon2id for extra protection
+
+---
+
+### Persona 4: Markus — DevOps / Platform Engineer
+
+*"Revoked tokens stay in the table — no cleanup. In production, old revoked tokens accumulate. Need a purge job (e.g., `DELETE FROM tokens WHERE revoked_at < NOW() - INTERVAL 90 DAY`). The `token_hash UNIQUE` constraint means a hash collision (SHA-256) would reject a valid new token — astronomically unlikely but worth noting."*
+
+**Rating**: ★★★★☆ (4/5)  
+**Gap**: No token expiry or cleanup for revoked tokens
+
+---
+
+### Persona 5: Amara — QA / Test Engineer
+
+*"12 attack tests, 29 total. ATK-04 is particularly tricky — I'd have missed it in a normal test pass. The double ownership check pattern should be in a checklist. The PHPStan bug (isset + !== null) was caught by static analysis before tests ran — good defense. Missing: token expiry (created_at + TTL validation)."*
+
+**Rating**: ★★★★★ (5/5)  
+**Highlight**: ATK-04 double IDOR caught by attack test, not regular tests
+
+---
+
+### Persona 6: Keiko — Non-technical Product Manager
+
+*"This is like GitHub personal access tokens — I use those! The token is shown once, you save it, you can see labels and revoke. Clear. My question: can I set an expiry date? GitHub PATs have expiry options now. Also: can I see the last-used time? That would help me decide which tokens to revoke."*
+
+**Rating**: ★★★☆☆ (3/5)  
+**Feature requests**: Token expiry, last-used timestamp — expected gaps at FT scale
+
+---
+
+### DX Summary
+
+| Persona | Rating | Primary concern |
+|---------|--------|-----------------|
+| Junko (Junior PHP) | ★★★★☆ | One-time token, isset+null PHPStan semantics |
+| Tariq (Mid backend) | ★★★★★ | Double ownership check pattern is excellent |
+| Priya (Tech Lead) | ★★★★☆ | SHA-256 vs Argon2id for token hashing |
+| Markus (DevOps) | ★★★★☆ | No token expiry or revoked token cleanup |
+| Amara (QA) | ★★★★★ | ATK-04 double IDOR only caught by attack test |
+| Keiko (PM) | ★★★☆☆ | No expiry or last-used timestamp |
+
+**Overall DX**: ★★★★☆ (4.2/5) — Token security posture is solid. The double ownership check and one-time token return are well-implemented patterns. Gaps are operational (expiry, cleanup) rather than security.
+
+---
+
+## Issues Raised for NENE2
+
+None. `TokenScope::tryFrom()`, `isset()` semantics, and PHPStan level 8 all behaved as expected.
+
+---
+
+## Howto
+
+`docs/howto/access-token-management.md`

--- a/docs/howto/access-token-management.md
+++ b/docs/howto/access-token-management.md
@@ -1,0 +1,206 @@
+# How to Build Access Token Management with NENE2
+
+This guide walks through building a personal access token (PAT) system — users issue, list, and revoke their own API tokens, each with a scope (`read`/`write`/`admin`). Tokens are never stored in plaintext; only their SHA-256 hash is kept.
+
+**Field Trial**: FT136  
+**NENE2 version**: ^1.5  
+**Covered topics**: token hashing, scope enums, ownership enforcement, revoke idempotency, verify endpoint
+
+---
+
+## What we're building
+
+- `POST /users/{id}/tokens` — issue a token (owner only, returns raw token once)
+- `GET /users/{id}/tokens` — list tokens (owner only, no raw token in response)
+- `DELETE /users/{id}/tokens/{tokenId}` — revoke a token (owner only, 409 if already revoked)
+- `POST /tokens/verify` — verify a raw token (returns valid/invalid + scope)
+
+---
+
+## Database schema
+
+```sql
+CREATE TABLE tokens (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token_hash TEXT    NOT NULL UNIQUE,
+    scope      TEXT    NOT NULL DEFAULT 'read',
+    label      TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    revoked_at TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    CHECK (scope IN ('read', 'write', 'admin'))
+);
+```
+
+- `token_hash` — SHA-256 of the raw token; never store the raw token
+- `revoked_at` — nullable timestamp; `NULL` = active, non-null = revoked
+- `CHECK (scope IN (...))` — DB-level scope constraint as defense-in-depth
+
+---
+
+## Token scope enum
+
+```php
+enum TokenScope: string
+{
+    case Read  = 'read';
+    case Write = 'write';
+    case Admin = 'admin';
+}
+```
+
+`TokenScope::tryFrom($value)` returns `null` for unknown scopes — use this to validate input before storing.
+
+---
+
+## Issuing tokens
+
+```php
+public function issueToken(int $userId, TokenScope $scope, string $label, string $now): string
+{
+    $raw  = bin2hex(random_bytes(32)); // 64-char hex string
+    $hash = hash('sha256', $raw);
+
+    $this->executor->execute(
+        'INSERT INTO tokens (user_id, token_hash, scope, label, created_at) VALUES (?, ?, ?, ?, ?)',
+        [$userId, $hash, $scope->value, $label, $now],
+    );
+
+    return $raw; // returned once, never stored
+}
+```
+
+The raw token is returned to the caller exactly once. After that, only the hash is in the database — there is no way to recover the raw token.
+
+---
+
+## Verifying tokens
+
+```php
+public function verifyToken(string $rawToken): ?array
+{
+    $hash = hash('sha256', $rawToken);
+    $row  = $this->executor->fetchOne(
+        'SELECT id, user_id, scope, revoked_at FROM tokens WHERE token_hash = ?',
+        [$hash],
+    );
+
+    if ($row === null) {
+        return null;
+    }
+
+    $arr = (array) $row;
+
+    return [
+        'valid'   => !isset($arr['revoked_at']),
+        'user_id' => isset($arr['user_id']) ? (int) $arr['user_id'] : 0,
+        'scope'   => isset($arr['scope']) && is_string($arr['scope']) ? $arr['scope'] : 'read',
+    ];
+}
+```
+
+**Why `!isset($arr['revoked_at'])` and not `=== null`?** After `isset()` returns true, PHPStan eliminates `null` from the type — comparing to `null` would be `identical.alwaysFalse`. Use `isset()` alone to check for null.
+
+The verify endpoint always returns 200 with `{ "valid": false }` for unknown or revoked tokens — never 404. This prevents token enumeration.
+
+---
+
+## Ownership enforcement
+
+Every mutating endpoint checks that the authenticated actor matches the resource owner:
+
+```php
+$actorId = $this->resolveActorId($request); // from X-User-Id header
+
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+For revoke, there's a second ownership check on the token itself:
+
+```php
+$token = $this->repo->findTokenById($tokenId);
+
+if ($token['user_id'] !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+This prevents ATK-04 — Bob using his own user path but revoking Alice's token ID.
+
+---
+
+## Revoke — 409 for already-revoked
+
+```php
+public function revokeToken(int $tokenId, string $now): bool
+{
+    $count = $this->executor->execute(
+        'UPDATE tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL',
+        [$now, $tokenId],
+    );
+
+    return $count > 0;
+}
+```
+
+The `WHERE revoked_at IS NULL` guard means the UPDATE is a no-op if the token is already revoked. The handler maps `$count === 0` to 409 Conflict.
+
+---
+
+## List tokens — never include raw token
+
+The list response includes `id`, `scope`, `label`, `created_at`, `revoked` (bool). The raw token is never returned after the initial issue call.
+
+---
+
+## PHPStan level 8 pitfall: isset + null comparison
+
+```php
+// WRONG — PHPStan reports `notIdentical.alwaysTrue`
+'revoked' => isset($arr['revoked_at']) && $arr['revoked_at'] !== null,
+
+// CORRECT — isset() already implies non-null
+'revoked' => isset($arr['revoked_at']),
+
+// WRONG — PHPStan reports `identical.alwaysFalse`
+'valid' => !isset($arr['revoked_at']) || $arr['revoked_at'] === null,
+
+// CORRECT
+'valid' => !isset($arr['revoked_at']),
+```
+
+---
+
+## Cracker attack test results (FT136)
+
+| Attack | Expected | Result |
+|--------|----------|--------|
+| ATK-01: Issue token for another user (IDOR) | 403 | Pass |
+| ATK-02: List another user's tokens (IDOR) | 403 | Pass |
+| ATK-03: Revoke another user's token via their path | 403 | Pass |
+| ATK-04: Revoke another user's token via own path | 403 | Pass |
+| ATK-05: Invalid scope (`superuser`) | 422 | Pass |
+| ATK-06: Use revoked token for verify | valid=false | Pass |
+| ATK-07: Brute-force random token | valid=false | Pass |
+| ATK-08: SQL injection in verify body | valid=false | Pass |
+| ATK-09: Non-numeric X-User-Id (`admin`) | not 201 | Pass |
+| ATK-10: Negative user ID | 404 | Pass |
+| ATK-11: 10KB scope string | 422 | Pass |
+| ATK-12: Empty/whitespace-only token | 422 | Pass |
+
+All 12 attack tests pass.
+
+---
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| `isset($x) && $x !== null` | Use `isset($x)` alone — PHPStan level 8 rejects the redundant check |
+| Storing raw token in DB | Store only `hash('sha256', $raw)` |
+| Returning raw token in list response | Only return raw token in the issue response |
+| Not checking token ownership on revoke | Check `token['user_id'] === userId` after finding the token |
+| Returning 404 for invalid token in verify | Always return 200 with `valid: false` — prevents enumeration |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.69
+  version: 1.5.70
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.69`（2026-05-21 リリース済み）
+- Latest release: `v1.5.70`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -51,10 +51,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT133 | ブックマーク | bookmarklog | 22/22 | v1.5.67 | bookmark-system.md（冪等 add・DatabaseConstraintException catch・コレクションフィルタ・204 vs 404）**MySQL 統合テスト: 5テスト** |
 | FT134 | ユーザーフォロー | followlog | 20/20 | v1.5.68 | user-follow-system.md（冪等フォロー 201/200・自己フォロー 422・相互フォロー・ORDER BY id DESC） |
 | FT135 | ダイレクトメッセージ | messagelog | 31/31 | v1.5.69 | direct-messaging-system.md（双方向会話検索・参加者アクセス制御・GET で parse() 禁止）**脆弱性診断: 12 攻撃全耐久** |
+| FT136 | アクセストークン管理 | tokenlog | 29/29 | v1.5.70 | access-token-management.md（SHA-256・TokenScope enum・二重所有権チェック・verify 常に 200）**クラッカー攻撃試験: 12 攻撃全耐久** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT136 以降・次のクラッカー攻撃試験は FT136・次の MySQL テストは FT138）
+- FT ループ継続中（FT137 以降・次の MySQL テストは FT138）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.69';
+    public const string VERSION = '1.5.70';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary
- `docs/howto/access-token-management.md` 追加: SHA-256 ハッシュ保存・TokenScope enum・二重所有権チェック・verify 常に 200・isset+null PHPStan 注意点
- `docs/field-trials/2026-05-field-trial-136.md` 追加: FT136 レポート（tokenlog、29/29 tests）6 ペルソナ DX レビュー付き
- `FrameworkInfo::VERSION` 1.5.69 → 1.5.70

## Test plan
- [x] 29/29 tests pass (17 normal + 12 attack tests)
- [x] PHPStan level 8: no errors
- [x] PHP-CS-Fixer: no violations

## Cracker Attack Test (FT136)
- ATK-04 (二重 IDOR): 他ユーザーのトークンを自分のパスで失効させる試みを 403 で阻止
- 全 12 攻撃耐久済み

Closes #776

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)