### PR TITLE
docs: FT ループ完了・全 FT カバー達成・引き継ぎ状態更新 (#1263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.322] — 2026-05-27
+
+### Changed
+- `docs/todo/current.md` — FT349 完了・全 FT カバー達成・引き継ぎ状態更新 (#1263)
+
+---
+
 ## [1.5.321] — 2026-05-27
 
 ### Changed

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.321
+  version: 1.5.322
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -9,12 +9,21 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 | 項目 | 値 |
 |------|-----|
-| 最終完了 FT | **FT339** (`NENE2-FT/sluglog` — スラグ URL VULN) |
-| 現在の VERSION | **1.5.310** |
-| 次の FT | **FT340** |
-| 次の ATK 回 | **FT340**（4件ごと: ...332 ✅, 336 ✅, 340） |
-| 次の VULN 回 | **FT345**（6件ごと: ...333 ✅, 339 ✅, 345） |
-| 進行中ブランチ | docs/1239-ft339-sluglog (PR #1240 CI 待ち) |
+| 最終完了 FT | **FT349** (`NENE2-FT/workflowlog` — ステートマシン型ワークフロー) |
+| 現在の VERSION | **1.5.322** |
+| 次の FT | **なし（全 FT カバー完了）** |
+| 次の ATK 回 | FT352（4件ごと: ...340 ✅, 344 ✅, 348 ✅, 352） |
+| 次の VULN 回 | FT351（6件ごと: ...339 ✅, 345 ✅, 351） |
+| 進行中ブランチ | なし |
+
+---
+
+## 🎉 全 FT カバー達成（2026-05-27）
+
+```bash
+bash tools/uncovered-fts.sh
+# → (すべての FT がカバー済みです)
+```
 
 ---
 
@@ -22,16 +31,16 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 | FT | タイプ | howto | VERSION |
 |----|--------|-------|---------|
-| FT330 | 通常 | `scheduled-publish-article.md` 新規 | 1.5.301 |
-| FT331 | 通常 | `password-auth-argon2id.md` 新規 | 1.5.302 |
-| FT332 | ATK | `leaderboard-ranking-api.md` 新規 | 1.5.303 |
-| FT333 | VULN | `rating-review-api.md` 新規 | 1.5.304 |
-| FT334 | 通常 | `article-relations-api.md` 新規 | 1.5.305 |
-| FT335 | 通常 | `resource-reservation-booking.md` 新規 | 1.5.306 |
-| FT336 | ATK | `reservation-availability-api.md` 新規 | 1.5.307 |
-| FT337 | 通常 | `url-shortener-ssrf-prevention.md` 新規 | 1.5.308 |
-| FT338 | 通常 | `signed-url-download.md` 新規 | 1.5.309 |
-| FT339 | VULN | `slug-url-history.md` 新規 | 1.5.310 |
+| FT340 | ATK | `soft-delete-trash-restore.md` 新規 | 1.5.311 |
+| FT341 | 通常 | `dynamic-sort-order-injection.md` 新規 | 1.5.312 |
+| FT342 | 通常 | `jwt-tenant-isolation.md` 新規 | 1.5.313 |
+| FT343 | 通常 | `threaded-comments-api.md` 新規 | 1.5.314 |
+| FT344 | ATK | `category-hierarchy-api.md` 新規 | 1.5.315 |
+| FT345 | VULN | `unicode-aware-text-api.md` 新規 | 1.5.316 |
+| FT346 | 通常 | `api-versioning.md` 新規 | 1.5.317 |
+| FT347 | 通常 | `upvote-downvote-api.md` 新規 | 1.5.318 |
+| FT348 | ATK | `webhook-delivery-api.md` 新規 | 1.5.319 |
+| FT349 | 通常 | `state-machine-workflow-api.md` 新規 | 1.5.320 |
 
 ---
 
@@ -44,17 +53,18 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | P3: ft-registry.md 台帳作成 | ✅ #1094/#1095 |
 | P4: ATK/VULN テンプレートを CLAUDE.md に追加 | ✅ #1096/#1097 |
 | FT270 featureflaglog howto 更新 | ✅ #1098/#1099 |
+| **全 FT カバー達成** | ✅ #1262 |
 
 ---
 
-## 次のアクション（FT316〜）
+## 次のアクション
 
 ```bash
-# 未カバー FT を確認
+# 未カバー FT を確認（新 FT が追加されたとき）
 bash tools/uncovered-fts.sh
 
 # FT を選んだらバージョンバンプ
-bash tools/bump-ft.sh 1.5.287
+bash tools/bump-ft.sh 1.5.322
 
 # CHANGELOG.md に手動追記してから
 docker compose run --rm app composer check
@@ -68,6 +78,7 @@ docker compose run --rm app composer check
 |------|------|
 | src/ 還元 batch 2（JSON ボディ整数バリデーター等） | 📋 候補 |
 | v2.0 設計検討（FT ループ摩擦点の還元） | 📋 候補 |
+| 新規 FT 追加（FT350〜）の ATK/VULN サイクル継続 | 📋 候補 |
 
 ---
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.321';
+    public const string VERSION = '1.5.322';
 
     public function name(): string
     {


### PR DESCRIPTION
Closes #1263

## 変更内容
- `docs/todo/current.md` 更新: FT349 完了・全 FT カバー達成
- VERSION 1.5.322 にバンプ
- CHANGELOG.md 更新

## 達成状況
```
bash tools/uncovered-fts.sh
# → (すべての FT がカバー済みです)
```

Self-review: docs-policy