### PR TITLE
feat(http): UtcClock + SecureTokenHelper を追加（howto パターン還元 batch 1）

### DIFF
--- a/src/Http/ClockInterface.php
+++ b/src/Http/ClockInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+/**
+ * Minimal clock abstraction for injecting time dependencies.
+ *
+ * Implement this interface in tests to return a fixed instant and eliminate
+ * flakiness caused by real-time drift.
+ *
+ * ```php
+ * // Production
+ * $clock = new UtcClock();
+ *
+ * // Test
+ * $clock = new class implements ClockInterface {
+ *     public function now(): \DateTimeImmutable {
+ *         return new \DateTimeImmutable('2026-01-01T00:00:00Z');
+ *     }
+ * };
+ * ```
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+interface ClockInterface
+{
+    /**
+     * Returns the current time as an immutable datetime object.
+     *
+     * Implementations MUST return a value in UTC.
+     */
+    public function now(): \DateTimeImmutable;
+}

--- a/src/Http/SecureTokenHelper.php
+++ b/src/Http/SecureTokenHelper.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+/**
+ * Utilities for generating, hashing, and verifying cryptographically secure tokens.
+ *
+ * The standard pattern used in password resets, magic links, API keys, invitation
+ * tokens, and signed URLs always looks the same:
+ *
+ * 1. Generate a high-entropy raw token.
+ * 2. Store only the SHA-256 hash — never the raw value.
+ * 3. Verify incoming tokens with a timing-safe comparison.
+ *
+ * This class codifies that pattern so that each implementation does not have to
+ * repeat the same low-level calls.
+ *
+ * ```php
+ * // Generating a new token (e.g. password reset, magic link, invitation)
+ * $raw  = SecureTokenHelper::generate();          // 64-char hex string, 256-bit entropy
+ * $hash = SecureTokenHelper::hash($raw);          // SHA-256 hex — store this in the DB
+ * // → send $raw to the user; persist $hash
+ *
+ * // Verifying an incoming token
+ * $storedHash = $repo->findHashByEmail($email);   // retrieved from DB
+ * if (!SecureTokenHelper::verify($incoming, $storedHash)) {
+ *     // token invalid — return 400/404/422
+ * }
+ * ```
+ *
+ * Security notes:
+ * - `generate()` uses `random_bytes()` — CSPRNG, suitable for security-sensitive tokens.
+ * - `hash()` uses SHA-256. A DB breach exposes only the hash; reversing it on a
+ *   256-bit random value is computationally infeasible.
+ * - `verify()` uses `hash_equals()` — constant-time comparison prevents timing attacks.
+ *   Never use `===` or `==` to compare token hashes.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class SecureTokenHelper
+{
+    /**
+     * Generates a cryptographically secure random token.
+     *
+     * Returns a lowercase hexadecimal string of length `$bytes * 2`.
+     * The default of 32 bytes gives 256 bits of entropy and a 64-character string.
+     *
+     * ```php
+     * $raw = SecureTokenHelper::generate();     // e.g. "a3f2c8..."  (64 chars)
+     * $raw = SecureTokenHelper::generate(16);   // 32-char token (128-bit)
+     * ```
+     *
+     * @param int<1, max> $bytes Number of random bytes. Must be at least 1.
+     */
+    public static function generate(int $bytes = 32): string
+    {
+        return bin2hex(random_bytes($bytes));
+    }
+
+    /**
+     * Returns the SHA-256 hash of a raw token as a lowercase hex string.
+     *
+     * Store this in the database, never the raw token.
+     *
+     * ```php
+     * $hash = SecureTokenHelper::hash($rawToken); // 64-char hex string
+     * ```
+     */
+    public static function hash(string $rawToken): string
+    {
+        return hash('sha256', $rawToken);
+    }
+
+    /**
+     * Verifies that a raw token matches a stored SHA-256 hash.
+     *
+     * Uses `hash_equals()` internally — the comparison runs in constant time
+     * regardless of where the strings differ, preventing timing-oracle attacks.
+     *
+     * Returns `true` only when the token is valid. Always returns `false` for
+     * empty inputs so callers do not need to guard against blank header values.
+     *
+     * ```php
+     * if (!SecureTokenHelper::verify($incoming, $storedHash)) {
+     *     return $this->problems->create($request, 'not-found', 'Not Found.', 404, '');
+     * }
+     * ```
+     */
+    public static function verify(string $rawToken, string $storedHash): bool
+    {
+        if ($rawToken === '' || $storedHash === '') {
+            return false;
+        }
+
+        return hash_equals($storedHash, self::hash($rawToken));
+    }
+
+    /**
+     * Generates a token and its SHA-256 hash in one call.
+     *
+     * Returns `[$rawToken, $hash]`. Use `$rawToken` to send to the user and
+     * `$hash` to persist in the database.
+     *
+     * ```php
+     * [$raw, $hash] = SecureTokenHelper::generateWithHash();
+     * $repo->storeResetToken($userId, $hash, $expiresAt);
+     * $mailer->sendResetLink($email, $raw);
+     * ```
+     *
+     * @param int<1, max> $bytes Number of random bytes. Must be at least 1.
+     *
+     * @return array{0: string, 1: string}
+     */
+    public static function generateWithHash(int $bytes = 32): array
+    {
+        $raw = self::generate($bytes);
+
+        return [$raw, self::hash($raw)];
+    }
+}

