### PR TITLE
docs(howto): FT282 grantlog 委任アクセス許可 howto 追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.253] — 2026-05-27
+
+### Added
+- `docs/howto/delegated-access-grants.md` — FT282 新規作成: 委任アクセス許可 (Delegated Access Grants) howto: read/write/admin スコープ・30日最大 TTL・UNIQUE 重複防止・CHECK 自己グラント禁止・IDOR 404・使用カウンタ (FT282)。 (#1124)
+
+---
+
 ## [1.5.252] — 2026-05-27
 
 ### Added

--- a/docs/howto/delegated-access-grants.md
+++ b/docs/howto/delegated-access-grants.md
@@ -1,6 +1,8 @@
 # How-to: Delegated Access Grants
 
-**FT176 — grantlog**
+> **FT reference**: FT282 (`NENE2-FT/grantlog`) — Delegated access grants: scoped (read/write/admin) time-limited resource access, UNIQUE(grantor, grantee, resource) + CHECK(grantor != grantee), IDOR → 404, soft-delete revocation, use-count tracking, GrantScope.satisfies() hierarchy, 23 tests / 71 assertions PASS.
+>
+> Also validated in FT176 — original implementation.
 
 Per-user, time-limited, revocable access delegation — a grantor gives a grantee
 scoped access to a named resource for a bounded time window.
@@ -199,3 +201,20 @@ Same pattern applies to `POST /grants/{id}/use` — return 404 if caller is not 
   from int after PHP json_encode).
 - **ATK-10**: Use `"\u{202E}"` (BIDI override) and Cyrillic homoglyphs to confirm verbatim storage.
 - **ATK-11**: Assert `revoked_at` value is unchanged in DB after second revoke attempt.
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| No `UNIQUE (grantor_id, grantee_id, resource)` | Same pair can create duplicate grants; grantee has stale and active grants for same resource |
+| Hard delete on revocation | Loses audit history; cannot tell when access was removed or how many times it was used |
+| Return 403 instead of 404 for ownership check | Reveals grant existence to unauthorized callers; IDOR enumeration surface |
+| No `CHECK (grantor_id != grantee_id)` | Defense-in-depth missing; self-grants could slip through if app-layer check is bypassed |
+| Accept free-form scope string | Typos silently default to `read`; use `GrantScope::tryFrom()` to reject unknown values |
+| Scope check without `satisfies()` hierarchy | `write` user must separately pass `read` checks; use hierarchy to check all lower levels |
+| No max TTL on `expires_at` | Grantor creates 100-year grants; effectively permanent access with no review |
+| No resource length limit | 10MB resource string causes slow index lookups and memory allocation |
+| Check expiry before revocation | Revoked + expired grant should show "revoked" — revocation wins in state machine |
+| Track `used_count` client-side | Client reports usage count; server must own the counter |

--- a/docs/howto/ft-registry.md
+++ b/docs/howto/ft-registry.md
@@ -72,6 +72,7 @@ FT 番号 → プロジェクト名 → howto ファイルの台帳。
 | FT279 | rbaclog | [rbac-jwt-auth.md](rbac-jwt-auth.md) | VULN |
 | FT280 | lockoutlog | [account-lockout.md](account-lockout.md) | ATK |
 | FT281 | refreshlog | [refresh-token-pattern.md](refresh-token-pattern.md) | 通常 |
+| FT282 | grantlog | [delegated-access-grants.md](delegated-access-grants.md) | 通常 |
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.252
+  version: 1.5.253
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.252';
+    public const string VERSION = '1.5.253';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT282 grantlog の委任アクセス許可 howto 更新。

## 変更点

- `docs/howto/delegated-access-grants.md` に FT282 参照と What NOT to do セクション追加
- `docs/howto/ft-registry.md` に FT282 追加
- VERSION 1.5.253

## 検証

`docker compose run --rm app composer check` → All OK, version 1.5.253

## 関連

Closes #1124

Self-review: docs-policy