### PR TITLE
feat(howto): FT172 Content Scheduling howto（時間指定公開・状態機械）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.106] — 2026-05-26
+
+### Added
+- `docs/howto/content-scheduling.md` — Content Scheduling ガイド: publish_at 時間指定・draft/scheduled/published/archived 状態機械・publish-due 一括トリガー・hash_equals admin key。脆弱性診断 VULN-A〜L 全Pass・クラッカー攻撃試験 ATK-01〜12 全Pass (FT172)。 (#886)
+
+---
+
+## [1.5.105] — 2026-05-26
+
+### Added
+- `docs/howto/hierarchical-data.md` — Hierarchical Data ガイド: 自己参照FK + マテリアライズドパス・MAX_DEPTH=5・循環参照検出・サブツリーカスケード (FT171)。 (#884)
+
+---
+
 ## [1.5.104] — 2026-05-22
 
 ### Added

--- a/docs/ft-registry.md
+++ b/docs/ft-registry.md
@@ -120,3 +120,4 @@ webhooklog wishlistlog workflowlog
 | FT169 | masklog | Data Masking |
 | FT170 | deduplog | Request Deduplication |
 | FT171 | hierarchylog | Hierarchical Data（自己参照FK＋マテリアライズドパス） |
+| FT172 | pubschedulelog | Content Scheduling（時間指定公開・ライフサイクル状態機械） |

--- a/docs/howto/content-scheduling.md
+++ b/docs/howto/content-scheduling.md
@@ -1,0 +1,183 @@
+# Content Scheduling — Time-Based Publish with Lifecycle States
+
+Schedule content to publish at a future datetime using a `publish_at` column,
+a status machine (`draft → scheduled → published → archived`), and a
+**publish-due trigger** endpoint that a cron job calls to flip due articles.
+
+**Reference implementation:** `FT172 pubschedulelog` in
+[hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)
+
+---
+
+## Status Lifecycle
+
+```
+draft ──┬──► scheduled ──► published ──► archived
+        │                               ▲
+        └───────────────────────────────┘
+        (also: scheduled → draft via unschedule)
+```
+
+| From | Allowed transitions |
+|---|---|
+| `draft` | `scheduled`, `published`, `archived` |
+| `scheduled` | `published`, `draft`, `archived` |
+| `published` | `archived` |
+| `archived` | *(none)* |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    author_id    INTEGER NOT NULL,
+    title        TEXT    NOT NULL,
+    body         TEXT    NOT NULL,
+    status       TEXT    NOT NULL DEFAULT 'draft',
+    -- 'draft' | 'scheduled' | 'published' | 'archived'
+    publish_at   TEXT,    -- ISO 8601; set when scheduled; NULL otherwise
+    published_at TEXT,    -- set when actually published
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL
+);
+```
+
+---
+
+## Endpoints
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `POST` | `/articles` | X-User-Id | Create a draft |
+| `GET` | `/articles` | optional | List (`?status=published` is public; other statuses require auth + own articles only) |
+| `GET` | `/articles/{id}` | optional | Get one article (published = public, draft/scheduled = owner only) |
+| `PUT` | `/articles/{id}` | X-User-Id | Update title/body (draft or scheduled only) |
+| `POST` | `/articles/{id}/schedule` | X-User-Id | Set `publish_at` → moves to `scheduled` |
+| `POST` | `/articles/{id}/unschedule` | X-User-Id | Cancel scheduling → reverts to `draft` |
+| `POST` | `/articles/{id}/publish` | X-User-Id | Publish immediately |
+| `POST` | `/articles/{id}/archive` | X-User-Id | Archive |
+| `POST` | `/articles/publish-due` | X-Admin-Key | Bulk-publish all due scheduled articles |
+
+---
+
+## Core Patterns
+
+### Status Enum with Transition Guard
+
+```php
+enum ArticleStatus: string {
+    case Draft     = 'draft';
+    case Scheduled = 'scheduled';
+    case Published = 'published';
+    case Archived  = 'archived';
+
+    public function canTransitionTo(self $next): bool {
+        return match ($this) {
+            self::Draft     => in_array($next, [self::Scheduled, self::Published, self::Archived], true),
+            self::Scheduled => in_array($next, [self::Published, self::Draft, self::Archived], true),
+            self::Published => $next === self::Archived,
+            self::Archived  => false,
+        };
+    }
+}
+```
+
+### Schedule: Future-Only Validation
+
+```php
+$ts = strtotime($publishAt);
+if ($ts === false || $ts === -1) {
+    throw new ArticleScheduleException('publish_at is not a valid datetime.');
+}
+if ($ts <= strtotime($now)) {
+    throw new ArticleScheduleException('publish_at must be in the future.');
+}
+```
+
+### Publish-Due Trigger (cron-safe, idempotent)
+
+```php
+public function publishDue(string $now): array
+{
+    $rows = $this->db->fetchAll(
+        "SELECT id FROM articles WHERE status = ? AND publish_at <= ? ORDER BY publish_at",
+        [ArticleStatus::Scheduled->value, $now],
+    );
+
+    $published = [];
+    foreach ($rows as $row) {
+        $id = (int) $row['id'];
+        $this->db->execute(
+            'UPDATE articles SET status = ?, published_at = ?, publish_at = NULL, updated_at = ? WHERE id = ?',
+            [ArticleStatus::Published->value, $now, $now, $id],
+        );
+        $published[] = $id;
+    }
+
+    return $published;  // list<int>
+}
+```
+
+Call this from a cron job every minute. Idempotent: re-running immediately finds
+no new due articles since `publish_at` is cleared to `NULL` on publish.
+
+### IDOR Prevention
+
+Draft and scheduled articles are **owner-only** — return 404 (not 403) to
+avoid leaking existence:
+
+```php
+if ($article->authorId !== $actorId) {
+    throw new ArticleNotFoundException($id);  // 404, not 403
+}
+```
+
+### Admin Key — Timing-Safe Comparison
+
+```php
+if ($apiKey === '' || !hash_equals($expected, $apiKey)) {
+    return $this->responseFactory->create(['error' => 'unauthorized'], 401);
+}
+```
+
+Never use `!==` for secret comparisons — use `hash_equals()` to prevent
+timing attacks.
+
+---
+
+## Security Notes
+
+| Risk | Mitigation |
+|---|---|
+| Past `publish_at` injection | `strtotime($publishAt) <= strtotime($now)` → 422 |
+| Cross-user state mutation | Ownership check before every transition; 404 not 403 |
+| Author ID injection via body | `authorId` taken from `X-User-Id` header only |
+| Status injection via body | `status` field in PUT body is ignored; transitions via dedicated action endpoints |
+| Timing attack on admin key | `hash_equals()` instead of `!==` |
+| Enumeration of unpublished articles | Public listing always filters by `status = published`; non-published requires auth + own articles only |
+| Edit after publish | PUT rejects non-draft/scheduled articles with 422 |
+| Double archive | Transition guard returns 409 for invalid transitions |
+
+---
+
+## Cron Integration
+
+```bash
+# /etc/cron.d/publish-due
+* * * * * www-data curl -s -X POST https://api.example.com/articles/publish-due \
+  -H "X-Admin-Key: $ADMIN_KEY"
+```
+
+For higher-volume workloads, move to a job queue (see
+[job-queue.md](./job-queue.md)) and have the queue worker call `publishDue()`.
+
+---
+
+## See Also
+
+- [Content Draft Lifecycle](./content-draft-lifecycle.md) — draft/active/archived without scheduling
+- [Job Queue](./job-queue.md) — background processing for high-volume publish triggers
+- [Soft Delete](./soft-delete.md) — complement to archiving
+- [Audit Trail](./audit-trail.md) — recording who published what and when

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.104
+  version: 1.5.106
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,8 +4,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.104`（2026-05-22 リリース済み）
-- Current branch: `main` — clean — FT171 PR 作成前（#872 vite Dependabot リベース待ち）
+- Latest release: `v1.5.105`（2026-05-26 リリース済み）
+- Current branch: `main` — clean — FT172 PR 作成前（#872 vite Dependabot リベース待ち）
 
 ## Recently Completed (FT ループ — FT96–FT170 / v1.5.30–v1.5.104)
 
@@ -86,7 +86,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT168 | Admin Report Aggregation | agglog | 26/26 | v1.5.102 | admin-report-aggregation.md（日付バリデーション・from>to拒否・limit クランプ・COALESCE NULL 防止）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 | FT169 | Data Masking | masklog | 24/24 | v1.5.103 | data-masking.md（デフォルトマスク・admin unmask・X-Accessor 強制・append-only 監査ログ）**脆弱性診断: VULN-A〜L 全Pass** |
 | FT170 | Request Deduplication | deduplog | 24/24 | v1.5.104 | request-deduplication.md（Idempotency-Key 必須・24h TTL・replayed フラグ・ctype_digit 型検証）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
-| FT171 | Hierarchical Data | hierarchylog | 21/21 | v1.5.105 予定 | hierarchical-data.md（自己参照FK + マテリアライズドパス・MAX_DEPTH=5・循環参照検出・サブツリーカスケード） |
+| FT171 | Hierarchical Data | hierarchylog | 21/21 | v1.5.105 | hierarchical-data.md（自己参照FK + マテリアライズドパス・MAX_DEPTH=5・循環参照検出・サブツリーカスケード） |
+| FT172 | Content Scheduling | pubschedulelog | 34/34 | v1.5.106 予定 | content-scheduling.md（publish_at 時間指定・draft/scheduled/published/archived 状態機械・publish-due 一括トリガー・hash_equals admin key）**脆弱性診断: VULN-A〜L 全Pass** ／ **クラッカー攻撃試験: ATK-01〜12 全Pass** |
 
 ## 次のアクション（2026-05-26〜）
 
@@ -95,8 +96,9 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT | テーマ案 | 備考 |
 |---|---|---|
 | ~~FT170~~ | ~~Request Deduplication（deduplog）~~ | ~~完了 v1.5.104~~ |
-| 🔄 FT171 | Hierarchical Data（hierarchylog） | 実装完了・PR 作成前 |
-| 📋 FT172 | 次テーマ | 脆弱性診断 ＋ クラッカー攻撃試験 両方が対象（周期到来） |
+| ~~FT171~~ | ~~Hierarchical Data（hierarchylog）~~ | ~~完了 v1.5.105~~ |
+| 🔄 FT172 | Content Scheduling（pubschedulelog） | 実装完了・PR 作成前 |
+| 📋 FT173 | 次テーマ | — |
 
 ### ループ終了後（FT170 以降）— 完了・進行状況
 
@@ -114,8 +116,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | チェック項目 | 次回 |
 |---|---|
 | MySQL 統合テスト | FT167 ✓ 完了 |
-| 脆弱性診断 | FT172（次） |
-| クラッカー攻撃試験 | FT172（次） |
+| 脆弱性診断 | FT172 ✓ 完了（次: FT175） |
+| クラッカー攻撃試験 | FT172 ✓ 完了（次: FT176） |
 
 ## 検討事項（決定不要・議題として保持）
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.104';
+    public const string VERSION = '1.5.106';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT172 field trial の成果を NENE2 本体に反映する。

## 変更内容

- **docs/howto/content-scheduling.md** 新規追加
  - ArticleStatus enum（draft/scheduled/published/archived）と遷移ガード
  - publish_at 未来日時のみ許可（strtotime 検証）
  - publishDue 一括トリガー実装例（cron-safe・冪等）
  - hash_equals admin key（タイミング攻撃防止）
  - IDOR 防止パターン（非公開記事は 404 で統一）

- **src/FrameworkInfo.php**: VERSION 1.5.104 → 1.5.106
- **docs/openapi/openapi.yaml**: info.version 同期
- **CHANGELOG.md**: 1.5.105（FT171 howto）・1.5.106（FT172 howto）追加

## FT172 テストサマリー

| 項目 | 内容 |
|---|---|
| プロジェクト | pubschedulelog |
| テスト | 34テスト / 95アサーション（全Pass） |
| 脆弱性診断 | VULN-A〜L 12件全Pass |
| クラッカー攻撃試験 | ATK-01〜12 全Pass |
| PHPStan | level 8 OK |
| CS | php-cs-fixer OK |

## 発見・修正事項

- PSR-7 は RFC 7230 に従いヘッダー値の前後空白を正規化する（ATK-07 で確認）
- admin key 比較を hash_equals() に変更（タイミング攻撃対策）

## 検証

composer check → 366 tests / Version consistency OK: 1.5.106

Self-review: docs-policy

Closes #885