### PR TITLE
docs(todo): DX 改善実装 TODO を current.md に追加 (#1276)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -58,6 +58,60 @@ bash tools/uncovered-fts.sh
 
 ---
 
+## 🛠️ DX 改善実装 TODO（Trial 01〜26 / 78試験より）
+
+詳細: `docs/todo/dx-trial-improvements.md`
+
+### Phase 1 — コードリリース（v1.5.23）
+
+フレームワーク本体の変更が必要。まとめて v1.5.23 としてリリースする。
+
+| # | 内容 | 効果 | 状態 |
+|---|------|------|------|
+| IMP-07 | `DatabaseConstraintException` を公開 API に昇格 | 全78試験で workaround が発生。最大インパクト | 📋 未着手 |
+| IMP-04 | `DatabaseConfig::sqlite(string $path): self` ファクトリメソッド追加 | テストの DatabaseConfig コンストラクタ8引数を1行に短縮 | 📋 未着手 |
+| IMP-14 | IMP-04 と合わせてテスト用 PDO 直注入パターンを公式化 | `@internal` 回避の匿名クラス不要に | 📋 未着手 |
+| IMP-01 | `Router::param()` を vendor に収録 or 乖離を howto に明記 | シニアが毎回実行時 500 を踏む | 📋 未着手 |
+
+### Phase 2 — howto 追記（最優先・`add-database-endpoint.md` 中心）
+
+コード変更不要。1ファイル集中で大部分を解消できる。
+
+| # | 追記先 | 内容 | 重要度 |
+|---|--------|------|--------|
+| IMP-09 | `add-database-endpoint.md` 冒頭 | **PSR-4 namespace 図解**（`"Ns\\": "src/Ns/"` → ファイル内は `namespace Ns;`）| 🔴 最高 |
+| IMP-19 | `add-database-endpoint.md` ファイル構成図 | **AppFactory は `src/Ns/` 内に置く**（`src/AppFactory.php` は autoload 対象外）| 🔴 最高 |
+| IMP-15 | `add-database-endpoint.md` | `create()` / `createList()` / `createEmpty()` 比較表 | 🟠 高 |
+| IMP-12/20 | `add-database-endpoint.md` HAVING/WHERE 節 | SQLite プレースホルダーと数値比較は **全般的に `CAST(? AS INTEGER)`** が必要 | 🟠 高 |
+| IMP-02 | `add-database-endpoint.md` transactional 節 | コールバック内では `$this->db` でなく引数の `$db` を使う | 🟠 高 |
+| IMP-11 | `add-database-endpoint.md` テストサンプル | 空ボディは `'{}'` or `json_encode(new \stdClass())`（`[]` は JSON 配列になる）| 🟡 中 |
+| IMP-16 | `add-database-endpoint.md` PHPStan 節 | 数値文字列キーを持つ配列は `array<int\|string, T>` で宣言 | 🟡 中 |
+
+### Phase 3 — howto 追記（その他ファイル）
+
+| # | 追記先 | 内容 | 重要度 |
+|---|--------|------|--------|
+| IMP-18 | `use-transactions.md` | `:memory:` SQLite + `transactional()` 非互換の警告 | 🟠 高 |
+| IMP-10 | `use-transactions.md` | コールバック内では `new Repository($txExecutor)` パターン | 🟡 中 |
+| IMP-13 | テスト howto | `withParsedBody()` は `JsonRequestBodyParser` をバイパス → `withBody()` + JSON stream | 🟡 中 |
+| IMP-06 | `add-database-endpoint.md` | `createEmpty(204)` の存在を明記（IMP-15 と同時対応可） | 🟡 中 |
+| IMP-17 | テスト howto / サンプルコード | `use Psr\Http\Server\RequestHandlerInterface` を明示 | 🟡 中 |
+| IMP-03 | `add-database-endpoint.md` | SQLite は `FOR UPDATE` 非対応 → アトミック UPDATE で代替 | 🟢 低 |
+| IMP-05 | `use-transactions.md` | 途中失敗をシミュレートするテスト例 | 🟢 低 |
+| IMP-21 | `add-database-endpoint.md` | PHP regex で `$` をデリミタ直前に使う場合は `\z` か `explode()` | 🟢 低 |
+
+### 着手順序（推奨）
+
+```
+1. v1.5.23 リリース（IMP-07 + IMP-04 + IMP-14 をまとめて）
+2. add-database-endpoint.md に IMP-09/19/15/12/20/02/11/16 を一括追記
+3. use-transactions.md に IMP-18/10 を追記
+4. テスト howto に IMP-13/17 を追記
+5. 残り（IMP-03/05/21）は余裕があれば
+```
+
+---
+
 ## 次のアクション
 
 ```bash


### PR DESCRIPTION
## 概要

Trial 01〜26（78試験）で発見した IMP-01〜21 を3フェーズに整理して `current.md` に追加。

## 追加内容

**Phase 1 — コードリリース（v1.5.23）**
- IMP-07: `DatabaseConstraintException` 公開（最大インパクト）
- IMP-04: `DatabaseConfig::sqlite()` ショートハンド
- IMP-14: PDO 直注入テストヘルパー公式化
- IMP-01: `Router::param()` vendor 収録

**Phase 2 — `add-database-endpoint.md` 集中追記（最優先）**
- IMP-09/19: namespace + AppFactory 配置の図解（最頻出フリクション）
- IMP-15: createList/createEmpty/create 比較表
- IMP-12/20: SQLite CAST パターン一般化
- その他 4 件

**Phase 3 — その他 howto 追記**
- `use-transactions.md`、テスト howto など 8 件

Closes #1276

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)