### PR TITLE
feat(ft): FT163 Payment Webhook 受信 (paymentlog)

### DIFF
--- a/docs/howto/payment-webhook.md
+++ b/docs/howto/payment-webhook.md
@@ -1,0 +1,179 @@
+# Payment Webhook 受信の実装ガイド
+
+## 概要
+
+このガイドでは NENE2 を使って Payment Webhook 受信 API を実装する方法を説明します。
+HMAC-SHA256 署名検証・冪等処理（event_id UNIQUE 制約）・ステータス遷移ガードを提供します。
+
+---
+
+## DB スキーマ
+
+```sql
+CREATE TABLE payments (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    external_id TEXT    NOT NULL UNIQUE,
+    amount      INTEGER NOT NULL,               -- 最小通貨単位（円・セント）
+    currency    TEXT    NOT NULL DEFAULT 'usd',
+    status      TEXT    NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'succeeded', 'failed', 'refunded')),
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+
+CREATE TABLE webhook_events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id     TEXT    NOT NULL UNIQUE,   -- 冪等キー
+    event_type   TEXT    NOT NULL,
+    payload      TEXT    NOT NULL,          -- JSON
+    processed_at TEXT    NOT NULL
+);
+```
+
+`webhook_events.event_id` が**冪等処理**の核心。同じ event_id を 2 回受け取っても 1 回のみ処理する。
+
+---
+
+## エンドポイント設計
+
+| メソッド | パス | 説明 |
+|---|---|---|
+| POST | `/webhooks/payment` | Webhook イベント受信・処理 |
+| GET | `/payments` | 決済一覧 |
+| GET | `/payments/{id}` | 決済詳細 |
+
+---
+
+## ステータス遷移
+
+```
+[created] → pending → succeeded → refunded
+                    ↘ failed
+```
+
+遷移テーブルで管理:
+
+```php
+private const array VALID_TRANSITIONS = [
+    'payment.succeeded' => ['from' => 'pending',   'to' => 'succeeded'],
+    'payment.failed'    => ['from' => 'pending',   'to' => 'failed'],
+    'payment.refunded'  => ['from' => 'succeeded', 'to' => 'refunded'],
+];
+```
+
+不正な遷移（failed → succeeded 等）は 409 Conflict を返す。
+
+---
+
+## 設計のポイント
+
+### HMAC-SHA256 署名検証
+
+リクエストボディ全体を HMAC-SHA256 で検証する。Stripe 互換の `X-Webhook-Signature: sha256=<hex>` ヘッダーを使用:
+
+```php
+private function verifySignature(string $body, string $header): bool
+{
+    if (!str_starts_with($header, 'sha256=')) {
+        return false;
+    }
+    $provided = substr($header, 7);
+    $expected = hash_hmac('sha256', $body, $this->webhookSecret);
+    return hash_equals($expected, $provided); // タイミング攻撃防止
+}
+```
+
+`hash_equals()` で定時間比較する。`===` や `strcmp()` は早期終了するため脆弱。
+
+### 冪等処理
+
+Webhook プロバイダーはリトライする。`event_id` で重複を排除:
+
+```php
+// 処理前に確認
+if ($this->repo->isEventProcessed($eventId)) {
+    return $this->json->create(['status' => 'already_processed']);
+}
+
+// 処理後に記録
+$this->repo->recordEvent($eventId, $eventType, $payload, $now);
+```
+
+### 処理順序
+
+```
+1. 署名検証 → 401
+2. event_id の重複確認 → 200 already_processed
+3. イベントタイプ別処理
+4. webhook_events に記録
+5. 200 processed を返す
+```
+
+**署名検証を最初に行う**ことで、攻撃者が event_id テーブルを汚染できないようにする。
+
+### 不明なイベントタイプは 200 で返す
+
+プロバイダーが新しいイベントタイプを追加したとき、4xx を返すとリトライが発生する。
+不明なタイプは静かに 200 で返して記録する:
+
+```php
+// Unknown event type — acknowledge without processing
+return null; // → 200 processed
+```
+
+### テスト: 署名をインジェクトした SECRET で生成
+
+```php
+private const string SECRET = 'test-webhook-secret';
+
+private function signedReq(string $path, array $body): ResponseInterface
+{
+    $rawBody = json_encode($body);
+    $sig     = 'sha256=' . hash_hmac('sha256', $rawBody, self::SECRET);
+    // ...
+}
+```
+
+`AppFactory::createSqlite($dbFile, self::SECRET)` で同じシークレットをアプリに渡す。
+
+---
+
+## イベントペイロード例
+
+### payment.created
+
+```json
+{
+  "event_id": "evt_001",
+  "event_type": "payment.created",
+  "data": {"id": "pay_abc", "amount": 5000, "currency": "jpy"}
+}
+```
+
+### payment.succeeded
+
+```json
+{
+  "event_id": "evt_002",
+  "event_type": "payment.succeeded",
+  "data": {"id": "pay_abc"}
+}
+```
+
+### レスポンス（成功）
+
+```json
+{"status": "processed", "event_type": "payment.succeeded"}
+```
+
+### レスポンス（冪等再送）
+
+```json
+{"status": "already_processed"}
+```
+
+---
+
+## 参照実装
+
+`../NENE2-FT/paymentlog/` — FT163 フィールドトライアル（18 テスト・署名検証・冪等処理・遷移ガード）

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.96`（2026-05-22 リリース済み）
+- Latest release: `v1.5.97`（2026-05-22 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -78,6 +78,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT160 | OAuth2 Social Login | oauthlog | 22/22 | v1.5.94 | oauth2-social-login.md（Authorization Code Flow・state CSRF 防止・コードリプレイ防止・セッション無効化）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 | FT161 | Application Caching | cachelog | 20/20 | v1.5.95 | application-caching.md（Cache-Aside・TTL クロック注入・書き込み時無効化・ヒット率統計） |
 | FT162 | Content Versioning | contentvlog | 18/18 | v1.5.96 | content-versioning.md（append-only 履歴・バージョン一覧・ロールバック = 新バージョン）|
+| FT163 | Payment Webhook 受信 | paymentlog | 18/18 | v1.5.97 | payment-webhook.md（HMAC-SHA256 署名検証・event_id 冪等処理・ステータス遷移ガード 409） |
 
 ## 次のアクション（2026-05-22〜）
 
@@ -87,8 +88,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 | FT | テーマ案 | 備考 |
 |---|---|---|
-| FT163 | Payment Webhook（paymentlog） | 冪等決済・べき等キー |
-| FT164 | Geolocation（geoloclog） | 距離クエリ・バウンディングボックス |
+| FT164 | Geolocation（geoloclog） | 距離クエリ・バウンディングボックス | **クラッカー攻撃試験** |
 | FT165 | A/B Testing（ablog） | 実験割当・メトリクス収集 |
 | FT166 | Multi-step Workflow（workflowlog） | ステートマシン・承認フロー |
 | FT167 | Inbound Webhook Receiver（inboundlog） | **MySQL 統合テスト** |


### PR DESCRIPTION
## Summary

- Payment Webhook 受信パターンを NENE2 で実装する FT163
- `../NENE2-FT/paymentlog/` に参照実装追加
- `docs/howto/payment-webhook.md` 追加

## 変更内容

- **HMAC-SHA256 署名検証**: `X-Webhook-Signature: sha256=<hex>` ヘッダー検証（`hash_equals()` で定時間比較）
- **冪等処理**: `webhook_events.event_id` UNIQUE 制約で重複イベントを 200 already_processed で返す
- **ステータス遷移**: `VALID_TRANSITIONS` 定数テーブルで管理（不正遷移は 409 Conflict）
- **不明イベントは 200 受理**: リトライループを防止

## テスト

- 18 テスト / 29 アサーション（署名・冪等・遷移・クエリ）
- PHPStan level 8 クリア・CS Fixer クリーン

Closes #835

Self-review: backend-api