### PR TITLE
feat(validation): V.php — HTTP パラメータ検証ヘルパー

### DIFF
--- a/src/Validation/V.php
+++ b/src/Validation/V.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Validation;
+
+use DateTimeImmutable;
+
+/**
+ * Stateless HTTP request parameter validation helpers.
+ *
+ * Design principles:
+ *  - All methods return null on invalid input; callers return 422.
+ *  - No framework dependencies — suitable for extraction as a standalone package.
+ *  - ReDoS-immune: ctype_digit() (O(n)) instead of regex for integer validation.
+ *  - Integer overflow guard: strlen > 18 before (int) cast.
+ *  - Absent vs invalid distinction: queryInt() returns $default when the key
+ *    is missing, null only when the key is present but invalid.
+ */
+final class V
+{
+    /**
+     * Validates an integer from a URL query string (PSR-7 getQueryParams()).
+     *
+     * - Key absent              → returns $default (not an error)
+     * - Key present and valid   → returns int in [$min, $max]
+     * - Key present and invalid → returns null (caller should return 422)
+     *
+     * Uses ctype_digit() (O(n), ReDoS-immune) and a strlen > 18 overflow guard
+     * to prevent silent PHP integer wrap on 20+ digit inputs.
+     *
+     * @param array<string, mixed> $params  Result of $request->getQueryParams()
+     * @param string               $key     Parameter name
+     * @param int                  $min     Inclusive lower bound
+     * @param int                  $max     Inclusive upper bound
+     * @param int|null             $default Returned when the key is absent
+     */
+    public static function queryInt(
+        array $params,
+        string $key,
+        int $min,
+        int $max,
+        ?int $default = null,
+    ): ?int {
+        if (!array_key_exists($key, $params)) {
+            return $default;
+        }
+
+        $raw = $params[$key];
+
+        // ctype_digit('') === false — empty string already rejected here.
+        // Also rejects: '-1', '+10', '10.5', '1e2', ' 10', '0x10', 'abc'.
+        if (!is_string($raw) || !ctype_digit($raw)) {
+            return null;
+        }
+
+        // Prevent silent PHP overflow: (int)'99999999999999999999' wraps to -1 on 64-bit.
+        // 18 chars safely covers PHP_INT_MAX (19 digits) with one digit of margin.
+        if (strlen($raw) > 18) {
+            return null;
+        }
+
+        $value = (int) $raw;
+
+        if ($value < $min || $value > $max) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Validates a strict integer from a JSON body (json_decode() output).
+     *
+     * Accepts only PHP int — rejects string "2", float 2.5, null, and bool.
+     * Note: json_encode(['x' => 2.0]) produces {"x":2}, so 2.0 and 2 are
+     * indistinguishable at the JSON level; use bodyInt() to catch string/bool/null.
+     *
+     * Returns null on type mismatch or out-of-range.
+     *
+     * @param int $min Inclusive lower bound
+     * @param int $max Inclusive upper bound
+     */
+    public static function bodyInt(mixed $raw, int $min, int $max): ?int
+    {
+        if (!is_int($raw)) {
+            return null;
+        }
+
+        if ($raw < $min || $raw > $max) {
+            return null;
+        }
+
+        return $raw;
+    }
+
+    /**
+     * Validates and trims a string field from any source.
+     *
+     * - Non-string input      → null
+     * - Exceeds $maxLen bytes → null (checked after trim)
+     * - Valid                 → trimmed string (may be empty; callers check for '')
+     *
+     * @param int $maxLen Maximum allowed byte length after trimming (default: 500)
+     */
+    public static function str(mixed $raw, int $maxLen = 500): ?string
+    {
+        if (!is_string($raw)) {
+            return null;
+        }
+
+        $trimmed = trim($raw);
+
+        return strlen($trimmed) <= $maxLen ? $trimmed : null;
+    }
+
+    /**
+     * Validates an ISO 8601 datetime string with explicit timezone offset.
+     *
+     * Accepted format: 2024-01-15T12:30:00+09:00
+     *
+     * Rejected: date-only, UTC 'Z' suffix, missing offset, overflow dates
+     * (e.g., Feb 30 — caught by round-trip re-format comparison).
+     *
+     * Uses DateTimeImmutable::createFromFormat() which preserves the input
+     * timezone for re-formatting — avoids the strtotime + date() pitfall where
+     * date() silently re-formats in the server's local timezone.
+     *
+     * Returns the canonical string unchanged, or null on any failure.
+     */
+    public static function isoDatetime(mixed $raw): ?string
+    {
+        if (!is_string($raw)) {
+            return null;
+        }
+
+        // Strict regex: full datetime with explicit ±HH:MM offset required.
+        // Rejects: date-only, 'Z' suffix, missing offset, float/sci notation.
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/', $raw)) {
+            return null;
+        }
+
+        // createFromFormat preserves the input timezone offset; format() re-emits it.
+        $dt = DateTimeImmutable::createFromFormat(DATE_ATOM, $raw);
+
+        if ($dt === false) {
+            return null;
+        }
+
+        // Round-trip comparison catches overflow dates that roll over silently:
+        // "2024-02-30T00:00:00+00:00" → parsed as Mar 1 → canonical ≠ input → null.
+        $canonical = $dt->format(DATE_ATOM);
+
+        return $canonical === $raw ? $raw : null;
+    }
+
+    /**
+     * Validates an ISO 8601 datetime that must be strictly after $now.
+     *
+     * $now should be the current moment in the same format (e.g., date('c')).
+     * String comparison is used — both strings must share the same timezone
+     * offset for the comparison to be meaningful; callers are responsible for
+     * normalising to a common offset when comparing across zones.
+     *
+     * Returns null if the datetime is invalid or not strictly in the future.
+     *
+     * @param string $now Current moment as an ISO 8601 datetime string
+     */
+    public static function futureDatetime(mixed $raw, string $now): ?string
+    {
+        $dt = self::isoDatetime($raw);
+
+        if ($dt === null) {
+            return null;
+        }
+
+        return $dt > $now ? $dt : null;
+    }
+
+    /**
+     * Validates a backed enum value from raw JSON input.
+     *
+     * Accepts only string input — rejects int, null, bool, array.
+     * Returns the matched enum case, or null for invalid cases.
+     *
+     * @template T of \BackedEnum
+     * @param  class-string<T> $enumClass
+     * @return T|null
+     */
+    public static function enum(mixed $raw, string $enumClass): ?\BackedEnum
+    {
+        if (!is_string($raw)) {
+            return null;
+        }
+
+        return $enumClass::tryFrom($raw);
+    }
+
+    /**
+     * Validates the X-User-Id HTTP header as a positive integer.
+     *
+     * Applies ctype_digit + overflow guard + > 0 check.
+     * Returns null if the header is absent, non-numeric, overflowing, or zero.
+     */
+    public static function userId(string $header): ?int
+    {
+        // ctype_digit('') === false — empty string already rejected.
+        if (!ctype_digit($header) || strlen($header) > 18) {
+            return null;
+        }
+
+        $id = (int) $header;
+
+        return $id > 0 ? $id : null;
+    }
+
+    /**
+     * Compares an API secret/key using constant-time comparison (timing-safe).
+     *
+     * Returns false when $expected is empty — an unconfigured key disables access
+     * rather than accidentally granting it.
+     */
+    public static function secret(string $expected, string $actual): bool
+    {
+        return $expected !== '' && hash_equals($expected, $actual);
+    }
+}

