### PR TITLE
chore(tools): new-ft.sh composer 呼び出し簡略化

### DIFF
--- a/tools/new-ft.sh
+++ b/tools/new-ft.sh
@@ -145,9 +145,7 @@ SCHEMA
 
 # ── dump-autoload ─────────────────────────────────────────────────────────────
 echo "Running dump-autoload..."
-PHP_BIN="${PHP_BIN:-$(command -v php8.4 || command -v php)}"
-COMPOSER_BIN="$(command -v composer)"
-(cd "${TARGET}" && "${PHP_BIN}" "${COMPOSER_BIN}" dump-autoload --quiet)
+(cd "${TARGET}" && composer dump-autoload --quiet)
 
 # ── done ──────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- `tools/new-ft.sh` の `php8.4 $(which composer)` を `composer` に統一
  - `/usr/local/bin/composer` v2.9.8 インストール済み（PHP 8.4 対応、Deprecated ノイズなし）
  - `php` が `php8.4` を指しているため `php8.4` 明示不要

## 環境変更（リポジトリ外）

- `/usr/local/bin/composer` v2.9.8 インストール（`sudo` なしで動く）
- `~/.bashrc` に `COMPOSER_ALLOW_SUPERUSER=1` と `ft-mysql-test` alias 追加
- `../NENE2-FT/.env.test` に MySQL テスト用 env vars を記録

## Ubuntu 22→24 移行について

不要。PHP 8.4 は ondrej/php PPA で Ubuntu 22.04 上に動作中。
Ubuntu 22.04 LTS のサポートは 2027年4月まで。

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)