### PR TITLE
docs(howto): PIN 検証ロックアウト howto に ATK FT252 参照追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.223] — 2026-05-27
+
+### Changed
+- `docs/howto/pin-verification-lockout.md` — FT252/ATK 参照を追加: NENE2-FT/pinverifylog との紐付け・HMAC-SHA256 PIN ハッシュ・hash_equals() 定数時間比較・ブルートフォースロックアウト・fail-closed 管理キー・ctype_digit() ReDoS 防止・ATK-01〜12 全 BLOCKED 対策済み。 (#1050)
+
+---
+
 ## [1.5.222] — 2026-05-27
 
 ### Added

--- a/docs/howto/pin-verification-lockout.md
+++ b/docs/howto/pin-verification-lockout.md
@@ -1,5 +1,8 @@
 # PIN 認証・ロックアウト
 
+> **FT reference**: FT252 (`NENE2-FT/pinverifylog`) — PIN Verification with Lockout
+> **ATK**: FT252 — cracker-mindset attack test (ATK-01 through ATK-12)
+
 6桁 PIN のブルートフォース防止・タイミング攻撃対策・管理者ロック解除の実装ガイド。
 HMAC-SHA256 ハッシュ保存・定数時間比較・試行回数ロックアウトを解説する。
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.222
+  version: 1.5.223
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.222';
+    public const string VERSION = '1.5.223';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT192 (pinverifylog) の ATK 参照を `pin-verification-lockout.md` に追加する。

## 変更内容

- `docs/howto/pin-verification-lockout.md` — FT252/ATK 参照追加
  - FT reference header: `FT252 (NENE2-FT/pinverifylog)`
  - 既存の包括的コンテンツと正式紐付け
  - HMAC-SHA256 PIN ハッシュ・hash_equals() 定数時間比較・ブルートフォースロックアウト・fail-closed 管理キー・ctype_digit() ReDoS 防止・ATK-01〜12 全 BLOCKED
- `src/FrameworkInfo.php` — VERSION 1.5.223
- `CHANGELOG.md` — v1.5.223 エントリ追加
- `docs/openapi/openapi.yaml` — version 1.5.223

## 検証

`docker compose run --rm app composer check → Version OK: 1.5.223`

Self-review: docs-policy

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)