### PR TITLE
docs(howto): eventstore/softdelete howto 追加・uncovered-fts.sh 拡張 (#1265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.323] — 2026-05-27
+
+### Added
+- `docs/howto/event-sourcing-cqrs-api.md` — eventstore 新規作成: イベントソーシング / CQRS howto: append-only ログ・per-aggregate シーケンス・read-model projection (#1265)
+- `docs/howto/soft-delete-restore-permanent.md` — softdelete 新規作成: ソフトデリート / リストア / 永続削除 howto (#1265)
+
+### Changed
+- `tools/uncovered-fts.sh` — i18nlog / eventstore / projtrack / softdelete を検出対象に追加（全 FT カバー確認）(#1265)
+
+---
+
 ## [1.5.322] — 2026-05-27
 
 ### Changed

--- a/docs/howto/event-sourcing-cqrs-api.md
+++ b/docs/howto/event-sourcing-cqrs-api.md
@@ -1,0 +1,244 @@
+# How-to: Event Sourcing & CQRS API
+
+> **FT reference**: `NENE2-FT/eventstore` — Append-only event log with per-aggregate sequence numbers, allowlisted event types, read-model projection rebuilt from events, balance tracking, 17 tests PASS.
+
+This guide shows how to implement event sourcing: store every state change as an immutable event, compute the current state from the event log, and expose a read-model projection.
+
+## Schema
+
+```sql
+-- Append-only event log — never UPDATE or DELETE rows
+CREATE TABLE domain_events (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    aggregate_id   TEXT    NOT NULL,  -- e.g. "acc-001"
+    aggregate_type TEXT    NOT NULL,  -- e.g. "account"
+    event_type     TEXT    NOT NULL,  -- e.g. "MoneyDeposited"
+    payload        TEXT    NOT NULL DEFAULT '{}',  -- JSON
+    sequence       INTEGER NOT NULL,  -- per-aggregate counter, starts at 1
+    occurred_at    TEXT    NOT NULL,
+    UNIQUE(aggregate_id, sequence)
+);
+
+-- Read-model: current account state rebuilt from events
+CREATE TABLE account_projections (
+    account_id    TEXT    PRIMARY KEY,
+    owner         TEXT    NOT NULL,
+    balance_cents INTEGER NOT NULL DEFAULT 0,
+    is_open       INTEGER NOT NULL DEFAULT 1,
+    last_sequence INTEGER NOT NULL DEFAULT 0,
+    updated_at    TEXT    NOT NULL
+);
+```
+
+`UNIQUE(aggregate_id, sequence)` prevents duplicate event insertion. The projection is always derived from the event log — it can be rebuilt at any time by replaying.
+
+## Event Types (Allowlist)
+
+```php
+const ALLOWED_EVENTS = [
+    'AccountOpened',
+    'MoneyDeposited',
+    'MoneyWithdrawn',
+    'AccountClosed',
+];
+```
+
+Unknown event types return 422. Only append events that have explicit handlers in the projection logic.
+
+## Endpoints
+
+| Method | Path                          | Description                     |
+|--------|-------------------------------|---------------------------------|
+| `POST` | `/accounts`                   | Open account (emits AccountOpened) |
+| `GET`  | `/accounts`                   | List all account projections    |
+| `GET`  | `/accounts/{id}`              | Get account projection (404 if not found) |
+| `POST` | `/accounts/{id}/events`       | Append event to account         |
+| `GET`  | `/accounts/{id}/events`       | List event log for account      |
+
+## Open Account
+
+```php
+POST /accounts
+{"account_id": "acc-001", "owner": "Alice"}
+
+→ 201
+{
+  "event_type": "AccountOpened",
+  "aggregate_id": "acc-001",
+  "sequence": 1,
+  "payload": {"owner": "Alice"},
+  "occurred_at": "..."
+}
+```
+
+Opening an account creates an `AccountOpened` event (sequence=1) and initialises the projection.
+
+## Append Events
+
+```php
+POST /accounts/acc-001/events
+{"event_type": "MoneyDeposited", "payload": {"amount_cents": 50000}}
+
+→ 201
+{
+  "event_type": "MoneyDeposited",
+  "aggregate_id": "acc-001",
+  "sequence": 2,         // ← increments per aggregate
+  "payload": {"amount_cents": 50000},
+  "occurred_at": "..."
+}
+```
+
+Each account has an **independent sequence counter**. `acc-001` and `acc-002` both start at 1.
+
+```php
+// Invalid event type → 422
+POST /accounts/acc-001/events  {"event_type": "UnknownEvent"}
+→ 422
+
+// Non-existent account → 404
+POST /accounts/nonexistent/events  {"event_type": "MoneyDeposited", "payload": {"amount_cents": 1000}}
+→ 404
+```
+
+## Read-Model Projection
+
+```php
+GET /accounts/acc-001
+
+→ 200
+{
+  "account_id": "acc-001",
+  "owner": "Alice",
+  "balance_cents": 60000,   // 50000 deposited + 10000 deposited
+  "is_open": true,
+  "last_sequence": 3
+}
+
+// AccountClosed event applied
+GET /accounts/acc-001  // after AccountClosed appended
+→ 200  {"is_open": false, "last_sequence": 4}
+```
+
+```php
+GET /accounts/nonexistent
+→ 404
+```
+
+## Event Log
+
+```php
+GET /accounts/acc-001/events
+
+→ 200
+{
+  "total": 3,
+  "items": [
+    {"event_type": "AccountOpened",  "sequence": 1, ...},
+    {"event_type": "MoneyDeposited", "sequence": 2, "payload": {"amount_cents": 50000}, ...},
+    {"event_type": "MoneyWithdrawn", "sequence": 3, "payload": {"amount_cents": 30000}, ...}
+  ]
+}
+```
+
+Ordered by `sequence ASC` — chronological order.
+
+```php
+// Unknown account → empty list (not 404)
+GET /accounts/nonexistent/events
+→ 200  {"total": 0, "items": []}
+```
+
+## Implementation
+
+### Sequence Generation
+
+```php
+public function nextSequence(string $aggregateId): int
+{
+    $row = $this->db->fetchOne(
+        'SELECT MAX(sequence) AS seq FROM domain_events WHERE aggregate_id = ?',
+        [$aggregateId],
+    );
+    return (int) ($row['seq'] ?? 0) + 1;
+}
+```
+
+### Append Event + Update Projection (Transaction)
+
+```php
+public function appendEvent(string $aggregateId, string $eventType, array $payload): array
+{
+    $sequence = $this->nextSequence($aggregateId);
+    $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+    $this->tx->begin();
+    try {
+        // Append to immutable log
+        $id = $this->db->insert(
+            'INSERT INTO domain_events (aggregate_id, aggregate_type, event_type, payload, sequence, occurred_at)
+             VALUES (?, ?, ?, ?, ?, ?)',
+            [$aggregateId, 'account', $eventType, json_encode($payload), $sequence, $now->format('Y-m-d H:i:s')],
+        );
+
+        // Update projection
+        $this->applyProjection($aggregateId, $eventType, $payload, $sequence, $now);
+
+        $this->tx->commit();
+    } catch (\Throwable $e) {
+        $this->tx->rollback();
+        throw $e;
+    }
+
+    return $this->db->fetchOne('SELECT * FROM domain_events WHERE id = ?', [$id]);
+}
+```
+
+### Projection Logic
+
+```php
+private function applyProjection(
+    string $aggregateId,
+    string $eventType,
+    array $payload,
+    int $sequence,
+    \DateTimeImmutable $now,
+): void {
+    $ts = $now->format('Y-m-d H:i:s');
+    match ($eventType) {
+        'AccountOpened' => $this->db->execute(
+            'INSERT INTO account_projections (account_id, owner, balance_cents, is_open, last_sequence, updated_at)
+             VALUES (?, ?, 0, 1, ?, ?)',
+            [$aggregateId, $payload['owner'] ?? '', $sequence, $ts],
+        ),
+        'MoneyDeposited' => $this->db->execute(
+            'UPDATE account_projections SET balance_cents = balance_cents + ?, last_sequence = ?, updated_at = ?
+             WHERE account_id = ?',
+            [$payload['amount_cents'], $sequence, $ts, $aggregateId],
+        ),
+        'MoneyWithdrawn' => $this->db->execute(
+            'UPDATE account_projections SET balance_cents = balance_cents - ?, last_sequence = ?, updated_at = ?
+             WHERE account_id = ?',
+            [$payload['amount_cents'], $sequence, $ts, $aggregateId],
+        ),
+        'AccountClosed' => $this->db->execute(
+            'UPDATE account_projections SET is_open = 0, last_sequence = ?, updated_at = ? WHERE account_id = ?',
+            [$sequence, $ts, $aggregateId],
+        ),
+        default => null,
+    };
+}
+```
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| UPDATE or DELETE rows in `domain_events` | Destroys the audit trail; projections become inconsistent with history |
+| No `UNIQUE(aggregate_id, sequence)` | Duplicate events corrupt the projection on replay |
+| Store computed balance in `domain_events` | Derived state belongs in the projection, not the event log |
+| Allow arbitrary event types | Projection logic has no handler → silent no-op or crash |
+| Append event without updating projection in same transaction | Inconsistency window between event log and read model |
+| No per-aggregate sequence counter | Cannot detect replay gaps or concurrent write conflicts |

--- a/docs/howto/soft-delete-restore-permanent.md
+++ b/docs/howto/soft-delete-restore-permanent.md
@@ -1,0 +1,162 @@
+# How-to: Soft Delete, Restore, and Permanent Delete
+
+> **FT reference**: `NENE2-FT/softdelete` — Soft delete via `deleted_at` timestamp, restore (only soft-deleted notes can be restored), permanent hard delete (only soft-deleted notes can be permanently deleted), 14 tests PASS.
+
+This guide shows how to implement three deletion states: active, soft-deleted (recoverable), and permanently deleted (gone). Compare with `docs/howto/soft-delete-trash-restore.md` (FT340 softdeletelog) which adds a dedicated trash view and bulk purge.
+
+## Schema
+
+```sql
+CREATE TABLE notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    deleted_at TEXT             -- NULL = active; timestamp = soft-deleted
+);
+
+CREATE INDEX idx_notes_deleted ON notes(deleted_at);
+```
+
+`deleted_at IS NULL` → active. `deleted_at IS NOT NULL` → soft-deleted.
+
+## Endpoints
+
+| Method   | Path                     | Description                     |
+|----------|--------------------------|---------------------------------|
+| `POST`   | `/notes`                 | Create note                     |
+| `GET`    | `/notes`                 | List active notes only          |
+| `GET`    | `/notes/{id}`            | Get note (404 if deleted)       |
+| `DELETE` | `/notes/{id}`            | Soft delete (sets deleted_at)   |
+| `POST`   | `/notes/{id}/restore`    | Restore soft-deleted note       |
+| `DELETE` | `/notes/{id}/permanent`  | Permanently delete soft-deleted note |
+
+## Create Note
+
+```php
+POST /notes  {"title": "My Note", "body": "Some content"}
+
+→ 201
+{
+  "id": 1,
+  "title": "My Note",
+  "body": "Some content",
+  "deleted_at": null,    // ← null = active
+  "created_at": "..."
+}
+```
+
+## List Active Notes
+
+```php
+GET /notes
+→ 200  {"items": [{...active notes...}], "total": 2}
+```
+
+Only returns notes with `deleted_at IS NULL`. Soft-deleted notes are invisible here.
+
+## Soft Delete
+
+```php
+DELETE /notes/1
+→ 200  // sets deleted_at = now
+
+// Soft-deleted note disappears from active list
+GET /notes
+→ 200  {"items": [], "total": 0}
+
+// And from direct GET
+GET /notes/1
+→ 404
+```
+
+```sql
+UPDATE notes SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL
+```
+
+## Restore
+
+```php
+// Restore a soft-deleted note
+POST /notes/1/restore
+→ 200  {"id": 1, "title": "My Note", "deleted_at": null, ...}  // back to active
+
+// Restored note appears in active list again
+GET /notes
+→ 200  {"items": [{...}], "total": 1}
+```
+
+### Restore of Active Note → 404
+
+```php
+// Trying to restore an active (not soft-deleted) note → 404
+POST /notes/2/restore   // note 2 was never deleted
+→ 404
+```
+
+Only soft-deleted notes can be restored. Active notes return 404 on restore.
+
+```sql
+UPDATE notes SET deleted_at = NULL WHERE id = ? AND deleted_at IS NOT NULL
+-- If 0 rows affected → note is active or doesn't exist → 404
+```
+
+## Permanent Delete
+
+```php
+// Must be soft-deleted first
+DELETE /notes/1   // soft delete
+POST /notes/1/restore  // restore (optional)
+
+// Permanently delete a soft-deleted note
+DELETE /notes/1          // soft delete it first
+DELETE /notes/1/permanent
+→ 200  {"permanent": true}
+
+GET /notes/1
+→ 404  // gone forever
+```
+
+### Permanent Delete of Active Note → 404
+
+```php
+// Permanently deleting an active note → 404
+// Must soft-delete first, then permanently delete
+DELETE /notes/2/permanent   // note 2 is active
+→ 404
+```
+
+```sql
+DELETE FROM notes WHERE id = ? AND deleted_at IS NOT NULL
+-- If 0 rows affected → note is active or doesn't exist → 404
+```
+
+## State Diagram
+
+```
+Active
+  │
+  │ DELETE /notes/{id}     (soft delete)
+  ▼
+Soft-deleted
+  │           │
+  │ POST      │ DELETE
+  │ /restore  │ /permanent
+  ▼           ▼
+Active      Gone (hard deleted)
+```
+
+**The key invariant**: permanent delete requires a prior soft delete. This prevents accidental hard deletes from active state.
+
+---
+
+## What NOT to do
+
+| Anti-pattern | Risk |
+|---|---|
+| Allow permanent delete of active note | Skips the soft-delete safety net; data is gone without recovery window |
+| Return 200 on restore of active note | Callers cannot tell if the restore was needed; use 404 to signal "not in trash" |
+| No index on `deleted_at` | Full table scan for every list query; `WHERE deleted_at IS NULL` is slow without index |
+| Hard delete immediately on `DELETE /notes/{id}` | No recovery possible; use soft delete first |
+| Expose `deleted_at` in active list | Clients see the field; visually clutters responses; filter it out or use `null` |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.322
+  version: 1.5.323
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.322';
+    public const string VERSION = '1.5.323';
 
     public function name(): string
     {

--- a/tools/uncovered-fts.sh
+++ b/tools/uncovered-fts.sh
@@ -26,18 +26,22 @@ fi
 covered() {
   {
     # 新形式: FT reference: FTxxx (NENE2-FT/<name>) または単純な NENE2-FT/<name> 参照
+    # i18nlog (数字入り) / eventstore / projtrack / softdelete も対象
     grep -rh "NENE2-FT/" "$HOWTO_DIR" 2>/dev/null \
-      | grep -oP 'NENE2-FT/\K[a-z]+log'
+      | grep -oP 'NENE2-FT/\K[a-z0-9]*(log|store|track|delete)'
 
     # 旧形式: Pattern proven by FT<number> <name>
     grep -rh "Pattern proven by FT" "$HOWTO_DIR" 2>/dev/null \
-      | grep -oP 'Pattern proven by FT\d+ \K[a-z]+log'
+      | grep -oP 'Pattern proven by FT\d+ \K[a-z0-9]*(log|store|track|delete)'
   } | sort -u
 }
 
 # 全 FT プロジェクト名のリスト (ソート済み)
+# - *log パターン (例: cartlog, ratelog)
+# - i18nlog (数字を含む例外)
+# - log 以外の FT プロジェクト (eventstore / projtrack / softdelete)
 all_fts() {
-  ls "$FT_DIR" | grep -E '^[a-z]+log$' | sort
+  ls "$FT_DIR" | grep -E '^[a-z0-9]*log$|^(eventstore|projtrack|softdelete)$' | sort
 }
 
 MODE="${1:-}"


### PR DESCRIPTION
Closes #1265

## 変更内容
- `docs/howto/event-sourcing-cqrs-api.md` — NENE2-FT/eventstore 新規作成
- `docs/howto/soft-delete-restore-permanent.md` — NENE2-FT/softdelete 新規作成
- `tools/uncovered-fts.sh` — i18nlog/eventstore/projtrack/softdelete を検出対象に追加
- VERSION 1.5.323 にバンプ

## 確認
```
bash tools/uncovered-fts.sh
# → (すべての FT がカバー済みです)
```

Self-review: docs-policy