### PR TITLE
docs(howto): DX シナリオ分析からの改善 5 件 (#1270)

### DIFF
--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -2,7 +2,45 @@
 
 Task-focused guides for building with NENE2. Each guide is self-contained and links to related topics.
 
-**100 guides** in this directory (excluding this index). VitePress sidebar lists common entry points; use this page for the full catalog.
+**100+ guides** in this directory (excluding this index). VitePress sidebar lists common entry points; use this page for the full catalog.
+
+---
+
+## 🔍 Find by what you want to build
+
+> Can't find the right guide by technical name? Start here.
+
+| I want to… | Guide |
+|-----------|-------|
+| Filter a list by optional query params (`?status=`, `?price_max=`) | [dynamic-filter-query.md](dynamic-filter-query.md) |
+| Filter by multiple tags / skills (AND: must have all) | [multi-value-tag-filter.md](multi-value-tag-filter.md) |
+| Sort by a query param safely (`?sort=name&order=asc`) | [dynamic-sort-order-injection.md](dynamic-sort-order-injection.md) |
+| Add pagination to a list endpoint | [add-pagination.md](add-pagination.md) |
+| Store and calculate money without rounding errors | [money-integer-arithmetic.md](money-integer-arithmetic.md) |
+| Manage status transitions (draft → published → archived) | [state-machine-workflow-api.md](state-machine-workflow-api.md) |
+| Build a hierarchy (categories, folders, org chart, regions) | [hierarchical-data.md](hierarchical-data.md) |
+| Store events / history (append-only, never update) | [event-sourcing-cqrs-api.md](event-sourcing-cqrs-api.md) |
+| Prevent double-booking (hotel, meeting room, appointment) | [prevent-double-booking.md](prevent-double-booking.md) |
+| Prevent race conditions on limited stock or seats | [flash-sale-api.md](flash-sale-api.md) |
+| Record who changed what and when (audit trail) | [audit-trail.md](audit-trail.md) |
+| Implement votes / likes (one per user) | [upvote-downvote-api.md](upvote-downvote-api.md) |
+| Add threaded comments or nested replies | [threaded-comments-api.md](threaded-comments-api.md) |
+| Generate a secure token (invite link, download URL, API key) | [api-key-management.md](api-key-management.md) |
+| Handle timezones and UTC storage | [handle-timezones.md](handle-timezones.md) |
+| Add JWT authentication | [jwt-authentication.md](jwt-authentication.md) |
+| Add multi-tenant isolation (per-tenant data separation) | [jwt-tenant-isolation.md](jwt-tenant-isolation.md) |
+| Hash passwords and verify on login | [password-auth-argon2id.md](password-auth-argon2id.md) |
+| Add leaderboard / ranking | [game-score-leaderboard-api.md](game-score-leaderboard-api.md) |
+| Upload and serve files securely | [file-upload.md](file-upload.md) |
+| Full-text search | [sqlite-fts5-search.md](sqlite-fts5-search.md) |
+| Use database transactions (wrap multiple writes atomically) | [use-transactions.md](use-transactions.md) |
+| Soft-delete (hide without permanently removing) | [soft-delete.md](soft-delete.md) |
+| Send a webhook when something happens | [webhook-delivery-api.md](webhook-delivery-api.md) |
+| Implement an approval / review workflow | [approval-workflow.md](approval-workflow.md) |
+| Manage points, credits, or a balance ledger | [point-ledger-api.md](point-ledger-api.md) |
+| Manage coupons and discounts | [coupon-discount-api.md](coupon-discount-api.md) |
+| Implement rate limiting | [add-rate-limiting.md](add-rate-limiting.md) |
+| Build a subscription / membership | [subscription-plan-management.md](subscription-plan-management.md) |
 
 ---
 

--- a/docs/howto/add-database-endpoint.md
+++ b/docs/howto/add-database-endpoint.md
@@ -741,9 +741,92 @@ provides the affinity.
 
 ---
 
+## Wrapping multiple writes in a transaction
+
+When a single operation must write to more than one table, wrap it in a transaction
+so that either **all** writes succeed or **none** do.
+
+A common example: create an order **and** decrement stock atomically.
+
+```php
+use Nene2\Database\DatabaseTransactionManagerInterface;
+
+final readonly class CreateOrderUseCase
+{
+    public function __construct(
+        private OrderRepositoryInterface   $orders,
+        private ProductRepositoryInterface $products,
+        private DatabaseTransactionManagerInterface $txManager,
+    ) {}
+
+    public function execute(int $productId, int $quantity): Order
+    {
+        return $this->txManager->transactional(function () use ($productId, $quantity): Order {
+            // 1. Check and decrement stock atomically
+            $affected = $this->products->decrementStock($productId, $quantity);
+            if ($affected === 0) {
+                throw new OutOfStockException("Product {$productId} is out of stock.");
+            }
+
+            // 2. Create the order record
+            return $this->orders->create($productId, $quantity);
+
+            // If an exception is thrown anywhere in this block, both writes are rolled back.
+        });
+    }
+}
+```
+
+The repository's `decrementStock` uses an atomic `UPDATE ... WHERE stock >= ?` to
+avoid race conditions:
+
+```php
+public function decrementStock(int $productId, int $quantity): int
+{
+    return $this->db->execute(
+        'UPDATE products SET stock = stock - ? WHERE id = ? AND stock >= ?',
+        [$quantity, $productId, $quantity],
+    ); // returns number of affected rows; 0 = insufficient stock
+}
+```
+
+### Injecting `DatabaseTransactionManagerInterface`
+
+Register it in your service provider alongside the repository:
+
+```php
+$container->bind(
+    CreateOrderUseCase::class,
+    fn ($c) => new CreateOrderUseCase(
+        orders:    $c->get(OrderRepositoryInterface::class),
+        products:  $c->get(ProductRepositoryInterface::class),
+        txManager: $c->get(DatabaseTransactionManagerInterface::class),
+    ),
+);
+```
+
+`DatabaseTransactionManagerInterface` is already registered by NENE2's core
+`DatabaseServiceProvider` — you only need to declare it as a constructor dependency.
+
+### When to use transactions
+
+| Situation | Use transaction? |
+|-----------|-----------------|
+| Single INSERT or UPDATE | No — a single SQL statement is atomic by default |
+| INSERT + INSERT (two tables) | **Yes** — must succeed or fail together |
+| INSERT + UPDATE (e.g., order + stock) | **Yes** |
+| Read-only SELECT queries | No |
+| UPDATE with a preceding SELECT for validation | **Yes** — prevents race between check and update |
+
+For a deeper guide including rollback testing, see [`use-transactions.md`](use-transactions.md).
+
+---
+
 ## Next steps
 
 - Add OpenAPI documentation for your endpoint: see `docs/development/endpoint-scaffold.md`
 - Add database migrations: see `docs/development/test-database-strategy.md`
 - See NENE2's built-in Note example as a reference: `src/Example/Note/`
 - PATCH endpoint pattern: see [`implement-patch-endpoint.md`](implement-patch-endpoint.md)
+- Transactions deep-dive: see [`use-transactions.md`](use-transactions.md)
+- Dynamic list filtering: see [`dynamic-filter-query.md`](dynamic-filter-query.md)

--- a/docs/howto/dynamic-filter-query.md
+++ b/docs/howto/dynamic-filter-query.md
@@ -1,0 +1,298 @@
+# How-to: Dynamic Filter Query (Dynamic WHERE Clause)
+
+> **Related scenarios**: DX Scenario 03, 18, 22, 25, 29, 30, 33, 37, 38, 41, 47, 48 — the most frequently cited missing howto across 50 DX scenarios.
+
+Many list endpoints accept optional query parameters that translate into SQL conditions.
+The key challenge: when a parameter is absent (`null`), the condition must be **skipped entirely** — not compared against `NULL` in SQL.
+
+This guide shows the canonical pattern used throughout NENE2 howtos.
+
+---
+
+## The Core Pattern: `$conditions` array + `implode`
+
+```php
+public function search(
+    ?string $status,
+    ?int    $categoryId,
+    ?string $keyword,
+): array {
+    $conditions = ['deleted_at IS NULL'];   // required condition — always included
+    $bindings   = [];
+
+    if ($status !== null) {
+        $conditions[] = 'status = ?';
+        $bindings[]   = $status;
+    }
+
+    if ($categoryId !== null) {
+        $conditions[] = 'category_id = ?';
+        $bindings[]   = $categoryId;
+    }
+
+    if ($keyword !== null && $keyword !== '') {
+        $conditions[] = '(title LIKE ? OR description LIKE ?)';
+        $bindings[]   = "%{$keyword}%";
+        $bindings[]   = "%{$keyword}%";
+    }
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+
+    return $this->db->fetchAll(
+        "SELECT * FROM products {$where} ORDER BY created_at DESC",
+        $bindings,
+    );
+}
+```
+
+**Why this works**:
+- `$conditions` always has at least one element (the required condition), so `implode(' AND ', $conditions)` never produces an empty string.
+- Each optional block appends both the SQL fragment and its binding value — they stay in sync.
+- If all optional parameters are `null`, the query reduces to `WHERE deleted_at IS NULL`.
+
+---
+
+## Anti-pattern: `WHERE 1=1`
+
+A common alternative is `WHERE 1=1` as the seed condition, then always appending `AND`:
+
+```php
+// Works, but less clear:
+$where = 'WHERE 1=1';
+if ($status !== null) {
+    $where    .= ' AND status = ?';
+    $bindings[] = $status;
+}
+```
+
+This also works. The `$conditions` array approach is preferred because it separates
+SQL fragments from their bindings cleanly and is easier to test each condition in isolation.
+
+---
+
+## Range conditions: min/max filters
+
+Price range, date range, and similar `>=` / `<=` filters:
+
+```php
+public function searchProperties(
+    ?int    $priceMin,
+    ?int    $priceMax,
+    ?int    $bedroomsMin,
+    ?string $dateFrom,
+    ?string $dateTo,
+): array {
+    $conditions = ['status = ?'];
+    $bindings   = ['available'];
+
+    if ($priceMin !== null) {
+        $conditions[] = 'price_yen >= ?';
+        $bindings[]   = $priceMin;
+    }
+
+    if ($priceMax !== null) {
+        $conditions[] = 'price_yen <= ?';
+        $bindings[]   = $priceMax;
+    }
+
+    if ($bedroomsMin !== null) {
+        $conditions[] = 'bedrooms >= ?';
+        $bindings[]   = $bedroomsMin;
+    }
+
+    if ($dateFrom !== null) {
+        $conditions[] = 'available_from >= ?';
+        $bindings[]   = $dateFrom;
+    }
+
+    if ($dateTo !== null) {
+        $conditions[] = 'available_from <= ?';
+        $bindings[]   = $dateTo;
+    }
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+
+    return $this->db->fetchAll(
+        "SELECT * FROM properties {$where} ORDER BY price_yen ASC",
+        $bindings,
+    );
+}
+```
+
+Separate `min` and `max` conditions rather than `BETWEEN` — it lets the client
+provide only one bound (e.g., "price up to 5M, no lower limit").
+
+---
+
+## Enum / allowlist filter
+
+When a parameter value must come from a fixed set, validate before adding to `$conditions`:
+
+```php
+private const VALID_STATUSES = ['draft', 'published', 'archived'];
+
+public function listByStatus(?string $status): array
+{
+    $conditions = ['deleted_at IS NULL'];
+    $bindings   = [];
+
+    if ($status !== null) {
+        if (!in_array($status, self::VALID_STATUSES, true)) {
+            throw new \InvalidArgumentException("Invalid status: {$status}");
+        }
+        $conditions[] = 'status = ?';
+        $bindings[]   = $status;
+    }
+
+    // ...
+}
+```
+
+Do **not** interpolate `$status` directly into the SQL string even if it looks safe.
+Always use a bind parameter (`?`) and let PDO handle the quoting.
+
+---
+
+## IN clause: multi-value filter
+
+When the client can pass multiple values (e.g., `?category_ids[]=1&category_ids[]=3`):
+
+```php
+public function filterByCategories(array $categoryIds): array
+{
+    if ($categoryIds === []) {
+        return $this->findAll();   // no filter — return everything
+    }
+
+    $placeholders = implode(',', array_fill(0, count($categoryIds), '?'));
+
+    return $this->db->fetchAll(
+        "SELECT * FROM products WHERE category_id IN ({$placeholders}) ORDER BY created_at DESC",
+        $categoryIds,
+    );
+}
+```
+
+`array_fill(0, count($ids), '?')` generates the correct number of `?` placeholders.
+Never use `implode(',', $categoryIds)` to build an `IN (1,2,3)` string — that is SQL injection.
+
+For AND semantics (items that match **all** given tags), see [`multi-value-tag-filter.md`](multi-value-tag-filter.md).
+
+---
+
+## Safe ORDER BY: allowlist interpolation
+
+`ORDER BY` column names **cannot** use bind parameters — they must be interpolated.
+Always validate against an allowlist:
+
+```php
+private const SORT_COLUMNS  = ['name', 'price_yen', 'created_at'];
+private const SORT_DIRECTION = ['asc', 'desc'];
+
+public function list(?string $sortBy, ?string $order): array
+{
+    $col = in_array($sortBy, self::SORT_COLUMNS, true)  ? $sortBy : 'created_at';
+    $dir = in_array($order,  self::SORT_DIRECTION, true) ? $order  : 'desc';
+
+    $conditions = ['deleted_at IS NULL'];
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+
+    return $this->db->fetchAll(
+        "SELECT * FROM products {$where} ORDER BY {$col} {$dir}",
+        [],
+    );
+}
+```
+
+See [`dynamic-sort-order-injection.md`](dynamic-sort-order-injection.md) for a full treatment
+of ORDER BY injection prevention.
+
+---
+
+## Combining filter with pagination
+
+A common pattern — dynamic filter + cursor or offset pagination:
+
+```php
+public function paginatedSearch(
+    ?string $status,
+    ?string $keyword,
+    int     $limit,
+    int     $offset,
+): array {
+    $conditions = ['deleted_at IS NULL'];
+    $bindings   = [];
+
+    if ($status !== null) {
+        $conditions[] = 'status = ?';
+        $bindings[]   = $status;
+    }
+
+    if ($keyword !== null && $keyword !== '') {
+        $conditions[] = 'title LIKE ?';
+        $bindings[]   = "%{$keyword}%";
+    }
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+
+    // Count query reuses the same WHERE
+    $total = (int) ($this->db->fetchOne(
+        "SELECT COUNT(*) AS cnt FROM products {$where}",
+        $bindings,
+    )['cnt'] ?? 0);
+
+    // Data query appends LIMIT/OFFSET — do NOT add them to $bindings before COUNT
+    $rows = $this->db->fetchAll(
+        "SELECT * FROM products {$where} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+        [...$bindings, $limit, $offset],
+    );
+
+    return ['total' => $total, 'items' => $rows];
+}
+```
+
+Build `$bindings` for the filter conditions first, then spread them into both the
+`COUNT` query and the data query. Append `$limit` and `$offset` only to the data query.
+
+---
+
+## Parsing optional query parameters
+
+Use `QueryStringParser` helpers to get `null`-safe typed values from the request:
+
+```php
+use Nene2\Http\QueryStringParser;
+
+$status     = QueryStringParser::string($request, 'status');     // ?string
+$priceMin   = QueryStringParser::int($request, 'price_min');     // ?int
+$priceMax   = QueryStringParser::int($request, 'price_max');     // ?int
+$keyword    = QueryStringParser::string($request, 'q');          // ?string
+$sortBy     = QueryStringParser::string($request, 'sort');       // ?string
+$categoryId = QueryStringParser::int($request, 'category_id');   // ?int
+```
+
+All helpers return `null` when the parameter is absent or cannot be parsed to the target type.
+Pass these `null`-able values directly to the repository method — the method skips
+conditions where the value is `null`.
+
+---
+
+## Common mistakes
+
+| Mistake | Problem | Fix |
+|---------|---------|-----|
+| `WHERE status = ?` with `null` binding | SQLite evaluates `status = NULL` → always false (should be `IS NULL`) | Skip condition when value is `null`; use `IS NULL` only when you explicitly want NULL rows |
+| `WHERE 1=1` with no required condition | Leaks all rows if all optional params are absent and there's no tenant/owner filter | Always include at least one required condition (tenant, owner, deleted_at) |
+| Interpolating `$status` directly | SQL injection | Always use `?` bind parameter |
+| `IN (implode(',', $ids))` | SQL injection | Use `array_fill` + `?` placeholders |
+| Adding `LIMIT`/`OFFSET` to `$bindings` before `COUNT(*)` | COUNT gets wrong results | Build filter `$bindings` first; spread into COUNT, then append LIMIT/OFFSET for data query |
+
+---
+
+## Related howtos
+
+- [`multi-value-tag-filter.md`](multi-value-tag-filter.md) — AND / OR semantics for N:M tag filters (`HAVING COUNT(DISTINCT)`)
+- [`dynamic-sort-order-injection.md`](dynamic-sort-order-injection.md) — safe ORDER BY with allowlist
+- [`add-pagination.md`](add-pagination.md) — combining with offset / cursor pagination
+- [`contact-management.md`](contact-management.md) — complete example with LIKE + EXISTS filter

--- a/docs/howto/handle-timezones.md
+++ b/docs/howto/handle-timezones.md
@@ -132,3 +132,100 @@ if ($viewTz !== null) {
     }
 }
 ```
+
+---
+
+## SQLite-specific: `datetime('now')` always returns UTC
+
+SQLite's built-in date/time functions always operate in **UTC**, regardless of the server's
+OS timezone or PHP's `date.timezone` setting.
+
+```sql
+SELECT datetime('now');          -- → "2026-05-27 11:30:00"  (UTC)
+SELECT date('now');              -- → "2026-05-27"            (UTC date)
+SELECT date('now', '+1 day');    -- → "2026-05-28"            (UTC + 1 day)
+SELECT datetime('now', '-9 hours'); -- → local JST approximate (manual offset — avoid this)
+```
+
+**This is usually what you want**: store timestamps as UTC TEXT and compare in UTC.
+
+### Filtering by "today" in UTC
+
+```sql
+-- Records created today (UTC)
+SELECT * FROM events WHERE DATE(created_at) = DATE('now');
+
+-- Records in the next 30 days (UTC)
+SELECT * FROM reminders WHERE reminder_at <= DATE('now', '+30 days');
+
+-- Records for a specific month (UTC)
+SELECT * FROM logs WHERE STRFTIME('%Y-%m', created_at) = '2026-05';
+```
+
+### The trap: "today" differs by timezone
+
+If your users are in JST (UTC+9), "today" in JST starts 9 hours before "today" in UTC.
+`DATE('now')` in SQLite returns the UTC date — this is a mismatch.
+
+```php
+// Wrong: SQLite DATE('now') = UTC date, not user's local date
+$rows = $this->db->fetchAll("SELECT * FROM tasks WHERE DATE(due_date) = DATE('now')");
+
+// Correct: compute the user's "today" in PHP and pass it as a parameter
+$todayUtc = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d');
+$rows = $this->db->fetchAll(
+    "SELECT * FROM tasks WHERE DATE(due_date) = ?",
+    [$todayUtc],
+);
+```
+
+For a service where "today" means UTC, `DATE('now')` is fine. For user-facing "due today"
+features, compute the boundary in PHP using the user's timezone and pass it as a bind parameter.
+
+### Dynamic interval with a column value
+
+SQLite allows combining `date()` with a string built from a column value:
+
+```sql
+-- Records where next_review_at = today based on interval_days column
+SELECT * FROM cards WHERE next_review_at <= DATE('now');
+
+-- Computing next review date dynamically (store result, don't rely on this in SELECT)
+SELECT DATE('now', '+' || interval_days || ' days') AS next_date FROM cards;
+```
+
+This is useful in a `UPDATE` statement when advancing a schedule:
+
+```php
+$this->db->execute(
+    "UPDATE cards SET next_review_at = DATE('now', '+' || interval_days || ' days') WHERE id = ?",
+    [$cardId],
+);
+```
+
+### `STRFTIME` format reference
+
+| Pattern | Output | Use |
+|---------|--------|-----|
+| `%Y-%m-%d` | `2026-05-27` | Full date |
+| `%Y-%m` | `2026-05` | Year-month grouping |
+| `%Y-%W` | `2026-22` | Year + **Sunday-starting** week number (0–53) |
+| `%H:%M:%S` | `11:30:00` | Time only |
+| `%s` | Unix timestamp | Integer seconds since epoch |
+
+**`%W` is Sunday-starting**, not ISO 8601 (Monday-starting). For Monday-starting week
+numbers, compute the week boundary in PHP:
+
+```php
+// Get the Monday of the current ISO week
+$monday = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+    ->modify('Monday this week')
+    ->format('Y-m-d');
+
+$sunday = (new \DateTimeImmutable($monday))->modify('+6 days')->format('Y-m-d');
+
+$rows = $this->db->fetchAll(
+    "SELECT * FROM workouts WHERE workout_date BETWEEN ? AND ?",
+    [$monday, $sunday],
+);
+```

--- a/docs/howto/money-integer-arithmetic.md
+++ b/docs/howto/money-integer-arithmetic.md
@@ -1,0 +1,231 @@
+# How-to: Money and Integer Arithmetic
+
+> **Related scenarios**: DX Scenario 10, 23, 32, 36, 40, 43, 44, 50 — the most frequently cited source of silent precision bugs across financial scenarios.
+
+Monetary amounts stored as floating-point (`REAL` / `float`) accumulate rounding errors.
+`1001 * 0.05` in IEEE 754 produces `50.049999999999997`, not `50.05`.
+The correct approach is to store and calculate amounts as **integers in the smallest currency unit**
+(yen for JPY, cents for USD/EUR).
+
+---
+
+## The rule: always store as integer
+
+```php
+// ❌ Wrong — REAL/float accumulates errors
+$fee = $amount * 0.05;           // 1001 * 0.05 = 50.04999...
+$tax = $price * 1.10;            // 1000 * 1.10 = 1100.0000000000002
+
+// ✅ Correct — integer arithmetic
+$fee = intdiv($amount * 5, 100); // 1001 * 5 / 100 = 50 (truncated)
+$tax = intdiv($amount * 110, 100); // 1000 * 110 / 100 = 1100
+```
+
+Schema:
+
+```sql
+CREATE TABLE orders (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    amount_yen   INTEGER NOT NULL CHECK(amount_yen > 0),  -- ✅ INTEGER, not REAL
+    fee_yen      INTEGER NOT NULL CHECK(fee_yen >= 0),
+    tax_yen      INTEGER NOT NULL CHECK(tax_yen >= 0),
+    total_yen    INTEGER NOT NULL CHECK(total_yen > 0)
+);
+```
+
+Use `CHECK` constraints to enforce non-negative values at the DB level.
+
+---
+
+## Choosing the rounding function
+
+When dividing integers, you must decide how to handle the remainder.
+**Decide and document this policy before writing code** — changing it later affects
+every historical record.
+
+| Function | Behavior | Example: `intdiv(1, 3)` | When to use |
+|----------|----------|------------------------|-------------|
+| `intdiv($a, $b)` | Truncate toward zero | `0` | Platform fees (payer keeps remainder) |
+| `(int) round($a / $b)` | Round half-up | `0` (rounds to 0) | Split bills, generic rounding |
+| `(int) ceil($a / $b)` | Round up (ceiling) | `1` | Tax calculation (always round up for government) |
+| `(int) floor($a / $b)` | Round down (floor) | `0` | Same as intdiv for positive values |
+
+### Platform fee (5%) — who keeps the remainder?
+
+```php
+// Option A: platform takes floor (payer favored)
+$fee = intdiv($amount * 5, 100);     // 1001 yen → fee = 50, seller gets 951
+
+// Option B: platform takes ceil (platform favored)
+$fee = (int) ceil($amount * 5 / 100); // 1001 yen → fee = 51, seller gets 950
+
+// Option C: round half-up (neutral)
+$fee = (int) round($amount * 5 / 100); // 1001 yen → fee = 50, seller gets 951
+```
+
+There is no universally correct answer. **Document the choice in the API spec.**
+
+---
+
+## Tax calculation (Japanese consumption tax: 10%)
+
+Japanese consumption tax requires **rounding down** per transaction (not per line item):
+
+```php
+// ✅ Truncate at transaction level
+$taxIncluded  = intdiv($priceExcl * 110, 100);  // 1000 → 1100
+$taxAmount    = intdiv($priceExcl * 10, 100);   // 1000 → 100
+
+// ❌ Do NOT round per line item and then sum — rounding errors accumulate
+$items = [100, 100, 100]; // 3 items × 100 yen
+$total = array_sum(array_map(fn($p) => (int)round($p * 1.1), $items)); // may differ from intdiv(300 * 110, 100)
+```
+
+If storing a `tax_rate`, store it as **basis points** (integer, 1/10000):
+`10% = 1000 bps`. Avoids floating-point in rate storage itself.
+
+```sql
+tax_rate_bps INTEGER NOT NULL DEFAULT 1000  -- 10.00%
+```
+
+```php
+$taxAmount = intdiv($amount * $taxRateBps, 10000);
+```
+
+---
+
+## Split / divvy: remainder distribution
+
+When splitting a total among N participants:
+
+```php
+function splitEvenly(int $totalYen, int $n): array
+{
+    $base      = intdiv($totalYen, $n);       // each person's share (truncated)
+    $remainder = $totalYen % $n;              // leftover yen (0 to n-1)
+
+    $shares = array_fill(0, $n, $base);
+
+    // Distribute remainder 1 yen at a time to the first participants
+    for ($i = 0; $i < $remainder; $i++) {
+        $shares[$i]++;
+    }
+
+    // Verify: sum must equal original total
+    assert(array_sum($shares) === $totalYen);
+
+    return $shares;
+}
+
+// splitEvenly(1000, 3) → [334, 333, 333]  (sum = 1000) ✅
+// splitEvenly(100,  3) → [34,  33,  33]   (sum = 100)  ✅
+```
+
+Never use `round($total / $n)` for each participant and call it done —
+the sum will often be off by 1 yen.
+
+---
+
+## SQLite integer division trap
+
+In SQLite, dividing two integers performs integer division:
+
+```sql
+SELECT 5 / 100;     -- → 0  (integer division: truncates)
+SELECT 5.0 / 100;   -- → 0.05 (real division)
+SELECT 5 * 100 / 100;  -- → 5 (multiply first, then divide — OK)
+```
+
+**In PHP** with PDO, all bound values are sent as strings. SQLite coerces them, but:
+
+```php
+// Safe: multiply first to avoid truncation
+$fee = $this->db->fetchOne(
+    'SELECT amount_yen * 5 / 100 AS fee FROM orders WHERE id = ?',
+    [$id],
+);
+// → amount_yen * 5 first (integer * integer = integer), then / 100
+
+// Risky: if PDO sends '5' and '100' as strings, SQLite may choose real division
+// Test this if your SQLite version or PDO behavior is unclear.
+```
+
+The safest approach: **do the arithmetic in PHP with `intdiv()`**, store the result,
+and only use SQL arithmetic for summation (`SUM`, `COUNT`), not for per-row computation.
+
+---
+
+## Depreciation (straight-line)
+
+```php
+// Annual depreciation (straight-line method)
+$annualDepr = intdiv($purchasePrice - $salvageValue, $usefulLifeYears);
+
+// Current book value
+$yearsElapsed = (int) floor(
+    (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->diff(
+        new \DateTimeImmutable($purchaseDateUtc)
+    )->days / 365
+);
+$currentValue = max($salvageValue, $purchasePrice - $annualDepr * $yearsElapsed);
+```
+
+`intdiv` truncates the annual depreciation, which means the asset depreciates slightly
+less per year and the remainder shows up as the final year's extra depreciation.
+This is the standard behavior for Japanese straight-line depreciation.
+
+---
+
+## Displaying to the user
+
+Convert to a human-readable format only at the response layer, never in the domain:
+
+```php
+final readonly class MoneyResponse
+{
+    public function __construct(
+        public int    $amountYen,
+        public string $displayAmount,  // "¥1,234"
+    ) {}
+
+    public static function fromYen(int $yen): self
+    {
+        return new self(
+            amountYen:     $yen,
+            displayAmount: '¥' . number_format($yen),
+        );
+    }
+}
+```
+
+Store `amountYen` (integer) for further computation; `displayAmount` (string) for the UI.
+Never store formatted strings — they cannot be summed.
+
+---
+
+## Summary: decision checklist
+
+Before writing any monetary calculation, answer these questions:
+
+1. **Unit**: yen (no decimal), cents (1/100), or micropennies (1/1000)?
+   → Store as integer in that unit; document the unit in the column name (`amount_yen`, `price_cents`).
+
+2. **Rounding direction**: `intdiv` (truncate), `ceil`, `floor`, or `round`?
+   → Choose one; add a comment in the code explaining why.
+
+3. **Who gets the remainder**: when splitting, who absorbs the rounding difference?
+   → Distribute the remainder explicitly (see `splitEvenly` above).
+
+4. **Tax rate storage**: basis points (`INTEGER`) not percent (`REAL`)?
+   → `1000` for 10%, `800` for 8%, never `0.10` or `0.08`.
+
+5. **Cumulative or per-transaction**: accumulate tax per line item or per invoice total?
+   → Per-transaction (single `intdiv`) is standard for JPY invoices.
+
+---
+
+## Related howtos
+
+- [`multi-currency-money-ledger.md`](multi-currency-money-ledger.md) — double-entry ledger with `Money` value object
+- [`point-ledger-api.md`](point-ledger-api.md) — point/credit system with integer amounts
+- [`expense-tracking-api.md`](expense-tracking-api.md) — expense recording with integer yen


### PR DESCRIPTION
## 概要

DX シナリオテスト 50 件の分析で特定した共通フリクション上位 5 件に対応。

## 変更内容

### 1. `dynamic-filter-query.md` 新規作成（12+ シナリオで言及）
- `$conditions` 配列 + `implode(' AND ', ...)` パターンの決定版
- NULL スキップ・範囲検索・IN 句・allowlist ORDER BY・ページネーションとの統合
- 典型的なミス一覧表付き

### 2. `money-integer-arithmetic.md` 新規作成（10+ シナリオで言及）
- `intdiv` / `ROUND` / `FLOOR` / `CEIL` の使い分けポリシー表
- SQLite 整数除算の落とし穴（`5 / 100 = 0`）
- 税率 bps 保存・割り勘余り分配・減価償却の実装例
- 決定チェックリスト

### 3. `handle-timezones.md` に SQLite 固有セクション追加（8+ シナリオで言及）
- `datetime('now')` が UTC を返すことの明示
- `DATE('now', '+30 days')` フィルタの使い方
- `strftime('%W')` が日曜始まりである問題と PHP での対処
- 動的 interval パターン（`'+' || column || ' days'`）

### 4. `howto/README.md` に逆引き索引追加（全体的な発見性問題）
- 「作りたいもの → howto」の対応表 30 件を冒頭に追加
- フィルタ・金額・状態管理・認証・階層・トランザクションなど主要テーマをカバー

### 5. `add-database-endpoint.md` にトランザクション例追加（6+ シナリオで言及）
- `transactional()` を使った在庫デクリメント + 注文作成の原子的パターン
- DI 登録方法
- 「いつトランザクションを使うか」の判断表

Closes #1270

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)