### PR TITLE
feat(ft150): クーポン・プロモコード管理（couponlog）v1.5.84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.84] — 2026-05-21
+
+### Added
+- `docs/howto/coupon-promo-code.md` — クーポン・プロモコード管理ガイド: admin RBAC・ユーザーごとの利用追跡・discount_pct範囲制約・user_id注入防止。 (#805)
+- `docs/field-trials/2026-05-field-trial-150.md` — FT150 レポート: couponlog（クーポン・プロモコード管理、34 tests = 22 正常 + 12 脆弱性診断）**脆弱性診断: VULN-A〜L 12件全Pass**。 (#805)
+
+---
+
 ## [1.5.83] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-150.md
+++ b/docs/field-trials/2026-05-field-trial-150.md
@@ -1,0 +1,187 @@
+# Field Trial 150 — クーポン・プロモコード管理（Coupon/Promo Code System）
+
+**Date**: 2026-05-21  
+**App**: `couponlog`  
+**Path**: `/home/xi/docker/NENE2-FT/couponlog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.84
+
+---
+
+## What was built
+
+admin RBAC とユーザーごとの利用追跡を備えたクーポン・プロモコード管理システムを実装した。
+
+| Endpoint | 説明 | 権限 |
+|---|---|---|
+| `POST /coupons` | クーポン作成 | admin |
+| `GET /coupons/{code}` | クーポン情報取得 | 誰でも |
+| `POST /coupons/{code}/use` | クーポン利用（1ユーザー1回） | 認証済み |
+| `GET /coupons/{code}/uses` | 利用履歴一覧 | admin |
+| `DELETE /coupons/{code}` | クーポン無効化 | admin |
+
+---
+
+## Architecture decisions
+
+### admin RBAC パターン
+
+`X-User-Role: admin` ヘッダーで権限を判定。
+クーポン作成・無効化・利用履歴閲覧は admin のみ許可。
+一般ユーザーが作成を試みると 403。認証なしは 401。
+
+### ユーザーごとの一利用制限
+
+`UNIQUE (coupon_id, user_id)` 制約がアプリ層の事前チェック（`findUse`）と組み合わさり、
+同一ユーザーの二重利用を防ぐ。DB 制約が最終防衛ライン。
+
+### 利用チェック順序
+
+1. 認証（401）
+2. クーポン存在（404）
+3. is_active（422）
+4. expires_at（422）
+5. max_uses（422、0=無制限）
+6. ユーザー重複（422）
+7. recordUse（INSERT + use_count インクリメント）
+
+### discount_pct の範囲制約
+
+`1-100` の整数のみ許可。アプリ層バリデーションと DB の `CHECK` 制約の二重防御。
+0 や 100 超は 422。
+
+### user_id 注入防止
+
+利用者 user_id はボディから受け付けない。`X-User-Id` ヘッダーのみから取得する。
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `CouponTest.php` (SQLite) | 22 | Pass |
+| `VulnTest.php` (SQLite) | 12 | Pass |
+| **Total** | **34** | **Pass** |
+
+---
+
+## 脆弱性診断（VulnTest.php）
+
+| ID | 内容 | 結果 |
+|---|---|---|
+| VULN-A | 非認証ユーザーはクーポン作成不可 → 401 | Pass |
+| VULN-B | 一般ユーザーはクーポン作成不可 → 403 | Pass |
+| VULN-C | 一般ユーザーは利用履歴閲覧不可 → 403 | Pass |
+| VULN-D | 一般ユーザーはクーポン無効化不可 → 403 | Pass |
+| VULN-E | 有効期限切れクーポンは利用不可 → 422 | Pass |
+| VULN-F | 無効化済みクーポンは利用不可 → 422 | Pass |
+| VULN-G | 同一ユーザーの二重利用防止 → 422 | Pass |
+| VULN-H | max_uses 超過後の利用防止 → 422 | Pass |
+| VULN-I | discount_pct=0 が拒否される → 422 | Pass |
+| VULN-J | discount_pct=101 が拒否される → 422 | Pass |
+| VULN-K | SQL インジェクション試みに 404 を返す | Pass |
+| VULN-L | user_id はボディから受け付けない | Pass |
+
+全 12 件 Pass — クーポン管理の主要な脆弱性パターンをすべて検出・防御確認。
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「クーポンコードは EC サイトでよく見る機能なので、作るものがイメージしやすかった。
+admin かどうかを `X-User-Role` ヘッダーで判定するパターンは最初シンプルすぎる気がしたが、
+『テスト中は自分で値を渡せる→実運用では認証ミドルウェアが付与する』という説明で納得した。
+discount_pct を 1〜100 の整数に限定するバリデーションは、DB の CHECK 制約とアプリ層の両方で
+書くことで『アプリが壊れても DB が最後に守る』という多層防御の概念を学べた。
+同一ユーザーの二重利用を `UNIQUE (coupon_id, user_id)` で防ぐ発想は
+FT146 の position 管理と同じパターンで、データベース制約の活用例として覚えやすかった。」
+
+★★★★☆ — EC 機能の実装で多層防御パターンが学べる
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel では `Policy::before()` で admin チェックを書くが、NENE2 は各ハンドラの冒頭で
+明示的に書く。その分、`if (!$this->isAdmin($request)) { return 403; }` の流れが
+コードを追うだけで分かるのはメリット。
+クーポンコードの lookup に `findByCode()` を使い、ユーザー重複チェックを事前に行ってから
+INSERT するパターンは Laravel の `firstOrFail()` と `syncWithoutDetaching()` に近い。
+`use_count = use_count + 1` でインクリメントするのは Eloquent の `increment()` に相当し、
+MySQL での並行アクセスに対しても安全なパターンだと理解した。
+有効期限を ISO 8601 文字列で比較する実装は、Laravel の Carbon を使わずに済む点が
+依存の少なさとして評価できる。」
+
+★★★★☆ — 明示的な権限チェックで可読性高い
+
+### Persona 3 — セキュリティエンジニア
+
+「RBAC チェックは各エンドポイントで明示的に実行されており、ミドルウェアの設定漏れによる
+バイパスリスクがない（ただしミドルウェア統合後は設定を二重確認すること）。
+
+`user_id` をボディではなく `X-User-Id` ヘッダーのみから取得する設計（VULN-L）は
+なりすまし防止として適切。
+
+クーポンコードのブルートフォース耐性については、短いコード（例: 8文字英数字）は
+十分なエントロピーを持つが、現実的にはレート制限が必要。
+本実装は `ThrottleMiddleware` を導入していないため、高頻度のコード推測が可能。
+
+`UNIQUE (coupon_id, user_id)` 制約は MySQL での並行 INSERT でも最終防衛ラインとして機能するが、
+TOCTOU（findUse 後に並行 INSERT）が発生しうる。
+MySQL では `DatabaseConstraintException` をキャッチして 422 を返す追加実装が望ましい。
+
+discount_pct の DB CHECK 制約（`>= 1 AND <= 100`）はアプリ側バリデーション失敗時の
+第二防衛ラインとして有効。」
+
+★★★★☆ — 主要な認可制御は適切、レート制限の追加を推奨
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「チェックアウト画面でのクーポン適用フローが直感的に実装できる。
+`GET /coupons/{code}` でコード検証（is_active、expires_at 表示）→
+`POST /coupons/{code}/use` で適用、という 2 ステップが明確。
+201 vs 422 の分岐が明確なのでトースト通知の出し分けが楽。
+エラーメッセージ（'not active'、'expired'、'limit reached'、'already used'）が
+ユーザー向けメッセージに変換しやすい粒度になっている。
+admin 側の利用履歴（`GET /coupons/{code}/uses`）で user_id と user_name が返るので、
+管理画面でユーザーテーブルとの JOIN 不要で表示できる。」
+
+★★★★☆ — チェックアウト UI への統合がシンプル
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「`coupons.code` に UNIQUE 制約あり（ルックアップが O(log n)）。
+`coupon_uses.(coupon_id, user_id)` の複合 UNIQUE インデックスが重複防止と
+ルックアップ両方に機能する。
+`use_count` のインクリメントは `UPDATE ... SET use_count = use_count + 1` を使っており、
+MySQL でもアトミックに機能する。
+高負荷時は `SELECT ... FOR UPDATE` または `INSERT ... ON CONFLICT DO NOTHING` で
+楽観的ロックを検討すること。
+クーポンコードの文字列長は定義されていないため、長いコード（例: 256 文字）でも
+UNIQUE インデックスが機能するか事前に確認すること（MySQL は 767 バイト制限あり）。」
+
+★★★★☆ — 小〜中規模で十分、高並行時はロック戦略追加
+
+### Persona 6 — プロダクトマネージャー
+
+「EC サイト・SaaS・サブスクリプションで必須のクーポン機能。
+'1 ユーザー 1 回のみ利用可能' は紹介キャンペーンや初回購入クーポンで最も使われるパターン。
+max_uses=0（無制限）と max_uses=N（上限あり）の切り替えが 1 フィールドでできるのは
+マーケティング施策の柔軟性につながる。
+今後の拡張:
+- 最小購入金額（`min_order_amount`）
+- 適用対象カテゴリ制限
+- クーポン有効化予約（`starts_at`）
+- admin によるコード一括生成（バルク作成）
+- 利用統計ダッシュボード（`GET /coupons` + 集計）
+'discount_pct 100 = 無料化' を許可するかは PM とビジネスルールで決めること
+（本実装では 1-100 を許可）。」
+
+★★★★★ — EC・SaaS 必須機能として即使えるレベル
+
+---
+
+## Howto
+
+`docs/howto/coupon-promo-code.md`

--- a/docs/howto/coupon-promo-code.md
+++ b/docs/howto/coupon-promo-code.md
@@ -1,0 +1,184 @@
+# クーポン・プロモコード管理
+
+admin RBAC・ユーザーごとの利用追跡・有効期限・上限制御を備えたクーポンシステムの実装ガイド。
+
+## 概要
+
+- admin ロールのみクーポン作成・無効化・利用履歴閲覧が可能
+- 一般ユーザーは 1 クーポン 1 回のみ利用可能（`UNIQUE (coupon_id, user_id)`）
+- `discount_pct`: 1〜100 の整数（バリデーション必須）
+- `max_uses = 0` は上限なし
+- `expires_at` は ISO 8601 文字列（NULL = 無期限）
+- user_id は **X-User-Id ヘッダーのみ**から取得（ボディ注入不可）
+
+## エンドポイント
+
+| Method | Path | 説明 | 権限 |
+|---|---|---|---|
+| `POST` | `/coupons` | クーポン作成 | admin |
+| `GET` | `/coupons/{code}` | クーポン情報取得 | 誰でも |
+| `POST` | `/coupons/{code}/use` | クーポン利用（1ユーザー1回） | 認証済み |
+| `GET` | `/coupons/{code}/uses` | 利用履歴一覧 | admin |
+| `DELETE` | `/coupons/{code}` | クーポン無効化 | admin |
+
+## データベース設計
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'user',
+    created_at TEXT NOT NULL,
+    CHECK (role IN ('user', 'admin'))
+);
+
+CREATE TABLE coupons (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    code TEXT NOT NULL UNIQUE,
+    discount_pct INTEGER NOT NULL CHECK (discount_pct >= 1 AND discount_pct <= 100),
+    max_uses INTEGER NOT NULL DEFAULT 0,
+    use_count INTEGER NOT NULL DEFAULT 0,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    expires_at TEXT,
+    created_by INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (created_by) REFERENCES users(id)
+);
+
+CREATE TABLE coupon_uses (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    coupon_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    used_at TEXT NOT NULL,
+    UNIQUE (coupon_id, user_id),
+    FOREIGN KEY (coupon_id) REFERENCES coupons(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`UNIQUE (coupon_id, user_id)` が同一ユーザーによる二重利用を DB レベルで防止する。
+
+## admin チェックパターン
+
+```php
+private function requireUserId(ServerRequestInterface $request): ?int
+{
+    $val = $request->getHeaderLine('X-User-Id');
+    return $val !== '' ? (int) $val : null;
+}
+
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    return $request->getHeaderLine('X-User-Role') === 'admin';
+}
+
+// handleCreate / handleDeactivate / handleListUses の冒頭
+$actorId = $this->requireUserId($request);
+if ($actorId === null) {
+    return $this->responseFactory->create(['error' => 'authentication required'], 401);
+}
+if (!$this->isAdmin($request)) {
+    return $this->responseFactory->create(['error' => 'admin role required'], 403);
+}
+```
+
+## クーポン利用チェック順序
+
+```php
+// 1. 認証チェック
+if ($actorId === null) { return 401; }
+
+// 2. クーポン存在確認
+$coupon = $this->repository->findByCode($code);
+if ($coupon === null) { return 404; }
+
+// 3. is_active チェック
+if (!(bool) $coupon['is_active']) { return 422 'not active'; }
+
+// 4. 有効期限チェック
+$now = date('c');
+if ($coupon['expires_at'] !== null && $now > $coupon['expires_at']) { return 422 'expired'; }
+
+// 5. max_uses チェック（0 は無制限）
+if ($maxUses > 0 && $coupon['use_count'] >= $maxUses) { return 422 'limit reached'; }
+
+// 6. ユーザー重複チェック（UNIQUE 制約のアプリ層確認）
+$existing = $this->repository->findUse($coupon['id'], $actorId);
+if ($existing !== null) { return 422 'already used'; }
+
+// 7. 利用記録 + use_count インクリメント
+$this->repository->recordUse($coupon['id'], $actorId, $now);
+return 201;
+```
+
+## クーポン利用記録
+
+```php
+public function recordUse(int $couponId, int $userId, string $now): int
+{
+    $id = $this->executor->insert(
+        'INSERT INTO coupon_uses (coupon_id, user_id, used_at) VALUES (?, ?, ?)',
+        [$couponId, $userId, $now]
+    );
+    $this->executor->execute(
+        'UPDATE coupons SET use_count = use_count + 1 WHERE id = ?',
+        [$couponId]
+    );
+    return $id;
+}
+```
+
+`use_count` のインクリメントは INSERT と同じ処理で実行する。
+MySQL では並行アクセス時に `use_count = use_count + 1` がアトミックに機能する。
+
+## discount_pct バリデーション
+
+```php
+$discountPct = isset($body['discount_pct']) && is_int($body['discount_pct']) ? $body['discount_pct'] : null;
+if ($discountPct === null || $discountPct < 1 || $discountPct > 100) {
+    return $this->responseFactory->create(['error' => 'discount_pct must be 1-100'], 422);
+}
+```
+
+`CHECK (discount_pct >= 1 AND discount_pct <= 100)` は DB 側でも保証するが、
+アプリ層でも先に拒否して適切な 422 を返す。
+
+## レスポンス例
+
+### POST /coupons（作成）
+```json
+{
+  "id": 1,
+  "code": "SUMMER20",
+  "discount_pct": 20,
+  "max_uses": 100,
+  "use_count": 0,
+  "is_active": true,
+  "expires_at": "2026-08-31T23:59:59+00:00",
+  "created_by": 1,
+  "created_at": "2026-05-21T..."
+}
+```
+
+### POST /coupons/{code}/use（利用）
+```json
+{
+  "id": 42,
+  "coupon_id": 1,
+  "code": "SUMMER20",
+  "discount_pct": 20,
+  "user_id": 7,
+  "used_at": "2026-05-21T..."
+}
+```
+
+## user_id 注入防止
+
+user_id は必ず `X-User-Id` ヘッダーから取得する。
+リクエストボディの `user_id` フィールドは無視する。
+
+```php
+// NG: $userId = (int) $body['user_id'];  // 攻撃者に操作される
+// OK:
+$actorId = $this->requireUserId($request);  // X-User-Id ヘッダーのみ
+```

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.83
+  version: 1.5.84
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.83`（2026-05-21 リリース済み）
+- Latest release: `v1.5.84`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -65,10 +65,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT147 | コンテンツ通報・モデレーション | reportlog | 32/32 | v1.5.81 | content-report-moderation.md（RBAC・IDOR防止・冪等通報201/200・一方向ステータス遷移）**脆弱性診断: VULN-A〜L 12件全Pass** |
 | FT148 | OTP 認証システム | otplog | 35/35 | v1.5.82 | otp-authentication.md（SHA-256ハッシュ・3回ロックアウト・最新OTPのみ有効・setRiskyAllowed）**クラッカー攻撃試験: 12件全Pass** / **MySQL統合テスト: 5件全Pass** |
 | FT149 | コンテンツコレクション | collectionlog | 20/20 | v1.5.83 | content-collection.md（存在非公開404・冪等追加201/200・位置詰め整合・複数パスパラメータ） |
+| FT150 | クーポン・プロモコード管理 | couponlog | 34/34 | v1.5.84 | coupon-promo-code.md（admin RBAC・ユーザー1回制限・discount_pct制約・user_id注入防止）**脆弱性診断: VULN-A〜L 12件全Pass** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT150 以降・次の MySQL テストは FT153・次の脆弱性診断: FT150・次のクラッカー攻撃試験: FT152）
+- FT ループ継続中（FT151 以降・次の MySQL テストは FT153・次の脆弱性診断: FT153・次のクラッカー攻撃試験: FT152）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.83';
+    public const string VERSION = '1.5.84';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- クーポン・プロモコード管理システムを実装（couponlog を FT34 から FT150 として再構築）
- admin RBAC: クーポン作成・無効化・利用履歴閲覧は admin のみ
- 1ユーザー1利用制限: `UNIQUE (coupon_id, user_id)` + アプリ層事前チェック
- discount_pct: 1〜100 の整数制約（アプリ + DB の二重防御）
- user_id 注入防止: X-User-Id ヘッダーのみから取得
- テスト 34/34 Pass (22 正常 + 12 脆弱性診断)

## Changes

- `docs/howto/coupon-promo-code.md` — 実装ガイド
- `docs/field-trials/2026-05-field-trial-150.md` — FT レポート（6 ペルソナ DX レビュー）
- `src/FrameworkInfo.php` — VERSION 1.5.84
- `docs/openapi/openapi.yaml` — version 1.5.84
- `CHANGELOG.md` — v1.5.84 エントリ追加
- `docs/todo/current.md` — FT150 完了行追加

## Validation

- `CouponTest.php`: 22/22 Pass（SQLite）
- `VulnTest.php`: 12/12 Pass（VULN-A〜L）
- PHPStan level 8: Pass
- PHP CS Fixer: Pass

## Related

Closes #804

Self-review: backend-api, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)