### PR TITLE
docs: howto ライブラリスプリント マイルストーン・ロードマップを整備

### DIFF
--- a/docs/milestones/2026-05-howto-library-sprint.md
+++ b/docs/milestones/2026-05-howto-library-sprint.md
@@ -1,0 +1,142 @@
+# Milestone: Howto Library Sprint
+
+## Goal
+
+Build a comprehensive, tested howto guide library covering the most common JSON API patterns,
+so that any developer (or AI agent) using NENE2 can implement production-ready features
+by following a self-contained guide with a reference field trial implementation.
+
+## Theme: Pattern Coverage × Security by Default
+
+Every guide ships with a reference field trial app (in `../NENE2-FT/<name>/`) and a
+corresponding PHPUnit test suite. Security assessments and attack tests are woven into
+the loop on a fixed cadence, ensuring guides document safe patterns by default.
+
+---
+
+## Phase I — FT96–FT120: Documentation Catch-up Sprint
+
+Goal: backfill howto guides for all FTs completed before the sprint began.
+
+| Range | Focus |
+|---|---|
+| FT96–FT105 | Content negotiation, SQL injection, file upload, CSRF/idempotency, pagination, nested JSON validation, transactions, mass assignment, webhook signature, optimistic locking |
+| FT106–FT115 | ETag, rate limiting, soft delete, password hashing, JWT auth, RBAC, multi-tenant isolation, JWT refresh token rotation, audit trail, API versioning |
+| FT116–FT120 | Background job queue, API key management, signed URLs, circuit breaker, outbound webhook delivery |
+
+Status: **✅ Complete** — howto guides merged into `docs/howto/`.
+
+---
+
+## Phase II — FT121–FT156: Implementation Sprint
+
+Goal: run full field trial implementations (code + tests + howto) for 36 new patterns,
+integrated with security assessments and MySQL integration tests.
+
+### Completed patterns
+
+| FT | Pattern | Tests | Security |
+|---|---|---|---|
+| FT121 | Feature flags (rollout_pct, kill switch) | 21/21 | — |
+| FT122 | Distributed locking (owner, stale claim) | 16/16 | — |
+| FT123 | Personal data export (opaque token, PII) | 19/19 | Vuln |
+| FT124 | User invitation (256-bit token, cancel ownership) | 26/26 | Cracker |
+| FT125 | Tagging system (M:N, atomic replace) | 20/20 | — |
+| FT126 | Password reset (hash, constant-time) | 15/15 | Vuln |
+| FT127 | Threaded comments (depth, soft delete) | 20/20 | — |
+| FT128 | Account lockout (brute-force defense) | 32/32 | Cracker + MySQL |
+| FT129 | Event sourcing (append-only, replay) | 17/17 | Vuln |
+| FT130 | Notification inbox (idempotent mark-read) | 23/23 | — |
+| FT131 | Comment voting (toggle, VoteDirection enum) | 20/20 | — |
+| FT132 | User profile management | 32/32 | Cracker + Vuln |
+| FT133 | Bookmark system | 22/22 | MySQL |
+| FT134 | User follow (mutual follow, self-follow guard) | 20/20 | — |
+| FT135 | Direct messaging (conversation isolation) | 31/31 | Vuln |
+| FT136 | Access token management (scoped, rotate) | 29/29 | Cracker |
+| FT137 | Subscription management | 20/20 | — |
+| FT138 | Group membership (MemberRole enum) | 38/38 | Vuln + MySQL |
+| FT139 | Guest order (price snapshot, stock check) | 23/23 | — |
+| FT140 | Flash sale (COUNT residual, ISO 8601 compare) | 29/29 | Cracker |
+| FT141 | Leaderboard ranking | 29/29 | Vuln |
+| FT142 | Content draft lifecycle (ArticleStatus enum) | 20/20 | — |
+| FT143 | Emoji reactions (UNIQUE, GROUP BY) | 23/23 | MySQL |
+| FT144 | Passwordless auth (Magic Link) | 43/43 | Vuln + Cracker |
+| FT145 | User preferences (PreferenceKey enum, upsert) | 20/20 | — |
+| FT146 | Content pinning (position compaction) | 19/19 | — |
+| FT147 | Content reporting / moderation (RBAC) | 32/32 | Vuln |
+| FT148 | OTP authentication (3-attempt lockout) | 35/35 | Cracker + MySQL |
+| FT149 | Content collections | 20/20 | — |
+| FT150 | Coupon / promo code (admin RBAC) | 34/34 | Vuln |
+| FT151 | Wishlist management | 23/23 | — |
+| FT152 | Points / loyalty (transaction history, idempotency) | 30/30 | Cracker |
+| FT153 | Activity feed (follow-based, cursor pagination) | 57/57 | Vuln + MySQL |
+| FT154 | Product review system (1-user-1-product) | 29/29 | — |
+| FT155 | Shopping cart (UNIQUE, quantity accumulation) | 28/28 | — |
+| FT156 | File metadata sharing (3-tier access, IDOR) | 59/59 | Vuln + Cracker |
+
+Status: **✅ Complete** — v1.5.90, 87 howto guides in `docs/howto/`.
+
+---
+
+## Phase III — FT157–FT170: Library Completion
+
+Goal: cover the remaining core patterns to complete the initial howto library.
+
+### Planned patterns
+
+| FT | Pattern | App | Security cadence |
+|---|---|---|---|
+| FT157 | Search & Autocomplete | searchlog | — |
+| FT158 | CSV Bulk Import | importlog | MySQL |
+| FT159 | TOTP Two-Factor Auth | totplog | Vuln |
+| FT160 | OAuth2 / Social Login pattern | oauthlog | Cracker |
+| FT161 | Application Caching (key design, invalidation) | cachelog | — |
+| FT162 | Content Versioning (history, diff, rollback) | versionlog | — |
+| FT163 | Payment Webhook (idempotent payment) | paymentlog | — |
+| FT164 | Geolocation (distance queries, bounding box) | geoloclog | MySQL |
+| FT165 | A/B Testing (experiment assignment, metrics) | ablog | Vuln |
+| FT166 | Multi-step Workflow (state machine, approval) | workflowlog | Cracker |
+| FT167 | Inbound Webhook Receiver | inboundlog | MySQL |
+| FT168 | Admin Report Aggregation | reportlog | — |
+| FT169 | Data Masking (PII field masking) | masklog | Vuln |
+| FT170 | Request Deduplication (at-most-once processing) | deduplog | Cracker |
+
+Status: **🔄 In progress** — starts FT157.
+
+---
+
+## Post-Sprint Actions
+
+After FT170:
+
+1. **Howto index overhaul** — `docs/howto/README.md` full 90+ guide index with search tags
+2. **VitePress site update** — add new howto pages to the documentation site
+3. **v2.0 design discussion** — review friction points accumulated across FT96–FT170
+   to decide what should move into the framework core vs. remain as howto-only patterns
+4. **Milestone: Howto Library v1** — tag the library as a usable reference corpus
+
+---
+
+## Security Cadence Summary
+
+| Type | Frequency | Next |
+|---|---|---|
+| 脆弱性診断 | Every 3rd FT from FT114 | FT159 |
+| クラッカー攻撃試験 | Every 4th FT from FT120 | FT160 |
+| MySQL 統合テスト | Every ~5th FT | FT158 |
+
+---
+
+## Acceptance Criteria (Phase III)
+
+- [ ] FT157–FT170 each merged to `main` with passing tests
+- [ ] 101+ howto guides in `docs/howto/`
+- [ ] All security assessments: VULN-A〜L Pass
+- [ ] All attack tests: ATK-01〜12 Pass
+- [ ] `docs/howto/README.md` updated with all new entries
+- [ ] `docs/todo/current.md` updated after each FT
+
+## Tracked by
+
+- Roadmap phases: 70–73 in `docs/roadmap.md`
+- Related milestones: `docs/milestones/2026-05-v1.1.md`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -739,6 +739,73 @@ App: **postboard** — 投稿ボード API (CompositeAuthMiddleware + M:N + JWT 
 Result: 31/31 PHPUnit, PHPStan level 8, PHP-CS-Fixer 全通過。摩擦 4 件（F-1〜F-4）。
 F-1 最重要: CompositeAuthMiddleware が v1.4.1 未収録 → v1.4.2 リリースで解消（Issue #481）。
 
+## Phase 70: Howto Library Sprint — Phase I: Documentation Catch-up ✓
+
+Goal: backfill howto guides for FT96–FT120, covering patterns implemented before
+the sprint formally began, to ensure every field trial has a self-contained guide.
+
+- `docs/howto/` guides for content negotiation, SQL injection, file upload, CSRF/idempotency,
+  pagination, nested JSON validation, transactions, mass assignment, webhook signature,
+  optimistic locking, ETag, rate limiting, soft delete, password hashing, JWT auth, RBAC,
+  multi-tenant isolation, JWT refresh token rotation, audit trail, API versioning,
+  background job queue, API key management, signed URLs, circuit breaker, outbound webhook delivery
+- Each guide links to field trial report and reference implementation
+
+Tracked by `docs/milestones/2026-05-howto-library-sprint.md`.
+
+## Phase 71: Howto Library Sprint — Phase II: Implementation Sprint ✓
+
+Goal: run 36 full field trial implementations (FT121–FT156) with code, tests, and howto guides,
+maintaining security cadence throughout.
+
+- Feature flags, distributed locking, personal data export, user invitation, tagging (M:N),
+  password reset, threaded comments, account lockout, event sourcing, notification inbox,
+  comment voting, user profile, bookmarks, user follow, direct messaging, access token management,
+  subscription management, group membership, guest order, flash sale, leaderboard,
+  content draft lifecycle, emoji reactions, passwordless auth (Magic Link), user preferences,
+  content pinning, content reporting/moderation, OTP auth, content collections, coupon management,
+  wishlist, points/loyalty, activity feed, product reviews, shopping cart, file metadata sharing
+- Reached **87 howto guides** and **v1.5.90**
+- Security coverage: 10 vulnerability assessments + 8 cracker attack tests + 6 MySQL test sessions
+
+Tracked by `docs/milestones/2026-05-howto-library-sprint.md`.
+
+## Phase 72: Howto Library Sprint — Phase III: Library Completion
+
+Goal: cover the remaining core API patterns (FT157–FT170) to complete the initial howto library,
+reaching ~100 self-contained guides with full test coverage and security assessments.
+
+- Search & autocomplete, CSV bulk import, TOTP two-factor auth, OAuth2/social login pattern,
+  application caching, content versioning, payment webhook, geolocation queries, A/B testing,
+  multi-step workflow (state machine), inbound webhook receiver, admin report aggregation,
+  data masking (PII), request deduplication
+- Security cadence: vuln assessment at FT159/FT165/FT169, cracker attack at FT160/FT166/FT170
+- MySQL integration tests at FT158/FT164/FT167
+
+Tracked by `docs/milestones/2026-05-howto-library-sprint.md`.
+
+## Phase 73: Howto Library Consolidation
+
+Goal: make the 100+ guide library navigable and publish it as a reference corpus.
+
+- `docs/howto/README.md` full index with categories, search tags, and cross-links
+- VitePress documentation site updated with all new howto pages
+- Sidebar / nav restructured around pattern categories
+  (Auth, Security, Database, API Design, Social, E-commerce, System Patterns)
+- "Pattern finder" guide: map business requirements to howto guides
+- Tag the library milestone as **Howto Library v1**
+
+## Phase 74: v2.0 Design and Framework Evolution
+
+Goal: review the friction and gaps accumulated across FT96–FT170 and decide
+what moves into the framework core vs. remains as howto-only patterns.
+
+- Collect top-friction patterns from field trial reports
+- ADR for each framework-level change candidate
+- Identify stable surface additions that the FT loop has validated
+- Draft v2.0 breaking change scope (if any)
+- Consumer project validation using `composer require hideyukimori/nene2:^2.0`
+
 ## Non-Goals
 
 - Recreating Laravel or Symfony.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -73,9 +73,43 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT155 | ショッピングカート | cartlog | 28/28 | v1.5.89 | shopping-cart.md（UNIQUE制約・数量加算冪等・quantity=0削除・price都度計算・RuntimeApplicationFactory必須） |
 | FT156 | ファイルメタデータ管理・共有 | filelog | 59/59 | v1.5.90 | file-metadata-sharing.md（3段階アクセス制御・IDOR防止 404・visibility エスカレーション防止・FK順序削除）**脆弱性診断: VULN-A〜L 全Pass** / **クラッカー攻撃試験: ATK-01〜12 全Pass** |
 
-## 次のアクション
+## 次のアクション（2026-05-22〜）
 
-- FT ループ継続中（FT156 完了・次の MySQL テストは FT158・次の脆弱性診断: FT159・次のクラッカー攻撃試験: FT160）
+### FT ループ継続（Howto Library Sprint Phase III）
+
+目標: **FT170 完了**でコアパターンライブラリを一区切りにする。
+
+| FT | テーマ案 | 備考 |
+|---|---|---|
+| FT157 | Search & Autocomplete（searchlog） | 全文検索・候補補完エンドポイント |
+| FT158 | CSV Bulk Import（importlog） | **MySQL 統合テスト** |
+| FT159 | TOTP 二要素認証（totplog） | **脆弱性診断** |
+| FT160 | OAuth2 / Social Login パターン（oauthlog） | **クラッカー攻撃試験** |
+| FT161 | Application Caching（cachelog） | キャッシュキー設計・無効化 |
+| FT162 | Content Versioning（versionlog） | 履歴管理・diff・ロールバック |
+| FT163 | Payment Webhook（paymentlog） | 冪等決済・べき等キー |
+| FT164 | Geolocation（geoloclog） | 距離クエリ・バウンディングボックス |
+| FT165 | A/B Testing（ablog） | 実験割当・メトリクス収集 |
+| FT166 | Multi-step Workflow（workflowlog） | ステートマシン・承認フロー |
+| FT167 | Inbound Webhook Receiver（inboundlog） | **MySQL 統合テスト** |
+| FT168 | Admin Report Aggregation（reportlog） | 集計クエリ・ダッシュボードパターン |
+| FT169 | Data Masking（masklog） | **脆弱性診断** PII フィールドマスク |
+| FT170 | Request Deduplication（deduplog） | **クラッカー攻撃試験** 二重送信防止 |
+
+### ループ終了後（FT170 以降）
+
+- **howto 索引（README.md）** の全 90+ ガイド分類整備
+- **VitePress サイト**への新規 howto ページ追加
+- **v2.0 設計検討**: FT ループで判明した摩擦点をもとにフレームワーク本体の次バージョン方針を議論
+- マイルストーン: `docs/milestones/2026-05-howto-library-sprint.md`
+
+### 次のトリガー値
+
+| チェック項目 | 次回 |
+|---|---|
+| MySQL 統合テスト | FT158 |
+| 脆弱性診断 | FT159 |
+| クラッカー攻撃試験 | FT160 |
 
 ## Open Issues
 


### PR DESCRIPTION
## 目的

FT156 完了（v1.5.90・howto 87 ガイド）を節目に、howto ライブラリスプリントの
マイルストーンとロードマップを整備する。

## 変更点

- `docs/milestones/2026-05-howto-library-sprint.md` — 新規（Phase I〜III 定義）
- `docs/roadmap.md` — Phase 70〜74 追加
- `docs/todo/current.md` — FT157〜FT170 方針・次のトリガー値を更新

## 検証

- `composer check` — 全 Pass（v1.5.90）

## 今日の成果サマリー（参照）

| 指標 | 値 |
|---|---|
| 完了 FT | FT99〜FT156（58 件） |
| バージョン | v1.5.33 → v1.5.90（+57） |
| howto 総数 | 87 ガイド |
| 脆弱性診断 / 攻撃試験 | 10 回 / 8 回（全 Pass） |
| リモートブランチ清掃 | 386 本 → 0 本 |

Closes #818

Self-review: docs-policy