### PR TITLE
docs(howto): FT 番号台帳 ft-registry.md を作成 (#1094)

### DIFF
--- a/docs/howto/ft-registry.md
+++ b/docs/howto/ft-registry.md
@@ -1,0 +1,89 @@
+# FT Registry
+
+FT 番号 → プロジェクト名 → howto ファイルの台帳。
+「FT268 って何だっけ？」と遡るときに使う。
+
+> **Auto-generated hint**: `docs/howto/` の `FT reference` ヘッダーから抽出。
+> 新規 FT を追加したら、対応する行をこのファイルに追記すること。
+
+---
+
+## Registry
+
+| FT | プロジェクト | howto ファイル | タイプ |
+|----|------------|----------------|--------|
+| FT24 | habitlog | [habit-tracker.md](habit-tracker.md) | ATK |
+| FT43 | shiftlog | [shift-management.md](shift-management.md) | VULN |
+| FT51 | statslog | [event-analytics.md](event-analytics.md) | 通常 |
+| FT59 | watchlog | [media-watchlist.md](media-watchlist.md) | 通常 |
+| FT67 | pricelog | [price-history.md](price-history.md) | ATK |
+| FT68 | approvallog | [approval-workflow.md](approval-workflow.md) | 通常 |
+| FT72 | deadletterlog | [dead-letter-queue.md](dead-letter-queue.md) | 通常 |
+| FT85 | bulkupdatelog | [bulk-status-update.md](bulk-status-update.md) | VULN |
+| FT186 | sessionlog | [session-management.md](session-management.md) | 通常 |
+| FT188 | verifylog | [numeric-verification-code.md](numeric-verification-code.md) | ATK |
+| FT189 | consentlog | [privacy-consent-management.md](privacy-consent-management.md) | VULN |
+| FT190 | announcelog | [system-announcement-management.md](system-announcement-management.md) | 通常 |
+| FT233 | cqrslog | [cqrs-pattern.md](cqrs-pattern.md) | 通常 |
+| FT234 | creditslog | [credit-ledger.md](credit-ledger.md) | 通常 |
+| FT235 | reminderlog | [scheduled-reminders.md](scheduled-reminders.md) | 通常 |
+| FT236 | quotalog | [quota-management.md](quota-management.md) | ATK |
+| FT237 | statemachinelog | [state-machine-audit-log.md](state-machine-audit-log.md) | VULN |
+| FT238 | contactlog | [contact-management.md](contact-management.md) | 通常 |
+| FT239 | doclog | [document-versioning.md](document-versioning.md) | 通常 |
+| FT240 | noteslog | [note-management-ownership.md](note-management-ownership.md) | ATK |
+| FT242 | cursorlog | [cursor-pagination.md](cursor-pagination.md) | 通常 |
+| FT243 | statslog | [event-analytics-api.md](event-analytics-api.md) | VULN |
+| FT244 | budgetlog | [budget-tracking.md](budget-tracking.md) | ATK |
+| FT245 | agglog | [aggregate-reporting.md](aggregate-reporting.md) | 通常 |
+| FT246 | timelog | [time-tracking.md](time-tracking.md) | 通常 |
+| FT247 | stepflowlog | [step-workflow-approval.md](step-workflow-approval.md) | 通常 |
+| FT248 | flowlog | [content-approval-workflow.md](content-approval-workflow.md) | ATK |
+| FT249 | contentvlog | [article-versioning-api.md](article-versioning-api.md) | VULN |
+| FT250 | tagfilterlog | [multi-value-tag-filter.md](multi-value-tag-filter.md) | 通常 |
+| FT251 | ratelimitlog | [fixed-window-rate-limiter.md](fixed-window-rate-limiter.md) | 通常 |
+| FT252 | pinverifylog | [pin-verification-lockout.md](pin-verification-lockout.md) | ATK |
+| FT253 | txlog | [transaction-scope-pattern.md](transaction-scope-pattern.md) | 通常 |
+| FT254 | ftslog | [sqlite-fts5-search.md](sqlite-fts5-search.md) | 通常 |
+| FT255 | queuelog | [job-queue-with-retry.md](job-queue-with-retry.md) | VULN |
+| FT256 | masslog | [mass-assignment-defence.md](mass-assignment-defence.md) | ATK |
+| FT257 | softdeletelog | [soft-delete-trash-purge.md](soft-delete-trash-purge.md) | 通常 |
+| FT258 | bulklog | [bulk-operations-partial-success.md](bulk-operations-partial-success.md) | 通常 |
+| FT259 | scorelog | [leaderboard-ranking-api.md](leaderboard-ranking-api.md) | 通常 |
+| FT260 | hmaclog | [webhook-signature-verification.md](webhook-signature-verification.md) | ATK |
+| FT261 | jwtlog | [jwt-authentication.md](jwt-authentication.md) | VULN |
+| FT262 | moneylog | [multi-currency-money-ledger.md](multi-currency-money-ledger.md) | 通常 |
+| FT263 | reactionlog | [emoji-reactions-toggle.md](emoji-reactions-toggle.md) | 通常 |
+| FT264 | injectionlog | [sql-injection-defence.md](sql-injection-defence.md) | ATK |
+| FT265 | linklog | [url-bookmark-api.md](url-bookmark-api.md) | 通常 |
+| FT266 | apikeylog | [api-key-management.md](api-key-management.md) | 通常 |
+| FT267 | encryptlog | [encrypted-field-storage.md](encrypted-field-storage.md) | VULN |
+| FT268 | auditlog | [audit-trail.md](audit-trail.md) | ATK |
+| FT269 | cartlog | [shopping-cart-api.md](shopping-cart-api.md) | 通常 |
+
+---
+
+## メンテナンス方法
+
+新規 FT を追加したときは以下の行を追記する（FT 番号順を維持）:
+
+```
+| FTxxx | <name>log | [<topic>.md](<topic>.md) | 通常/ATK/VULN |
+```
+
+### タイプの判定基準
+
+| タイプ | 判定 |
+|--------|------|
+| **ATK** | クラッカー攻撃試験（ATK-01〜12）を含む |
+| **VULN** | 脆弱性診断（VULN-A〜L / V-01〜10）を含む |
+| **通常** | 上記以外の実装 how-to |
+
+### 自動生成コマンド（素材として）
+
+```bash
+# FT reference ヘッダーから台帳素材を抽出
+grep -rn "FT reference.*NENE2-FT/" docs/howto/ \
+  | grep -oP '[^/]+\.md:\d+:.*FT\d+.*NENE2-FT/[a-z]+log' \
+  | sort
+```


### PR DESCRIPTION
## 変更内容

`docs/howto/ft-registry.md` を新規作成。

FT 番号・プロジェクト名・howto ファイル名・タイプ（通常/ATK/VULN）を一覧化。

### 収録件数

- 新形式（`NENE2-FT/<name>`）から自動抽出: 44 件
- 旧形式（`Pattern proven by FT`）から追加: 4 件（FT186/188/189/190）
- **合計: 48 件**

### 使い方

| 操作 | 方法 |
|------|------|
| 「FT268 って何？」 | ft-registry.md の FT 列で検索 |
| 「audit-trail はどの FT？」 | howto ファイル列で検索 |
| 新 FT 追加時 | FT 番号順で 1 行追記 |

## 検証

```bash
ls docs/howto/ft-registry.md  # ファイルが存在すること
grep 'FT269' docs/howto/ft-registry.md  # 最新 FT が収録されていること
```

Closes #1094

Self-review: docs-policy