### PR TITLE
docs(howto): コンテンツ下書きライフサイクルガイドを追加 (#788)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.76] — 2026-05-21
+
+### Added
+- `docs/howto/content-draft-lifecycle.md` — コンテンツ下書きライフサイクルガイド: ArticleStatus enum遷移ガード・非公開記事の404隠蔽・同秒ソート安定性（ORDER BY published_at DESC, id DESC）。 (#788)
+- `docs/field-trials/2026-05-field-trial-142.md` — FT142 レポート: draftlog（下書き管理、20 tests）6 ペルソナ DX レビュー。 (#788)
+
+---
+
 ## [1.5.75] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-142.md
+++ b/docs/field-trials/2026-05-field-trial-142.md
@@ -1,0 +1,106 @@
+# Field Trial 142 — コンテンツ下書き管理（Draft → Published ライフサイクル）
+
+**Date**: 2026-05-21  
+**App**: `draftlog`  
+**Path**: `/home/xi/docker/NENE2-FT/draftlog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.76  
+**Special**: なし（通常 FT）
+
+---
+
+## What was built
+
+記事の下書き・公開・アーカイブのステータス遷移を管理する CMS 基本機能を実装した。
+
+| Endpoint | 説明 |
+|---|---|
+| `POST /articles` | 記事作成（常に draft で開始） |
+| `GET /articles` | 公開中記事一覧のみ |
+| `GET /articles/{id}` | 記事詳細（作者は全ステータス・他者は published のみ） |
+| `PUT /articles/{id}` | 記事編集（draft のみ・作者のみ） |
+| `POST /articles/{id}/publish` | draft → published（作者のみ） |
+| `POST /articles/{id}/archive` | published → archived（作者のみ） |
+
+---
+
+## Architecture decisions
+
+### ArticleStatus enum でステータス遷移ガード
+
+```php
+enum ArticleStatus: string {
+    public function canEdit(): bool    { return $this === self::Draft; }
+    public function canPublish(): bool { return $this === self::Draft; }
+    public function canArchive(): bool { return $this === self::Published; }
+}
+```
+
+ハンドラーはガードメソッドを呼び出し、遷移が不正な場合は 422 を返す。逆方向遷移（published → draft）は不可。
+
+### 非公開記事は 404 で隠す
+
+ドラフトを作者以外が読もうとした場合、存在を明かさないために 404 を返す（403 ではない）。403 はリソースの存在を認める。
+
+### 同秒ソートの安定性
+
+`ORDER BY published_at DESC, id DESC` により、同秒に公開された複数記事の表示順が決定論的になる。
+
+### テストで1件失敗 → 修正
+
+最初の実装で `ORDER BY published_at DESC` のみだったため、同秒に公開した2記事の順序が不定でテストが失敗した。`id DESC` をセカンダリソートに追加して解決。
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `DraftTest.php` | 20 | Pass |
+| **Total** | **20** | **Pass** |
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「ブログの下書き→公開のフローは身近でわかりやすかった。enum にガードメソッドを持たせるパターンが前の FT（グループメンバーシップ）でも出てきたので、今回は自然に理解できた。draft を読もうとしたら 403 ではなく 404 が返ってくる設計は、最初「なぜ?」と思ったが、存在を知らせないためという説明で納得した。ソートの安定性の問題は自分では気づかなかったと思う。」
+
+★★★★☆ — ガードパターンの再利用で理解が深まる
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel だと `Publishable` トレイトや `$casts = ['status' => 'App\Enums\Status']` でステータス管理できる。NENE2 では手動で enum を使う必要があるが、コードが明示的で追いやすい。`canPublish()` / `canArchive()` のメソッドはシンプルで、業務ロジックとしてどこに何を書けばいいかが明確。同秒ソートのバグは本番でも起きやすいので、テストで発見できて良かった。」
+
+★★★★☆ — 明示的な設計で理解しやすい。同秒バグの発見は実用的
+
+### Persona 3 — セキュリティエンジニア
+
+「`GET /articles/{id}` で非公開記事を 404 で返す設計は正しい（存在漏洩防止）。作者所有権チェックが publish / archive / update の全アクションで一貫して実装されている。ステータス遷移の一方向性（逆遷移なし）はビジネスルールとして適切。VulnTest がないが、通常 FT なので問題なし。次の FT144 で脆弱性診断が入る予定。」
+
+★★★★☆ — セキュリティ設計が適切。次回の脆弱性診断に期待
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「`GET /articles` が公開記事のみを返すのはフロント側で最も使いやすい設計。`published_at` が一覧に含まれているので新着順ソートができる。`POST /articles/{id}/publish` と `POST /articles/{id}/archive` が独立したエンドポイントなので、ボタンとの対応が明確。ステータスが記事取得レスポンスに含まれているので UI の表示切り替えも簡単。」
+
+★★★★★ — API 設計がフロント要件に合っている
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「`status` カラムに CHECK 制約があるのでデータ整合性が保証されている。`published_at` と `archived_at` が nullable なのは正しい設計（未遷移は NULL）。`ORDER BY published_at DESC, id DESC` の複合ソートはインデックスを張れば効率的。`updated_at` を毎トランジションで更新しているのは監査として有用。テストが 20 件で主要フローをカバーしている。」
+
+★★★★☆ — DB 設計が堅牢。本番化しやすい
+
+### Persona 6 — プロダクトマネージャー
+
+「CMS の基本フロー（下書き→公開→アーカイブ）が完全に実装されている。一方向遷移（逆にできない）はコンテンツ管理のベストプラクティスに沿っている。読者からは公開記事のみ見えるのは当然の設計。作者は自分の下書きを確認できるのも重要。今後の拡張として、公開スケジュール予約（scheduled ステータス）・複数著者のコラボ・タグ付けなどが考えられる。」
+
+★★★★☆ — CMS として使えるレベルの完成度
+
+---
+
+## Howto
+
+`docs/howto/content-draft-lifecycle.md`

--- a/docs/howto/content-draft-lifecycle.md
+++ b/docs/howto/content-draft-lifecycle.md
@@ -1,0 +1,121 @@
+# How to Build a Content Draft Lifecycle (Draft → Published → Archived) with NENE2
+
+This guide walks through building an article management system with a draft/publish/archive state machine, where only the author can transition states and only published articles are visible to readers.
+
+**Field Trial**: FT142  
+**NENE2 version**: ^1.5  
+**Covered topics**: status machine with enum, transition guards, author ownership check, status-filtered public list, same-second sort stability
+
+---
+
+## What we're building
+
+- `POST /articles` — create an article (always starts as `draft`)
+- `GET /articles` — list published articles only
+- `GET /articles/{id}` — get article (author sees any status; others see only `published`)
+- `PUT /articles/{id}` — edit article (draft only, author only)
+- `POST /articles/{id}/publish` — transition `draft → published` (author only)
+- `POST /articles/{id}/archive` — transition `published → archived` (author only)
+
+---
+
+## Database schema
+
+```sql
+CREATE TABLE articles (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    author_id    INTEGER NOT NULL,
+    title        TEXT    NOT NULL,
+    body         TEXT    NOT NULL DEFAULT '',
+    status       TEXT    NOT NULL DEFAULT 'draft',
+    published_at TEXT,
+    archived_at  TEXT,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL,
+    CHECK (status IN ('draft', 'published', 'archived')),
+    FOREIGN KEY (author_id) REFERENCES users(id)
+);
+```
+
+`published_at` and `archived_at` are nullable — they are set only on the corresponding transition.
+
+---
+
+## ArticleStatus enum with transition guards
+
+```php
+enum ArticleStatus: string
+{
+    case Draft     = 'draft';
+    case Published = 'published';
+    case Archived  = 'archived';
+
+    public function canEdit(): bool
+    {
+        return $this === self::Draft;
+    }
+
+    public function canPublish(): bool
+    {
+        return $this === self::Draft;
+    }
+
+    public function canArchive(): bool
+    {
+        return $this === self::Published;
+    }
+}
+```
+
+The handler reads the current status, calls the guard method, and returns 422 if the transition is invalid:
+
+```php
+$status = ArticleStatus::tryFrom($article['status']) ?? ArticleStatus::Draft;
+
+if (!$status->canPublish()) {
+    return $this->responseFactory->create(['error' => 'only draft articles can be published'], 422);
+}
+```
+
+Valid transitions:
+- `draft → published` (via publish)
+- `published → archived` (via archive)
+- There is no transition back to draft.
+
+---
+
+## Author visibility — draft hidden from others
+
+Non-authors cannot read drafts. Return 404 (not 403) to avoid leaking that the article exists:
+
+```php
+if ($article['status'] !== 'published' && $article['author_id'] !== $actorId) {
+    return $this->responseFactory->create(['error' => 'article not found'], 404);
+}
+```
+
+Returning 403 would confirm the article exists. 404 is the correct choice for content that is not yet public.
+
+---
+
+## Same-second sort stability
+
+When multiple articles are published within the same second, `ORDER BY published_at DESC` alone gives non-deterministic order. Add `id DESC` as a tiebreaker:
+
+```sql
+SELECT ... FROM articles WHERE status = 'published' ORDER BY published_at DESC, id DESC
+```
+
+Higher `id` means created later, so this effectively sorts by insertion order within the same second.
+
+---
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Returning 403 for non-author draft reads | Return 404 — prevents content existence leakage |
+| Allowing `published → draft` re-open | `canEdit()` returns false unless `Draft`; no "unpublish" endpoint |
+| Publishing an already-published article | `canPublish()` returns false for `Published` → 422 |
+| Archiving a draft | `canArchive()` returns false unless `Published` → 422 |
+| Non-deterministic list order at same timestamp | Add `id DESC` as secondary sort |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.75
+  version: 1.5.76
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.75`（2026-05-21 リリース済み）
+- Latest release: `v1.5.76`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -57,10 +57,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT139 | ゲスト注文 | orderlog | 23/23 | v1.5.73 | guest-order-system.md（price snapshot・在庫先行検証・カート数量加算・ユーザー別カート分離） |
 | FT140 | フラッシュセール | salelog | 29/29 | v1.5.74 | flash-sale-system.md（COUNT残数計算・ISO 8601時間比較・UNIQUE二重購入防止・matchステータス）**クラッカー攻撃試験: 12件全Pass** |
 | FT141 | リーダーボード | ranklog | 29/29 | v1.5.75 | leaderboard-ranking-system.md（ベストスコア UPDATE・COUNT(*)ランク計算・IDOR防止・limitクランプ）**脆弱性診断: 12件全Pass** |
+| FT142 | コンテンツ下書き | draftlog | 20/20 | v1.5.76 | content-draft-lifecycle.md（ArticleStatus enum遷移ガード・404隠蔽・同秒ソート id DESC tiebreaker） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT142 以降・次の MySQL テストは FT143・次の脆弱性診断は FT144・次のクラッカー攻撃試験は FT144）
+- FT ループ継続中（FT143 以降・次の MySQL テストは FT143・次の脆弱性診断 + クラッカー攻撃試験は FT144）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.75';
+    public const string VERSION = '1.5.76';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- `docs/howto/content-draft-lifecycle.md` — コンテンツ下書きライフサイクルガイド追加（FT142）
- `docs/field-trials/2026-05-field-trial-142.md` — FT142 フィールドトライアルレポート（6ペルソナ DX レビュー）
- VERSION 1.5.75 → 1.5.76

## Key decisions in FT142

- `ArticleStatus` enum に `canEdit()` / `canPublish()` / `canArchive()` ガードメソッド
- 非公開記事を非作者が読もうとした場合 404（存在漏洩防止）
- `ORDER BY published_at DESC, id DESC` で同秒ソートの安定性確保

## Bug found and fixed

- `ORDER BY published_at DESC` のみでは同秒公開した記事の順序が不定
- `id DESC` をセカンダリソートに追加して解決

## Test plan

- [x] 20/20 tests pass
- [x] PHPStan level 8 OK
- [x] CS fixer OK
- [x] VERSION / CHANGELOG / openapi.yaml 整合確認

Closes #788

Self-review: docs-policy, backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)