### PR TITLE
feat(ft): FT165 A/B Testing（ablog）

### DIFF
--- a/docs/howto/ab-testing.md
+++ b/docs/howto/ab-testing.md
@@ -1,0 +1,136 @@
+# How to Add A/B Testing
+
+Run controlled experiments by assigning users to variants and collecting conversion events.
+
+## Schema
+
+```sql
+CREATE TABLE experiments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'draft' CHECK(status IN ('draft', 'active', 'stopped')),
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE experiment_variants (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    experiment_id INTEGER NOT NULL REFERENCES experiments(id) ON DELETE CASCADE,
+    name TEXT NOT NULL, weight INTEGER NOT NULL DEFAULT 100,
+    UNIQUE(experiment_id, name)
+);
+CREATE TABLE experiment_assignments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    experiment_id INTEGER NOT NULL REFERENCES experiments(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL, variant_id INTEGER NOT NULL REFERENCES experiment_variants(id),
+    assigned_at TEXT NOT NULL, UNIQUE(experiment_id, user_id)
+);
+CREATE TABLE experiment_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    experiment_id INTEGER NOT NULL REFERENCES experiments(id) ON DELETE CASCADE,
+    assignment_id INTEGER NOT NULL REFERENCES experiment_assignments(id),
+    event_type TEXT NOT NULL, created_at TEXT NOT NULL
+);
+```
+
+## Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/experiments` | Create experiment (starts in `draft`) |
+| `GET` | `/experiments` | List all experiments |
+| `GET` | `/experiments/{id}` | Get experiment + variants |
+| `PUT` | `/experiments/{id}/status` | Transition status |
+| `POST` | `/experiments/{id}/variants` | Add a variant |
+| `POST` | `/experiments/{id}/assign` | Assign user to variant (idempotent) |
+| `POST` | `/experiments/{id}/events` | Record a conversion event |
+| `GET` | `/experiments/{id}/results` | Aggregated CVR per variant |
+
+## Status Lifecycle
+
+```
+draft → active → stopped
+```
+
+Reject invalid transitions with 422:
+
+```php
+private const array VALID_TRANSITIONS = [
+    'draft'   => ['active'],
+    'active'  => ['stopped'],
+    'stopped' => [],
+];
+
+$allowed = self::VALID_TRANSITIONS[$current] ?? [];
+if (!in_array($status, $allowed, true)) {
+    throw new ValidationException([...]);
+}
+```
+
+## Deterministic Variant Assignment
+
+Users must always land in the same variant — use `crc32` for a reproducible, stateless bucket:
+
+```php
+class VariantAssigner
+{
+    /** @param list<array<string, mixed>> $variants */
+    public function assign(array $variants, string $userId, int $experimentId): ?array
+    {
+        $totalWeight = array_sum(array_column($variants, 'weight'));
+        $seed        = abs(crc32($userId . ':' . $experimentId));
+        $bucket      = $seed % $totalWeight;
+
+        $cumulative = 0;
+        foreach ($variants as $v) {
+            $cumulative += (int) $v['weight'];
+            if ($bucket < $cumulative) {
+                return $v;
+            }
+        }
+        return $variants[0];
+    }
+}
+```
+
+The DB stores the assignment on first call; subsequent calls return the stored variant — determinism + DB truth.
+
+## Idempotent Assignment
+
+```php
+// Return existing assignment without re-rolling
+$existing = $this->repo->findAssignment($id, $userId);
+if ($existing !== null) {
+    return $this->json->create($existing);   // 200, not 201
+}
+// First time: compute and store
+$variant      = $this->assigner->assign($variants, $userId, $id);
+$assignmentId = $this->repo->createAssignment($id, $userId, $variant['id'], $now);
+return $this->json->create($assignment, 201);
+```
+
+## Results Aggregation (CVR)
+
+```sql
+SELECT ev.id AS variant_id, ev.name AS variant_name,
+       COUNT(DISTINCT ea.id) AS assignments,
+       COUNT(ee.id) AS events
+FROM experiment_variants ev
+LEFT JOIN experiment_assignments ea ON ea.variant_id = ev.id
+LEFT JOIN experiment_events ee ON ee.assignment_id = ea.id
+WHERE ev.experiment_id = ?
+GROUP BY ev.id, ev.name, ev.weight
+ORDER BY ev.id ASC
+```
+
+Then compute CVR in PHP:
+
+```php
+$row['cvr'] = $assignments > 0 ? round($events / $assignments, 4) : 0.0;
+```
+
+## Guard Rails
+
+- Only `active` experiments accept assignments (409 otherwise).
+- Events require the user to be assigned (404 otherwise).
+- `UNIQUE(experiment_id, user_id)` prevents double-assignment at the DB level.
+- Weights must be positive integers; zero-weight variants are rejected (422).

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.98`（2026-05-22 リリース済み）
+- Latest release: `v1.5.99`（2026-05-22 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -80,6 +80,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT162 | Content Versioning | contentvlog | 18/18 | v1.5.96 | content-versioning.md（append-only 履歴・バージョン一覧・ロールバック = 新バージョン）|
 | FT163 | Payment Webhook 受信 | paymentlog | 18/18 | v1.5.97 | payment-webhook.md（HMAC-SHA256 署名検証・event_id 冪等処理・ステータス遷移ガード 409） |
 | FT164 | Geolocation | geoloclog | 25/25 | v1.5.98 | geolocation.md（Haversine 距離・バウンディングボックス2パス・固定パス順序・座標バリデーション）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
+| FT165 | A/B Testing | ablog | 16/16 | v1.5.99 | ab-testing.md（draft→active→stopped遷移・crc32決定論的割当・冪等・CVR集計） |
 
 ## 次のアクション（2026-05-22〜）
 
@@ -90,7 +91,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT | テーマ案 | 備考 |
 |---|---|---|
 | ~~FT164~~ | ~~Geolocation（geoloclog）~~ | ~~完了~~ | ~~v1.5.98~~ |
-| FT165 | A/B Testing（ablog） | 実験割当・メトリクス収集 |
+| ~~FT165~~ | ~~A/B Testing（ablog）~~ | ~~完了~~ | ~~v1.5.99~~ |
 | FT166 | Multi-step Workflow（workflowlog） | ステートマシン・承認フロー |
 | FT167 | Inbound Webhook Receiver（inboundlog） | **MySQL 統合テスト** |
 | FT168 | Admin Report Aggregation（reportlog） | 集計クエリ・ダッシュボードパターン |


### PR DESCRIPTION
## Summary

- Experiment CRUD + draft/active/stopped ステータス遷移ガード
- VariantAssigner: `crc32(user_id:experiment_id)` による決定論的重み付き割当
- 冪等な割当（同一 user_id は常に同一 variant）
- イベントトラッキング + CVR 集計（`LEFT JOIN` 2段・PHP 側 CVR 計算）
- ガードレール: 非アクティブ実験への割当 409、未割当ユーザーのイベント 404

## テスト結果

- 16テスト / 26アサーション ✅
- PHPStan level 8: エラーなし ✅
- CS Fixer: 差分なし ✅

## Self-review: backend-api

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)