--- a/tests/Validation/VTest.php
+++ b/tests/Validation/VTest.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Validation;
+
+use Nene2\Validation\V;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Backed enum used only in this test file to exercise V::enum().
+ *
+ * @internal
+ */
+enum TestRole: string
+{
+    case Viewer = 'viewer';
+    case Editor = 'editor';
+    case Admin  = 'admin';
+}
+
+/**
+ * Unit tests for V — stateless HTTP parameter validation helpers.
+ *
+ * Covers the VULN patterns identified in FT175–FT177:
+ *   - Type confusion (string "2" vs int 2, bool, null, float)
+ *   - Integer overflow (20-digit strings)
+ *   - ReDoS immunity (ctype_digit instead of regex)
+ *   - Padding / signed integers (+10, space)
+ *   - Float strings (10.5, 1e2)
+ *   - Hex / octal notation (0x10, 010)
+ *   - ISO date overflow (Feb 30)
+ *   - Empty / unconfigured secret bypass
+ */
+final class VTest extends TestCase
+{
+    // ── V::queryInt ──────────────────────────────────────────────────────────
+
+    /** @return array<string, mixed[]> */
+    public static function queryIntAbsentProvider(): array
+    {
+        return [
+            'no default returns null'   => [[], 'limit', 1, 100, null, null],
+            'with default returns it'   => [[], 'limit', 1, 100, 20, 20],
+            'zero default is returned'  => [[], 'page', 0, PHP_INT_MAX, 0, 0],
+        ];
+    }
+
+    /** @param array<string, mixed> $params */
+    #[DataProvider('queryIntAbsentProvider')]
+    public function testQueryIntAbsentKey(
+        array $params,
+        string $key,
+        int $min,
+        int $max,
+        ?int $default,
+        ?int $expected,
+    ): void {
+        self::assertSame($expected, V::queryInt($params, $key, $min, $max, $default));
+    }
+
+    /** @return array<string, array{string, int, int, int}> */
+    public static function queryIntValidProvider(): array
+    {
+        return [
+            'minimum boundary'    => ['1', 1, 100, 1],
+            'maximum boundary'    => ['100', 1, 100, 100],
+            'mid value'           => ['50', 1, 100, 50],
+            'zero when min=0'     => ['0', 0, 100, 0],
+            'octal-like 010'      => ['010', 1, 100, 10],   // ctype_digit passes; (int) = 10 decimal (safe)
+        ];
+    }
+
+    #[DataProvider('queryIntValidProvider')]
+    public function testQueryIntValidValues(string $raw, int $min, int $max, int $expected): void
+    {
+        self::assertSame($expected, V::queryInt(['limit' => $raw], 'limit', $min, $max));
+    }
+
+    /** @return array<string, array{mixed}> */
+    public static function queryIntInvalidProvider(): array
+    {
+        return [
+            // Non-digit strings
+            'alpha string'        => ['abc'],
+            'hex 0x10'            => ['0x10'],
+            'sql injection'       => ['1;DROP TABLE'],
+            // Sign / whitespace / float markers — all fail ctype_digit
+            'negative -1'         => ['-1'],
+            'positive-sign +10'   => ['+10'],
+            'url-encoded space %2010' => ['%2010'],  // decoded to ' 10' by PSR-7
+            'leading space'       => [' 10'],
+            'trailing space'      => ['10 '],
+            'float dot 10.5'      => ['10.5'],
+            'float sci 1e2'       => ['1e2'],
+            'float 1.0'           => ['1.0'],
+            // Overflow
+            '20 nines overflow'   => [str_repeat('9', 20)],
+            '19 digit boundary'   => [str_repeat('9', 19)],  // > 18 chars → null
+            // Empty
+            'empty string'        => [''],
+            // Non-string types (e.g., duplicate param parsed as array by some servers)
+            'array value'         => [['5', '1000']],
+            'int type'            => [5],
+            'null type'           => [null],
+            'bool type'           => [true],
+        ];
+    }
+
+    #[DataProvider('queryIntInvalidProvider')]
+    public function testQueryIntInvalidValues(mixed $raw): void
+    {
+        self::assertNull(V::queryInt(['limit' => $raw], 'limit', 1, 100));
+    }
+
+    public function testQueryIntOutOfRange(): void
+    {
+        self::assertNull(V::queryInt(['limit' => '0'], 'limit', 1, 100));     // below min
+        self::assertNull(V::queryInt(['limit' => '101'], 'limit', 1, 100));   // above max
+        self::assertNull(V::queryInt(['limit' => '999999'], 'limit', 1, 100));// VULN-A: oversized
+    }
+
+    public function testQueryIntReDoSImmunity(): void
+    {
+        // 50 ones + 'x' — exponential backtracking on /^\d+$/ but O(n) on ctype_digit
+        $payload = str_repeat('1', 50) . 'x';
+        $start   = microtime(true);
+        $result  = V::queryInt(['limit' => $payload], 'limit', 1, 100);
+        $elapsed = microtime(true) - $start;
+
+        self::assertNull($result);
+        self::assertLessThan(0.1, $elapsed, 'VULN-L: ReDoS guard must complete in < 100ms');
+    }
+
+    // ── V::bodyInt ───────────────────────────────────────────────────────────
+
+    public function testBodyIntAcceptsValidInt(): void
+    {
+        self::assertSame(1, V::bodyInt(1, 1, 100));
+        self::assertSame(100, V::bodyInt(100, 1, 100));
+        self::assertSame(50, V::bodyInt(50, 1, 100));
+    }
+
+    public function testBodyIntRejectsStringInt(): void
+    {
+        // ATK-07: type confusion — string "2" must not pass strict int check
+        self::assertNull(V::bodyInt('2', 1, 100));
+        self::assertNull(V::bodyInt('1', 1, 100));
+    }
+
+    public function testBodyIntRejectsFloat(): void
+    {
+        // 2.5 is a true float; 2.0 encodes as 2 in JSON so cannot be tested here
+        self::assertNull(V::bodyInt(2.5, 1, 100));
+        self::assertNull(V::bodyInt(1.5, 1, 100));
+    }
+
+    public function testBodyIntRejectsNullAndBool(): void
+    {
+        self::assertNull(V::bodyInt(null, 1, 100));
+        self::assertNull(V::bodyInt(true, 1, 100));
+        self::assertNull(V::bodyInt(false, 1, 100));
+    }
+
+    public function testBodyIntRejectsArray(): void
+    {
+        self::assertNull(V::bodyInt([1, 2], 1, 100));
+    }
+
+    public function testBodyIntOutOfRange(): void
+    {
+        self::assertNull(V::bodyInt(0, 1, 100));
+        self::assertNull(V::bodyInt(101, 1, 100));
+        self::assertNull(V::bodyInt(-1, 1, 100));
+        self::assertNull(V::bodyInt(PHP_INT_MAX, 1, 100));
+    }
+
+    // ── V::str ───────────────────────────────────────────────────────────────
+
+    public function testStrAcceptsNormalString(): void
+    {
+        self::assertSame('hello', V::str('hello'));
+        self::assertSame('', V::str(''));
+    }
+
+    public function testStrTrims(): void
+    {
+        self::assertSame('hello', V::str('  hello  '));
+        self::assertSame('', V::str('   '));
+    }
+
+    public function testStrRejectsOverLength(): void
+    {
+        self::assertNull(V::str(str_repeat('a', 501)));
+        self::assertNull(V::str(str_repeat('a', 501), 500));
+        self::assertSame(str_repeat('a', 500), V::str(str_repeat('a', 500)));  // exact max ok
+    }
+
+    public function testStrCustomMaxLen(): void
+    {
+        self::assertSame('abc', V::str('abc', 10));
+        self::assertNull(V::str('abcdefghijk', 10));  // 11 chars, max 10
+    }
+
+    public function testStrRejectsNonString(): void
+    {
+        self::assertNull(V::str(42));
+        self::assertNull(V::str(null));
+        self::assertNull(V::str(true));
+        self::assertNull(V::str(['a', 'b']));
+    }
+
+    public function testStrPreservesUnicode(): void
+    {
+        // Unicode / BIDI characters must be stored verbatim, not normalised
+        $bidi = "\u{202E}evitcepsreP"; // right-to-left override
+        self::assertSame($bidi, V::str($bidi));
+    }
+
+    // ── V::isoDatetime ───────────────────────────────────────────────────────
+
+    public function testIsoDatetimeAcceptsValidFormat(): void
+    {
+        self::assertSame('2024-01-15T12:30:00+09:00', V::isoDatetime('2024-01-15T12:30:00+09:00'));
+        self::assertSame('2024-06-01T00:00:00+00:00', V::isoDatetime('2024-06-01T00:00:00+00:00'));
+        self::assertSame('2024-12-31T23:59:59-05:00', V::isoDatetime('2024-12-31T23:59:59-05:00'));
+    }
+
+    public function testIsoDatetimeRejectsDateOnly(): void
+    {
+        self::assertNull(V::isoDatetime('2024-01-15'));
+    }
+
+    public function testIsoDatetimeRejectsZSuffix(): void
+    {
+        self::assertNull(V::isoDatetime('2024-01-15T12:00:00Z'));
+    }
+
+    public function testIsoDatetimeRejectsMissingOffset(): void
+    {
+        self::assertNull(V::isoDatetime('2024-01-15T12:00:00'));
+    }
+
+    public function testIsoDatetimeRejectsOverflowDate(): void
+    {
+        // Feb 30 does not exist — strtotime rolls over to Mar 1; re-format catches it
+        self::assertNull(V::isoDatetime('2024-02-30T00:00:00+00:00'));
+        // Month 13 does not exist
+        self::assertNull(V::isoDatetime('2024-13-01T00:00:00+00:00'));
+    }
+
+    public function testIsoDatetimeRejectsNonString(): void
+    {
+        self::assertNull(V::isoDatetime(42));
+        self::assertNull(V::isoDatetime(null));
+        self::assertNull(V::isoDatetime([]));
+    }
+
+    // ── V::futureDatetime ────────────────────────────────────────────────────
+
+    public function testFutureDatetimeAcceptsFuture(): void
+    {
+        $now    = '2024-01-01T00:00:00+00:00';
+        $future = '2024-12-31T23:59:59+00:00';
+
+        self::assertSame($future, V::futureDatetime($future, $now));
+    }
+
+    public function testFutureDatetimeRejectsPast(): void
+    {
+        $now  = '2024-12-31T23:59:59+00:00';
+        $past = '2024-01-01T00:00:00+00:00';
+
+        self::assertNull(V::futureDatetime($past, $now));
+    }
+
+    public function testFutureDatetimeRejectsEqualToNow(): void
+    {
+        $now = '2024-06-01T12:00:00+00:00';
+
+        self::assertNull(V::futureDatetime($now, $now));
+    }
+
+    public function testFutureDatetimeRejectsInvalidFormat(): void
+    {
+        self::assertNull(V::futureDatetime('2024-01-15', '2024-01-01T00:00:00+00:00'));
+        self::assertNull(V::futureDatetime(null, '2024-01-01T00:00:00+00:00'));
+    }
+
+    // ── V::enum ──────────────────────────────────────────────────────────────
+
+    public function testEnumAcceptsValidCase(): void
+    {
+        self::assertSame(TestRole::Viewer, V::enum('viewer', TestRole::class));
+        self::assertSame(TestRole::Editor, V::enum('editor', TestRole::class));
+        self::assertSame(TestRole::Admin, V::enum('admin', TestRole::class));
+    }
+
+    public function testEnumRejectsInvalidCase(): void
+    {
+        self::assertNull(V::enum('superuser', TestRole::class));
+        self::assertNull(V::enum('', TestRole::class));
+        self::assertNull(V::enum('ADMIN', TestRole::class));  // case-sensitive
+    }
+
+    public function testEnumRejectsNonString(): void
+    {
+        // ATK-07 style: int, null, bool must not match a string-backed enum
+        self::assertNull(V::enum(0, TestRole::class));
+        self::assertNull(V::enum(null, TestRole::class));
+        self::assertNull(V::enum(true, TestRole::class));
+        self::assertNull(V::enum(['admin'], TestRole::class));
+    }
+
+    // ── V::userId ────────────────────────────────────────────────────────────
+
+    public function testUserIdAcceptsPositiveInt(): void
+    {
+        self::assertSame(1, V::userId('1'));
+        self::assertSame(42, V::userId('42'));
+        self::assertSame(999, V::userId('999'));
+    }
+
+    public function testUserIdRejectsZero(): void
+    {
+        self::assertNull(V::userId('0'));
+    }
+
+    public function testUserIdRejectsEmpty(): void
+    {
+        // ctype_digit('') === false — already rejected
+        self::assertNull(V::userId(''));
+    }
+
+    public function testUserIdRejectsNegativeAndSigned(): void
+    {
+        self::assertNull(V::userId('-1'));
+        self::assertNull(V::userId('+1'));
+    }
+
+    public function testUserIdRejectsNonDigit(): void
+    {
+        self::assertNull(V::userId('abc'));
+        self::assertNull(V::userId('1.5'));
+        self::assertNull(V::userId('0x01'));
+    }
+
+    public function testUserIdRejectsOverflow(): void
+    {
+        // 19 chars > 18 — overflow guard
+        self::assertNull(V::userId(str_repeat('9', 19)));
+    }
+
+    // ── V::secret ────────────────────────────────────────────────────────────
+
+    public function testSecretMatchesCorrectKey(): void
+    {
+        self::assertTrue(V::secret('super-secret-key', 'super-secret-key'));
+    }
+
+    public function testSecretRejectsMismatch(): void
+    {
+        self::assertFalse(V::secret('correct', 'wrong'));
+    }
+
+    public function testSecretRejectsEmptyExpected(): void
+    {
+        // Unconfigured key must never grant access — not even with empty actual
+        self::assertFalse(V::secret('', ''));
+        self::assertFalse(V::secret('', 'any-value'));
+    }
+
+    public function testSecretRejectsEmptyActual(): void
+    {
+        self::assertFalse(V::secret('expected-key', ''));
+    }
+}


