### PR TITLE
feat(howto): FT171 階層データ howto ガイド追加（自己参照FK＋マテリアライズドパス）

### DIFF
--- a/docs/ft-registry.md
+++ b/docs/ft-registry.md
@@ -119,3 +119,4 @@ webhooklog wishlistlog workflowlog
 | FT168 | agglog | Admin Report Aggregation ※reportlog(FT147)と衝突のため変更 |
 | FT169 | masklog | Data Masking |
 | FT170 | deduplog | Request Deduplication |
+| FT171 | hierarchylog | Hierarchical Data（自己参照FK＋マテリアライズドパス） |

--- a/docs/howto/hierarchical-data.md
+++ b/docs/howto/hierarchical-data.md
@@ -1,0 +1,195 @@
+# Hierarchical Data — Self-Referential FK + Materialized Path
+
+Store a tree of categories (or any hierarchy) in a single SQL table using a
+**self-referential foreign key** (`parent_id`) plus a **materialized path**
+(`/1/3/7/`) to enable O(1) subtree queries.
+
+**Reference implementation:** `FT171 hierarchylog` in
+[hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)
+
+---
+
+## When to Use This Pattern
+
+| Use this when… | Consider alternatives when… |
+|---|---|
+| Depth is bounded (≤ 5–10 levels) | Unlimited depth with frequent re-parenting |
+| Subtree reads are common | Tree is write-heavy with many moves |
+| Single-database solution is preferred | Graph relationships (multiple parents) |
+
+---
+
+## Schema Design
+
+```sql
+CREATE TABLE categories (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    parent_id  INTEGER,                      -- NULL = root node
+    path       TEXT    NOT NULL UNIQUE,      -- materialized path: "/1/", "/1/3/", "/1/3/7/"
+    depth      INTEGER NOT NULL DEFAULT 0,  -- 0 = root
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (parent_id) REFERENCES categories(id)
+);
+```
+
+### Path Convention
+
+- Root node: `/1/` (matches `/{id}/`)
+- Level-1 child of root: `/1/3/`
+- Level-2 grandchild: `/1/3/7/`
+- Always starts and ends with `/`.
+- After INSERT, compute `path = parentPath . newId . '/'` and UPDATE the row.
+
+---
+
+## Core Operations
+
+### Create (with path calculation)
+
+```php
+// 1. INSERT with a temporary placeholder
+$id = $this->db->insert(
+    'INSERT INTO categories (name, parent_id, path, depth, created_at) VALUES (?, ?, ?, ?, ?)',
+    [$name, $parentId, '__tmp__', $depth, $now],
+);
+// 2. Fix path now that we know the id
+$path = $parentPath . $id . '/';
+$this->db->execute('UPDATE categories SET path = ? WHERE id = ?', [$path, $id]);
+```
+
+### Subtree Query (O(1) on indexed path column)
+
+```php
+// All descendants of node with path "/1/3/"
+$rows = $this->db->fetchAll(
+    "SELECT * FROM categories WHERE path LIKE ? AND id != ? ORDER BY path",
+    [$root->path . '%', $rootId],
+);
+```
+
+### Ancestors
+
+```php
+// Path "/1/3/7/" → ancestor ids [1, 3]
+$parts = array_filter(explode('/', $node->path));
+$ancestorIds = array_filter(
+    array_map('intval', $parts),
+    fn(int $pid) => $pid !== $node->id,
+);
+```
+
+### Move (cascade to descendants)
+
+```php
+$oldPath = $node->path;
+$newPath = $newParentPath . $id . '/';
+
+// Update the node itself
+$this->db->execute(
+    'UPDATE categories SET parent_id = ?, path = ?, depth = ? WHERE id = ?',
+    [$newParentId, $newPath, $newDepth, $id],
+);
+
+// Cascade to all descendants
+foreach ($this->subtree($id) as $desc) {
+    $updatedPath  = $newPath . substr($desc->path, strlen($oldPath));
+    $updatedDepth = $desc->depth - $node->depth + $newDepth;
+    $this->db->execute(
+        'UPDATE categories SET path = ?, depth = ? WHERE id = ?',
+        [$updatedPath, $updatedDepth, $desc->id],
+    );
+}
+```
+
+---
+
+## Validation Rules
+
+| Rule | Implementation |
+|---|---|
+| Max depth | `if ($parent->depth >= MAX_DEPTH - 1) throw CategoryDepthException` |
+| Circular (self-move) | `if ($newParentId === $id) throw CategoryCircularException` |
+| Circular (descendant) | `if (str_starts_with($newParent->path, $node->path)) throw CategoryCircularException` |
+| Delete leaf only | `if ($children !== []) throw CategoryHasChildrenException` |
+| Move depth overflow | Check `$newDepth + maxSubtreeRelativeDepth >= MAX_DEPTH` before moving |
+
+---
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/categories` | List root categories (`?parent_id=N` for children) |
+| `POST` | `/categories` | Create a category |
+| `GET` | `/categories/{id}` | Get one category with its ancestor chain |
+| `GET` | `/categories/{id}/subtree` | Get all descendants |
+| `PUT` | `/categories/{id}` | Rename a category |
+| `PATCH` | `/categories/{id}/move` | Move to a new parent (`parent_id: null` for root) |
+| `DELETE` | `/categories/{id}` | Delete a leaf (reject if has children → 409) |
+
+---
+
+## Response Shapes
+
+### Category object
+
+```json
+{
+  "id": 7,
+  "name": "PHP Frameworks",
+  "parent_id": 3,
+  "path": "/1/3/7/",
+  "depth": 2,
+  "created_at": "2026-01-01T00:00:00+00:00"
+}
+```
+
+### GET /categories/{id} with ancestors
+
+```json
+{
+  "data": { ... },
+  "ancestors": [
+    { "id": 1, "name": "Technology", "depth": 0, ... },
+    { "id": 3, "name": "Programming", "depth": 1, ... }
+  ]
+}
+```
+
+---
+
+## Domain Layer Structure
+
+```
+src/Category/
+├── Category.php                    # readonly entity
+├── CategoryRepository.php          # tree operations (create / list / subtree / ancestors / move / delete)
+├── RouteRegistrar.php              # wires HTTP handlers to Router
+├── CategoryNotFoundException.php
+├── CategoryDepthException.php
+├── CategoryCircularException.php
+└── CategoryHasChildrenException.php
+```
+
+---
+
+## Trade-offs vs. Nested Sets / Closure Tables
+
+| Approach | Subtree read | Insert | Move |
+|---|---|---|---|
+| **Materialized path** (this guide) | Fast (`LIKE`) | O(1) | O(subtree size) |
+| Closure table | Fast (join) | O(ancestors) | O(subtree × ancestors) |
+| Nested sets | Fast (`BETWEEN`) | O(table) | O(table) |
+
+Materialized path is the sweet spot for bounded-depth trees where moves are
+infrequent. Use a closure table when ancestor queries must be index-only and
+moves are frequent.
+
+---
+
+## See Also
+
+- [Add a database-backed endpoint](./add-database-endpoint.md)
+- [Add pagination](./add-pagination.md)
+- [Soft delete](./soft-delete.md)

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,7 +5,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 ## Status
 
 - Latest release: `v1.5.104`（2026-05-22 リリース済み）
-- Current branch: `main` — clean — open Issue なし（#872 vite Dependabot リベース待ち）
+- Current branch: `main` — clean — FT171 PR 作成前（#872 vite Dependabot リベース待ち）
 
 ## Recently Completed (FT ループ — FT96–FT170 / v1.5.30–v1.5.104)
 
@@ -86,22 +86,17 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT168 | Admin Report Aggregation | agglog | 26/26 | v1.5.102 | admin-report-aggregation.md（日付バリデーション・from>to拒否・limit クランプ・COALESCE NULL 防止）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 | FT169 | Data Masking | masklog | 24/24 | v1.5.103 | data-masking.md（デフォルトマスク・admin unmask・X-Accessor 強制・append-only 監査ログ）**脆弱性診断: VULN-A〜L 全Pass** |
 | FT170 | Request Deduplication | deduplog | 24/24 | v1.5.104 | request-deduplication.md（Idempotency-Key 必須・24h TTL・replayed フラグ・ctype_digit 型検証）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
+| FT171 | Hierarchical Data | hierarchylog | 21/21 | v1.5.105 予定 | hierarchical-data.md（自己参照FK + マテリアライズドパス・MAX_DEPTH=5・循環参照検出・サブツリーカスケード） |
 
-## 次のアクション（2026-05-22〜）
+## 次のアクション（2026-05-26〜）
 
-### FT ループ継続（Howto Library Sprint Phase III）
-
-目標: **FT170 完了**でコアパターンライブラリを一区切りにする。
+### FT ループ継続（Phase IV）
 
 | FT | テーマ案 | 備考 |
 |---|---|---|
-| ~~FT164~~ | ~~Geolocation（geoloclog）~~ | ~~完了~~ | ~~v1.5.98~~ |
-| ~~FT165~~ | ~~A/B Testing（ablog）~~ | ~~完了~~ | ~~v1.5.99~~ |
-| ~~FT166~~ | ~~Multi-step Workflow（stepflowlog）~~ | ~~完了~~ | ~~v1.5.100~~ |
-| ~~FT167~~ | ~~Inbound Webhook Receiver（inboundlog）~~ | ~~完了~~ | ~~v1.5.101~~ |
-| ~~FT168~~ | ~~Admin Report Aggregation（agglog）~~ | ~~完了~~ | ~~v1.5.102~~ |
-| ~~FT169~~ | ~~Data Masking（masklog）~~ | ~~完了~~ | ~~v1.5.103~~ |
-| ~~FT170~~ | ~~Request Deduplication（deduplog）~~ | ~~完了~~ | ~~v1.5.104~~ |
+| ~~FT170~~ | ~~Request Deduplication（deduplog）~~ | ~~完了 v1.5.104~~ |
+| 🔄 FT171 | Hierarchical Data（hierarchylog） | 実装完了・PR 作成前 |
+| 📋 FT172 | 次テーマ | 脆弱性診断 ＋ クラッカー攻撃試験 両方が対象（周期到来） |
 
 ### ループ終了後（FT170 以降）— 完了・進行状況
 
@@ -119,8 +114,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | チェック項目 | 次回 |
 |---|---|
 | MySQL 統合テスト | FT167 ✓ 完了 |
-| 脆弱性診断 | FT169 ✓ 完了 |
-| クラッカー攻撃試験 | FT170 ✓ 完了 |
+| 脆弱性診断 | FT172（次） |
+| クラッカー攻撃試験 | FT172（次） |
 
 ## 検討事項（決定不要・議題として保持）
 


### PR DESCRIPTION
## 概要

FT171 field trial の成果を NENE2 本体に反映する。

## 変更内容

- **`docs/howto/hierarchical-data.md`** 新規追加
  - 自己参照 FK ＋ マテリアライズドパス（`/1/3/7/`）パターン
  - INSERT → tmp → UPDATE によるパス計算手順
  - `LIKE path%` サブツリークエリ・ancestors パース・move カスケード実装例
  - Nested Sets / Closure Table との比較表
  - 7エンドポイント仕様・レスポンス形式・ドメインレイヤー構成

- **`docs/ft-registry.md`**: FT171 hierarchylog エントリ追加

- **`docs/todo/current.md`**: FT171 進行中・Phase IV ロードマップ更新

## FT 実装サマリー

| 項目 | 内容 |
|---|---|
| プロジェクト | `../NENE2-FT/hierarchylog/` |
| テスト | 21テスト / 43アサーション（全Pass） |
| PHPStan | level 8 OK |
| CS | php-cs-fixer OK |

## 検証

```
cd /home/xi/docker/NENE2-FT/hierarchylog && php8.4 vendor/bin/phpunit
OK (21 tests, 43 assertions)
```

`docker compose run --rm app composer check`
→ 366 tests, 887 assertions / PHPStan OK / CS OK / OpenAPI OK / MCP OK

## セルフレビュー

Self-review: docs-policy

Closes #883