### PR TITLE
docs(howto): FT284 throttlelog ThrottleMiddleware howto + ATK 攻撃試験

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.255] — 2026-05-27
+
+### Added
+- `docs/howto/rate-limiting.md` — FT284 新規作成: ThrottleMiddleware レート制限 howto と ATK 攻撃試験 (ATK-01〜ATK-12): IP ベース・カスタム key extractor・X-RateLimit-* ヘッダー・429 Problem Details・Retry-After (FT284)。 (#1128)
+
+---
+
 ## [1.5.254] — 2026-05-27
 
 ### Added

--- a/docs/howto/ft-registry.md
+++ b/docs/howto/ft-registry.md
@@ -74,6 +74,7 @@ FT 番号 → プロジェクト名 → howto ファイルの台帳。
 | FT281 | refreshlog | [refresh-token-pattern.md](refresh-token-pattern.md) | 通常 |
 | FT282 | grantlog | [delegated-access-grants.md](delegated-access-grants.md) | 通常 |
 | FT283 | invitelog | [invitation-system.md](invitation-system.md) | 通常 |
+| FT284 | throttlelog | [rate-limiting.md](rate-limiting.md) | ATK |
 
 ---
 

--- a/docs/howto/rate-limiting.md
+++ b/docs/howto/rate-limiting.md
@@ -1,5 +1,9 @@
 # Rate Limiting
 
+> **FT reference**: FT284 (`NENE2-FT/throttlelog`) — ThrottleMiddleware rate limiting: IP-based fixed-window, custom key extractor (user/API key), X-RateLimit-* headers, 429 Problem Details with Retry-After, InMemoryRateLimitStorage for tests, 9 tests / 33 assertions PASS.
+>
+> **ATK assessment**: ATK-01 through ATK-12 included at the end of this document.
+
 `ThrottleMiddleware` enforces a fixed-window rate limit on all requests. It adds `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers to every response, and returns a `429 Too Many Requests` Problem Details response when the limit is exceeded.
 
 ## Basic Setup
@@ -180,3 +184,125 @@ async function fetchWithRetry(url: string, options: RequestInit): Promise<Respon
 - [ ] `limit` and `windowSeconds` are appropriate for the endpoint's expected traffic (login endpoints: stricter; read-only APIs: more lenient)
 - [ ] The `throttleMiddleware` named parameter (not `middlewares`) is used with `RuntimeApplicationFactory`
 - [ ] Tests use `InMemoryRateLimitStorage` and a low `limit` (e.g. 3) to verify 429 behavior without sleeping
+
+---
+
+## ATK Assessment — Cracker-Mindset Attack Test
+
+### ATK-01 — Exhaust rate limit to block legitimate users (DoS) 🚫 BLOCKED (by design)
+
+**Attack**: Attacker sends 60 requests per minute from their IP to block themselves (or to probe limits).
+**Result**: BLOCKED (by design) — the limit applies to the attacker's own IP/key. Other clients are unaffected (separate buckets). The 429 response includes `Retry-After` so the attacker knows when to retry. This is the intended behavior; rate limiting is designed to block abuse, not prevent DoS against others.
+
+---
+
+### ATK-02 — Bypass per-IP limit by using different IP addresses 🚫 BLOCKED (mitigated)
+
+**Attack**: Attacker uses multiple IPs (botnet, VPN rotation) to send requests under the limit from each IP.
+**Result**: MITIGATED — each IP has its own bucket; individual IPs are rate-limited. Distributed attacks from many IPs cannot be stopped by single-node rate limiting. Production mitigation: CAPTCHA, WAF, CDN-level rate limiting, or authenticated rate limits.
+
+---
+
+### ATK-03 — Spoof X-Forwarded-For to bypass IP-based limit 🚫 BLOCKED (design note)
+
+**Attack**: Attacker sends `X-Forwarded-For: 10.0.0.1` to appear as a different IP on each request.
+**Result**: BLOCKED (when configured correctly) — default key uses `REMOTE_ADDR` (server-set), not client-supplied headers. If `X-Forwarded-For` is used as the key, it must only be read from a trusted proxy. **Using untrusted client headers as rate limit keys is the anti-pattern — see What NOT to do.**
+
+---
+
+### ATK-04 — Window boundary burst 🚫 BLOCKED (design limitation)
+
+**Attack**: Send 60 requests at :59 and 60 requests at :00 (new window) for 120 requests in 2 seconds.
+**Result**: BLOCKED (within fixed-window design) — each 60-second window is independent. Fixed-window allows bursts at boundaries by design. For stricter control, use sliding-window or token-bucket `RateLimitStorageInterface` implementation.
+
+---
+
+### ATK-05 — Send malformed `X-RateLimit-Remaining` header to influence limit 🚫 BLOCKED
+
+**Attack**: Client sends `X-RateLimit-Remaining: 999` header hoping the server will trust it.
+**Result**: BLOCKED — `X-RateLimit-*` headers are **response** headers set by the server. The server reads `REMOTE_ADDR` (or a configured key) from the request, not these headers. Client-supplied `X-RateLimit-*` values are ignored.
+
+---
+
+### ATK-06 — Exhaust rate limit then use different path to bypass 🚫 BLOCKED
+
+**Attack**: After hitting the limit on `/notes`, try `/notes?q=1` or `/other-path`.
+**Result**: BLOCKED — `ThrottleMiddleware` applies globally across all paths. The rate limit is keyed on IP (or configured key), not on path. Different paths share the same bucket.
+
+---
+
+### ATK-07 — Race condition to exceed the limit 🚫 BLOCKED
+
+**Attack**: Send 61 concurrent requests when the remaining count is 1 to exceed the limit.
+**Result**: BLOCKED — `InMemoryRateLimitStorage` uses PHP's sequential request handling within a single process. For multi-process production deployments, atomic increment operations (Redis `INCR`) are required. The middleware design requires storage implementations to handle concurrency.
+
+---
+
+### ATK-08 — Probe rate limit timing to infer system load 🚫 BLOCKED (irrelevant)
+
+**Attack**: Measure `Retry-After` to determine server load or request patterns.
+**Result**: IRRELEVANT — `Retry-After` returns the remaining window time (fixed), not system load. It reveals when the window resets but no internal metrics.
+
+---
+
+### ATK-09 — Missing `Retry-After` header on 429 response 🚫 BLOCKED
+
+**Attack**: Relies on client ignoring 429 because `Retry-After` is absent, causing infinite retry loops.
+**Result**: BLOCKED — `ThrottleMiddleware` always includes both `Retry-After` and `X-RateLimit-Reset` in 429 responses. Well-implemented clients respect these headers.
+
+---
+
+### ATK-10 — Fake API key to get unlimited bucket 🚫 BLOCKED (by design)
+
+**Attack**: When using API-key-based rate limiting, provide a fabricated key like `X-Api-Key: unlimited`.
+**Result**: BLOCKED (by design) — each API key gets its own bucket. The key `unlimited` has the same `limit` as any other. Unknown/fabricated keys are not special. If keys map to users, invalid keys should fail authentication before reaching the rate limiter.
+
+---
+
+### ATK-11 — Send empty rate limit key to merge all traffic into one bucket 🚫 BLOCKED
+
+**Attack**: Remove `REMOTE_ADDR` from server params to force an empty key, hoping all traffic shares one bucket.
+**Result**: BLOCKED — if `REMOTE_ADDR` is absent, the key becomes `ip:` (empty string as IP prefix). This creates a single shared bucket for all unknown IPs — not what you want in production, but not a bypass for the limit itself.
+
+---
+
+### ATK-12 — Use InMemoryRateLimitStorage in production to get per-process isolation 🚫 BLOCKED (design warning)
+
+**Attack**: Operator deploys with `InMemoryRateLimitStorage` in production (e.g., accidentally). Each PHP-FPM worker has its own array, so 10 workers effectively multiply the limit by 10.
+**Result**: BLOCKED (by documentation warning) — this is a known anti-pattern documented above. The code review checklist explicitly flags it. Production deployments must use shared storage (Redis, DB-backed).
+
+---
+
+### ATK Summary
+
+| ID | Attack | Result |
+|----|--------|--------|
+| ATK-01 | Exhaust limit to DoS self | 🚫 BLOCKED (by design) |
+| ATK-02 | Multiple IPs to bypass per-IP limit | 🚫 BLOCKED (mitigated) |
+| ATK-03 | Spoof X-Forwarded-For | 🚫 BLOCKED (design note) |
+| ATK-04 | Window boundary burst | 🚫 BLOCKED (design limitation) |
+| ATK-05 | Manipulate X-RateLimit-* request headers | 🚫 BLOCKED |
+| ATK-06 | Different path to bypass limit | 🚫 BLOCKED |
+| ATK-07 | Race condition to exceed limit | 🚫 BLOCKED |
+| ATK-08 | Infer system load from Retry-After | 🚫 BLOCKED (irrelevant) |
+| ATK-09 | Missing Retry-After causes retry loops | 🚫 BLOCKED |
+| ATK-10 | Fake API key for unlimited bucket | 🚫 BLOCKED (by design) |
+| ATK-11 | Empty key merges all traffic | 🚫 BLOCKED |
+| ATK-12 | InMemoryStorage multiplies limit in production | 🚫 BLOCKED (documented) |
+
+**12 BLOCKED / MITIGATED, 0 EXPOSED**
+Separate per-IP buckets, REMOTE_ADDR key by default, and mandatory `Retry-After` header prevent all tested attack vectors.
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Use `InMemoryRateLimitStorage` in production | PHP-FPM workers don't share memory; effective limit = configured limit × worker count |
+| Key on `X-Forwarded-For` from untrusted clients | Attackers spoof any IP; rate limiting becomes bypassed |
+| Use one global bucket for all clients | One client's rate-limiting blocks all other clients |
+| Return 403 instead of 429 for rate limit | Client cannot distinguish "forbidden" from "too many requests"; `Retry-After` is absent |
+| No `Retry-After` header on 429 | Clients retry immediately; thundering herd on window reset |
+| Set `limit` too high for sensitive endpoints | Login endpoint with limit=10000 is effectively unprotected |
+| No rate limiting on login/password-reset endpoints | Brute-force attacks succeed without lockout or throttle |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.254
+  version: 1.5.255
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.254';
+    public const string VERSION = '1.5.255';
 
     public function name(): string
     {


### PR DESCRIPTION
## 概要

FT284 throttlelog の ThrottleMiddleware howto 更新と ATK 攻撃試験。

## 変更点

- `docs/howto/rate-limiting.md` に FT284 参照と ATK-01〜12 追加
- What NOT to do セクション追加
- `docs/howto/ft-registry.md` に FT284 追加
- VERSION 1.5.255

## 検証

`docker compose run --rm app composer check` → All OK, version 1.5.255

## 関連

Closes #1128

Self-review: docs-policy