### PR TITLE
docs(howto): FT281 refreshlog リフレッシュトークンパターン howto 追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.252] — 2026-05-27
+
+### Added
+- `docs/howto/refresh-token-pattern.md` — FT281 新規作成: リフレッシュトークンパターン howto: 短命アクセストークン (5分) + 長命リフレッシュトークン・SHA-256 ハッシュ保存・トークンローテーション・リプレイ攻撃検知・ログアウト 204 (FT281)。 (#1122)
+
+---
+
 ## [1.5.251] — 2026-05-27
 
 ### Added

--- a/docs/howto/ft-registry.md
+++ b/docs/howto/ft-registry.md
@@ -71,6 +71,7 @@ FT 番号 → プロジェクト名 → howto ファイルの台帳。
 | FT278 | messagelog | [direct-messaging-system.md](direct-messaging-system.md) | 通常 |
 | FT279 | rbaclog | [rbac-jwt-auth.md](rbac-jwt-auth.md) | VULN |
 | FT280 | lockoutlog | [account-lockout.md](account-lockout.md) | ATK |
+| FT281 | refreshlog | [refresh-token-pattern.md](refresh-token-pattern.md) | 通常 |
 
 ---
 

--- a/docs/howto/refresh-token-pattern.md
+++ b/docs/howto/refresh-token-pattern.md
@@ -1,0 +1,173 @@
+# How-to: Refresh Token Pattern
+
+> **FT reference**: FT281 (`NENE2-FT/refreshlog`) — Refresh token pattern: short-lived access token (5 min JWT) + long-lived refresh token (7 days), SHA-256 hash storage, token rotation on use, replay attack detection (revoked token → revoke all), logout returns 204 always, 15 tests / 63 assertions PASS.
+
+This guide shows how to implement the refresh token pattern — short-lived access tokens for security, refresh tokens for session continuity.
+
+## Why it matters
+
+JWTs are stateless. Once issued, they cannot be revoked until they expire. A 5-minute TTL limits exposure if a token is stolen. Refresh tokens extend sessions without repeated password prompts, and can be rotated (revoked and re-issued) on each use to detect theft.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id),
+    token_hash TEXT    NOT NULL UNIQUE,
+    expires_at TEXT    NOT NULL,
+    revoked    INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+```
+
+`token_hash` stores SHA-256 of the raw token — never the raw value. `revoked` is a soft-delete flag (vs hard delete for replay detection).
+
+## Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/auth/login` | None | Email + password → access token + refresh token |
+| `POST` | `/auth/refresh` | Refresh token in body | Rotate refresh token, issue new pair |
+| `POST` | `/auth/logout` | Refresh token in body | Revoke refresh token |
+| `GET` | `/auth/me` | Bearer access token | Get current user info |
+
+## Token Lifetimes
+
+```php
+private const int ACCESS_TOKEN_TTL_SECONDS = 300; // 5 minutes — short for security
+// Refresh tokens: 7 days (RefreshTokenRepository::TTL_DAYS)
+```
+
+Short access tokens limit exposure if stolen. Long refresh tokens allow users to stay logged in across sessions without re-entering passwords.
+
+## Issuing the Token Pair
+
+```php
+private function issueTokenPair(User $user): array
+{
+    $now         = time();
+    $accessToken = $this->issuer->issue([
+        'jti'   => bin2hex(random_bytes(8)),  // unique token ID — enables future revocation tracking
+        'sub'   => $user->id,
+        'email' => $user->email,
+        'iat'   => $now,
+        'exp'   => $now + self::ACCESS_TOKEN_TTL_SECONDS,
+    ]);
+
+    $refreshToken = $this->refreshTokens->issue($user->id);
+
+    return [
+        'access_token'  => $accessToken,
+        'token_type'    => 'Bearer',
+        'expires_in'    => self::ACCESS_TOKEN_TTL_SECONDS,
+        'refresh_token' => $refreshToken,
+    ];
+}
+```
+
+## Storing Only the Hash
+
+```php
+public function issue(int $userId): string
+{
+    $raw       = bin2hex(random_bytes(32));  // 64 hex chars = 256 bits entropy
+    $hash      = hash('sha256', $raw);
+    // INSERT token_hash = $hash ...
+
+    return $raw;  // ← return raw to client; never stored
+}
+
+public function findByRaw(string $raw): ?RefreshToken
+{
+    $hash = hash('sha256', $raw);
+    // SELECT WHERE token_hash = $hash
+}
+```
+
+If the DB is breached, attackers get hashes — useless without the raw tokens held by clients.
+
+## Token Rotation
+
+```php
+// On successful /auth/refresh:
+$this->refreshTokens->revoke($stored->id);      // revoke old
+return $this->json->create($this->issueTokenPair($user));  // issue new pair
+```
+
+Each refresh rotates the token. The old token becomes invalid immediately, so a stolen refresh token can only be used once before rotation invalidates it.
+
+## Replay Attack Detection
+
+```php
+$stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+
+if ($stored === null || !$stored->isValid()) {
+    // A revoked token being re-used → potential replay attack
+    if ($stored !== null && $stored->revoked) {
+        $this->refreshTokens->revokeAllForUser($stored->userId);
+    }
+    return $this->problems->create($request, 'invalid-refresh-token', '...', 401);
+}
+```
+
+If an attacker steals a refresh token, uses it, and the legitimate client then tries to use it (now revoked) — the system detects this and revokes all sessions for the user, forcing re-authentication.
+
+## Logout Always Returns 204
+
+```php
+private function logout(ServerRequestInterface $request): ResponseInterface
+{
+    $stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+
+    if ($stored !== null && !$stored->revoked) {
+        $this->refreshTokens->revoke($stored->id);
+    }
+
+    // Always 204 — never reveal whether the token was valid
+    return $this->json->createEmpty(204);
+}
+```
+
+Returning 401 for an already-revoked token on logout would allow an attacker to probe whether they've been logged out.
+
+## Token Validity Check
+
+```php
+public function isValid(): bool
+{
+    if ($this->revoked) {
+        return false;
+    }
+    return $this->expiresAt > (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+}
+```
+
+Both revocation and expiry are checked. Expired but not-revoked tokens are also rejected.
+
+## Security Properties Summary
+
+| Property | Implementation |
+|---|---|
+| Access token TTL | 5 minutes (minimize theft exposure) |
+| Refresh token TTL | 7 days (session continuity) |
+| Token storage | SHA-256 hash only; raw value never stored |
+| Token rotation | Old token revoked on each successful refresh |
+| Replay detection | Revoked token re-use → revoke all user sessions |
+| Logout | Always 204 (never leak token validity) |
+| `jti` claim | Unique per token (future revocation tracking) |
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Store raw refresh token in DB | DB breach exposes all active sessions |
+| Use hard delete on revoke | Cannot detect replay attacks (need `revoked = 1` to know the token existed) |
+| Long access token TTL (hours/days) | Stolen token provides long-term access; defeat the purpose of refresh tokens |
+| Return 401 on logout with invalid token | Attacker can probe whether they're still logged in |
+| No `jti` in access token | Cannot track individual tokens for future revocation lists |
+| Single token (access only, no refresh) | User must re-authenticate every 5 minutes, or use dangerously long TTLs |
+| MD5 or SHA-1 for token hash | Weak hash; use SHA-256 or better |
+| No expiry on refresh tokens | Refresh tokens live forever; a stolen token provides indefinite access |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.251
+  version: 1.5.252
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -9,11 +9,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 | 項目 | 値 |
 |------|-----|
