### PR TITLE
feat(ft): FT167 Inbound Webhook Receiver（inboundlog）

### DIFF
--- a/docs/howto/inbound-webhook-receiver.md
+++ b/docs/howto/inbound-webhook-receiver.md
@@ -1,0 +1,91 @@
+# How to Add an Inbound Webhook Receiver
+
+Receive webhooks from multiple external services, validate HMAC signatures per source, and store events with idempotency.
+
+## Schema
+
+```sql
+CREATE TABLE webhook_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE, secret TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 1, created_at TEXT NOT NULL
+);
+CREATE TABLE inbound_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id INTEGER NOT NULL REFERENCES webhook_sources(id),
+    event_id TEXT NOT NULL, event_type TEXT NOT NULL,
+    payload TEXT NOT NULL, processed_at TEXT NOT NULL,
+    UNIQUE(source_id, event_id)
+);
+```
+
+## Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/sources` | Register a webhook source |
+| `POST` | `/sources/{id}/receive` | Receive a webhook |
+| `GET` | `/sources/{id}/events` | List received events |
+| `GET` | `/events/{id}` | Get a specific event |
+
+## HMAC-SHA256 Signature Validation
+
+Each source has its own HMAC secret. Never expose it in responses.
+
+```php
+private function verifySignature(string $body, string $header, string $secret): bool
+{
+    if (!str_starts_with($header, 'sha256=')) {
+        return false;
+    }
+    $expected = hash_hmac('sha256', $body, $secret);
+    return hash_equals($expected, substr($header, 7)); // timing-safe
+}
+```
+
+Call order: **validate signature first**, then idempotency check, then store:
+
+```php
+if (!$this->verifySignature($rawBody, $sigHeader, $source['secret'])) {
+    return $this->json->create(['error' => 'Invalid signature'], 401);
+}
+// ... idempotency check ...
+$this->repo->storeEvent($sourceId, $eventId, $eventType, $rawBody, $now);
+```
+
+## Idempotency (event_id per source)
+
+```php
+$existing = $this->repo->findEventBySourceAndEventId($sourceId, $eventId);
+if ($existing !== null) {
+    return $this->json->create(['status' => 'already_processed', 'id' => $existing['id']]);
+}
+```
+
+The `UNIQUE(source_id, event_id)` constraint is the DB-level backstop. The PHP check above avoids the exception path on first duplicate.
+
+## Never Expose the Secret
+
+```php
+$source = $this->repo->findSource($id);
+unset($source['secret']); // strip before returning
+return $this->json->create($source, 201);
+```
+
+## Inactive Source Check
+
+```php
+if (!(bool) $source['active']) {
+    return $this->json->create(['error' => 'Source is inactive'], 403);
+}
+```
+
+## MySQL Notes
+
+The `UNIQUE KEY uq_source_event (source_id, event_id)` constraint works the same in MySQL. Use `VARCHAR(191)` for indexed text columns to stay within InnoDB's key length limit.
+
+## Security Notes
+
+- `hash_equals()` prevents timing attacks on signature comparison.
+- Raw JSON body is stored as-is; do not parse before signature verification.
+- Same `event_id` from two different sources creates separate records — the UNIQUE constraint is `(source_id, event_id)`, not just `event_id`.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.100`（2026-05-22 リリース済み）
+- Latest release: `v1.5.101`（2026-05-22 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -82,6 +82,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT164 | Geolocation | geoloclog | 25/25 | v1.5.98 | geolocation.md（Haversine 距離・バウンディングボックス2パス・固定パス順序・座標バリデーション）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 | FT165 | A/B Testing | ablog | 16/16 | v1.5.99 | ab-testing.md（draft→active→stopped遷移・crc32決定論的割当・冪等・CVR集計） |
 | FT166 | Multi-step Workflow | stepflowlog | 18/18 | v1.5.100 | multi-step-workflow.md（順序付きステップ・approve→次ステップ/完了・reject→即終了・アクション履歴） |
+| FT167 | Inbound Webhook Receiver | inboundlog | 17/17 | v1.5.101 | inbound-webhook-receiver.md（per-source HMAC secret・署名検証→冪等→保存順序・UNIQUE(source_id,event_id)）**MySQL 統合テスト: 5件全Pass** |
 
 ## 次のアクション（2026-05-22〜）
 
@@ -94,7 +95,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | ~~FT164~~ | ~~Geolocation（geoloclog）~~ | ~~完了~~ | ~~v1.5.98~~ |
 | ~~FT165~~ | ~~A/B Testing（ablog）~~ | ~~完了~~ | ~~v1.5.99~~ |
 | ~~FT166~~ | ~~Multi-step Workflow（stepflowlog）~~ | ~~完了~~ | ~~v1.5.100~~ |
-| FT167 | Inbound Webhook Receiver（inboundlog） | **MySQL 統合テスト** |
+| ~~FT167~~ | ~~Inbound Webhook Receiver（inboundlog）~~ | ~~完了~~ | ~~v1.5.101~~ |
 | FT168 | Admin Report Aggregation（reportlog） | 集計クエリ・ダッシュボードパターン |
 | FT169 | Data Masking（masklog） | **脆弱性診断** PII フィールドマスク |
 | FT170 | Request Deduplication（deduplog） | **クラッカー攻撃試験** 二重送信防止 |


### PR DESCRIPTION
## Summary

- per-source HMAC-SHA256 secret 管理（レスポンスに公開しない）
- 受信処理順序: 署名検証 → 冪等チェック → 保存（順序厳守）
- `UNIQUE(source_id, event_id)` で重複は `already_processed`（200）
- 非アクティブソースへの受信は 403

## テスト結果

- SQLite 機能テスト: 12テスト ✅
- MySQL 統合テスト: 5テスト ✅（UNIQUE制約・署名検証・idempotency・イベント一覧・クロスソース分離）
- 合計: 17テスト / 28アサーション ✅
- PHPStan level 8: エラーなし ✅
- CS Fixer: 適用済み ✅

## Self-review: backend-api, database

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)