### PR TITLE
feat(emoji): 絵文字リアクションシステム FT143 (#790)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.77] — 2026-05-21
+
+### Added
+- `docs/howto/emoji-reaction-system.md` — 絵文字リアクションガイド: UNIQUE(post_id, user_id, emoji)・GROUP BY集計・optional actor per-user tracking・mb_strlen絵文字長・is_array常にtrue回避。 (#790)
+- `docs/field-trials/2026-05-field-trial-143.md` — FT143 レポート: emojilog（絵文字リアクション、23 tests = 18 正常 + 5 MySQL）**MySQL統合テスト: 5テスト**。 (#790)
+
+---
+
 ## [1.5.76] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-143.md
+++ b/docs/field-trials/2026-05-field-trial-143.md
@@ -1,0 +1,118 @@
+# Field Trial 143 — 絵文字リアクション
+
+**Date**: 2026-05-21  
+**App**: `emojilog`  
+**Path**: `/home/xi/docker/NENE2-FT/emojilog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.77  
+**Special**: MySQL 統合テスト（5FT ごと）
+
+---
+
+## What was built
+
+投稿に絵文字でリアクションを付けるシステムを実装した。
+
+| Endpoint | 説明 |
+|---|---|
+| `POST /posts` | 投稿作成 |
+| `POST /posts/{id}/reactions` | リアクション追加（同一絵文字は1ユーザー1回のみ） |
+| `DELETE /posts/{id}/reactions/{emoji}` | リアクション削除（自分のみ） |
+| `GET /posts/{id}/reactions` | リアクション集計（emoji 別カウント・ユーザー別リアクション） |
+
+---
+
+## Architecture decisions
+
+### UNIQUE (post_id, user_id, emoji) で重複防止
+
+同一ユーザーが同一投稿に同じ絵文字で複数回リアクションできないよう制約。異なる絵文字は OK（👍 と ❤️ は別行）。複数ユーザーが同じ絵文字を使うのも OK（各ユーザーで別行）。
+
+### GROUP BY emoji で集計
+
+リアクション数を COUNT(*) で集計し、カウント降順・絵文字名昇順でソート。集計は読み取り時に計算（カウントのためのカラムは持たない）。
+
+### Optional actor で per-user リアクション
+
+`GET /reactions` の `X-User-Id` ヘッダーはオプション。存在する場合、呼び出しユーザーが何の絵文字でリアクションしたかのリストを `user_reactions` として返す。フロントの UI でどの絵文字をハイライトするかの判定に使用。
+
+### `mb_strlen` で絵文字長チェック
+
+絵文字は Unicode マルチバイト文字のため `strlen` ではなく `mb_strlen` で長さを制限。8 文字以内に制限（ほとんどの絵文字シーケンスを許容）。
+
+### PHPStan: `is_array()` on `fetchAll` result は常に true
+
+`fetchAll` は `array<int, array<string, mixed>>` を返すため、各要素に対する `is_array()` チェックは常に true。代わりに `(array) $row` キャストを使用して `foreach` ループで処理。
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `EmojiTest.php` (SQLite) | 18 | Pass |
+| `MysqlEmojiTest.php` | 5 | Pass (MySQL環境) |
+| **Total** | **23** | **Pass** |
+
+---
+
+## MySQL integration tests (FT143)
+
+| テスト | 確認内容 |
+|---|---|
+| `testMysqlAddReactionAndGetCounts` | リアクション追加 → カウント確認 |
+| `testMysqlDuplicateReactionReturns409` | 重複リアクション → 409 |
+| `testMysqlRemoveReaction` | リアクション削除 → 204 |
+| `testMysqlUserReactions` | ユーザー別リアクション確認 |
+| `testMysqlMultipleEmojisOnSamePost` | 複数絵文字・複数ユーザーの集計 |
+
+MySQL テストのキーポイント:
+- `VARCHAR(32)` で emoji カラムを定義（UNIQUE キーに必要）
+- `SET FOREIGN_KEY_CHECKS = 0` で FK 依存テーブルを安全に DROP
+- `getenv()` は `=== false` でチェック（PHPStan level 8 対応）
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「絵文字リアクションは Twitter/Slack でよく使う機能なので概念がわかりやすかった。UNIQUE 制約が 3 カラム（post_id, user_id, emoji）にまたがるのは最初驚いたが、理由を聞いて納得した。`mb_strlen` と `strlen` の違いは知らなかった。絵文字が UTF-8 でマルチバイトという話は日本語の Web 開発をするときにもう一度思い出すことになりそう。`GROUP BY` での集計は SQL の基本なので理解しやすかった。」
+
+★★★★☆ — 身近な機能で学習効果が高い
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel なら `Reaction::where('post_id', $postId)->groupBy('emoji')->count()` などで同様のことができる。NENE2 では GROUP BY を自分で書くが、Repository でカプセル化されているので handlers は読みやすい。`DatabaseConstraintException` のパターンは複数 FT で繰り返し登場するので覚えてきた。MySQL のスキーマで `VARCHAR(32)` を使う理由（UNIQUE キー）は実際のプロジェクトで役立つ知識。」
+
+★★★★☆ — パターンの一貫性が学習を助ける
+
+### Persona 3 — セキュリティエンジニア
+
+「UNIQUE 制約 + `DatabaseConstraintException` で二重リアクションを DB レベルで防止しているのは正しい。削除は自分のリアクションのみ可能（`WHERE user_id = ?`）。`mb_strlen` で絵文字長制限があるので極端に長い文字列インジェクションを防止できる。MySQL の utf8mb4 設定が必要な点（VARCHAR で絵文字対応）は実際の設定ミスになりやすい箇所で、howto に明記されているのが良い。」
+
+★★★★☆ — 基本的な安全性が確保されている
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「`GET /reactions` が `counts`・`total`・`user_reactions` を一度に返してくれるのがとても使いやすい。`user_reactions` でどの絵文字を自分が押したか確認できるのは「ハイライト」演出の実装に必須。`counts` が `{emoji: count}` のオブジェクト形式なのでフロントでの取り扱いが簡単。削除が `DELETE /reactions/{emoji}` で emoji を URL に含むのは REST として自然。」
+
+★★★★★ — API レスポンス設計がフロント視点で完璧
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「MySQL と SQLite の両方でテスト通過済みなのは本番移行の安心感がある。MySQL で `VARCHAR(32)` を使うのは UNIQUE キーのインデックス制限回避として正しい。`utf8mb4` charset が必要で接続文字列に含まれているのが良い。`GROUP BY emoji` は `post_id` のインデックスがあれば効率的。テスト環境で MySQL コンテナが必要だが、環境変数なしで自動スキップされるので CI に優しい。」
+
+★★★★★ — MySQL/SQLite 両対応が本番移行を容易にする
+
+### Persona 6 — プロダクトマネージャー
+
+「絵文字リアクションはソーシャル機能として欠かせない。1ユーザー1絵文字の制約は公平性を保証し、スパムを防ぐ。集計が `{emoji: count}` 形式なのでランキング表示も簡単。削除（取り消し）ができるのは UX として重要。今後の拡張として、リアクションへの通知・トップリアクターの表示・カスタム絵文字などが考えられる。」
+
+★★★★☆ — ソーシャル機能として必要な要件が揃っている
+
+---
+
+## Howto
+
+`docs/howto/emoji-reaction-system.md`

--- a/docs/howto/emoji-reaction-system.md
+++ b/docs/howto/emoji-reaction-system.md
@@ -1,0 +1,133 @@
+# How to Build an Emoji Reaction System with NENE2
+
+This guide walks through building a reaction system where users react to posts with emojis, with grouped counts and per-user reaction tracking.
+
+**Field Trial**: FT143  
+**NENE2 version**: ^1.5  
+**Covered topics**: UNIQUE(post_id, user_id, emoji) constraint, GROUP BY emoji counts, per-user reaction tracking, emoji length validation, MySQL integration tests
+
+---
+
+## What we're building
+
+- `POST /posts` — create a post
+- `POST /posts/{id}/reactions` — add a reaction (emoji string, one per emoji per user)
+- `DELETE /posts/{id}/reactions/{emoji}` — remove a reaction (own only)
+- `GET /posts/{id}/reactions` — get reaction counts and current user's reactions
+
+---
+
+## Database schema
+
+```sql
+CREATE TABLE reactions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    post_id    INTEGER NOT NULL,
+    user_id    INTEGER NOT NULL,
+    emoji      TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    UNIQUE (post_id, user_id, emoji),
+    FOREIGN KEY (post_id) REFERENCES posts(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`UNIQUE (post_id, user_id, emoji)` — one row per emoji per user per post. The same user can react with different emojis (👍 and ❤️ = 2 rows). Multiple users can use the same emoji (each gets their own row).
+
+---
+
+## Duplicate reaction → 409
+
+```php
+public function addReaction(int $postId, int $userId, string $emoji, string $now): bool
+{
+    try {
+        $this->executor->execute(
+            'INSERT INTO reactions (post_id, user_id, emoji, created_at) VALUES (?, ?, ?, ?)',
+            [$postId, $userId, $emoji, $now],
+        );
+        return true;
+    } catch (DatabaseConstraintException) {
+        return false;
+    }
+}
+```
+
+The handler returns 409 when `addReaction()` returns `false`. No separate existence check needed.
+
+---
+
+## Grouped reaction counts with GROUP BY
+
+```sql
+SELECT emoji, COUNT(*) as cnt
+FROM reactions
+WHERE post_id = ?
+GROUP BY emoji
+ORDER BY cnt DESC, emoji ASC
+```
+
+Sorted by count descending (most popular emoji first), then alphabetically as a tiebreaker. The result maps directly to a PHP `array<string, int>`:
+
+```php
+$counts = [];
+foreach ($rows as $row) {
+    $arr = (array) $row;
+    if (isset($arr['emoji']) && is_string($arr['emoji'])) {
+        $counts[$arr['emoji']] = isset($arr['cnt']) ? (int) $arr['cnt'] : 0;
+    }
+}
+```
+
+---
+
+## Per-user reactions (optional actor)
+
+The `GET /reactions` endpoint accepts an optional `X-User-Id` header. When present, the response includes the list of emojis the caller has used:
+
+```php
+$actorId       = (int) $request->getHeaderLine('X-User-Id');
+$userReactions = $actorId > 0 ? $this->repository->getUserReactions($postId, $actorId) : [];
+```
+
+This allows the UI to show which emojis the current user has already reacted with.
+
+---
+
+## Emoji validation
+
+```php
+if (mb_strlen($emoji) > 8) {
+    return $this->responseFactory->create(['error' => 'emoji too long'], 422);
+}
+```
+
+`mb_strlen` counts Unicode code points, not bytes. A single emoji like 🧑‍💻 (person: technologist) is 3 code points; an 8-char limit accommodates most emoji sequences. Adjust to your requirements.
+
+---
+
+## MySQL integration tests (FT143)
+
+MySQL teardown order matters:
+
+```php
+$this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+$this->pdo->exec('DROP TABLE IF EXISTS reactions');
+$this->pdo->exec('DROP TABLE IF EXISTS posts');
+$this->pdo->exec('DROP TABLE IF EXISTS users');
+$this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+```
+
+MySQL schema uses `VARCHAR(32)` for emoji (not `TEXT`) to allow the column in a UNIQUE key without a prefix length. `VARCHAR(32)` stores up to 32 characters, which covers all emoji sequences.
+
+---
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Allowing duplicate emoji reactions | `UNIQUE (post_id, user_id, emoji)` + catch `DatabaseConstraintException` |
+| Using `strlen()` for emoji length | Use `mb_strlen()` — emoji are multi-byte Unicode |
+| Mutable count column gets out of sync | Count from `reactions` table with `GROUP BY emoji` |
+| Missing MySQL emoji support | Use `utf8mb4` charset and `VARCHAR` (not `CHAR`) for emoji column |
+| `is_array()` on `fetchAll` result is always true | Skip the check; `fetchAll` already returns `array<int, array<string, mixed>>` |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.76
+  version: 1.5.77
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.76`（2026-05-21 リリース済み）
+- Latest release: `v1.5.77`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -58,10 +58,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT140 | フラッシュセール | salelog | 29/29 | v1.5.74 | flash-sale-system.md（COUNT残数計算・ISO 8601時間比較・UNIQUE二重購入防止・matchステータス）**クラッカー攻撃試験: 12件全Pass** |
 | FT141 | リーダーボード | ranklog | 29/29 | v1.5.75 | leaderboard-ranking-system.md（ベストスコア UPDATE・COUNT(*)ランク計算・IDOR防止・limitクランプ）**脆弱性診断: 12件全Pass** |
 | FT142 | コンテンツ下書き | draftlog | 20/20 | v1.5.76 | content-draft-lifecycle.md（ArticleStatus enum遷移ガード・404隠蔽・同秒ソート id DESC tiebreaker） |
+| FT143 | 絵文字リアクション | emojilog | 23/23 | v1.5.77 | emoji-reaction-system.md（UNIQUE(post_id,user_id,emoji)・GROUP BY集計・optional actor tracking・mb_strlen）**MySQL統合テスト: 5テスト** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT143 以降・次の MySQL テストは FT143・次の脆弱性診断 + クラッカー攻撃試験は FT144）
+- FT ループ継続中（FT144 以降・次の MySQL テストは FT148・次の脆弱性診断: FT144・次のクラッカー攻撃試験: FT144）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.76';
+    public const string VERSION = '1.5.77';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- 投稿に絵文字でリアクションを付けるシステムを実装（FT143 emojilog）
- UNIQUE(post_id, user_id, emoji) で重複防止、GROUP BY で集計、オプション actor でユーザー別リアクション返却
- MySQL 統合テスト 5 件追加（5FT ごと）、mb_strlen で絵文字長バリデーション

## Test plan

- [x] EmojiTest.php (SQLite): 18/18 Pass
- [x] MysqlEmojiTest.php: 5/5 Pass (MySQL 環境)
- [x] composer check (PHPStan level 8, CS fixer, openapi)
- [x] VERSION 1.5.76 → 1.5.77

Closes #790

Self-review: backend-api, database