### PR TITLE
feat(howto): 注文管理 API ガイドを追加 (FT215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.150] — 2026-05-27
+
+### Added
+- `docs/howto/order-management.md` — 注文管理 API ガイド: 複数行アイテム・自動合計計算・ステータスライフサイクル (pending→cancelled)・IDOR 防止 (404 返却)・管理者オーバーライド・二重キャンセル競合検出 409 (FT215)。 (#975)
+
+---
+
 ## [1.5.114] — 2026-05-26
 
 ### Added

--- a/docs/howto/order-management.md
+++ b/docs/howto/order-management.md
@@ -1,0 +1,117 @@
+# How-to: Order Management API
+
+This guide shows how to build a multi-item order management API with NENE2.
+Pattern demonstrated by the **orderlog** field trial (FT215).
+
+## Features
+
+- Create orders with line items (SKU + quantity + unit price)
+- Automatic total calculation from items
+- Status lifecycle: `pending → confirmed → shipped → delivered → cancelled`
+- User-scoped IDOR protection (returns 404, not 403, to hide existence)
+- Admin override for cross-user operations
+- Atomic cancel with conflict detection (cannot cancel `cancelled` or `delivered`)
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS orders (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'pending',
+    total_cents INTEGER NOT NULL,
+    note        TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+CREATE TABLE IF NOT EXISTS order_items (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id    INTEGER NOT NULL,
+    sku         TEXT    NOT NULL,
+    quantity    INTEGER NOT NULL,
+    unit_cents  INTEGER NOT NULL,
+    FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_orders_user ON orders (user_id, id DESC);
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/orders` | Create order with items |
+| `GET` | `/orders/{id}` | Get order with items (owner or admin) |
+| `POST` | `/orders/{id}/cancel` | Cancel order (owner or admin) |
+| `GET` | `/users/{userId}/orders` | List orders for a user (self or admin) |
+
+## Item Validation
+
+```php
+/** SKU: uppercase alphanumeric and hyphens, 1–32 chars */
+private const string SKU_PATTERN = '/\A[A-Z0-9\-]{1,32}\z/';
+
+// Per item:
+// - sku: must match SKU_PATTERN
+// - quantity: integer 1–9999
+// - unit_cents: non-negative integer
+// Max 50 items per order
+```
+
+## Repository Pattern
+
+```php
+/**
+ * @param list<array{sku: string, quantity: int, unit_cents: int}> $items
+ * @return array<string, mixed>
+ */
+public function create(int $userId, string $note, array $items): array
+{
+    $totalCents = 0;
+    foreach ($items as $item) {
+        $totalCents += $item['quantity'] * $item['unit_cents'];
+    }
+    // INSERT order, then INSERT items, return findById()
+}
+
+/** @return 'not_found'|'not_cancellable'|'ok' */
+public function cancel(int $id, int $userId, bool $isAdmin): string
+{
+    // Returns 'not_found' for wrong user (IDOR protection)
+    // Returns 'not_cancellable' for cancelled/delivered orders
+}
+```
+
+## IDOR Protection
+
+User-scoped endpoints return `404` (not `403`) when a user accesses another user's resource:
+
+```php
+// GET /orders/{id}
+if (!$isAdmin && (int) $order['user_id'] !== $uid) {
+    return $this->problem(404, 'not-found', 'Order not found.');
+}
+
+// GET /users/{userId}/orders
+if (!$isAdmin && $callerUid !== $targetUid) {
+    return $this->problem(404, 'not-found', 'User not found.');
+}
+```
+
+## Cancel with Match Expression
+
+```php
+$result = $this->repo->cancel($id, $uid ?? 0, $isAdmin);
+
+return match ($result) {
+    'not_found'       => $this->problem(404, 'not-found', 'Order not found.'),
+    'not_cancellable' => $this->problem(409, 'conflict', 'Order cannot be cancelled.'),
+    default           => $this->json(['message' => 'Order cancelled.']),
+};
+```
+
+## Security Patterns
+
+- **Admin fail-closed**: `if ($this->adminKey === '') return false;` before `hash_equals()`
+- **`ctype_digit()`**: ReDoS-safe integer validation for path and header IDs
+- **`is_int()`**: Strict type check — rejects floats (e.g., `1.5`) passed as JSON
+- **Max items guard**: Limits to 50 items to prevent oversized payloads

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.114
+  version: 1.5.150
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.114';
+    public const string VERSION = '1.5.150';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要
複数行アイテムを持つ注文管理 API パターンを示す FT215 (orderlog) の howto ガイドを追加。

## 変更点
- `docs/howto/order-management.md` — 注文管理 API ガイド
- `src/FrameworkInfo.php` — VERSION 1.5.150
- `CHANGELOG.md` — v1.5.150 エントリ
- `docs/openapi/openapi.yaml` — version 1.5.150

## 実証パターン
- 複数行アイテム (SKU + 数量 + 単価) 注文
- 自動合計計算 (total_cents = Σ quantity × unit_cents)
- ステータスライフサイクル: pending → confirmed → shipped → delivered → cancelled
- IDOR 防止: 他ユーザーのリソースは 404 返却 (403 ではない)
- 管理者オーバーライド: X-Admin-Key で全ユーザー操作可能
- 二重キャンセル競合検出: cancelled/delivered → 409 Conflict
- Admin fail-closed: 空キー → false
- ctype_digit() による ReDoS 安全な ID バリデーション

## 検証
- PHPUnit 36 tests, 48 assertions — OK
- PHPStan level 8 — No errors
- PHP CS Fixer — No diff

## 関連
Closes #975

Self-review: backend-api, docs-policy