### PR TITLE
docs(howto): FT293 ablog A/B テスト実験フレームワーク howto 追加 (#1146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.264] — 2026-05-27
+
+### Added
+- `docs/howto/ab-testing.md` — FT293 新規作成: A/B テスト実験フレームワーク howto: 重み付き確定的バリアント割当・draft→active→stopped ステートマシン・冪等割当 (FT293)。 (#1146)
+
+---
+
 ## [1.5.263] — 2026-05-27
 
 ### Added

--- a/docs/howto/ab-testing.md
+++ b/docs/howto/ab-testing.md
@@ -1,4 +1,6 @@
-# How to Add A/B Testing
+# How-to: A/B Testing Framework
+
+> **FT reference**: FT293 (`NENE2-FT/ablog`) — A/B experiment framework: weighted deterministic variant assignment via crc32 seed, draft→active→stopped state machine, UNIQUE(experiment_id, user_id) idempotent assignment, CVR aggregation in SQL, 16 tests / 26 assertions PASS.
 
 Run controlled experiments by assigning users to variants and collecting conversion events.
 
@@ -134,3 +136,17 @@ $row['cvr'] = $assignments > 0 ? round($events / $assignments, 4) : 0.0;
 - Events require the user to be assigned (404 otherwise).
 - `UNIQUE(experiment_id, user_id)` prevents double-assignment at the DB level.
 - Weights must be positive integers; zero-weight variants are rejected (422).
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Random (non-deterministic) assignment | Same user gets different variants on each call; inconsistent experience |
+| No `UNIQUE(experiment_id, user_id)` | Concurrent assignments create duplicate rows; user ends up in multiple variants |
+| Allow assignment in `draft` or `stopped` status | Draft experiments have no valid variants; stopped experiments should not collect new data |
+| Allow backward status transitions | `stopped → active` re-opens a closed experiment; historical data contaminated |
+| No weight validation (allow 0) | Zero total weight causes division-by-zero in bucket calculation |
+| Compute CVR in application with all rows | Fetch all rows then loop; use `GROUP BY` SQL aggregation instead |
+| No event → assignment validation | Events without valid assignment skew per-variant conversion rates |

--- a/docs/howto/ft-registry.md
+++ b/docs/howto/ft-registry.md
@@ -83,6 +83,7 @@ FT 番号 → プロジェクト名 → howto ファイルの台帳。
 | FT290 | otplog | [otp-authentication.md](otp-authentication.md) | ATK |
 | FT291 | grouplog | [group-member-management.md](group-member-management.md) | VULN |
 | FT292 | deduplog | [idempotency-key.md](idempotency-key.md) | ATK |
+| FT293 | ablog | [ab-testing.md](ab-testing.md) | 通常 |
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.263
+  version: 1.5.264
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.263';
+    public const string VERSION = '1.5.264';
 
     public function name(): string
     {


### PR DESCRIPTION
FT293 ablog: crc32 確定的割当・ステートマシン・冪等割当・CVR 集計。Closes #1146. Self-review: docs-policy. 🤖 Generated with [Claude Code](https://claude.com/claude-code)