### PR TITLE
feat(ft): FT161 Application Caching (cachelog)

### DIFF
--- a/docs/howto/application-caching.md
+++ b/docs/howto/application-caching.md
@@ -1,0 +1,214 @@
+# Application Caching の実装ガイド
+
+## 概要
+
+このガイドでは NENE2 を使ってアプリケーションキャッシュを実装する方法を説明します。
+Cache-Aside（ルックアサイド）パターン・TTL ベース期限・書き込み時無効化・統計を REST API として提供します。
+
+---
+
+## エンドポイント設計
+
+| メソッド | パス | 説明 |
+|---|---|---|
+| GET | `/products` | 商品一覧（キャッシュあり） |
+| GET | `/products/{id}` | 商品詳細（キャッシュあり） |
+| POST | `/products` | 商品作成（一覧キャッシュを無効化） |
+| PUT | `/products/{id}` | 商品更新（個別＋一覧を無効化） |
+| DELETE | `/products/{id}` | 商品削除（個別＋一覧を無効化） |
+| POST | `/cache/clear` | 全キャッシュクリア |
+| GET | `/cache/stats` | ヒット数・ミス数・エントリ数 |
+
+---
+
+## キャッシュインターフェース
+
+```php
+interface CacheInterface
+{
+    public function get(string $key): mixed;
+    public function set(string $key, mixed $value, int $ttl = 60): void;
+    public function delete(string $key): void;
+    public function flush(): void;
+    /** @return array{hits: int, misses: int, size: int} */
+    public function stats(): array;
+}
+```
+
+---
+
+## InMemoryCache（TTL 付きキャッシュ）
+
+```php
+class InMemoryCache implements CacheInterface
+{
+    private array $store  = [];
+    private array $expiry = [];
+    private int $hits     = 0;
+    private int $misses   = 0;
+
+    public function __construct(
+        private readonly int $defaultTtl = 60,
+        private readonly ?\Closure $clock = null, // テスト用クロック注入
+    ) {}
+
+    public function get(string $key): mixed
+    {
+        if (!array_key_exists($key, $this->store)) {
+            $this->misses++;
+            return null;
+        }
+        if ($this->expiry[$key] <= $this->now()) {
+            unset($this->store[$key], $this->expiry[$key]);
+            $this->misses++;
+            return null;
+        }
+        $this->hits++;
+        return $this->store[$key];
+    }
+
+    public function set(string $key, mixed $value, int $ttl = 0): void
+    {
+        $effectiveTtl = $ttl > 0 ? $ttl : $this->defaultTtl;
+        $this->store[$key]  = $value;
+        $this->expiry[$key] = $this->now() + $effectiveTtl;
+    }
+
+    private function now(): int
+    {
+        return $this->clock !== null ? ($this->clock)() : time();
+    }
+}
+```
+
+---
+
+## 設計のポイント
+
+### Cache-Aside パターン
+
+読み取り時にキャッシュを確認し、ミスなら DB から取得してキャッシュに保存する:
+
+```php
+public function handleGet(int $id): ResponseInterface
+{
+    $key = "product:{$id}";
+
+    $cached = $this->cache->get($key);
+    if ($cached !== null) {
+        return $this->json->create(array_merge($cached, ['cached' => true]));
+    }
+
+    $product = $this->repo->find($id);
+    if ($product === null) {
+        return $this->json->create(['error' => 'Not found'], 404);
+    }
+
+    $this->cache->set($key, $product);
+    return $this->json->create(array_merge($product, ['cached' => false]));
+}
+```
+
+### 書き込み時無効化
+
+create/update/delete 後は関連キャッシュを削除して次の読み取りで DB から新鮮なデータを取得させる:
+
+```php
+// POST /products
+$this->cache->delete('products:list');
+
+// PUT /products/{id}
+$this->cache->delete("product:{$id}");
+$this->cache->delete('products:list');
+
+// DELETE /products/{id}
+$this->cache->delete("product:{$id}");
+$this->cache->delete('products:list');
+```
+
+### キャッシュキー設計
+
+| パターン | キー例 |
+|---|---|
+| 単一リソース | `product:42` |
+| コレクション | `products:list` |
+| フィルター付き | `products:category:3:page:2` |
+| ユーザースコープ | `user:7:cart` |
+
+コレクションキャッシュは **書き込みが多い場合は TTL を短めに** 設定するか、**書き込み時に削除** する方針を選ぶ。
+
+### TTL 設計指針
+
+| データ性質 | 推奨 TTL |
+|---|---|
+| 静的マスター（カテゴリ等） | 5〜60 分 |
+| 在庫・価格（更新頻度中程度） | 30〜60 秒 |
+| ユーザーセッション系 | 必要に応じてセッション有効期限まで |
+| リアルタイム性が必要なデータ | キャッシュしない |
+
+### テスト: クロック注入で TTL をシミュレート
+
+実際の `time()` に依存せず、インジェクトしたクロックで時刻を制御できる:
+
+```php
+$time  = time();
+$clock = function () use (&$time): int { return $time; };
+$app   = AppFactory::createSqlite($dbFile, $clock);
+
+$this->req('GET', '/products/1'); // warm cache (TTL=60s)
+
+$time += 61; // advance clock past TTL
+
+$res = $this->req('GET', '/products/1');
+$this->assertFalse($data['cached']); // expired → cache miss
+```
+
+PHP の `static fn()` は参照キャプチャに非対応なため `function () use (&$time)` を使う。
+
+### キャッシュ統計でオブザーバビリティ
+
+```php
+GET /cache/stats
+→ {"hits": 42, "misses": 8, "size": 5}
+```
+
+ヒット率 = hits / (hits + misses)。本番では Prometheus/StatsD にエクスポートすることで
+キャッシュ効果を継続的に測定できる。
+
+---
+
+## レスポンス例
+
+### GET /products（1回目 — キャッシュミス）
+
+```json
+{
+  "products": [{"id": 1, "name": "Widget", "price": 9.99, "stock": 10}],
+  "cached": false
+}
+```
+
+### GET /products（2回目 — キャッシュヒット）
+
+```json
+{
+  "products": [...],
+  "cached": true
+}
+```
+
+### GET /cache/stats
+
+```json
+{
+  "hits": 5,
+  "misses": 2,
+  "size": 3
+}
+```
+
+---
+
+## 参照実装
+
+`../NENE2-FT/cachelog/` — FT161 フィールドトライアル（20 テスト・TTL 期限・書き込み無効化・統計）

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.94`（2026-05-22 リリース済み）
+- Latest release: `v1.5.95`（2026-05-22 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -76,6 +76,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT158 | CSV バルクインポート | importlog | 22/22 | v1.5.92 | csv-bulk-import.md（str_getcsv $escape 必須化・部分成功・バッチ内重複検知・CRLF 対応・errors JSON 永続化）**MySQL 統合テスト: 5テスト** |
 | FT159 | TOTP 二要素認証 | totplog | 32/32 | v1.5.93 | totp-authentication.md（RFC 6238・Base32・リプレイ防止 used_totp_steps・window=1 許容・hash_equals タイミング攻撃防止）**脆弱性診断: VULN-A〜L 全Pass** |
 | FT160 | OAuth2 Social Login | oauthlog | 22/22 | v1.5.94 | oauth2-social-login.md（Authorization Code Flow・state CSRF 防止・コードリプレイ防止・セッション無効化）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
+| FT161 | Application Caching | cachelog | 20/20 | v1.5.95 | application-caching.md（Cache-Aside・TTL クロック注入・書き込み時無効化・ヒット率統計） |
 
 ## 次のアクション（2026-05-22〜）
 
@@ -85,7 +86,6 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 | FT | テーマ案 | 備考 |
 |---|---|---|
-| FT161 | Application Caching（cachelog） | キャッシュキー設計・無効化 |
 | FT162 | Content Versioning（versionlog） | 履歴管理・diff・ロールバック |
 | FT163 | Payment Webhook（paymentlog） | 冪等決済・べき等キー |
 | FT164 | Geolocation（geoloclog） | 距離クエリ・バウンディングボックス |


### PR DESCRIPTION
## Summary

- Application Caching パターンを NENE2 で実装する FT161
- `../NENE2-FT/cachelog/` に参照実装・テスト・スキーマを追加
- `docs/howto/application-caching.md` に設計ガイドを追加

## 変更内容

- **Cache-Aside パターン**: read → cache miss → DB fetch → store（`cached` フラグでヒット/ミスを応答に含める）
- **書き込み時無効化**: create/update/delete で `product:{id}` と `products:list` を削除
- **TTL 期限**: デフォルト 60 秒、クロック注入（`\Closure(): int`）でテスト時に時刻を制御
- **キャッシュ統計**: `GET /cache/stats` → `{hits, misses, size}`
- **全フラッシュ**: `POST /cache/clear`

## テスト

- 20 テスト / 32 アサーション（Cache-Aside・TTL 期限・無効化・統計・バリデーション）
- PHPStan level 8 クリア・PHP-CS-Fixer クリーン

## 関連

Closes #831

Self-review: backend-api