### PR TITLE
chore(tools): new-ft.sh スキャフォールドスクリプトと FT レジストリ

### DIFF
--- a/docs/ft-registry.md
+++ b/docs/ft-registry.md
@@ -1,0 +1,121 @@
+# FT Registry
+
+FT 番号とディレクトリ名の対応表。  
+新規 FT を追加する前に `tools/new-ft.sh` がこのファイルを参照して重複を検出する。
+
+## 使い方
+
+```bash
+# 新規 FT のスキャフォールド（FT番号とディレクトリ名を指定）
+tools/new-ft.sh 171 newfeaturelog
+```
+
+スクリプトが以下を行う:
+1. ディレクトリ名の重複チェック
+2. `../NENE2-FT/<dirname>/` 作成（src/ tests/ database/ 含む）
+3. 直近の FT プロジェクトから vendor をコピー + dump-autoload
+4. このファイルへの追記を促すメッセージを表示
+
+## FT001〜FT095（名前のみ）
+
+> FT096 以前はレジストリ導入前。ディレクトリ名は以下の通り使用済み。
+
+```
+ablog approvallog apikeylog auditlog authlog batchlog bookinglog bookmarklog
+budgetlog bulklog bulkupdatelog cachelog cartlog circuitlog collectionlog
+commentlog contactlog contentlog contentvlog couponlog cqrslog creditslog
+csrflog cursorlog deadletterlog distlocklog doclog draftlog emojilog etaglog
+eventsourcelog eventstore expenselog exportlog featureflaglog feedlog filelog
+flaglog flowlog followlog ftslog grouplog habitlog hmaclog i18nlog
+idempotencylog importlog injectionlog inventorylog invitelog jwtlog
+leaderboardlog linklog locklog lockoutlog magiclog masslog messagelog
+moneylog nestedlog noteslog notificationlog oauthlog optimisticlog optlocklog
+orderlog otplog pagelog paymentlog pinlog planlog pointlog polllog preflog
+pricelog profilelog projtrack pwdlog queuelog quotalog ranklog ratelimitlog
+ratelog ratinglog rbaclog reactionlog refreshlog reservelog resetlog reviewlog
+salelog schedulelog scorelog searchlog sessionlog shiftlog signedlog
+softdelete softdeletelog softlog statemachinelog statslog subscriptionlog
+tagfilterlog taglog tenantlog threadlog throttlelog timelog tokenlog totplog
+treelog unicodelog uploadlog votelog waitlistlog watchlog webhookdeliverylog
+webhooklog wishlistlog workflowlog
+```
+
+## FT096〜FT170（番号 ↔ ディレクトリ対応）
+
+| FT | ディレクトリ | テーマ |
+|---|---|---|
+| FT096 | contentlog | コンテントネゴシエーション |
+| FT097 | injectionlog | SQL インジェクション防御 |
+| FT098 | uploadlog | ファイルアップロード |
+| FT099 | csrflog | CSRF 的パターン・冪等性 |
+| FT100 | pagelog | OFFSET vs カーソルページネーション |
+| FT101 | nestedlog | ネスト JSON バリデーション |
+| FT102 | txlog | DB トランザクション境界 |
+| FT103 | masslog | マスアサインメント防御 |
+| FT104 | hmaclog | Webhook シグネチャ検証 |
+| FT105 | optlocklog | 楽観的ロック |
+| FT106 | etaglog | ETag・条件付きリクエスト |
+| FT107 | throttlelog | レートリミット |
+| FT108 | softdeletelog | ソフトデリート |
+| FT109 | pwdlog | パスワードハッシュ |
+| FT110 | jwtlog | JWT 認証 |
+| FT111 | rbaclog | RBAC |
+| FT112 | tenantlog | マルチテナント隔離 |
+| FT113 | refreshlog | JWT Refresh Token Rotation |
+| FT114 | auditlog | 監査ログ（Audit Trail） |
+| FT115 | versionlog | API バージョニング |
+| FT116 | queuelog | バックグラウンドジョブキュー |
+| FT117 | apikeylog | API キー管理 |
+| FT118 | signedlog | 署名付き URL |
+| FT119 | circuitlog | サーキットブレーカー |
+| FT120 | webhookdeliverylog | アウトバウンド Webhook 配信 |
+| FT121 | featureflaglog | フィーチャーフラグ |
+| FT122 | distlocklog | 分散ロック |
+| FT123 | exportlog | 個人データエクスポート |
+| FT124 | invitelog | ユーザー招待システム |
+| FT125 | taglog | タグシステム（M:N） |
+| FT126 | resetlog | パスワードリセット |
+| FT127 | commentlog | スレッドコメント |
+| FT128 | lockoutlog | アカウントロックアウト |
+| FT129 | eventsourcelog | イベントソーシング（基本） |
+| FT130 | notificationlog | 通知インボックス |
+| FT131 | votelog | コメント投票 |
+| FT132 | profilelog | プロフィール管理 |
+| FT133 | bookmarklog | ブックマーク |
+| FT134 | followlog | ユーザーフォロー |
+| FT135 | messagelog | ダイレクトメッセージ |
+| FT136 | tokenlog | アクセストークン管理 |
+| FT137 | planlog | サブスクリプション管理 |
+| FT138 | grouplog | グループメンバーシップ |
+| FT139 | orderlog | ゲスト注文 |
+| FT140 | salelog | フラッシュセール |
+| FT141 | ranklog | リーダーボード |
+| FT142 | draftlog | コンテンツ下書き |
+| FT143 | emojilog | 絵文字リアクション |
+| FT144 | magiclog | パスワードレス認証（Magic Link） |
+| FT145 | preflog | ユーザー設定管理 |
+| FT146 | pinlog | コンテンツピン留め |
+| FT147 | reportlog | コンテンツ通報・モデレーション |
+| FT148 | otplog | OTP 認証システム |
+| FT149 | collectionlog | コンテンツコレクション |
+| FT150 | couponlog | クーポン・プロモコード管理 |
+| FT151 | wishlistlog | ウィッシュリスト管理 |
+| FT152 | pointlog | ポイント・ロイヤルティシステム |
+| FT153 | feedlog | アクティビティフィード |
+| FT154 | reviewlog | プロダクトレビュー・評価システム |
+| FT155 | cartlog | ショッピングカート |
+| FT156 | filelog | ファイルメタデータ管理・共有 |
+| FT157 | searchlog | 全文検索・オートコンプリート |
+| FT158 | importlog | CSV バルクインポート |
+| FT159 | totplog | TOTP 二要素認証 |
+| FT160 | oauthlog | OAuth2 Social Login |
+| FT161 | cachelog | Application Caching |
+| FT162 | contentvlog | Content Versioning |
+| FT163 | paymentlog | Payment Webhook 受信 |
+| FT164 | geoloclog | Geolocation |
+| FT165 | ablog | A/B Testing |
+| FT166 | stepflowlog | Multi-step Workflow ※workflowlog(FT081)と衝突のため変更 |
+| FT167 | inboundlog | Inbound Webhook Receiver |
+| FT168 | agglog | Admin Report Aggregation ※reportlog(FT147)と衝突のため変更 |
+| FT169 | masklog | Data Masking |
+| FT170 | deduplog | Request Deduplication |

