### PR TITLE
docs(howto): FT298 circuitlog サーキットブレーカー howto 追加 (#1156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.269] — 2026-05-27
+
+### Added
+- `docs/howto/circuit-breaker.md` — FT298 新規作成: サーキットブレーカー howto: closed/open/half_open 3状態・失敗閾値・タイムアウト後自動 half_open 遷移・503 ブロック (FT298)。 (#1156)
+
+---
+
 ## [1.5.268] — 2026-05-27
 
 ### Added

--- a/docs/howto/circuit-breaker.md
+++ b/docs/howto/circuit-breaker.md
@@ -1,4 +1,6 @@
-# Circuit Breaker
+# How-to: Circuit Breaker
+
+> **FT reference**: FT298 (`NENE2-FT/circuitlog`) — Circuit breaker pattern: closed/open/half_open three-state machine, configurable failure threshold, timeout-based automatic half_open transition, 503 Service Unavailable on open circuit, `isCallAllowed()` readonly check, 15 tests / 28 assertions PASS.
 
 The circuit breaker pattern prevents cascading failures when calling external services. Instead of letting slow or failed calls pile up, the circuit trips open and immediately rejects calls until the dependency recovers.
 
@@ -122,3 +124,18 @@ Clients and load balancers that respect `503` can stop routing to this instance 
 **Why lazy Half-Open transition?** Proactive background transitions require a scheduler or daemon. Lazy transitions are simpler, stateless from the scheduler's perspective, and sufficient for most web APIs where request volume ensures the check runs promptly.
 
 **Why `failure_count` resets on any success?** This is "consecutive failures" semantics. An alternative is "failure rate over a sliding window" (e.g., >50% failures in the last 60 seconds). The sliding window is more accurate for services with low but steady traffic; consecutive failures is simpler and sufficient for services that are either up or down.
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| No `UNIQUE(name)` constraint | Concurrent creates produce multiple rows for the same circuit |
+| No timeout on open circuit | Circuit stays open forever after threshold breach |
+| No half_open state | Circuit goes directly open → closed; no probe-then-verify |
+| Return 200 when circuit is open | Callers think call succeeded; downstream errors hidden |
+| No `open_until` in 503 response | Callers retry immediately (thundering herd); include retry timing |
+| Accept string `"true"` as success | JSON type confusion; use `is_bool()` strictly |
+| Check `isCallAllowed()` without `maybeTransitionToHalfOpen()` first | Open circuit never becomes half_open; stuck permanently |
+| In-memory state only | State lost on worker restart; no sharing across PHP-FPM workers |

--- a/docs/howto/ft-registry.md
+++ b/docs/howto/ft-registry.md
@@ -88,6 +88,7 @@ FT 番号 → プロジェクト名 → howto ファイルの台帳。
 | FT295 | bookmarklog | [bookmark-api.md](bookmark-api.md) | 通常 |
 | FT296 | geoloclog | [geolocation-api.md](geolocation-api.md) | ATK |
 | FT297 | masklog | [pii-masking.md](pii-masking.md) | VULN |
+| FT298 | circuitlog | [circuit-breaker.md](circuit-breaker.md) | 通常 |
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.268
+  version: 1.5.269
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.268';
+    public const string VERSION = '1.5.269';
 
     public function name(): string
     {


### PR DESCRIPTION
FT298 circuitlog: closed/open/half_open・失敗閾値・lazy half_open 遷移・503。Closes #1156. Self-review: docs-policy. 🤖 Generated with [Claude Code](https://claude.com/claude-code)