### PR TITLE
chore(tools): uncovered-fts.sh に旧形式 FT 参照の検出を追加 (#1092)

### DIFF
--- a/tools/uncovered-fts.sh
+++ b/tools/uncovered-fts.sh
@@ -6,8 +6,10 @@
 #   bash tools/uncovered-fts.sh --all     # 全件（カバー済み・未カバー両方）
 #   bash tools/uncovered-fts.sh --check <name>  # 特定 FT がカバー済みか確認
 #
-# 判定基準: docs/howto/ 内のいずれかのファイルに "NENE2-FT/<name>" への
-#           参照が存在すればカバー済みとみなす。
+# 判定基準: docs/howto/ 内のいずれかのファイルに以下のいずれかが含まれれば
+#           カバー済みとみなす:
+#   - 新形式: "NENE2-FT/<name>"
+#   - 旧形式: "Pattern proven by FT<number> <name>"
 
 set -euo pipefail
 
@@ -22,9 +24,15 @@ fi
 
 # カバー済み FT 名のリスト (ソート済み)
 covered() {
-  grep -rh "NENE2-FT/" "$HOWTO_DIR" 2>/dev/null \
-    | grep -oP 'NENE2-FT/\K[a-z]+log' \
-    | sort -u
+  {
+    # 新形式: FT reference: FTxxx (NENE2-FT/<name>) または単純な NENE2-FT/<name> 参照
+    grep -rh "NENE2-FT/" "$HOWTO_DIR" 2>/dev/null \
+      | grep -oP 'NENE2-FT/\K[a-z]+log'
+
+    # 旧形式: Pattern proven by FT<number> <name>
+    grep -rh "Pattern proven by FT" "$HOWTO_DIR" 2>/dev/null \
+      | grep -oP 'Pattern proven by FT\d+ \K[a-z]+log'
+  } | sort -u
 }
 
 # 全 FT プロジェクト名のリスト (ソート済み)


### PR DESCRIPTION
## 変更内容

`covered()` 関数に旧形式 `Pattern proven by FT<number> <name>` の検出を追加。

### 背景

旧形式の howto ファイル（4件: verifylog, consentlog, sessionlog, announcelog）は
`NENE2-FT/<name>` 形式の参照がなくても、旧形式で FT 参照が記録されている。
今回の変更でスクリプトが両方の形式に対応した。

### 確認

```bash
bash tools/uncovered-fts.sh --check verifylog   # → ✅
bash tools/uncovered-fts.sh --check consentlog  # → ✅
bash tools/uncovered-fts.sh --check sessionlog  # → ✅
bash tools/uncovered-fts.sh --check announcelog # → ✅
```

Closes #1092

Self-review: docs-policy