### PR TITLE
feat(magic-link): パスワードレス認証 FT144 (#792)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.78] — 2026-05-21
+
+### Added
+- `docs/howto/passwordless-auth-magic-link.md` — パスワードレス認証（Magic Link）ガイド: SHA-256ハッシュ保存・ユーザー列挙防止（常に202）・expiry before used_at・セッション無効化。 (#792)
+- `docs/field-trials/2026-05-field-trial-144.md` — FT144 レポート: magiclog（パスワードレス認証、43 tests = 19 正常 + 12 脆弱性診断 + 12 クラッカー攻撃）**脆弱性診断: 12件全Pass** / **クラッカー攻撃試験: 12件全Pass**。 (#792)
+
+---
+
 ## [1.5.77] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-144.md
+++ b/docs/field-trials/2026-05-field-trial-144.md
@@ -1,0 +1,186 @@
+# Field Trial 144 — パスワードレス認証（Magic Link）
+
+**Date**: 2026-05-21  
+**App**: `magiclog`  
+**Path**: `/home/xi/docker/NENE2-FT/magiclog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.78  
+**Special**: 脆弱性診断（12件）+ クラッカー攻撃試験（12件）両方実施
+
+---
+
+## What was built
+
+パスワードレス認証（Magic Link）システムを実装した。
+パスワードなしでメールアドレスだけでログインできる。
+
+| Endpoint | 説明 |
+|---|---|
+| `POST /auth/request` | メールアドレス提示 → Magic Link 生成（常に 202） |
+| `POST /auth/verify` | Magic Link トークン検証 → セッショントークン発行 |
+| `POST /auth/logout` | セッション無効化（常に 204） |
+| `GET /me` | 認証済みユーザー情報取得 |
+
+---
+
+## Architecture decisions
+
+### トークンは SHA-256 ハッシュで保存
+
+Magic Link トークンも Session トークンも、DB には生値を保存しない。
+`bin2hex(random_bytes(32))` で 256-bit ランダム hex 文字列を生成し、`hash('sha256', $rawToken)` のみ保存。
+DB 漏洩時にトークンから生値を復元できない。
+
+### ユーザー列挙防止（常に 202）
+
+`POST /auth/request` は登録済みメールでも未登録メールでも常に 202 を返す。
+攻撃者がメールアドレスの登録状況を確認できない。
+
+### expiry チェックは used_at チェックより先
+
+```php
+if ($now > (string) $link['expires_at']) { return 401 'expired'; }
+if ($link['used_at'] !== null) { return 401 'already used'; }
+```
+
+期限切れトークンが「使用済みかどうか」という情報を漏らさない。
+
+### 新規ユーザー自動作成（findOrCreate）
+
+初回ログイン時にユーザーレコードを自動作成する。パスワードレス認証の特性として
+ユーザー登録フロー自体が不要（認証 = 登録）。
+
+### logout は常に 204
+
+セッションが存在するかどうかを漏らさない。有効なセッションがあれば無効化する。
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `MagicTest.php` (SQLite) | 19 | Pass |
+| `VulnTest.php` (脆弱性診断) | 12 | Pass |
+| `AttackTest.php` (攻撃試験) | 12 | Pass |
+| **Total** | **43** | **Pass** |
+
+---
+
+## 脆弱性診断 (FT144)
+
+| ID | 脆弱性項目 | 結果 |
+|---|---|---|
+| VULN-A | 期限切れトークンは used_at チェックより先に弾かれる | Pass |
+| VULN-B | Session トークンは SHA-256 ハッシュで保存（生値は DB にない） | Pass |
+| VULN-C | 使用済み Magic Link の再使用防止（リプレイ攻撃） | Pass |
+| VULN-D | logout 後のセッションで /me が 401 | Pass |
+| VULN-E | 存在しないメールでも 202（ユーザー列挙防止） | Pass |
+| VULN-F | revoked セッションは /me で 401 | Pass |
+| VULN-G | 期限切れセッションは /me で 401 | Pass |
+| VULN-H | Magic Link トークンも SHA-256 ハッシュ保存 | Pass |
+| VULN-I | Magic Link 有効期限は 15 分以内 | Pass |
+| VULN-J | Session トークンに有効期限が設定されている | Pass |
+| VULN-K | Session トークンは 64 文字以上の hex（256-bit） | Pass |
+| VULN-L | X-User-Id ヘッダーで認証バイパスできない | Pass |
+
+**12/12 Pass**
+
+---
+
+## クラッカー攻撃試験 (FT144)
+
+| ID | 攻撃手法 | 結果 |
+|---|---|---|
+| ATK-01 | ランダムトークンで verify ブルートフォース | Pass（全て 401） |
+| ATK-02 | 期限切れ Magic Link での verify | Pass（401 + expired メッセージ） |
+| ATK-03 | 使用済み Magic Link の再利用（リプレイ） | Pass（401 + already been used） |
+| ATK-04 | 無効なメール形式（5種類）でリクエスト | Pass（全て 422） |
+| ATK-05 | 空トークンで verify | Pass（422） |
+| ATK-06 | email フィールドへの SQL インジェクション | Pass（422 or 202、テーブル破壊なし） |
+| ATK-07 | 極端に長いメールアドレス（300文字+） | Pass（422） |
+| ATK-08 | revoked セッションで /me アクセス | Pass（401） |
+| ATK-09 | 他ユーザーのセッショントークンで /me | Pass（正しいユーザーデータのみ返す） |
+| ATK-10 | 期限切れセッションで /me アクセス | Pass（401） |
+| ATK-11 | logout 後の同セッション再利用 | Pass（401） |
+| ATK-12 | X-User-Id ヘッダーだけで /me（認証バイパス試行） | Pass（401） |
+
+**12/12 Pass**
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「パスワードレス認証は Slack の Magic Link や Apple の Sign-in with Apple で知っていたが、
+実装したことがなかった。コードを見ると意外とシンプルで、『トークンを生成してハッシュを DB に保存し、
+メールで送る』という流れが明快だった。`bin2hex(random_bytes(32))` という書き方が安全な乱数生成の
+標準的な方法だと知れた。SHA-256 で保存する理由（DB 漏洩時の安全性）が最初ピンとこなかったが、
+パスワードハッシュと同じ考え方だと説明されて納得した。有効期限（15 分）や一回限り使用の概念も
+セキュリティの基本として理解できた。」
+
+★★★★☆ — セキュリティ概念の入門として丁度よい難易度
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel Fortify の Passwordless login 機能と同等のものを自分で組んだ感じ。Laravel では
+`notification` でメール送信 + `signed URL` で実現することが多いが、NENE2 ではシンプルなトークン
+テーブルで同等のことができた。`findOrCreateUser` パターンは Eloquent の `firstOrCreate` に
+相当する。`hash_equals` を使っていないことが気になったが、SHA-256 ハッシュを DB から引いて
+比較しているので厳密な意味でのタイミング攻撃リスクは低いと判断できる（`findByHash` が 0/1 行
+返すため）。expiry を used_at より先にチェックする設計は Laravel でも意識すべき点。」
+
+★★★★☆ — パターンの一貫性が理解を助ける
+
+### Persona 3 — セキュリティエンジニア
+
+「256-bit ランダムトークン + SHA-256 ハッシュ保存は標準的な正しい設計。トークン生成に
+`random_bytes()` を使っているので暗号論的安全性が確保されている。ユーザー列挙防止（常に 202）、
+リプレイ攻撃防止（used_at）、セッション無効化（revoked_at）がすべて実装されている。
+気になる点は 2 点: (1) `POST /auth/request` にレートリミットがない — 大量メール送信攻撃が可能。
+(2) Magic Link トークンを DB から引くとき `findByHash` でハッシュ全体を比較しているが、
+strict constant-time compare（`hash_equals`）を明示的に使っていない。
+SQL WHERE 句で比較する設計は DB 側でタイミング一定化されているためリスクは実質低いが、
+明示的な `hash_equals` の方がより明確な意図を示す。FT スコープとしては十分な安全性。」
+
+★★★★☆ — セキュリティ基礎は揃っている、レートリミットが次の課題
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「Magic Link の UX 実装に必要なものが揃っている。`POST /auth/request` で 202 を受け取ったら
+『メールを確認してください』UI を表示。ユーザーがメールのリンクをクリックすると `POST /auth/verify`
+で `session_token` と `expires_at` が返る — これを localStorage に保存すれば以降の API コールに
+使える。`Authorization: Bearer <token>` ヘッダーで認証する点は標準的で扱いやすい。
+`GET /me` でユーザー情報を取得できるのでプロフィール表示も簡単。logout は 204 なのでシンプルに
+処理できる。ただし `expires_at` をクライアントで監視してリダイレクトする処理が必要になる。」
+
+★★★★☆ — フロントの実装に必要な情報が揃っている
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「SQLite で動作するため開発環境の追加サービスが不要。本番では MySQL / PostgreSQL に乗り換える
+想定で設計されており、SQL が標準的でポータブル。`auth_sessions` テーブルのインデックスは
+`session_token_hash` の UNIQUE 制約が自動でカバーする。`magic_links` の期限切れレコードを
+定期的に削除する cleanup ジョブが必要になる点は要注意（DB に蓄積し続ける）。
+`UNIQUE(token_hash)` が magic_links にあるため、ハッシュ衝突（256-bit では現実的には不可能）
+でも INSERT 失敗で安全に処理される。セッショントークンも同様。」
+
+★★★☆☆ — 本番で cleanup ジョブが必要な点は明記が必要
+
+### Persona 6 — プロダクトマネージャー
+
+「Magic Link 認証はパスワードを覚える必要がないため、ユーザー登録の摩擦が大幅に減る。
+特に偶発的な訪問者（ゲスト注文などのユースケース）に有効。15 分の有効期限は
+メール開封までの実際の行動時間として適切。ただし『メールが届かない』場合のリカバリが
+UX の重要課題 — 再送機能とサポートフローの設計が必要。今後の拡張として、
+複数デバイスからのログイン管理、セッション一覧・個別失効、アクティビティログなどが考えられる。
+パスワードレスは Google・Apple のパスキーに並ぶトレンドで戦略的に正しい方向性。」
+
+★★★★☆ — 基本 UX は揃っている、メール不達のリカバリが課題
+
+---
+
+## Howto
+
+`docs/howto/passwordless-auth-magic-link.md`

--- a/docs/howto/passwordless-auth-magic-link.md
+++ b/docs/howto/passwordless-auth-magic-link.md
@@ -1,0 +1,188 @@
+# Passwordless Auth (Magic Link)
+
+パスワードレス認証（Magic Link）の実装ガイド。メールアドレスだけで認証できる
+ワンタイムリンクシステムのセキュアな設計パターンを解説する。
+
+## 概要
+
+Magic Link 認証は以下のフローで動作する:
+
+1. ユーザーがメールアドレスを送信する
+2. サーバーがワンタイムトークン（Magic Link）を生成し、メールで送る
+3. ユーザーがトークンを送信してセッショントークンを取得する
+4. セッショントークンで API にアクセスする
+
+## エンドポイント
+
+| Method | Path | 説明 |
+|---|---|---|
+| `POST` | `/auth/request` | メールアドレス提示 → Magic Link 生成（常に 202） |
+| `POST` | `/auth/verify` | Magic Link トークン検証 → セッショントークン発行 |
+| `POST` | `/auth/logout` | セッション無効化（常に 204） |
+| `GET` | `/me` | 認証済みユーザー情報取得 |
+
+## データベース設計
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE magic_links (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,  -- SHA-256 ハッシュ保存（生値は保存しない）
+    expires_at TEXT NOT NULL,          -- 15 分の有効期限
+    used_at TEXT,                      -- 一回限り使用（NULL = 未使用）
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE auth_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    session_token_hash TEXT NOT NULL UNIQUE,  -- SHA-256 ハッシュ保存
+    expires_at TEXT NOT NULL,                  -- 24 時間の有効期限
+    revoked_at TEXT,                           -- logout で設定
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+## セキュリティ設計
+
+### トークンは SHA-256 ハッシュで保存
+
+```php
+// 生成: 256-bit ランダム → hex 文字列（64文字）
+$rawToken = bin2hex(random_bytes(32));
+$tokenHash = hash('sha256', $rawToken);
+
+// DB には tokenHash だけ保存
+// rawToken だけがメールで送られる（DB 漏洩時の安全性）
+```
+
+DB が漏洩してもハッシュからトークンを復元できない。パスワードハッシュと同じ原理。
+
+### ユーザー列挙防止
+
+```php
+// POST /auth/request は常に 202 を返す
+// 登録済み / 未登録メールで応答を変えない
+return $this->responseFactory->create([
+    'message' => 'if this email is registered, a magic link has been sent',
+], 202);
+```
+
+攻撃者がメールアドレスの有効性を確認できない。
+
+### expiry チェックは used_at チェックより先
+
+```php
+// expiry を先にチェックする
+if ($now > (string) $link['expires_at']) {
+    return $this->responseFactory->create(['error' => 'token has expired'], 401);
+}
+
+// その後で used_at を確認
+if ($link['used_at'] !== null) {
+    return $this->responseFactory->create(['error' => 'token has already been used'], 401);
+}
+```
+
+期限切れトークンが「使用済み」かどうかを知られない（タイミング情報の漏洩防止）。
+
+### 一回限り使用（リプレイ攻撃防止）
+
+```php
+// verify 成功時に immediately used_at をセット
+$this->repository->markMagicLinkUsed($linkId, $now);
+```
+
+同じ Magic Link を二度使えない。傍受されたリンクの再利用を防ぐ。
+
+### セッション無効化（logout）
+
+```php
+// logout は常に 204 — セッション存在を漏らさない
+if ($session !== null && $session['revoked_at'] === null) {
+    $this->repository->revokeSession((int) $session['id'], date('c'));
+}
+return $this->responseFactory->createEmpty(204);
+```
+
+`/me` では `revoked_at !== null` なら 401 を返す。
+
+## セッション検証フロー
+
+```php
+private function handleMe(ServerRequestInterface $request): ResponseInterface
+{
+    $rawToken = $this->extractBearerToken($request);
+    if ($rawToken === '') {
+        return $this->responseFactory->create(['error' => 'authentication required'], 401);
+    }
+
+    $tokenHash = hash('sha256', $rawToken);
+    $session = $this->repository->findSessionByTokenHash($tokenHash);
+
+    if ($session === null) { return 401; }
+    if ($session['revoked_at'] !== null) { return 401 revoked; }
+    if ($now > $session['expires_at']) { return 401 expired; }
+
+    // ...
+}
+```
+
+## Bearer トークン抽出
+
+```php
+private function extractBearerToken(ServerRequestInterface $request): string
+{
+    $header = $request->getHeaderLine('Authorization');
+    if (!str_starts_with($header, 'Bearer ')) {
+        return '';
+    }
+    return trim(substr($header, 7));
+}
+```
+
+`X-User-Id` ヘッダーは認証に使用しない。`Authorization: Bearer <token>` のみ。
+
+## 新規ユーザー自動作成
+
+```php
+public function findOrCreateUser(string $email, string $now): int
+{
+    $user = $this->findUserByEmail($email);
+    if ($user !== null) {
+        return (int) $user['id'];
+    }
+    $this->executor->execute('INSERT INTO users (email, created_at) VALUES (?, ?)', [$email, $now]);
+    return (int) $this->executor->lastInsertId();
+}
+```
+
+初回ログインでユーザーを自動作成。パスワードレス認証の特性。
+
+## Magic Link の有効期限
+
+- **Magic Link**: 15 分（900 秒）— メールの開封・クリックまでの余裕
+- **Session Token**: 24 時間（86400 秒）— 通常の API セッション
+
+```php
+$expiresAt = date('c', time() + 900);    // magic link: 15 min
+$sessionExpiresAt = date('c', time() + 86400);  // session: 24h
+```
+
+## 本番環境での考慮事項
+
+- **メール送信**: 本 FT では `token` をレスポンスに含めている（テスト用）。
+  本番では SMTP でユーザーのメールアドレスに送信し、レスポンスから削除する。
+- **レートリミット**: `/auth/request` へのリクエストを IP / email でレート制限する。
+- **古い未使用リンクの無効化**: 同じメールで `/auth/request` を複数回呼んだとき、
+  古い未使用リンクを明示的に無効化することを検討する。
+- **HTTPS 必須**: Magic Link トークンは URL パラメーターに含まれるため
+  HTTPS が必須（中間者攻撃防止）。

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.77
+  version: 1.5.78
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.77`（2026-05-21 リリース済み）
+- Latest release: `v1.5.78`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -59,10 +59,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT141 | リーダーボード | ranklog | 29/29 | v1.5.75 | leaderboard-ranking-system.md（ベストスコア UPDATE・COUNT(*)ランク計算・IDOR防止・limitクランプ）**脆弱性診断: 12件全Pass** |
 | FT142 | コンテンツ下書き | draftlog | 20/20 | v1.5.76 | content-draft-lifecycle.md（ArticleStatus enum遷移ガード・404隠蔽・同秒ソート id DESC tiebreaker） |
 | FT143 | 絵文字リアクション | emojilog | 23/23 | v1.5.77 | emoji-reaction-system.md（UNIQUE(post_id,user_id,emoji)・GROUP BY集計・optional actor tracking・mb_strlen）**MySQL統合テスト: 5テスト** |
+| FT144 | パスワードレス認証（Magic Link）| magiclog | 43/43 | v1.5.78 | passwordless-auth-magic-link.md（SHA-256ハッシュ保存・常に202・expiry before used_at・セッション無効化）**脆弱性診断: 12件全Pass** / **クラッカー攻撃試験: 12件全Pass** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT144 以降・次の MySQL テストは FT148・次の脆弱性診断: FT144・次のクラッカー攻撃試験: FT144）
+- FT ループ継続中（FT145 以降・次の MySQL テストは FT148・次の脆弱性診断: FT147・次のクラッカー攻撃試験: FT148）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.77';
+    public const string VERSION = '1.5.78';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- パスワードレス認証（Magic Link）システムを実装（FT144 magiclog）
- SHA-256ハッシュ保存・常に202でユーザー列挙防止・expiry before used_at・セッション無効化
- 脆弱性診断 12件全Pass + クラッカー攻撃試験 12件全Pass（同時実施）

## Test plan

- [x] MagicTest.php (SQLite): 19/19 Pass
- [x] VulnTest.php (脆弱性診断): 12/12 Pass
- [x] AttackTest.php (クラッカー攻撃試験): 12/12 Pass
- [x] PHPStan level 8 clean
- [x] PHP-CS-Fixer clean
- [x] VERSION 1.5.77 → 1.5.78

Closes #792

Self-review: backend-api, middleware-security