### PR TITLE
feat(howto): FT169 Data Masking + 脆弱性診断 VULN-A〜L

### DIFF
--- a/docs/howto/data-masking.md
+++ b/docs/howto/data-masking.md
@@ -1,0 +1,118 @@
+# How to Add Data Masking
+
+Mask PII fields (email, phone, name) in API responses by default, with an audited admin unmask path.
+
+## Schema
+
+```sql
+CREATE TABLE customers (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    email      TEXT NOT NULL,
+    phone      TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE mask_audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    customer_id INTEGER NOT NULL REFERENCES customers(id),
+    accessor    TEXT NOT NULL,
+    accessed_at TEXT NOT NULL
+);
+```
+
+## Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/customers` | Create customer (response is masked) |
+| `GET` | `/customers/{id}` | Get customer (masked by default, unmasked for admin) |
+| `GET` | `/customers/{id}/audit` | View audit log (admin only) |
+
+## Masking Patterns
+
+```php
+class MaskService
+{
+    public function maskEmail(string $email): string
+    {
+        $at     = strpos($email, '@');
+        $local  = substr($email, 0, $at);
+        $domain = substr($email, $at + 1);
+        return substr($local, 0, 1) . '***@' . $domain;
+    }
+
+    public function maskPhone(string $phone): string
+    {
+        // Preserve last 4 digits; mask everything else character-by-character
+        $digits  = preg_replace('/\D/', '', $phone) ?? '';
+        $keepFrom = strlen($digits) - 4;
+        $replaced = 0;
+        $result   = '';
+        for ($i = 0; $i < strlen($phone); $i++) {
+            $ch = $phone[$i];
+            if (ctype_digit($ch)) {
+                $result .= ($replaced < $keepFrom) ? '*' : $ch;
+                if (ctype_digit($ch)) { $replaced++; }
+            } else {
+                $result .= $ch;
+            }
+        }
+        return $result;
+    }
+
+    public function maskName(string $name): string
+    {
+        return implode(' ', array_map(
+            fn($w) => mb_substr($w, 0, 1) . '***',
+            array_filter(explode(' ', $name))
+        ));
+    }
+}
+```
+
+Examples:
+- `john@example.com` → `j***@example.com`
+- `555-123-4567` → `***-***-4567`
+- `John Doe` → `J*** D***`
+
+## Role-Based Unmask
+
+The handler checks the `X-Role` header. Admin access requires `X-Accessor` to enforce audit trail:
+
+```php
+$role     = $request->getHeaderLine('X-Role');
+$accessor = trim($request->getHeaderLine('X-Accessor'));
+
+if ($role === 'admin') {
+    if ($accessor === '') {
+        return $this->json->create(['error' => 'X-Accessor header required'], 403);
+    }
+    $this->repo->logAccess($id, $accessor, $this->now());
+    return $this->json->create($customer);        // raw PII
+}
+
+return $this->json->create($this->masker->applyMask($customer));  // masked
+```
+
+## Audit Log
+
+Every admin unmask writes to `mask_audit_log`. The audit log has no DELETE or UPDATE route — it is append-only by design.
+
+```php
+public function logAccess(int $customerId, string $accessor, string $now): void
+{
+    $stmt = $this->pdo->prepare(
+        'INSERT INTO mask_audit_log (customer_id, accessor, accessed_at) VALUES (?, ?, ?)'
+    );
+    $stmt->execute([$customerId, $accessor, $now]);
+}
+```
+
+## Security Properties
+
+- **Default masked**: all GET responses mask PII unless `X-Role: admin` is present.
+- **Forced accessor**: admin unmask requires `X-Accessor`; 403 if absent — no anonymous admin access.
+- **Immutable audit**: no route deletes or updates audit entries.
+- **Parameterized storage**: PII is stored via prepared statements — SQL injection attempts are stored as literals.
+- **Role precision**: only exact `admin` value grants unmask; `ADMIN`, `superuser`, etc. are treated as regular users.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.102`（2026-05-22 リリース済み）
+- Latest release: `v1.5.103`（2026-05-22 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -84,6 +84,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT166 | Multi-step Workflow | stepflowlog | 18/18 | v1.5.100 | multi-step-workflow.md（順序付きステップ・approve→次ステップ/完了・reject→即終了・アクション履歴） |
 | FT167 | Inbound Webhook Receiver | inboundlog | 17/17 | v1.5.101 | inbound-webhook-receiver.md（per-source HMAC secret・署名検証→冪等→保存順序・UNIQUE(source_id,event_id)）**MySQL 統合テスト: 5件全Pass** |
 | FT168 | Admin Report Aggregation | agglog | 26/26 | v1.5.102 | admin-report-aggregation.md（日付バリデーション・from>to拒否・limit クランプ・COALESCE NULL 防止）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
+| FT169 | Data Masking | masklog | 24/24 | v1.5.103 | data-masking.md（デフォルトマスク・admin unmask・X-Accessor 強制・append-only 監査ログ）**脆弱性診断: VULN-A〜L 全Pass** |
 
 ## 次のアクション（2026-05-22〜）
 
@@ -98,7 +99,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | ~~FT166~~ | ~~Multi-step Workflow（stepflowlog）~~ | ~~完了~~ | ~~v1.5.100~~ |
 | ~~FT167~~ | ~~Inbound Webhook Receiver（inboundlog）~~ | ~~完了~~ | ~~v1.5.101~~ |
 | ~~FT168~~ | ~~Admin Report Aggregation（agglog）~~ | ~~完了~~ | ~~v1.5.102~~ |
-| FT169 | Data Masking（masklog） | **脆弱性診断** PII フィールドマスク |
+| ~~FT169~~ | ~~Data Masking（masklog）~~ | ~~完了~~ | ~~v1.5.103~~ |
 | FT170 | Request Deduplication（deduplog） | **クラッカー攻撃試験** 二重送信防止 |
 
 ### ループ終了後（FT170 以降）
@@ -112,8 +113,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 | チェック項目 | 次回 |
 |---|---|
-| MySQL 統合テスト | FT167 |
-| 脆弱性診断 | FT169 |
+| MySQL 統合テスト | FT167 ✓ 完了 |
+| 脆弱性診断 | FT169 ✓ 完了 |
 | クラッカー攻撃試験 | FT170 |
 
 ## 検討事項（決定不要・議題として保持）


### PR DESCRIPTION
## Summary

- `docs/howto/data-masking.md` 新規追加 — PII フィールドマスク・role-based unmask・append-only 監査ログパターン
- FT プロジェクト `../NENE2-FT/masklog/` 実装: 24 tests / 49 assertions (MaskTest 12 + VulnTest 12)
- **脆弱性診断 VULN-A〜L 全 12 件 Pass**: PII 非露出・SQL インジェクション・IDOR・ロールエスカレーション・XSS ペイロード保存・監査ログ改ざん不可

## Test plan

- [x] `php8.4 vendor/bin/phpunit --testdox` → 24 tests OK
- [x] `php8.4 vendor/bin/phpstan analyse --level=8 src tests` → No errors
- [x] `php8.4 vendor/bin/php-cs-fixer fix` → 2 files fixed (constructor brace style)

## Related

Closes #847

Self-review: backend-api, middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)