### PR TITLE
docs(howto): FT278 messagelog ダイレクトメッセージシステム howto 追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.249] — 2026-05-27
+
+### Changed
+- `docs/howto/direct-messaging-system.md` — FT278 参照と What NOT to do セクションを追加: conversations UNIQUE(initiator_id, recipient_id)・CHECK(initiator_id != recipient_id)・参加者のみアクセス可・方向非依存 conversation lookup (FT278)。 (#1116)
+
+---
+
 ## [1.5.248] — 2026-05-27
 
 ### Changed

--- a/docs/howto/direct-messaging-system.md
+++ b/docs/howto/direct-messaging-system.md
@@ -1,8 +1,11 @@
 # How to Build a Direct Messaging System with NENE2
 
+> **FT reference**: FT278 (`NENE2-FT/messagelog`) — Direct messaging: conversation threading, UNIQUE(initiator_id, recipient_id) + CHECK(initiator_id != recipient_id), participant-only access control, direction-agnostic lookup, idempotent conversation start, 31 tests / 96 assertions PASS.
+>
+> Also validated in FT135 — original implementation.
+
 This guide walks through building a Twitter/Instagram-style direct message (DM) system — users start conversations with each other, send messages, and only participants can read or send in a conversation.
 
-**Field Trial**: FT135  
 **NENE2 version**: ^1.5  
 **Covered topics**: conversation threading, participant access control, direction-agnostic conversation lookup, idempotent conversation start
 
@@ -253,3 +256,20 @@ All 12 vulnerability tests pass. No vulnerabilities found.
 | `UNIQUE (initiator_id, recipient_id)` doesn't prevent A→B and B→A as two conversations | Look up direction-agnostic with OR query before INSERT |
 | Checking participant after checking content validity | Check participant *before* content to avoid leaking info |
 | Accepting any non-zero integer as actor ID without user existence check | Always verify `findUserById(actorId)` before checking participation |
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Store conversations as `(user_a, user_b)` with direction — two separate rows for A→B and B→A | Same two users accumulate duplicate conversations; direction-agnostic lookup fails |
+| No `CHECK (initiator_id != recipient_id)` constraint | Users can message themselves, creating confusing self-conversations |
+| No `UNIQUE (initiator_id, recipient_id)` constraint | Concurrent conversation-start requests create duplicate rows for the same pair |
+| Return 404 instead of 403 on non-participant access | Reveals conversation ID existence to non-participants |
+| Call `JsonRequestBodyParser::parse()` on GET `/conversations/{id}/messages` | GET requests have no body; parser returns 400 |
+| Check content validity before participant check | Leaks info — attacker can probe valid conversation IDs by sending empty content and watching for 403 vs 422 |
+| Use `is_numeric()` without cast to `int` then `> 0` | `is_numeric("0")` is true; user ID 0 would be treated as valid |
+| Skip user existence check after participant check | `isParticipant()` only checks FK — deleted or non-existent users can still appear if DB has no cascade |
+| Allow any user to list another user's conversations | IDOR — always verify `actorId === targetUserId` before returning conversation list |
+| Index only on `conversation_id` for messages | Missing `id ASC` in index causes slow ORDER BY on large message histories |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.248
+  version: 1.5.249
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.248';
+    public const string VERSION = '1.5.249';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT278 messagelog の参照とセキュリティパターンを `docs/howto/direct-messaging-system.md` に追加。

## 変更点

- FT278 参照ヘッダーを追加（31 tests / 96 assertions PASS）
- FT135 との関連を記載
- What NOT to do セクションを追加（10 項目）

## 検証

`docker compose run --rm app composer check` → All OK, version 1.5.249

## 関連

Closes #1116

Self-review: docs-policy