### PR TITLE
docs(howto): サブスクリプション管理ガイドを追加 (#778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.71] — 2026-05-21
+
+### Added
+- `docs/howto/subscription-plan-management.md` — サブスクリプション管理ガイド: UNIQUE制約でのre-subscribe（UPDATE）・キャンセル後の再加入・PUT要アクティブ制約・409 vs 404。 (#778)
+- `docs/field-trials/2026-05-field-trial-137.md` — FT137 レポート: planlog（サブスクリプション、20 tests）6 ペルソナ DX レビュー。 (#778)
+
+---
+
 ## [1.5.70] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-137.md
+++ b/docs/field-trials/2026-05-field-trial-137.md
@@ -1,0 +1,165 @@
+# Field Trial 137 — Subscription Plan Management (planlog)
+
+**Date**: 2026-05-21  
+**Theme**: サブスクリプション・プラン管理 — 加入・変更・解約・再加入  
+**Project**: `NENE2-FT/planlog/`  
+**NENE2 version**: ^1.5 (released as v1.5.71)  
+**Issue**: #778  
+**Special**: 通常 FT（特別診断なし）
+
+---
+
+## Overview
+
+This trial implements a subscription management system where users subscribe to plans, upgrade or downgrade, cancel, and re-subscribe. The key challenge was handling re-subscription after cancellation — the `UNIQUE (user_id)` constraint on the subscriptions table means INSERT fails for returning subscribers, requiring UPDATE logic instead.
+
+---
+
+## Implementation Summary
+
+### Schema
+
+Three tables: `users`, `plans`, `subscriptions`. Plans are seeded at schema time (free/pro/enterprise). Subscriptions have a `UNIQUE (user_id)` constraint — one row per user, with `status` tracking the lifecycle.
+
+### API
+
+| Method | Path                           | Status codes      |
+|--------|--------------------------------|-------------------|
+| POST   | `/users`                       | 201, 422          |
+| GET    | `/plans`                       | 200               |
+| POST   | `/users/{id}/subscription`     | 201, 403, 404, 409 |
+| GET    | `/users/{id}/subscription`     | 200, 403, 404     |
+| PUT    | `/users/{id}/subscription`     | 200, 403, 404, 409 |
+| DELETE | `/users/{id}/subscription`     | 204, 403, 404     |
+
+### Key design choices
+
+**One row per user** — `UNIQUE (user_id)` on subscriptions. Re-subscription after cancel UPDATEs the existing row (`cancelled_at = NULL, status = 'active'`) rather than inserting a new one.
+
+**409 only for active subscriptions** — `POST /subscription` returns 409 if `status = 'active'`. A cancelled subscription can be reactivated with POST. This was a bug in the initial implementation (see below).
+
+**409 for PUT on cancelled** — `PUT /subscription` requires an active subscription. If `status = 'cancelled'`, the handler returns 409 with a message directing the user to POST instead.
+
+**404 for double-cancel** — `UPDATE ... WHERE status = 'active'` affects 0 rows when already cancelled → handler returns 404. Explicit and predictable.
+
+**Denormalized plan data in response** — `findSubscription()` JOINs plans, so the response includes `plan_slug`, `plan_name`, and `price_cents`. Clients don't need a second request to display the plan details.
+
+---
+
+## Bug Found and Fixed
+
+**testReSubscribeAfterCancel: 409 instead of 201**
+
+Initial implementation returned 409 for any existing subscription (active or cancelled). Re-subscribing after cancel should be allowed.
+
+**Root cause**: The handler checked `$existing !== null` (any subscription) instead of `$existing !== null && $existing['status'] === 'active'`.
+
+**Fix**: 
+1. Handler only blocks active subscriptions with 409
+2. Repository `subscribe()` checks for an existing cancelled row and UPDATEs instead of INSERTs
+
+---
+
+## Test Results
+
+```
+20 tests, 69 assertions — all pass
+```
+
+Test coverage:
+- Plans list (all 3, ordered by price)
+- Subscribe to free/pro
+- Subscribe while active → 409
+- Subscribe unknown plan → 404
+- Subscribe as another user → 403
+- Get subscription, get with no subscription (404), get as another user (403)
+- Change plan (upgrade + downgrade)
+- Change plan with no subscription (404), change plan on cancelled (409)
+- Cancel (204), check cancelled status
+- Double-cancel → 404
+- Cancel with no subscription → 404
+- Re-subscribe after cancel → 201 with new plan
+- Subscription isolation per user
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1: Junko — Junior PHP Developer (2 years experience)
+
+*"The subscription lifecycle diagram in the howto helped a lot. I was confused about when to use POST vs PUT — the error messages in the API ('use PUT to change plan', 'use POST to re-subscribe') guide the client, which I liked. I tripped on the UNIQUE constraint for re-subscribe — I initially tried INSERT and got a constraint error."*
+
+**Rating**: ★★★★☆ (4/5)  
+**Learning**: UNIQUE constraint means UPDATE for re-subscribe, not INSERT
+
+---
+
+### Persona 2: Tariq — Mid-level Backend Developer (5 years, first time with NENE2)
+
+*"The one-row-per-user pattern is clean for simple subscription tracking. The `findSubscription()` JOIN for denormalized response is efficient. I like that cancelled subscriptions stay in the table — you get a full audit trail. For production I'd want a separate `subscription_history` table for every plan change."*
+
+**Rating**: ★★★★☆ (4/5)  
+**Note**: No change history — every plan change overwrites `started_at` and `plan_id`
+
+---
+
+### Persona 3: Priya — Senior Developer / Tech Lead
+
+*"The `WHERE status = 'active'` guard on the cancel UPDATE is correct — makes it safe to call twice without silent success. The plan seeding in schema.sql is fine for FT scale but production needs a migrations-based approach for plan changes. No price change history either — if you change `price_cents` in plans, existing subscribers' historical pricing is lost."*
+
+**Rating**: ★★★☆☆ (3/5)  
+**Concern**: No pricing history, no subscription change audit trail
+
+---
+
+### Persona 4: Markus — DevOps / Platform Engineer
+
+*"Plan seeding is in schema.sql which runs at test setup time — clean for testing. Operationally, adding a new plan requires a migration (ALTER or INSERT INTO plans). The `subscriptions.UNIQUE (user_id)` makes the table simple but limits one active plan at a time — correct for most SaaS billing models. No trial period or grace period logic."*
+
+**Rating**: ★★★★☆ (4/5)  
+**Gap**: No trial period, grace period, or scheduled downgrade at billing cycle end
+
+---
+
+### Persona 5: Amara — QA / Test Engineer
+
+*"20 tests is good coverage for 5 endpoints. The bug (re-subscribe after cancel → 409) was caught immediately by the test. The isolation test (`testSubscriptionsArePerUser`) prevents a counting/lookup bug category. Missing: concurrent subscription race (two simultaneous POSTs), and plan change after cancellation (covered — 409)."*
+
+**Rating**: ★★★★☆ (4/5)  
+**Bug caught**: Re-subscribe after cancel tested before code was shipped
+
+---
+
+### Persona 6: Keiko — Non-technical Product Manager
+
+*"I can follow the subscription lifecycle: subscribe, upgrade, downgrade, cancel, re-subscribe. The price in cents is clear (just divide by 100). My question: what happens at the billing cycle end? Can a user cancel 'at period end' rather than immediately? And can I offer a free trial period? Those are real business requirements for a SaaS product."*
+
+**Rating**: ★★★☆☆ (3/5)  
+**Feature requests**: Cancel at period end, free trial — expected gaps at FT scale
+
+---
+
+### DX Summary
+
+| Persona | Rating | Primary concern |
+|---------|--------|-----------------|
+| Junko (Junior PHP) | ★★★★☆ | UNIQUE constraint → UPDATE for re-subscribe |
+| Tariq (Mid backend) | ★★★★☆ | No plan change history |
+| Priya (Tech Lead) | ★★★☆☆ | No pricing history, no audit trail |
+| Markus (DevOps) | ★★★★☆ | No trial period or billing cycle logic |
+| Amara (QA) | ★★★★☆ | Bug caught early, good isolation test |
+| Keiko (PM) | ★★★☆☆ | No cancel-at-period-end or free trial |
+
+**Overall DX**: ★★★★☆ (3.7/5) — The subscription lifecycle is well-modelled for a basic system. The one-row-per-user pattern is clean. Production gaps are expected (billing cycles, history, trials).
+
+---
+
+## Issues Raised for NENE2
+
+None. Framework behaviour was as expected.
+
+---
+
+## Howto
+
+`docs/howto/subscription-plan-management.md`

--- a/docs/howto/subscription-plan-management.md
+++ b/docs/howto/subscription-plan-management.md
@@ -1,0 +1,197 @@
+# How to Build Subscription Plan Management with NENE2
+
+This guide walks through building a subscription system — users subscribe to plans, upgrade/downgrade, cancel, and re-subscribe. Plans are seeded in the database at schema time.
+
+**Field Trial**: FT137  
+**NENE2 version**: ^1.5  
+**Covered topics**: plan seeding, subscription lifecycle, re-subscribe after cancel, idempotent cancel, ownership enforcement
+
+---
+
+## What we're building
+
+- `GET /plans` — list all available plans (public)
+- `POST /users/{id}/subscription` — subscribe to a plan (or re-subscribe after cancel)
+- `GET /users/{id}/subscription` — view current subscription (owner only)
+- `PUT /users/{id}/subscription` — change plan (owner only, active subscription required)
+- `DELETE /users/{id}/subscription` — cancel subscription (owner only)
+
+---
+
+## Database schema
+
+```sql
+CREATE TABLE plans (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug        TEXT    NOT NULL UNIQUE,
+    name        TEXT    NOT NULL,
+    price_cents INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE subscriptions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL UNIQUE,  -- one subscription per user
+    plan_id      INTEGER NOT NULL,
+    status       TEXT    NOT NULL DEFAULT 'active',
+    started_at   TEXT    NOT NULL,
+    cancelled_at TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (plan_id) REFERENCES plans(id),
+    CHECK (status IN ('active', 'cancelled'))
+);
+
+-- Seed plans
+INSERT INTO plans (slug, name, price_cents) VALUES ('free', 'Free', 0);
+INSERT INTO plans (slug, name, price_cents) VALUES ('pro', 'Pro', 999);
+INSERT INTO plans (slug, name, price_cents) VALUES ('enterprise', 'Enterprise', 4999);
+```
+
+`UNIQUE (user_id)` on subscriptions means only one row per user — re-subscription UPDATEs the existing row rather than inserting a new one.
+
+---
+
+## Subscription lifecycle
+
+```
+No subscription
+    ↓ POST /subscription (plan=X)
+Active (plan=X)
+    ↓ PUT /subscription (plan=Y)     ↓ DELETE /subscription
+Active (plan=Y)                   Cancelled
+    ↑ POST /subscription (plan=Z) ←── (re-subscribe reactivates the row)
+```
+
+---
+
+## Re-subscribe after cancel
+
+When a user cancels and then subscribes again, there's already a row in `subscriptions` for them. INSERT would fail the UNIQUE constraint. Instead, UPDATE the existing row:
+
+```php
+public function subscribe(int $userId, int $planId, string $now): void
+{
+    $existing = $this->findSubscription($userId);
+
+    if ($existing !== null) {
+        // Reactivate a cancelled subscription
+        $this->executor->execute(
+            "UPDATE subscriptions SET plan_id = ?, status = 'active', started_at = ?, cancelled_at = NULL WHERE user_id = ?",
+            [$planId, $now, $userId],
+        );
+
+        return;
+    }
+
+    $this->executor->execute(
+        'INSERT INTO subscriptions (user_id, plan_id, status, started_at) VALUES (?, ?, ?, ?)',
+        [$userId, $planId, 'active', $now],
+    );
+}
+```
+
+The handler only returns 409 for *active* subscriptions, not cancelled ones:
+
+```php
+if ($existing !== null && $existing['status'] === 'active') {
+    return $this->responseFactory->create(['error' => 'already subscribed, use PUT to change plan'], 409);
+}
+```
+
+---
+
+## Cancel — idempotent via `WHERE status = 'active'`
+
+```php
+public function cancel(int $userId, string $now): bool
+{
+    $count = $this->executor->execute(
+        "UPDATE subscriptions SET status = 'cancelled', cancelled_at = ?
+         WHERE user_id = ? AND status = 'active'",
+        [$now, $userId],
+    );
+
+    return $count > 0;
+}
+```
+
+If the subscription is already cancelled, the UPDATE affects 0 rows → handler returns 404. This prevents double-cancel from silently succeeding.
+
+---
+
+## Change plan — PUT requires active subscription
+
+```php
+$sub = $this->repo->findSubscription($userId);
+
+if ($sub === null) {
+    return $this->responseFactory->create(['error' => 'no subscription, use POST to subscribe'], 404);
+}
+
+if ($sub['status'] === 'cancelled') {
+    return $this->responseFactory->create(['error' => 'subscription is cancelled, use POST to re-subscribe'], 409);
+}
+```
+
+PUT is for changing an *active* plan. If the subscription is cancelled, the user must re-subscribe with POST first.
+
+---
+
+## Plan data in the response
+
+The subscription response includes denormalized plan data (via JOIN) so clients don't need a second request:
+
+```json
+{
+  "id": 1,
+  "user_id": 1,
+  "plan_slug": "pro",
+  "plan_name": "Pro",
+  "price_cents": 999,
+  "status": "active",
+  "started_at": "2026-05-21 12:00:00",
+  "cancelled_at": null
+}
+```
+
+---
+
+## AppFactory
+
+```php
+final class AppFactory
+{
+    public static function createSqliteApp(string $dbPath): RequestHandlerInterface
+    {
+        $dbConfig = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: '', port: 1, name: $dbPath, user: '', password: '', charset: '',
+        );
+
+        $factory  = new PdoConnectionFactory($dbConfig);
+        $executor = new PdoDatabaseQueryExecutor($factory);
+        $psr17    = new Psr17Factory();
+        $json     = new JsonResponseFactory($psr17, $psr17);
+
+        $repo      = new PlanRepository($executor);
+        $registrar = new RouteRegistrar($repo, $json);
+
+        return new RuntimeApplicationFactory($psr17, $psr17,
+            routeRegistrars: [static fn(Router $r) => $registrar->register($r)],
+        )->create();
+    }
+}
+```
+
+---
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| 409 for re-subscribe after cancel | Only 409 for `status = 'active'`; UPDATE the row for cancelled |
+| INSERT for re-subscribe | UNIQUE constraint on user_id prevents it — use UPDATE instead |
+| PUT on cancelled subscription silently works | Check `$sub['status'] === 'cancelled'` → 409 before UPDATE |
+| Returning 404 on double-cancel | Already cancelled → UPDATE affects 0 rows → return 404 explicitly |
+| Forgetting JOIN for plan data in response | Use `INNER JOIN plans p ON p.id = s.plan_id` in findSubscription |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.70
+  version: 1.5.71
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.70`（2026-05-21 リリース済み）
+- Latest release: `v1.5.71`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -52,10 +52,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT134 | ユーザーフォロー | followlog | 20/20 | v1.5.68 | user-follow-system.md（冪等フォロー 201/200・自己フォロー 422・相互フォロー・ORDER BY id DESC） |
 | FT135 | ダイレクトメッセージ | messagelog | 31/31 | v1.5.69 | direct-messaging-system.md（双方向会話検索・参加者アクセス制御・GET で parse() 禁止）**脆弱性診断: 12 攻撃全耐久** |
 | FT136 | アクセストークン管理 | tokenlog | 29/29 | v1.5.70 | access-token-management.md（SHA-256・TokenScope enum・二重所有権チェック・verify 常に 200）**クラッカー攻撃試験: 12 攻撃全耐久** |
+| FT137 | サブスクリプション管理 | planlog | 20/20 | v1.5.71 | subscription-plan-management.md（UNIQUE制約→re-subscribe UPDATE・PUT要アクティブ・cancel 404 vs 409） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT137 以降・次の MySQL テストは FT138）
+- FT ループ継続中（FT138 以降・次の MySQL テストは FT138・次の脆弱性診断は FT138・次のクラッカー攻撃試験は FT140）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.70';
+    public const string VERSION = '1.5.71';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary
- `docs/howto/subscription-plan-management.md` 追加: UNIQUE制約→re-subscribe UPDATE・キャンセル後の再加入・PUT要アクティブ・cancel 404 vs 409
- `docs/field-trials/2026-05-field-trial-137.md` 追加: FT137 レポート（planlog、20/20 tests）6 ペルソナ DX レビュー付き
- `FrameworkInfo::VERSION` 1.5.70 → 1.5.71

## Test plan
- [x] 20/20 tests pass
- [x] PHPStan level 8: no errors
- [x] PHP-CS-Fixer: no violations

Closes #778

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)