### PR TITLE
docs(howto): FT295 bookmarklog ブックマーク API howto 追加 (#1150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.266] — 2026-05-27
+
+### Added
+- `docs/howto/bookmark-api.md` — FT295 新規作成: ブックマーク API howto: UNIQUE(user_id,item_id)・コレクション分類・重複 409・ユーザースコープ IDOR 防止 (FT295)。 (#1150)
+
+---
+
 ## [1.5.265] — 2026-05-27
 
 ### Added

--- a/docs/howto/bookmark-api.md
+++ b/docs/howto/bookmark-api.md
@@ -1,0 +1,113 @@
+# How-to: Bookmark API
+
+> **FT reference**: FT295 (`NENE2-FT/bookmarklog`) — Bookmark management: UNIQUE(user_id, item_id) prevents duplicate bookmarks, collection grouping with optional filter, user-scoped access (IDOR prevention), 409 on duplicate, 22 tests / 64 assertions PASS.
+
+This guide shows how to build a bookmark API where users save items to named collections with deduplication and user-scoped access control.
+
+## Schema
+
+```sql
+CREATE TABLE bookmarks (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    collection TEXT    NOT NULL DEFAULT 'default',
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+```
+
+`UNIQUE(user_id, item_id)` ensures each user can bookmark an item exactly once. The `collection` field groups bookmarks into named lists (default: `'default'`).
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/users/{userId}/bookmarks` | Add bookmark |
+| `DELETE` | `/users/{userId}/bookmarks/{itemId}` | Remove bookmark |
+| `GET` | `/users/{userId}/bookmarks` | List bookmarks (optionally filtered by collection) |
+| `GET` | `/users/{userId}/bookmarks/count` | Count bookmarks |
+| `GET` | `/users/{userId}/bookmarks/{itemId}` | Get specific bookmark |
+
+## Route Registration Order
+
+`/users/{userId}/bookmarks/count` must be registered **before** `/users/{userId}/bookmarks/{itemId}` to prevent `count` being captured as `{itemId}`:
+
+```php
+$router->get('/users/{userId}/bookmarks', $this->listBookmarks(...));
+$router->get('/users/{userId}/bookmarks/count', $this->countBookmarks(...));  // static before dynamic
+$router->get('/users/{userId}/bookmarks/{itemId}', $this->getBookmark(...));
+```
+
+## Adding a Bookmark
+
+```php
+private function addBookmark(ServerRequestInterface $request): ResponseInterface
+{
+    $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $userId = isset($params['userId']) && is_numeric($params['userId']) ? (int) $params['userId'] : 0;
+
+    if ($userId <= 0 || !$this->repo->findUserById($userId)) {
+        return $this->responseFactory->create(['error' => 'user not found'], 404);
+    }
+
+    $body       = JsonRequestBodyParser::parse($request);
+    $itemId     = isset($body['item_id']) && is_int($body['item_id']) ? $body['item_id'] : 0;
+    $collection = isset($body['collection']) && is_string($body['collection'])
+        ? trim($body['collection']) : 'default';
+
+    if ($itemId <= 0 || !$this->repo->findItemById($itemId)) {
+        return $this->responseFactory->create(['error' => 'item not found'], 404);
+    }
+
+    if ($collection === '') {
+        $collection = 'default';  // empty collection string → fall back to 'default'
+    }
+
+    $now      = date('Y-m-d H:i:s');
+    $bookmark = $this->repo->add($userId, $itemId, $collection, $now);
+    return $this->responseFactory->create($bookmark->toArray(), 201);
+}
+```
+
+`item_id` requires `is_int()` — JSON string `"5"` is rejected. The `UNIQUE` constraint in the DB catches races; the repository should catch the constraint violation and return 409.
+
+## Collection Filter on List
+
+```php
+$query      = $request->getQueryParams();
+$collection = isset($query['collection']) && is_string($query['collection']) && $query['collection'] !== ''
+    ? $query['collection'] : null;
+
+$items = $this->repo->listByUser($userId, $collection);
+```
+
+Without `?collection=`, all bookmarks are returned. With `?collection=favorites`, only that collection is returned. Empty collection query parameter is treated as "no filter."
+
+## User Scoping — IDOR Prevention
+
+Every endpoint validates `userId` against the DB before returning data:
+
+```php
+if ($userId <= 0 || !$this->repo->findUserById($userId)) {
+    return $this->responseFactory->create(['error' => 'user not found'], 404);
+}
+```
+
+Requesting `/users/999/bookmarks` as a different user returns 404 (not the other user's bookmarks). All queries are scoped to the path's `userId`.
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| No `UNIQUE(user_id, item_id)` | User bookmarks same item multiple times; confusing duplicates |
+| Return 200 on duplicate bookmark | Client cannot distinguish "added" from "already exists"; use 409 |
+| Accept `item_id` as string from body | JSON type confusion: `"5"` ≠ `5`; use `is_int()` |
+| Register `/{itemId}` before `/count` | `GET /users/1/bookmarks/count` resolves to `itemId = "count"` (wrong handler) |
+| No user existence check | Non-existent userId returns empty list instead of 404 |
+| No user scoping in queries | User A sees user B's bookmarks (IDOR) |
+| No collection default | Missing `collection` field crashes or leaves `NULL` in DB |

--- a/docs/howto/ft-registry.md
+++ b/docs/howto/ft-registry.md
@@ -85,6 +85,7 @@ FT 番号 → プロジェクト名 → howto ファイルの台帳。
 | FT292 | deduplog | [idempotency-key.md](idempotency-key.md) | ATK |
 | FT293 | ablog | [ab-testing.md](ab-testing.md) | 通常 |
 | FT294 | batchlog | [batch-api-partial-success.md](batch-api-partial-success.md) | 通常 |
+| FT295 | bookmarklog | [bookmark-api.md](bookmark-api.md) | 通常 |
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.265
+  version: 1.5.266
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.265';
+    public const string VERSION = '1.5.266';
 
     public function name(): string
     {


### PR DESCRIPTION
FT295 bookmarklog: UNIQUE(user_id,item_id)・collection 分類・IDOR 防止。Closes #1150. Self-review: docs-policy. 🤖 Generated with [Claude Code](https://claude.com/claude-code)