### PR TITLE
docs(howto): FT277 feedlog — activity feed API howto 更新 (#1114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.248] — 2026-05-27
+
+### Changed
+- `docs/howto/activity-feed.md` — FT277 参照と What NOT to do セクションを追加: type allowlist 9種・payload JSON TEXT・user_id インデックス (user_id, id DESC)・limit/offset クランプ・IDOR → 404・admin fail-closed (FT277)。 (#1114)
+
+---
+
 ## [1.5.247] — 2026-05-27
 
 ### Changed

--- a/docs/howto/activity-feed.md
+++ b/docs/howto/activity-feed.md
@@ -1,7 +1,10 @@
 # How-to: Activity Feed / Timeline API
 
+> **FT reference**: FT277 (`NENE2-FT/feedlog`) — Activity feed: type-allowlisted events (9 types), JSON payload per event, user-scoped feed with IDOR → 404, pagination clamping (max 100), admin fail-closed, 24 tests / 37 assertions PASS.
+>
+> Also validated in FT219 (`NENE2-FT/feedlog` precursor) — VULN assessment on same pattern.
+
 This guide shows how to build an activity feed system with typed events, user scoping, and pagination using NENE2.
-Pattern demonstrated by the **feedlog** field trial (FT219, VULN assessment).
 
 ## Features
 
@@ -108,3 +111,16 @@ Unknown types in the `?type=` parameter are silently ignored (null = no filter a
 - **`is_array()`**: Payload must be a JSON object (array in PHP) — not string, number, null
 - **Parameterized queries**: All SQL uses `:named` parameters — no string concatenation
 - **`in_array(..., true)`**: Strict comparison prevents type-coercion bypass
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Accept free-form event type string | Uncontrolled types pollute the feed; hard to build type-specific queries |
+| Store payload as TEXT without JSON validation | `is_array($payload)` ensures a JSON object; scalars/arrays break downstream consumers |
+| Trust raw `limit` from query string | No upper bound → full table scan on large datasets |
+| Use `in_array($type, TYPES)` without `true` | Loose comparison; `0 == 'post_created'` in some PHP versions |
+| Return 403 on feed access for wrong user | Reveals the user exists; use 404 to hide user enumeration |
+| Index only on `user_id` | Missing `id DESC` in composite index causes slow ORDER BY on large feeds |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.247
+  version: 1.5.248
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.247';
+    public const string VERSION = '1.5.248';
 
     public function name(): string
     {


### PR DESCRIPTION
FT277 FT reference + What NOT to do + v1.5.248。Closes #1114. Self-review: docs-policy