### PR TITLE
docs(howto): OTP認証システムガイドを追加 (#800)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.82] — 2026-05-21
+
+### Added
+- `docs/howto/otp-authentication.md` — OTP認証ガイド: 6桁コード生成・SHA-256ハッシュ保存・ブルートフォース対策・ロックアウト・セッション管理・MySQL対応・setRiskyAllowed(true)。 (#801)
+- `docs/field-trials/2026-05-field-trial-148.md` — FT148 レポート: otplog（OTP認証、35 tests = 18 正常 + 12 攻撃試験 + 5 MySQL）**クラッカー攻撃試験: 12件全Pass** / **MySQL統合テスト: 5件全Pass**。 (#801)
+
+---
+
 ## [1.5.81] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-148.md
+++ b/docs/field-trials/2026-05-field-trial-148.md
@@ -1,0 +1,192 @@
+# Field Trial 148 — OTP 認証システム（OTP Authentication）
+
+**Date**: 2026-05-21  
+**App**: `otplog`  
+**Path**: `/home/xi/docker/NENE2-FT/otplog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.82  
+**Special**: MySQL 統合テスト（5テスト）+ クラッカー攻撃試験（AttackTest.php, 12テスト）
+
+---
+
+## What was built
+
+ワンタイムパスワード（OTP）認証システムを実装した。
+メールアドレスに 6 桁コードを送り、検証後にセッショントークンを発行する。
+
+| Endpoint | 説明 |
+|---|---|
+| `POST /otp/request` | OTP コードを生成・発行（常に 202、列挙防止） |
+| `POST /otp/verify` | OTP を検証してセッション発行 |
+| `GET /otp/session` | セッション有効性確認 |
+| `DELETE /otp/session` | ログアウト（セッション無効化） |
+
+---
+
+## Architecture decisions
+
+### コード生成とハッシュ保存
+
+`random_int(0, 999999)` で 6 桁コードを生成し、`str_pad` でゼロ埋めする。
+コードは SHA-256 ハッシュで DB に保存し、生コードは保存しない。
+検証時は `hash('sha256', $input)` と `hash_equals()` でタイミング攻撃を防ぐ。
+
+### ユーザー列挙防止
+
+`POST /otp/request` は存在しないメールアドレスにも 202 を返す（`findOrCreateUser` パターン）。
+存在確認と作成を 1 アトミック操作に統合することで、ステータスコードによる列挙を防ぐ。
+
+### 試行回数制限（3回でロックアウト）
+
+失敗ごとに `attempt_count` をインクリメントし、`MAX_ATTEMPTS`（3）到達で `locked_until` を 10 分後に設定。
+ロックアウトチェックを検証ロジックの最優先として行うことで、ロック中に有効なコードが
+送られても試行を完全に拒否する。
+
+### 最新 OTP のみ有効
+
+`ORDER BY id DESC LIMIT 1` で最新の OTP レコードのみを検証対象とする。
+複数回リクエストしても古いコードは無効になるため、古いコードの横流しができない。
+
+### セッショントークン
+
+`bin2hex(random_bytes(32))` = 256-bit ランダム → SHA-256 ハッシュで DB 保存。
+Bearer トークンで認証し、`DELETE /otp/session` でセッションを無効化（`revoked_at` 設定）。
+
+### .php-cs-fixer の setRiskyAllowed(true)
+
+`declare_strict_types` は CS Fixer のリスキーフィクサーに分類されるため、
+`.php-cs-fixer.php` に `->setRiskyAllowed(true)` が必要。これなしだと exit code 16 で失敗する。
+
+---
+
+## Attack test results (AttackTest.php)
+
+12 件のクラッカー攻撃シナリオを検証した。
+
+| ID | 攻撃シナリオ | 結果 |
+|---|---|---|
+| ATK-01 | ブルートフォース（3回でロックアウト） | Pass |
+| ATK-02 | 使用済み OTP のリプレイ攻撃 | Pass |
+| ATK-03 | ユーザー列挙（/otp/request は常に 202） | Pass |
+| ATK-04 | 存在しないユーザーへの verify（401、500 でない） | Pass |
+| ATK-05 | メールフィールドへの SQL インジェクション | Pass |
+| ATK-06 | 5 桁コード（短すぎる）| Pass |
+| ATK-07 | 7 桁コード（長すぎる）| Pass |
+| ATK-08 | ログアウト後のセッショントークン再利用 | Pass |
+| ATK-09 | ランダムトークン推測 | Pass |
+| ATK-10 | 空の Bearer トークン | Pass |
+| ATK-11 | アルファベットコード（非数字）| Pass |
+| ATK-12 | 古い OTP は新規リクエスト後に無効 | Pass |
+
+---
+
+## MySQL integration test results (MysqlOtpTest.php)
+
+| テスト | 内容 | 結果 |
+|---|---|---|
+| testMysql_requestAndVerify | リクエスト→検証フルフロー | Pass |
+| testMysql_sessionValidationAndRevocation | セッション確認→ログアウト | Pass |
+| testMysql_lockoutAfterFailedAttempts | 3回失敗→429 | Pass |
+| testMysql_sameEmailNotDuplicated | 同メール重複なし | Pass |
+| testMysql_invalidCodeReturns401 | 誤コード→401 | Pass |
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `OtpTest.php` (SQLite) | 18 | Pass |
+| `AttackTest.php` (SQLite) | 12 | Pass |
+| `MysqlOtpTest.php` (MySQL) | 5 | Pass |
+| **Total** | **35** | **Pass** |
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「OTP は SMS や銀行アプリで使ったことがある身近な機能なのでイメージしやすかった。
+`random_int(0, 999999)` で 6 桁コードを作って `str_pad` でゼロ埋めする、という組み合わせが
+シンプルで気に入った。`hash_equals()` を使う理由が最初は謎だったが、
+『=== と比較時間が変わることでコードの桁数を推測される』タイミング攻撃の説明で理解できた。
+ロックアウトが `attempt_count` カラムで管理されているのは、同じテーブルにカウントを
+持つシンプルな設計で把握しやすかった。
+`str_pad` を忘れると `42` → `42` になってしまうバグに気づいてよかった。」
+
+★★★★☆ — 身近な機能で実用的な暗号パターンが学べる
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel の Auth::attempt() + Sanctum に相当する機能を素の PHP で書く体験。
+`findOrCreateUser` パターンは `firstOrCreate` と同じ発想で直感的。
+OTP レコードに `attempt_count` を持たせる設計は、Laravel では Cache::increment() で
+レート制限することが多いが、DB 管理の方が永続性と監査性が高いというトレードオフを理解した。
+最新 OTP のみ有効にする `ORDER BY id DESC LIMIT 1` は Eloquent の `->latest()->first()` に
+相当するシンプルなパターン。MySQL 統合テストで `AppFactory::createMysql()` を使う設計が
+テスト環境の切り替えをきれいに分離していると感じた。」
+
+★★★★☆ — Laravel ユーザーに馴染みある発想で NENE2 の設計が理解できる
+
+### Persona 3 — セキュリティエンジニア
+
+「コード保存: SHA-256 ハッシュのみ保存、生コード非保存 ✓
+タイミング攻撃防止: `hash_equals()` 使用 ✓
+列挙防止: `/otp/request` が常に 202 ✓
+ブルートフォース: 3 回失敗でロックアウト ✓
+リプレイ防止: `used_at` で使用済みチェック ✓
+セッション: 256-bit ランダムトークン、ハッシュ保存 ✓
+古いコード無効化: 最新 OTP のみ使用 ✓
+気になる点: メールアドレス形式の検証は `filter_var(FILTER_VALIDATE_EMAIL)` + 長さ制限あり。
+ただし internationalized email (IDN) の扱いは未考慮。本番では追加検証を推奨。
+また `locked_until` はリクエスト時ではなく検証時に設定されるため、
+ロック解除後に新しい OTP を発行するとロックがリセットされる。
+本番では OTP と独立したロックアウトカウンターを users テーブルに持つことを検討すべき。」
+
+★★★★☆ — 主要なセキュリティ対策は網羅。本番はロックアウト設計要検討
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「ログインフォームの実装がシンプル。
+Step 1: メール入力 → POST /otp/request → 202 → 『コードをメールに送りました』UI
+Step 2: コード入力 → POST /otp/verify → 200 → session_token をローカルストレージに保存
+Step 3: 各リクエストに Authorization: Bearer <token> を付ける
+Step 4: GET /otp/session で定期的にトークン有効性を確認
+Step 5: DELETE /otp/session でログアウト
+422 と 401 の区別がはっきりしている（フォームバリデーションエラー vs 認証失敗）ので
+エラーメッセージ出し分けが楽。429 のロックアウトは UI でカウントダウン表示が必要なのが
+唯一の複雑さ。」
+
+★★★★☆ — 2ステップログインの UX が実装しやすい
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「`otp_codes` テーブルは認証のたびに INSERT されるため、長期運用では定期的な
+期限切れレコードの PURGE が必要（`DELETE FROM otp_codes WHERE expires_at < NOW() AND used_at IS NOT NULL`）。
+MySQL: `VARCHAR(64)` で code_hash / session_token_hash を保存。UNIQUE INDEX は
+`otp_sessions.session_token_hash` に設定済み。
+`otp_codes.user_id` に INDEX があると `ORDER BY id DESC LIMIT 1` の絞り込みが速くなる。
+本番スケールでは Redis でレート制限するのが定番だが、
+この DB アプローチは永続性があり監査ログとしても使える。
+MySQL 統合テストが 5 件 Pass しており、SQLite → MySQL 差異のリスクは低い。」
+
+★★★☆☆ — 本番運用はレコード purge とインデックス追加が必要
+
+### Persona 6 — プロダクトマネージャー
+
+「パスワードレス認証は近年の主流トレンド。ユーザーがパスワードを覚えなくてよく、
+フィッシング耐性も高い。OTP のシンプルさがユーザー受け入れのハードルを下げる。
+今後の拡張: SMS OTP（Twilio 等）、TOTP（Google Authenticator 連携）、
+マジックリンクとの選択制（FT144 参照）。
+セキュリティ観点: 3 回失敗ロックアウトはユーザーが SIM スワップ等の攻撃を受けた場合にも
+有効なガード。管理者向けの強制ロック解除 API の追加も検討価値がある。
+OTP の有効期限（5分）と再送間隔の設定は UX と安全性のバランスをプロダクトチームで決定すべき。」
+
+★★★★☆ — 現代的なパスワードレス認証の基盤として実用的
+
+---
+
+## Howto
+
+`docs/howto/otp-authentication.md`

--- a/docs/howto/otp-authentication.md
+++ b/docs/howto/otp-authentication.md
@@ -1,0 +1,185 @@
+# OTP 認証システム
+
+ワンタイムパスワード（OTP）認証の実装ガイド。
+6桁コード生成・SHA-256ハッシュ保存・試行回数制限・セッション管理を解説する。
+
+## 概要
+
+- 6桁数字コードを生成（`random_int`）
+- コードは SHA-256 ハッシュで保存（生コード非保存）
+- 5分間有効・使用後無効化
+- 3回失敗でロックアウト（10分）
+- 検証成功でセッショントークン発行（24時間有効）
+- `/otp/request` は常に 202（ユーザー列挙防止）
+
+## エンドポイント
+
+| Method | Path | 説明 |
+|---|---|---|
+| `POST` | `/otp/request` | OTP コードを生成・発行（常に 202） |
+| `POST` | `/otp/verify` | OTP を検証してセッション発行 |
+| `GET` | `/otp/session` | セッション有効性確認 |
+| `DELETE` | `/otp/session` | ログアウト（セッション無効化） |
+
+## データベース設計
+
+```sql
+CREATE TABLE otp_codes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    code_hash TEXT NOT NULL,        -- SHA-256 ハッシュ
+    expires_at TEXT NOT NULL,       -- 5分後
+    used_at TEXT,                   -- 使用済みフラグ
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    locked_until TEXT,              -- ロックアウト期限
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE otp_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    session_token_hash TEXT NOT NULL UNIQUE,  -- SHA-256 ハッシュ
+    expires_at TEXT NOT NULL,                 -- 24時間後
+    revoked_at TEXT,                          -- ログアウトフラグ
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+## OTP コード生成
+
+```php
+$rawCode = str_pad((string) random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+$codeHash = hash('sha256', $rawCode);
+$this->repository->createOtp($userId, $codeHash, $now);
+
+// Always 202 — prevents user enumeration
+// In production: send email. In testing: return code in response.
+return $this->responseFactory->create([
+    'message' => 'OTP code sent',
+    'code' => $rawCode,  // テスト用。本番では除去
+], 202);
+```
+
+`str_pad` で必ず 6 桁にする（例: `random_int(0, 999999)` が `42` → `'000042'`）。
+
+## 検証ロジックの順序
+
+```php
+// 1. ロックアウトチェック（最優先）
+if ($otp['locked_until'] !== null && $now < (string) $otp['locked_until']) {
+    return $this->responseFactory->create(['error' => 'too many attempts, try again later'], 429);
+}
+
+// 2. 有効期限チェック（used_at より前）
+if ($now > (string) $otp['expires_at']) {
+    return $this->responseFactory->create(['error' => 'code expired'], 401);
+}
+
+// 3. 使用済みチェック
+if ($otp['used_at'] !== null) {
+    return $this->responseFactory->create(['error' => 'code already used'], 401);
+}
+
+// 4. コードハッシュ比較（タイミング攻撃防止）
+$codeHash = hash('sha256', $code);
+if (!hash_equals((string) $otp['code_hash'], $codeHash)) {
+    $this->repository->incrementAttempt((int) $otp['id'], $now);
+    return $this->responseFactory->create(['error' => 'invalid code'], 401);
+}
+```
+
+ロックアウトチェックを最初に行うことで、ロック中に有効な OTP が送られてきても試行を拒否する。
+
+## 試行回数制限（ロックアウト）
+
+```php
+public function incrementAttempt(int $otpId, string $now): void
+{
+    $otp = $this->executor->fetchOne('SELECT * FROM otp_codes WHERE id = ?', [$otpId]);
+    $newCount = (int) $otp['attempt_count'] + 1;
+    $lockedUntil = null;
+    if ($newCount >= self::MAX_ATTEMPTS) {  // 3回
+        $lockedUntil = date('c', strtotime($now) + self::LOCK_MINUTES * 60);  // 10分
+    }
+    $this->executor->execute(
+        'UPDATE otp_codes SET attempt_count = ?, locked_until = ? WHERE id = ?',
+        [$newCount, $lockedUntil, $otpId]
+    );
+}
+```
+
+`attempt_count >= MAX_ATTEMPTS` に達したら `locked_until` を設定し、それ以降のリクエストを 429 で拒否する。
+
+## 最新の OTP を使用する設計
+
+```php
+public function findLatestOtpForUser(int $userId): ?array
+{
+    return $this->executor->fetchOne(
+        'SELECT * FROM otp_codes WHERE user_id = ? ORDER BY id DESC LIMIT 1',
+        [$userId]
+    );
+}
+```
+
+複数回 OTP をリクエストしても、常に最新（最後に生成した）コードのみが有効。
+古いコードは自動的に無効化される（ATK-12 対策）。
+
+## セッショントークン
+
+```php
+$rawToken = bin2hex(random_bytes(32));     // 256-bit ランダム
+$tokenHash = hash('sha256', $rawToken);   // SHA-256 で保存
+$this->repository->createSession((int) $user['id'], $tokenHash, $now);
+
+return $this->responseFactory->create([
+    'session_token' => $rawToken,          // 生トークンをクライアントに返す
+    'user_id' => (int) $user['id'],
+], 200);
+```
+
+セッション確認は `Authorization: Bearer <token>` ヘッダーで行う。
+
+## Bearer トークン抽出
+
+```php
+private function extractBearerToken(ServerRequestInterface $request): string
+{
+    $header = $request->getHeaderLine('Authorization');
+    if (!str_starts_with($header, 'Bearer ')) {
+        return '';
+    }
+    return trim(substr($header, 7));
+}
+```
+
+## MySQL 対応
+
+MySQL スキーマは `database/schema.mysql.sql` を用意する（`INT AUTO_INCREMENT`・`ENGINE=InnoDB`）。
+`AppFactory::createMysql()` で `DatabaseConfig` + `PdoConnectionFactory` 経由で接続する。
+
+```php
+public static function createMysql(string $host, int $port, string $name, string $user, string $password): Router
+{
+    $dbConfig = new DatabaseConfig(
+        url: null, environment: 'test', adapter: 'mysql',
+        host: $host, port: $port, name: $name, user: $user,
+        password: $password, charset: 'utf8mb4',
+    );
+    $factory = new PdoConnectionFactory($dbConfig);
+    return self::create($factory);
+}
+```
+
+## .php-cs-fixer.php の注意点
+
+`declare_strict_types` はリスキーフィクサーのため `setRiskyAllowed(true)` が必要:
+
+```php
+return (new PhpCsFixer\Config())
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
+    ->setRules(['@PSR12' => true, 'declare_strict_types' => true]);
+```

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.81
+  version: 1.5.82
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.81`（2026-05-21 リリース済み）
+- Latest release: `v1.5.82`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -63,10 +63,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT145 | ユーザー設定管理 | preflog | 20/20 | v1.5.79 | user-preferences-management.md（PreferenceKey enum・型バリデーション・upsert・デフォルト値フォールバック・IDOR防止） |
 | FT146 | コンテンツピン留め | pinlog | 19/19 | v1.5.80 | content-pinning.md（position連続管理・冪等追加201/200・unpin後位置詰め・完全一致reorder） |
 | FT147 | コンテンツ通報・モデレーション | reportlog | 32/32 | v1.5.81 | content-report-moderation.md（RBAC・IDOR防止・冪等通報201/200・一方向ステータス遷移）**脆弱性診断: VULN-A〜L 12件全Pass** |
+| FT148 | OTP 認証システム | otplog | 35/35 | v1.5.82 | otp-authentication.md（SHA-256ハッシュ・3回ロックアウト・最新OTPのみ有効・setRiskyAllowed）**クラッカー攻撃試験: 12件全Pass** / **MySQL統合テスト: 5件全Pass** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT148 以降・次の MySQL テストは FT148・次の脆弱性診断: FT150・次のクラッカー攻撃試験: FT148）
+- FT ループ継続中（FT149 以降・次の MySQL テストは FT153・次の脆弱性診断: FT150・次のクラッカー攻撃試験: FT152）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.81';
+    public const string VERSION = '1.5.82';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- FT148: `otplog` — OTP（ワンタイムパスワード）認証システムを実装
- 6桁コード・SHA-256ハッシュ保存・3回失敗ロックアウト・最新OTPのみ有効
- クラッカー攻撃試験 AttackTest.php（ATK-01〜12, 12件全Pass）
- MySQL 統合テスト MysqlOtpTest.php（5件全Pass）
- テスト合計 35/35 Pass

## Changes

- `docs/howto/otp-authentication.md` — 実装ガイド（setRiskyAllowed パターン等）
- `docs/field-trials/2026-05-field-trial-148.md` — FT レポート（6ペルソナ DX レビュー）
- `src/FrameworkInfo.php` — VERSION → 1.5.82
- `docs/openapi/openapi.yaml` — version 1.5.82
- `CHANGELOG.md` — v1.5.82 エントリ追加
- `docs/todo/current.md` — FT148 完了・次サイクル更新

## Test plan

- [x] otplog: `composer check` 全 Pass（CS / PHPStan level 8 / 30 SQLite tests）
- [x] クラッカー攻撃試験 ATK-01〜12: ブルートフォース・リプレイ・列挙・SQL注入・トークン奪取
- [x] MySQL 統合テスト 5件: フルフロー・セッション・ロックアウト・重複防止・誤コード

Closes #800

Self-review: docs-policy, backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)