--- a/src/Http/UtcClock.php
+++ b/src/Http/UtcClock.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Http;
+
+/**
+ * Production {@see ClockInterface} that always returns the current time in UTC.
+ *
+ * Inject {@see ClockInterface} into use cases and handlers that need the current
+ * time. In tests, replace with an anonymous class or a simple stub that returns
+ * a fixed instant — no mocking framework required.
+ *
+ * ```php
+ * // Handler constructor
+ * public function __construct(private readonly ClockInterface $clock) {}
+ *
+ * // Usage
+ * $now       = $this->clock->now();              // DateTimeImmutable (UTC)
+ * $nowIso    = $this->clock->nowIso();           // "2026-05-26T12:00:00Z"
+ * $expiresAt = $this->clock->nowIso('+24 hours'); // ISO string 24 h from now
+ * ```
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class UtcClock implements ClockInterface
+{
+    private static \DateTimeZone $utc;
+
+    public function now(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('now', self::utcZone());
+    }
+
+    /**
+     * Returns the current UTC time as an ISO 8601 string (`Y-m-d\TH:i:s\Z`).
+     *
+     * Pass a `$modify` string (same format as {@see \DateTimeImmutable::modify()})
+     * to shift the instant — e.g. `'+24 hours'`, `'-30 minutes'`.
+     *
+     * ```php
+     * $now       = $clock->nowIso();            // "2026-05-26T12:00:00Z"
+     * $expiresAt = $clock->nowIso('+1 hour');   // "2026-05-26T13:00:00Z"
+     * ```
+     */
+    public function nowIso(string $modify = ''): string
+    {
+        $dt = $this->now();
+
+        if ($modify !== '') {
+            $dt = $dt->modify($modify);
+        }
+
+        return $dt->format('Y-m-d\TH:i:s\Z');
+    }
+
+    /**
+     * Converts any {@see \DateTimeImmutable} to an ISO 8601 UTC string.
+     *
+     * Useful when you have a datetime from another source and need to normalise
+     * it to the same format used throughout the application.
+     *
+     * ```php
+     * UtcClock::toIso(new \DateTimeImmutable('2026-05-26T12:00:00+09:00'));
+     * // → "2026-05-26T03:00:00Z"
+     * ```
+     */
+    public static function toIso(\DateTimeImmutable $dt): string
+    {
+        return $dt->setTimezone(self::utcZone())->format('Y-m-d\TH:i:s\Z');
+    }
+
+    private static function utcZone(): \DateTimeZone
+    {
+        return self::$utc ??= new \DateTimeZone('UTC');
+    }
+}

