### PR TITLE
chore(tools): TRIAL_LOG.md 雛形に YAML フロントマター追加 (#1279)

### DIFF
--- a/tools/setup-dx-trial.sh
+++ b/tools/setup-dx-trial.sh
@@ -121,6 +121,51 @@ EOF
   composer dump-autoload -q
   cd - > /dev/null
 
+  # TRIAL_LOG.md — YAML フロントマターつき雛形
+  # 集計時に grep/yq で tests/assertions 等を抽出できる
+  cat > "${DIR}/TRIAL_LOG.md" <<EOF
+---
+trial: ${TRIAL_NUM}
+persona: ${PERSONA}
+app: ""          # アプリ名を記入 (例: "クーポン割引")
+tests: 0         # 完了後に更新
+assertions: 0    # 完了後に更新
+phpstan: pass    # pass | fail
+tx: false        # transactional() を使ったか (true/false)
+enum: false      # backed enum を使ったか (true/false)
+vo: false        # Value Object を使ったか (true/false)
+notes: ""        # 特記事項（ひとことで）
+---
+
+# DX Trial ${TRIAL_NUM} — Persona ${PERSONA}
+
+## セットアップ
+
+\`\`\`bash
+cd ../NENE2-FT/dx-trial-${TRIAL_NUM}-persona-${PERSONA}
+\`\`\`
+
+## 実装ログ
+
+<!-- ここに実装の手順・詰まった点・解決策を記録する -->
+
+## テスト結果
+
+\`\`\`
+# php8.4 vendor/bin/phpunit tests/ --no-coverage --testdox
+\`\`\`
+
+## PHPStan
+
+\`\`\`
+# php8.4 vendor/bin/phpstan analyse --level=8 src tests
+\`\`\`
+
+## 気づき・フリクション
+
+<!-- DX 上の問題点、ハマりポイント、howto への改善提案を記録する -->
+EOF
+
   echo "    ✅ done (vendor: hard-link + composer/ independent)"
 done
 


### PR DESCRIPTION
## 概要

`tools/setup-dx-trial.sh` が生成する `TRIAL_LOG.md` に YAML フロントマターを追加。

## 変更内容

`for PERSONA in A B C` ループ内で、各サンドボックスに `TRIAL_LOG.md` を生成するようにした。

### 生成例（Trial 27 / Persona A）

```yaml
---
trial: 27
persona: A
app:           # アプリ名を記入
tests: 0         # 完了後に更新
assertions: 0    # 完了後に更新
phpstan: pass    # pass | fail
tx: false        # transactional() を使ったか
enum: false      # backed enum を使ったか
vo: false        # Value Object を使ったか
notes:         # 特記事項
---
```

セクションヘッダー（セットアップ / 実装ログ / テスト結果 / PHPStan / 気づき）も含む。

## 動機

Trial 01〜26（78試験）の集計作業で、試験数・アサーション数・機能フラグを各ログから手動収集する必要があった。
フロントマターがあれば `yq` などで自動集計が可能になる。

## 影響範囲

- 既存の 78 試験ログは変更しない
- Trial 27 以降で自然に使われる
- `TRIAL_LOG.md` は git 管理外（各 sandbox は `../NENE2-FT/` に生成）

## Self-review: docs-policy

Closes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)