### PR TITLE
docs(howto): FT270 featureflaglog — feature flag API howto 更新 (#1098)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.241] — 2026-05-27
+
+### Changed
+- `docs/howto/feature-flags.md` — FT270 参照と HTTP API 詳細を追加: 7 エンドポイント（create/get/toggle/rollout/targeting/evaluate）・FlagEvaluator の優先順位チェーン（user target → tenant target → globally_enabled → rollout_pct hash → false）・crc32 ハッシュによる決定的バケット割り当て（同一ユーザーは常に同じバケット）・abs() による符号対策・ユーザー kill switch（globally_enabled=1 でも user target enabled=false で除外）・flag name の UNIQUE 制約と 409 Conflict・target_type は 'user' か 'tenant' のみ許可 (FT270)。 (#1098)
+
+---
+
 ## [1.5.240] — 2026-05-27
 
 ### Added

--- a/docs/howto/feature-flags.md
+++ b/docs/howto/feature-flags.md
@@ -1,6 +1,24 @@
-# Feature Flags
+# How-to: Feature Flags API
+
+> **FT reference**: FT270 (`NENE2-FT/featureflaglog`) — Feature flag API: priority-chain evaluation (user target → tenant target → globally_enabled → rollout_pct hash), crc32-based deterministic bucket assignment, user/tenant kill switches, flag UNIQUE name constraint, 21 tests / 31 assertions PASS.
 
 Feature flags let you toggle functionality at runtime without deploying code. The core decisions are: where to store state (DB vs config), how to evaluate priority when multiple rules apply, and how to handle rollout percentages without per-user tracking.
+
+---
+
+## Routes
+
+| Method   | Path                                  | Description                              |
+|----------|---------------------------------------|------------------------------------------|
+| `POST`   | `/flags`                              | Create a new feature flag                |
+| `GET`    | `/flags/{name}`                       | Get flag details with targets            |
+| `POST`   | `/flags/{name}/toggle`                | Set globally_enabled on/off              |
+| `PUT`    | `/flags/{name}/rollout`               | Set rollout percentage (0–100)           |
+| `PUT`    | `/flags/{name}/targets`               | Upsert a user or tenant target override  |
+| `DELETE` | `/flags/{name}/targets/{type}/{id}`   | Remove a specific target override        |
+| `POST`   | `/flags/{name}/evaluate`              | Evaluate the flag for a user/tenant      |
+
+---
 
 ## Core components
 
@@ -141,3 +159,62 @@ A flag system without kill switches is incomplete. `enabled = false` is the safe
 
 **Why separate `globally_enabled` and `rollout_pct`?**
 `globally_enabled = 1` is an explicit all-or-nothing switch. `rollout_pct` is for gradual exposure. Keeping them separate avoids overloading one field with two different meanings.
+
+---
+
+## Example responses
+
+**POST /flags** (201 Created):
+```json
+{
+    "id": 1,
+    "name": "new-checkout",
+    "description": "New checkout flow",
+    "globally_enabled": false,
+    "rollout_pct": 0,
+    "created_at": "2026-05-27 10:00:00"
+}
+```
+
+**GET /flags/{name}** (200 OK):
+```json
+{
+    "flag": {
+        "id": 1,
+        "name": "new-checkout",
+        "globally_enabled": false,
+        "rollout_pct": 30
+    },
+    "targets": [
+        {
+            "id": 1,
+            "flag_id": 1,
+            "target_type": "user",
+            "target_id": "user-42",
+            "enabled": true
+        }
+    ]
+}
+```
+
+**POST /flags/{name}/evaluate** (200 OK):
+```json
+{
+    "flag": "new-checkout",
+    "user_id": "user-42",
+    "enabled": true
+}
+```
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Use random number for rollout per request | Same user flips between enabled/disabled across requests — inconsistent UX |
+| Forget `abs()` on `crc32()` | crc32 can return negative values on 64-bit PHP — modulo gives wrong bucket |
+| Allow arbitrary `target_type` values | Uncontrolled enum makes evaluation logic unbounded; restrict to `'user'` and `'tenant'` |
+| No `UNIQUE (flag_id, target_type, target_id)` | Duplicate targets make evaluation ambiguous — first row wins arbitrarily |
+| Use flag name as `target_id` | Flag name can change; use stable IDs for user/tenant targeting |
+| Return 500 on duplicate flag name | The name uniqueness violation is a domain error, not a server error; map to 409 Conflict |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.240
+  version: 1.5.241
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.240';
+    public const string VERSION = '1.5.241';
 
     public function name(): string
     {


### PR DESCRIPTION
## 変更内容

`NENE2-FT/featureflaglog` (FT270) の実装をもとに `docs/howto/feature-flags.md` を更新。

### 追加内容

- **FT reference** ヘッダー (FT270)
- **Routes** テーブル（7 エンドポイント）
- **Example responses** (create / get / evaluate)
- **What NOT to do** アンチパターン表（crc32 abs・重複 target・任意 target_type 等）
- バージョン 1.5.241 バンプ

### 既存内容（そのまま維持）

- Schema（feature_flags + flag_targets）
- FlagEvaluator の優先順位チェーン（コード付き）
- crc32 ハッシュによる決定的バケット割り当て
- Targets as overrides（kill switch / early access）
- Upsert パターン
- 設計上の判断

### 検証

```bash
docker compose run --rm app composer check
# OK (429 tests, 989 assertions)
# Version consistency OK: 1.5.241
```

21 tests / 31 assertions (featureflaglog) PASS 確認済み。

## 関連

Closes #1098

Self-review: docs-policy