### PR DESCRIPTION
## 目的

FT175〜FT177 で繰り返し書かれた検証パターンを `src/Validation/V.php` として共通化する。

フレームワーク内部に依存しない純粋 PHP ユーティリティとして設計し、
将来 `hideyukimori/nene-validate` として独立パッケージに抽出できる構造にした。

## 変更点

### 追加: `src/Validation/V.php`

| メソッド | 用途 |
|---|---|
| `V::queryInt()` | クエリ文字列整数（ctype_digit + 18桁オーバーフローガード） |
| `V::bodyInt()` | JSON ボディ整数（is_int() 厳格チェック — 文字列 "2" を拒否） |
| `V::str()` | 文字列フィールドのトリムと長さチェック |
| `V::isoDatetime()` | ISO 8601 日時（DateTimeImmutable 再フォーマット検証） |
| `V::futureDatetime()` | ISO 8601 日時 + 未来チェック |
| `V::enum()` | BackedEnum tryFrom ラッパー（文字列のみ受付） |
| `V::userId()` | X-User-Id ヘッダーの正整数変換 |
| `V::secret()` | hash_equals 定数時間 API キー比較 |

### 追加: `tests/Validation/VTest.php`

63 tests / 102 assertions — VULN-A〜L パターン網羅:
- ReDoS 免疫: 50桁+1 ペイロードで < 100ms 保証
- 型混乱: string "2" / float 2.5 / null / bool を is_int() で厳格拒否
- ISO 日付オーバーフロー: Feb 30 → 再フォーマット不一致で null
- タイムゾーン保持: strtotime+date() の罠を DateTimeImmutable で回避

## 技術メモ

**strtotime + date() の落とし穴**: `date('Y-m-d\TH:i:sP', $ts)` はサーバーのローカルタイムゾーンで再フォーマットするため、
`+09:00` 入力を `+00:00` で再フォーマットしてしまう。`DateTimeImmutable::createFromFormat(DATE_ATOM, ...)` を使うことで入力タイムゾーンが保持される。

**2.0 vs 2.5 の罠**: `json_encode(['x' => 2.0])` は `{"x":2}` を生成するため、整数値の float は JSON レベルで区別不能。float 型混乱テストは `2.5` を使う。

## 検証

```
composer check → test + analyse + cs すべて通過
63 tests, 102 assertions, OK
PHPStan level 8: No errors
CS: 0 files to fix
```

## 関連

Closes #897

Self-review: backend-api