### PR TITLE
feat(howto): FT174 Slug Management howto（衝突解決・履歴リダイレクト）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.108] — 2026-05-26
+
+### Added
+- `docs/howto/slug-management.md` — Slug Management ガイド: SlugHelper（fromTitle/makeUnique）・slug_history テーブル・301 リダイレクトヒント・更新時衝突解決 (FT174)。 (#890)
+
+---
+
 ## [1.5.107] — 2026-05-26
 
 ### Added

--- a/docs/ft-registry.md
+++ b/docs/ft-registry.md
@@ -122,3 +122,4 @@ webhooklog wishlistlog workflowlog
 | FT171 | hierarchylog | Hierarchical Data（自己参照FK＋マテリアライズドパス） |
 | FT172 | pubschedulelog | Content Scheduling（時間指定公開・ライフサイクル状態機械） |
 | FT173 | relatedlog | Content Relations（型付きM:N自己参照リンク） |
+| FT174 | sluglog | Slug Management（URL スラグ生成・衝突解決・履歴リダイレクト） |

--- a/docs/howto/slug-management.md
+++ b/docs/howto/slug-management.md
@@ -1,0 +1,194 @@
+# Slug Management — Unique URL Slugs with Collision Resolution and History
+
+Generate URL-safe slugs from titles, resolve collisions automatically, and keep
+a **slug history table** so that old slugs redirect to the canonical URL without
+breaking inbound links.
+
+**Reference implementation:** `FT174 sluglog` in
+[hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    slug       TEXT    NOT NULL UNIQUE,   -- current canonical slug
+    body       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+-- Old slugs kept for redirect support
+CREATE TABLE slug_history (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    article_id  INTEGER NOT NULL,
+    old_slug    TEXT    NOT NULL UNIQUE,  -- redirect source; UNIQUE prevents duplicates
+    replaced_at TEXT    NOT NULL,
+    FOREIGN KEY (article_id) REFERENCES articles(id)
+);
+```
+
+---
+
+## Slug Generation
+
+```php
+final class SlugHelper
+{
+    public static function fromTitle(string $title): string
+    {
+        $slug = mb_strtolower($title);
+        $slug = (string) preg_replace('/[^a-z0-9]+/', '-', $slug);
+        $slug = trim($slug, '-');
+        return $slug !== '' ? $slug : 'untitled';
+    }
+
+    /**
+     * @param callable(string): bool $exists  Returns true if slug is taken.
+     */
+    public static function makeUnique(string $base, callable $exists): string
+    {
+        if (!$exists($base)) {
+            return $base;
+        }
+        $counter = 2;
+        while ($exists("{$base}-{$counter}")) {
+            $counter++;
+        }
+        return "{$base}-{$counter}";
+    }
+}
+```
+
+### Uniqueness Check — Include Both Tables
+
+When checking whether a slug is "taken", check **both** `articles.slug` and
+`slug_history.old_slug`. Otherwise a new article could claim a slug that is
+still in active use as a redirect source:
+
+```php
+private function slugExists(string $slug): bool
+{
+    return $this->db->fetchOne('SELECT id FROM articles WHERE slug = ?', [$slug]) !== null
+        || $this->db->fetchOne('SELECT id FROM slug_history WHERE old_slug = ?', [$slug]) !== null;
+}
+```
+
+---
+
+## Slug Lookup with Redirect Hint
+
+```php
+public function findBySlugWithRedirect(string $slug): ?array
+{
+    // 1. Check current slug column (200 OK)
+    $article = $this->findBySlug($slug);
+    if ($article !== null) {
+        return ['found' => $article, 'redirect' => false];
+    }
+
+    // 2. Check slug history (301 Redirect hint)
+    $row = $this->db->fetchOne(
+        'SELECT article_id FROM slug_history WHERE old_slug = ?', [$slug],
+    );
+    if ($row === null) {
+        return null;  // 404
+    }
+
+    $article = $this->findById((int) $row['article_id']);
+    return $article !== null ? ['found' => $article, 'redirect' => true] : null;
+}
+```
+
+The handler then returns HTTP 301 with `canonical_slug` and `data`:
+
+```json
+// GET /articles/by-slug/old-title  →  301
+{
+  "redirect": true,
+  "canonical_slug": "new-title",
+  "data": { "id": 1, "slug": "new-title", ... }
+}
+```
+
+---
+
+## Slug Update — Record History
+
+When an article is renamed, move the old slug to `slug_history`:
+
+```php
+if ($newSlug !== $article->slug) {
+    // Only insert if not already in history (idempotent)
+    $alreadyIn = $this->db->fetchOne(
+        'SELECT id FROM slug_history WHERE old_slug = ?', [$article->slug],
+    );
+    if ($alreadyIn === null) {
+        $this->db->insert(
+            'INSERT INTO slug_history (article_id, old_slug, replaced_at) VALUES (?, ?, ?)',
+            [$id, $article->slug, $now],
+        );
+    }
+}
+```
+
+### Collision Handling on Update
+
+When computing the new slug for an updated article, exclude the article's own
+**current** slug from the "exists" check — otherwise it would unnecessarily
+increment to `-2`:
+
+```php
+$newSlug = SlugHelper::makeUnique(
+    $newSlugBase,
+    fn (string $s): bool => $s !== $article->slug && $this->slugExists($s),
+);
+```
+
+---
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/articles` | Create article — slug auto-derived from title |
+| `GET` | `/articles/{id}` | Get by numeric ID |
+| `GET` | `/articles/by-slug/{slug}` | Get by slug (200 current / 301 historical / 404) |
+| `PUT` | `/articles/{id}` | Update title/body/slug; old slug → history |
+| `GET` | `/articles/{id}/slug-history` | List historical slugs |
+
+---
+
+## Collision Scenarios
+
+| Scenario | Result |
+|---|---|
+| First "Hello World" | `hello-world` |
+| Second "Hello World" | `hello-world-2` |
+| Third "Hello World" | `hello-world-3` |
+| Article renamed from `hello` to an already-taken slug | `taken-slug-2` |
+| Same title, no change to slug | No history entry, slug unchanged |
+| Old slug matches a history entry | 301 redirect response |
+
+---
+
+## Domain Layer Structure
+
+```
+src/Article/
+├── Article.php
+├── ArticleRepository.php   # create / findBySlug / findBySlugWithRedirect / update / slugHistory
+├── SlugHelper.php          # fromTitle() + makeUnique()
+└── ArticleNotFoundException.php
+```
+
+---
+
+## See Also
+
+- [Soft Delete](./soft-delete.md) — combining slug history with soft-deleted records
+- [Content Versioning](./content-versioning.md) — version history alongside slug history
+- [Content Draft Lifecycle](./content-draft-lifecycle.md) — slug behavior across draft states

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.107
+  version: 1.5.108
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,8 +4,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.106`（2026-05-26 リリース済み）
-- Current branch: `main` — clean — FT173 PR 作成前（#872 vite Dependabot リベース待ち）
+- Latest release: `v1.5.107`（2026-05-26 リリース済み）
+- Current branch: `main` — clean — FT174 PR 作成前（#872 vite Dependabot リベース待ち）
 
 ## Recently Completed (FT ループ — FT96–FT170 / v1.5.30–v1.5.104)
 
@@ -88,7 +88,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT170 | Request Deduplication | deduplog | 24/24 | v1.5.104 | request-deduplication.md（Idempotency-Key 必須・24h TTL・replayed フラグ・ctype_digit 型検証）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 | FT171 | Hierarchical Data | hierarchylog | 21/21 | v1.5.105 | hierarchical-data.md（自己参照FK + マテリアライズドパス・MAX_DEPTH=5・循環参照検出・サブツリーカスケード） |
 | FT172 | Content Scheduling | pubschedulelog | 34/34 | v1.5.106 | content-scheduling.md（publish_at 時間指定・draft/scheduled/published/archived 状態機械・publish-due 一括トリガー・hash_equals admin key）**脆弱性診断: VULN-A〜L 全Pass** ／ **クラッカー攻撃試験: ATK-01〜12 全Pass** |
-| FT173 | Content Relations | relatedlog | 19/19 | v1.5.107 予定 | content-relations.md（型付きM:N自己参照・sequel↔prequel 自動逆辺・UNIQUE 制約・カスケード削除） |
+| FT173 | Content Relations | relatedlog | 19/19 | v1.5.107 | content-relations.md（型付きM:N自己参照・sequel↔prequel 自動逆辺・UNIQUE 制約・カスケード削除） |
+| FT174 | Slug Management | sluglog | 19/19 | v1.5.108 予定 | slug-management.md（SlugHelper fromTitle/makeUnique・slug_history 301 リダイレクト・両テーブル重複チェック） |
 
 ## 次のアクション（2026-05-26〜）
 
@@ -99,8 +100,9 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | ~~FT170~~ | ~~Request Deduplication（deduplog）~~ | ~~完了 v1.5.104~~ |
 | ~~FT171~~ | ~~Hierarchical Data（hierarchylog）~~ | ~~完了 v1.5.105~~ |
 | ~~FT172~~ | ~~Content Scheduling（pubschedulelog）~~ | ~~完了 v1.5.106~~ |
-| 🔄 FT173 | Content Relations（relatedlog） | 実装完了・PR 作成前 |
-| 📋 FT174 | 次テーマ | — |
+| ~~FT173~~ | ~~Content Relations（relatedlog）~~ | ~~完了 v1.5.107~~ |
+| 🔄 FT174 | Slug Management（sluglog） | 実装完了・PR 作成前 |
+| 📋 FT175 | 次テーマ | 脆弱性診断（周期: FT175） |
 
 ### ループ終了後（FT170 以降）— 完了・進行状況
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.107';
+    public const string VERSION = '1.5.108';
 
     public function name(): string
     {


### PR DESCRIPTION
FT174 の成果を反映。slug-management.md: SlugHelper / slug_history / 301 リダイレクト / 両テーブル重複チェック。Version 1.5.108。テスト 19/19 Pass。Self-review: docs-policy。Closes #889