### PR TITLE
docs: NENE2-examples 公開 + README / llms.txt から参照を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,19 +188,29 @@ NENE2's quality baseline includes PHP-CS-Fixer for backend style checks and npm,
 
 ## How-to guides
 
-Step-by-step recipes for common tasks:
+100 task-focused guides covering authentication, security, database patterns, API design, background jobs, and 40+ product feature recipes.
+
+**[Full guide index →](docs/howto/README.md)**
+
+Common entry points:
 
 - [Add a custom route](docs/howto/add-custom-route.md)
 - [Add a database-backed endpoint](docs/howto/add-database-endpoint.md)
-- [Use database transactions](docs/howto/use-transactions.md)
-- [Add a second entity](docs/howto/add-second-entity.md)
-- [Add pagination](docs/howto/add-pagination.md)
 - [Add JWT authentication](docs/howto/add-jwt-authentication.md)
+- [Add pagination](docs/howto/add-pagination.md)
 - [Add rate limiting](docs/howto/add-rate-limiting.md)
-- [Add a health check](docs/howto/add-health-check.md)
-- [Add an HTML view](docs/howto/add-html-view.md)
-- [Add MCP tools](docs/howto/add-mcp-tools.md)
 - [Deploy to production](docs/howto/deploy-production.md)
+
+## Reference Implementations
+
+**[hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)** — 73 field-trial applications built with `hideyukimori/nene2` as a Composer dependency. Each directory is a self-contained, runnable JSON API corresponding to one howto guide.
+
+```bash
+git clone https://github.com/hideyukiMORI/NENE2-examples.git
+cd NENE2-examples/deduplog   # or any other example
+composer install
+vendor/bin/phpunit
+```
 
 ## Delivery Starter Docs
 
@@ -240,7 +250,7 @@ NENE2 is designed to be AI-readable and usable as a tool by AI agents.
 - **[AGENTS.md](./AGENTS.md)** — entry point for AI agents working in this repository.
 - **OpenAPI contract** — `GET /openapi.php` or `docs/openapi/openapi.yaml` — the authoritative API contract for LLM tool use.
 - **Local MCP server** — `composer mcp` validates the MCP tool catalog; `docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/local-mcp-server.php` starts the local server.
-- **Field trial reports** — real-world AI implementation records: [hoplog](https://github.com/hideyukiMORI/hoplog) (FT10), [tasklog](https://github.com/hideyukiMORI/tasklog) (FT11).
+- **Reference implementations** — **[hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)**: 73 runnable field-trial apps covering every major howto pattern (auth, security, queues, social features, and more). Each app is `composer install && phpunit`-ready.
 
 ## License
 

--- a/llms.txt
+++ b/llms.txt
@@ -162,19 +162,26 @@ The spec covers all shipped JSON endpoints including health, examples (Note/Tag 
 - [`src/Mcp/LocalMcpServer.php`](https://github.com/hideyukiMORI/NENE2/blob/main/src/Mcp/LocalMcpServer.php): Local MCP server backed by the OpenAPI contract.
 - [`src/Example/`](https://github.com/hideyukiMORI/NENE2/tree/main/src/Example/): Reference Note/Tag CRUD implementation — canonical patterns for routes, use cases, repositories.
 
-## Field trial reports
+## Reference implementations
 
-AI-autonomously built applications using NENE2 as a Composer dependency, with recorded friction points:
+73 field-trial applications built with `hideyukimori/nene2` as a Composer dependency, each corresponding to one howto guide.
 
-- [FT10 — hoplog (craft beer tasting notes API)](https://github.com/hideyukiMORI/hoplog): 3 domains, 15 routes, 9 friction points → resolved in v1.4.
-- [FT11 — tasklog (JWT-authenticated task API)](https://github.com/hideyukiMORI/tasklog): 2 domains, 7 routes, 4 friction points → resolved in v1.4.1+.
-- [FT12-A — tagmark (bookmark + M:N tag API)](https://github.com/hideyukiMORI/tagmark): 3 entities, 13 endpoints, 7 friction points → resolved in v1.4.1+.
-- [FT12-B — knowledgelog (knowledge base + MCP tools)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-12b.md): 8 endpoints, 7 MCP tools, 5 friction points → resolved in v1.4.2+.
-- [FT12-C — shoplog (three-tier access model)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-12c.md): 12 endpoints, 6 friction points → resolved in v1.4.2+.
-- [FT13 — eventlog (MySQL + Phinx migrations)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-13.md): 10 endpoints, 5 friction points → resolved in v1.4.2+.
-- [FT14 — postboard (CompositeAuthMiddleware + M:N)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-14.md): 13 endpoints, 4 friction points → resolved in v1.4.2+.
-- [FT15 — noteboard (HTML View layer)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-15.md): 7 endpoints (HTML + JSON coexist), 3 friction points → resolved in v1.5.0.
-- [FT16 — noteboard (MCP tool layer)](https://github.com/hideyukiMORI/NENE2/blob/main/docs/field-trials/2026-05-field-trial-16.md): 3 MCP tools (2 read + 1 write), no friction — `add-mcp-tools.md` howto validated end-to-end.
+**Repository**: [hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)
+
+Each example is runnable with `composer install && vendor/bin/phpunit`. No vendor/ committed.
+
+Selected examples:
+
+- [deduplog](https://github.com/hideyukiMORI/NENE2-examples/tree/main/deduplog) — Request Deduplication (Idempotency-Key, 24h TTL)
+- [jwtlog](https://github.com/hideyukiMORI/NENE2-examples/tree/main/jwtlog) — JWT Authentication (LocalBearerTokenVerifier)
+- [rbaclog](https://github.com/hideyukiMORI/NENE2-examples/tree/main/rbaclog) — RBAC (JWT claim roles)
+- [apikeylog](https://github.com/hideyukiMORI/NENE2-examples/tree/main/apikeylog) — API Key Management (SHA-256, scoped)
+- [feedlog](https://github.com/hideyukiMORI/NENE2-examples/tree/main/feedlog) — Activity Feed (follow-based, cursor pagination)
+- [lockoutlog](https://github.com/hideyukiMORI/NENE2-examples/tree/main/lockoutlog) — Account Lockout (brute-force defense)
+- [totplog](https://github.com/hideyukiMORI/NENE2-examples/tree/main/totplog) — TOTP Two-Factor Auth (RFC 6238)
+- [oauthlog](https://github.com/hideyukiMORI/NENE2-examples/tree/main/oauthlog) — OAuth2 Social Login (Authorization Code Flow)
+
+Full index: [NENE2-examples/README.md](https://github.com/hideyukiMORI/NENE2-examples/blob/main/README.md)
 
 ## Design principles
 


### PR DESCRIPTION
## 概要

Packagist ユーザーから不可視だった 73 本のフィールドトライアル参照実装を公開し、NENE2 本体から参照する。

## 外部変更（PR マージ前に完了済み）

**[hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)** を新規公開リポジトリとして作成。
- 73 FT プロジェクトを収録（vendor/ 除き、18 MB、464 PHP ファイル）
- 各ディレクトリが howto ガイド 1 本に対応
- `composer install && vendor/bin/phpunit` で即実行可能

## 本 PR の変更内容

### `README.md`

- How-to guides セクション: 「100 本のガイド全インデックスへのリンク」に刷新
- **Reference Implementations** セクションを新設（NENE2-examples を紹介）

### `llms.txt`

- Field trial reports → **Reference implementations** に刷新
- NENE2-examples へのリンク + 代表 8 例を記載

## Self-review

docs-policy チェックリスト確認済み。

Closes #879