### PR TITLE
fix(docs): FT148 の VitePress ビルド失敗を修正

### DIFF
--- a/docs/field-trials/2026-05-field-trial-148.md
+++ b/docs/field-trials/2026-05-field-trial-148.md
@@ -151,7 +151,7 @@ OTP レコードに `attempt_count` を持たせる設計は、Laravel では Ca
 「ログインフォームの実装がシンプル。
 Step 1: メール入力 → POST /otp/request → 202 → 『コードをメールに送りました』UI
 Step 2: コード入力 → POST /otp/verify → 200 → session_token をローカルストレージに保存
-Step 3: 各リクエストに Authorization: Bearer <token> を付ける
+Step 3: 各リクエストに `Authorization: Bearer <token>` を付ける
 Step 4: GET /otp/session で定期的にトークン有効性を確認
 Step 5: DELETE /otp/session でログアウト
 422 と 401 の区別がはっきりしている（フォームバリデーションエラー vs 認証失敗）ので


### PR DESCRIPTION
## Summary

- `docs/field-trials/2026-05-field-trial-148.md` の `<token>` 表記が VitePress で未閉じ HTML タグとして解釈され、Docs CI が連続失敗していた
- FT144 と同様に `Authorization: Bearer <token>` をインラインコードで囲み、ビルドエラーを解消

## Test plan

- [x] `npm run docs:build` が成功することをローカルで確認

## Self-review

- docs-policy

Closes #859

Made with [Cursor](https://cursor.com)