-| 最終完了 FT | **FT270** (`NENE2-FT/featureflaglog` — フィーチャーフラグ API) |
-| 現在の VERSION | **1.5.241** |
-| 次の FT | **FT271** |
-| 次の ATK 回 | **FT272**（4件ごと: FT252, 256, 260, 264, 268, 272 ✅ 予定） |
-| 次の VULN 回 | **FT273**（6件ごと: FT249, 255, 261, 267, 273 ✅ 予定） |
+| 最終完了 FT | **FT280** (`NENE2-FT/lockoutlog` — アカウントロックアウト ATK) |
+| 現在の VERSION | **1.5.251** |
+| 次の FT | **FT281** |
+| 次の ATK 回 | **FT284**（4件ごと: 272 ✅, 276 ✅, 280 ✅, 284） |
+| 次の VULN 回 | **FT285**（6件ごと: 273 ✅, 279 ✅, 285） |
 | 進行中ブランチ | なし（main クリーン） |
 
 ---
@@ -22,16 +22,16 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 | FT | タイプ | howto | VERSION |
 |----|--------|-------|---------|
-| FT261 | VULN | `jwt-authentication.md` 更新 | 1.5.232 |
-| FT262 | 通常 | `multi-currency-money-ledger.md` | 1.5.233 |
-| FT263 | 通常 | `emoji-reactions-toggle.md` | 1.5.234 |
-| FT264 | ATK | `sql-injection-defence.md` | 1.5.235 |
-| FT265 | 通常 | `url-bookmark-api.md` | 1.5.236 |
-| FT266 | 通常 | `api-key-management.md` 更新 | 1.5.237 |
-| FT267 | VULN | `encrypted-field-storage.md` 更新 | 1.5.238 |
-| FT268 | ATK | `audit-trail.md` 更新 | 1.5.239 |
-| FT269 | 通常 | `shopping-cart-api.md` | 1.5.240 |
-| FT270 | 通常 | `feature-flags.md` 更新 | 1.5.241 |
+| FT271 | 通常 | `notification-inbox.md` 更新 | 1.5.242 |
+| FT272 | ATK | `token-lifecycle-api.md` 新規 | 1.5.243 |
+| FT273 | VULN | `bearer-token-middleware.md` 新規 | 1.5.244 |
+| FT274 | 通常 | `order-management.md` 更新 | 1.5.245 |
+| FT275 | 通常 | `user-profile-api.md` 新規 | 1.5.246 |
+| FT276 | ATK | `idempotency.md` 更新 | 1.5.247 |
+| FT277 | 通常 | `activity-feed.md` 更新 | 1.5.248 |
+| FT278 | 通常 | `direct-messaging-system.md` 更新 | 1.5.249 |
+| FT279 | VULN | `rbac-jwt-auth.md` 新規 | 1.5.250 |
+| FT280 | ATK | `account-lockout.md` 更新 | 1.5.251 |
 
 ---
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.251';
+    public const string VERSION = '1.5.252';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT281 refreshlog のリフレッシュトークンパターン howto 新規作成。

## 変更点

- `docs/howto/refresh-token-pattern.md` 新規作成（15 tests / 63 assertions PASS）
- `docs/todo/current.md` を FT280 完了後の状態に更新
- `docs/howto/ft-registry.md` に FT281 追加
- VERSION 1.5.252

## 検証

`docker compose run --rm app composer check` → All OK, version 1.5.252

## 関連

Closes #1122

Self-review: docs-policy