### PR TITLE
docs(howto): コンテンツ通報・モデレーションガイドを追加 (#798)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.81] — 2026-05-21
+
+### Added
+- `docs/howto/content-report-moderation.md` — コンテンツ通報・モデレーションガイド: RBAC・IDOR防止・冪等通報（201/200）・一方向ステータス遷移・Router::param()パターン。 (#799)
+- `docs/field-trials/2026-05-field-trial-147.md` — FT147 レポート: reportlog（コンテンツ通報・モデレーション、32 tests、脆弱性診断 VULN-A〜L）。 (#799)
+
+---
+
 ## [1.5.80] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-147.md
+++ b/docs/field-trials/2026-05-field-trial-147.md
@@ -1,0 +1,177 @@
+# Field Trial 147 — コンテンツ通報・モデレーション（Content Report & Moderation）
+
+**Date**: 2026-05-21  
+**App**: `reportlog`  
+**Path**: `/home/xi/docker/NENE2-FT/reportlog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.81  
+**Special**: 脆弱性診断（VulnTest.php）— 3FT サイクル
+
+---
+
+## What was built
+
+コンテンツ（記事）の通報・モデレーションシステムを実装した。
+ユーザーが記事を通報し、モデレーターが通報を確認・解決・却下できる。
+
+| Endpoint | 説明 |
+|---|---|
+| `POST /reports` | 記事を通報（冪等: 同記事再通報 = 200 / 新規 = 201） |
+| `GET /reports` | 通報一覧（モデレーター専用） |
+| `GET /reports/{id}` | 通報詳細（自分の通報 or モデレーター） |
+| `PUT /reports/{id}/resolve` | 通報を解決（モデレーター専用） |
+| `PUT /reports/{id}/dismiss` | 通報を却下（モデレーター専用） |
+
+---
+
+## Architecture decisions
+
+### RBAC — ロールベースアクセス制御
+
+`users.role` カラムに `CHECK (role IN ('user', 'moderator'))` で DB 制約を持たせる。
+アプリ層では各ハンドラー先頭で `role === 'moderator'` をチェックし、非モデレーターに 403 を返す。
+フレームワークの認証ミドルウェアとは独立したシンプルなロールチェックで十分なスコープを達成できた。
+
+### IDOR 防止
+
+`GET /reports/{id}` は「自分の通報」か「モデレーター」のみ参照可能。
+reporter_id は常に `X-User-Id` ヘッダーから設定し、リクエストボディの `reporter_id` フィールドは無視する。
+これによりなりすまし（他ユーザーの ID を body に詰めてレポートを偽造）を防ぐ。
+
+### 冪等通報（201 / 200）
+
+`UNIQUE (reporter_id, article_id)` 制約を基盤として、
+アプリ層では INSERT 前に既存チェックをして 200 / 201 を切り替える。
+UNIQUE 違反を `DatabaseConstraintException` でキャッチするより、事前チェックの方が冪等セマンティクスが明確。
+
+### ステータス遷移の一方向性
+
+`pending → resolved / dismissed` のみを許可し、逆方向遷移は 422 で拒否する。
+DB に `CHECK (status IN (...))` を持たせることで、アプリ層のバリデーション漏れを DB が二重保護する。
+
+### NENE2 Router パスパラメータ
+
+パスパラメータは `nene2.route.parameters` 属性（`Router::PARAMETERS_ATTRIBUTE`）に格納される。
+`$request->getAttribute('id')` では取得できず、`Router::param($request, 'id')` が正しい。
+（FT147 でこのハマりを発見・修正した重要なパターン。）
+
+---
+
+## Vulnerability assessment (VulnTest.php)
+
+12 件の脆弱性シナリオを検証した。
+
+| ID | テスト内容 | 結果 |
+|---|---|---|
+| VULN-A | IDOR: 他ユーザーの通報を参照できない | Pass |
+| VULN-B | 通常ユーザーは通報一覧を取得できない | Pass |
+| VULN-C | 通常ユーザーは通報を解決できない | Pass |
+| VULN-D | 通常ユーザーは通報を却下できない | Pass |
+| VULN-E | 重複通報は冪等（UNIQUE 違反で 500 にならない） | Pass |
+| VULN-F | 解決済み通報の再解決を拒否（422） | Pass |
+| VULN-G | 却下済み通報の再却下を拒否（422） | Pass |
+| VULN-H | reporter_id はボディから偽造できない | Pass |
+| VULN-I | X-User-Id=0 は認証失敗（401） | Pass |
+| VULN-J | X-User-Id ヘッダーなしは認証失敗（401） | Pass |
+| VULN-K | モデレーターは任意の通報を参照できる | Pass |
+| VULN-L | 存在しない通報は 404（DB エラー非公開） | Pass |
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `ReportTest.php` (SQLite) | 20 | Pass |
+| `VulnTest.php` (SQLite) | 12 | Pass |
+| **Total** | **32** | **Pass** |
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「通報システムは YouTube や Twitter でよく見る機能なのでイメージしやすかった。
+モデレーター専用の API があること自体は理解できたが、IDOR という言葉は初めて聞いた。
+『自分の通報を他のユーザーが見られる』という脆弱性の説明を受けて、初めてアクセス制御の
+重要性が感じられた。ステータス遷移が一方向しか許可されない設計は『一度解決したら
+やり直せない』という業務ルールをコードで表現しているんだとわかった。
+reporter_id をヘッダーから取って body からは無視する仕組みは、最初はなぜかわからなかったが
+VulnTest で『body に reporter_id=999 を入れて別人として投稿する』攻撃シナリオを見て納得した。」
+
+★★★★☆ — 脆弱性テストが概念理解を助ける良い学習素材
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel では `Policy` クラスで `before()` メソッドにモデレーター判定を入れるパターンが
+一般的だが、NENE2 ではハンドラーごとに明示的なロールチェックを書いている。
+冗長に見えるが可読性は高い。
+`firstOrCreate` パターンと同じ冪等追加ロジックが PHP 8.4 の enum + match で
+すっきり書けているのは好印象。IDOR 防止で `reporter_id` をボディから取らない設計は
+Laravel の `$request->user()->id` に相当する発想で、フレームワークが違っても
+同じ原則が適用されていると感じた。VulnTest が Policy テストに対応するものとして
+参照できるのは NENE2 固有の良さだと思う。」
+
+★★★★☆ — 明示的ロールチェックで可読性高い
+
+### Persona 3 — セキュリティエンジニア
+
+「RBAC の実装は適切。モデレーター専用エンドポイント（GET /reports, PUT /reports/{id}/resolve, dismiss）は
+先頭でロールチェックを行い、早期リターンしている。
+IDOR 防止: GET /reports/{id} は reporter_id と X-User-Id を照合してアクセス制御している。
+reporter_id の body 注入攻撃: VULN-H で検証済み、createReport に reporter_id 引数が存在し
+handler が actorId のみを渡す設計なので問題なし。
+ステータス遷移: VULN-F/G で一方向性を確認。DB CHECK 制約がアプリ層のバリデーション漏れを補完している。
+気になる点: X-User-Id の存在は確認しているが、実際のユーザー存在を GET /reports/{id} でも
+確認している（findUserById）のは良い。ただし rate limiting がないため大量通報は可能。
+本番では 1 ユーザーあたりの通報上限（例: 1 記事につき 1 通報の UNIQUE 制約は実装済み）や
+報告レート制限が必要。」
+
+★★★★☆ — 基本的なアクセス制御・IDOR 防止は適切
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「通報フォームの実装に必要な情報が揃っている。
+POST /reports が 201（新規）/ 200（既存）で区別できるので
+『通報済みです』メッセージとの切り替えが容易。
+reason フィールドは enum 値（spam/harassment/misinformation/other）が
+エラーレスポンスの valid_reasons 配列で返るので、フォームの選択肢を動的に構築できる。
+GET /reports/{id} がステータス・解決者・解決メモを返すので、通報者側のステータス確認 UI も作れる。
+モデレーター画面では GET /reports の count フィールドで件数バッジを表示できる。
+404 と 403 の区別（通報が見えない vs 見る権限がない）の使い分けを UI 側がどう処理するかは
+設計の余地がある（通報の存在自体を隠したければ 404 統一も選択肢）。」
+
+★★★★☆ — 通報フォームとモデレーション UI の両方が実装できる
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「`UNIQUE (reporter_id, article_id)` は通報が増えても低コストなインデックスになる。
+`CHECK` 制約は SQLite・MySQL・PostgreSQL すべてで有効。
+`status` カラムには現状インデックスがないが、モデレーター画面で
+`WHERE status = 'pending'` のクエリが頻出する場合は `(status, created_at)` 複合インデックスを追加すべき。
+`resolved_by` の FOREIGN KEY はソフトデリート実装時に注意が必要（モデレーターアカウントを削除できなくなる）。
+MySQL 移行時: `CHECK` 制約は MySQL 8.0.16+ で有効。それ以前では無効なので注意。
+SQLite テストが全 32 件 pass していることで回帰リスクは低い。」
+
+★★★★☆ — 小規模に十分、中規模以上はインデックス追加を検討
+
+### Persona 6 — プロダクトマネージャー
+
+「コミュニティの健全性維持に通報・モデレーション機能は必須。
+設計の良い点: モデレーター権限を DB で管理しているので、ユーザーへのロール付与が
+SQL 1 行で可能（`UPDATE users SET role = 'moderator' WHERE id = ?`）。
+resolution_note が通報者に返るので、なぜ解決・却下されたかのフィードバックが
+ユーザーに提供できる（将来の UX 改善に使える）。
+冪等通報（201/200）は重複クリックに強いため、モバイルアプリとの相性が良い。
+今後の拡張: 通報カテゴリの追加（著作権侵害、成人向けコンテンツ等）、
+通報統計ダッシュボード（何が最も通報されているか）、自動モデレーション連携（AI フィルター）、
+モデレーターへの新規通報メール通知。」
+
+★★★★★ — プロダクト機能として即座に使えるレベル
+
+---
+
+## Howto
+
+`docs/howto/content-report-moderation.md`

--- a/docs/howto/content-report-moderation.md
+++ b/docs/howto/content-report-moderation.md
@@ -1,0 +1,184 @@
+# Content Report & Moderation
+
+コンテンツ（記事）の通報・モデレーションシステムの実装ガイド。
+RBAC（ロールベースアクセス制御）・IDOR 防止・冪等通報・一方向ステータス遷移を解説する。
+
+## 概要
+
+- ユーザーが記事を通報（冪等: 同じ記事を再通報しても 200）
+- モデレーターのみが通報一覧を参照・解決・却下できる
+- 通報者は自分の通報のみ参照可能（IDOR 防止）
+- ステータスは `pending → resolved / dismissed` の一方向のみ
+
+## エンドポイント
+
+| Method | Path | 説明 |
+|---|---|---|
+| `POST` | `/reports` | 記事を通報（冪等） |
+| `GET` | `/reports` | 通報一覧（モデレーター専用） |
+| `GET` | `/reports/{id}` | 通報詳細（自分の通報 or モデレーター） |
+| `PUT` | `/reports/{id}/resolve` | 通報を解決（モデレーター専用） |
+| `PUT` | `/reports/{id}/dismiss` | 通報を却下（モデレーター専用） |
+
+## データベース設計
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'user',
+    created_at TEXT NOT NULL,
+    CHECK (role IN ('user', 'moderator'))
+);
+
+CREATE TABLE reports (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    reporter_id INTEGER NOT NULL,
+    article_id INTEGER NOT NULL,
+    reason TEXT NOT NULL,
+    details TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    resolved_by INTEGER,
+    resolved_at TEXT,
+    resolution_note TEXT,
+    created_at TEXT NOT NULL,
+    UNIQUE (reporter_id, article_id),
+    CHECK (status IN ('pending', 'resolved', 'dismissed')),
+    CHECK (reason IN ('spam', 'harassment', 'misinformation', 'other')),
+    FOREIGN KEY (reporter_id) REFERENCES users(id),
+    FOREIGN KEY (article_id) REFERENCES articles(id),
+    FOREIGN KEY (resolved_by) REFERENCES users(id)
+);
+```
+
+`UNIQUE (reporter_id, article_id)` が冪等追加の基盤。
+`CHECK` 制約で有効なステータス・通報理由をDB層で保証。
+
+## 冪等通報
+
+```php
+$existing = $this->repository->findReportByReporterAndArticle($actorId, $articleId);
+if ($existing !== null) {
+    return $this->responseFactory->create($this->formatReport($existing), 200);
+}
+
+$id = $this->repository->createReport($actorId, $articleId, $reason, $details, date('c'));
+$report = $this->repository->findReportById($id);
+
+return $this->responseFactory->create($this->formatReport($report ?? []), 201);
+```
+
+戻り値 `201` = 新規通報、`200` = 既存通報（呼び出し元がステータスで判別）。
+
+## RBAC — ロールチェック
+
+```php
+$actor = $this->repository->findUserById($actorId);
+if ($actor === null || $actor['role'] !== 'moderator') {
+    return $this->responseFactory->create(['error' => 'moderator role required'], 403);
+}
+```
+
+モデレーター専用エンドポイントはハンドラー先頭でロールを検証する。
+
+## IDOR 防止
+
+```php
+$isModerator = $actor !== null && $actor['role'] === 'moderator';
+$isReporter  = (int) $report['reporter_id'] === $actorId;
+
+if (!$isModerator && !$isReporter) {
+    return $this->responseFactory->create(['error' => 'access denied'], 403);
+}
+```
+
+`GET /reports/{id}` は「自分の通報」か「モデレーター」だけが参照可能。
+`reporter_id` はリクエストボディから取得せず、常に `X-User-Id` ヘッダーから設定する。
+
+## ステータス遷移（一方向）
+
+```php
+if ($report['status'] !== 'pending') {
+    return $this->responseFactory->create([
+        'error' => 'report is not pending',
+        'current_status' => $report['status'],
+    ], 422);
+}
+```
+
+`resolved` や `dismissed` に一度遷移した通報は再操作できない。
+DB の `CHECK` 制約がアプリ層のバリデーション漏れをバックアップする。
+
+## パスパラメータ取得
+
+NENE2 Router は path params を `nene2.route.parameters` 属性に格納する。
+
+```php
+// 正しい取得方法
+$id = (int) Router::param($request, 'id');
+
+// NG（直接 getAttribute('id') では取得できない）
+$id = (int) $request->getAttribute('id');
+```
+
+## reporter_id のセキュリティ
+
+```php
+// createReport: actorId は X-User-Id ヘッダーから確定済み
+$id = $this->repository->createReport($actorId, $articleId, $reason, $details, date('c'));
+```
+
+`reporter_id` はリクエストボディの `reporter_id` フィールドを無視し、
+認証された `X-User-Id` を使用する。これにより他ユーザーへのなりすましを防ぐ。
+
+## POST /reports レスポンス例
+
+```json
+{
+  "id": 1,
+  "reporter_id": 1,
+  "article_id": 3,
+  "reason": "spam",
+  "details": "This article contains repeated spam links",
+  "status": "pending",
+  "resolved_by": null,
+  "resolved_at": null,
+  "resolution_note": null,
+  "created_at": "2026-05-21T12:00:00+00:00"
+}
+```
+
+## PUT /reports/{id}/resolve レスポンス例
+
+```json
+{
+  "id": 1,
+  "reporter_id": 1,
+  "article_id": 3,
+  "reason": "spam",
+  "details": "...",
+  "status": "resolved",
+  "resolved_by": 3,
+  "resolved_at": "2026-05-21T13:00:00+00:00",
+  "resolution_note": "Article removed for TOS violation",
+  "created_at": "2026-05-21T12:00:00+00:00"
+}
+```
+
+## GET /reports レスポンス例（モデレーター）
+
+```json
+{
+  "reports": [
+    {
+      "id": 2,
+      "reporter_id": 2,
+      "article_id": 5,
+      "reason": "harassment",
+      "status": "pending",
+      ...
+    }
+  ],
+  "count": 1
+}
+```

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.80
+  version: 1.5.81
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.80`（2026-05-21 リリース済み）
+- Latest release: `v1.5.81`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -62,10 +62,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT144 | パスワードレス認証（Magic Link）| magiclog | 43/43 | v1.5.78 | passwordless-auth-magic-link.md（SHA-256ハッシュ保存・常に202・expiry before used_at・セッション無効化）**脆弱性診断: 12件全Pass** / **クラッカー攻撃試験: 12件全Pass** |
 | FT145 | ユーザー設定管理 | preflog | 20/20 | v1.5.79 | user-preferences-management.md（PreferenceKey enum・型バリデーション・upsert・デフォルト値フォールバック・IDOR防止） |
 | FT146 | コンテンツピン留め | pinlog | 19/19 | v1.5.80 | content-pinning.md（position連続管理・冪等追加201/200・unpin後位置詰め・完全一致reorder） |
+| FT147 | コンテンツ通報・モデレーション | reportlog | 32/32 | v1.5.81 | content-report-moderation.md（RBAC・IDOR防止・冪等通報201/200・一方向ステータス遷移）**脆弱性診断: VULN-A〜L 12件全Pass** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT147 以降・次の MySQL テストは FT148・次の脆弱性診断: FT147・次のクラッカー攻撃試験: FT148）
+- FT ループ継続中（FT148 以降・次の MySQL テストは FT148・次の脆弱性診断: FT150・次のクラッカー攻撃試験: FT148）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.80';
+    public const string VERSION = '1.5.81';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- FT147: `reportlog` — コンテンツ通報・モデレーションシステムを実装
- RBAC（ロールベース）・IDOR 防止・冪等通報（201/200）・一方向ステータス遷移を実装
- 脆弱性診断 VulnTest.php（VULN-A〜L 12件）付き — FT147 は 3FT 脆弱性診断サイクル
- テスト合計 32/32 Pass（ReportTest 20 + VulnTest 12）

## Changes

- `docs/howto/content-report-moderation.md` — 実装ガイド（Router::param() パターン含む）
- `docs/field-trials/2026-05-field-trial-147.md` — FT レポート（6ペルソナ DX レビュー）
- `src/FrameworkInfo.php` — VERSION → 1.5.81
- `docs/openapi/openapi.yaml` — version 1.5.81
- `CHANGELOG.md` — v1.5.81 エントリ追加
- `docs/todo/current.md` — FT147 完了・次サイクル更新

## Test plan

- [x] reportlog: `composer check` 全 Pass（CS / PHPStan level 8 / 32 tests）
- [x] 脆弱性診断 VULN-A〜L: RBAC・IDOR・冪等・ステータス遷移・認証バイパス
- [x] Router::param() パスパラメータ取得パターンを howto に明文化

Closes #798

Self-review: docs-policy, backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)