### PR TITLE
feat(preferences): ユーザー設定管理 FT145 (#794)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.79] — 2026-05-21
+
+### Added
+- `docs/howto/user-preferences-management.md` — ユーザー設定管理ガイド: PreferenceKey enum・型バリデーション・upsert・デフォルト値フォールバック・IDOR防止。 (#794)
+- `docs/field-trials/2026-05-field-trial-145.md` — FT145 レポート: preflog（ユーザー設定管理、20 tests）。 (#794)
+
+---
+
 ## [1.5.78] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-145.md
+++ b/docs/field-trials/2026-05-field-trial-145.md
@@ -1,0 +1,147 @@
+# Field Trial 145 — ユーザー設定管理（User Preferences）
+
+**Date**: 2026-05-21  
+**App**: `preflog`  
+**Path**: `/home/xi/docker/NENE2-FT/preflog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.79
+
+---
+
+## What was built
+
+ユーザー設定（Preferences）管理システムを実装した。
+事前定義された設定キー（enum）に対して型バリデーション付きで設定値を保存・更新・リセットできる。
+
+| Endpoint | 説明 |
+|---|---|
+| `GET /users/{id}/preferences` | 設定一覧取得（全キー、デフォルト含む） |
+| `PUT /users/{id}/preferences/{key}` | 設定値更新（upsert） |
+| `DELETE /users/{id}/preferences/{key}` | 設定リセット（デフォルトに戻す） |
+
+---
+
+## Architecture decisions
+
+### 設定キーは enum で管理
+
+`PreferenceKey` enum がキーの網羅性・デフォルト値・バリデーション規則を一元管理する。
+未知のキーは 422 で弾き、有効なキー一覧をレスポンスに含める（自己説明 API）。
+
+### 値は TEXT で保存、型はクライアント解釈
+
+DB には全値を TEXT として保存。`items_per_page: "20"` をフロントで `parseInt()` するパターン。
+型安全性をサーバー側のバリデーション（enum の `validate()` メソッド）で担保する。
+
+### GET は全キーを返す（デフォルト含む）
+
+保存済みの設定と未保存のデフォルト値を統合して全キーを返す。
+クライアントは存在チェックなしに全設定値を使用できる。
+
+```php
+foreach (PreferenceKey::cases() as $key) {
+    $storedRow = $stored[$key->value] ?? null;
+    $preferences[] = [
+        'key' => $key->value,
+        'value' => $storedRow !== null ? (string) $storedRow['pref_value'] : $key->defaultValue(),
+        'is_default' => $storedRow === null,
+        'updated_at' => $storedRow !== null ? (string) $storedRow['updated_at'] : null,
+    ];
+}
+```
+
+### DELETE は物理削除（= リセット）
+
+DELETE で DB から行を削除し、次の GET でデフォルト値が返る。
+未設定状態で DELETE しても 200 を返す（冪等）。
+
+### IDOR 防止（所有権チェック）
+
+`X-User-Id` ヘッダーと URL の `{id}` を比較。他ユーザーの設定変更は 403。
+GET は全ユーザー公開（設定は通常 public 情報）。
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `PrefTest.php` (SQLite) | 20 | Pass |
+| **Total** | **20** | **Pass** |
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「ユーザー設定は普段から使っているもの（ダークモード切り替えなど）なので概念が身近だった。
+enum でキーを管理するのが最初は大げさに思えたが、`valid_keys` をエラーレスポンスに含めることで
+API の自己説明性が上がるというメリットがわかった。`is_default: true/false` という設計が、
+フロントで『この設定はユーザーがカスタマイズしたか』を判定するのに便利だとすぐ理解できた。
+`DELETE でリセット（物理削除）` という設計は直感に反した（DELETE したら消えてほしい）が、
+GET でデフォルトが返るという動作を確認して納得した。」
+
+★★★★☆ — 日常的な機能で学習効果が高い
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel の User Settings パッケージ（spatie/laravel-settings 等）と同等の機能を自分で組んだ感じ。
+`user_preferences` テーブルの `UNIQUE(user_id, pref_key)` + upsert パターンは汎用的で
+他のプロジェクトでもすぐ使える。Laravel では Eloquent の `updateOrCreate()` が対応するが、
+NENE2 では明示的に find → update/insert で書くのでロジックが見えやすい。
+`PreferenceKey::tryFrom($keyStr)` で未知のキーを安全に弾くパターンは PHP 8.1+ の enum の
+典型的な使い方で、よく設計されている。」
+
+★★★★★ — パターンが汎用的で即戦力になる
+
+### Persona 3 — セキュリティエンジニア
+
+「IDOR チェック（`$actorId !== $userId` → 403）が PUT・DELETE 両方に適用されている。
+GET は読み取りのみなので全ユーザー公開は問題なし（設定が機密情報でないことが前提）。
+設定値のバリデーションが enum の `validate()` メソッドに集約されているので、
+バリデーション漏れリスクが低い。SQL インジェクションはプリペアドステートメントで防止済み。
+懸念点: timezone の値検証が `strlen <= 64` のみで実際の IANA タイムゾーン名を検証していない。
+本番では `timezone_identifiers_list()` でホワイトリスト検証を推奨。」
+
+★★★★☆ — 基本的なセキュリティは確保、timezone 検証が改善余地あり
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「`GET /preferences` が全キーをデフォルト含めて返すのが最高に使いやすい。
+フロントで『設定が存在するか』チェックをしなくてよい。`is_default` フラグで
+『このユーザーがカスタマイズした設定』を区別してハイライト表示できる。
+`updated_at` がキーごとに取得できるので、最後に変更された設定の日時を表示する UX も実装できる。
+`items_per_page: "20"` が文字列なのは少し違和感あるが、一貫性（全部 TEXT）の方が
+フロント側のハンドリングが楽という判断は理解できる。」
+
+★★★★☆ — レスポンス設計がフロントにとって使いやすい
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「`UNIQUE(user_id, pref_key)` がインデックスを兼ねるため、設定取得クエリが効率的。
+ユーザー数が増えても `WHERE user_id = ?` でインデックス検索できる。
+全設定取得が 1 クエリ（`SELECT ... WHERE user_id = ?`）で済む設計はシンプル。
+将来の拡張として、設定変更の監査ログが必要になった場合は
+別テーブルへの INSERT を追加するだけで対応できる（現在の設計を壊さない）。
+SQLite → MySQL 移行もスキーマが標準的なので問題なし。」
+
+★★★★★ — インフラ的にシンプルで効率的な設計
+
+### Persona 6 — プロダクトマネージャー
+
+「ユーザー設定は UX の基本機能で、この実装で主要なニーズを網羅できている。
+ダークモード（theme）・言語（language）・通知（notifications_enabled）は
+どのアプリでも必要な設定で、FT で作ったパターンを再利用できる。
+`is_default: true` のユーザーは設定を変えたことがない人 = デフォルト設定で満足している人として
+分析に使えると気づいた。削除（リセット）機能があることで
+『元に戻す』ボタンの UX が実装しやすい。今後の拡張として、
+設定のエクスポート/インポート（他デバイスに設定を引き継ぐ）が考えられる。」
+
+★★★★★ — プロダクト機能として完成度が高い
+
+---
+
+## Howto
+
+`docs/howto/user-preferences-management.md`

--- a/docs/howto/user-preferences-management.md
+++ b/docs/howto/user-preferences-management.md
@@ -1,0 +1,154 @@
+# User Preferences Management
+
+ユーザー設定（Preferences）管理の実装ガイド。
+事前定義されたキーセットに対して型バリデーション付きで設定値を保存・更新・リセットできる。
+
+## 概要
+
+- 設定キーは enum で管理（未知のキーは 422）
+- 値はキーごとに型バリデーション
+- 他ユーザーの設定変更は 403（所有権チェック）
+- 未設定キーはデフォルト値を返す（`is_default: true`）
+- DELETE でデフォルト値にリセット
+
+## エンドポイント
+
+| Method | Path | 説明 |
+|---|---|---|
+| `GET` | `/users/{id}/preferences` | 設定一覧取得（全キー、デフォルト含む） |
+| `PUT` | `/users/{id}/preferences/{key}` | 設定値更新（upsert） |
+| `DELETE` | `/users/{id}/preferences/{key}` | 設定リセット（デフォルトに戻す） |
+
+## データベース設計
+
+```sql
+CREATE TABLE user_preferences (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    pref_key TEXT NOT NULL,
+    pref_value TEXT NOT NULL,   -- 常に文字列として保存
+    updated_at TEXT NOT NULL,
+    UNIQUE (user_id, pref_key), -- ユーザーごとにキー一意
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+値は常に `TEXT` として保存する。型の解釈はクライアント側で行う
+（`items_per_page: "20"` → フロントで `parseInt()`）。
+
+## 設定キー enum
+
+```php
+enum PreferenceKey: string
+{
+    case Theme = 'theme';
+    case Language = 'language';
+    case NotificationsEnabled = 'notifications_enabled';
+    case ItemsPerPage = 'items_per_page';
+    case Timezone = 'timezone';
+
+    public function defaultValue(): string
+    {
+        return match ($this) {
+            self::Theme => 'light',
+            self::Language => 'en',
+            self::NotificationsEnabled => 'true',
+            self::ItemsPerPage => '20',
+            self::Timezone => 'UTC',
+        };
+    }
+
+    public function validate(string $value): bool
+    {
+        return match ($this) {
+            self::Theme => in_array($value, ['light', 'dark', 'system'], true),
+            self::Language => preg_match('/^[a-z]{2}(-[A-Z]{2})?$/', $value) === 1,
+            self::NotificationsEnabled => in_array($value, ['true', 'false'], true),
+            self::ItemsPerPage => ctype_digit($value) && (int) $value >= 5 && (int) $value <= 100,
+            self::Timezone => strlen($value) <= 64 && strlen($value) > 0,
+        };
+    }
+}
+```
+
+## GET /users/{id}/preferences レスポンス
+
+```json
+{
+  "preferences": [
+    {"key": "theme", "value": "dark", "is_default": false, "updated_at": "2026-05-21T10:00:00+00:00"},
+    {"key": "language", "value": "en", "is_default": true, "updated_at": null},
+    {"key": "notifications_enabled", "value": "true", "is_default": true, "updated_at": null},
+    {"key": "items_per_page", "value": "20", "is_default": true, "updated_at": null},
+    {"key": "timezone", "value": "UTC", "is_default": true, "updated_at": null}
+  ]
+}
+```
+
+全キーを返す（保存済みのものはその値、未保存のものはデフォルト値）。
+
+## Upsert パターン
+
+```php
+public function upsertPreference(int $userId, string $key, string $value, string $now): void
+{
+    $existing = $this->findPreference($userId, $key);
+    if ($existing !== null) {
+        $this->executor->execute(
+            'UPDATE user_preferences SET pref_value = ?, updated_at = ? WHERE user_id = ? AND pref_key = ?',
+            [$value, $now, $userId, $key]
+        );
+    } else {
+        $this->executor->execute(
+            'INSERT INTO user_preferences (user_id, pref_key, pref_value, updated_at) VALUES (?, ?, ?, ?)',
+            [$userId, $key, $value, $now]
+        );
+    }
+}
+```
+
+UNIQUE(user_id, pref_key) 制約と組み合わせて、1 ユーザー 1 キーにつき 1 行を保証する。
+
+## 所有権チェック（IDOR 防止）
+
+```php
+$actorId = (int) $request->getHeaderLine('X-User-Id');
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'cannot modify another user\'s preferences'], 403);
+}
+```
+
+他ユーザーの設定を変更・削除できない。読み取りは誰でも可能（設定は通常 public）。
+
+## DELETE = リセット（物理削除）
+
+DELETE は設定行を DB から削除し、GET では再びデフォルト値が返る:
+
+```php
+$this->repository->deletePreference($userId, $prefKey->value);
+return $this->responseFactory->create([
+    'key' => $prefKey->value,
+    'value' => $prefKey->defaultValue(),
+    'is_default' => true,
+], 200);
+```
+
+未設定時（初めて DELETE した場合）も 200 を返す（冪等性）。
+
+## 不明なキーへのレスポンス
+
+```json
+{
+  "error": "unknown preference key",
+  "valid_keys": ["theme", "language", "notifications_enabled", "items_per_page", "timezone"]
+}
+```
+
+有効なキー一覧を返すことで API の自己説明性を高める。
+
+## 拡張パターン
+
+- **カテゴリ分け**: `PreferenceCategory` enum を追加して UI・通知・表示などでグループ化
+- **ユーザー種別ごとのデフォルト**: `defaultValue(UserType $type)` で条件分岐
+- **監査ログ**: `updated_at` + 変更履歴テーブルで設定変更を追跡
+- **一括更新**: `PATCH /users/{id}/preferences` で複数設定を一度に更新

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.78
+  version: 1.5.79
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.78`（2026-05-21 リリース済み）
+- Latest release: `v1.5.79`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -60,10 +60,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT142 | コンテンツ下書き | draftlog | 20/20 | v1.5.76 | content-draft-lifecycle.md（ArticleStatus enum遷移ガード・404隠蔽・同秒ソート id DESC tiebreaker） |
 | FT143 | 絵文字リアクション | emojilog | 23/23 | v1.5.77 | emoji-reaction-system.md（UNIQUE(post_id,user_id,emoji)・GROUP BY集計・optional actor tracking・mb_strlen）**MySQL統合テスト: 5テスト** |
 | FT144 | パスワードレス認証（Magic Link）| magiclog | 43/43 | v1.5.78 | passwordless-auth-magic-link.md（SHA-256ハッシュ保存・常に202・expiry before used_at・セッション無効化）**脆弱性診断: 12件全Pass** / **クラッカー攻撃試験: 12件全Pass** |
+| FT145 | ユーザー設定管理 | preflog | 20/20 | v1.5.79 | user-preferences-management.md（PreferenceKey enum・型バリデーション・upsert・デフォルト値フォールバック・IDOR防止） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT145 以降・次の MySQL テストは FT148・次の脆弱性診断: FT147・次のクラッカー攻撃試験: FT148）
+- FT ループ継続中（FT146 以降・次の MySQL テストは FT148・次の脆弱性診断: FT147・次のクラッカー攻撃試験: FT148）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.78';
+    public const string VERSION = '1.5.79';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- ユーザー設定管理システムを実装（FT145 preflog）
- PreferenceKey enum で型バリデーション・デフォルト値・有効キー一覧を一元管理
- upsert パターン・デフォルト値フォールバック・IDOR防止（X-User-Id チェック）

## Test plan

- [x] PrefTest.php (SQLite): 20/20 Pass
- [x] PHPStan level 8 clean
- [x] PHP-CS-Fixer clean
- [x] VERSION 1.5.78 → 1.5.79

Closes #794

Self-review: backend-api, database