### PR TITLE
docs(daily): 2026-05-27 日報

### DIFF
--- a/docs/daily/2026-05-27.md
+++ b/docs/daily/2026-05-27.md
@@ -1,0 +1,83 @@
+# 日報 — 2026-05-27
+
+## 作業時間帯
+
+2026-05-27（FT252 の途中からコンテキスト引き継ぎで継続）
+
+---
+
+## 本日の成果
+
+### FT ループ — FT252〜FT269（計 18 件）
+
+| FT | タイプ | テーマ | アプリ | VERSION |
+|----|--------|--------|--------|---------|
+| FT252 | ATK | マスアサインメント防御 | masslog | — |
+| FT253〜254 | 通常 | — | — | — |
+| FT255 | VULN | — | — | — |
+| FT256 | ATK | マスアサインメント（詳細） | masslog | 1.5.227 |
+| FT257 | 通常 | ソフトデリート + ゴミ箱 + 物理削除 | softdeletelog | 1.5.228 |
+| FT258 | 通常 | 部分成功 Bulk 操作 | bulklog | 1.5.229 |
+| FT259 | 通常 | リーダーボード（RANK ウィンドウ関数） | scorelog | 1.5.230 |
+| FT260 | ATK | Webhook HMAC 署名検証 | webhooklog | 1.5.231 |
+| FT261 | VULN | JWT 認証 | jwtlog | 1.5.232 |
+| FT262 | 通常 | 多通貨マネー台帳 | moneylog | 1.5.233 |
+| FT263 | 通常 | 絵文字リアクション トグル | emojilog | 1.5.234 |
+| FT264 | ATK | SQL インジェクション防御 | injectionlog | 1.5.235 |
+| FT265 | 通常 | URL ブックマーク + タグフィルタ | linklog | 1.5.236 |
+| FT266 | 通常 | API キー管理 | apikeylog | 1.5.237 |
+| FT267 | VULN | 暗号化フィールドストレージ | encryptlog | 1.5.238 |
+| FT268 | ATK | 監査ログ | auditlog | 1.5.239 |
+| FT269 | 通常 | ショッピングカート API | cartlog | 1.5.240 |
+
+**全 18 PR マージ / 全 CI グリーン**
+
+---
+
+### 主なパターンと学び
+
+#### 暗号化フィールド（FT267/VULN）
+
+AES-256-GCM によるフィールド単位の暗号化と HMAC-SHA256 ブラインドインデックスを整理。V-01〜V-10 の評価では「鍵ローテーション未実装」「認証なし」「ログへの平文漏洩」の 4 件が EXPOSED。暗号設計自体の欠陥はなく、運用・統合面のギャップに集中していた。
+
+#### 監査ログ（FT268/ATK）— 重大発見あり
+
+ATK-07「`GET /audit` が未認証で全公開」を検出。すべての actor の行動履歴（before/after スナップショット含む）が認証なしで閲覧できる状態だった。JWT の改竄（None アルゴリズム・署名改竄・期限切れリプレイ）は全 BLOCKED。ログイン ブルートフォースと任意 status 値注入も EXPOSED として記録。
+
+#### ショッピングカート（FT269）
+
+`UNIQUE(user_id, product_id)` 制約下での「SELECT-then-UPDATE/INSERT」upsert パターン、`quantity=0` → 自動削除セマンティクス、price/subtotal の INTEGER 強制（float 禁止）を明文化。
+
+---
+
+### 効率化ツール整備
+
+FT ループ作業のやりづらさを解消するツール・ルールを整備した（PR #1087）。
+
+| 成果物 | 内容 |
+|--------|------|
+| `tools/bump-ft.sh` | VERSION を `FrameworkInfo.php` + `openapi.yaml` で一括バンプ |
+| `tools/uncovered-fts.sh` | howto 未カバー FT の一覧（`--all` / `--check` オプション付き） |
+| `CLAUDE.md` セクション 18 | FT ループ作業ルール（CHANGELOG read 必須・ATK/VULN サイクル管理・5FT ごと引き継ぎ更新） |
+| `docs/todo/current.md` | 引き継ぎドキュメントとして再整備 |
+
+---
+
+### 次回最優先 TODO（PR #1088 で記録済み）
+
+| 優先 | 内容 |
+|------|------|
+| P1 | `shopping-cart.md` / `shopping-cart-api.md` 重複解消 |
+| P2 | `uncovered-fts.sh` 精度改善（110 件参照なし howto の整理） |
+| P3 | FT 番号 → プロジェクト台帳 `ft-registry.md` 作成 |
+| P4 | ATK/VULN セクションテンプレートを CLAUDE.md に追加 |
+
+詳細・対応方針・確認コマンドは `docs/todo/current.md` に記録済み。
+
+---
+
+## 所感
+
+セキュリティ評価回（VULN × 2、ATK × 3）を含みながら 18 件を 1 日でこなせた。FT268 で実質的な重大発見（未認証監査ログ公開）があり、評価回を一定間隔で入れることの意義を改めて確認できた。
+
+終盤に効率化ツールを整備したことで、コンテキスト圧縮後の引き継ぎ精度と次セッションの立ち上がり速度が上がる見込み。


### PR DESCRIPTION
2026-05-27 の日報を `docs/daily/2026-05-27.md` に保存。

- FT252〜FT269（18件）の成果まとめ
- 重大発見: FT268 ATK-07 監査ログ未認証公開
- 効率化ツール整備の記録
- 次回最優先 TODO（P1〜P4）への参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)