### PR TITLE
docs(howto): グループメンバーシップ管理ガイドを追加 (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.72] — 2026-05-21
+
+### Added
+- `docs/howto/group-membership-management.md` — グループメンバーシップ管理ガイド: `user_groups` テーブル名（MySQL予約語回避）・MemberRole enum権限メソッド・owner自動追加・自己脱退・MySQL FK teardown パターン。 (#780)
+- `docs/field-trials/2026-05-field-trial-138.md` — FT138 レポート: grouplog（グループメンバーシップ、38 tests = 21 正常 + 12 脆弱性診断 + 5 MySQL）**脆弱性診断: 12件全Pass** / **MySQL統合テスト: 5テスト** (#780)
+
+---
+
 ## [1.5.71] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-138.md
+++ b/docs/field-trials/2026-05-field-trial-138.md
@@ -1,0 +1,159 @@
+# Field Trial 138 — グループメンバーシップ管理
+
+**Date**: 2026-05-21  
+**App**: `grouplog`  
+**Path**: `/home/xi/docker/NENE2-FT/grouplog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.72  
+**Special**: 脆弱性診断 (3FT ごと) + MySQL 統合テスト (5FT ごと)
+
+---
+
+## What was built
+
+グループ作成・メンバー招待・ロール管理・脱退を実装した。
+
+| Endpoint | 説明 |
+|---|---|
+| `POST /users` | ユーザー作成 |
+| `POST /groups` | グループ作成（作成者は owner として自動追加） |
+| `GET /groups/{groupId}/members` | メンバー一覧（メンバーのみ） |
+| `POST /groups/{groupId}/members` | メンバー追加（owner/admin のみ・role: member or admin） |
+| `DELETE /groups/{groupId}/members/{userId}` | メンバー削除（owner/admin が他者を削除・本人は自己脱退可） |
+| `PUT /groups/{groupId}/members/{userId}/role` | ロール変更（owner のみ） |
+
+---
+
+## Architecture decisions
+
+### `groups` は MySQL 予約語 → `user_groups` を使用
+
+MySQL の `GROUP BY` 句で `groups` は予約語として扱われる。CREATE TABLE に使うと構文エラーになる。`user_groups` に改名することで SQLite・MySQL 両方で動作する。
+
+### MemberRole enum に権限メソッドを持たせる
+
+```php
+enum MemberRole: string {
+    public function canManageMembers(): bool { ... }
+    public function canChangeRoles(): bool { ... }
+}
+```
+
+ハンドラーに `if ($role === 'owner' || $role === 'admin')` の文字列比較を書かない。enum のメソッドが権限の単一の真実源となる。
+
+### Owner の自動追加
+
+`createGroup()` の中でグループ INSERT の直後に `memberships` へ owner を INSERT する。アプリコードが owner の追加を忘れられない構造。
+
+### Owner は削除・ロール変更不可
+
+- `DELETE` で owner を指定 → 422
+- `PUT /role` で owner ロールを付与しようとする → 422 (add-member API では 422)
+- ロール変更は owner のみ実行可能（admin は不可）
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `GroupTest.php` | 21 | Pass |
+| `VulnTest.php` | 12 | Pass |
+| `MysqlGroupTest.php` | 5 | Pass |
+| **Total** | **38** | **Pass** |
+
+---
+
+## Vulnerability assessment (FT138)
+
+| ID | Attack | Expected | Result |
+|---|---|---|---|
+| VULN-A | IDOR: 非メンバーがメンバー一覧を取得 | 403 | Pass |
+| VULN-B | IDOR: 非メンバーがメンバーを追加 | 403 | Pass |
+| VULN-C | 一般 member がメンバーを追加しようとする | 403 | Pass |
+| VULN-D | admin が owner ロールを付与しようとする | not 200 | Pass |
+| VULN-E | member が自分を admin に昇格しようとする | 403 | Pass |
+| VULN-F | group owner を削除しようとする | 422 | Pass |
+| VULN-G | X-User-Id なしでグループ作成 | not 201 | Pass |
+| VULN-H | 非数値の X-User-Id | not 200 | Pass |
+| VULN-I | グループ名に SQL インジェクション | 201 (verbatim) | Pass |
+| VULN-J | 別グループのメンバー操作（cross-group） | 403 | Pass |
+| VULN-K | 負の groupId | 404 | Pass |
+| VULN-L | admin がロール変更を試みる | 403 | Pass |
+
+**全12件 Pass。脆弱性なし。**
+
+---
+
+## MySQL integration tests (FT138)
+
+`MysqlGroupTest.php` の 5 テストが MySQL 環境で通過。
+
+| テスト | 確認内容 |
+|---|---|
+| `testMysqlCreateGroupAndListMembers` | グループ作成 → owner が自動追加される |
+| `testMysqlAddAndRemoveMember` | メンバー追加・削除・一覧確認 |
+| `testMysqlDuplicateMemberReturns409` | 重複追加 → 409 |
+| `testMysqlRoleChange` | ロール変更 → 200 + 新ロール |
+| `testMysqlNonMemberCannotViewMembers` | 非メンバー → 403 |
+
+MySQL テストのキーポイント:
+- `FOREIGN_KEY_CHECKS = 0` で FK 依存テーブルを安全に DROP
+- `getenv()` は `string|false` を返すため `=== false` チェックが必須（PHPStan level 8）
+- `schema.mysql.sql` で `VARCHAR`・`AUTO_INCREMENT`・`ENGINE=InnoDB`・`CONSTRAINT chk_role` を使用
+
+---
+
+## Common pitfalls encountered
+
+| Pitfall | Fix |
+|---|---|
+| `groups` テーブル名が MySQL でエラー | `user_groups` に改名 |
+| `getenv()` の型チェック不足 | `=== false` を先にチェック、その後 `=== ''` |
+| MySQL FK 制約で DROP TABLE が失敗 | `SET FOREIGN_KEY_CHECKS = 0` を前置 |
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「グループとメンバーシップで2テーブルに分かれていることは理解できた。でも `groups` テーブルという名前が MySQL で使えないとは知らなかった。フレームワークのドキュメントを読んでいたら気づけたかもしれないけど、エラーメッセージだけ見てもすぐには原因を特定できなかった。howto の最初に警告として書いてあるのが助かった。`MemberRole::canManageMembers()` という書き方はすごく読みやすいと感じた。」
+
+★★★☆☆ — MySQL 予約語のトラップは初心者がはまりやすい落とし穴
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Eloquent だったら `belongsToMany` でリレーションを定義するだけでメンバーシップはできる。NENE2 はすべて生 SQL なので JOIN も自分で書く必要があった。でも Repository パターンで SQL がきれいに分離されているのは好感が持てる。enum に権限チェックメソッドを持たせるパターンは Laravel でも真似できそう。」
+
+★★★★☆ — 生 SQL の明示性は高く評価。ORM に慣れた人でも理解しやすい構造
+
+### Persona 3 — セキュリティエンジニア
+
+「12 件の脆弱性テストが全部 Pass しているのは良い。特に VULN-J（クロスグループ操作）と VULN-L（admin のロール変更禁止）の分離は正確に実装されている。`canChangeRoles()` が Owner のみ `true` を返す設計は、最小権限の原則に沿っている。SQL インジェクション（VULN-I）がプリペアドステートメントで確実に防がれているのも確認できた。MySQL でも同じテストが通るのは特に重要。」
+
+★★★★★ — 権限分離が明確で安全。脆弱性テストの網羅性が高い
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「`GET /groups/{groupId}/members` が一覧を返すのは自然。`X-User-Id` がなければ 403 というのは実装するときに混乱したが、howto を読んで理解できた。`role` フィールドが `owner`/`admin`/`member` の 3 段階あるのはフロント側でも使いやすい。削除系のレスポンスが 204 No Content なのは HTTP の作法として正しい。」
+
+★★★★☆ — シンプルな API 設計。ヘッダー認証の説明がもう少し充実すると嬉しい
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「MySQL と SQLite の両方でテストが通ることが確認済みなのは本番移行の安心感につながる。`SET FOREIGN_KEY_CHECKS = 0` のパターンをテストコードに明示しているのが気に入った。テスト環境で MySQL コンテナが必要になるが、`MYSQL_HOST` 環境変数なしで自動スキップされるので CI で余計な手間がかからない。FK 制約のあるスキーマは `user_groups` と `memberships` の drop 順が正しく制御されている。」
+
+★★★★★ — MySQL テストが環境変数ゲート付きで CI フレンドリー
+
+### Persona 6 — プロダクトマネージャー
+
+「グループ機能は多くの SaaS に必要な基盤機能。owner・admin・member の 3 ロールはシンプルで理解しやすい。owner が自動追加される仕組みは UX 上正しい（作成者がメンバー一覧に表示されないバグを防ぐ）。自己脱退（self-leave）と admin による強制削除が同一エンドポイントで制御されているのは API がシンプルで良い。owner を削除できない制約は運営上も重要。」
+
+★★★★☆ — 権限設計がプロダクト要件に合っている。グループ名変更・削除機能は次のステップ
+
+---
+
+## Howto
+
+`docs/howto/group-membership-management.md`

--- a/docs/howto/group-membership-management.md
+++ b/docs/howto/group-membership-management.md
@@ -1,0 +1,204 @@
+# How to Build Group Membership Management with NENE2
+
+This guide walks through building a group system where users create groups, invite members with roles (owner/admin/member), manage membership, and control role promotion.
+
+**Field Trial**: FT138  
+**NENE2 version**: ^1.5  
+**Covered topics**: role-based membership, owner auto-join, self-leave, MySQL reserved word pitfall (`groups`), vulnerability assessment
+
+---
+
+## What we're building
+
+- `POST /groups` — create a group (creator becomes owner)
+- `GET /groups/{groupId}/members` — list members (members only)
+- `POST /groups/{groupId}/members` — add a member (owner/admin only, role: member or admin)
+- `DELETE /groups/{groupId}/members/{userId}` — remove member (owner/admin can remove others; anyone can self-leave)
+- `PUT /groups/{groupId}/members/{userId}/role` — change role (owner only)
+
+---
+
+## Database schema — IMPORTANT: avoid `groups` as table name
+
+`groups` is a **reserved word in MySQL** (used in `GROUP BY`). Use `user_groups` instead.
+
+```sql
+-- SQLite
+CREATE TABLE user_groups (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    owner_id   INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (owner_id) REFERENCES users(id)
+);
+
+CREATE TABLE memberships (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id  INTEGER NOT NULL,
+    user_id   INTEGER NOT NULL,
+    role      TEXT    NOT NULL DEFAULT 'member',
+    joined_at TEXT    NOT NULL,
+    UNIQUE (group_id, user_id),
+    CHECK (role IN ('owner', 'admin', 'member')),
+    FOREIGN KEY (group_id) REFERENCES user_groups(id),
+    FOREIGN KEY (user_id)  REFERENCES users(id)
+);
+```
+
+```sql
+-- MySQL
+CREATE TABLE user_groups (
+    id         INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name       VARCHAR(255) NOT NULL,
+    owner_id   INT          NOT NULL,
+    created_at VARCHAR(32)  NOT NULL,
+    FOREIGN KEY (owner_id) REFERENCES users(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE memberships (
+    id        INT         NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    group_id  INT         NOT NULL,
+    user_id   INT         NOT NULL,
+    role      VARCHAR(16) NOT NULL DEFAULT 'member',
+    joined_at VARCHAR(32) NOT NULL,
+    UNIQUE KEY uq_group_user (group_id, user_id),
+    CONSTRAINT chk_role CHECK (role IN ('owner', 'admin', 'member')),
+    FOREIGN KEY (group_id) REFERENCES user_groups(id),
+    FOREIGN KEY (user_id)  REFERENCES users(id)
+) ENGINE=InnoDB;
+```
+
+---
+
+## Role enum with capability methods
+
+```php
+enum MemberRole: string
+{
+    case Owner  = 'owner';
+    case Admin  = 'admin';
+    case Member = 'member';
+
+    public function canManageMembers(): bool
+    {
+        return $this === self::Owner || $this === self::Admin;
+    }
+
+    public function canChangeRoles(): bool
+    {
+        return $this === self::Owner;
+    }
+}
+```
+
+Capability methods on the enum keep authorization logic out of the handlers.
+
+---
+
+## Owner auto-join on group creation
+
+When a group is created, the owner is automatically added as a member with the `owner` role:
+
+```php
+public function createGroup(string $name, int $ownerId, string $now): int
+{
+    $this->executor->execute(
+        'INSERT INTO user_groups (name, owner_id, created_at) VALUES (?, ?, ?)',
+        [$name, $ownerId, $now],
+    );
+
+    $groupId = (int) $this->executor->lastInsertId();
+
+    // Owner is automatically a member with 'owner' role
+    $this->executor->execute(
+        'INSERT INTO memberships (group_id, user_id, role, joined_at) VALUES (?, ?, ?, ?)',
+        [$groupId, $ownerId, 'owner', $now],
+    );
+
+    return $groupId;
+}
+```
+
+---
+
+## Add member handler — role validation
+
+The `owner` role cannot be assigned via the add-member API. `TokenScope::tryFrom()` pattern applied to `MemberRole::tryFrom()`:
+
+```php
+$role = MemberRole::tryFrom($roleValue);
+
+if ($role === null || $role === MemberRole::Owner) {
+    return $this->responseFactory->create(['error' => 'role must be member or admin'], 422);
+}
+```
+
+---
+
+## Remove member — self-leave and admin remove
+
+A member can leave their own group (self-leave) without admin rights. Admins can remove others. The owner can never be removed:
+
+```php
+$isSelfLeave = $actorId === $userId;
+
+if (!$isSelfLeave && !$actorRole->canManageMembers()) {
+    return $this->responseFactory->create(['error' => 'only owner or admin can remove members'], 403);
+}
+
+$targetRole = MemberRole::tryFrom($targetMembership['role']) ?? MemberRole::Member;
+
+if ($targetRole === MemberRole::Owner) {
+    return $this->responseFactory->create(['error' => 'cannot remove the group owner'], 422);
+}
+```
+
+---
+
+## MySQL FK teardown — order matters
+
+When resetting MySQL in tests, drop FK-dependent tables first with `FOREIGN_KEY_CHECKS = 0`:
+
+```php
+$this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+$this->pdo->exec('DROP TABLE IF EXISTS memberships');
+$this->pdo->exec('DROP TABLE IF EXISTS user_groups');
+$this->pdo->exec('DROP TABLE IF EXISTS users');
+$this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+```
+
+---
+
+## Vulnerability assessment (FT138)
+
+Twelve vulnerability tests verify:
+
+| ID | Attack | Expected | Result |
+|----|--------|----------|--------|
+| VULN-A | IDOR: non-member reads member list | 403 | Pass |
+| VULN-B | IDOR: non-member adds a member | 403 | Pass |
+| VULN-C | Regular member tries to add someone | 403 | Pass |
+| VULN-D | Admin tries to set owner role | not 200 | Pass |
+| VULN-E | Member tries to promote self to admin | 403 | Pass |
+| VULN-F | Remove group owner | 422 | Pass |
+| VULN-G | Missing X-User-Id on create | not 201 | Pass |
+| VULN-H | Non-numeric X-User-Id | not 200 | Pass |
+| VULN-I | SQL injection in group name | 201 (verbatim) | Pass |
+| VULN-J | Cross-group member operation | 403 | Pass |
+| VULN-K | Negative group ID | 404 | Pass |
+| VULN-L | Admin cannot change roles | 403 | Pass |
+
+All 12 vulnerability tests pass. No vulnerabilities found.
+
+---
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Using `groups` as table name in MySQL | Use `user_groups` — `groups` is a MySQL reserved word |
+| Owner not auto-added to memberships | INSERT owner membership in `createGroup()` |
+| Admin being able to change roles | `canChangeRoles()` returns true only for `Owner` |
+| Allowing `owner` role via add-member API | Reject `role === MemberRole::Owner` → 422 |
+| Non-member bypassing 403 via missing actor | Check `findMembership(groupId, actorId) !== null` |
+| MySQL DROP TABLE fails with FK constraints | `SET FOREIGN_KEY_CHECKS = 0` before DROP |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.71
+  version: 1.5.72
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.71`（2026-05-21 リリース済み）
+- Latest release: `v1.5.72`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -53,10 +53,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT135 | ダイレクトメッセージ | messagelog | 31/31 | v1.5.69 | direct-messaging-system.md（双方向会話検索・参加者アクセス制御・GET で parse() 禁止）**脆弱性診断: 12 攻撃全耐久** |
 | FT136 | アクセストークン管理 | tokenlog | 29/29 | v1.5.70 | access-token-management.md（SHA-256・TokenScope enum・二重所有権チェック・verify 常に 200）**クラッカー攻撃試験: 12 攻撃全耐久** |
 | FT137 | サブスクリプション管理 | planlog | 20/20 | v1.5.71 | subscription-plan-management.md（UNIQUE制約→re-subscribe UPDATE・PUT要アクティブ・cancel 404 vs 409） |
+| FT138 | グループメンバーシップ | grouplog | 38/38 | v1.5.72 | group-membership-management.md（`user_groups`・MemberRole enum権限メソッド・owner自動追加・自己脱退）**脆弱性診断: 12件全Pass** / **MySQL 統合テスト: 5テスト** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT138 以降・次の MySQL テストは FT138・次の脆弱性診断は FT138・次のクラッカー攻撃試験は FT140）
+- FT ループ継続中（FT139 以降・次の MySQL テストは FT143・次の脆弱性診断は FT141・次のクラッカー攻撃試験は FT140）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.71';
+    public const string VERSION = '1.5.72';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/group-membership-management.md` — グループメンバーシップ管理ガイド追加（FT138）
- `docs/field-trials/2026-05-field-trial-138.md` — FT138 フィールドトライアルレポート（6ペルソナ DX レビュー）
- VERSION 1.5.71 → 1.5.72
- CHANGELOG.md v1.5.72 追加
- `docs/todo/current.md` FT138 行追加・次ポインタ更新

## Key decisions in FT138

- `user_groups` テーブル名（`groups` は MySQL 予約語）
- `MemberRole` enum に `canManageMembers()` / `canChangeRoles()` 権限メソッド
- Owner 自動追加（`createGroup()` 内で memberships INSERT）
- MySQL 統合テスト 5件（`SET FOREIGN_KEY_CHECKS = 0` / `getenv()` PHPStan-safe パターン）
- 脆弱性診断 12件全 Pass

## Test plan

- [x] 38/38 tests pass (21 normal + 12 vuln + 5 MySQL)
- [x] VERSION / CHANGELOG / openapi.yaml 整合確認
- [x] current.md 更新済み

Closes #780

Self-review: docs-policy, backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)