### PR TITLE
feat(howto): FT170 Request Deduplication + クラッカー攻撃試験 ATK-01〜12

### DIFF
--- a/docs/howto/request-deduplication.md
+++ b/docs/howto/request-deduplication.md
@@ -1,0 +1,90 @@
+# How to Add Request Deduplication
+
+Prevent duplicate processing from network retries or double-clicks using an `Idempotency-Key` header. The server caches responses per key and replays them on subsequent identical requests.
+
+## Schema
+
+```sql
+CREATE TABLE idempotency_keys (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    method          TEXT NOT NULL,
+    path            TEXT NOT NULL,
+    status_code     INTEGER NOT NULL,
+    response_body   TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    expires_at      TEXT NOT NULL
+);
+```
+
+## Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/payments` | Process payment (idempotency-key required) |
+| `POST` | `/orders` | Create order (idempotency-key required) |
+
+## Handler Pattern
+
+Every mutating endpoint that should be idempotent follows the same three-step pattern:
+
+```php
+// 1. Require the Idempotency-Key header
+$key = trim($request->getHeaderLine('Idempotency-Key'));
+if ($key === '') {
+    return $this->json->create(['error' => 'Idempotency-Key header is required'], 400);
+}
+
+// 2. Return cached response if key already used
+$cached = $this->repo->find($key);
+if ($cached !== null && $cached['expires_at'] >= $this->now()) {
+    $body = json_decode($cached['response_body'], true);
+    return $this->json->create(
+        array_merge($body, ['replayed' => true]),
+        (int) $cached['status_code']
+    );
+}
+
+// 3. Process and cache
+$result = $this->doWork($body);
+$this->repo->store($key, 'POST', '/payments', 201, json_encode($result), $now, $expiresAt);
+return $this->json->create($result, 201);
+```
+
+The `replayed: true` field signals to clients that the response was served from cache.
+
+## Strict Amount Validation
+
+Reject non-integer inputs at the boundary — PHP's `(int)` cast silently truncates strings like `"100; DROP TABLE …"` to `100`. Use an explicit type check:
+
+```php
+$rawAmount = $body['amount'] ?? null;
+if (!is_int($rawAmount) && !(is_string($rawAmount) && ctype_digit($rawAmount))) {
+    $errors[] = new ValidationError('amount', 'amount must be a positive integer', 'invalid');
+} else {
+    $amount = (int) $rawAmount;
+    if ($amount <= 0) {
+        $errors[] = new ValidationError('amount', 'amount must be a positive integer', 'invalid');
+    }
+}
+```
+
+## TTL and Expiry
+
+Keys expire after 24 hours (86400 seconds). Expired entries are treated as fresh — the same key can be reused after expiry:
+
+```php
+private const int TTL_SECONDS = 86400;
+
+$expiresAt = (new \DateTimeImmutable($now, new \DateTimeZone('UTC')))
+    ->modify('+' . self::TTL_SECONDS . ' seconds')
+    ->format('Y-m-d\TH:i:s\Z');
+```
+
+## Security Properties
+
+- **SQL injection via key header**: parameterized queries store malicious keys as literals.
+- **Replay flood**: 10 identical requests create exactly 1 record in the business table.
+- **Whitespace-only key**: `trim()` before empty check prevents `"   "` as a valid key.
+- **Type injection in numeric fields**: `ctype_digit()` check rejects partial-integer strings.
+- **No internal leaks**: 400/422 responses contain only the `error` or `errors` fields — no paths, stack traces, or engine details.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.103`（2026-05-22 リリース済み）
+- Latest release: `v1.5.104`（2026-05-22 リリース済み）
 - Current branch: `main` — clean — open Issue なし
 
 ## Recently Completed (FT ループ — v1.5.27 〜 v1.5.39)
@@ -85,6 +85,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT167 | Inbound Webhook Receiver | inboundlog | 17/17 | v1.5.101 | inbound-webhook-receiver.md（per-source HMAC secret・署名検証→冪等→保存順序・UNIQUE(source_id,event_id)）**MySQL 統合テスト: 5件全Pass** |
 | FT168 | Admin Report Aggregation | agglog | 26/26 | v1.5.102 | admin-report-aggregation.md（日付バリデーション・from>to拒否・limit クランプ・COALESCE NULL 防止）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 | FT169 | Data Masking | masklog | 24/24 | v1.5.103 | data-masking.md（デフォルトマスク・admin unmask・X-Accessor 強制・append-only 監査ログ）**脆弱性診断: VULN-A〜L 全Pass** |
+| FT170 | Request Deduplication | deduplog | 24/24 | v1.5.104 | request-deduplication.md（Idempotency-Key 必須・24h TTL・replayed フラグ・ctype_digit 型検証）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 
 ## 次のアクション（2026-05-22〜）
 
@@ -100,7 +101,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | ~~FT167~~ | ~~Inbound Webhook Receiver（inboundlog）~~ | ~~完了~~ | ~~v1.5.101~~ |
 | ~~FT168~~ | ~~Admin Report Aggregation（agglog）~~ | ~~完了~~ | ~~v1.5.102~~ |
 | ~~FT169~~ | ~~Data Masking（masklog）~~ | ~~完了~~ | ~~v1.5.103~~ |
-| FT170 | Request Deduplication（deduplog） | **クラッカー攻撃試験** 二重送信防止 |
+| ~~FT170~~ | ~~Request Deduplication（deduplog）~~ | ~~完了~~ | ~~v1.5.104~~ |
 
 ### ループ終了後（FT170 以降）
 
@@ -115,7 +116,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 |---|---|
 | MySQL 統合テスト | FT167 ✓ 完了 |
 | 脆弱性診断 | FT169 ✓ 完了 |
-| クラッカー攻撃試験 | FT170 |
+| クラッカー攻撃試験 | FT170 ✓ 完了 |
 
 ## 検討事項（決定不要・議題として保持）
 


### PR DESCRIPTION
## Summary

- `docs/howto/request-deduplication.md` 新規追加 — Idempotency-Key 必須パターン・24h TTL・replayed フラグ・ctype_digit 型検証
- FT プロジェクト `../NENE2-FT/deduplog/` 実装: 24 tests / 57 assertions (DedupTest 12 + AttackTest 12)
- **クラッカー攻撃試験 ATK-01〜12 全 Pass**: SQL インジェクション・リプレイ攻撃・ホワイトスペースキー・XSS・情報漏洩なし
- **ATK-02 で発見した実際の脆弱性**: PHP `(int)` キャストが `"100; DROP TABLE …"` を `100` として処理 → `ctype_digit()` チェックで修正済み

## Test plan

- [x] `php8.4 vendor/bin/phpunit --testdox` → 24 tests OK
- [x] `php8.4 vendor/bin/phpstan analyse --level=8 src tests` → No errors
- [x] `php8.4 vendor/bin/php-cs-fixer fix` → No changes needed

## Related

Closes #849

Self-review: backend-api, middleware-security

**FT157〜FT170 全ループ完了** 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)