### PR TITLE
docs(howto): ゲスト注文システムガイドを追加 (#782)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.73] — 2026-05-21
+
+### Added
+- `docs/howto/guest-order-system.md` — ゲスト注文システムガイド: price snapshot in order_items・在庫先行検証・カート数量加算（UPDATE on conflict）・ユーザー別カート分離・array_sum 合計計算。 (#782)
+- `docs/field-trials/2026-05-field-trial-139.md` — FT139 レポート: orderlog（カート→注文→明細、23 tests）6 ペルソナ DX レビュー。 (#782)
+
+---
+
 ## [1.5.72] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-139.md
+++ b/docs/field-trials/2026-05-field-trial-139.md
@@ -1,0 +1,99 @@
+# Field Trial 139 — ゲスト注文（カート → 注文 → 明細）
+
+**Date**: 2026-05-21  
+**App**: `orderlog`  
+**Path**: `/home/xi/docker/NENE2-FT/orderlog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.73  
+**Special**: なし（通常 FT）
+
+---
+
+## What was built
+
+カートに商品を追加し、注文として確定する E コマース基本フローを実装した。
+
+| Endpoint | 説明 |
+|---|---|
+| `POST /users` | ユーザー作成 |
+| `POST /products` | 商品作成（name, price, stock） |
+| `POST /cart` | カートに商品追加（同一商品は数量加算） |
+| `GET /cart` | カート内容確認（合計金額付き） |
+| `DELETE /cart/{productId}` | カートから商品削除 |
+| `POST /orders` | 注文確定（在庫チェック → 在庫減算 → カートクリア） |
+| `GET /orders/{orderId}` | 注文詳細取得（明細 + 合計、所有者のみ） |
+
+---
+
+## Architecture decisions
+
+### price snapshot を order_items に持つ
+
+注文確定時に `products.name` と `products.price` を `order_items` にコピーする。これにより価格改定後も過去の注文金額が正確に保存される。`GET /orders/{orderId}` は `order_items.price` を返す（`products.price` ではない）。
+
+### 在庫チェックは先にまとめて実施
+
+複数商品がカートにある場合、一部だけ在庫不足で途中でロールバックするのは複雑。全商品を事前に検証し、全て在庫あることを確認してから一括で在庫減算・注文作成を行う。
+
+### カートの数量加算
+
+`UNIQUE (user_id, product_id)` 制約でカートの重複行を防ぐ。同一商品を再度追加すると INSERT ではなく `quantity = quantity + N` の UPDATE になる。
+
+### カートは user_id で完全分離
+
+`cart_items` の全クエリに `WHERE user_id = ?` が付く。他ユーザーのカートは参照できない。
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `OrderTest.php` | 23 | Pass |
+| **Total** | **23** | **Pass** |
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「カートと注文とアイテムで3テーブル（cart_items, orders, order_items）に分かれているのが最初は難しく感じた。でも order_items に name と price をコピーする理由（価格スナップショット）を理解したら納得できた。在庫チェックを先にまとめてやる設計も、失敗時のロールバックが複雑になるという説明で理解できた。addToCart の UPDATE ロジックが少しわかりにくかった。」
+
+★★★☆☆ — 複数テーブルの役割が最初は混乱しやすい
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel なら Cart モデルと Order モデルを Eloquent で作れば自動的にリレーション管理できる。NENE2 では JOIN クエリを自分で書く必要があった。でも Repository に集約されているのでコードの流れは追いやすい。`addToCart()` が既存チェックと INSERT/UPDATE を1メソッドで扱っているのはシンプルで好き。PHPStan level 8 で `array_sum` の型が通るかどうか少し心配だったが問題なかった。」
+
+★★★★☆ — 生 SQL だが Repository 内で整理されており読みやすい
+
+### Persona 3 — セキュリティエンジニア
+
+「在庫チェックは全商品を先に検証してから減算するので、レースコンディションのウィンドウは残る（並行リクエストで在庫が二重減算される可能性）が、単一サーバーの FT スコープでは許容範囲。本番ではトランザクション + SELECT FOR UPDATE が必要。注文詳細の GET は `order['user_id'] !== $actorId` で所有者チェックしているので IDOR は防がれている。X-User-Id ヘッダーは認証なしのため、本番ではベアラートークンに置き換えが必須。」
+
+★★★☆☆ — FT 実装として基本的な安全性は確保。本番化には認証とトランザクション追加が必要
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「カートの `GET /cart` が `items` + `count` + `total` を一度に返してくれるのはフロント側でとても使いやすい。注文確定時に `total` がレスポンスに含まれるのも良い。在庫不足の 422 レスポンスに `product_id` が含まれているのでどの商品が問題かすぐわかる。DELETE /cart/{productId} が 204 を返すのは HTTP の作法として正しい。」
+
+★★★★★ — API レスポンス設計がフロント視点で使いやすい
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「SQLite のみの実装なのでデプロイは簡単。テストが23件あり、在庫減算・カートクリア・複数商品など重要なフローをカバーしている。`array_sum` と `array_map` の組み合わせは PHP 標準なので依存パッケージなし。スキーマが5テーブルと少し複雑になってきたが、`schema.sql` 1ファイルに集約されているのは管理しやすい。本番では stock カラムのマイナス防止に DB レベルの CHECK 制約も検討したい。」
+
+★★★★☆ — シンプルな構成で運用しやすい。本番向けには CHECK(stock >= 0) を追加推奨
+
+### Persona 6 — プロダクトマネージャー
+
+「カート → 注文の基本フローが実装されている。在庫切れは 422 で正確に応答し、どの商品が問題かわかる。注文確定後にカートがクリアされるのは当然の UX。価格スナップショットが注文明細に保存されるのは重要で、返金・問い合わせ対応時に必要。次のステップとして注文キャンセル・注文一覧・ゲスト注文（ユーザー登録なし）などを追加できる。」
+
+★★★★☆ — E コマースの核となる機能が揃っている。拡張性の高い設計
+
+---
+
+## Howto
+
+`docs/howto/guest-order-system.md`

--- a/docs/howto/guest-order-system.md
+++ b/docs/howto/guest-order-system.md
@@ -1,0 +1,174 @@
+# How to Build a Guest Order System (Cart → Order → Order Items) with NENE2
+
+This guide walks through building an e-commerce ordering flow where users add products to a cart, check stock, and place an order that captures price snapshots in order items.
+
+**Field Trial**: FT139  
+**NENE2 version**: ^1.5  
+**Covered topics**: multi-table joins, stock validation, price snapshot in order_items, cart isolation, `array_sum` total calculation
+
+---
+
+## What we're building
+
+- `POST /products` — create a product (name, price, stock)
+- `POST /cart` — add a product to cart (accumulates quantity if already present)
+- `GET /cart` — view cart contents with total (X-User-Id identifies the user)
+- `DELETE /cart/{productId}` — remove an item from the cart
+- `POST /orders` — place an order (validates stock, decrements stock, clears cart)
+- `GET /orders/{orderId}` — view order details with items (owner only)
+
+---
+
+## Database schema
+
+```sql
+CREATE TABLE products (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    price      INTEGER NOT NULL,
+    stock      INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE cart_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    product_id INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL DEFAULT 1,
+    added_at   TEXT    NOT NULL,
+    UNIQUE (user_id, product_id),
+    FOREIGN KEY (user_id)    REFERENCES users(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+CREATE TABLE orders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    total      INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE order_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id   INTEGER NOT NULL,
+    product_id INTEGER NOT NULL,
+    name       TEXT    NOT NULL,
+    price      INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL,
+    FOREIGN KEY (order_id)   REFERENCES orders(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+```
+
+`UNIQUE (user_id, product_id)` on `cart_items` prevents duplicate rows — adding the same product again accumulates quantity.
+
+---
+
+## Price snapshot in order_items
+
+When an order is placed, the current product `name` and `price` are copied into `order_items`. This protects historical orders from future price changes.
+
+```php
+/** @param array<int, array{product_id: int, name: string, price: int, quantity: int}> $items */
+public function createOrder(int $userId, array $items, int $total, string $now): int
+{
+    $this->executor->execute(
+        'INSERT INTO orders (user_id, total, created_at) VALUES (?, ?, ?)',
+        [$userId, $total, $now],
+    );
+
+    $orderId = (int) $this->executor->lastInsertId();
+
+    foreach ($items as $item) {
+        $this->executor->execute(
+            'INSERT INTO order_items (order_id, product_id, name, price, quantity) VALUES (?, ?, ?, ?, ?)',
+            [$orderId, $item['product_id'], $item['name'], $item['price'], $item['quantity']],
+        );
+    }
+
+    return $orderId;
+}
+```
+
+---
+
+## Cart quantity accumulation
+
+`UNIQUE (user_id, product_id)` means a second `POST /cart` for the same product must UPDATE, not INSERT:
+
+```php
+public function addToCart(int $userId, int $productId, int $quantity, string $now): void
+{
+    $existing = $this->findCartItem($userId, $productId);
+
+    if ($existing !== null) {
+        $this->executor->execute(
+            'UPDATE cart_items SET quantity = quantity + ? WHERE user_id = ? AND product_id = ?',
+            [$quantity, $userId, $productId],
+        );
+        return;
+    }
+
+    $this->executor->execute(
+        'INSERT INTO cart_items (user_id, product_id, quantity, added_at) VALUES (?, ?, ?, ?)',
+        [$userId, $productId, $quantity, $now],
+    );
+}
+```
+
+---
+
+## Stock validation before order placement
+
+Check all items before decrementing any stock. Partial-decrement rollback is complex — validate first, then act:
+
+```php
+// Validate all items
+foreach ($items as $item) {
+    $product = $this->repository->findProductById($item['product_id']);
+
+    if ($product === null || $product['stock'] < $item['quantity']) {
+        return $this->responseFactory->create([
+            'error'      => 'insufficient stock',
+            'product_id' => $item['product_id'],
+        ], 422);
+    }
+}
+
+// Decrement and create order
+foreach ($items as $item) {
+    $this->repository->decrementStock($item['product_id'], $item['quantity']);
+}
+
+$orderId = $this->repository->createOrder($actorId, $items, $total, date('c'));
+$this->repository->clearCart($actorId);
+```
+
+---
+
+## Cart total calculation
+
+```php
+$total = array_sum(array_map(fn(array $i) => $i['price'] * $i['quantity'], $items));
+```
+
+This is computed in PHP from the joined query result, not in SQL. Same calculation is used for the cart preview and the stored order total.
+
+---
+
+## Cart isolation per user
+
+Cart items are always filtered by `user_id`. Each user only sees and modifies their own cart. The `GET /cart` handler returns an empty list for users with no items — never another user's cart.
+
+---
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Adding same product twice creates duplicate rows | `UNIQUE (user_id, product_id)` + UPDATE on conflict |
+| Price changes after order placement corrupt history | Copy `name` and `price` into `order_items` at order time |
+| Partial stock decrement on multi-item failure | Validate all items first, then decrement all |
+| Returning product's live price in order detail | Query `order_items.price`, not `products.price` |
+| Cart visible across users | Always filter `cart_items` by `user_id` |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.72
+  version: 1.5.73
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.72`（2026-05-21 リリース済み）
+- Latest release: `v1.5.73`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -54,10 +54,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT136 | アクセストークン管理 | tokenlog | 29/29 | v1.5.70 | access-token-management.md（SHA-256・TokenScope enum・二重所有権チェック・verify 常に 200）**クラッカー攻撃試験: 12 攻撃全耐久** |
 | FT137 | サブスクリプション管理 | planlog | 20/20 | v1.5.71 | subscription-plan-management.md（UNIQUE制約→re-subscribe UPDATE・PUT要アクティブ・cancel 404 vs 409） |
 | FT138 | グループメンバーシップ | grouplog | 38/38 | v1.5.72 | group-membership-management.md（`user_groups`・MemberRole enum権限メソッド・owner自動追加・自己脱退）**脆弱性診断: 12件全Pass** / **MySQL 統合テスト: 5テスト** |
+| FT139 | ゲスト注文 | orderlog | 23/23 | v1.5.73 | guest-order-system.md（price snapshot・在庫先行検証・カート数量加算・ユーザー別カート分離） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT139 以降・次の MySQL テストは FT143・次の脆弱性診断は FT141・次のクラッカー攻撃試験は FT140）
+- FT ループ継続中（FT140 以降・次の MySQL テストは FT143・次の脆弱性診断は FT141・次のクラッカー攻撃試験は FT140）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.72';
+    public const string VERSION = '1.5.73';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/guest-order-system.md` — ゲスト注文システムガイド追加（FT139）
- `docs/field-trials/2026-05-field-trial-139.md` — FT139 フィールドトライアルレポート（6ペルソナ DX レビュー）
- VERSION 1.5.72 → 1.5.73

## Key decisions in FT139

- price snapshot: `order_items` に name/price をコピー（価格改定から注文履歴を守る）
- 在庫先行検証: 全商品チェック完了後に一括減算（部分ロールバック回避）
- カート数量加算: `UNIQUE (user_id, product_id)` + UPDATE on conflict
- カート分離: 全クエリ `WHERE user_id = ?`

## Test plan

- [x] 23/23 tests pass
- [x] PHPStan level 8 OK
- [x] CS fixer OK
- [x] VERSION / CHANGELOG / openapi.yaml 整合確認

Closes #782

Self-review: docs-policy, backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)