### PR TITLE
feat(ft149): コンテンツコレクション（collectionlog）v1.5.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.83] — 2026-05-21
+
+### Added
+- `docs/howto/content-collection.md` — コンテンツコレクションガイド: 存在非公開パターン（404 vs 403）・冪等アイテム追加（201/200）・位置詰め整合・複数パスパラメータ。 (#803)
+- `docs/field-trials/2026-05-field-trial-149.md` — FT149 レポート: collectionlog（コンテンツコレクション、20 tests）。 (#803)
+
+---
+
 ## [1.5.82] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-149.md
+++ b/docs/field-trials/2026-05-field-trial-149.md
@@ -1,0 +1,155 @@
+# Field Trial 149 — コンテンツコレクション（Content Collection）
+
+**Date**: 2026-05-21  
+**App**: `collectionlog`  
+**Path**: `/home/xi/docker/NENE2-FT/collectionlog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.83
+
+---
+
+## What was built
+
+記事のキュレーションコレクション（公開/非公開）システムを実装した。
+ユーザーが名前付きコレクションを作成し、記事を順序付きで追加できる。
+
+| Endpoint | 説明 |
+|---|---|
+| `POST /collections` | コレクション作成 |
+| `GET /collections/{id}` | コレクション取得（公開 or 自分） |
+| `PUT /collections/{id}` | コレクション名・公開設定変更 |
+| `DELETE /collections/{id}` | コレクション削除 |
+| `POST /collections/{id}/items` | 記事を追加（冪等） |
+| `DELETE /collections/{id}/items/{articleId}` | 記事を削除 |
+
+---
+
+## Architecture decisions
+
+### 存在非公開パターン（404 vs 403）
+
+非公開コレクションへのアクセスに対し 403 でなく 404 を返す。
+403 は「存在するが権限がない」という情報を開示するため、
+コレクションの存在自体を隠したいケースでは 404 が適切。
+変更系操作（PUT/DELETE/POST items）では 403 を使用して権限不足を明示し、
+GET のみ 404 で存在を隠蔽する。この使い分けがコレクションシステムの標準的な設計。
+
+### 冪等アイテム追加（201/200）
+
+`UNIQUE (collection_id, article_id)` を基盤として、
+アプリ層での事前チェック（findItem）で 201/200 を切り替える。
+上限チェックは「新規追加の場合のみ」実行し、既存の冪等呼び出しはスキップする。
+
+### 位置整合（position compact）
+
+アイテム削除後に `UPDATE ... SET position = position - 1 WHERE position > ?` でギャップを埋める。
+ピン留め（FT146）と同じパターンを適用。最大 50 件制限下では性能問題なし。
+
+### 複数パスパラメータ
+
+`DELETE /collections/{id}/items/{articleId}` でルート内に 2 つのパスパラメータを持つ。
+`Router::param($request, 'id')` と `Router::param($request, 'articleId')` をそれぞれ取得する。
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `CollectionTest.php` (SQLite) | 20 | Pass |
+| **Total** | **20** | **Pass** |
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「コレクション機能は Spotify のプレイリストや Pinterest のボードと同じ概念で入りやすかった。
+非公開コレクションに 404 を返す設計が最初は混乱したが、
+『403 は存在を認めること、404 は存在自体を隠す』という説明で理解できた。
+冪等追加（同じ記事を 2 回追加しても壊れない）というパターンは、
+ユーザーが『追加済みかどうか』を気にせずボタンを押せる UX に繋がると気づいた。
+position の自動整合も FT146（ピン留め）と同じ SQL 1 行で実現できていて、
+パターンとして覚えやすかった。」
+
+★★★★☆ — 身近な UI 概念で実装パターンが学べる
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel では `Collection::where('is_public', 1)->orWhere('user_id', $user->id)` という
+Eloquent クエリ一発で書けるが、NENE2 では PHP コードで条件を書いている。
+可読性的にはどちらも明確で甲乙つけがたい。
+404 vs 403 の使い分けは Laravel の Policy でも同じ問題が起きる
+（`before()` で 403 を返すか `view()` で false を返すか）。
+NENE2 のアプローチは明示的で理解しやすい。
+`PUT` エンドポイントで `array_key_exists('is_public', $body)` を使って
+フィールドが送られてきた場合のみ更新する Partial Update パターンが
+Laravel の `$request->has()` パターンと同じで親しみやすかった。」
+
+★★★★☆ — 明示的な条件分岐で可読性高い
+
+### Persona 3 — セキュリティエンジニア
+
+「存在非公開パターン（404）は適切。非公開コレクションの ID 列挙攻撃に対して
+存在自体を開示しない。
+所有権チェック: POST /collections/{id}/items, PUT, DELETE はすべて
+`user_id !== actorId` で 403 を返している ✓
+冪等追加: `findItem` で既存チェック後に INSERT するため TOCTOU は
+シングルスレッド・SQLite では問題なし。MySQL での並行アクセスは
+UNIQUE 制約の `DatabaseConstraintException` をキャッチする追加実装が必要。
+気になる点: コレクション削除時に items を物理削除している（`DELETE FROM collection_items`）。
+これは正しいが、ON DELETE CASCADE を使う設計も検討価値がある。
+最大 50 件制限の定数（MAX_ITEMS）が Repository に隠蔽されており、
+ビジネスルールをアプリ層に明示する設計として適切。」
+
+★★★★☆ — 基本的なアクセス制御・存在非公開は適切
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「ブックマーク/コレクション UI の実装がシンプル。
+GET /collections/{id} が items を position 順で返すため追加ソート不要。
+item_count フィールドで『あと何件追加できるか』（50 - count）を表示できる。
+POST /collections/{id}/items が 201/200 で新規/既存を区別できるため、
+追加ボタンの状態切り替え（『追加』→『追加済み』）が API だけで実現できる。
+非公開コレクションの共有 URL を踏んだ場合は 404 が返るため、
+フロント側では「見つかりません」UI を出すだけでよい（403 の場合より処理が単純）。
+DELETE /collections/{id} 後に items も消える（サーバー側で整合済み）のは
+フロント的に追加処理不要でよい。」
+
+★★★★☆ — コレクション UI の実装がストレート
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「`collection_items` の `UNIQUE (collection_id, article_id)` インデックスが
+冪等追加の基盤として機能する。`position` カラムは最大 50 件のため
+フルスキャンでも問題なし。スケール時は `(collection_id, position)` 複合インデックスを追加。
+`is_public = 1` でのグローバル公開コレクション一覧が必要になった場合は
+`(is_public, created_at)` インデックスを追加すべき。
+コレクション削除が 2 段階（items DELETE → collection DELETE）になっているが、
+MySQL では ON DELETE CASCADE で 1 クエリにできる。
+SQLite ではデフォルトで PRAGMA foreign_keys = ON が必要。」
+
+★★★★☆ — 小規模に十分、スケールアップ時はインデックス追加
+
+### Persona 6 — プロダクトマネージャー
+
+「コレクション機能はユーザーエンゲージメントを高める重要な機能。
+Spotify のプレイリスト、Pinterest のボード、YouTube の再生リストと同じ発想。
+公開コレクションはバイラル性（シェア機能）に繋がる。
+上限 50 件は使い勝手の観点から適切（多すぎるとコレクションの意味が薄まる）。
+今後の拡張:
+- コレクション一覧（GET /collections?user_id=X）
+- コレクションへのいいね・フォロー
+- 公開コレクションの検索
+- コレクション内の順序変更（PUT /collections/{id}/items/order）— FT146 参照
+冪等追加（201/200）はモバイルアプリの『追加済みか確認してからボタン表示切替』より
+『押すたびに正しい状態を返す』設計で実装コスト削減。」
+
+★★★★★ — プロダクト機能として即使えるレベル
+
+---
+
+## Howto
+
+`docs/howto/content-collection.md`

--- a/docs/howto/content-collection.md
+++ b/docs/howto/content-collection.md
@@ -1,0 +1,127 @@
+# コンテンツコレクション
+
+記事のキュレーションコレクション（公開/非公開）システムの実装ガイド。
+公開設定・IDOR 防止（存在非公開）・冪等追加・位置詰め整合を解説する。
+
+## 概要
+
+- ユーザーが名前付きコレクション（リスト）を作成
+- 各コレクションに記事を追加（最大 50 件）
+- `is_public` フラグ: 公開コレクションは誰でも閲覧可能
+- 非公開コレクションは非オーナーに 404（存在非公開パターン）
+- 記事追加は冪等（既存なら 200、新規なら 201）
+- アイテム削除後に position が自動整合
+
+## エンドポイント
+
+| Method | Path | 説明 |
+|---|---|---|
+| `POST` | `/collections` | コレクション作成 |
+| `GET` | `/collections/{id}` | コレクション取得（公開 or 自分） |
+| `PUT` | `/collections/{id}` | コレクション名・公開設定変更 |
+| `DELETE` | `/collections/{id}` | コレクション削除 |
+| `POST` | `/collections/{id}/items` | 記事を追加（冪等） |
+| `DELETE` | `/collections/{id}/items/{articleId}` | 記事を削除 |
+
+## データベース設計
+
+```sql
+CREATE TABLE collections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    is_public INTEGER NOT NULL DEFAULT 0,  -- 0=private, 1=public
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE collection_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    collection_id INTEGER NOT NULL,
+    article_id INTEGER NOT NULL,
+    position INTEGER NOT NULL,
+    added_at TEXT NOT NULL,
+    UNIQUE (collection_id, article_id),
+    FOREIGN KEY (collection_id) REFERENCES collections(id),
+    FOREIGN KEY (article_id) REFERENCES articles(id)
+);
+```
+
+## 存在非公開パターン（IDOR 防止）
+
+非公開コレクションへのアクセスは 403 でなく **404** を返す。
+403 を返すと「存在するが権限がない」という情報が漏れるため。
+
+```php
+if (!$isOwner && !$isPublic) {
+    return $this->responseFactory->create(['error' => 'collection not found'], 404);
+}
+```
+
+## 冪等アイテム追加
+
+```php
+$existing = $this->repository->findItem($id, $articleId);
+if ($existing !== null) {
+    return $this->responseFactory->create(['message' => 'already in collection', 'article_id' => $articleId], 200);
+}
+
+$count = $this->repository->countItems($id);
+if ($count >= CollectionRepository::maxItems()) {
+    return $this->responseFactory->create(['error' => 'collection is full', 'max' => 50], 422);
+}
+
+$this->repository->addItem($id, $articleId, date('c'));
+return $this->responseFactory->create(['message' => 'article added', 'article_id' => $articleId], 201);
+```
+
+上限チェックは「まだ追加されていない記事」の場合のみ実行する。
+既に追加済みの記事は上限に影響しない（冪等呼び出し）。
+
+## アイテム削除後の位置整合
+
+```php
+public function removeItem(int $collectionId, int $articleId): void
+{
+    $item = $this->findItem($collectionId, $articleId);
+    $removedPosition = (int) $item['position'];
+    $this->executor->execute('DELETE FROM collection_items WHERE collection_id = ? AND article_id = ?', ...);
+    $this->executor->execute(
+        'UPDATE collection_items SET position = position - 1 WHERE collection_id = ? AND position > ?',
+        [$collectionId, $removedPosition]
+    );
+}
+```
+
+削除された位置より後ろのアイテムを 1 つ前にシフトしてギャップを埋める。
+
+## GET /collections/{id} レスポンス例
+
+```json
+{
+  "id": 1,
+  "user_id": 1,
+  "name": "My Reading List",
+  "is_public": false,
+  "item_count": 2,
+  "items": [
+    {"article_id": 3, "title": "Article 3", "position": 1, "added_at": "2026-05-21T..."},
+    {"article_id": 1, "title": "Article 1", "position": 2, "added_at": "2026-05-21T..."}
+  ],
+  "created_at": "2026-05-21T...",
+  "updated_at": "2026-05-21T..."
+}
+```
+
+## 所有権チェックパターン
+
+全ての変更エンドポイント（PUT/DELETE/POST items）でオーナーチェックを行う:
+
+```php
+if ((int) $collection['user_id'] !== $actorId) {
+    return $this->responseFactory->create(['error' => 'access denied'], 403);
+}
+```
+
+GET の場合は公開/非公開と所有権で 404/200 を分岐させ、403 を使わない。

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.82
+  version: 1.5.83
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.82`（2026-05-21 リリース済み）
+- Latest release: `v1.5.83`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -64,10 +64,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT146 | コンテンツピン留め | pinlog | 19/19 | v1.5.80 | content-pinning.md（position連続管理・冪等追加201/200・unpin後位置詰め・完全一致reorder） |
 | FT147 | コンテンツ通報・モデレーション | reportlog | 32/32 | v1.5.81 | content-report-moderation.md（RBAC・IDOR防止・冪等通報201/200・一方向ステータス遷移）**脆弱性診断: VULN-A〜L 12件全Pass** |
 | FT148 | OTP 認証システム | otplog | 35/35 | v1.5.82 | otp-authentication.md（SHA-256ハッシュ・3回ロックアウト・最新OTPのみ有効・setRiskyAllowed）**クラッカー攻撃試験: 12件全Pass** / **MySQL統合テスト: 5件全Pass** |
+| FT149 | コンテンツコレクション | collectionlog | 20/20 | v1.5.83 | content-collection.md（存在非公開404・冪等追加201/200・位置詰め整合・複数パスパラメータ） |
 
 ## 次のアクション
 
-- FT ループ継続中（FT149 以降・次の MySQL テストは FT153・次の脆弱性診断: FT150・次のクラッカー攻撃試験: FT152）
+- FT ループ継続中（FT150 以降・次の MySQL テストは FT153・次の脆弱性診断: FT150・次のクラッカー攻撃試験: FT152）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.82';
+    public const string VERSION = '1.5.83';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- コンテンツコレクション（公開/非公開）システムを実装（collectionlog）
- 存在非公開パターン: 非公開コレクションに 404（403 は存在を開示するため）
- 冪等アイテム追加: 既存なら 200、新規なら 201
- 位置詰め整合: 削除後に `UPDATE position = position - 1 WHERE position > ?`
- `DELETE /collections/{id}/items/{articleId}` で複数パスパラメータ対応
- テスト 20/20 Pass

## Changes

- `docs/howto/content-collection.md` — 実装ガイド
- `docs/field-trials/2026-05-field-trial-149.md` — FT レポート（6 ペルソナ DX レビュー）
- `src/FrameworkInfo.php` — VERSION 1.5.83
- `docs/openapi/openapi.yaml` — version 1.5.83
- `CHANGELOG.md` — v1.5.83 エントリ追加
- `docs/todo/current.md` — FT149 完了行追加

## Validation

- `CollectionTest.php`: 20/20 Pass（SQLite）
- PHPStan level 8: Pass
- PHP CS Fixer: Pass

## Related

Closes #802

Self-review: backend-api, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)