### PR TITLE
feat(docs): FT178 patchlog — JSON Merge Patch & ETag Conflict Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.113] — 2026-05-26
+
+### Added
+- `docs/howto/json-merge-patch.md` — JSON Merge Patch & ETag ガイド: RFC 7396 null セマンティクス・不変フィールド保護・If-Match 競合検出 412・V.php 実戦投入・`?? ''` トラップ・Router::param() 正しい使い方。ATK-01〜12 全Pass (FT178)。 (#899)
+
+---
+
+## [1.5.112] — 2026-05-26
+
+### Added
+- `src/Validation/V.php` — HTTP パラメータ検証ヘルパー: queryInt/bodyInt/str/isoDatetime/futureDatetime/enum/userId/secret の8メソッド。フレームワーク非依存の純粋 PHP ユーティリティ、将来 hideyukimori/nene-validate として独立抽出可能な構造。63 tests / 102 assertions。 (#897)
+
+---
+
 ## [1.5.111] — 2026-05-26
 
 ### Added

--- a/docs/howto/json-merge-patch.md
+++ b/docs/howto/json-merge-patch.md
@@ -1,0 +1,202 @@
+# How-to: JSON Merge Patch & ETag Conflict Detection
+
+**FT178 — patchlog**
+
+Implementing PATCH (RFC 7396 JSON Merge Patch) and PUT semantics with
+optimistic locking via ETag, immutable field protection, and V.php integration.
+
+---
+
+## The problem with PUT
+
+`PUT` replaces the entire resource. Clients must send every field, even those
+they didn't change. This creates:
+
+- **Race conditions**: concurrent readers both see version 1, both PUT, last one
+  wins and silently discards the other's changes.
+- **Bandwidth waste**: full payload even for a one-field change.
+- **Permission confusion**: writing fields the client doesn't own.
+
+`PATCH` with **JSON Merge Patch (RFC 7396)** solves the first two; `ETag` /
+`If-Match` solves the race condition for both PATCH and PUT.
+
+---
+
+## JSON Merge Patch semantics (RFC 7396)
+
+The patch document describes changes using a simple rule:
+
+| Patch value | Meaning |
+|-------------|---------|
+| `"new value"` | Set the field to this value |
+| `null` | Reset the field (delete or revert to default) |
+| *(key absent)* | Leave the field unchanged |
+
+```json
+// Document before PATCH:
+{ "title": "Hello", "body": "World", "status": "draft" }
+
+// PATCH body:
+{ "title": "Goodbye", "status": null }
+
+// Result:
+{ "title": "Goodbye", "body": "World", "status": "draft" }
+//                              ^^^^^     ^^^^^^^^^^^^^^
+//                              unchanged  null → reset to default
+```
+
+### Immutable fields
+
+Some fields must never be modifiable via PATCH or PUT:
+
+```php
+private const array IMMUTABLE_FIELDS = ['id', 'owner_id', 'version', 'created_at', 'updated_at'];
+
+$violations = array_intersect(array_keys($body), self::IMMUTABLE_FIELDS);
+
+if ($violations !== []) {
+    return $this->responseFactory->create(
+        ['error' => 'Fields are immutable: ' . implode(', ', $violations)],
+        422,
+    );
+}
+```
+
+### Empty PATCH is valid (no-op)
+
+RFC 7396 §3 explicitly allows an empty patch `{}`:
+
+```php
+// No keys in $patch → skip UPDATE, return current document unchanged
+if ($patch === []) {
+    return $doc;  // no-op; version NOT incremented
+}
+```
+
+---
+
+## ETag and If-Match for optimistic locking
+
+### ETag format
+
+```php
+public function etag(): string
+{
+    return sprintf('"doc-%d-%d"', $this->id, $this->version);
+    // e.g. "doc-42-7"
+}
+```
+
+Return `ETag` on every GET/PATCH/PUT response:
+
+```php
+return $this->responseFactory->create($doc->toArray())
+    ->withHeader('ETag', $doc->etag());
+```
+
+### Conflict detection
+
+```php
+$ifMatch = $request->getHeaderLine('If-Match');
+
+if ($ifMatch !== '' && $ifMatch !== $doc->etag()) {
+    return $this->responseFactory->create(
+        ['error' => 'Version conflict. Fetch the document and retry.'],
+        412,  // Precondition Failed
+    );
+}
+```
+
+**If-Match absent**: optimistic update without conflict check (last-write-wins).
+**If-Match present and matching**: safe concurrent update.
+**If-Match present but stale**: 412 — client must re-fetch and retry.
+
+### Version increment in SQL
+
+Use the database to atomically increment version:
+
+```sql
+UPDATE documents
+SET title = ?, version = version + 1, updated_at = ?
+WHERE id = ? AND version = ?
+```
+
+The `WHERE version = ?` clause double-checks the optimistic lock at the DB level,
+preventing a concurrent write from sneaking in between our read and write.
+
+---
+
+## V.php integration
+
+FT178 is the first FT to use `Nene2\Validation\V` as a shared utility:
+
+```php
+// Query params
+$page  = V::queryInt($params, 'page', 1, PHP_INT_MAX, 1);
+$limit = V::queryInt($params, 'limit', 1, 50, 20);
+
+// Auth header
+$ownerId = V::userId($request->getHeaderLine('X-User-Id'));
+
+// String fields (with explicit length limits)
+$title = V::str($body['title'] ?? null, 200);
+
+// Enum validation
+$status = V::enum($body['status'] ?? null, DocumentStatus::class);
+```
+
+### The `?? ''` trap for optional body fields
+
+```php
+// ❌ WRONG — bypasses V::str null return for over-length input
+$text = V::str($body['body'] ?? null, 10000) ?? '';
+
+// ✅ CORRECT — validate when present, default when absent
+$rawText = $body['body'] ?? null;
+if ($rawText !== null) {
+    $text = V::str($rawText, 10000);
+    if ($text === null) {
+        return $this->responseFactory->create(['error' => 'body too long'], 422);
+    }
+} else {
+    $text = '';
+}
+```
+
+`V::str(null, ...)` returns `null` because `null` is not a string.  
+`V::str(too_long_string, 10000)` also returns `null`.  
+Using `?? ''` collapses both cases into empty string — silently accepting the over-length input.
+
+---
+
+## Route parameter extraction
+
+The NENE2 Router stores path parameters in the `nene2.route.parameters`
+attribute, not as individual request attributes:
+
+```php
+// ❌ WRONG
+$id = $request->getAttribute('id');  // always null for path params
+
+// ✅ CORRECT
+$id = Router::param($request, 'id');  // reads from nene2.route.parameters
+```
+
+---
+
+## Attack checklist (ATK-01 through ATK-12)
+
+| # | Test | Expectation |
+|---|------|-------------|
+| ATK-01 | PATCH `{"id": 999}` | 422 — immutable field |
+| ATK-02 | PATCH `{"owner_id": 99}` | 422 — immutable field |
+| ATK-03 | PATCH `{"version": 999}` | 422 — immutable field |
+| ATK-04 | PATCH `{"title": 42}` (type confusion) | 422 — V::str rejects non-string |
+| ATK-05 | PATCH by non-owner | 404 — IDOR protection |
+| ATK-06 | If-Match stale ETag | 412 — optimistic lock conflict |
+| ATK-07 | PUT missing required title | 422 |
+| ATK-08 | PATCH empty `{}` | 200 — valid no-op (RFC 7396 §3) |
+| ATK-09 | PATCH `{"status": null}` | 200 — reset to default `draft` |
+| ATK-10 | PATCH `{"status": 2}` (type confusion) | 422 — V::enum rejects non-string |
+| ATK-11 | PATCH `{"__proto__": {...}}` | 200 — unknown key ignored, no crash |
+| ATK-12 | `?limit=999999`, `?page=-1`, 20-digit overflow | 422 — V::queryInt guards |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.111
+  version: 1.5.113
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.111';
+    public const string VERSION = '1.5.113';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的

FT178 patchlog — JSON Merge Patch (RFC 7396) + 楽観的ロック (ETag/If-Match) の実装とドキュメント化。
`Nene2\Validation\V` の初実戦投入。

## 変更点

### 追加: `docs/howto/json-merge-patch.md`

| トピック | 内容 |
|---|---|
| JSON Merge Patch | null=リセット / absent=変更なし / value=更新 の3パターン |
| 不変フィールド | IMMUTABLE_FIELDS 配列で POST/PATCH/PUT 全体を保護 |
| ETag 競合検出 | If-Match + `WHERE version = ?` による二重ガード |
| V.php 統合 | queryInt/str/enum/userId の実使用例 |
| `?? ''` トラップ | optional body フィールドの over-length バイパス防止 |
| Router::param() | getAttribute('id') の罠と正しい取得法 |

### バージョン更新

- v1.5.112 — `src/Validation/V.php` (V.php, PR #897/#898)
- v1.5.113 — FT178 patchlog howto (本PR)
- FrameworkInfo::VERSION → 1.5.113
- OpenAPI info.version → 1.5.113
- CHANGELOG 両エントリ追記

## FT実装（../NENE2-FT/patchlog/）

42 tests / 141 assertions、ATK-01〜12 全Pass:

| ATK | 攻撃 | 結果 |
|-----|------|------|
| 01-03 | 不変フィールド (id/owner_id/version) PATCH | 422 |
| 04 | title型混乱 (int/bool/array) | 422 |
| 05 | 他ユーザー文書 PATCH (IDOR) | 404 |
| 06 | If-Match 古い ETag | 412 |
| 07 | PUT title 欠落 | 422 |
| 08 | PATCH {} 空ボディ | 200 no-op |
| 09 | status null → draft リセット | 200 |
| 10 | status 型混乱 (int 2/bool) | 422 |
| 11 | __proto__ キー | 200 無視 |
| 12 | limit=999999, page=-1 | 422 |

## 検証

```
NENE2 composer check → test + analyse + cs 全通過 (Version: 1.5.113)
patchlog: 42 tests, 141 assertions, OK
PHPStan level 8: No errors
```

Closes #899

Self-review: backend-api, docs-policy