### PR TITLE
docs(howto): API キー管理 howto に FT266 参照を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.237] — 2026-05-27
+
+### Changed
+- `docs/howto/api-key-management.md` — FT266 参照を追加: NENE2-FT/apikeylog との紐付け (FT266)。 (#1078)
+
+---
+
 ## [1.5.236] — 2026-05-27
 
 ### Added

--- a/docs/howto/api-key-management.md
+++ b/docs/howto/api-key-management.md
@@ -1,5 +1,7 @@
 # API Key Management
 
+> **FT reference**: FT266 (`NENE2-FT/apikeylog`) — API key lifecycle: generation, SHA-256 hash storage, prefix-based lookup, scope enforcement, rotation
+
 This guide covers implementing API key management in NENE2 applications: key generation, secure storage, scope-based authorization, revocation, and rotation.
 
 ## Core design principles

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.236
+  version: 1.5.237
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.236';
+    public const string VERSION = '1.5.237';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要
既存 `api-key-management.md` に `NENE2-FT/apikeylog` (FT266) FT 参照ヘッダーを追加する。

## 変更点
- `docs/howto/api-key-management.md` 更新: FT266 参照追加
- VERSION: 1.5.236 → 1.5.237

## 検証
- `composer check` — Version consistency OK: 1.5.237
- FT テスト: 19 tests, all pass

Self-review: docs-policy

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)