### PR TITLE
feat(howto): 招待・リファラル API ガイドを追加 (#987)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.156] — 2026-05-27
+
+### Added
+- `docs/howto/invitation-referral.md` — 招待・リファラル API ガイド: トークン as capability パターン・bin2hex(random_bytes(16)) 生成・有効期限・1回限り使用・IDOR 防止 (自分の招待のみ) (FT221)。 (#987)
+
+---
+
 ## [1.5.155] — 2026-05-27
 
 ### Added

--- a/docs/howto/invitation-referral.md
+++ b/docs/howto/invitation-referral.md
@@ -1,0 +1,90 @@
+# How-to: Invitation / Referral API
+
+This guide shows how to build a token-based invitation system with expiry and one-time use using NENE2.
+Pattern demonstrated by the **invitelog** field trial (FT221).
+
+## Features
+
+- Generate invitation tokens (`bin2hex(random_bytes(16))` = 32 lowercase hex chars)
+- Set per-invitation expiry date (ISO 8601)
+- Accept/use invitation (one-time, tracks invitee)
+- User-scoped invitation list (IDOR: only self can view)
+- Status lifecycle: `pending → used` (expired detected on use)
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS invitations (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    token       TEXT    NOT NULL UNIQUE,
+    inviter_id  INTEGER NOT NULL,
+    invitee_id  INTEGER,
+    status      TEXT    NOT NULL DEFAULT 'pending',
+    expires_at  TEXT    NOT NULL,
+    used_at     TEXT,
+    created_at  TEXT    NOT NULL
+);
+```
+
+## Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/invitations` | User | Create invitation (returns token) |
+| `GET` | `/invitations/{token}` | Public (token = secret) | Get invitation status |
+| `POST` | `/invitations/{token}/use` | User | Accept invitation |
+| `GET` | `/users/{userId}/invitations` | User (self only) | List own invitations |
+
+## Token Generation
+
+```php
+$token = bin2hex(random_bytes(16)); // 32 lowercase hex chars, cryptographically secure
+```
+
+Token pattern validated in path params:
+
+```php
+/** Token: 32 lowercase hex chars (16 random bytes) */
+public const string TOKEN_PATTERN = '/\A[0-9a-f]{32}\z/';
+```
+
+## One-Time Use Logic
+
+```php
+/** @return 'ok'|'not_found'|'already_used'|'expired' */
+public function use(string $token, int $inviteeId): string
+{
+    $inv = $this->findByToken($token);
+    if ($inv === null) return 'not_found';
+    if ($inv['status'] === 'used') return 'already_used'; // → 409
+    if ($inv['expires_at'] < $this->now()) return 'expired'; // → 409
+
+    // Mark as used + record invitee
+    $this->pdo->prepare(
+        "UPDATE invitations SET status = 'used', invitee_id = :iid, used_at = :now WHERE token = :token"
+    )->execute([...]);
+
+    return 'ok';
+}
+```
+
+## IDOR Protection
+
+The invitation list endpoint enforces self-only access:
+
+```php
+$callerUid = $this->uid($req);
+if ($callerUid !== $targetUid) {
+    return $this->problem(404, 'not-found', 'User not found.');
+}
+```
+
+The `GET /invitations/{token}` endpoint uses the token itself as the secret — knowing the token grants access. This is the "token = capability" pattern.
+
+## Security Patterns
+
+- **`bin2hex(random_bytes(16))`**: Cryptographically secure, 128-bit entropy token
+- **Token pattern validation**: `/\A[0-9a-f]{32}\z/` — blocks SQL injection, oversized tokens
+- **`ctype_digit()`**: ReDoS-safe integer validation for user ID path params
+- **ISO 8601 expiry validation**: Regex pattern + lexicographic comparison (UTC)
+- **Expiry checked on use**: Not pre-filtered — token lookup returns result, then expiry is checked

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.155
+  version: 1.5.156
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.155';
+    public const string VERSION = '1.5.156';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT221 invitelog フィールドトライアルで実証した招待・リファラル API パターンのガイドを追加。

## 変更点

- `docs/howto/invitation-referral.md` — 招待・リファラル API ガイド
- `src/FrameworkInfo.php` — VERSION 1.5.156
- `CHANGELOG.md` — v1.5.156 エントリ追加
- `docs/openapi/openapi.yaml` — version 1.5.156

## 実証パターン

- **Token as capability**: トークン自体が権限証明 (SECRET URL パターン)
- **`bin2hex(random_bytes(16))`**: 32 文字 hex トークン生成
- **有効期限**: ISO 8601 UTC 文字列の辞書順比較
- **1回限り使用**: status `pending` → `used` + used_at 記録
- **IDOR 防止**: 自分の招待一覧のみアクセス可 (404 で存在を隠す)
- **Admin fail-closed**: adminKey 空 → false

## 検証

- PHPUnit: 23 tests, 47 assertions — OK
- PHPStan level 8: No errors
- PHP CS Fixer: No diff

Closes #987

Self-review: backend-api, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)