### PR TITLE
feat(pinning): コンテンツピン留め FT146 (#796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.80] — 2026-05-21
+
+### Added
+- `docs/howto/content-pinning.md` — コンテンツピン留めガイド: position連続管理・冪等追加（201/200）・unpin後の位置詰め・完全一致reorder。 (#796)
+- `docs/field-trials/2026-05-field-trial-146.md` — FT146 レポート: pinlog（コンテンツピン留め、19 tests）。 (#796)
+
+---
+
 ## [1.5.79] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-146.md
+++ b/docs/field-trials/2026-05-field-trial-146.md
@@ -1,0 +1,138 @@
+# Field Trial 146 — コンテンツピン留め（Content Pinning）
+
+**Date**: 2026-05-21  
+**App**: `pinlog`  
+**Path**: `/home/xi/docker/NENE2-FT/pinlog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.80
+
+---
+
+## What was built
+
+コンテンツ（記事）のピン留めシステムを実装した。
+ユーザーが記事を順序付きでピン留めし、ダッシュボード等に固定表示できる。
+
+| Endpoint | 説明 |
+|---|---|
+| `POST /pins` | 記事をピン留め（冪等: 既存 200 / 新規 201） |
+| `DELETE /pins/{articleId}` | ピン解除（位置を自動整合） |
+| `GET /pins` | ピン留め一覧（position 昇順） |
+| `PUT /pins/order` | ピン留め順序変更 |
+
+---
+
+## Architecture decisions
+
+### position カラムで順序管理
+
+`position INTEGER` で 1 から始まる連続整数を保持する。
+追加時は `MAX(position) + 1`、削除時は削除位置より後の行を -1 シフトして整合を維持。
+
+### 冪等追加（201 / 200）
+
+同じ記事を既にピン留めしている場合は INSERT しない（200 を返す）。
+初回ピンは 201 Created を返す。ステータスで追加 / 既存を区別できる。
+
+### 上限チェック（10 件）
+
+カウントが上限以上かつ未登録の記事 → 422 with `max` フィールド。
+冪等呼び出し（同じ記事のピン）は上限チェックをスキップ。
+
+### 順序変更の完全一致チェック
+
+`PUT /pins/order` は `article_ids` が現在のピン集合と完全一致（ソート比較）する場合のみ成功。
+一致しない場合は 422 — 追加・削除なしで純粋な順序変更のみを受け付ける設計。
+
+### Unpin 後の位置詰め
+
+`DELETE FROM pins WHERE ... AND article_id = ?` の後に
+`UPDATE pins SET position = position - 1 WHERE user_id = ? AND position > ?` で整合。
+SQLite のアトミック更新で安全。
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `PinTest.php` (SQLite) | 19 | Pass |
+| **Total** | **19** | **Pass** |
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「ピン留めは Twitter の固定ツイートや Slack の固定メッセージで知っている機能。
+冪等設計（同じ記事を2回ピンしても壊れない）という考え方が実践的で学べた。
+`position` の自動整合（unpin 後に詰める）が `UPDATE pins SET position = position - 1 WHERE ...`
+という1行の SQL で実現できるのが驚きだった。順序変更（reorder）が完全一致チェックを
+している理由（追加・削除と混同しないため）は設計の意図として理解できた。
+ピン上限（10件）はハードコードより設定値にした方がいいのでは？と思ったが、
+YAGNI（必要になってから変える）という判断として理解できた。」
+
+★★★★☆ — 身近な UI 機能で概念が入りやすい
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel では `user->pins()->attach($articleId)` + `pivot` テーブルで似たことができるが、
+`position` の自動整合を Eloquent だけで実現しようとするとかなりトリッキーになる。
+NENE2 では Repository に明示的なロジックとして書かれているので可読性が高い。
+冪等追加の戻り値（bool: true = 201, false = 200）パターンは
+`firstOrCreate` の return value パターンと似ていて理解しやすい。
+`reorder` の `sort() + 比較` による完全一致チェックは Laravel では書いたことがなかったが
+堅牢な設計だと感じた。」
+
+★★★★☆ — 明示的なロジックで理解しやすい
+
+### Persona 3 — セキュリティエンジニア
+
+「`X-User-Id` ヘッダーが全エンドポイントで必須チェックされている。
+`GET /pins` も X-User-Id で絞り込むため他ユーザーのピン一覧を見ることはできない。
+`DELETE /pins/{articleId}` は `WHERE user_id = ? AND article_id = ?` で所有権を検証している。
+位置詰め操作（`UPDATE ... WHERE user_id = ?`）もユーザーフィルターが正確に適用されている。
+気になる点: `PUT /pins/order` の `article_ids` に同じ ID が重複して含まれた場合の動作が
+テストされていない（同じ記事を2度 UPDATE することになる）。本番では `array_unique` チェックを推奨。」
+
+★★★★☆ — 基本的なアクセス制御は適切
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「ピン留め UI の実装に必要なものが揃っている。
+`POST /pins` が 201（新規）/ 200（既存）で区別できるのでトースト表示の制御ができる。
+`GET /pins` が `position` 順で返るので追加処理なしにリスト表示できる。
+ドラッグ&ドロップで順序変更したあと `PUT /pins/order` を呼ぶだけでよい。
+`count` フィールドがあるので『あと何件ピンできるか』（10 - count）を表示できる。
+`DELETE /pins/{articleId}` が 204 No Content なので削除後のレスポンス解析が不要。」
+
+★★★★★ — フロント実装がストレートにできる
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「`position` カラムにはインデックスがないが、1 ユーザーが最大 10 件のため
+テーブルスキャンのコストは実質ゼロ。スケール時（ユーザー数増）に問題になるのは
+`WHERE user_id = ?` のフィルタリングで、`(user_id, position)` 複合インデックスを
+追加することで対応できる。`UPDATE SET position = position - 1` は SQLite で
+アトミック実行されるので並行アクセスでも安全（SQLite はファイルロック）。
+MySQL 移行時は `InnoDB` トランザクションで両 UPDATE をまとめて実行すべき。」
+
+★★★★☆ — 小規模には十分、大規模インデックスは要検討
+
+### Persona 6 — プロダクトマネージャー
+
+「ピン留めはユーザーが使い続けるための重要な機能。お気に入り / ブックマークとの違いは
+『少数の重要なものを画面上部に固定表示する』という UX の意図。
+上限 10 件は適切（多すぎると意味がなくなる）。順序変更（drag & drop）は
+コンテンツのパーソナライゼーション体験として重要。
+今後の拡張として: ピン留めカテゴリ（仕事・趣味など）、ピン留め統計（何が多く固定されるか）、
+チームピン（グループ全員に共有するピン）などが考えられる。」
+
+★★★★☆ — プロダクト機能として整っている
+
+---
+
+## Howto
+
+`docs/howto/content-pinning.md`

--- a/docs/howto/content-pinning.md
+++ b/docs/howto/content-pinning.md
@@ -1,0 +1,135 @@
+# Content Pinning
+
+コンテンツ（記事）のピン留め機能の実装ガイド。
+順序付きピン留め・上限管理・冪等追加・位置の自動整合を解説する。
+
+## 概要
+
+- ユーザーが記事をピン留め（最大 10 件）
+- `position` カラムで順序管理（1 始まり）
+- 冪等追加（既存なら 200、新規なら 201）
+- unpin 後に position が自動的に詰まる
+- 順序は `PUT /pins/order` で任意に変更可能
+
+## エンドポイント
+
+| Method | Path | 説明 |
+|---|---|---|
+| `POST` | `/pins` | 記事をピン留め（冪等） |
+| `DELETE` | `/pins/{articleId}` | ピン解除 |
+| `GET` | `/pins` | ピン留め一覧（順序付き） |
+| `PUT` | `/pins/order` | ピン留め順序変更 |
+
+## データベース設計
+
+```sql
+CREATE TABLE pins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    article_id INTEGER NOT NULL,
+    position INTEGER NOT NULL,    -- 1 始まり、連続整数
+    pinned_at TEXT NOT NULL,
+    UNIQUE (user_id, article_id), -- ユーザーごとに記事を一度だけピン
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (article_id) REFERENCES articles(id)
+);
+```
+
+## 冪等ピン追加
+
+```php
+public function pin(int $userId, int $articleId, string $now): bool
+{
+    $existing = $this->findPin($userId, $articleId);
+    if ($existing !== null) {
+        return false;  // 既存: false = 200
+    }
+    $nextPosition = $this->maxPosition($userId) + 1;
+    $this->executor->execute('INSERT INTO pins ...', [$userId, $articleId, $nextPosition, $now]);
+    return true;  // 新規: true = 201
+}
+```
+
+戻り値 `true` → 201 Created、`false` → 200 OK（呼び出し元がステータスを決定）。
+
+## Unpin 後の位置詰め
+
+```php
+public function unpin(int $userId, int $articleId): bool
+{
+    $removedPosition = (int) $existing['position'];
+    $this->executor->execute('DELETE FROM pins WHERE user_id = ? AND article_id = ?', [...]);
+    // 削除した位置より後ろを1つ前にシフト
+    $this->executor->execute(
+        'UPDATE pins SET position = position - 1 WHERE user_id = ? AND position > ?',
+        [$userId, $removedPosition]
+    );
+    return true;
+}
+```
+
+位置にギャップが生まれないよう自動整合する。
+
+## 上限チェック
+
+```php
+if ($this->repository->countPins($actorId) >= $this->repository->maxPins()) {
+    $existing = $this->repository->findPin($actorId, $articleId);
+    if ($existing === null) {
+        return $this->responseFactory->create([
+            'error' => 'pin limit reached',
+            'max' => $this->repository->maxPins()
+        ], 422);
+    }
+}
+```
+
+既存の記事を再ピン（冪等）する場合は上限チェックをスキップする。
+
+## 順序変更（reorder）
+
+```php
+public function reorder(int $userId, array $orderedArticleIds): bool
+{
+    $currentPins = $this->listPins($userId);
+    $currentIds = array_map(fn (array $p) => (int) $p['article_id'], $currentPins);
+    sort($currentIds);
+    $sortedInput = $orderedArticleIds;
+    sort($sortedInput);
+    if ($currentIds !== $sortedInput) {
+        return false;  // 現在のピン一覧と一致しない
+    }
+    foreach ($orderedArticleIds as $position => $articleId) {
+        $this->executor->execute(
+            'UPDATE pins SET position = ? WHERE user_id = ? AND article_id = ?',
+            [$position + 1, $userId, $articleId]
+        );
+    }
+    return true;
+}
+```
+
+`article_ids` が現在のピン一覧（順不同）と完全一致しないと 422。
+追加・削除なしで順序変更のみを受け付ける。
+
+## GET /pins レスポンス
+
+```json
+{
+  "pins": [
+    {"article_id": 3, "title": "Article 3", "position": 1, "pinned_at": "2026-05-21T10:00:00+00:00"},
+    {"article_id": 1, "title": "Article 1", "position": 2, "pinned_at": "2026-05-21T09:00:00+00:00"}
+  ],
+  "count": 2
+}
+```
+
+`position` 昇順でソート。`ORDER BY p.position ASC` で JOIN して取得。
+
+## 上限解放（unpin して新規ピン可能に）
+
+```
+10件ピン → DELETE /pins/{id} → 9件 → POST /pins で追加可能
+```
+
+上限は現在のカウントで動的に判定するため、unpin 直後に新規ピンできる。

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.79
+  version: 1.5.80
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.79`（2026-05-21 リリース済み）
+- Latest release: `v1.5.80`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -61,10 +61,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT143 | 絵文字リアクション | emojilog | 23/23 | v1.5.77 | emoji-reaction-system.md（UNIQUE(post_id,user_id,emoji)・GROUP BY集計・optional actor tracking・mb_strlen）**MySQL統合テスト: 5テスト** |
 | FT144 | パスワードレス認証（Magic Link）| magiclog | 43/43 | v1.5.78 | passwordless-auth-magic-link.md（SHA-256ハッシュ保存・常に202・expiry before used_at・セッション無効化）**脆弱性診断: 12件全Pass** / **クラッカー攻撃試験: 12件全Pass** |
 | FT145 | ユーザー設定管理 | preflog | 20/20 | v1.5.79 | user-preferences-management.md（PreferenceKey enum・型バリデーション・upsert・デフォルト値フォールバック・IDOR防止） |
+| FT146 | コンテンツピン留め | pinlog | 19/19 | v1.5.80 | content-pinning.md（position連続管理・冪等追加201/200・unpin後位置詰め・完全一致reorder） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT146 以降・次の MySQL テストは FT148・次の脆弱性診断: FT147・次のクラッカー攻撃試験: FT148）
+- FT ループ継続中（FT147 以降・次の MySQL テストは FT148・次の脆弱性診断: FT147・次のクラッカー攻撃試験: FT148）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.79';
+    public const string VERSION = '1.5.80';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- コンテンツピン留めシステムを実装（FT146 pinlog）
- position連続管理・冪等追加（201/200）・unpin後の位置詰め・完全一致reorder

## Test plan

- [x] PinTest.php (SQLite): 19/19 Pass
- [x] PHPStan level 8 clean
- [x] PHP-CS-Fixer clean
- [x] VERSION 1.5.79 → 1.5.80

Closes #796

Self-review: backend-api, database