### PR TITLE
docs: CLAUDE.md のリリース・バージョニング情報を現状に同期

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,10 +464,11 @@ ADR ファイル: `docs/adr/NNNN-kebab-case-title.md`、テンプレート: `doc
 
 ## 15. リリース・バージョニング
 
-- Semantic Versioning。`0.x.y` 期間中は公開契約はまだ形成中。
-- タグは `main` のコミットを指す（`v0.1.0` 形式）。
+- Semantic Versioning。現在 `v1.5.x`。
+- タグは `main` のコミットを指す（`v1.5.NNN` 形式）。
+- タグを push したら対応する GitHub Release も作成する（`gh release create`）。
 - リリース前に `docs/development/release-checklist.md` を使う。
-- Packagist 公開は契約が安定してから。
+- Packagist 公開済み: `composer require hideyukimori/nene2`
 
 ---
 


### PR DESCRIPTION
## Summary

- バージョン表記を `v0.x.y` → `v1.5.x` に修正
- Packagist 公開済みの旨を記載（`composer require hideyukimori/nene2`）
- タグ push 時に GitHub Release も作成する旨を追記

## Test plan

- [ ] CLAUDE.md セクション 15 の記述が実態と一致していること

Closes #863

Self-review: docs-policy