--- a/tools/new-ft.sh
+++ b/tools/new-ft.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# new-ft.sh — scaffold a new FT project under ../NENE2-FT/
+#
+# Usage: tools/new-ft.sh <ft-number> <dirname>
+# Example: tools/new-ft.sh 171 newfeaturelog
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NENE2_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FT_BASE="$(cd "${NENE2_DIR}/../NENE2-FT" && pwd)"
+REGISTRY="${NENE2_DIR}/docs/ft-registry.md"
+
+# ── argument check ────────────────────────────────────────────────────────────
+if [[ $# -lt 2 ]]; then
+    echo "Usage: tools/new-ft.sh <ft-number> <dirname>"
+    echo "  e.g. tools/new-ft.sh 171 newfeaturelog"
+    exit 1
+fi
+
+FT_NUM="$1"
+DIRNAME="$2"
+TARGET="${FT_BASE}/${DIRNAME}"
+
+# ── registry collision check ──────────────────────────────────────────────────
+if grep -q "\b${DIRNAME}\b" "${REGISTRY}" 2>/dev/null; then
+    echo "ERROR: '${DIRNAME}' is already registered in docs/ft-registry.md"
+    echo "  Check the registry and pick a different name."
+    grep "${DIRNAME}" "${REGISTRY}"
+    exit 1
+fi
+
+# ── existing directory check ──────────────────────────────────────────────────
+if [[ -d "${TARGET}" ]]; then
+    echo "ERROR: ${TARGET} already exists."
+    exit 1
+fi
+
+# ── find vendor source (most recently modified FT project with vendor/) ────────
+VENDOR_SRC=""
+VENDOR_MTIME=0
+for d in "${FT_BASE}"/*/vendor; do
+    [[ -d "$d" ]] || continue
+    mt=$(stat -c "%Y" "$d" 2>/dev/null || stat -f "%m" "$d" 2>/dev/null || echo 0)
+    if (( mt > VENDOR_MTIME )); then
+        VENDOR_MTIME=$mt
+        VENDOR_SRC="$d"
+    fi
+done
+
+if [[ -z "${VENDOR_SRC}" ]]; then
+    echo "ERROR: No vendor/ directory found in any FT project under ${FT_BASE}"
+    echo "  Run 'composer install' in an existing FT project first."
+    exit 1
+fi
+
+# ── create directory structure ────────────────────────────────────────────────
+echo "Creating ${TARGET}..."
+mkdir -p "${TARGET}/src" "${TARGET}/tests" "${TARGET}/database"
+
+# ── copy vendor ───────────────────────────────────────────────────────────────
+VENDOR_PROJECT="$(dirname "${VENDOR_SRC}")"
+echo "Copying vendor from $(basename "${VENDOR_PROJECT}")..."
+cp -r "${VENDOR_SRC}" "${TARGET}/vendor"
+
+# ── write skeleton files ──────────────────────────────────────────────────────
+NAMESPACE="$(echo "${DIRNAME:0:1}" | tr '[:lower:]' '[:upper:]')${DIRNAME:1}"
+
+cat > "${TARGET}/composer.json" <<COMPOSER
+{
+    "name": "${DIRNAME}/${DIRNAME}",
+    "description": "FT${FT_NUM}: TODO — add description",
+    "type": "project",
+    "require": {
+        "php": ">=8.4",
+        "hideyukimori/nene2": "^1.5",
+        "nyholm/psr7": "^1.8"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0",
+        "phpstan/phpstan": "^2.0",
+        "friendsofphp/php-cs-fixer": "^3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "${NAMESPACE}\\\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "${NAMESPACE}\\\\Tests\\\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit --testdox",
+        "analyse": "vendor/bin/phpstan analyse --level=8 src tests",
+        "cs": "vendor/bin/php-cs-fixer fix --dry-run --diff",
+        "cs:fix": "vendor/bin/php-cs-fixer fix",
+        "check": ["@cs", "@analyse", "@test"]
+    }
+}
+COMPOSER
+
+cat > "${TARGET}/phpunit.xml" <<PHPUNIT
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="${DIRNAME}">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>
+PHPUNIT
+
+cat > "${TARGET}/phpstan.neon" <<PHPSTAN
+parameters:
+    level: 8
+    paths:
+        - src
+        - tests
+PHPSTAN
+
+cat > "${TARGET}/.php-cs-fixer.php" <<CSFIXER
+<?php
+
+\$finder = PhpCsFixer\Finder::create()
+    ->in([__DIR__ . '/src', __DIR__ . '/tests']);
+
+return (new PhpCsFixer\Config())
+    ->setRules(['@PSR12' => true])
+    ->setFinder(\$finder);
+CSFIXER
+
+cat > "${TARGET}/database/schema.sql" <<SCHEMA
+-- FT${FT_NUM}: TODO — add schema
+SCHEMA
+
+# ── dump-autoload ─────────────────────────────────────────────────────────────
+echo "Running dump-autoload..."
+PHP_BIN="${PHP_BIN:-$(command -v php8.4 || command -v php)}"
+COMPOSER_BIN="$(command -v composer)"
+(cd "${TARGET}" && "${PHP_BIN}" "${COMPOSER_BIN}" dump-autoload --quiet)
+
+# ── done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo "✓ ${TARGET} created"
+echo ""
+echo "Next steps:"
+echo "  1. Edit ${TARGET}/composer.json  (description)"
+echo "  2. Edit ${TARGET}/database/schema.sql"
+echo "  3. Add source files under ${TARGET}/src/"
+echo "  4. Add tests under ${TARGET}/tests/"
+echo "  5. Register in docs/ft-registry.md:"
+echo "     | FT${FT_NUM} | ${DIRNAME} | TODO — theme |"


### PR DESCRIPTION
## Summary

- **`tools/new-ft.sh <ft-number> <dirname>`**: FT プロジェクト作成を自動化
  - レジストリ重複チェック → ディレクトリ作成 → vendor コピー → dump-autoload → スケルトン生成まで一括
- **`docs/ft-registry.md`**: FT 番号 ↔ ディレクトリ名対応表（FT096〜FT170 完全収録）
  - FT166/FT168 の命名衝突経緯も記録

## 使い方

```bash
tools/new-ft.sh 171 newfeaturelog
# → ../NENE2-FT/newfeaturelog/ が30秒で使える状態になる
```

## Test plan

- [x] 既存名（deduplog）を指定 → ERROR + 該当行を表示して中断
- [x] 新規名（testftlog）を指定 → ディレクトリ・全スケルトン・vendor 生成を確認
- [x] テスト用ディレクトリは削除済み

## Related

Closes #853

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)