--- a/tests/Http/SecureTokenHelperTest.php
+++ b/tests/Http/SecureTokenHelperTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\SecureTokenHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SecureTokenHelperTest extends TestCase
+{
+    // ------------------------------------------------------------------ generate
+
+    #[Test]
+    public function generateReturnsHexString(): void
+    {
+        $token = SecureTokenHelper::generate();
+
+        self::assertMatchesRegularExpression('/^[0-9a-f]+$/', $token);
+    }
+
+    #[Test]
+    public function generateDefaultIs64Chars(): void
+    {
+        // 32 bytes → 64 hex chars
+        self::assertSame(64, strlen(SecureTokenHelper::generate()));
+    }
+
+    #[Test]
+    public function generateWithCustomBytes(): void
+    {
+        self::assertSame(32, strlen(SecureTokenHelper::generate(16)));
+    }
+
+    #[Test]
+    public function generateIsUnique(): void
+    {
+        $a = SecureTokenHelper::generate();
+        $b = SecureTokenHelper::generate();
+
+        self::assertNotSame($a, $b);
+    }
+
+    // ------------------------------------------------------------------ hash
+
+    #[Test]
+    public function hashReturnsSha256HexString(): void
+    {
+        $hash = SecureTokenHelper::hash('sometoken');
+
+        // SHA-256 always produces 64 hex chars
+        self::assertSame(64, strlen($hash));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
+    }
+
+    #[Test]
+    public function hashIsDeterministic(): void
+    {
+        self::assertSame(
+            SecureTokenHelper::hash('abc'),
+            SecureTokenHelper::hash('abc'),
+        );
+    }
+
+    #[Test]
+    public function differentInputsProduceDifferentHashes(): void
+    {
+        self::assertNotSame(
+            SecureTokenHelper::hash('token-a'),
+            SecureTokenHelper::hash('token-b'),
+        );
+    }
+
+    // ------------------------------------------------------------------ verify
+
+    #[Test]
+    public function verifyReturnsTrueForMatchingToken(): void
+    {
+        $raw  = SecureTokenHelper::generate();
+        $hash = SecureTokenHelper::hash($raw);
+
+        self::assertTrue(SecureTokenHelper::verify($raw, $hash));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForWrongToken(): void
+    {
+        $hash = SecureTokenHelper::hash('correct-token');
+
+        self::assertFalse(SecureTokenHelper::verify('wrong-token', $hash));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForEmptyRawToken(): void
+    {
+        $hash = SecureTokenHelper::hash('sometoken');
+
+        self::assertFalse(SecureTokenHelper::verify('', $hash));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForEmptyStoredHash(): void
+    {
+        self::assertFalse(SecureTokenHelper::verify('sometoken', ''));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForBothEmpty(): void
+    {
+        self::assertFalse(SecureTokenHelper::verify('', ''));
+    }
+
+    // ------------------------------------------------------------------ generateWithHash
+
+    #[Test]
+    public function generateWithHashReturnsTwoStrings(): void
+    {
+        [$raw, $hash] = SecureTokenHelper::generateWithHash();
+
+        self::assertNotEmpty($raw);
+        self::assertNotEmpty($hash);
+    }
+
+    #[Test]
+    public function generateWithHashRawAndHashAreConsistent(): void
+    {
+        [$raw, $hash] = SecureTokenHelper::generateWithHash();
+
+        self::assertTrue(SecureTokenHelper::verify($raw, $hash));
+    }
+
+    #[Test]
+    public function generateWithHashDefaultRawIs64Chars(): void
+    {
+        [$raw] = SecureTokenHelper::generateWithHash();
+
+        self::assertSame(64, strlen($raw));
+    }
+
+    #[Test]
+    public function generateWithHashCustomBytes(): void
+    {
+        [$raw] = SecureTokenHelper::generateWithHash(16);
+
+        self::assertSame(32, strlen($raw));
+    }
+}

--- a/tests/Http/UtcClockTest.php
+++ b/tests/Http/UtcClockTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\ClockInterface;
+use Nene2\Http\UtcClock;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class UtcClockTest extends TestCase
+{
+    #[Test]
+    public function implementsClockInterface(): void
+    {
+        self::assertInstanceOf(ClockInterface::class, new UtcClock());
+    }
+
+    #[Test]
+    public function nowReturnsDateTimeImmutable(): void
+    {
+        $clock = new UtcClock();
+        $now   = $clock->now();
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $now);
+    }
+
+    #[Test]
+    public function nowIsInUtc(): void
+    {
+        $clock = new UtcClock();
+        $now   = $clock->now();
+
+        self::assertSame('UTC', $now->getTimezone()->getName());
+    }
+
+    #[Test]
+    public function nowIsoReturnsIso8601UtcString(): void
+    {
+        $clock = new UtcClock();
+        $iso   = $clock->nowIso();
+
+        // Matches "YYYY-MM-DDTHH:MM:SSZ"
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/',
+            $iso,
+        );
+    }
+
+    #[Test]
+    public function nowIsoWithModifyShiftsTime(): void
+    {
+        $clock = new UtcClock();
+        $base  = $clock->nowIso();
+        $later = $clock->nowIso('+1 hour');
+
+        $baseTs  = (new \DateTimeImmutable($base))->getTimestamp();
+        $laterTs = (new \DateTimeImmutable($later))->getTimestamp();
+
+        self::assertSame(3600, $laterTs - $baseTs);
+    }
+
+    #[Test]
+    public function nowIsoWithNegativeModify(): void
+    {
+        $clock  = new UtcClock();
+        $base   = $clock->nowIso();
+        $before = $clock->nowIso('-30 minutes');
+
+        $baseTs   = (new \DateTimeImmutable($base))->getTimestamp();
+        $beforeTs = (new \DateTimeImmutable($before))->getTimestamp();
+
+        self::assertSame(-1800, $beforeTs - $baseTs);
+    }
+
+    #[Test]
+    public function toIsoNormalisesToUtc(): void
+    {
+        // +09:00 Japan time — UTC is 9 hours behind
+        $jst = new \DateTimeImmutable('2026-05-26T12:00:00+09:00');
+        $iso = UtcClock::toIso($jst);
+
+        self::assertSame('2026-05-26T03:00:00Z', $iso);
+    }
+
+    #[Test]
+    public function toIsoAlreadyUtcPassesThrough(): void
+    {
+        $utc = new \DateTimeImmutable('2026-01-01T00:00:00Z');
+        $iso = UtcClock::toIso($utc);
+
+        self::assertSame('2026-01-01T00:00:00Z', $iso);
+    }
+
+    #[Test]
+    public function clockInterfaceIsReplaceableForTesting(): void
+    {
+        $fixed = new \DateTimeImmutable('2026-06-01T10:00:00Z');
+
+        $stub = new class ($fixed) implements ClockInterface {
+            public function __construct(private readonly \DateTimeImmutable $instant)
+            {
+            }
+
+            public function now(): \DateTimeImmutable
+            {
+                return $this->instant;
+            }
+        };
+
+        self::assertSame($fixed, $stub->now());
+    }
+}


### PR DESCRIPTION
## 概要

FT96〜FT170 で 100 本の howto ガイドを書く中で繰り返し登場した 2 パターンを `src/` に追加する。
コード変更なし・破壊変更なし。新クラスの追加のみ。

## 追加クラス

### `ClockInterface` / `UtcClock`（18 本のガイドで手書きされていたパターン）

```php
// before — 18 本が手書き
$now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d\TH:i:s\Z');

// after
$now    = $clock->now();            // DateTimeImmutable (UTC)
$nowIso = $clock->nowIso();         // "2026-05-26T12:00:00Z"
$exp    = $clock->nowIso('+24 hours'); // "2026-05-27T12:00:00Z"
```

テスト時は `ClockInterface` を実装した anonymous class を渡すだけ — モックフレームワーク不要。

### `SecureTokenHelper`（9〜10 本のガイドで手書きされていたパターン）

```php
// before — 毎回 3 行コピペ
$raw  = bin2hex(random_bytes(32));
$hash = hash('sha256', $raw);
hash_equals($stored, hash('sha256', $incoming)); // verify

// after
$raw        = SecureTokenHelper::generate();
$hash       = SecureTokenHelper::hash($raw);
$ok         = SecureTokenHelper::verify($incoming, $stored);
[$raw, $hash] = SecureTokenHelper::generateWithHash(); // 一括
```

## テスト

- `tests/Http/UtcClockTest.php` — 9 tests
- `tests/Http/SecureTokenHelperTest.php` — 16 tests
- 合計 **25 / 25 pass**
- `composer check` 全項目 ✅

## Self-review

backend-api チェックリスト確認済み。

Closes #877