### PR TITLE
docs(ft176): Delegated Access Grants howto + v1.5.110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.110] — 2026-05-26
+
+### Added
+- `docs/howto/delegated-access-grants.md` — Delegated Access Grants ガイド: multi-party 委譲・time-limited scoped アクセス・state machine（expired/revoked）・IDOR防止 404・型強制チェック（is_int 厳密検証）・Unicode/BIDI verbatim 保存。**クラッカー攻撃試験 ATK-01〜12 全Pass** (FT176)。 (#895)
+
+---
+
 ## [1.5.109] — 2026-05-26
 
 ### Added

--- a/docs/ft-registry.md
+++ b/docs/ft-registry.md
@@ -124,3 +124,4 @@ webhooklog wishlistlog workflowlog
 | FT173 | relatedlog | Content Relations（型付きM:N自己参照リンク） |
 | FT174 | sluglog | Slug Management（URL スラグ生成・衝突解決・履歴リダイレクト） |
 | FT175 | meterlog | API Usage Metering（per-user 日次クォータ・usage_events 追記・ゲートチェック） |
+| FT176 | grantlog | Delegated Access Grants（multi-party 委譲・time-limited・revocable・state machine 攻撃試験） |

--- a/docs/howto/delegated-access-grants.md
+++ b/docs/howto/delegated-access-grants.md
@@ -1,0 +1,201 @@
+# How-to: Delegated Access Grants
+
+**FT176 — grantlog**
+
+Per-user, time-limited, revocable access delegation — a grantor gives a grantee
+scoped access to a named resource for a bounded time window.
+
+---
+
+## Overview
+
+Delegated Access Grants let one user (`grantor`) give another user (`grantee`)
+time-limited, scoped access to a resource identifier.  Think "share document:42
+as read-only with user 7, expires in 24 hours, revocable at any time."
+
+Key properties:
+
+- **Multi-party** — grantor and grantee are always different users; self-grants are rejected.
+- **State machine** — active → revoked (one-way); expired state is computed from `expires_at`.
+- **Opaque resource** — `resource` is a free-form string; the server stores it verbatim.
+- **Idempotent uniqueness** — one unique grant per `(grantor_id, grantee_id, resource)`.
+- **IDOR-safe** — all ownership checks return 404, not 403, to prevent existence enumeration.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE grants (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    grantor_id  INTEGER NOT NULL,
+    grantee_id  INTEGER NOT NULL,
+    resource    TEXT    NOT NULL,
+    scope       TEXT    NOT NULL DEFAULT 'read',
+    expires_at  TEXT    NOT NULL,
+    revoked_at  TEXT,
+    used_count  INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT    NOT NULL,
+    UNIQUE (grantor_id, grantee_id, resource),
+    CHECK (scope IN ('read', 'write', 'admin')),
+    CHECK (grantor_id != grantee_id)
+);
+```
+
+The `CHECK (grantor_id != grantee_id)` is a defence-in-depth measure —
+self-grant must also be rejected at the application layer for a clear error response.
+
+---
+
+## Domain layer
+
+### GrantScope enum with hierarchy
+
+```php
+enum GrantScope: string
+{
+    case Read  = 'read';
+    case Write = 'write';
+    case Admin = 'admin';
+
+    public function satisfies(self $required): bool
+    {
+        $rank = [self::Read->value => 0, self::Write->value => 1, self::Admin->value => 2];
+        return $rank[$this->value] >= $rank[$required->value];
+    }
+}
+```
+
+### Grant entity — computed state methods
+
+```php
+final readonly class Grant
+{
+    public function isExpired(string $now): bool  { return $this->expiresAt <= $now; }
+    public function isRevoked(): bool             { return $this->revokedAt !== null; }
+    public function isActive(string $now): bool   { return !$this->isExpired($now) && !$this->isRevoked(); }
+}
+```
+
+Check **revoked first**, then expiry — both paths return 403 but with distinct error bodies
+so grantees understand why access failed without exposing system internals.
+
+---
+
+## HTTP endpoints
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `POST` | `/grants` | `X-User-Id` (grantor) | Create a grant |
+| `GET` | `/grants/issued` | `X-User-Id` | List grants issued by caller |
+| `GET` | `/grants/received` | `X-User-Id` | List grants received by caller |
+| `DELETE` | `/grants/{id}` | `X-User-Id` (must be grantor) | Revoke a grant |
+| `POST` | `/grants/{id}/use` | `X-User-Id` (must be grantee) | Use a grant |
+
+---
+
+## Validation rules
+
+| Field | Rule |
+|-------|------|
+| `grantee_id` | Must be a **JSON integer** > 0; string `"2"`, null, boolean, float rejected |
+| `resource` | Non-empty string; ≤ 500 UTF-8 chars; stored verbatim (opaque) |
+| `scope` | Must be one of `read` / `write` / `admin` |
+| `expires_at` | Valid ISO 8601; must be in the future; ≤ 30 days from now |
+| Self-grant | `grantee_id == grantor X-User-Id` → 422 |
+
+### Strict integer field parsing
+
+A common vulnerability is implicit type coercion — accepting `"2"` (JSON string)
+as `2` (int).  Use explicit type checking:
+
+```php
+private function intField(array $body, string $key): ?int
+{
+    if (!array_key_exists($key, $body)) {
+        return null;
+    }
+    // is_int() returns false for "2", null, true, 2.5 — only true for PHP int
+    return is_int($body[$key]) ? $body[$key] : null;
+}
+```
+
+Note: `2.0` (PHP float) is indistinguishable from `2` (int) after `json_encode` — use `2.5`
+to test float rejection in unit tests.
+
+---
+
+## State machine
+
+```
+         revoke()
+active ─────────────→ revoked   (409 on second revoke)
+  │
+  │ expires_at ≤ now
+  ↓
+expired
+
+revoked + expired → revoked wins (check revoked first)
+```
+
+Double-revoke must be rejected with **409**, not silently accepted.
+The `revoked_at` timestamp must not change on the second call.
+
+---
+
+## IDOR protection pattern
+
+```php
+// DELETE /grants/{id}
+$grant = $this->repository->find($id);
+
+// Return 404 for both "not found" AND "not your grant"
+// Never return 403 here — that would leak existence
+if ($grant === null || $grant->grantorId !== $callerId) {
+    return $this->responseFactory->create(['error' => "Grant #{$id} not found."], 404);
+}
+```
+
+Same pattern applies to `POST /grants/{id}/use` — return 404 if caller is not the grantee.
+
+---
+
+## Multi-party confusion prevention
+
+| Scenario | Expected |
+|----------|----------|
+| Grantor calls `POST /grants/{id}/use` (own grant) | 404 — grantor is not the grantee |
+| Grantee calls `DELETE /grants/{id}` | 404 — grantee is not the grantor |
+| User 3 calls either on a grant between user 1 and 2 | 404 — IDOR |
+| `X-User-Id: 0` or `X-User-Id: -1` | 401 — non-positive IDs rejected |
+| Missing `X-User-Id` | 401 |
+
+---
+
+## Security checklist (ATK-01 through ATK-12)
+
+| # | Attack vector | Mitigation |
+|---|---|---|
+| ATK-01 | Expired grant (clock-boundary) | `isExpired()` comparison; DB `expires_at` back-dated in test |
+| ATK-02 | Revoked grant state bypass | `isRevoked()` check before use |
+| ATK-03 | Self-grant (grantor == grantee) | App-layer 422 + DB `CHECK` |
+| ATK-04 | Wrong grantee uses grant (IDOR) | 404, not 403 |
+| ATK-05 | Non-grantor revokes grant (IDOR) | 404, not 403; original grant remains active |
+| ATK-06 | Past `expires_at` on creation | `strtotime($expiresAt) <= strtotime($now)` → 422 |
+| ATK-07 | Type confusion on `grantee_id` | `is_int()` strict check; rejects `"2"`, `null`, `true`, `2.5` |
+| ATK-08 | Path traversal in `resource` | Opaque storage; no filesystem access |
+| ATK-09 | SQL injection in `resource`/`scope` | Parameterised queries; scope enum rejects injected value |
+| ATK-10 | Unicode/BIDI in `resource` | Stored verbatim; homoglyph and BIDI are distinct resources |
+| ATK-11 | Double revoke (state-machine) | 409 on second revoke; `revoked_at` immutable after first |
+| ATK-12 | Grantor uses own grant as grantee | 404 — party roles enforced strictly |
+
+---
+
+## Testing approach
+
+- **ATK-01, ATK-02**: Force DB state directly (`UPDATE grants SET expires_at/revoked_at`)
+  to simulate time-travel without sleeping.
+- **ATK-07**: Test `"2"` (string), `null`, `true`, `2.5` (float) — not `2.0` (indistinguishable
+  from int after PHP json_encode).
+- **ATK-10**: Use `"\u{202E}"` (BIDI override) and Cyrillic homoglyphs to confirm verbatim storage.
+- **ATK-11**: Assert `revoked_at` value is unchanged in DB after second revoke attempt.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.109
+  version: 1.5.110
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ## Status
 
-- Latest release: `v1.5.109`（2026-05-26 リリース済み）
+- Latest release: `v1.5.110`（2026-05-26 リリース済み）
 - Current branch: `main` — clean
 
 ## Recently Completed (FT ループ — FT96–FT170 / v1.5.30–v1.5.104)
@@ -91,6 +91,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT173 | Content Relations | relatedlog | 19/19 | v1.5.107 | content-relations.md（型付きM:N自己参照・sequel↔prequel 自動逆辺・UNIQUE 制約・カスケード削除） |
 | FT174 | Slug Management | sluglog | 19/19 | v1.5.108 | slug-management.md（SlugHelper fromTitle/makeUnique・slug_history 301 リダイレクト・両テーブル重複チェック） |
 | FT175 | API Usage Metering | meterlog | 24/24 | v1.5.109 | api-usage-metering.md（per-user 日次クォータ・usage_events 追記・day_key インデックス・ゲートチェック・エンドポイント別内訳）**脆弱性診断: VULN-A〜L 全Pass** |
+| FT176 | Delegated Access Grants | grantlog | 23/23 | v1.5.110 | delegated-access-grants.md（multi-party 委譲・expired/revoked state machine・IDOR防止・型強制・Unicode/BIDI verbatim）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 
 ## 次のアクション（2026-05-26〜）
 
@@ -104,7 +105,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | ~~FT173~~ | ~~Content Relations（relatedlog）~~ | ~~完了 v1.5.107~~ |
 | ~~FT174~~ | ~~Slug Management（sluglog）~~ | ~~完了 v1.5.108~~ |
 | ~~FT175~~ | ~~API Usage Metering（meterlog）~~ | ~~完了 v1.5.109~~ |
-| 📋 FT176 | 次テーマ | クラッカー攻撃試験（周期: FT176） |
+| ~~FT176~~ | ~~Delegated Access Grants（grantlog）~~ | ~~完了 v1.5.110~~ |
+| 📋 FT177 | 次テーマ | — |
 
 ### ループ終了後（FT170 以降）— 完了・進行状況
 
@@ -123,7 +125,7 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 |---|---|
 | MySQL 統合テスト | FT167 ✓ 完了 |
 | 脆弱性診断 | FT175 ✓ 完了（次: FT178） |
-| クラッカー攻撃試験 | FT172 ✓ 完了（次: FT176） |
+| クラッカー攻撃試験 | FT176 ✓ 完了（次: FT180） |
 
 ## 検討事項（決定不要・議題として保持）
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.109';
+    public const string VERSION = '1.5.110';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要
FT176 (grantlog) の Delegated Access Grants howto ガイドを追加し、v1.5.110 に更新する。

## 難易度の引き上げ（今回から）

| Lv | 攻撃パターン | ATK# |
|---|---|---|
| Lv.2 State Machine | Double revoke → 409、revoked_at 不変 | ATK-11 |
| Lv.3 Multi-party | Grantor/grantee 役割混同、IDOR 404 | ATK-04,05,12 |
| Lv.4 Type Confusion | string/null/bool/float grantee_id → 422 | ATK-07 |
| Lv.5 Encoding | Unicode BIDI + 同形異字 verbatim 保存 | ATK-10 |

## FT176 実績
- 23/23 tests ✅ (71 assertions)
- PHPStan level 8: 0 errors ✅
- **ATK-01〜12 全Pass** ✅

## Self-review: backend-api, docs-policy

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)