### PR TITLE
feat(howto): FT173 Content Relations howto（型付きM:N自己参照リンク）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.107] — 2026-05-26
+
+### Added
+- `docs/howto/content-relations.md` — Content Relations ガイド: 型付きM:N自己参照リンク（related/sequel/prequel/reference）・双方向自動挿入・逆辺カスケード削除 (FT173)。 (#888)
+
+---
+
 ## [1.5.106] — 2026-05-26
 
 ### Added

--- a/docs/ft-registry.md
+++ b/docs/ft-registry.md
@@ -121,3 +121,4 @@ webhooklog wishlistlog workflowlog
 | FT170 | deduplog | Request Deduplication |
 | FT171 | hierarchylog | Hierarchical Data（自己参照FK＋マテリアライズドパス） |
 | FT172 | pubschedulelog | Content Scheduling（時間指定公開・ライフサイクル状態機械） |
+| FT173 | relatedlog | Content Relations（型付きM:N自己参照リンク） |

--- a/docs/howto/content-relations.md
+++ b/docs/howto/content-relations.md
@@ -1,0 +1,221 @@
+# Content Relations — Typed M:N Self-Referential Links
+
+Link articles (or any resource) to each other using a **join table with a
+`relation_type` column**. Support asymmetric types (sequel ↔ prequel) with
+automatic inverse insertion, and symmetric types (related, reference) with
+the same inverse logic.
+
+**Reference implementation:** `FT173 relatedlog` in
+[hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)
+
+---
+
+## When to Use This Pattern
+
+| Use this when… | Consider alternatives when… |
+|---|---|
+| Resources link to each other with typed edges | You only need untyped "related" links |
+| Asymmetric edges are needed (A is a sequel of B) | A simple tagging system is sufficient |
+| Bidirectional queries must stay fast | Graph traversal across many hops is required |
+| Relation type drives UI behavior ("See sequels") | — |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE article_relations (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    article_id    INTEGER NOT NULL,
+    related_id    INTEGER NOT NULL,
+    relation_type TEXT    NOT NULL,
+    -- 'related' | 'sequel' | 'prequel' | 'reference'
+    created_at    TEXT    NOT NULL,
+    UNIQUE (article_id, related_id, relation_type),
+    FOREIGN KEY (article_id) REFERENCES articles(id),
+    FOREIGN KEY (related_id) REFERENCES articles(id),
+    CHECK (article_id != related_id)      -- self-relation prevented at DB level
+);
+```
+
+### Design Notes
+
+- The `UNIQUE (article_id, related_id, relation_type)` constraint prevents
+  duplicate edges of the same type. The same pair can have **multiple** types
+  (e.g., A → B as both `related` and `reference`).
+- `CHECK (article_id != related_id)` prevents self-loops at the database level.
+- **Both directions are stored**: adding `A → B (sequel)` also inserts `B → A (prequel)`.
+  This makes per-article queries trivial (`WHERE article_id = ?`) with no joins.
+
+---
+
+## Relation Types
+
+```php
+enum RelationType: string
+{
+    case Related   = 'related';    // symmetric: A related B ↔ B related A
+    case Sequel    = 'sequel';     // asymmetric: A sequel→B ↔ B prequel→A
+    case Prequel   = 'prequel';    // asymmetric: inverse of sequel
+    case Reference = 'reference';  // symmetric: bidirectional citation
+
+    public function inverse(): self
+    {
+        return match ($this) {
+            self::Sequel  => self::Prequel,
+            self::Prequel => self::Sequel,
+            default       => $this,  // related, reference are self-inverse
+        };
+    }
+}
+```
+
+---
+
+## Core Operation: Add Relation with Automatic Inverse
+
+```php
+public function addRelation(int $articleId, int $relatedId, RelationType $type, string $now): ArticleRelation
+{
+    // 1. Validate both articles exist
+    // 2. Check for duplicate (UNIQUE constraint would also catch this)
+    $existing = $this->db->fetchOne(
+        'SELECT id FROM article_relations WHERE article_id = ? AND related_id = ? AND relation_type = ?',
+        [$articleId, $relatedId, $type->value],
+    );
+    if ($existing !== null) {
+        throw new RelationAlreadyExistsException($articleId, $relatedId, $type);
+    }
+
+    // 3. Insert forward relation
+    $id = $this->db->insert(
+        'INSERT INTO article_relations (article_id, related_id, relation_type, created_at) VALUES (?, ?, ?, ?)',
+        [$articleId, $relatedId, $type->value, $now],
+    );
+
+    // 4. Insert inverse (if not already there)
+    $inverse = $type->inverse();
+    $inverseExists = $this->db->fetchOne(
+        'SELECT id FROM article_relations WHERE article_id = ? AND related_id = ? AND relation_type = ?',
+        [$relatedId, $articleId, $inverse->value],
+    );
+    if ($inverseExists === null) {
+        $this->db->insert(
+            'INSERT INTO article_relations (article_id, related_id, relation_type, created_at) VALUES (?, ?, ?, ?)',
+            [$relatedId, $articleId, $inverse->value, $now],
+        );
+    }
+
+    return new ArticleRelation($id, $articleId, $relatedId, $type, $now);
+}
+```
+
+### Remove Relation (cascade inverse)
+
+```php
+public function removeRelation(int $articleId, int $relatedId, RelationType $type): bool
+{
+    $deleted = $this->db->execute(
+        'DELETE FROM article_relations WHERE article_id = ? AND related_id = ? AND relation_type = ?',
+        [$articleId, $relatedId, $type->value],
+    );
+    // Remove inverse
+    $inverse = $type->inverse();
+    $this->db->execute(
+        'DELETE FROM article_relations WHERE article_id = ? AND related_id = ? AND relation_type = ?',
+        [$relatedId, $articleId, $inverse->value],
+    );
+    return $deleted > 0;
+}
+```
+
+---
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/articles` | Create an article |
+| `GET` | `/articles/{id}` | Get article with embedded related stubs |
+| `POST` | `/articles/{id}/relations` | Add a relation (+ auto-inserts inverse) |
+| `GET` | `/articles/{id}/relations` | List relations (`?type=sequel` to filter) |
+| `DELETE` | `/articles/{id}/relations/{relatedId}` | Remove relation (`?type=sequel` required) |
+
+---
+
+## Response Shapes
+
+### GET /articles/{id} — with embedded relations
+
+```json
+{
+  "data": { "id": 1, "title": "Part 1", ... },
+  "relations": [
+    {
+      "relation": { "id": 1, "article_id": 1, "related_id": 2, "relation_type": "sequel", ... },
+      "related":  { "id": 2, "title": "Part 2", ... }
+    }
+  ]
+}
+```
+
+### POST /articles/{id}/relations — request
+
+```json
+{
+  "related_id": 2,
+  "relation_type": "sequel"
+}
+```
+
+### DELETE /articles/{id}/relations/{relatedId}
+
+```
+DELETE /articles/1/relations/2?type=sequel
+```
+
+The `type` query param is **required** — a pair can have multiple relation types
+simultaneously, so the type disambiguates which edge to remove.
+
+---
+
+## Domain Layer Structure
+
+```
+src/Article/
+├── Article.php
+├── ArticleRelation.php
+├── ArticleRepository.php       # addRelation / removeRelation / listRelations / findWithRelations
+├── RelationType.php            # enum with inverse()
+├── ArticleNotFoundException.php
+└── RelationAlreadyExistsException.php
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| Self-relation (`article_id == related_id`) | 422 — checked in handler before DB |
+| Duplicate type between same pair | 409 Conflict |
+| Same pair with different type | 201 — valid, stored as separate rows |
+| Remove non-existent relation | 404 |
+| Remove without `type` param | 422 |
+| Missing articles | 404 for each invalid ID |
+
+---
+
+## See Also
+
+- [Tagging System (M:N)](./tagging-system.md) — resource-to-tag M:N without typed edges
+- [Threaded Comments](./threaded-comments.md) — self-referential `parent_id`
+- [Hierarchical Data](./hierarchical-data.md) — materialized path tree
+- [User Follow System](./user-follow-system.md) — directed M:N between users

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.106
+  version: 1.5.107
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,8 +4,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.105`（2026-05-26 リリース済み）
-- Current branch: `main` — clean — FT172 PR 作成前（#872 vite Dependabot リベース待ち）
+- Latest release: `v1.5.106`（2026-05-26 リリース済み）
+- Current branch: `main` — clean — FT173 PR 作成前（#872 vite Dependabot リベース待ち）
 
 ## Recently Completed (FT ループ — FT96–FT170 / v1.5.30–v1.5.104)
 
@@ -87,7 +87,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT169 | Data Masking | masklog | 24/24 | v1.5.103 | data-masking.md（デフォルトマスク・admin unmask・X-Accessor 強制・append-only 監査ログ）**脆弱性診断: VULN-A〜L 全Pass** |
 | FT170 | Request Deduplication | deduplog | 24/24 | v1.5.104 | request-deduplication.md（Idempotency-Key 必須・24h TTL・replayed フラグ・ctype_digit 型検証）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 | FT171 | Hierarchical Data | hierarchylog | 21/21 | v1.5.105 | hierarchical-data.md（自己参照FK + マテリアライズドパス・MAX_DEPTH=5・循環参照検出・サブツリーカスケード） |
-| FT172 | Content Scheduling | pubschedulelog | 34/34 | v1.5.106 予定 | content-scheduling.md（publish_at 時間指定・draft/scheduled/published/archived 状態機械・publish-due 一括トリガー・hash_equals admin key）**脆弱性診断: VULN-A〜L 全Pass** ／ **クラッカー攻撃試験: ATK-01〜12 全Pass** |
+| FT172 | Content Scheduling | pubschedulelog | 34/34 | v1.5.106 | content-scheduling.md（publish_at 時間指定・draft/scheduled/published/archived 状態機械・publish-due 一括トリガー・hash_equals admin key）**脆弱性診断: VULN-A〜L 全Pass** ／ **クラッカー攻撃試験: ATK-01〜12 全Pass** |
+| FT173 | Content Relations | relatedlog | 19/19 | v1.5.107 予定 | content-relations.md（型付きM:N自己参照・sequel↔prequel 自動逆辺・UNIQUE 制約・カスケード削除） |
 
 ## 次のアクション（2026-05-26〜）
 
@@ -97,8 +98,9 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 |---|---|---|
 | ~~FT170~~ | ~~Request Deduplication（deduplog）~~ | ~~完了 v1.5.104~~ |
 | ~~FT171~~ | ~~Hierarchical Data（hierarchylog）~~ | ~~完了 v1.5.105~~ |
-| 🔄 FT172 | Content Scheduling（pubschedulelog） | 実装完了・PR 作成前 |
-| 📋 FT173 | 次テーマ | — |
+| ~~FT172~~ | ~~Content Scheduling（pubschedulelog）~~ | ~~完了 v1.5.106~~ |
+| 🔄 FT173 | Content Relations（relatedlog） | 実装完了・PR 作成前 |
+| 📋 FT174 | 次テーマ | — |
 
 ### ループ終了後（FT170 以降）— 完了・進行状況
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.106';
+    public const string VERSION = '1.5.107';
 
     public function name(): string
     {


### PR DESCRIPTION
FT173 field trial の成果を反映。

- docs/howto/content-relations.md: RelationType enum + inverse()・双方向自動挿入・カスケード削除・UNIQUE制約・self-loop防止
- Version 1.5.107 (FrameworkInfo / openapi / CHANGELOG)

テスト: 19/19 Pass / PHPStan level 8 OK / CS OK

Self-review: docs-policy

Closes #887