### PR TITLE
docs(howto): FT269 ショッピングカート API howto 追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.240] — 2026-05-27
+
+### Added
+- `docs/howto/shopping-cart-api.md` — ショッピングカート API howto: UNIQUE (user_id, product_id) 制約による重複防止・upsert add-item（既存なら数量加算 SELECT-then-UPDATE/INSERT）・quantity=0 自動削除セマンティクス・JOIN による合計金額リアルタイム計算・price/subtotal を INTEGER (float 禁止)・X-User-Id ヘッダー識別（本番は JWT 推奨）・201/200 ステータス使い分け (FT269)。 (#1085)
+
+---
+
 ## [1.5.239] — 2026-05-27
 
 ### Changed

--- a/docs/howto/shopping-cart-api.md
+++ b/docs/howto/shopping-cart-api.md
@@ -1,0 +1,245 @@
+# How-to: Shopping Cart API
+
+> **FT reference**: FT269 (`NENE2-FT/cartlog`) — Shopping cart: UNIQUE (user_id, product_id) per-user cart, upsert add-item (quantity accumulation), quantity=0 auto-remove semantics, integer price/subtotal, X-User-Id header identification
+
+Demonstrates a stateful per-user shopping cart: add items (with quantity accumulation on re-add), update quantities, remove items, and view a running total. All prices are stored as integers (cents or base units) — never floats.
+
+---
+
+## Routes
+
+| Method   | Path                        | Description                              |
+|----------|-----------------------------|------------------------------------------|
+| `GET`    | `/cart`                     | List cart contents with subtotals and total |
+| `POST`   | `/cart/items`               | Add a product (quantity accumulates if already in cart) |
+| `PUT`    | `/cart/items/{productId}`   | Set quantity (0 = remove item)           |
+| `DELETE` | `/cart/items/{productId}`   | Remove a specific item                   |
+| `DELETE` | `/cart`                     | Clear the entire cart                    |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE products (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    price      INTEGER NOT NULL CHECK (price >= 0),
+    stock      INTEGER NOT NULL DEFAULT 0 CHECK (stock >= 0),
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE cart_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    product_id INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL CHECK (quantity > 0),
+    added_at   TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE (user_id, product_id),
+    FOREIGN KEY (user_id)    REFERENCES users(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+```
+
+Key design choices:
+- `UNIQUE (user_id, product_id)` — one row per (user, product) pair. Re-adding the same product accumulates quantity rather than inserting a duplicate row.
+- `price INTEGER` — stored in smallest currency unit (e.g., cents). Never use `FLOAT` for money.
+- `quantity INTEGER CHECK (quantity > 0)` — zero-quantity rows are deleted, not stored.
+- No FK on `cart_items.price` — the price is read from `products.price` at query time (JOIN), not stored in the cart. If product price changes, the cart reflects the new price.
+
+---
+
+## Upsert add-item pattern
+
+Adding an item that already exists in the cart accumulates quantity:
+
+```php
+public function addItem(int $userId, int $productId, int $quantity, string $now): void
+{
+    $existing = $this->db->fetchOne(
+        'SELECT id, quantity FROM cart_items WHERE user_id = ? AND product_id = ?',
+        [$userId, $productId],
+    );
+
+    if ($existing !== null) {
+        $newQty = (int) $existing['quantity'] + $quantity;
+        $this->db->execute(
+            'UPDATE cart_items SET quantity = ?, updated_at = ? WHERE id = ?',
+            [$newQty, $now, $existing['id']],
+        );
+    } else {
+        $this->db->execute(
+            'INSERT INTO cart_items (user_id, product_id, quantity, added_at, updated_at)
+             VALUES (?, ?, ?, ?, ?)',
+            [$userId, $productId, $quantity, $now, $now],
+        );
+    }
+}
+```
+
+The SELECT-then-INSERT/UPDATE pattern avoids `INSERT OR REPLACE` (which changes the `id` and `added_at`) and avoids `ON CONFLICT DO UPDATE` (not portable across all DB engines). The `UNIQUE (user_id, product_id)` constraint still guards against a race-condition duplicate INSERT.
+
+Response status: `201 Created` if the item was new; `200 OK` if quantity was accumulated on an existing item.
+
+---
+
+## Quantity=0 auto-remove semantics
+
+`PUT /cart/items/{productId}` with `quantity: 0` removes the item rather than storing a zero-quantity row:
+
+```php
+if ($quantity === 0) {
+    $this->repo->removeItem($userId, $productId);
+    return $this->json->createEmpty(204);
+}
+
+$this->repo->updateQuantity($userId, $productId, $quantity, $now);
+```
+
+This matches common shopping cart UX: dragging the stepper to zero removes the item. The DB `CHECK (quantity > 0)` also enforces this at the storage level.
+
+---
+
+## Cart total: JOIN + loop calculation
+
+The cart response includes a real-time total computed from the JOIN result:
+
+```php
+public function getCart(int $userId): array
+{
+    return $this->db->fetchAll(
+        'SELECT ci.id, ci.product_id, ci.quantity, ci.added_at, ci.updated_at,
+                p.name AS product_name, p.price
+         FROM cart_items ci
+         JOIN products p ON p.id = ci.product_id
+         WHERE ci.user_id = ?
+         ORDER BY ci.added_at ASC, ci.id ASC',
+        [$userId],
+    );
+}
+```
+
+```php
+$items = $this->repo->getCart($userId);
+$total = 0;
+$formatted = [];
+
+foreach ($items as $item) {
+    $subtotal = (int) $item['price'] * (int) $item['quantity'];
+    $total   += $subtotal;
+    $formatted[] = $this->formatItem($item, $subtotal);
+}
+
+return $this->json->create([
+    'items' => $formatted,
+    'total' => $total,
+    'count' => count($formatted),
+]);
+```
+
+Both `price` and `subtotal` are integers. The API consumer divides by 100 for display (e.g., `1999` → `$19.99`).
+
+---
+
+## User identification via X-User-Id header
+
+The FT uses a simple `X-User-Id` header (no JWT) to identify the cart owner:
+
+```php
+private function requireUserId(ServerRequestInterface $request): ?int
+{
+    $header = $request->getHeaderLine('X-User-Id');
+    if ($header === '') {
+        return null;
+    }
+    $id = (int) $header;
+    return $id > 0 ? $id : null;
+}
+```
+
+The handler verifies that the user exists in the `users` table before proceeding:
+```php
+if ($this->repo->findUserById($userId) === null) {
+    return $this->json->create(['error' => 'User not found'], 404);
+}
+```
+
+**Production note**: Replace `X-User-Id` with a verified JWT or session token. The header is trivially spoofable — any caller can claim any `user_id`. Use `X-User-Id` only in trusted internal service-to-service contexts, never for public APIs.
+
+---
+
+## Validation
+
+```php
+// POST /cart/items body validation
+private function parseAddBody(array $body): array
+{
+    $errors = [];
+
+    if (!isset($body['product_id']) || !is_int($body['product_id'])) {
+        $errors[] = new ValidationError('product_id', 'product_id must be an integer', 'invalid_type');
+    }
+
+    $productId = isset($body['product_id']) && is_int($body['product_id']) ? $body['product_id'] : 0;
+    if ($productId <= 0 && $errors === []) {
+        $errors[] = new ValidationError('product_id', 'product_id must be positive', 'invalid_value');
+    }
+
+    if (!isset($body['quantity']) || !is_int($body['quantity'])) {
+        $errors[] = new ValidationError('quantity', 'quantity must be an integer', 'invalid_type');
+    }
+
+    $quantity = isset($body['quantity']) && is_int($body['quantity']) ? $body['quantity'] : 0;
+    if ($quantity <= 0 && !isset($errors[1])) {
+        $errors[] = new ValidationError('quantity', 'quantity must be positive', 'invalid_value');
+    }
+
+    return [$productId, $quantity, $errors];
+}
+```
+
+Type checks (`is_int`) reject float or string quantities — `"3"` and `3.0` are both invalid.
+
+---
+
+## Example responses
+
+**GET /cart**:
+```json
+{
+    "items": [
+        {
+            "id": 1,
+            "product_id": 5,
+            "product_name": "Widget",
+            "price": 999,
+            "quantity": 2,
+            "subtotal": 1998,
+            "added_at": "2026-01-01T10:00:00Z",
+            "updated_at": "2026-01-01T10:00:00Z"
+        }
+    ],
+    "total": 1998,
+    "count": 1
+}
+```
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Store `price` in `cart_items` at add time | Stale price if product price changes; refund / overcharge disputes |
+| Use `FLOAT` for price | Floating-point rounding errors in financial totals |
+| Use `X-User-Id` in a public API | Trivially spoofable; use JWT/session instead |
+| Allow `quantity: 0` to store a zero row | Violates `CHECK (quantity > 0)`; confusing semantics |
+| Use `INSERT OR REPLACE` for upsert | Resets `id` and `added_at`; breaks order-preserving sort |
+| No `UNIQUE (user_id, product_id)` constraint | Race condition creates duplicate cart rows |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.239
+  version: 1.5.240
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.239';
+    public const string VERSION = '1.5.240';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT269 (`NENE2-FT/cartlog`) の `docs/howto/shopping-cart-api.md` を新規作成。

## 変更内容

- `docs/howto/shopping-cart-api.md` — ショッピングカート API howto 新規作成
- `src/FrameworkInfo.php` — VERSION 1.5.239 → 1.5.240
- `CHANGELOG.md` — v1.5.240 エントリ追加
- `docs/openapi/openapi.yaml` — version 1.5.239 → 1.5.240

## 主なパターン

- `UNIQUE (user_id, product_id)` 制約で重複防止
- upsert add-item: SELECT-then-UPDATE/INSERT で数量加算
- `quantity=0` → 自動削除セマンティクス
- price/subtotal は INTEGER (float 禁止)
- JOIN で合計金額をリアルタイム計算
- X-User-Id ヘッダー識別 (本番は JWT 推奨)
- 201/200 ステータス使い分け

## 検証

```
docker compose run --rm app composer check
Version consistency OK: 1.5.240
```

Self-review: docs-policy

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)