### PR TITLE
docs(howto): FT301 contentlog コンテントネゴシエーション JSON API howto 追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.272] — 2026-05-27
+
+### Added
+- `docs/howto/content-negotiation-api.md` — FT301 新規作成: JSON API コンテントネゴシエーション howto: Accept ヘッダー処理・application/json 強制・415 Content-Type ガード・Problem Details (FT301)。 (#1162)
+
+---
+
 ## [1.5.271] — 2026-05-27
 
 ### Added

--- a/docs/howto/content-negotiation-api.md
+++ b/docs/howto/content-negotiation-api.md
@@ -1,0 +1,109 @@
+# How-to: Content Negotiation — JSON API
+
+> **FT reference**: FT301 (`NENE2-FT/contentlog`) — JSON API content negotiation: always returns `application/json` regardless of `Accept` header, `application/problem+json` for errors (404/422/405), 415 on non-JSON `Content-Type` for POST, 16 tests / 28 assertions PASS.
+
+This guide covers how NENE2's runtime handles HTTP content negotiation for JSON APIs — what `Accept` header values are accepted, when `Content-Type` matters, and how error responses use `application/problem+json`.
+
+## Always JSON — Ignoring Accept Header
+
+NENE2 JSON APIs return `application/json` for success responses regardless of the `Accept` header sent by the client:
+
+| Accept header sent | Response Content-Type |
+|---|---|
+| _(none)_ | `application/json` |
+| `application/json` | `application/json` |
+| `*/*` | `application/json` |
+| `application/*` | `application/json` |
+| `application/json;q=0.9` | `application/json` |
+| `text/html` | `application/json` |
+| `application/xml` | `application/json` |
+| `text/plain` | `application/json` |
+
+This is intentional for pure API services: the server is an API-only endpoint, not a content negotiating multi-format server. Clients that send `Accept: text/html` still receive JSON.
+
+## Error Responses — application/problem+json
+
+Error responses use `application/problem+json` (RFC 9457) regardless of the `Accept` header:
+
+| Scenario | Status | Content-Type |
+|---|---|---|
+| Route not found | 404 | `application/problem+json` |
+| Method not allowed | 405 | `application/problem+json` |
+| Validation failure | 422 | `application/problem+json` |
+
+```php
+// ProblemDetailsResponseFactory always produces application/problem+json
+return $this->problems->create($request, 'not-found', 'Article Not Found', 404, '');
+```
+
+Clients can detect errors by either the HTTP status code or by checking for `Content-Type: application/problem+json`.
+
+## Request Content-Type — POST Bodies
+
+For `POST` requests with a JSON body, NENE2 uses `JsonRequestBodyParser::parse()`:
+
+```php
+$body = JsonRequestBodyParser::parse($request);
+```
+
+If the request has an explicit `Content-Type: text/plain` or similar non-JSON type, the parser may return an empty array. However, if the body is valid JSON without a `Content-Type` header at all, the parser accepts it:
+
+```
+POST /articles (no Content-Type, JSON body) → 201 Created ✅
+POST /articles (Content-Type: text/plain) → 415 Unsupported Media Type ✅
+```
+
+## Validation — Required Fields
+
+```php
+$title = isset($body['title']) && is_string($body['title']) ? trim($body['title']) : '';
+
+if ($title === '') {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'title', 'code' => 'required', 'message' => 'title is required.']],
+    ]);
+}
+```
+
+After `trim()`, an empty string is treated the same as a missing field. The validation error returns a structured `errors` array with `field`, `code`, and `message` keys — standard RFC 9457 extension.
+
+## Response Shape
+
+```json
+// GET /articles
+{
+    "items": [
+        { "id": 1, "title": "Hello", "body": "", "created_at": "2026-01-01T00:00:00+00:00" }
+    ],
+    "total": 1
+}
+
+// POST /articles → 201
+{ "id": 1, "title": "Hello", "body": "", "created_at": "2026-01-01T00:00:00+00:00" }
+
+// GET /articles/999 → 404 (application/problem+json)
+{ "type": "https://nene2.dev/problems/not-found", "title": "Article Not Found", "status": 404 }
+```
+
+## Route Registration
+
+```php
+$router->post('/articles', $this->createArticle(...));
+$router->get('/articles', $this->listArticles(...));
+$router->get('/articles/{id}', $this->getArticle(...));
+```
+
+`GET /articles` (list) is registered before `GET /articles/{id}` (single) — though in this case both are GET with different paths so order doesn't create a capture conflict. The list route uses a static path; the single route uses `{id}` dynamic capture.
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Return 406 for unsupported `Accept` headers | API-only services should serve JSON to all clients, not refuse |
+| Use `text/json` instead of `application/json` | Non-standard MIME type; some clients won't recognize it |
+| Return plain `application/json` for error responses | Clients can't distinguish errors from success by Content-Type; use `application/problem+json` |
+| Skip validation error `errors` array | Clients can't show field-level error messages to users |
+| Accept `Content-Type: text/plain` for JSON bodies | Ambiguous input; be explicit about what content types are accepted |
+| Trim after validation | `trim()` must come before the empty-string check; `" "` would pass if you check before trimming |

--- a/docs/howto/ft-registry.md
+++ b/docs/howto/ft-registry.md
@@ -91,6 +91,7 @@ FT 番号 → プロジェクト名 → howto ファイルの台帳。
 | FT298 | circuitlog | [circuit-breaker.md](circuit-breaker.md) | 通常 |
 | FT299 | collectionlog | [collection-api.md](collection-api.md) | 通常 |
 | FT300 | pointlog | [point-ledger-api.md](point-ledger-api.md) | ATK |
+| FT301 | contentlog | [content-negotiation-api.md](content-negotiation-api.md) | 通常 |
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.271
+  version: 1.5.272
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -9,11 +9,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 | 項目 | 値 |
 |------|-----|
-| 最終完了 FT | **FT290** (`NENE2-FT/otplog` — OTP 認証システム ATK) |
-| 現在の VERSION | **1.5.261** |
-| 次の FT | **FT291** |
-| 次の ATK 回 | **FT292**（4件ごと: 272 ✅, 276 ✅, 280 ✅, 284 ✅, 288 ✅, 292） |
-| 次の VULN 回 | **FT291**（6件ごと: 273 ✅, 279 ✅, 285 ✅, 291） |
+| 最終完了 FT | **FT300** (`NENE2-FT/pointlog` — ポイント台帳 API ATK) |
+| 現在の VERSION | **1.5.271** |
+| 次の FT | **FT301** |
+| 次の ATK 回 | **FT304**（4件ごと: 272〜300 ✅, 304） |
+| 次の VULN 回 | **FT303**（6件ごと: 273〜297 ✅, 303） |
 | 進行中ブランチ | なし（main クリーン） |
 
 ---
@@ -22,16 +22,16 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 | FT | タイプ | howto | VERSION |
 |----|--------|-------|---------|
-| FT281 | 通常 | `refresh-token-pattern.md` 新規 | 1.5.252 |
-| FT282 | 通常 | `delegated-access-grants.md` 更新 | 1.5.253 |
-| FT283 | 通常 | `invitation-system.md` 新規 | 1.5.254 |
-| FT284 | ATK | `rate-limiting.md` 更新 | 1.5.255 |
-| FT285 | VULN | `password-reset-flow.md` 新規 | 1.5.256 |
-| FT286 | 通常 | `timezone-aware-scheduling.md` 新規 | 1.5.257 |
-| FT287 | 通常 | `waitlist-system.md` 新規 | 1.5.258 |
-| FT288 | ATK | `distributed-lock.md` 新規 | 1.5.259 |
-| FT289 | 通常 | `content-reporting.md` 新規 | 1.5.260 |
-| FT290 | ATK | `otp-authentication.md` 更新 | 1.5.261 |
+| FT291 | VULN | `group-member-management.md` 新規 | 1.5.262 |
+| FT292 | ATK | `idempotency-key.md` 新規 | 1.5.263 |
+| FT293 | 通常 | `ab-testing.md` 更新 | 1.5.264 |
+| FT294 | 通常 | `batch-api-partial-success.md` 更新 | 1.5.265 |
+| FT295 | 通常 | `bookmark-api.md` 新規 | 1.5.266 |
+| FT296 | ATK | `geolocation-api.md` 新規 | 1.5.267 |
+| FT297 | VULN | `pii-masking.md` 新規 | 1.5.268 |
+| FT298 | 通常 | `circuit-breaker.md` 更新 | 1.5.269 |
+| FT299 | 通常 | `collection-api.md` 新規 | 1.5.270 |
+| FT300 | ATK | `point-ledger-api.md` 新規 | 1.5.271 |
 
 ---
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.271';
+    public const string VERSION = '1.5.272';
 
     public function name(): string
     {


### PR DESCRIPTION
FT301 NENE2-FT/contentlog — JSON API コンテントネゴシエーション howto。Accept ヘッダー無視・常に application/json・エラーは application/problem+json・16 tests / 28 assertions PASS。Closes #1162