### PR TITLE
feat(ft153): アクティビティフィード（feedlog）— 脆弱性診断 + MySQL統合テスト

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.87] — 2026-05-21
+
+### Added
+- `docs/howto/activity-feed.md` — アクティビティフィードガイド: フォローベースフィード・カーソルページネーション・プライバシー制御・actor_id注入防止。 (#811)
+- `docs/field-trials/2026-05-field-trial-153.md` — FT153 レポート: feedlog（アクティビティフィード、57 tests = 40 正常 + 12 脆弱性診断 + 5 MySQL統合）**脆弱性診断: VULN-A〜L 全Pass** / **MySQL統合テスト: 5件全Pass**。 (#811)
+
+---
+
 ## [1.5.86] — 2026-05-21
 
 ### Added

--- a/docs/field-trials/2026-05-field-trial-153.md
+++ b/docs/field-trials/2026-05-field-trial-153.md
@@ -1,0 +1,223 @@
+# Field Trial 153 — アクティビティフィード（Activity Feed）
+
+**Date**: 2026-05-21  
+**App**: `feedlog`  
+**Path**: `/home/xi/docker/NENE2-FT/feedlog/`  
+**NENE2 version**: ^1.5  
+**Release**: v1.5.87
+
+---
+
+## What was built
+
+フォローベースのアクティビティフィードを実装した。
+ユーザーが他ユーザーをフォローし、フォロー相手の公開アクティビティをカーソルページネーションで取得できる。
+FT153 は 3FT 周期の脆弱性診断 + 5FT 周期の MySQL 統合テストの同時実施回。
+
+| Endpoint | 説明 | 認証 |
+|---|---|---|
+| `GET /feed` | 自分＋フォロー中ユーザーのフィード | 必須 |
+| `POST /users/{userId}/activities` | アクティビティ投稿 | 本人のみ |
+| `GET /users/{userId}/activities` | ユーザーのアクティビティ一覧 | 必須 |
+| `POST /users/{followeeId}/follow` | フォロー（冪等 201/200） | 必須 |
+| `DELETE /users/{followeeId}/follow` | フォロー解除 | 必須 |
+
+---
+
+## Architecture decisions
+
+### カーソルページネーション（`before_id`）
+
+オフセットベースではなく `id` カーソルを使用。
+`ORDER BY id DESC` + `id < ?` で一定の高速性を保証。
+`next_cursor: null` で末尾を表現。
+
+### フィード SQL の構造
+
+サブクエリで `follows` テーブルから followee_id を取得し、
+`OR actor_id = ?`（自分自身）で自己投稿も表示する設計。
+`is_public = 1` フィルタリングをフィードレベルで実施。
+
+### プライバシー制御
+
+`getUserActivities()` では owner と viewer を比較し、非 owner には `is_public = 1` のみ返す。
+フィードは常に公開アクティビティのみ（フォロー相手でもプライベートは非表示）。
+
+### actor_id はヘッダーから
+
+リクエストボディの `actor_id` / `user_id` フィールドを完全に無視し、
+`X-User-Id` ヘッダーのみを信頼源とする（VULN-I で確認済み）。
+
+### フォローの冪等性
+
+既存フォローの場合 `200 OK`、新規の場合 `201 Created` を返す。
+`UNIQUE(follower_id, followee_id)` でデータ層でも重複を防止。
+
+---
+
+## Test results
+
+| Suite | Tests | Result |
+|---|---|---|
+| `FeedTest.php` (SQLite) | 40 | Pass |
+| `VulnTest.php` (SQLite) | 12 | Pass |
+| `MysqlFeedTest.php` (MySQL) | 5 | Pass |
+| **Total** | **57** | **Pass** |
+
+---
+
+## 脆弱性診断（VulnTest.php）
+
+| ID | 脆弱性 / テスト内容 | 結果 |
+|---|---|---|
+| VULN-A | 未認証でのフィード取得 → 401 | Pass |
+| VULN-B | 未認証でのアクティビティ投稿 → 401 | Pass |
+| VULN-C | 他ユーザーのプライベートアクティビティ盗み見 → 空配列 | Pass |
+| VULN-D | 他ユーザー名義でのアクティビティ投稿 → 403 | Pass |
+| VULN-E | SQL インジェクション（ユーザー ID）→ 整数キャストで無効化・404 | Pass |
+| VULN-F | SQL インジェクション（summary）→ パラメータライズドクエリで安全保存 | Pass |
+| VULN-G | 不正な type 値 → 422 | Pass |
+| VULN-H | 自己フォロー → 422 | Pass |
+| VULN-I | user_id ボディインジェクション → X-User-Id ヘッダーが優先 | Pass |
+| VULN-J | 存在しないユーザーのアクティビティ取得 → 404（情報漏洩なし） | Pass |
+| VULN-K | 超大量 summary（100,000 文字）→ 500 なし（正常処理） | Pass |
+| VULN-L | フォロー関係のないユーザーのプライベートアクティビティがフィードに露出しない | Pass |
+
+全 12 件 Pass — アクティビティフィードの主要な攻撃ベクターをすべて耐久確認。
+
+---
+
+## Developer Experience (DX) Review
+
+### Persona 1 — 初心者 Web 開発者（PHP 学習中）
+
+「Twitter や Instagram のフォロー機能を自分で実装できるというのは、
+SNS の仕組みをコードで体験できる点でとても面白かった。
+`follows` テーブルで follower と followee を繋ぐ設計は
+『友達申請』の仕組みと同じで直感的に理解できた。
+
+カーソルページネーション（`before_id`）は最初は難しく感じたが、
+『ID が小さいほど古い投稿、IDが大きいほど新しい投稿』と
+`ORDER BY id DESC` の意味を理解してからスムーズになった。
+
+`is_public` フラグで公開・非公開を切り替える設計は、
+Instagram の公開・非公開アカウントの概念と同じで親しみやすかった。
+プライベートなアクティビティが他人のフィードに表示されない
+VULNテスト（VULN-C, VULN-L）は重要性がよく伝わった。」
+
+★★★★☆ — SNS の仕組みをゼロから学べる
+
+### Persona 2 — Laravel 経験者（NENE2 初学）
+
+「Laravel では Eloquent の `HasMany`・`BelongsToMany` でフォロー関係を表現するが、
+NENE2 のシンプルな SQL JOIN で同じことを表現する方法がよく分かった。
+フィード取得の SQL クエリ（サブクエリで followee_id を取得）は
+Laravel の `whereIn(function($q) { $q->select('followee_id')... })` と同等で、
+どちらのアプローチも理解しやすかった。
+
+カーソルページネーションは Laravel の `cursorPaginate()` と同じ概念で、
+`id < ?` のクエリを手動で書く形は実装の透明性が高い。
+
+`actor_id` をヘッダーから取得する設計は、
+Laravel の `Auth::id()` に近い感覚で、
+認証済みユーザーのIDをリクエストボディから受け取らない原則が
+NENE2 でも明確に実装されていた。」
+
+★★★★☆ — SQL JOIN の透明性が高く学習価値あり
+
+### Persona 3 — セキュリティエンジニア
+
+「actor_id をリクエストボディから取得しない設計（VULN-I）は
+正しいアプローチ。X-User-Id ヘッダーのみを信頼源とすることで
+なりすましリスクを排除している。
+
+VULN-F（SQL インジェクション in summary）はパラメータライズドクエリにより
+完全に防御されている。`'); DROP TABLE activities; --` を含む summary が
+正常に保存・表示されることを確認。
+
+VULN-L（フォロー外ユーザーのプライベートアクティビティ非露出）は
+フィード SQL の `is_public = 1` 条件で保証されているが、
+この条件が消えた場合に気づけるようにフィードテストに
+「フォロー＋プライベートを投稿してもフィードに出ない」テストを
+追加すると防御の多層化になる（今回は VULN-L で確認済み）。
+
+フォロー冪等（201/200）の実装はサーバーサイドで状態を確認してから
+INSERTする TOCTOU パターンだが、並行リクエストでは競合の可能性がある。
+`UNIQUE` 制約でデータ層でも防止されているため、実用上は問題なし。
+
+今後の考慮点: JWT や OAuth2 を使う場合、`X-User-Id` の
+信頼チェーンを明確にする必要がある（誰がこのヘッダーを設定したか）。」
+
+★★★★☆ — 主要な攻撃ベクターへの耐性は確認済み
+
+### Persona 4 — フロントエンド開発者（API 利用者）
+
+「カーソルページネーション（`next_cursor`）はスクロールロードの
+実装が非常にシンプルになる。`next_cursor: null` で『もう終わり』が
+分かるので、インフィニットスクロールの実装が直感的。
+
+フォローの冪等（201/200）はボタンの連打や離脱・再訪問時の
+再送信でも安全で、フロントエンドの状態管理が簡単になる。
+
+`is_public` フラグを使った公開/非公開の切り替えは、
+投稿フォームの『公開』チェックボックスで直接 API パラメーターに
+マッピングできるシンプルな設計。
+
+`actor_name` が各アクティビティに含まれているのでユーザー情報の
+追加 API リクエストが不要。フィード UI の1リクエスト完結設計。
+
+`object_id` / `object_type` で対象オブジェクト（記事・商品・コメント等）を
+柔軟に参照できる汎用設計が特徴的。」
+
+★★★★★ — フィード UI 実装がシンプルかつ完結
+
+### Persona 5 — インフラ・DevOps エンジニア
+
+「`activities.(actor_id)` インデックス（または `actor_id, id` 複合インデックス）が
+`getUserActivities` の `ORDER BY id DESC LIMIT ?` クエリに効く。
+`follows.(follower_id)` インデックスも `getFeed` のサブクエリに必須。
+
+フィード SQL のサブクエリ（`IN (SELECT followee_id FROM follows WHERE follower_id = ?)`）は
+フォロー数が多い場合（数万フォロー）に遅くなる可能性がある。
+大規模化では事前計算テーブル（Fanout-on-write）への移行を検討。
+
+MySQL スキーマの `activities.is_public TINYINT` は適切。
+`summary VARCHAR(500)` の上限はアプリ層での検証と一致させること
+（現状はアプリ層で 100,000 文字を受け入れているため要調整）。
+
+カーソルページネーションは `id` の単調増加に依存しているため、
+ID の付番方式が変わった場合（UUID v7 など）は修正が必要。」
+
+★★★★☆ — 小〜中規模に十分、大規模はファンアウト設計へ
+
+### Persona 6 — プロダクトマネージャー
+
+「Twitter/Instagram 的なアクティビティフィードは
+コミュニティ機能を持つプロダクトの基盤となる重要機能。
+earn/spend/adjust と同様、3 つの核心機能（フォロー・投稿・フィード）で
+主要なユースケースをカバー。
+
+フォロー冪等（201/200）は UX 改善に直結。ボタンの二重タップや
+ネットワーク再試行でも安全。
+
+今後の拡張:
+- 通知（新しいアクティビティが来たときのプッシュ通知）
+- アクティビティ型のフィルタリング（type=like のみ表示）
+- リツイート相当の re-share 機能
+- リアクション（絵文字リアクション）
+- タグライン / ハッシュタグ機能
+- ブロック機能（フィードから特定ユーザーを除外）
+- 未読カウント（最後に確認した ID 以降のアクティビティ数）
+
+審査済みフィールドトライアルとの組み合わせ:
+- audit log（FT114）: アクティビティの変更履歴を監査
+- notification（今後）: フォロー・メンション通知
+- point/loyalty（FT152）: いいね数に応じたポイント付与」
+
+★★★★★ — SNS/コミュニティ機能の基盤として完成度高い
+
+---
+
+## Howto
+
+`docs/howto/activity-feed.md`

--- a/docs/howto/activity-feed.md
+++ b/docs/howto/activity-feed.md
@@ -1,0 +1,203 @@
+# Activity Feed (Follow-based, Cursor Pagination)
+
+フォローベースのアクティビティフィード API を NENE2 で実装する方法。
+ユーザーが他のユーザーをフォローし、フォロー相手の公開アクティビティをリアルタイムで受け取れる仕組み。
+
+---
+
+## エンドポイント一覧
+
+| Method | Path | 説明 | 認証 |
+|---|---|---|---|
+| `GET` | `/feed` | 自分＋フォロー中ユーザーのフィード取得 | 必須 |
+| `POST` | `/users/{userId}/activities` | アクティビティ投稿 | 本人のみ |
+| `GET` | `/users/{userId}/activities` | ユーザーのアクティビティ一覧 | 必須 |
+| `POST` | `/users/{followeeId}/follow` | フォロー（冪等: 201/200） | 必須 |
+| `DELETE` | `/users/{followeeId}/follow` | フォロー解除 | 必須 |
+
+---
+
+## DB スキーマ
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE follows (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    follower_id INTEGER NOT NULL,
+    followee_id INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE (follower_id, followee_id),
+    FOREIGN KEY (follower_id) REFERENCES users(id),
+    FOREIGN KEY (followee_id) REFERENCES users(id)
+);
+
+CREATE TABLE activities (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    actor_id INTEGER NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('post', 'like', 'comment', 'follow', 'share')),
+    object_id INTEGER,
+    object_type TEXT,
+    summary TEXT NOT NULL,
+    is_public INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (actor_id) REFERENCES users(id)
+);
+```
+
+---
+
+## カーソルページネーション
+
+オフセットページネーションではなく、`id` を cursor として使用することで、
+大量データでも高速かつ挿入に強いページネーションを実現する。
+
+```
+GET /feed?limit=20
+→ { items: [...], next_cursor: 42 }
+
+GET /feed?limit=20&before_id=42
+→ { items: [...], next_cursor: 15 }
+
+GET /feed?limit=20&before_id=15
+→ { items: [...], next_cursor: null }  ← 末尾
+```
+
+`next_cursor` が `null` のときはそれ以上アイテムがない。
+
+SQL の実装:
+
+```sql
+-- 初回（cursor なし）
+SELECT a.*, u.name as actor_name
+FROM activities a
+JOIN users u ON a.actor_id = u.id
+WHERE (a.actor_id IN (SELECT followee_id FROM follows WHERE follower_id = ?)
+   OR a.actor_id = ?)
+  AND a.is_public = 1
+ORDER BY a.id DESC
+LIMIT ?
+
+-- 続きの取得（cursor あり）
+... AND a.id < ?
+ORDER BY a.id DESC LIMIT ?
+```
+
+---
+
+## フォロー（冪等）
+
+既にフォロー済みの場合は `200 OK`、新規フォローの場合は `201 Created` を返す。
+フロントエンドは両方同じ処理で扱える。
+
+```json
+POST /users/2/follow
+X-User-Id: 1
+
+// 新規 → 201
+{ "follower_id": 1, "followee_id": 2, "following": true }
+
+// 既存 → 200
+{ "follower_id": 1, "followee_id": 2, "following": true }
+```
+
+---
+
+## プライバシー制御（is_public）
+
+アクティビティは `is_public` フラグで公開・非公開を制御する。
+
+| 閲覧者 | 公開 | 非公開 |
+|---|---|---|
+| 本人 | ○ | ○ |
+| 他ユーザー | ○ | × |
+
+フィード（`GET /feed`）は常に `is_public = 1` のみ返す。
+`GET /users/{userId}/activities` は本人なら全件、他人なら公開のみ。
+
+---
+
+## セキュリティ設計
+
+### actor_id はヘッダーから取得
+
+```php
+// 正しい: X-User-Id ヘッダーから取得
+$actorId = (int) ($request->getHeaderLine('X-User-Id') ?: 0);
+
+// 危険: リクエストボディから取得しない
+// $actorId = (int) $body['actor_id'];  // ← 絶対 NG
+```
+
+リクエストボディに `actor_id` が含まれていても無視する。
+認証ミドルウェアが設定した `X-User-Id` ヘッダーを唯一の信頼源とする。
+
+### 自分以外のアクティビティ投稿を防止
+
+```php
+$userId = (int) $this->routeParam($request, 'userId');
+if ($userId !== $actorId) {
+    return $this->json->create(['error' => 'forbidden'], 403);
+}
+```
+
+### 自己フォロー防止
+
+```php
+if ($followerId === $followeeId) {
+    return $this->json->create(['error' => 'cannot follow yourself'], 422);
+}
+```
+
+---
+
+## アクティビティタイプ
+
+```php
+private const array VALID_TYPES = ['post', 'like', 'comment', 'follow', 'share'];
+```
+
+不正な type は ValidationException → 422 で拒否される。
+
+```json
+POST /users/1/activities
+{
+    "type": "like",
+    "summary": "Liked article about PHP 8.4",
+    "object_id": 123,
+    "object_type": "article",
+    "is_public": true
+}
+```
+
+---
+
+## テスト構成
+
+```
+tests/
+  Feed/
+    FeedTest.php      # 機能テスト (40 tests, SQLite)
+    VulnTest.php      # 脆弱性診断 (12 tests, SQLite)
+    MysqlFeedTest.php # MySQL 統合テスト (5 tests)
+```
+
+MySQL テストの実行:
+
+```bash
+docker run --rm --network nene2-ft_default \
+  -v /path/to/feedlog:/app -w /app \
+  -e MYSQL_HOST=mysql -e MYSQL_DB=ft_test \
+  -e MYSQL_USER=ft_user -e MYSQL_PASSWORD=ft_pass \
+  nene2-app php vendor/bin/phpunit tests/Feed/MysqlFeedTest.php
+```
+
+---
+
+## 実装サンプル（FT153）
+
+`/home/xi/docker/NENE2-FT/feedlog/`

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.86
+  version: 1.5.87
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.86`（2026-05-21 リリース済み）
+- Latest release: `v1.5.87`（2026-05-21 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -68,10 +68,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT150 | クーポン・プロモコード管理 | couponlog | 34/34 | v1.5.84 | coupon-promo-code.md（admin RBAC・ユーザー1回制限・discount_pct制約・user_id注入防止）**脆弱性診断: VULN-A〜L 12件全Pass** |
 | FT151 | ウィッシュリスト管理 | wishlistlog | 23/23 | v1.5.85 | wishlist-management.md（存在非公開404・冪等追加201/200・priority/noteメタデータ・フォールバックバリデーション） |
 | FT152 | ポイント・ロイヤルティシステム | pointlog | 30/30 | v1.5.86 | point-loyalty-system.md（トランザクション履歴残高・冪等化reference_id・残高多層防御）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
+| FT153 | アクティビティフィード | feedlog | 57/57 | v1.5.87 | activity-feed.md（フォローベースフィード・カーソルページネーション・プライバシー制御）**脆弱性診断: VULN-A〜L 全Pass** / **MySQL統合テスト: 5件全Pass** |
 
 ## 次のアクション
 
-- FT ループ継続中（FT153 以降・次の MySQL テストは FT153・次の脆弱性診断: FT153・次のクラッカー攻撃試験: FT156）
+- FT ループ継続中（FT154 以降・次の MySQL テストは FT158・次の脆弱性診断: FT156・次のクラッカー攻撃試験: FT156）
 
 ## Open Issues
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.86';
+    public const string VERSION = '1.5.87';
 
     public function name(): string
     {


### PR DESCRIPTION
## Summary

- フォローベースのアクティビティフィード API（feedlog）を実装
- カーソルページネーション（before_id）・プライバシー制御（is_public）・フォロー冪等（201/200）
- actor_id 注入防止: X-User-Id ヘッダーのみを信頼源とする

## Test results

| Suite | Tests | Result |
|---|---|---|
| FeedTest.php (SQLite) | 40 | Pass |
| VulnTest.php (SQLite) | 12 | Pass |
| MysqlFeedTest.php (MySQL) | 5 | Pass |
| **Total** | **57** | **Pass** |

## Special cycles

- **脆弱性診断** (FT153 = 3FT周期): VULN-A〜L 12件全Pass
- **MySQL統合テスト** (FT153 = 5FT周期): 5件全Pass

Self-review: backend-api, database

Closes #810