### PR TITLE
feat(howto): ウェイティングリスト管理ガイドを追加 v1.5.126 (FT191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.170] — 2026-05-27
+
+### Added
+- `docs/howto/waitlist-management.md` — ウェイティングリスト管理ガイド: 動的ポジション計算・状態機械・IDOR 防止 (FT191)。 (#928)
+
+---
+
+
 ## [1.5.158] — 2026-05-27
 
 ### Added

--- a/docs/howto/waitlist-management.md
+++ b/docs/howto/waitlist-management.md
@@ -1,0 +1,221 @@
+# ウェイティングリスト管理
+
+位置ベースのウェイティングリスト（順番待ち）の実装ガイド。
+動的ポジション計算・状態機械・IDOR 防止・管理者専用エンドポイントを解説する。
+
+## 概要
+
+- ユーザーがウェイティングリストに参加（任意メモ付き）
+- **動的ポジション計算**: ポジションを DB に保存せず、`COUNT(*)` で都度算出
+- 状態機械: `waiting` → `approved` / `declined`（一方向、取消不可）
+- 待機中のユーザーのみ離脱可能（`approved`/`declined` 後は不可）
+- 管理者は全エントリを一覧・承認・拒否（`X-Admin-Key` ヘッダー）
+- ユーザー向けレスポンスに `user_id` を含めない（IDOR 防止）
+
+## エンドポイント
+
+| Method | Path | 認証 | 説明 |
+|---|---|---|---|
+| `POST` | `/waitlist` | `X-User-Id` | ウェイティングリストに参加 |
+| `GET` | `/waitlist/me` | `X-User-Id` | 自分のエントリとポジションを取得 |
+| `DELETE` | `/waitlist/me` | `X-User-Id` | ウェイティングリストから離脱 |
+| `GET` | `/waitlist` | `X-Admin-Key` | 全エントリ一覧（管理者用） |
+| `POST` | `/waitlist/{id}/approve` | `X-Admin-Key` | エントリを承認 |
+| `POST` | `/waitlist/{id}/decline` | `X-Admin-Key` | エントリを拒否 |
+
+## データベース設計
+
+```sql
+CREATE TABLE IF NOT EXISTS waitlist_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL UNIQUE,
+    status     TEXT    NOT NULL DEFAULT 'waiting',
+    note       TEXT,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+`user_id` に `UNIQUE` 制約を置くことで、1ユーザー1エントリを保証する。
+ポジション用のカラムは持たない（動的計算）。
+
+## 動的ポジション計算
+
+待機中エントリのポジションを、`id` の相対順で計算する:
+
+```sql
+SELECT COUNT(*) FROM waitlist_entries
+WHERE status = 'waiting' AND id <= :id
+```
+
+メリット:
+- 離脱・承認・拒否のたびに全エントリを UPDATE しなくて済む
+- 書き込み競合が発生しない
+- `status` が `waiting` 以外のエントリは `null` を返す
+
+```php
+public function positionOf(WaitlistEntry $entry): ?int
+{
+    if ($entry->status !== WaitlistStatus::Waiting) {
+        return null;
+    }
+
+    $stmt = $this->pdo->prepare(
+        "SELECT COUNT(*) FROM waitlist_entries
+         WHERE status = 'waiting' AND id <= :id",
+    );
+    $stmt->execute(['id' => $entry->id]);
+
+    return (int) $stmt->fetchColumn();
+}
+```
+
+## 状態機械
+
+```
+waiting ──→ approved
+        └─→ declined
+```
+
+- `waiting` は `approved` または `declined` にのみ遷移可能
+- 一度 terminal 状態になったら変更不可（`isTerminal()` で判定）
+- 待機中のユーザーのみ `DELETE /waitlist/me` で離脱可能
+
+```php
+enum WaitlistStatus: string
+{
+    case Waiting  = 'waiting';
+    case Approved = 'approved';
+    case Declined = 'declined';
+
+    public function isTerminal(): bool
+    {
+        return $this !== self::Waiting;
+    }
+}
+```
+
+## IDOR 防止
+
+ユーザー向けエンドポイント（`/waitlist/me`）は `X-User-Id` ヘッダーで**自分のエントリのみ**取得できる。
+他のユーザーの `user_id` をパスに渡す余地がなく、レスポンスにも `user_id` を含めない。
+
+```php
+/** ユーザー向けレスポンス（user_id なし） */
+public function toPublicArray(): array
+{
+    return [
+        'id'         => $this->id,
+        'status'     => $this->status->value,
+        'note'       => $this->note,
+        'created_at' => $this->createdAt,
+    ];
+}
+
+/** 管理者向けレスポンス（user_id あり） */
+public function toAdminArray(): array
+{
+    return [
+        'id'         => $this->id,
+        'user_id'    => $this->userId,
+        'status'     => $this->status->value,
+        'note'       => $this->note,
+        'created_at' => $this->createdAt,
+        'updated_at' => $this->updatedAt,
+    ];
+}
+```
+
+## 管理者認証
+
+`X-Admin-Key` ヘッダーを `hash_equals()` で定数時間比較する。
+空の adminKey は常に `false`（fail-closed）:
+
+```php
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    if ($this->adminKey === '') {
+        return false; // fail-closed
+    }
+
+    $provided = $request->getHeaderLine('X-Admin-Key');
+
+    return $provided !== '' && hash_equals($this->adminKey, $provided);
+}
+```
+
+## ルート順序
+
+`GET /waitlist/me` は `GET /waitlist` よりも先に登録する。
+後から登録すると `me` が `{id}` として捕捉される可能性があるため:
+
+```php
+$this->router->post('/waitlist',            $this->handleJoin(...));
+$this->router->get('/waitlist/me',          $this->handleMe(...));      // /waitlist より先
+$this->router->delete('/waitlist/me',       $this->handleLeave(...));
+$this->router->get('/waitlist',             $this->handleAdminList(...));
+$this->router->post('/waitlist/{id}/approve', $this->handleApprove(...));
+$this->router->post('/waitlist/{id}/decline', $this->handleDecline(...));
+```
+
+## X-User-Id バリデーション
+
+整数オーバーフロー・ゼロ・負数・非数値を防ぐ:
+
+```php
+private function resolveUserId(ServerRequestInterface $request): ?int
+{
+    $raw = $request->getHeaderLine('X-User-Id');
+
+    if ($raw === '' || !ctype_digit($raw) || strlen($raw) > 18) {
+        return null;
+    }
+
+    $id = (int) $raw;
+
+    return $id > 0 ? $id : null;
+}
+```
+
+## セキュリティポイント
+
+| 脅威 | 対策 |
+|---|---|
+| IDOR | `/waitlist/me` で自分のみ、レスポンスに `user_id` を含めない |
+| 管理者キー盗聴 | `hash_equals()` で定数時間比較 |
+| 整数オーバーフロー | `strlen > 18` ガード |
+| 重複参加 | `UNIQUE(user_id)` 制約 → 409 |
+| 状態遷移の不正 | `isTerminal()` で terminal 後の変更を禁止 |
+| SQL インジェクション | PDO プリペアドステートメント |
+
+## レスポンス例
+
+```json
+// POST /waitlist (201)
+{
+    "entry": { "id": 1, "status": "waiting", "note": "VIP希望", "created_at": "..." },
+    "position": 1
+}
+
+// GET /waitlist/me — approved の場合 (200)
+{
+    "entry": { "id": 1, "status": "approved", "note": "VIP希望", "created_at": "..." },
+    "position": null
+}
+
+// GET /waitlist (admin, 200)
+{
+    "data": [
+        { "id": 1, "user_id": 101, "status": "approved", "note": "VIP希望", ... },
+        { "id": 2, "user_id": 102, "status": "waiting",  "note": null,      ... }
+    ],
+    "total": 2
+}
+```
+
+## 関連ガイド
+
+- [システムアナウンスメント管理](system-announcement-management.md) — 管理者キー認証パターン（同様の `hash_equals()` 使用）
+- [プライバシーコンセント管理](privacy-consent-management.md) — UPSERT と冪等操作
+- [ソフトデリート](soft-delete.md) — 削除フラグパターン（離脱は物理削除）
+- [予約ダブルブッキング防止](prevent-double-booking.md) — UNIQUE 制約による競合防止

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.158
+  version: 1.5.170
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -93,6 +93,13 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | FT175 | API Usage Metering | meterlog | 24/24 | v1.5.109 | api-usage-metering.md（per-user 日次クォータ・usage_events 追記・day_key インデックス・ゲートチェック・エンドポイント別内訳）**脆弱性診断: VULN-A〜L 全Pass** |
 | FT176 | Delegated Access Grants | grantlog | 23/23 | v1.5.110 | delegated-access-grants.md（multi-party 委譲・expired/revoked state machine・IDOR防止・型強制・Unicode/BIDI verbatim）**クラッカー攻撃試験: ATK-01〜12 全Pass** |
 | FT177 | Pagination Boundary Attack | limitlog | 20/20 | v1.5.111 | pagination-boundary-attack.md（ctype_digit O(n)・overflow guard・clampInt・ReDoS safe）**脆弱性診断: VULN-A〜L 全Pass** |
+| FT178 | JSON Merge Patch & ETag | patchlog | — | v1.5.112〜 | json-merge-patch.md（RFC 7396 null セマンティクス・If-Match 412・V.php）→ PR #899 |
+| FT179 | テナント分離 & IDOR | isolationlog | — | v1.5.114 | tenant-isolation.md（SQL tenant_id・ヘッダー認証・ATK 全Pass）→ PR #901 |
+| FT180〜187 | 各種 howto | — | — | v1.5.115〜122 | — → PR #903〜#920 |
+| FT188 | 数値認証コード | verifylog | — | v1.5.123 | numeric-verification-code.md（ATK-01〜12 全Pass）→ PR #922 |
+| FT189 | プライバシーコンセント | consentlog | 51/51 | v1.5.124 | privacy-consent-management.md（VULN-A〜L 全Pass）→ PR #924 |
+| FT190 | システムアナウンス | announcelog | 38/38 | v1.5.125 | system-announcement-management.md（hash_equals admin key）→ PR #926 |
+| FT191 | ウェイティングリスト | waitlistlog | 39/39 | v1.5.126 | waitlist-management.md（動的ポジション・状態機械・IDOR防止）→ PR #928 |
 
 ## 次のアクション（2026-05-26〜）
 
@@ -126,8 +133,8 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | チェック項目 | 次回 |
 |---|---|
 | MySQL 統合テスト | FT167 ✓ 完了 |
-| 脆弱性診断 | FT177 ✓ 完了（次: FT180） |
-| クラッカー攻撃試験 | FT176 ✓ 完了（次: FT180） |
+| 脆弱性診断 | FT189 ✓ 完了（次: FT192） |
+| クラッカー攻撃試験 | FT188 ✓ 完了（次: FT192） |
 
 ## 検討事項（決定不要・議題として保持）
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.158';
+    public const string VERSION = '1.5.170';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT191 waitlistlog — 位置ベースのウェイティングリスト管理 API の実装と howto ガイドを追加する。

## 変更点

- `docs/howto/waitlist-management.md` — 新規 howto
  - 動的ポジション計算（COUNT(*) WHERE id <= :id、ポジション用カラムなし）
  - 状態機械（waiting → approved / declined、一方向・取消不可）
  - IDOR 防止（toPublicArray() に user_id なし / toAdminArray() に user_id あり）
  - /waitlist/me を /waitlist より先にルート登録する必要性
  - hash_equals() による管理者キー認証（fail-closed）
  - 整数オーバーフロー防止（ctype_digit + strlen > 18 ガード）
- `src/FrameworkInfo.php`: VERSION 1.5.126
- `docs/openapi/openapi.yaml`: version 1.5.126
- `CHANGELOG.md`: v1.5.126 エントリ
- `docs/todo/current.md`: FT191 完了・次トリガー更新

## FT アプリ（../NENE2-FT/waitlistlog/）

- エンドポイント: POST /waitlist, GET /waitlist/me, DELETE /waitlist/me, GET /waitlist, POST /waitlist/{id}/approve, POST /waitlist/{id}/decline
- 39 tests / 98 assertions PASS
- PHPStan level 8 clean
- PHP CS Fixer clean

## 検証

```
cd /home/xi/docker/NENE2-FT/waitlistlog
php8.4 vendor/bin/phpunit --testdox   # 39/39 OK
php8.4 vendor/bin/phpstan analyse --level=8 src tests   # No errors
php8.4 vendor/bin/php-cs-fixer fix --dry-run  # No changes
```

Self-review: backend-api, docs-policy

Closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)