### PR TITLE
docs(howto): FT274 orderlog — order management API howto 更新 (#1108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.245] — 2026-05-27
+
+### Changed
+- `docs/howto/order-management.md` — FT274 参照と What NOT to do セクションを追加: SKU パターン制約 (A-Z0-9-)・items 上限 50・total_cents 整数計算・cancel match 式・IDOR → 404・admin fail-closed (FT274)。 (#1108)
+
+---
+
 ## [1.5.244] — 2026-05-27
 
 ### Added

--- a/docs/howto/order-management.md
+++ b/docs/howto/order-management.md
@@ -1,7 +1,10 @@
 # How-to: Order Management API
 
+> **FT reference**: FT274 (`NENE2-FT/orderlog`) — Order management: SKU-validated line items, total_cents auto-calculation, status lifecycle (pending→confirmed→shipped→delivered→cancelled), IDOR → 404, admin override, cancel conflict detection, 36 tests PASS.
+>
+> Also validated in FT215 (`NENE2-FT/orderlog` precursor) — same pattern, earlier implementation.
+
 This guide shows how to build a multi-item order management API with NENE2.
-Pattern demonstrated by the **orderlog** field trial (FT215).
 
 ## Features
 
@@ -115,3 +118,17 @@ return match ($result) {
 - **`ctype_digit()`**: ReDoS-safe integer validation for path and header IDs
 - **`is_int()`**: Strict type check — rejects floats (e.g., `1.5`) passed as JSON
 - **Max items guard**: Limits to 50 items to prevent oversized payloads
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Store price as FLOAT | Floating-point rounding errors in totals (use INTEGER cents) |
+| Accept free-form SKU strings | Injection surface; allowlist with regex (e.g., `[A-Z0-9\-]{1,32}`) |
+| No max items limit | Attacker sends 10,000-item array causing slow INSERT loop |
+| Calculate total client-side | Client can send any total; always derive from `quantity × unit_cents` |
+| Return 403 on wrong-user order access | Reveals the order exists; use 404 to hide ownership |
+| Allow cancel of delivered orders | Fulfilled orders should be immutable; use state machine |
+| Omit `ON DELETE CASCADE` on order_items | Deleting an order leaves orphan items |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.244
+  version: 1.5.245
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.244';
+    public const string VERSION = '1.5.245';
 
     public function name(): string
     {


### PR DESCRIPTION
FT274 FT reference + What NOT to do + v1.5.245。Closes #1108. Self-review: docs-policy