### PR TITLE
feat(ft): FT166 Multi-step Workflow（stepflowlog）

### DIFF
--- a/docs/howto/multi-step-workflow.md
+++ b/docs/howto/multi-step-workflow.md
@@ -1,0 +1,120 @@
+# How to Add a Multi-step Workflow
+
+Model sequential approval flows where each step must be approved before advancing to the next.
+
+## Schema
+
+```sql
+CREATE TABLE workflows (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE, description TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+CREATE TABLE workflow_steps (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id INTEGER NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+    name TEXT NOT NULL, step_order INTEGER NOT NULL,
+    UNIQUE(workflow_id, step_order)
+);
+CREATE TABLE workflow_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id INTEGER NOT NULL REFERENCES workflows(id),
+    title TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','in_progress','completed','rejected')),
+    current_step_id INTEGER REFERENCES workflow_steps(id),
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE workflow_actions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    step_id INTEGER NOT NULL REFERENCES workflow_steps(id),
+    action TEXT NOT NULL CHECK(action IN ('approve','reject')),
+    actor TEXT NOT NULL, comment TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+```
+
+## Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/workflows` | Define a workflow |
+| `GET` | `/workflows/{id}` | Get workflow + steps |
+| `POST` | `/workflows/{id}/steps` | Append a step (auto-ordered) |
+| `POST` | `/runs` | Start a new run (begins at step 1) |
+| `GET` | `/runs/{id}` | Get run state + full action history |
+| `POST` | `/runs/{id}/approve` | Approve current step |
+| `POST` | `/runs/{id}/reject` | Reject → terminates run |
+
+## State Machine
+
+```
+in_progress --approve (more steps)--> in_progress (next step)
+in_progress --approve (final step)--> completed
+in_progress --reject (any step)-----> rejected
+```
+
+Completed and rejected runs return 409 on further approve/reject.
+
+## Step Auto-ordering
+
+Append-only: each new step gets `max(step_order) + 1`:
+
+```php
+$existingSteps = $this->repo->findSteps($workflowId);
+$maxOrder      = 0;
+foreach ($existingSteps as $s) {
+    $maxOrder = max($maxOrder, (int) $s['step_order']);
+}
+$stepOrder = $maxOrder + 1;
+$this->repo->addStep($workflowId, $name, $stepOrder);
+```
+
+## Advance-or-complete on Approve
+
+```php
+// Record action first, then transition
+$this->repo->recordAction($runId, $currentStepId, 'approve', $actor, $comment, $now);
+
+$nextStep = $this->repo->findNextStep($workflowId, $currentStepOrder);
+if ($nextStep !== null) {
+    $this->repo->updateRun($runId, 'in_progress', (int) $nextStep['id'], $now);
+} else {
+    $this->repo->updateRun($runId, 'completed', null, $now);
+}
+```
+
+Find the next step with a single SQL query:
+
+```sql
+SELECT * FROM workflow_steps
+WHERE workflow_id = ? AND step_order > ?
+ORDER BY step_order ASC LIMIT 1
+```
+
+## Guard Completed/Rejected Runs
+
+```php
+if ((string) $run['status'] !== 'in_progress') {
+    return $this->json->create(['error' => 'Run is not in progress'], 409);
+}
+```
+
+## History Join
+
+Return the full action history with step names in the `GET /runs/{id}` response:
+
+```sql
+SELECT wa.*, ws.name AS step_name
+FROM workflow_actions wa
+JOIN workflow_steps ws ON wa.step_id = ws.id
+WHERE wa.run_id = ?
+ORDER BY wa.id ASC
+```
+
+## Key Design Decisions
+
+- **Append-only steps**: `step_order` is monotonic; no reordering after creation.
+- **Reject terminates immediately**: any step rejection ends the run (no partial approval).
+- **`current_step_id = NULL`** on completed/rejected runs — use `status` to distinguish.
+- **Start run requires at least one step**: return 409 if workflow has no steps.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.99`（2026-05-22 リリース済み）
+- Latest release: `v1.5.100`（2026-05-22 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -81,6 +81,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT163 | Payment Webhook 受信 | paymentlog | 18/18 | v1.5.97 | payment-webhook.md（HMAC-SHA256 署名検証・event_id 冪等処理・ステータス遷移ガード 409） |
 | FT164 | Geolocation | geoloclog | 25/25 | v1.5.98 | geolocation.md（Haversine 距離・バウンディングボックス2パス・固定パス順序・座標バリデーション）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 | FT165 | A/B Testing | ablog | 16/16 | v1.5.99 | ab-testing.md（draft→active→stopped遷移・crc32決定論的割当・冪等・CVR集計） |
+| FT166 | Multi-step Workflow | stepflowlog | 18/18 | v1.5.100 | multi-step-workflow.md（順序付きステップ・approve→次ステップ/完了・reject→即終了・アクション履歴） |
 
 ## 次のアクション（2026-05-22〜）
 
@@ -92,7 +93,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 |---|---|---|
 | ~~FT164~~ | ~~Geolocation（geoloclog）~~ | ~~完了~~ | ~~v1.5.98~~ |
 | ~~FT165~~ | ~~A/B Testing（ablog）~~ | ~~完了~~ | ~~v1.5.99~~ |
-| FT166 | Multi-step Workflow（workflowlog） | ステートマシン・承認フロー |
+| ~~FT166~~ | ~~Multi-step Workflow（stepflowlog）~~ | ~~完了~~ | ~~v1.5.100~~ |
 | FT167 | Inbound Webhook Receiver（inboundlog） | **MySQL 統合テスト** |
 | FT168 | Admin Report Aggregation（reportlog） | 集計クエリ・ダッシュボードパターン |
 | FT169 | Data Masking（masklog） | **脆弱性診断** PII フィールドマスク |


### PR DESCRIPTION
## Summary

- Workflow 定義 + 順序付きステップ（step_order 自動採番・append-only）
- Workflow Run のステートマシン: `in_progress` → `completed` / `rejected`
- approve: 次ステップへ進む or 最終ステップで `completed`
- reject: 任意のステップで即座に `rejected`
- アクション履歴を `GET /runs/{id}` レスポンスに同梱（step_name JOIN）
- 完了/拒否済みの Run への追加操作は 409

## テスト結果

- 18テスト / 32アサーション ✅
- PHPStan level 8: エラーなし ✅
- CS Fixer: 適用済み ✅

## Self-review: backend-api

Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)