### PR TITLE
docs(howto): JWT 認証 howto に FT261/VULN 参照を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.232] — 2026-05-27
+
+### Changed
+- `docs/howto/jwt-authentication.md` — FT261/VULN 参照を追加: タイミング攻撃対策（ダミーハッシュで password_verify() を必ず実行）・VULN V-01〜10（ブルートフォース・JWT シークレット強度・トークン失効なし EXPOSED、メール大小文字正規化なし・メールバリデーションなし・HTTPS 未強制 EXPOSED、password_hash クレーム未含有 SAFE、SQL インジェクション BLOCKED）(FT261/VULN)。 (#1068)
+
+---
+
 ## [1.5.231] — 2026-05-27
 
 ### Added

--- a/docs/howto/jwt-authentication.md
+++ b/docs/howto/jwt-authentication.md
@@ -1,5 +1,8 @@
 # How-To: JWT Authentication
 
+> **FT reference**: FT261 (`NENE2-FT/jwtlog`) — JWT Authentication with Argon2id password hashing and BearerTokenMiddleware
+> **VULN**: FT261 — vulnerability assessment (V-01 through V-10)
+
 Issuing and verifying JWT Bearer tokens with `LocalBearerTokenVerifier` and `BearerTokenMiddleware`.
 
 ---
@@ -171,3 +174,161 @@ new RuntimeApplicationFactory($psr17, $psr17, authMiddleware: $authMiddleware);
 - [ ] Token response does not contain `password_hash` or other secrets
 - [ ] `Authorization` header is not logged
 - [ ] 401 is returned for auth failures (not 404)
+
+---
+
+## Timing attack protection: dummy hash for user enumeration
+
+When an email is not found, `$user === null`. Without a dummy hash, the code would skip
+`password_verify()` entirely — making the response noticeably faster for unknown emails.
+
+```php
+$user = $this->repo->findByEmail(trim($body['email']));
+
+// Always run password_verify — prevents timing-based user enumeration.
+$dummyHash   = '$argon2id$v=19$m=65536,t=4,p=1$dummysaltdummysaltdummysalt$dummyhashvaluedummyhashvaluedummyh';
+$hashToCheck = $user !== null ? $user->passwordHash : $dummyHash;
+
+// ⚠️  Order matters: password_verify() BEFORE || $user === null
+// Short-circuit evaluation would skip password_verify() if $user were checked first.
+if (!password_verify($body['password'], $hashToCheck) || $user === null) {
+    return 401;  // same error regardless of whether email is unknown or password is wrong
+}
+```
+
+---
+
+## VULN — Vulnerability assessment (FT261)
+
+### V-01 — No brute-force protection on login
+
+**Risk**: `POST /auth/login` has no rate limiting.
+
+**Impact**: An attacker can submit unlimited login attempts. Argon2id is intentionally slow (~100ms),
+but without rate limiting, distributed requests can still try thousands of passwords.
+
+**Verdict**: **EXPOSED** — add `ThrottleMiddleware` on `POST /auth/login` (e.g. 5 req/min/IP).
+Return 429 with `Retry-After`.
+
+---
+
+### V-02 — JWT secret strength is environment-dependent
+
+**Risk**: If `NENE2_LOCAL_JWT_SECRET` is empty or weak (`secret`, `test`), HMAC-HS256 tokens
+can be brute-forced or guessed. A forged token with admin claims would be accepted.
+
+**Verdict**: **EXPOSED** — fail-closed startup check:
+```php
+if (strlen($jwtSecret) < 32) {
+    throw new \RuntimeException('NENE2_LOCAL_JWT_SECRET must be at least 32 random bytes.');
+}
+```
+
+---
+
+### V-03 — No token revocation
+
+**Risk**: Issued JWTs remain valid until `exp`. Stolen tokens, or tokens belonging to deleted
+users, remain accepted for up to 1 hour.
+
+**Verdict**: **EXPOSED** — implement a token blocklist (e.g., `revoked_tokens(jti TEXT PK, revoked_at TEXT)`)
+or use short-lived tokens (15 min) with refresh tokens.
+
+---
+
+### V-04 — No user registration endpoint
+
+**Risk**: No `POST /auth/register` route exists. Test users require direct DB insertion, bypassing
+the password hashing policy enforced by the application.
+
+**Verdict**: **DESIGN GAP** — add `POST /auth/register` with email validation and Argon2id hashing.
+
+---
+
+### V-05 — Email case sensitivity: no normalization
+
+**Risk**: `WHERE email = ?` is case-sensitive. `USER@EXAMPLE.COM` and `user@example.com` are
+different lookups. Two accounts with different cases can co-exist.
+
+**Verdict**: **EXPOSED** — normalize email to lowercase (`strtolower()`) at registration and login.
+
+---
+
+### V-06 — Token TTL: 1 hour may be too long for sensitive APIs
+
+**Risk**: `TOKEN_TTL_SECONDS = 3600`. Stolen tokens stay valid for up to an hour.
+
+**Verdict**: **DESIGN CONSIDERATION** — 1 hour is acceptable for most APIs. For sensitive operations,
+use shorter TTLs (5–15 min) with refresh tokens. Make TTL configurable.
+
+---
+
+### V-07 — `password_hash` is not in JWT claims
+
+**Risk**: The `issue()` call only includes `sub`, `email`, `iat`, `exp`.
+
+**Verdict**: **SAFE** — claims are minimal. Even if a token is decoded (base64, not encrypted),
+no sensitive internal data is exposed.
+
+---
+
+### V-08 — SQL injection via email
+
+**Attack**: `{"email": "' OR '1'='1", "password": "x"}`
+
+**Observed**: `WHERE email = ?` is a parameterized query. The injection is treated as a literal
+string. No user is found; 401 is returned.
+
+**Verdict**: **BLOCKED** — parameterized queries prevent SQL injection.
+
+---
+
+### V-09 — No email format validation
+
+**Risk**: Any non-empty string is accepted as email (e.g., `"not-an-email"`).
+
+**Impact**: Wasted Argon2id computation; invalid users in DB; broken password reset flows.
+
+**Verdict**: **EXPOSED** — add `filter_var($email, FILTER_VALIDATE_EMAIL)` at registration and login.
+
+---
+
+### V-10 — No HTTPS enforcement
+
+**Risk**: JWT tokens and passwords are transmitted in plaintext over HTTP.
+
+**Verdict**: **EXPOSED** — enforce HTTPS in production. Add `Strict-Transport-Security` header via
+`SecurityHeadersMiddleware`.
+
+---
+
+## VULN summary
+
+| # | Vulnerability | Verdict |
+|---|---------------|---------|
+| V-01 | No brute-force protection | EXPOSED |
+| V-02 | JWT secret strength (env-dependent) | EXPOSED |
+| V-03 | No token revocation | EXPOSED |
+| V-04 | No registration endpoint | DESIGN GAP |
+| V-05 | Email case sensitivity / no normalization | EXPOSED |
+| V-06 | Token TTL 1 hour | DESIGN CONSIDERATION |
+| V-07 | password_hash not in JWT claims | SAFE |
+| V-08 | SQL injection via email | BLOCKED |
+| V-09 | No email format validation | EXPOSED |
+| V-10 | No HTTPS enforcement | EXPOSED |
+
+**Critical fixes before production**:
+1. **V-01** — `ThrottleMiddleware` on `POST /auth/login` (5 req/min/IP)
+2. **V-02** — Fail-closed JWT secret validation at startup (`strlen >= 32`)
+3. **V-03** — Token revocation list or short TTL + refresh tokens
+4. **V-05** — Normalize email to lowercase at registration and login
+5. **V-09** — `filter_var($email, FILTER_VALIDATE_EMAIL)` at registration
+
+---
+
+## Related howtos
+
+- [`pin-verification-lockout.md`](pin-verification-lockout.md) — brute-force lockout for PIN verification
+- [`fixed-window-rate-limiter.md`](fixed-window-rate-limiter.md) — rate limiting middleware
+- [`webhook-signature-verification.md`](webhook-signature-verification.md) — HMAC-SHA256 + timing-safe comparison
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — explicit DTO whitelisting

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.231
+  version: 1.5.232
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.231';
+    public const string VERSION = '1.5.232';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要
`NENE2-FT/jwtlog` (FT261) を参照して、既存 `jwt-authentication.md` に FT261/VULN 参照ヘッダーと脆弱性アセスメントを追加する。

## 変更点
- `docs/howto/jwt-authentication.md` 更新: FT261/VULN 参照ヘッダー追加・タイミング攻撃対策解説・VULN V-01〜10 アセスメント追記
- VERSION: 1.5.231 → 1.5.232

## VULN サマリー (FT261)
| # | 脆弱性 | 判定 |
|---|---|---|
| V-01 | ブルートフォース保護なし | EXPOSED |
| V-02 | JWT シークレット強度 | EXPOSED |
| V-03 | トークン失効なし | EXPOSED |
| V-04 | 登録エンドポイントなし | DESIGN GAP |
| V-05 | メール大小文字正規化なし | EXPOSED |
| V-06 | Token TTL 1 時間 | DESIGN CONSIDERATION |
| V-07 | password_hash クレーム未含有 | SAFE |
| V-08 | SQL インジェクション | BLOCKED |
| V-09 | メールバリデーションなし | EXPOSED |
| V-10 | HTTPS 未強制 | EXPOSED |

Self-review: docs-policy

Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)