### PR TITLE
fix(dev): FT MySQL コンテナ永続化とテスト手順追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,14 @@ docker compose run --rm app composer test:database
 docker compose up -d mysql
 docker compose run --rm app composer test:database:mysql
 
+# FT MySQL 統合テスト（../NENE2-FT/ プロジェクト共通）
+# コンテナ起動（port 3308、永続ボリューム ft_mysql_data）
+docker compose -f ../NENE2-FT/docker-compose.yml up -d mysql
+# テスト実行（MYSQL_HOST 未設定なら自動 skip）
+MYSQL_HOST=127.0.0.1 MYSQL_PORT=3308 MYSQL_DATABASE=ft_test \
+  MYSQL_USER=ft_user MYSQL_PASSWORD=ft_pass \
+  php8.4 vendor/bin/phpunit --filter Mysql
+
 # マイグレーション
 docker compose run --rm app composer migrations:status
 docker compose run --rm app composer migrations:migrate

--- a/docs/howto/inbound-webhook-receiver.md
+++ b/docs/howto/inbound-webhook-receiver.md
@@ -84,6 +84,24 @@ if (!(bool) $source['active']) {
 
 The `UNIQUE KEY uq_source_event (source_id, event_id)` constraint works the same in MySQL. Use `VARCHAR(191)` for indexed text columns to stay within InnoDB's key length limit.
 
+### Running MySQL Integration Tests
+
+Start the shared FT MySQL container (port 3308, persistent volume):
+
+```bash
+docker compose -f ../NENE2-FT/docker-compose.yml up -d mysql
+```
+
+Then run the integration tests with environment variables:
+
+```bash
+MYSQL_HOST=127.0.0.1 MYSQL_PORT=3308 MYSQL_DATABASE=ft_test \
+  MYSQL_USER=ft_user MYSQL_PASSWORD=ft_pass \
+  php8.4 vendor/bin/phpunit --filter Mysql
+```
+
+Without `MYSQL_HOST`, the MySQL tests are automatically skipped (`markTestSkipped`).
+
 ## Security Notes
 
 - `hash_equals()` prevents timing attacks on signature comparison.


### PR DESCRIPTION
## Summary

- `../NENE2-FT/docker-compose.yml` に `ports: 3308:3306` と named volume `ft_mysql_data` を追加
- コンテナ再起動後も `ft_test` DB・`ft_user` が保持される
- `CLAUDE.md` に FT MySQL 統合テスト実行コマンドを追記
- `docs/howto/inbound-webhook-receiver.md` に MySQL テスト手順セクションを追記

## Test plan

- [x] `docker compose -f ../NENE2-FT/docker-compose.yml up -d mysql` → `nene2-ft-mysql-1` が port 3308 で起動
- [x] `MYSQL_HOST=127.0.0.1 MYSQL_PORT=3308 … php8.4 vendor/bin/phpunit --filter Mysql` → 5 tests OK (inboundlog)

## Related

Closes #851

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)