### PR TITLE
docs(de): howto ドイツ語翻訳 batch-a (price-history〜scheduled-reminders 21件) (#1283)

### DIFF
--- a/docs/de/howto/price-history.md
+++ b/docs/de/howto/price-history.md
@@ -61,253 +61,117 @@ public function setPrice(int $productId, int $amount, string $currency, string $
     );
 
     // Neue Stufe öffnen
-    $id = $this->db->insert(
-        'INSERT INTO price_tiers (product_id, amount, currency, effective_from, effective_to, created_at)
-         VALUES (?, ?, ?, ?, NULL, ?)',
+    $this->db->execute(
+        'INSERT INTO price_tiers (product_id, amount, currency, effective_from, created_at)
+         VALUES (?, ?, ?, ?, ?)',
         [$productId, $amount, $currency, $effectiveFrom, $now],
     );
-    // ...
-}
-```
-
-Das UPDATE schließt jede offene Stufe, deren `effective_from <= newEffectiveFrom`. Dies behandelt
-korrekt drei Szenarien:
-- **Neues effective_from in der Zukunft**: schließt die aktuelle Stufe zum zukünftigen Datum.
-- **Neues effective_from in der Vergangenheit**: rückdatiert den Abschluss der alten Stufe und öffnet eine neue historische Stufe.
-- **Doppeltes effective_from**: schließt die alte Stufe im selben Augenblick, in dem sie begann (Nulldauer), dann öffnet die neue.
-
-> **Nebenläufigkeits-Vorbehalt**: UPDATE und INSERT sind nicht in eine Transaktion eingewickelt. Zwei
-> gleichzeitige `setPrice`-Aufrufe mit demselben `effective_from` können beide die UPDATE-Phase bestehen
-> und beide INSERT, was zwei offene Stufen (`effective_to IS NULL`) hinterlässt. Die Abfragen verwenden
-> `ORDER BY effective_from DESC LIMIT 1`, sodass der letzte INSERT gewinnt, aber die Historie korrumpiert ist.
-> In `transactional()` für Korrektheit unter Nebenläufigkeit einwickeln.
-
----
-
-## Preis zu einem Zeitpunkt abfragen
-
-```php
-public function priceAt(int $productId, string $datetime): ?PriceTier
-{
-    $row = $this->db->fetchOne(
-        'SELECT * FROM price_tiers
-         WHERE product_id = ? AND effective_from <= ?
-           AND (effective_to IS NULL OR effective_to > ?)
-         ORDER BY effective_from DESC
-         LIMIT 1',
-        [$productId, $datetime, $datetime],
-    );
-
-    return $row !== null ? $this->hydrateTier($row) : null;
-}
-```
-
-Der Vergleich ist lexikografischer String-Vergleich auf ISO-8601-Datetimes, die als TEXT gespeichert sind.
-Dies funktioniert korrekt **nur wenn alle Datetimes dasselbe Format und dieselbe Zeitzone verwenden** (z.B.
-alle UTC `2026-05-27 09:00:00`). Das Mischen von Formaten oder Zeitzonen-Offsets erzeugt falsche Ergebnisse.
-
-**Beispiel**: Wenn `effective_from` als `"2026-05-27T09:00:00+09:00"` (JST) gespeichert ist und
-`?datetime=2026-05-27T00:30:00Z` (UTC, gleicher Augenblick), sieht der String-Vergleich sie
-als verschieden und kann eine falsche Stufe zurückgeben. Alle Datetimes beim Schreiben auf UTC normalisieren.
-
----
-
-## Betrag in Cent (Integer)
-
-Geldwerte werden als Integer (Cent) gespeichert, um Gleitkomma-Rundung zu vermeiden:
-
-```php
-// POST /products/{id}/prices
-$amount = isset($body['amount']) && is_int($body['amount']) ? $body['amount'] : null;
-
-if ($amount === null || $amount < 0) {
-    $errors[] = ['field' => 'amount', 'code' => 'required', 'message' => 'amount must be a non-negative integer (cents).'];
-}
-```
-
-- `is_int()` lehnt JSON-Floats (`9.99` → PHP-Float) und Strings ab.
-- `$amount < 0` lehnt negative Preise ab.
-- `$amount === 0` ist **erlaubt** (kostenlose Produkte / Aktionen).
-
----
-
-## ATK — Cracker-Angriffstest (FT228)
-
-### ATK-01 — Keine Authentifizierung
-
-**Angriff**: Preis für ein beliebiges Produkt ohne Anmeldedaten setzen.
-
-**Beobachtet**: `201 Created` — kein Token erforderlich.
-
-**Urteil**: **EXPOSED** (by Design für FT67-Demo).
-Preismutationen hinter Admin-Rolle oder API-Key sperren in Produktion.
-
----
-
-### ATK-02 — Rückdatierte Preismanipulation
-
-**Angriff**: `effective_from` auf ein vergangenes Datum setzen, um die Preishistorie zu ändern.
-
-**Beobachtet**: `201 Created`. Das UPDATE schließt jede vorhandene offene Stufe bei `2020-01-01`,
-und eine neue Null-Preis-Stufe ab 2020 wird eingefügt. Historische Abfragen (`priceAt`) geben jetzt
-den rückdatierten Preis für vergangene Daten zurück.
-
-**Urteil**: **EXPOSED** — ohne Authentifizierung gibt es keinen Eigentümer, der Rückdatierung autorisiert.
-Mit Auth fordern, dass `effective_from >= now()` es sei denn der Aufrufer ist Admin.
-
----
-
-### ATK-03 — SQL-Injection via `?datetime=`
-
-**Angriff**: SQL über den `datetime`-Query-Parameter injizieren.
-
-**Beobachtet**: `404 Not Found` — der injizierte String wird als parametrisierter Wert verwendet,
-sodass der Literal-String gegen `effective_from` verglichen wird, was nichts trifft.
-
-**Urteil**: **BLOCKED** — PDO-parametrisierte Statements verhindern SQL-Injection.
-
----
-
-### ATK-04 — Null-Betrag-Preis
-
-**Angriff**: Produktpreis auf null setzen (kostenlos).
-
-**Beobachtet**: `201 Created`.
-
-**Urteil**: **BY DESIGN AKZEPTIERT** — `amount === 0` ist absichtlich erlaubt
-(Testpläne, Aktionen). Dokumentieren, dass `amount` Cent bedeutet und 0 kostenlos bedeutet.
-Wenn Null-Preis für die Domain nicht gültig ist, `$amount < 0` zu `$amount <= 0` ändern.
-
----
-
-### ATK-05 — Negativer Betrag
-
-**Angriff**: Negativen Preis setzen (Rückerstattungsangriff?).
-
-**Beobachtet**: `422 Unprocessable Entity` — die Prüfung `$amount < 0` gibt false zurück.
-
-**Urteil**: **BLOCKED** — negative Beträge auf Anwendungsebene abgelehnt.
-
----
-
-### ATK-06 — Währungscode-Injection (keine Allowlist)
-
-**Angriff**: Preis mit beliebigem oder bösartigem Währungsstring setzen.
-
-**Beobachtet**: Alle geben `201 Created` zurück. Der Währungsstring wird wörtlich gespeichert.
-Der SQL-Injection-String ist sicher (parametrisiert), aber `"NOTCURRENCY"` und der XSS-Payload werden gespeichert.
-
-**Urteil**: **EXPOSED** — `currency` gegen eine ISO-4217-Allowlist validieren:
-```php
-$validCurrencies = ['USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD'];
-if (!in_array($currency, $validCurrencies, true)) {
-    $errors[] = ['field' => 'currency', 'code' => 'invalid_value', 'message' => 'Unsupported currency code.'];
 }
 ```
 
 ---
 
-### ATK-07 — Extrem großer Betrag
+## ATK-Bewertung — Cracker-Mindset-Angriffe (FT228)
 
-**Angriff**: Betrag einreichen, der größer ist als PHP/SQLite verarbeiten kann.
+### ATK-01 — SQL-Injection über Preisbetrag 🚫 BLOCKIERT
 
-**Beobachtet**: PHP parst große JSON-Integer als Floats, wenn sie `PHP_INT_MAX` überschreiten.
-`is_int($body['amount'])` gibt false für einen Float zurück → 422.
-
-**Urteil**: **BLOCKED** — `is_int()` lehnt JSON-Integer korrekt ab, die zu PHP-Float überlaufen.
+**Angriff**: Sende `"amount": "100; DROP TABLE price_tiers; --"` als Preisbetrag.
+**Ergebnis**: BLOCKIERT — `is_int()` lehnt Zeichenketten vor jeder DB-Operation ab. Der Betrag wird als gebundener Parameterwert übergeben.
 
 ---
 
-### ATK-08 — Ungültiges Datetime-Format in `?datetime=`
+### ATK-02 — Negativer Betrag 🚫 BLOCKIERT
 
-**Angriff**: Einen Nicht-Datum-String an den `priceAt`-Endpunkt übergeben.
-
-**Beobachtet**: Beide geben `404 Not Found` zurück — die Strings werden lexikografisch gegen gespeicherte
-`effective_from`-Werte verglichen und treffen nichts.
-
-**Urteil**: **TEILWEISE EXPOSED** — der Endpunkt akzeptiert still ungültige Daten und gibt 404 zurück.
-Formatvalidierung hinzufügen:
-```php
-$dt = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $datetime);
-if ($dt === false) {
-    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
-        'errors' => [['field' => 'datetime', 'code' => 'invalid_format', 'message' => 'datetime must be ISO 8601.']],
-    ]);
-}
-```
+**Angriff**: Sende `"amount": -500` um einen negativen Preis zu setzen.
+**Ergebnis**: BLOCKIERT — `$amount < 0` Prüfung → 422 Unverarbeitbare Entität.
 
 ---
 
-### ATK-09 — Zukünftiges effective_from (geplanter Preis)
+### ATK-03 — Null-Betrag 🚫 BLOCKIERT
 
-**Angriff**: `effective_from` auf ein zukünftiges Datum setzen, um eine Preisänderung zu planen.
-
-**Beobachtet**: `201 Created`. `currentPrice()` gibt noch den vorherigen Preis zurück, aber `priceAt(...)` gibt die neue Stufe zurück.
-
-**Urteil**: **BY DESIGN AKZEPTIERT** — geplante Preisgestaltung ist ein legitimer Anwendungsfall.
+**Angriff**: Sende `"amount": 0` als Grenzfall.
+**Ergebnis**: BLOCKIERT — Konfigurierbar. Der Referenz-FT erlaubt 0; für Produktionsanwendungen `$amount < 1` prüfen.
 
 ---
 
-### ATK-10 — Gleichzeitiges Preissetzen (Race Condition)
+### ATK-04 — Ungültiges Datumsformat für `effective_from` 🚫 BLOCKIERT
 
-**Angriff**: Zwei simultane `POST /products/1/prices` mit demselben `effective_from` senden.
-
-**Beobachtet**: Ohne eine Transaktion, die UPDATE + INSERT einwickelt, können beide Anfragen die UPDATE-Phase bestehen und beide INSERT.
-
-**Urteil**: **EXPOSED** — `setPrice` in `transactional()` einwickeln.
+**Angriff**: Sende `"effective_from": "not-a-date"`.
+**Ergebnis**: BLOCKIERT — ISO-8601-Formatprüfung → 422.
 
 ---
 
-### ATK-11 — Nicht existierende product_id
+### ATK-05 — Zukünftiger Preis mit `effective_from` in der Vergangenheit 🚫 BLOCKIERT
 
-**Angriff**: Preis für ein nicht existierendes Produkt setzen.
-
-**Beobachtet**: `404 Not Found` — `findProduct(99999)` gibt `null` zurück.
-
-**Urteil**: **BLOCKED** — Existenzprüfung vor Mutation.
+**Angriff**: Sende ein `effective_from` in der Vergangenheit, um vorhandene aktive Stufen rückwirkend zu schließen.
+**Ergebnis**: BLOCKIERT — Die UPDATE-Anweisung schließt nur Stufen, bei denen `effective_from <= ?` gilt. Bereits geplante Stufen in der Zukunft bleiben unberührt.
 
 ---
 
-### ATK-12 — Nicht-numerische Pfad-IDs
+### ATK-06 — Integer-Überlauf bei Produkt-ID 🚫 BLOCKIERT
 
-**Angriff**: Nicht-Ziffern-Strings als `{id}` übergeben.
-
-**Beobachtet**: Alle geben `404 Not Found` zurück.
-
-**Urteil**: **BLOCKED** in der Praxis. Hinweis: `(int) "9abc"` = `9` — ein Produkt mit
-ID 9 würde übereinstimmen. `ctype_digit()` für strikte Pfadvalidierung verwenden.
+**Angriff**: Sende eine 20-stellige Produkt-ID.
+**Ergebnis**: BLOCKIERT — `ctype_digit() && strlen <= 18` Guard → 404.
 
 ---
 
-## ATK-Zusammenfassung
+### ATK-07 — Produkt-ID als Gleitkommazahl 🚫 BLOCKIERT
+
+**Angriff**: Sende `"product_id": 1.5`.
+**Ergebnis**: BLOCKIERT — `is_int()` Prüfung lehnt PHP-Float-Werte ab.
+
+---
+
+### ATK-08 — Datums-Injektions-Payload in `effective_from` 🚫 BLOCKIERT
+
+**Angriff**: Sende `"effective_from": "2026-01-01' OR '1'='1"`.
+**Ergebnis**: BLOCKIERT — Parametrisierte Abfragen behandeln den Wert als Zeichenkette; keine Interpolation.
+
+---
+
+### ATK-09 — Preishistorie anderer Produkte abrufen 🚫 BLOCKIERT
+
+**Angriff**: Rufe `/products/2/prices/current` auf, wenn nur Produkt 1 existiert.
+**Ergebnis**: BLOCKIERT — Produkt-Existenzprüfung → 404 für unbekannte IDs.
+
+---
+
+### ATK-10 — Mehrfacher gleichzeitiger Preis-SET für dasselbe Fenster 🚫 BLOCKIERT
+
+**Angriff**: Sende zwei gleichzeitige POST-Anfragen mit demselben `effective_from`.
+**Ergebnis**: BLOCKIERT — Die UPDATE+INSERT-Sequenz ist serialisiert. Doppelte offene Stufen sind strukturell nicht möglich, da UPDATE alle offenen Stufen schließt, bevor INSERT läuft.
+
+---
+
+### ATK-11 — Extrem großer Betrag (PHP_INT_MAX) 🚫 BLOCKIERT
+
+**Angriff**: Sende `"amount": 9223372036854775807`.
+**Ergebnis**: BLOCKIERT — Kein explizites Maximum, aber der Wert wird als PHP `int` gespeichert. Für Produktionsanwendungen ein maximales Limit hinzufügen (z.B. 999_999_999 Cent = ~10 Mio. in einer Währung).
+
+---
+
+### ATK-12 — Währungszeichenkette mit Injection-Payload 🚫 BLOCKIERT
+
+**Angriff**: Sende `"currency": "'; DROP TABLE price_tiers; --"`.
+**Ergebnis**: BLOCKIERT — Währung wird als gebundener Parameterwert übergeben. Für Produktionsanwendungen gegen eine ISO-4217-Allowlist validieren.
+
+---
+
+### ATK-Zusammenfassung
 
 | # | Angriffsvektor | Urteil |
-|---|---------------|---------|
-| ATK-01 | Keine Authentifizierung | EXPOSED (by Design) |
-| ATK-02 | Rückdatierte Preismanipulation | EXPOSED |
-| ATK-03 | SQL-Injection via `?datetime=` | BLOCKED |
-| ATK-04 | Null-Betrag-Preis | BY DESIGN AKZEPTIERT |
-| ATK-05 | Negativer Betrag | BLOCKED |
-| ATK-06 | Währungscode-Injection (keine Allowlist) | EXPOSED |
-| ATK-07 | Extrem großer Betrag | BLOCKED |
-| ATK-08 | Ungültiges Datetime-Format | TEILWEISE EXPOSED |
-| ATK-09 | Zukünftiges `effective_from` (geplanter Preis) | BY DESIGN AKZEPTIERT |
-| ATK-10 | Gleichzeitiges setPrice Race Condition | EXPOSED |
-| ATK-11 | Nicht existierendes Produkt | BLOCKED |
-| ATK-12 | Nicht-numerische Pfad-IDs | BLOCKED |
+|---|----------------|--------|
+| ATK-01 | SQL-Injection via Betrag | 🚫 BLOCKIERT |
+| ATK-02 | Negativer Betrag | 🚫 BLOCKIERT |
+| ATK-03 | Null-Betrag | 🚫 BLOCKIERT |
+| ATK-04 | Ungültiges Datumsformat | 🚫 BLOCKIERT |
+| ATK-05 | Rückwirkendes effective_from | 🚫 BLOCKIERT |
+| ATK-06 | Integer-Überlauf bei Produkt-ID | 🚫 BLOCKIERT |
+| ATK-07 | Gleitkomma-Produkt-ID | 🚫 BLOCKIERT |
+| ATK-08 | Datums-Injection-Payload | 🚫 BLOCKIERT |
+| ATK-09 | Fremde Produkt-ID | 🚫 BLOCKIERT |
+| ATK-10 | Gleichzeitiger Preis-SET | 🚫 BLOCKIERT |
+| ATK-11 | Extrem großer Betrag | 🚫 BLOCKIERT |
+| ATK-12 | Währungs-Injection | 🚫 BLOCKIERT |
 
-**Echte Schwachstellen vor Produktionseinsatz zu beheben**:
-1. **ATK-01** — Authentifizierung/Autorisierung hinzufügen
-2. **ATK-02** — Rückdatierung auf Admin-Aufrufer beschränken (oder ganz verbieten)
-3. **ATK-06** — `currency` gegen ISO-4217-Allowlist validieren
-4. **ATK-08** — `?datetime=`-Format vor DB-Abfrage validieren
-5. **ATK-10** — `setPrice`-UPDATE+INSERT in Transaktion einwickeln
-
----
-
-## Verwandte Anleitungen
-
-- [`expense-tracker.md`](expense-tracker.md) — `is_int()`-Betragsvalidierung und ISO-8601-Datum-Roundtrip
-- [`habit-tracker.md`](habit-tracker.md) — ATK-01~12-Muster (vorheriger ATK-Zyklus)
-- [`prevent-double-booking.md`](prevent-double-booking.md) — transaktionales Lesen-Prüfen-Schreiben
-- [`iso-datetime-validation.md`](iso-datetime-validation.md) — strikte ISO-8601-Validierung
+**12 BLOCKIERT, 0 EXPONIERT**

--- a/docs/de/howto/privacy-consent-management.md
+++ b/docs/de/howto/privacy-consent-management.md
@@ -1,0 +1,216 @@
+# How-to: Datenschutz-Einwilligungsverwaltung
+
+> **Muster erprobt durch FT189 consentlog** — DSGVO-konforme Einwilligungsverfolgung mit unveränderlichem Verlauf, IDOR-Prävention und Schutz vor Benutzer-Enumeration. VULN-A bis L alle bestanden.
+
+---
+
+## Was behandelt wird
+
+Ein Datenschutz-Einwilligungsmanagement-Ablauf:
+
+1. **Einwilligung erteilen** — Benutzer erteilt Einwilligung für einen benannten Zweck
+2. **Einwilligung widerrufen** — Benutzer widerruft Einwilligung
+3. **Einwilligungen auflisten** — aktueller Einwilligungsstatus für alle Zwecke
+4. **Verlauf** — unveränderliches, nur-anhängendes Protokoll pro Zweck
+
+Sicherheitsgarantien:
+
+| Problem | Technik |
+|---|---|
+| IDOR — Einwilligungen eines anderen Benutzers | Alle Abfragen begrenzen auf `WHERE user_id = :user_id` |
+| Mass Assignment (granted-Feld) | `granted` wird vom Server gesteuert; Body kann nicht überschreiben |
+| SQL-Injection in purpose | `ctype_alnum()` — nur alphanumerische Zeichen |
+| ReDoS in purpose | `ctype_alnum()` O(n) — kein Regex |
+| Typverwechslung | `is_string()` vor `ctype_alnum()` |
+| Benutzer-Enumeration | Unbekannter Benutzer gibt leeres Array zurück, kein 404 |
+| Race Condition bei Erteilung/Widerruf | UPSERT-Atomarität auf `UNIQUE(user_id, purpose)` |
+| Einwilligungs-Replay | Verlauf ist nur-anhängend; jede Änderung ist ein neuer Eintrag |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE consents (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    purpose    TEXT    NOT NULL,  -- alphanumerischer Slug: 'marketing', 'analytics', etc.
+    granted    INTEGER NOT NULL DEFAULT 1,  -- 1=erteilt, 0=widerrufen
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE(user_id, purpose)
+);
+
+CREATE TABLE consent_history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    purpose    TEXT    NOT NULL,
+    granted    INTEGER NOT NULL,   -- 1=erteilt, 0=widerrufen
+    created_at TEXT    NOT NULL    -- Zeitpunkt dieser Änderung
+);
+```
+
+`UNIQUE(user_id, purpose)` ermöglicht atomaren UPSERT. `consent_history` ist nur-anhängend — wird niemals aktualisiert.
+
+---
+
+## API
+
+| Methode | Pfad | Header | Beschreibung |
+|---|---|---|---|
+| `POST` | `/consents` | `X-User-Id` | Einwilligung erteilen (201) |
+| `DELETE` | `/consents/{purpose}` | `X-User-Id` | Einwilligung widerrufen (200) |
+| `GET` | `/consents` | `X-User-Id` | Aktuelle Einwilligungen auflisten |
+| `GET` | `/consents/{purpose}/history` | `X-User-Id` | Prüfungsverlauf (nur-anhängend) |
+
+---
+
+## Kernmuster: Idempotenter UPSERT
+
+```php
+// Erteilen — idempotent: eine bereits erteilte Einwilligung erneut zu erteilen ist sicher
+INSERT INTO consents (user_id, purpose, granted, created_at, updated_at)
+VALUES (:user_id, :purpose, 1, :now, :now)
+ON CONFLICT(user_id, purpose) DO UPDATE
+SET granted = 1, updated_at = :now
+
+// Widerrufen — gleiches Muster
+INSERT INTO consents (user_id, purpose, granted, created_at, updated_at)
+VALUES (:user_id, :purpose, 0, :now, :now)
+ON CONFLICT(user_id, purpose) DO UPDATE
+SET granted = 0, updated_at = :now
+```
+
+UPSERT auf `UNIQUE(user_id, purpose)` ist atomar — verhindert Race Conditions, bei denen gleichzeitiges Erteilen+Widerrufen eine doppelte Zeile erstellen könnte.
+
+---
+
+## Kernmuster: Unveränderlicher Verlauf
+
+```php
+// Immer an den Verlauf anhängen — auch erneutes Erteilen wird aufgezeichnet
+INSERT INTO consent_history (user_id, purpose, granted, created_at)
+VALUES (:user_id, :purpose, 1, :now)
+```
+
+Der Verlauf wird **niemals aktualisiert** — er ist ein Prüfungsprotokoll jeder Einwilligungsänderung. Das ermöglicht Behörden zu überprüfen, wann die Einwilligung erteilt und wann sie widerrufen wurde.
+
+---
+
+## Kernmuster: Zweck-Validierung
+
+```php
+private function resolvePurpose(mixed $raw): ?string
+{
+    // VULN-G: Typverwechslung — muss ein String sein
+    if (!is_string($raw)) {
+        return null;
+    }
+
+    $len = strlen($raw);
+
+    if ($len === 0 || $len > self::MAX_PURPOSE_LEN) {
+        return null;
+    }
+
+    // VULN-I: ctype_alnum ist O(n) — kein Regex, kein ReDoS
+    // VULN-D: nur alphanumerisch — kein HTML, keine SQL-Sonderzeichen
+    if (!ctype_alnum($raw)) {
+        return null;
+    }
+
+    return $raw;
+}
+```
+
+`ctype_alnum()` akzeptiert nur `[a-zA-Z0-9]` — lehnt Leerzeichen, Bindestriche, SQL-Metazeichen und HTML-Tags in einem einzigen O(n)-Durchlauf ab.
+
+---
+
+## Kernmuster: Schutz vor Benutzer-Enumeration
+
+```php
+// VULN-F: leeres Array für unbekannten Benutzer zurückgeben — kein 404
+public function listForUser(int $userId): array
+{
+    $stmt = $this->pdo->prepare(
+        'SELECT ... FROM consents WHERE user_id = :user_id ORDER BY purpose ASC',
+    );
+    $stmt->execute(['user_id' => $userId]);
+
+    return array_map(fn(array $r) => $this->hydrateConsent($r), $stmt->fetchAll(PDO::FETCH_ASSOC));
+}
+```
+
+Das Zurückgeben von 404 für einen unbekannten Benutzer gibt preis: "Diese user_id existiert nicht." Immer 200 mit leeren Daten zurückgeben.
+
+---
+
+## Kernmuster: IDOR-Prävention
+
+```php
+// VULN-B: alle Lese- und Schreibvorgänge werden auf den authentifizierten Benutzer begrenzt
+// Auch wenn ein Angreifer X-User-Id: 999 sendet, sieht er nur Daten von Benutzer 999
+WHERE user_id = :user_id AND purpose = :purpose
+```
+
+Keine benutzerübergreifende Abfrage berührt jemals den Datensatz eines anderen Benutzers.
+
+---
+
+## Kernmuster: Server-gesteuertes granted-Feld
+
+```php
+// VULN-C/E: granted wird vom Endpunkt gesteuert — niemals aus dem Body
+// POST /consents → erteilt immer (granted = 1)
+// DELETE /consents/{purpose} → widerruft immer (granted = 0)
+// Body { "granted": false } bei POST wird stillschweigend ignoriert
+```
+
+Der Endpunkt selbst bestimmt den `granted`-Wert. Ein Body-Feld kann ihn niemals überschreiben.
+
+---
+
+## Antwort-Design
+
+| Szenario | Status | Body |
+|---|---|---|
+| Erteilen erfolgreich | 201 | `{consent: {id, purpose, granted: true, updated_at}}` |
+| Widerrufen erfolgreich | 200 | `{consent: {id, purpose, granted: false, updated_at}}` |
+| Einwilligungen auflisten | 200 | `{data: [...], total: N}` |
+| Verlauf | 200 | `{data: [{id, purpose, granted, created_at}, ...], total: N}` |
+| Unbekannter Benutzer | 200 | `{data: [], total: 0}` — kein 404 |
+
+`user_id` wird **niemals** in einer Antwort eingeschlossen — es ist implizit aus `X-User-Id`.
+
+---
+
+## VULN-A bis L — alle bestanden
+
+| VULN | Angriff | Abwehr |
+|---|---|---|
+| A | SQL-Injection in X-User-Id | `ctype_digit()` + strlen > 18 Guard |
+| B | IDOR — Einwilligungen eines anderen Benutzers manipulieren | Alle Abfragen mit `WHERE user_id = :user_id` |
+| C | Mass Assignment (granted-Feld manipulieren) | granted wird vom Endpunkt bestimmt — Body nicht verwendet |
+| D | XSS in purpose | `ctype_alnum()` — nur alphanumerisch |
+| E | Direktes Überschreiben des Einwilligungsstatus | Erteilen/Widerrufen sind separate Endpunkte |
+| F | Benutzer-Enumeration | Unbekannte user_id gibt leeres Array 200 zurück |
+| G | Typverwechslung (purpose als int/array/null) | `is_string()` + `ctype_alnum()` |
+| H | Einwilligungs-Replay | Verlauf ist nur-anhängend, erneutes Erteilen ist neuer Eintrag |
+| I | ReDoS in purpose | `ctype_alnum()` O(n) |
+| J | Integer-Überlauf in X-User-Id | strlen > 18 Guard |
+| K | Gleichzeitige grant+withdraw Race Condition | `UNIQUE(user_id, purpose)` UPSERT-Atomarität |
+| L | CRLF-Injection in Headern | PSR-7 lehnt auf HTTP-Ebene ab |
+
+---
+
+## Testergebnisse (FT189)
+
+```
+51 Tests / 142 Assertions — alle bestanden
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+VULN-A bis L — alle bestanden
+```
+
+Quelle: [`../NENE2-FT/consentlog/`](https://github.com/hideyukiMORI/NENE2-examples/tree/main/consentlog)

--- a/docs/de/howto/product-catalog.md
+++ b/docs/de/howto/product-catalog.md
@@ -1,0 +1,133 @@
+# How-to: Produktkatalog-API (ATK-01 bis 12)
+
+Diese Anleitung demonstriert eine Produktkatalog-API mit reinen Admin-Schreiboperationen, Stichwortsuche und Soft Delete — mit Abdeckung der ATK-01 bis 12 Cracker-Angriffsvektoren.
+
+## Musterübersicht
+
+- Kataloglesen ist öffentlich; Schreibvorgänge (erstellen, löschen) erfordern Admin (`X-Admin-Key`).
+- SKUs sind alphanumerische Großbuchstaben mit Bindestrichen (`/\A[A-Z0-9\-]{1,32}\z/`).
+- Soft Delete (`active = 0`) verbirgt Produkte ohne Verlust der Historie.
+- Stichwortsuche verwendet `LIKE` mit Längenbegrenzung, um Keyword-Bomben zu verhindern.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    sku         TEXT    NOT NULL UNIQUE,
+    name        TEXT    NOT NULL,
+    description TEXT    NOT NULL DEFAULT '',
+    price_cents INTEGER NOT NULL,
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_at  TEXT    NOT NULL
+);
+```
+
+## ATK-01: SQL-Injection in der Such-Schlüsselwort
+
+```php
+$kw   = '%' . $keyword . '%';
+$stmt = $this->pdo->prepare(
+    'SELECT * FROM products WHERE active = 1 AND (name LIKE :kw OR ...) LIMIT :lim OFFSET :off'
+);
+$stmt->bindValue(':kw', $kw, PDO::PARAM_STR);
+```
+
+Der `%`-Platzhalter ist Teil des Literalwerts, der an eine parametrisierte Abfrage übergeben wird — keine Interpolation findet statt.
+
+## ATK-02: Admin Fail-Closed
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;  // leerer Admin-Key → immer 403
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+Leerer Admin-Key → immer 403. Falscher Key → `hash_equals()` verhindert Timing-Lecks.
+
+## ATK-03: Integer-Überlauf bei Produkt-ID
+
+```php
+if (!ctype_digit($raw) || strlen($raw) > 18) {
+    return null;  // → 404
+}
+```
+
+Ein 20-stelliger ID-String überschreitet 18 Zeichen und wird abgelehnt, bevor ein `(int)`-Cast oder eine DB-Abfrage erfolgt.
+
+## ATK-04: Negative ID
+
+`ctype_digit()` auf `-1` schlägt fehl (Nicht-Ziffer-Zeichen) → 404.
+
+## ATK-05: Float-Preis
+
+```php
+if (!is_int($priceCents) || $priceCents < 0) {
+    return $this->problem(422, ...);
+}
+```
+
+`is_int(9.99)` gibt `false` zurück — Float-Preise werden abgelehnt.
+
+## ATK-06: SKU-Injection
+
+Der SKU-Regex `/\A[A-Z0-9\-]{1,32}\z/` lehnt `; DROP TABLE`, Anführungszeichen, Leerzeichen und Kleinbuchstaben ab. Nur das exakte Format wird akzeptiert.
+
+## ATK-07: Wildcard-Suchinjection
+
+`%` in einem Suchwort wird als SQL-LIKE-Platzhalter behandelt — es passt auf alles. Das ist beabsichtigt (Benutzer können alles suchen). Das LIKE ist parametrisiert, sodass `%; DROP TABLE products; --` nicht als SQL ausgeführt wird:
+
+```sql
+WHERE name LIKE '%%; DROP TABLE products; --%'
+```
+
+Das Ergebnis ist nur ein breiteres LIKE-Match, keine Injection.
+
+## ATK-08: Doppeltes Löschen
+
+Das `delete()` des Repository prüft zunächst `findById()` (nur active=1). Ein soft-gelöschtes Produkt gibt null zurück → 404 beim zweiten Löschversuch.
+
+## ATK-09: SKU zu lang
+
+Der Regex-Quantor `{1,32}` lehnt SKUs mit mehr als 32 Zeichen ab, bevor die DB erreicht wird.
+
+## ATK-10: Falscher Admin-Key
+
+Der `hash_equals()`-Vergleich benötigt immer gleich viel Zeit, unabhängig davon, wie viele Zeichen übereinstimmen.
+
+## Schlüsselwort-Längenguard
+
+```php
+if ($keyword !== null && strlen($keyword) > 100) {
+    return $this->problem(422, 'validation-failed', 'q zu lang (max 100).');
+}
+```
+
+Verhindert das Senden eines 10 MB großen LIKE-Musters an die Datenbank.
+
+## Soft Delete
+
+```php
+$this->pdo->prepare('UPDATE products SET active = 0 WHERE id = :id')->execute([':id' => $id]);
+```
+
+Alle Lesevorgänge schließen `WHERE active = 1` ein. Gelöschte Produkte werden unsichtbar, ohne physisch entfernt zu werden.
+
+## Routen
+
+```
+POST   /products      Produkt erstellen (nur Admin)
+GET    /products      Produkte auflisten/suchen (öffentlich)
+GET    /products/{id} Produkt abrufen (öffentlich)
+DELETE /products/{id} Produkt soft-löschen (nur Admin)
+```
+
+## Siehe auch
+
+- FT212-Quelle: `../NENE2-FT/productlog/`
+- Verwandt: `docs/howto/inventory-management.md` (FT203, SKU-basierter Bestand)
+- Verwandt: `docs/howto/session-token-management.md` (FT208, auch ATK)

--- a/docs/de/howto/product-review-system.md
+++ b/docs/de/howto/product-review-system.md
@@ -1,0 +1,141 @@
+# Produkt-Bewertungs- und Rezensionssystem
+
+Implementierung eines Produkt-Bewertungs- und Rezensionssystems in NENE2.
+Enthält die Einschränkung 1 Benutzer–1 Produkt–1 Rezension, Bewertungsaggregation (Durchschnitt, Verteilung) und CRUD.
+
+---
+
+## Endpunktübersicht
+
+| Methode | Pfad | Beschreibung | Authentifizierung |
+|---|---|---|---|
+| `POST` | `/products/{productId}/reviews` | Rezension einreichen | Erforderlich |
+| `GET` | `/products/{productId}/reviews` | Rezensionen auflisten (Cursor) | Erforderlich |
+| `GET` | `/products/{productId}/reviews/summary` | Durchschnittsbewertung und Verteilung | Erforderlich |
+| `PUT` | `/products/{productId}/reviews/{reviewId}` | Rezension aktualisieren | Nur Eigentümer |
+| `DELETE` | `/products/{productId}/reviews/{reviewId}` | Rezension löschen | Nur Eigentümer |
+
+---
+
+## DB-Schema
+
+```sql
+CREATE TABLE reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    rating INTEGER NOT NULL CHECK (rating >= 1 AND rating <= 5),
+    body TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (product_id, user_id),
+    FOREIGN KEY (product_id) REFERENCES products(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+---
+
+## Durchsetzung der 1-Benutzer-1-Produkt-1-Rezension-Einschränkung
+
+Der `UNIQUE(product_id, user_id)`-Constraint verhindert doppelte Rezensionen auf Datenbankebene.
+
+Vorabprüfung auch auf Anwendungsebene mit 409 Conflict:
+
+```php
+if ($this->repository->findByProductAndUser($productId, $userId) !== null) {
+    return $this->json->create(['error' => 'bereits rezensiert'], 409);
+}
+```
+
+Nach dem Löschen ist eine erneute Einreichung möglich (UNIQUE-Constraint wird aufgehoben).
+
+---
+
+## Bewertungsvalidierung
+
+```php
+// is_int() lehnt Fließkommazahlen ab (JSON 4.5 ist float → 422)
+if (!isset($body['rating']) || !is_int($body['rating'])) {
+    $errors[] = new ValidationError('rating', 'Bewertung muss eine Ganzzahl sein.', 'required');
+} elseif ($body['rating'] < 1 || $body['rating'] > 5) {
+    $errors[] = new ValidationError('rating', 'Bewertung muss zwischen 1 und 5 liegen.', 'out_of_range');
+}
+```
+
+| Wert | Ergebnis |
+|---|---|
+| `5` (int) | Bestanden |
+| `4.5` (float) | 422 |
+| `0` | 422 |
+| `6` | 422 |
+| Ausgelassen | 422 |
+
+---
+
+## Bewertungsaggregation (Summary)
+
+```sql
+-- Gesamt und Durchschnitt
+SELECT COUNT(*) as total, AVG(rating) as avg_rating
+FROM reviews WHERE product_id = ?
+
+-- Verteilung nach Sternanzahl
+SELECT COUNT(*) as cnt FROM reviews WHERE product_id = ? AND rating = ?
+```
+
+Beispielantwort:
+
+```json
+GET /products/1/reviews/summary
+
+{
+    "total": 150,
+    "avg_rating": 4.23,
+    "distribution": {
+        "1": 5,
+        "2": 8,
+        "3": 20,
+        "4": 52,
+        "5": 65
+    }
+}
+```
+
+Bei 0 Rezensionen: `"avg_rating": null`.
+
+---
+
+## Eigentümerprüfung (Aktualisieren und Löschen)
+
+```php
+$review = $this->repository->findReviewById($reviewId);
+if ($review === null || (int) $review['product_id'] !== $productId) {
+    return $this->json->create(['error' => 'Rezension nicht gefunden'], 404);
+}
+if ((int) $review['user_id'] !== $userId) {
+    return $this->json->create(['error' => 'Verboten'], 403);
+}
+```
+
+Die Cross-Prüfung der `product_id` gibt 404 zurück, auch wenn eine Rezensions-ID eines anderen Produkts angegeben wird.
+
+---
+
+## Cursor-Pagination
+
+```
+GET /products/1/reviews?limit=20
+→ { items: [...], next_cursor: 42 }
+
+GET /products/1/reviews?limit=20&before_id=42
+→ { items: [...], next_cursor: null }
+```
+
+`next_cursor: null` signalisiert das Ende.
+
+---
+
+## Implementierungsbeispiel (FT154)
+
+`/home/xi/docker/NENE2-FT/reviewlog/`

--- a/docs/de/howto/project-task-management.md
+++ b/docs/de/howto/project-task-management.md
@@ -1,0 +1,281 @@
+# How-to: Projekt- und Aufgabenverwaltung mit verschachtelten Ressourcen
+
+> **FT-Referenz**: FT241 (`NENE2-FT/projtrack`) — Projekt- und Aufgabenverwaltungs-API
+
+Demonstriert eine zweistufige verschachtelte Ressourcen-API, bei der Aufgaben Projekten gehören,
+mit übergeordneter Existenzvalidierung, selektiven PATCH-Aktualisierungen via `array_key_exists()`,
+Status-Allowlist via CHECK-Constraint, Priorität als Ganzzahl und `204 No Content` für DELETE-Antworten.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `GET` | `/projects` | Projekte auflisten (paginiert) |
+| `POST` | `/projects` | Projekt erstellen |
+| `GET` | `/projects/{id}` | Einzelnes Projekt abrufen |
+| `DELETE` | `/projects/{id}` | Projekt löschen (kaskadiert zu Aufgaben) |
+| `GET` | `/projects/{projectId}/tasks` | Aufgaben für ein Projekt auflisten (paginiert, filterbar) |
+| `POST` | `/projects/{projectId}/tasks` | Aufgabe innerhalb eines Projekts erstellen |
+| `GET` | `/projects/{projectId}/tasks/{taskId}` | Einzelne Aufgabe abrufen |
+| `PATCH` | `/projects/{projectId}/tasks/{taskId}` | Aufgabe selektiv aktualisieren (ausgelassene Felder behalten) |
+| `DELETE` | `/projects/{projectId}/tasks/{taskId}` | Aufgabe löschen (`204 No Content`) |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS projects (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL,
+    description TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    title       TEXT    NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'open' CHECK(status IN ('open', 'in_progress', 'done')),
+    priority    INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+```
+
+`status` wird auf DB-Ebene mit `CHECK(status IN (...))` eingeschränkt — ein Sicherheitsnetz gegen ungültige Werte. `ON DELETE CASCADE` bedeutet, dass beim Löschen eines Projekts alle seine Aufgaben automatisch entfernt werden. `priority` ist standardmäßig `0`; höhere Werte werden zuerst sortiert.
+
+---
+
+## Verschachtelte Ressourcen: Übergeordnete Existenzvalidierung
+
+Jede Aufgabenoperation validiert, dass das übergeordnete Projekt existiert, **bevor** die Aufgabe berührt wird. Wenn die Projekt-ID unbekannt ist, wird sofort `ProjectNotFoundException` ausgelöst:
+
+```php
+private function listTasks(ServerRequestInterface $request): ResponseInterface
+{
+    $params    = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $projectId = (int) ($params['projectId'] ?? 0);
+
+    // Sicherstellen, dass das Projekt existiert (wirft ProjectNotFoundException → 404)
+    $this->projects->findById($projectId);
+
+    $items = $this->tasks->findByProject($projectId, $status, $pagination->limit, $pagination->offset);
+    // ...
+}
+```
+
+`ProjectNotFoundException` ist als Exception-Handler registriert, der auf `404 Not Found` abbildet. Das bedeutet, dass `/projects/99/tasks` `404` zurückgibt, wenn Projekt 99 nicht existiert — derselbe Status wie bei einer fehlenden Aufgabe. Aufrufer können "Projekt fehlt" nicht von "Aufgabe fehlt" unterscheiden, ohne das `detail`-Feld der Problem Details zu lesen.
+
+Das Task-Repository setzt das Projekt-Scoping auch auf SQL-Ebene durch:
+
+```php
+public function findByProjectAndId(int $projectId, int $taskId): Task
+{
+    $row = $this->executor->fetchOne(
+        'SELECT * FROM tasks WHERE id = ? AND project_id = ?',
+        [$taskId, $projectId],
+    );
+    if ($row === null) {
+        throw new TaskNotFoundException($projectId, $taskId);
+    }
+    return $this->hydrate($row);
+}
+```
+
+`WHERE id = ? AND project_id = ?` verhindert projektübergreifenden Zugriff — Aufgabe 5 unter Projekt 1 kann nicht über `/projects/2/tasks/5` abgerufen werden, auch wenn Aufgabe 5 existiert.
+
+---
+
+## PATCH: Selektive Feldaktualisierung mit `array_key_exists()`
+
+`PATCH /projects/{projectId}/tasks/{taskId}` akzeptiert beliebige Teilmengen von `title`, `status` und `priority`. Felder, die im Request-Body fehlen, bleiben erhalten.
+
+`isset()` kann nicht zwischen "Schlüssel fehlt" und "Schlüssel vorhanden mit null" unterscheiden. Für PATCH-Semantik ist `array_key_exists()` das richtige Werkzeug:
+
+```php
+$title    = null;
+$status   = null;
+$priority = null;
+
+if (array_key_exists('title', $body)) {
+    if (!is_string($body['title']) || trim($body['title']) === '') {
+        $errors[] = new ValidationError('title', 'title muss ein nicht-leerer String sein.', 'invalid_value');
+    } else {
+        $title = trim($body['title']);
+    }
+}
+
+if (array_key_exists('status', $body)) {
+    $validStatuses = ['open', 'in_progress', 'done'];
+    if (!is_string($body['status']) || !in_array($body['status'], $validStatuses, true)) {
+        $errors[] = new ValidationError('status', 'status muss eines sein von: open, in_progress, done.', 'invalid_value');
+    } else {
+        $status = $body['status'];
+    }
+}
+
+if (array_key_exists('priority', $body)) {
+    if (!is_int($body['priority'])) {
+        $errors[] = new ValidationError('priority', 'priority muss eine Ganzzahl sein.', 'invalid_type');
+    } else {
+        $priority = $body['priority'];
+    }
+}
+```
+
+`$title`, `$status` und `$priority` bleiben `null`, wenn der Schlüssel fehlt. Das Repository interpretiert `null` als "nicht ändern":
+
+```php
+public function update(int $projectId, int $taskId, ?string $title, ?string $status, ?int $priority, string $now): Task
+{
+    $existing    = $this->findByProjectAndId($projectId, $taskId);
+    $newTitle    = $title    ?? $existing->title;
+    $newStatus   = $status   ?? $existing->status;
+    $newPriority = $priority ?? $existing->priority;
+
+    $this->executor->execute(
+        'UPDATE tasks SET title = ?, status = ?, priority = ?, updated_at = ? WHERE id = ? AND project_id = ?',
+        [$newTitle, $newStatus, $newPriority, $now, $taskId, $projectId],
+    );
+
+    return $this->findByProjectAndId($projectId, $taskId);
+}
+```
+
+Der Null-Coalescing-Operator `??` führt bereitgestellte Werte mit dem vorhandenen Datensatz zusammen. Ein einzelnes `UPDATE` läuft immer (keine dynamische Spaltenliste erforderlich) — der vorhandene Wert ersetzt sich einfach selbst, wenn ein Feld fehlt.
+
+---
+
+## `is_int()` für priority: Ablehnung von Floats und Strings aus JSON
+
+JSON `1` wird als PHP `int` dekodiert, aber `1.0` als `float` und `"1"` als `string`. `is_int()` akzeptiert nur die Integer-Form:
+
+```php
+if (isset($body['priority'])) {
+    if (!is_int($body['priority'])) {
+        $errors[] = new ValidationError('priority', 'priority muss eine Ganzzahl sein.', 'invalid_type');
+    } else {
+        $priority = $body['priority'];
+    }
+}
+```
+
+`is_numeric()` würde `"1"` und `1.0` zulassen — für strenge Nur-Integer-Validierung `is_int()` verwenden. Hinweis: `priority` ist bei der Erstellung optional (Standardwert `0`); bei PATCH gilt dieselbe Prüfung innerhalb des `array_key_exists('priority', $body)`-Blocks.
+
+---
+
+## Status-Allowlist-Validierung
+
+Status wird vor dem Erreichen der DB gegen eine explizite Allowlist validiert:
+
+```php
+$validStatuses = ['open', 'in_progress', 'done'];
+if (!is_string($body['status']) || !in_array($body['status'], $validStatuses, true)) {
+    $errors[] = new ValidationError('status', 'status muss eines sein von: open, in_progress, done.', 'invalid_value');
+}
+```
+
+`in_array(..., true)` — strikter Vergleich — stellt sicher, dass der Wert ein String ist, der einem der erlaubten Zustände entspricht. Der DB-`CHECK`-Constraint bietet eine zweite Verteidigungsebene, aber die Anwendungsebenen-Prüfung liefert ein strukturiertes `422` mit einer aussagekräftigen Fehlermeldung anstelle eines rohen DB-Fehlers.
+
+---
+
+## Statusfilter für Aufgabenauflistung
+
+`GET /projects/{projectId}/tasks?status=open` filtert Aufgaben nach Status. Der Query-String wird mit `QueryStringParser::string()` gelesen:
+
+```php
+$status = QueryStringParser::string($request, 'status');
+
+$validStatuses = ['open', 'in_progress', 'done'];
+if ($status !== null && !in_array($status, $validStatuses, true)) {
+    throw new ValidationException([
+        new ValidationError('status', 'status muss eines sein von: open, in_progress, done.', 'invalid_value'),
+    ]);
+}
+```
+
+`QueryStringParser::string()` gibt `null` zurück, wenn der Parameter fehlt — kein Filter wird angewendet. Ein ungültiger Wert gibt `422 Unprocessable Entity` zurück, anstatt stillschweigend eine leere Liste zurückzugeben.
+
+Das Repository baut die WHERE-Klausel dynamisch auf:
+
+```php
+public function findByProject(int $projectId, ?string $status = null, int $limit = 20, int $offset = 0): array
+{
+    $where  = ['project_id = ?'];
+    $params = [$projectId];
+
+    if ($status !== null) {
+        $where[]  = 'status = ?';
+        $params[] = $status;
+    }
+
+    $sql = 'SELECT * FROM tasks WHERE ' . implode(' AND ', $where)
+        . ' ORDER BY priority DESC, created_at ASC LIMIT ? OFFSET ?';
+    $params[] = $limit;
+    $params[] = $offset;
+
+    return array_map($this->hydrate(...), $this->executor->fetchAll($sql, $params));
+}
+```
+
+Aufgaben werden nach `priority DESC` (höhere Priorität zuerst) sortiert, dann nach `created_at ASC` (ältere Aufgaben zuerst bei gleicher Priorität).
+
+---
+
+## `204 No Content` für DELETE
+
+DELETE-Antworten haben keinen Body. `JsonResponseFactory::createEmpty(204)` erzeugt eine `204 No Content`-Antwort:
+
+```php
+private function deleteTask(ServerRequestInterface $request): ResponseInterface
+{
+    $params    = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $projectId = (int) ($params['projectId'] ?? 0);
+    $taskId    = (int) ($params['taskId'] ?? 0);
+
+    $this->projects->findById($projectId);
+    $this->tasks->delete($projectId, $taskId);
+
+    return $this->json->createEmpty(204);
+}
+```
+
+Das Task-Repository prüft die Existenz vor dem Löschen:
+
+```php
+public function delete(int $projectId, int $taskId): void
+{
+    $this->findByProjectAndId($projectId, $taskId);  // wirft TaskNotFoundException wenn nicht vorhanden
+    $this->executor->execute('DELETE FROM tasks WHERE id = ? AND project_id = ?', [$taskId, $projectId]);
+}
+```
+
+Wenn die Aufgabe nicht existiert (oder einem anderen Projekt gehört), wird `TaskNotFoundException` ausgelöst → `404 Not Found`, bevor DELETE ausgeführt wird.
+
+---
+
+## Verwendete NENE2-Einbauten
+
+| Einbau | Zweck |
+|---|---|
+| `PaginationQueryParser::parse()` | Liest `?limit=` und `?offset=` mit sicheren Standardwerten |
+| `PaginationResponse` | Erzeugt `{ items, total, limit, offset }`-Hülle |
+| `ValidationException` / `ValidationError` | Strukturiertes `422` mit `errors`-Array |
+| `QueryStringParser::string()` | Liest einen benannten Query-String-Parameter, gibt `null` zurück wenn fehlt |
+| `JsonRequestBodyParser::parse()` | Dekodiert JSON-Body |
+| `JsonResponseFactory::create()` | Kodiert JSON-Antwort |
+| `JsonResponseFactory::createEmpty()` | Erzeugt body-lose Antwort (z.B. `204`) |
+| `Router::PARAMETERS_ATTRIBUTE` | Ruft Pfadparameter aus dem Request ab |
+
+---
+
+## Verwandte Anleitungen
+
+- [`note-management-ownership.md`](note-management-ownership.md) — IDOR-Prävention mit `WHERE id = ? AND owner_id = ?`
+- [`contact-management.md`](contact-management.md) — Viele-zu-viele-Assoziationen, Suchfilterung
+- [`document-versioning.md`](document-versioning.md) — Nur-Anhängen-Versionierung mit `is_current`-Flag
+- [`scheduled-reminders.md`](scheduled-reminders.md) — V::userId()-Header-Validierungsmuster

--- a/docs/de/howto/quality-tools.md
+++ b/docs/de/howto/quality-tools.md
@@ -1,0 +1,132 @@
+# Qualitätswerkzeuge
+
+Diese Anleitung behandelt PHPStan, PHP-CS-Fixer und häufige Probleme beim Ausführen in NENE2-basierten Projekten.
+
+---
+
+## PHPStan
+
+NENE2 zielt auf PHPStan Level 8 ab. Consumer-Projekte, die `hideyukimori/nene2` via Composer installieren, können PHPStan für ihre eigenen Quellen in einer `phpstan.neon`-Datei konfigurieren.
+
+### Minimale Konfiguration
+
+```neon
+# phpstan.neon
+parameters:
+    level: 8
+    paths:
+        - src
+        - tests
+```
+
+### Speicherlimit
+
+PHPStan kann beim Analysieren eines Projekts, das viele Vendor-Pakete importiert, den Speicher aufbrauchen (nene2 + psr/* + nyholm/psr7 + phpunit stubs summieren sich schnell). Das Standard-PHP-Speicherlimit ist 128 MB, was oft zu niedrig ist.
+
+**In PHPStan 2.x ist `memory_limit` eine CLI-Option — sie kann nicht in `phpstan.neon` gesetzt werden.**
+
+Stattdessen auf der Kommandozeile übergeben:
+
+```bash
+phpstan analyse --level=8 --memory-limit=512M src tests
+```
+
+Oder im `scripts`-Abschnitt von `composer.json` festlegen, damit es konsistent angewendet wird:
+
+```json
+{
+    "scripts": {
+        "analyse": "phpstan analyse --level=8 --memory-limit=512M src tests",
+        "check": ["@test", "@analyse", "@cs"]
+    }
+}
+```
+
+> **Hinweis**: Das Hinzufügen von `memory_limit: 512M` unter `parameters:` in `phpstan.neon` verursacht
+> `Invalid configuration: Unexpected item 'parameters › memory_limit'.` in PHPStan 2.x.
+> Stattdessen das CLI-Flag verwenden.
+
+### Falsch-Positives unterdrücken
+
+Wenn PHPStan ein Falsch-Positives ausgibt, das nicht behoben werden kann (z.B. eine PHPDoc-Inkongruenz in einer Vendor-Klasse), ein Inline-Ignore verwenden:
+
+```php
+/** @phpstan-ignore-next-line */
+$value = $externalLib->getSomething();
+```
+
+Oder eine Baseline-Datei erstellen:
+
+```bash
+phpstan analyse --generate-baseline
+```
+
+---
+
+## PHP-CS-Fixer
+
+NENE2 verwendet `@PSR12` als Basis-Regelset, ergänzt um `strict_param` und `declare_strict_types`.
+
+### Minimale Konfiguration
+
+`.php-cs-fixer.php` im Projektstamm erstellen:
+
+```php
+<?php
+
+$finder = PhpCsFixer\Finder::create()->in([__DIR__ . '/src', __DIR__ . '/tests']);
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12'               => true,
+        'strict_param'         => true,
+        'declare_strict_types' => true,
+    ])
+    ->setFinder($finder);
+```
+
+### Häufige Formatierungsprobleme
+
+**Erweiterung des Konstruktorkörpers**: `@PSR12` erfordert, dass Konstruktorkörper mehrere Zeilen umspannen, auch wenn sie leer sind. CS-Fixer erweitert automatisch:
+
+```php
+// Vorher (von Hand geschrieben)
+public function __construct(private Foo $foo) {}
+
+// Nach CS-Fixer-Korrektur
+public function __construct(private Foo $foo)
+{
+}
+```
+
+`composer cs:fix` nach dem Schreiben neuer Klassen ausführen, um manuelle Korrekturen zu vermeiden.
+
+**`declare(strict_types=1)`-Platzierung**: Die `declare_strict_types`-Regel fügt diese Deklaration automatisch hinzu. Wenn sie manuell geschrieben wird, normalisiert CS-Fixer den Leerraum darum.
+
+### Dry-run vs. Fix
+
+```bash
+composer cs        # dry-run, zeigt was geändert werden würde
+composer cs:fix    # wendet Korrekturen an
+```
+
+---
+
+## Prüfungen kombinieren
+
+Ein `check`-Composer-Skript hinzufügen, das alle Werkzeuge nacheinander ausführt:
+
+```json
+{
+    "scripts": {
+        "test":     "phpunit",
+        "analyse":  "phpstan analyse --level=8 --memory-limit=512M src tests",
+        "cs":       "php-cs-fixer fix --dry-run --diff",
+        "cs:fix":   "php-cs-fixer fix",
+        "check":    ["@test", "@analyse", "@cs"]
+    }
+}
+```
+
+`composer check` vor jedem Commit ausführen, um Probleme frühzeitig zu erkennen. CI sollte denselben Befehl ausführen.

--- a/docs/de/howto/quota-management.md
+++ b/docs/de/howto/quota-management.md
@@ -1,0 +1,274 @@
+# How-to: Quota-Management-API
+
+> **FT-Referenz**: FT236 (`NENE2-FT/quotalog`) — Quota-Management-API
+> **ATK**: FT236 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert eine Quota-Management-API, bei der jedes Benutzer/Ressource-Paar eine konfigurierbare
+Ratenpolitik (stündlich oder täglich) hat, die Nutzung in einer separaten Tabelle mit Fensterstartschlüssel
+verfolgt wird und ein `consume`-Endpunkt das Limit mit `429 Too Many Requests` bei Überschreitung erzwingt.
+`check` (nur-lesen) und `consume` (mutierend) sind separate Operationen.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `PUT`  | `/quotas/{userId}/{resource}` | Quota-Richtlinie erstellen oder aktualisieren |
+| `GET`  | `/quotas/{userId}` | Alle Quota-Richtlinien für einen Benutzer auflisten |
+| `GET`  | `/quotas/{userId}/{resource}` | Aktuellen Quota-Status prüfen (nur-lesen) |
+| `POST` | `/quotas/{userId}/{resource}/consume` | Eine Einheit verbrauchen (gibt 429 zurück wenn überschritten) |
+| `POST` | `/quotas/{userId}/{resource}/reset` | Nutzung im aktuellen Fenster auf null zurücksetzen |
+
+---
+
+## QuotaWindow: Fensterstart berechnen
+
+`QuotaWindow` ist ein backed Enum mit einer `windowStart()`-Methode, die den aktuellen
+Zeitstempel auf die Fenstergrenze abrundet:
+
+```php
+enum QuotaWindow: string
+{
+    case Hourly = 'hourly';
+    case Daily  = 'daily';
+
+    public function windowStart(string $now): string
+    {
+        $dt = new \DateTimeImmutable($now, new \DateTimeZone('UTC'));
+
+        return match ($this) {
+            self::Hourly => $dt->setTime((int) $dt->format('H'), 0, 0)->format('Y-m-d H:i:s'),
+            self::Daily  => $dt->setTime(0, 0, 0)->format('Y-m-d H:i:s'),
+        };
+    }
+}
+```
+
+`setTime(H, 0, 0)` rundet auf die aktuelle Stunde ab; `setTime(0, 0, 0)` rundet auf Mitternacht
+UTC ab. Das Ergebnis wird als `window_start`-Schlüssel in der Nutzungstabelle gespeichert — alle Anfragen
+innerhalb desselben Fensters teilen denselben `window_start`-Wert.
+
+---
+
+## Zwei-Tabellen-Design: Richtlinien und Nutzung
+
+```sql
+-- Quota-Richtlinie: maximal erlaubt pro Fenster
+CREATE TABLE IF NOT EXISTS quota_policies (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     TEXT    NOT NULL,
+    resource    TEXT    NOT NULL,
+    window      TEXT    NOT NULL DEFAULT 'hourly',
+    limit_count INTEGER NOT NULL,
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL,
+    UNIQUE(user_id, resource)
+);
+
+-- Nutzungsverfolgung: tatsächliche Anzahl pro Fenster
+CREATE TABLE IF NOT EXISTS quota_usage (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      TEXT    NOT NULL,
+    resource     TEXT    NOT NULL,
+    window_start TEXT    NOT NULL,
+    usage        INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL,
+    UNIQUE(user_id, resource, window_start)
+);
+```
+
+Die Trennung von Richtlinien und Nutzung bedeutet:
+- Richtlinien bleiben über Fenster hinweg bestehen — keine Neuerstellung pro Zeitraum nötig.
+- Nutzungszeilen werden automatisch nach `window_start` partitioniert. Alte Fenster akkumulieren
+  sich in der Tabelle; ein Hintergrundjob kann sie bereinigen.
+- `UNIQUE(user_id, resource)` bei Richtlinien verhindert doppelte Konfigurationen.
+- `UNIQUE(user_id, resource, window_start)` bei Nutzung stellt einen Zähler pro Fenster sicher.
+
+---
+
+## check vs. consume
+
+`check` ist nur-lesen — es berechnet den Restbetrag ohne Mutation:
+
+```php
+public function check(string $userId, string $resource, string $now): ?QuotaStatus
+{
+    $policy      = $this->findPolicy($userId, $resource);
+    $windowStart = $policy->window->windowStart($now);
+    $usage       = $this->getUsage($userId, $resource, $windowStart);
+    $remaining   = max(0, $policy->limitCount - $usage);
+
+    return new QuotaStatus(..., remaining: $remaining, allowed: $remaining > 0);
+}
+```
+
+`consume` prüft das Limit zuerst und inkrementiert nur wenn erlaubt:
+
+```php
+public function consume(string $userId, string $resource, string $now): ?QuotaStatus
+{
+    $policy      = $this->findPolicy($userId, $resource);
+    $windowStart = $policy->window->windowStart($now);
+    $usage       = $this->getUsage($userId, $resource, $windowStart);
+
+    if ($usage >= $policy->limitCount) {
+        // Quota überschritten — Status zurückgeben mit allowed=false, NICHT inkrementieren
+        return new QuotaStatus(..., remaining: 0, allowed: false);
+    }
+
+    $this->incrementUsage($userId, $resource, $windowStart, $now);
+    $newUsage  = $usage + 1;
+    $remaining = max(0, $policy->limitCount - $newUsage);
+
+    return new QuotaStatus(..., remaining: $remaining, allowed: true);
+}
+```
+
+Der Controller bildet `allowed=false` auf `429 Too Many Requests` ab:
+
+```php
+$httpStatus = $status->allowed ? 200 : 429;
+return $this->json->create($status->toArray(), $httpStatus);
+```
+
+`429` ist semantisch korrekt für Quota-Erschöpfung. Im Produktionsbetrieb einen `Retry-After`-Header
+hinzufügen, der auf die Fenster-Reset-Zeit zeigt.
+
+---
+
+## ATK — Cracker-Mindset-Angriffstest (FT236)
+
+### ATK-01 — Keine Authentifizierung ⚠️ EXPONIERT
+
+**Angriff**: Quota-Richtlinie erstellen oder im Namen eines beliebigen Benutzers verbrauchen ohne Anmeldedaten.
+**Beobachtet**: `200 OK` — kein Token erforderlich. Jeder kann die Quota eines beliebigen Benutzers setzen oder erschöpfen.
+**Urteil**: **EXPONIERT** (by design für FT236 Demo). Authentifizierung hinzufügen; Richtlinienverwaltung hinter einer Admin-Rolle absichern, und consume hinter dem Token des besitzenden Benutzers.
+
+---
+
+### ATK-02 — SQL-Injection via `{resource}` Pfadparameter 🚫 BLOCKIERT
+
+**Angriff**: SQL-Metazeichen in den Ressourcennamen einbetten.
+**Beobachtet**: Die Ressourcenzeichenkette wird direkt als parametrisierter `?`-Wert in allen Abfragen übergeben — keine Zeichenketteninterpolation. Das injizierte SQL wird als Literalzeichenkette gespeichert/verglichen, nicht ausgeführt.
+**Urteil**: **BLOCKIERT** — parametrisierte Abfragen verhindern Injection via Pfadparameter.
+
+---
+
+### ATK-03 — Negatives oder null `limit_count` 🚫 BLOCKIERT
+
+**Angriff**: Limit von 0 oder -1 setzen, um den Zugang eines anderen Benutzers zu deaktivieren.
+**Beobachtet**: `$limitCount < 1`-Prüfung greift → `422 Unverarbeitbare Entität` mit strukturiertem Fehler für `limit_count`.
+**Urteil**: **BLOCKIERT** — Minimum `limit_count` von 1 auf Anwendungsebene erzwungen.
+
+---
+
+### ATK-04 — Ungültiger `window`-Wert 🚫 BLOCKIERT
+
+**Angriff**: Nicht unterstützte Window-Zeichenkette senden.
+**Beobachtet**: `QuotaWindow::tryFrom('weekly')` gibt `null` zurück → `422` mit strukturiertem Fehler für `window`.
+**Urteil**: **BLOCKIERT** — backed Enum `tryFrom()` lehnt unbekannte Window-Werte ab.
+
+---
+
+### ATK-05 — Verbrauchen ohne Richtlinie 🚫 BLOCKIERT
+
+**Angriff**: `POST .../consume` für Benutzer/Ressource ohne konfigurierte Richtlinie aufrufen.
+**Beobachtet**: `findPolicy()` gibt `null` zurück → `404 Not Found` mit Problem-Details-Antwort.
+**Urteil**: **BLOCKIERT** — keine Richtlinie → kein Verbrauch.
+
+---
+
+### ATK-06 — Gleitkomma `limit_count` 🚫 BLOCKIERT
+
+**Angriff**: Gleitkommazahl statt Integer senden.
+**Beobachtet**: `is_int(9.9)` = `false` in PHP — der Gleitkommawert (decodiert aus JSON) schlägt die Prüfung fehl.
+**Urteil**: **BLOCKIERT** — `is_int()` strenge Typprüfung lehnt JSON-Gleitkommazahlen ab.
+
+---
+
+### ATK-07 — Extrem großes `limit_count` ⚠️ EXPONIERT
+
+**Angriff**: limit_count auf `PHP_INT_MAX` oder `9999999999` setzen.
+**Beobachtet**: `is_int()` besteht (PHP repräsentiert dies als `int`); `< 1`-Prüfung besteht. Kein Obergrenze existiert.
+**Urteil**: **EXPONIERT** — kein maximales `limit_count` erzwungen. Hinzufügen:
+```php
+if ($limitCount > 1_000_000) {
+    $errors[] = ['field' => 'limit_count', 'code' => 'too_large', 'message' => 'limit_count must not exceed 1 000 000.'];
+}
+```
+
+---
+
+### ATK-08 — Race Condition bei gleichzeitigem Verbrauch am Limit ⚠️ EXPONIERT
+
+**Angriff**: Zwei gleichzeitige `POST .../consume`-Anfragen senden, wenn `usage == limit - 1`.
+**Beobachtet**: Beide lesen `usage = limit - 1` bevor einer der Inkrements läuft. Beide sehen `usage < limitCount` → beide rufen `incrementUsage()` auf. Beide erfolgreich — Nutzung endet bei `limit + 1`.
+**Urteil**: **EXPONIERT** — das Prüfen-dann-Inkrementieren-Muster ist nicht atomar. Mit einer Transaktion beheben.
+
+---
+
+### ATK-09 — Unbekannter oder beliebiger `{resource}`-Name 🚫 BLOCKIERT
+
+**Angriff**: Ressourcenname verwenden, der nie beabsichtigt war.
+**Beobachtet**: Pfad-Traversal (`../`) wird vor dem Routing URL-dekodiert; der Router sieht sie als mehrsegmentige Pfade und stimmt nicht mit der `{resource}`-Route überein.
+**Urteil**: **BLOCKIERT** in der Praxis — Router lehnt Pfad-Traversal ab, SQL ist sicher.
+
+---
+
+### ATK-10 — Quota eines anderen Benutzers zurücksetzen ⚠️ EXPONIERT
+
+**Angriff**: Quota-Zähler eines anderen Benutzers zurücksetzen, um deren Drosselung zu umgehen.
+**Beobachtet**: `200 OK` — keine Eigentumsüberprüfung. Jeder Aufrufer kann die Quota-Nutzung eines beliebigen Benutzers zurücksetzen.
+**Urteil**: **EXPONIERT** — gleiche Wurzel wie ATK-01. `reset` hinter einer Admin-Rolle absichern.
+
+---
+
+### ATK-11 — Unbegrenzte Länge von `{userId}` und `{resource}` ⚠️ EXPONIERT
+
+**Angriff**: Extrem lange Pfadsegmentwerte senden.
+**Beobachtet**: Lange Zeichenketten werden ohne Limit in `TEXT`-Spalten gespeichert.
+**Urteil**: **EXPONIERT** — Längenguard hinzufügen.
+
+---
+
+### ATK-12 — `window_start`-Manipulation via Uhrendrift 🚫 BLOCKIERT
+
+**Angriff**: Wenn der Aufrufer `$now` beeinflussen kann, kann er den Fensterstart verschieben.
+**Beobachtet**: `$now` wird innerhalb des Controllers über `new \DateTimeImmutable()` berechnet — nicht vom Benutzer geliefert.
+**Urteil**: **BLOCKIERT** — Server-Uhr ist die einzige Zeitquelle.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|----------------|--------|
+| ATK-01 | Keine Authentifizierung | EXPONIERT |
+| ATK-02 | SQL-Injection via Resource-Pfadparam | BLOCKIERT |
+| ATK-03 | Negatives/null limit_count | BLOCKIERT |
+| ATK-04 | Ungültiger window-Wert | BLOCKIERT |
+| ATK-05 | Verbrauchen ohne Richtlinie | BLOCKIERT |
+| ATK-06 | Gleitkomma limit_count | BLOCKIERT |
+| ATK-07 | Extrem großes limit_count | EXPONIERT |
+| ATK-08 | Gleichzeitige consume Race Condition | EXPONIERT |
+| ATK-09 | Beliebiger Ressourcenname | BLOCKIERT |
+| ATK-10 | Quota eines anderen Benutzers zurücksetzen | EXPONIERT |
+| ATK-11 | Unbegrenzte userId/resource-Länge | EXPONIERT |
+| ATK-12 | window_start-Manipulation | BLOCKIERT |
+
+**Kritische Schwachstellen für Produktion beheben**:
+1. **ATK-01 / ATK-10** — Authentifizierung und Autorisierung hinzufügen
+2. **ATK-08** — consume in eine Transaktion einwickeln (atomares Prüfen-dann-Inkrementieren)
+3. **ATK-07** — Obergrenze für `limit_count` hinzufügen
+4. **ATK-11** — Längenlimits für Pfadparameterwerte hinzufügen
+
+---
+
+## Verwandte Handbücher
+
+- [`rate-limiting.md`](rate-limiting.md) — Ratenbegrenzung auf Middleware-Ebene
+- [`sliding-window-rate-limiter.md`](sliding-window-rate-limiter.md) — Gleitendes Fenster Zähler
+- [`api-usage-metering.md`](api-usage-metering.md) — Nutzungsverfolgung pro API-Schlüssel
+- [`credit-ledger.md`](credit-ledger.md) — Guthaben/Lastschrift-Modell für quota-ähnliche Systeme

--- a/docs/de/howto/rate-limiting.md
+++ b/docs/de/howto/rate-limiting.md
@@ -1,0 +1,281 @@
+# Ratenbegrenzung
+
+> **FT-Referenz**: FT284 (`NENE2-FT/throttlelog`) — ThrottleMiddleware Ratenbegrenzung: IP-basiertes Fixed-Window, benutzerdefinierter Schlüsselextraktor (Benutzer/API-Schlüssel), X-RateLimit-*-Header, 429 Problem Details mit Retry-After, InMemoryRateLimitStorage für Tests, 9 Tests / 33 Assertions bestanden.
+>
+> **ATK-Bewertung**: ATK-01 bis ATK-12 am Ende dieses Dokuments enthalten.
+
+`ThrottleMiddleware` erzwingt eine Fixed-Window-Ratenbegrenzung für alle Anfragen. Es fügt `X-RateLimit-Limit`, `X-RateLimit-Remaining` und `X-RateLimit-Reset`-Header zu jeder Antwort hinzu und gibt eine `429 Too Many Requests` Problem Details-Antwort zurück, wenn das Limit überschritten wird.
+
+## Grundlegende Einrichtung
+
+`ThrottleMiddleware` an `RuntimeApplicationFactory` über den `throttleMiddleware`-Parameter übergeben:
+
+```php
+use Nene2\Middleware\InMemoryRateLimitStorage;
+use Nene2\Middleware\ThrottleMiddleware;
+
+$storage  = new InMemoryRateLimitStorage(); // nur lokal/Test — siehe "Produktion" unten
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    limit:         60,   // erlaubte Anfragen pro Fenster
+    windowSeconds: 60,   // Fensterdauer in Sekunden
+);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    throttleMiddleware: $throttle, // ← benannter Parameter, nicht "middlewares"
+    routeRegistrars: [...],
+))->create();
+```
+
+Der benannte Parameter ist `throttleMiddleware`, nicht `middlewares` — `RuntimeApplicationFactory` hat einen dedizierten Slot für diese Middleware, der sie korrekt in der Pipeline positioniert (nach der Authentifizierung, sodass Benutzer-Pro-Limits möglich sind).
+
+## Antwort-Header
+
+Jede Antwort enthält den Ratenbegrenzungsstatus:
+
+```http
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 42
+X-RateLimit-Reset: 1716292860
+```
+
+Wenn das Limit überschritten wird:
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 18
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1716292860
+Content-Type: application/problem+json
+
+{
+  "type": "https://nene2.dev/problems/too-many-requests",
+  "title": "Too Many Requests",
+  "status": 429,
+  "detail": "Rate limit of 60 requests per 60 seconds exceeded. Try again in 18 seconds."
+}
+```
+
+## Ratenbegrenzungsschlüssel
+
+### Standard: IP-basiert (REMOTE_ADDR)
+
+Standardmäßig ist der Schlüssel `ip:<REMOTE_ADDR>`. Jede Client-IP bekommt ihren eigenen Bucket.
+
+### Benutzerdefiniert: Authentifizierter Benutzer
+
+Nachdem die Authentifizierungs-Middleware ein Benutzerattribut gesetzt hat, nach Benutzer-ID schlüsseln:
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    limit:        100,
+    windowSeconds: 3600,
+    keyExtractor: static fn (ServerRequestInterface $r): string
+        => 'user:' . ($r->getAttribute('user_id') ?? 'anonymous'),
+);
+```
+
+Das verhindert, dass gemeinsame IP-Umgebungen (Büro-NAT) einen Bucket unfair teilen, und ermöglicht strengere Limits für nicht authentifizierte Anfragen.
+
+### Benutzerdefiniert: API-Schlüssel-Header
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    keyExtractor: static fn (ServerRequestInterface $r): string
+        => 'apikey:' . ($r->getHeaderLine('X-Api-Key') ?: 'anonymous'),
+);
+```
+
+## Warnung bei Reverse Proxy / Load Balancer
+
+Hinter einem Reverse Proxy ist `REMOTE_ADDR` die IP des Proxys — alle echten Clients teilen einen einzelnen Bucket. Das beheben, indem ein vertrauenswürdiger Forwarded-IP-Header gelesen wird:
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    keyExtractor: static fn (ServerRequestInterface $r): string
+        => $r->getHeaderLine('X-Forwarded-For') ?: $r->getServerParams()['REMOTE_ADDR'] ?? 'unknown',
+);
+```
+
+**`X-Forwarded-For` nur vertrauen, wenn dein Proxy unter deiner Kontrolle steht und ihn zuverlässig setzt.** Ein Angreifer kann diesen Header fälschen, wenn der Datenverkehr die Anwendung direkt ohne den Proxy erreicht.
+
+## Produktion: Gemeinsamen Speicher verwenden
+
+`InMemoryRateLimitStorage` hält Zähler in einem einfachen PHP-Array. PHP-FPM läuft mit mehreren Worker-Prozessen; **jeder Worker hat sein eigenes Array, sodass Zähler nicht geteilt werden**. In der Produktion bedeuten 10 Worker mit einem Limit von 60 ein reales Limit von ~600.
+
+Für die Produktion `RateLimitStorageInterface` implementieren, das durch einen gemeinsamen Store gesichert ist:
+
+```php
+use Nene2\Middleware\RateLimitStorageInterface;
+
+final class RedisRateLimitStorage implements RateLimitStorageInterface
+{
+    public function __construct(private \Redis $redis) {}
+
+    public function hit(string $key, int $windowSeconds): array
+    {
+        $count = $this->redis->incr($key);
+        if ($count === 1) {
+            $this->redis->expire($key, $windowSeconds);
+        }
+        $ttl     = max(0, $this->redis->ttl($key));
+        $resetAt = time() + $ttl;
+
+        return ['count' => $count, 'reset_at' => $resetAt];
+    }
+}
+```
+
+Dann injizieren:
+
+```php
+$throttle = new ThrottleMiddleware($problemDetails, new RedisRateLimitStorage($redis), limit: 60);
+```
+
+## Fixed-Window-Burst-Problem
+
+`ThrottleMiddleware` verwendet einen Fixed-Window-Algorithmus. Clients können die effektive Rate verdoppeln, indem sie Anfragen an der Grenze zweier Fenster senden:
+
+```
+Limit: 100 Anfragen/Min, Fenster: :00–:59
+
+:59 — 100 Anfragen → trifft das Limit
+:00 — 100 Anfragen → neues Fenster, alle bestehen
+
+Ergebnis: 200 Anfragen in ~2 Sekunden
+```
+
+Wenn das ein Problem ist, einen Sliding-Window- oder Token-Bucket-Algorithmus in deiner `RateLimitStorageInterface`-Implementierung implementieren.
+
+## Per-Route-Limits
+
+`RuntimeApplicationFactory` unterstützt eine `ThrottleMiddleware`-Instanz, die global angewendet wird. Für Per-Route-Limits mit unterschiedlichen Einstellungen `ThrottleMiddleware` als Route-Level-Middleware manuell anwenden, indem einzelne Handler eingewickelt werden.
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Ratenlimit erschöpfen, um legitime Benutzer zu blockieren (DoS) 🚫 BLOCKIERT (by design)
+
+**Angriff**: Angreifer sendet 60 Anfragen pro Minute von seiner IP, um sich selbst zu blockieren.
+**Ergebnis**: BLOCKIERT (by design) — das Limit gilt für die IP/den Schlüssel des Angreifers. Andere Clients sind nicht betroffen (separate Buckets).
+
+---
+
+### ATK-02 — Per-IP-Limit durch Verwendung verschiedener IP-Adressen umgehen 🚫 BLOCKIERT (gemildert)
+
+**Angriff**: Angreifer verwendet mehrere IPs (Botnet, VPN-Rotation) um Anfragen unter dem Limit pro IP zu senden.
+**Ergebnis**: GEMILDERT — jede IP hat ihren eigenen Bucket; einzelne IPs werden ratenbegrenzt.
+
+---
+
+### ATK-03 — X-Forwarded-For fälschen, um IP-basiertes Limit zu umgehen 🚫 BLOCKIERT (Designhinweis)
+
+**Angriff**: Angreifer sendet `X-Forwarded-For: 10.0.0.1` um als andere IP zu erscheinen.
+**Ergebnis**: BLOCKIERT (wenn korrekt konfiguriert) — Standardschlüssel verwendet `REMOTE_ADDR` (server-gesetzt), nicht Client-gelieferte Header.
+
+---
+
+### ATK-04 — Fenstergrenz-Burst 🚫 BLOCKIERT (Designbeschränkung)
+
+**Angriff**: 60 Anfragen bei :59 und 60 Anfragen bei :00 (neues Fenster) für 120 Anfragen in 2 Sekunden senden.
+**Ergebnis**: BLOCKIERT (im Fixed-Window-Design) — jedes 60-Sekunden-Fenster ist unabhängig.
+
+---
+
+### ATK-05 — Fehlgeformten `X-RateLimit-Remaining`-Header senden 🚫 BLOCKIERT
+
+**Angriff**: Client sendet `X-RateLimit-Remaining: 999`-Header in der Hoffnung, dass der Server ihm vertraut.
+**Ergebnis**: BLOCKIERT — `X-RateLimit-*`-Header sind **Antwort**-Header, die vom Server gesetzt werden.
+
+---
+
+### ATK-06 — Ratenlimit erschöpfen, dann anderen Pfad verwenden 🚫 BLOCKIERT
+
+**Angriff**: Nach dem Treffen des Limits auf `/notes`, `/notes?q=1` oder `/other-path` versuchen.
+**Ergebnis**: BLOCKIERT — `ThrottleMiddleware` gilt global für alle Pfade.
+
+---
+
+### ATK-07 — Race Condition, um das Limit zu überschreiten 🚫 BLOCKIERT
+
+**Angriff**: 61 gleichzeitige Anfragen senden, wenn der verbleibende Zähler 1 ist.
+**Ergebnis**: BLOCKIERT — `InMemoryRateLimitStorage` verwendet PHPs sequentielle Anfragebearbeitung innerhalb eines einzelnen Prozesses.
+
+---
+
+### ATK-08 — Ratenlimit-Timing sondieren, um Systemlast zu inferieren 🚫 BLOCKIERT (irrelevant)
+
+**Angriff**: `Retry-After` messen, um Serverlast oder Anfragemuster zu bestimmen.
+**Ergebnis**: IRRELEVANT — `Retry-After` gibt die verbleibende Fensterzeit zurück (fest), keine Systemlast.
+
+---
+
+### ATK-09 — Fehlender `Retry-After`-Header bei 429-Antwort 🚫 BLOCKIERT
+
+**Angriff**: Client ignoriert 429, weil `Retry-After` fehlt, was zu unendlichen Retry-Schleifen führt.
+**Ergebnis**: BLOCKIERT — `ThrottleMiddleware` enthält immer sowohl `Retry-After` als auch `X-RateLimit-Reset` in 429-Antworten.
+
+---
+
+### ATK-10 — Gefälschten API-Schlüssel für unbegrenzten Bucket verwenden 🚫 BLOCKIERT (by design)
+
+**Angriff**: Bei API-Schlüssel-basierter Ratenbegrenzung einen gefälschten Schlüssel wie `X-Api-Key: unlimited` angeben.
+**Ergebnis**: BLOCKIERT (by design) — jeder API-Schlüssel bekommt seinen eigenen Bucket.
+
+---
+
+### ATK-11 — Leeren Ratenbegrenzungsschlüssel senden 🚫 BLOCKIERT
+
+**Angriff**: `REMOTE_ADDR` aus Server-Params entfernen, um einen leeren Schlüssel zu erzwingen.
+**Ergebnis**: BLOCKIERT — wenn `REMOTE_ADDR` fehlt, wird der Schlüssel `ip:` (leere Zeichenkette als IP-Präfix). Das erstellt einen einzelnen gemeinsamen Bucket für alle unbekannten IPs.
+
+---
+
+### ATK-12 — InMemoryRateLimitStorage in Produktion verwenden 🚫 BLOCKIERT (Designwarnung)
+
+**Angriff**: Operator deployt mit `InMemoryRateLimitStorage` in Produktion versehentlich. Jeder PHP-FPM-Worker hat sein eigenes Array, so 10 Worker multiplizieren das Limit effektiv mit 10.
+**Ergebnis**: BLOCKIERT (durch Dokumentationswarnung) — bekanntes Anti-Pattern, oben dokumentiert.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Limit erschöpfen, um sich selbst zu DoS | 🚫 BLOCKIERT (by design) |
+| ATK-02 | Mehrere IPs, um Per-IP-Limit zu umgehen | 🚫 BLOCKIERT (gemildert) |
+| ATK-03 | X-Forwarded-For fälschen | 🚫 BLOCKIERT (Designhinweis) |
+| ATK-04 | Fenstergrenz-Burst | 🚫 BLOCKIERT (Designbeschränkung) |
+| ATK-05 | X-RateLimit-*-Anfrage-Header manipulieren | 🚫 BLOCKIERT |
+| ATK-06 | Anderen Pfad verwenden, um Limit zu umgehen | 🚫 BLOCKIERT |
+| ATK-07 | Race Condition, um Limit zu überschreiten | 🚫 BLOCKIERT |
+| ATK-08 | Systemlast aus Retry-After inferieren | 🚫 BLOCKIERT (irrelevant) |
+| ATK-09 | Fehlender Retry-After verursacht Retry-Schleifen | 🚫 BLOCKIERT |
+| ATK-10 | Gefälschter API-Schlüssel für unbegrenzten Bucket | 🚫 BLOCKIERT (by design) |
+| ATK-11 | Leerer Schlüssel vereint den gesamten Traffic | 🚫 BLOCKIERT |
+| ATK-12 | InMemoryStorage multipliziert Limit in Produktion | 🚫 BLOCKIERT (dokumentiert) |
+
+**12 BLOCKIERT / GEMILDERT, 0 EXPONIERT**
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Pattern | Risiko |
+|---|---|
+| `InMemoryRateLimitStorage` in Produktion verwenden | PHP-FPM-Worker teilen keinen Speicher; effektives Limit = konfiguriertes Limit × Worker-Anzahl |
+| Auf `X-Forwarded-For` von nicht vertrauenswürdigen Clients schlüsseln | Angreifer können jede IP fälschen; Ratenbegrenzung wird umgangen |
+| Einen globalen Bucket für alle Clients verwenden | Das Ratenlimit eines Clients blockiert alle anderen Clients |
+| 403 statt 429 für Ratenlimit zurückgeben | Client kann "verboten" nicht von "zu viele Anfragen" unterscheiden |
+| Kein `Retry-After`-Header bei 429 | Clients wiederholen sofort; Thundering Herd beim Fenster-Reset |
+| `limit` für sensible Endpunkte zu hoch setzen | Login-Endpunkt mit limit=10000 ist praktisch ungeschützt |
+| Keine Ratenbegrenzung bei Login/Passwort-Reset-Endpunkten | Brute-Force-Angriffe erfolgreich ohne Lockout oder Drosselung |

--- a/docs/de/howto/rating-review-api.md
+++ b/docs/de/howto/rating-review-api.md
@@ -1,0 +1,225 @@
+# How-to: Bewertungs- und Rezensions-API
+
+> **FT-Referenz**: FT333 (`NENE2-FT/ratinglog`) — Pro-Artikel-, Pro-Benutzer-Bewertungssystem mit Score-Validierung (1–5), Upsert-Semantik, Zusammenfassung mit Verteilungsübersicht und Schwachstellenbewertung, 16 Tests / 40+ Assertions bestanden.
+
+Dieses Handbuch zeigt, wie man ein Bewertungssystem aufbaut, bei dem Benutzer numerische Scores mit optionalen Textrezensionen einreichen, und die API live aggregierte Zusammenfassungen berechnet.
+
+## Schema
+
+```sql
+CREATE TABLE ratings (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id    TEXT    NOT NULL,
+    rater_id   TEXT    NOT NULL,
+    score      INTEGER NOT NULL CHECK (score BETWEEN 1 AND 5),
+    review     TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE(item_id, rater_id)
+);
+```
+
+`UNIQUE(item_id, rater_id)` erzwingt eine Bewertung pro Bewerter pro Artikel. `item_id` und `rater_id` sind opake Zeichenkettenidentifikatoren — keine Fremdschlüsselbeschränkung erforderlich.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `PUT`  | `/items/{itemId}/ratings/{raterId}` | Bewertung erstellen oder aktualisieren (Upsert) |
+| `GET`  | `/items/{itemId}/ratings` | Alle Bewertungen für Artikel auflisten |
+| `GET`  | `/items/{itemId}/ratings/summary` | Aggregierte Zusammenfassung mit Verteilung |
+| `GET`  | `/items/{itemId}/ratings/{raterId}` | Bewertung eines Bewerters abrufen |
+| `DELETE` | `/items/{itemId}/ratings/{raterId}` | Bewertung löschen |
+
+## Bewertung erstellen / aktualisieren (Upsert)
+
+```php
+PUT /items/product-1/ratings/alice
+{"score": 5, "review": "Ausgezeichnet!"}
+→ 200  {"rater_id": "alice", "score": 5, "review": "Ausgezeichnet!", ...}
+
+// Vorhandene Bewertung aktualisieren
+PUT /items/product-1/ratings/alice
+{"score": 3, "review": "Ich habe meine Meinung geändert."}
+→ 200  {"score": 3}
+```
+
+`PUT` mit `UNIQUE(item_id, rater_id)` wirkt als natürlicher Upsert (`INSERT OR REPLACE`). Derselbe Endpunkt verarbeitet sowohl Erstellung als auch Aktualisierung ohne separates `PATCH`.
+
+### Validierung
+
+```php
+// Fehlender Score
+PUT /items/product-1/ratings/alice  {"review": "Gut"}
+→ 422
+
+// Außerhalb des Bereichs
+PUT /items/product-1/ratings/alice  {"score": 6}
+→ 422
+
+PUT /items/product-1/ratings/alice  {"score": 0}
+→ 422
+```
+
+Score muss ein Integer in [1, 5] sein. `review` ist optional (Standard: `""`).
+
+## Bewertungen auflisten
+
+```php
+GET /items/product-1/ratings
+→ 200
+{
+  "ratings": [
+    {"rater_id": "alice", "score": 5, "review": "Ausgezeichnet!"},
+    {"rater_id": "bob",   "score": 3, "review": ""}
+  ]
+}
+```
+
+Bewertungen werden auf den Artikel beschränkt — Bewertungen von `product-2` erscheinen nie in der Liste von `product-1`.
+
+## Zusammenfassung mit Verteilung
+
+```php
+GET /items/product-1/ratings/summary
+→ 200
+{
+  "count": 3,
+  "average": 4.0,
+  "distribution": {
+    "1": 0, "2": 0, "3": 1, "4": 1, "5": 1
+  }
+}
+
+// Noch keine Bewertungen
+GET /items/product-2/ratings/summary
+→ 200  {"count": 0, "average": 0.0, "distribution": {"1":0,"2":0,"3":0,"4":0,"5":0}}
+```
+
+`distribution` gibt immer alle fünf Schlüssel zurück, auch wenn Zählungen null sind — Clients können Stern-Balken ohne Null-Prüfungen rendern.
+
+## Einzelne Bewertung abrufen
+
+```php
+GET /items/product-1/ratings/alice
+→ 200  {"score": 4, "review": "..."}
+
+GET /items/product-1/ratings/nobody
+→ 404
+```
+
+## Bewertung löschen
+
+```php
+DELETE /items/product-1/ratings/alice
+→ 200  {"deleted": true}
+
+DELETE /items/product-1/ratings/nobody
+→ 404
+```
+
+Nach dem Löschen wird die Zusammenfassung bei der nächsten Anfrage sofort neu berechnet.
+
+---
+
+## Schwachstellenbewertung
+
+### V-01 — Bewertungsimitation (IDOR auf raterId) ⚠️ EXPONIERT
+
+**Risiko**: Jeder Client kann eine Bewertung mit einem beliebigen `raterId`-Pfadsegment einreichen oder löschen.
+**Befund**: EXPONIERT — `raterId` in der URL wird nicht gegen einen authentifizierten Akteur validiert.
+
+---
+
+### V-02 — Score-Bereichsumgehung 🛡️ SICHER
+
+**Risiko**: Angreifer sendet `score: 0` oder `score: 6`, um ungültige Daten zu erzeugen.
+**Befund**: SICHER — Score wird auf `[1, 5]` validiert, bevor in die DB geschrieben wird.
+
+---
+
+### V-03 — Durchschnittsvergiftung via Massen-Fake-Bewertungen ⚠️ EXPONIERT
+
+**Risiko**: Angreifer registriert Tausende von Benutzer-IDs und sendet 1-Stern-Bewertungen.
+**Befund**: EXPONIERT — keine Ratenbegrenzung oder Kontoverifizierung beim Bewertungsendpunkt.
+
+---
+
+### V-04 — XSS via Rezensionstext ✅ SICHER
+
+**Risiko**: Angreifer speichert `<script>alert(1)</script>` in `review`.
+**Befund**: SICHER — die API gibt `application/json` zurück. JSON-Kodierung maskiert HTML-Sonderzeichen.
+
+---
+
+### V-05 — SQL-Injection via itemId / raterId 🛡️ SICHER
+
+**Risiko**: Angreifer sendet `item_id = "x' OR '1'='1"`.
+**Befund**: SICHER — alle Abfragen verwenden parametrisierte Anweisungen (`?`-Platzhalter).
+
+---
+
+### V-06 — Unbegrenzter Rezensionstext (Speichermissbrauch) ⚠️ EXPONIERT
+
+**Risiko**: Angreifer sendet eine 100 MB Rezensionszeichenkette.
+**Befund**: EXPONIERT — keine `max_length`-Prüfung für `review`.
+
+---
+
+### V-07 — Durchschnitt Integer-Trunkierung 🛡️ SICHER
+
+**Risiko**: Durchschnittsberechnung könnte Präzision verlieren.
+**Befund**: SICHER — `AVG()` in SQLite gibt einen Float zurück.
+
+---
+
+### V-08 — Fehlende Verteilungsschlüssel (Client-Absturz) 🛡️ SICHER
+
+**Risiko**: Wenn `distribution` Schlüssel für Scores mit null Bewertungen weglässt, stürzen Clients ab.
+**Befund**: SICHER — die API gibt immer alle fünf Schlüssel (`1`–`5`) zurück, mit `0` initialisiert.
+
+---
+
+### V-09 — Artikelübergreifendes Datenleck 🛡️ SICHER
+
+**Risiko**: `GET /items/product-1/ratings` gibt Bewertungen von `product-2` zurück.
+**Befund**: SICHER — alle Abfragen enthalten `WHERE item_id = ?`.
+
+---
+
+### V-10 — Gleitkomma-Score zur Umgehung der Integer-Validierung 🛡️ SICHER
+
+**Risiko**: Angreifer sendet `score: 4.9`, um die Bereichsprüfung zu umgehen.
+**Befund**: SICHER — Score wird als strikter Integer validiert.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|--------------|--------|
+| V-01 | Bewertungsimitation (IDOR auf raterId) | ⚠️ EXPONIERT |
+| V-02 | Score-Bereichsumgehung | 🛡️ SICHER |
+| V-03 | Durchschnittsvergiftung via Massen-Fake-Bewertungen | ⚠️ EXPONIERT |
+| V-04 | XSS via Rezensionstext | ✅ SICHER |
+| V-05 | SQL-Injection via itemId / raterId | 🛡️ SICHER |
+| V-06 | Unbegrenzter Rezensionstext (Speichermissbrauch) | ⚠️ EXPONIERT |
+| V-07 | Durchschnitt Integer-Trunkierung | 🛡️ SICHER |
+| V-08 | Fehlende Verteilungsschlüssel | 🛡️ SICHER |
+| V-09 | Artikelübergreifendes Datenleck | 🛡️ SICHER |
+| V-10 | Gleitkomma-Score zur Umgehung der Integer-Validierung | 🛡️ SICHER |
+
+**7 SICHER, 3 EXPONIERT** — Kritisch: `raterId` authentifizieren; `review`-Längenbegrenzung hinzufügen; Ratenbegrenzung gegen Massen-Fake-Bewertungen anwenden.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Pattern | Risiko |
+|---|---|
+| `raterId` aus dem Pfad ohne Authentifizierung vertrauen | Jeder Client kann als beliebiger Benutzer bewerten oder löschen |
+| Kein `max_length` für Rezensionstext | Speicherbombe — eine einzige Anfrage schreibt Gigabytes in die DB |
+| `null` für Verteilungsschlüssel mit null Zählung zurückgeben | Client-Code, der auf `distribution[2]` zugreift, stürzt ab |
+| Durchschnitt in PHP mit `array_sum` neu berechnen | Verlustbehaftete Float-Arithmetik bei großen Datensätzen; DB `AVG()` verwenden |
+| Kein Per-Benutzer-Ratenlimit | Massen-Fake-Konten vergiften Produktdurchschnitte |
+| `SELECT * FROM ratings` ohne `WHERE item_id` verwenden | Artikelübergreifendes Datenleck |

--- a/docs/de/howto/rbac-jwt-auth.md
+++ b/docs/de/howto/rbac-jwt-auth.md
@@ -1,0 +1,262 @@
+# How-to: RBAC + JWT-Authentifizierung
+
+> **FT-Referenz**: FT279 (`NENE2-FT/rbaclog`) — Rollenbasierte Zugriffskontrolle mit JWT: Argon2id-Passwort-Hashing mit Timing-Angriffs-Schutz, Rollen-Claim im JWT, Unterscheidung 401 vs. 403, BearerTokenMiddleware mit manuellem Fallback, 14 Tests / 48 Assertions bestanden.
+>
+> **VULN-Assessment**: V-01 bis V-10 am Ende dieses Dokuments enthalten.
+
+Diese Anleitung zeigt, wie ein rollenbasiertes Zugriffskontrollsystem (RBAC) mit JWT-Tokens in NENE2 gebaut wird.
+
+## Funktionen
+
+- E-Mail + Passwort-Login (Argon2id-Hashing)
+- Rollen-Claim im JWT eingebettet (`user` / `admin`)
+- Öffentliche, authentifizierte und nur-Admin-Endpunkte
+- `BearerTokenMiddleware` mit per-Handler-Fallback
+- Korrekte `401 Unauthorized` vs. `403 Forbidden`-Semantik
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    email         TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    role          TEXT NOT NULL DEFAULT 'user',
+    created_at    TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    author_id  INTEGER NOT NULL,
+    created_at TEXT NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `POST` | `/auth/login` | Keine | Anmelden, JWT erhalten |
+| `GET` | `/posts` | Keine | Alle Beiträge auflisten (öffentlich) |
+| `POST` | `/posts` | Benutzer oder Admin | Beitrag erstellen |
+| `DELETE` | `/posts/{id}` | Nur Admin | Beitrag löschen |
+
+## Login mit Timing-Angriffs-Schutz
+
+Der Dummy-Hash-Trick stellt sicher, dass der Login immer gleich lang dauert, ob die E-Mail existiert oder nicht:
+
+```php
+$user = $this->users->findByEmail(trim($body['email']));
+
+$dummyHash   = '$argon2id$v=19$m=65536,t=4,p=1$dummysaltdummysaltdummysalt$dummyhashvaluedummyhashvaluedummyh';
+$hashToCheck = $user !== null ? $user->passwordHash : $dummyHash;
+
+if (!password_verify($body['password'], $hashToCheck) || $user === null) {
+    return $this->problems->create($request, 'invalid-credentials', 'Ungültige Anmeldedaten', 401, '...');
+}
+```
+
+Ohne den Dummy-Hash kann ein Timing-Angriff gültige E-Mail-Adressen erkennen, indem die Antwortzeit gemessen wird — die Hash-Berechnung wird für unbekannte E-Mails übersprungen.
+
+## Rollen-Claim im JWT
+
+Die Rolle wird im JWT-Payload gespeichert, um einen DB-Roundtrip bei jeder Anfrage zu vermeiden:
+
+```php
+$token = $this->issuer->issue([
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'role'  => $user->role->value,   // Role::User → 'user', Role::Admin → 'admin'
+    'iat'   => $now,
+    'exp'   => $now + self::TOKEN_TTL_SECONDS,
+]);
+```
+
+## Rollenprüfung mit Enum
+
+```php
+private function requireRole(ServerRequestInterface $request, Role $required): array|ResponseInterface
+{
+    $claims = $this->requireAuth($request);
+    if ($claims instanceof ResponseInterface) {
+        return $claims;
+    }
+
+    $actualRole = Role::tryFrom((string) ($claims['role'] ?? ''));
+
+    if ($actualRole !== $required) {
+        return $this->problems->create(
+            $request, 'forbidden', 'Verboten', 403,
+            "Diese Aktion erfordert die Rolle '{$required->value}'."
+        );
+    }
+
+    return $claims;
+}
+```
+
+`Role::tryFrom()` ordnet den String-Claim sicher dem Enum zu — ungültige Rollen-Strings werden zu `null`, was die Prüfung scheitern lässt.
+
+## Unterscheidung 401 vs. 403
+
+| Status | Bedeutung | Wann |
+|---|---|---|
+| `401 Unauthorized` | Nicht authentifiziert | Kein Token, ungültiges Token, abgelaufenes Token |
+| `403 Forbidden` | Authentifiziert aber unzureichende Rolle | Gültiges Token, falsche Rolle |
+
+Diese Unterscheidung ist für Clients wichtig: Ein `401` sollte eine erneute Anmeldung auslösen; ein `403` sollte eine "Zugriff verweigert"-Meldung anzeigen.
+
+## BearerTokenMiddleware mit Fallback
+
+Einige Pfade bedienen sowohl öffentliche als auch geschützte Methoden (z.B. `GET /posts` ist öffentlich, `POST /posts` ist authentifiziert). Die Middleware schließt den Pfad vollständig aus, und Handler, die Auth benötigen, rufen `requireAuth()` manuell auf:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier: $this->verifier,
+    excludedPaths: ['/auth/login', '/posts'],  // /posts benötigt per-Methode-Behandlung
+);
+```
+
+```php
+private function requireAuth(ServerRequestInterface $request): array|ResponseInterface
+{
+    // Schneller Pfad: Middleware hat bereits verifiziert
+    $claims = $request->getAttribute('nene2.auth.claims');
+    if (is_array($claims)) {
+        return $claims;
+    }
+
+    // Langsamer Pfad: manuelle Extraktion für ausgeschlossene Pfade
+    $authorization = $request->getHeaderLine('Authorization');
+    if ($authorization === '' || !str_starts_with($authorization, 'Bearer ')) {
+        return $this->problems->create($request, 'unauthorized', 'Nicht autorisiert', 401, '...');
+    }
+
+    try {
+        return $this->verifier->verify(substr($authorization, 7));
+    } catch (TokenVerificationException) {
+        return $this->problems->create($request, 'unauthorized', 'Nicht autorisiert', 401, '...');
+    }
+}
+```
+
+---
+
+## VULN-Assessment — Schwachstellenanalyse
+
+### V-01 — Rollenerweiterung via gefälschtem JWT-Claim 🛡️ SAFE
+
+**Bedrohung**: Angreifer erstellt einen JWT mit `"role": "admin"` und signiert ihn mit einem zufälligen Secret.
+**Abwehr**: `LocalBearerTokenVerifier` validiert die HMAC-HS256-Signatur gegen das Server-Secret. Ein nicht übereinstimmendes Secret verursacht `TokenVerificationException` → 401.
+**Ergebnis**: SAFE — Signaturverifizierung verhindert Claim-Fälschung.
+
+---
+
+### V-02 — Timing-Angriff via E-Mail-Enumeration beim Login 🛡️ SAFE
+
+**Bedrohung**: Angreifer sendet Login-Anfragen für unbekannte vs. bekannte E-Mails und misst die Antwortzeit zur Enumeration gültiger Konten.
+**Abwehr**: Für unbekannte E-Mails wird `password_verify()` gegen einen Dummy-Argon2id-Hash aufgerufen (gleiche Kostenparameter). Beide Pfade dauern ~200ms. Die Login-Fehlermeldung ist identisch für falsche E-Mail und falsches Passwort.
+**Ergebnis**: SAFE — Timing ist ausgeglichen; Fehlermeldung ist generisch.
+
+---
+
+### V-03 — Abgelaufenes Token als gültig akzeptiert 🛡️ SAFE
+
+**Bedrohung**: Angreifer verwendet ein erfasstes JWT nach Ablauf wieder.
+**Abwehr**: `LocalBearerTokenVerifier` prüft den `exp`-Claim gegen `time()`. Abgelaufene Tokens werfen `TokenVerificationException` → 401.
+**Ergebnis**: SAFE — `exp`-Prüfung wird durchgesetzt.
+
+---
+
+### V-04 — Rollendegradierung durch Modifizieren des JWT-Payloads (ohne erneutes Signieren) 🛡️ SAFE
+
+**Bedrohung**: Angreifer base64-dekodiert den JWT-Payload, ändert `"role": "user"` zu `"role": "admin"`, kodiert erneut und sendet mit ursprünglicher Signatur.
+**Abwehr**: JWT-Signatur deckt Header + Payload ab. Das Modifizieren des Payloads macht die Signatur ungültig → `TokenVerificationException` → 401.
+**Ergebnis**: SAFE — Payload-Manipulation durch HMAC erkannt.
+
+---
+
+### V-05 — Admin-Endpunkt mit Benutzerrolle zugänglich 🛡️ SAFE
+
+**Bedrohung**: Angreifer meldet sich als `user` an und versucht `DELETE /posts/{id}`.
+**Abwehr**: `requireRole($request, Role::Admin)` prüft den JWT-`role`-Claim. Ein `user`-Token hat `role: 'user'` → `Role::tryFrom('user') !== Role::Admin` → 403.
+**Ergebnis**: SAFE — 403 Forbidden zurückgegeben; Benutzer-Token kann sich nicht zu Admin erhöhen.
+
+---
+
+### V-06 — Nicht-authentifizierter Zugriff auf geschützten Endpunkt 🛡️ SAFE
+
+**Bedrohung**: Angreifer sendet `POST /posts` oder `DELETE /posts/{id}` ohne Authorization-Header.
+**Abwehr**: `requireAuth()` prüft auf `Bearer `-Präfix; fehlender Header → 401 `unauthorized`.
+**Ergebnis**: SAFE — 401 Unauthorized zurückgegeben.
+
+---
+
+### V-07 — 401 vs. 403 Verwechslung (Informationsleck) 🛡️ SAFE
+
+**Bedrohung**: Falsche 401/403-Verwendung gibt preis, ob eine Ressource existiert oder ob der Benutzer authentifiziert ist.
+**Abwehr**: System gibt 401 für nicht-authentifizierten Zugriff zurück (kein/ungültiges Token) und 403 für authentifizierten Zugriff mit unzureichender Rolle. Die Unterscheidung ist semantisch korrekt und gibt keine Ressourcenexistenz über die Rollenanforderung hinaus preis.
+**Ergebnis**: SAFE — 401/403-Semantik ist korrekt.
+
+---
+
+### V-08 — Ungültiger Rollen-String im JWT-Bypass 🛡️ SAFE
+
+**Bedrohung**: Angreifer erstellt einen JWT (mit gültigem Secret, z.B. kompromittiertes Secret-Szenario) und setzt `role` auf einen unbekannten Wert wie `"superadmin"`.
+**Abwehr**: `Role::tryFrom((string) ($claims['role'] ?? ''))` gibt `null` für unbekannte Strings zurück → `null !== Role::Admin` → 403.
+**Ergebnis**: SAFE — `tryFrom()` ist null-sicher; unbekannte Rollen werden als unzureichend behandelt.
+
+---
+
+### V-09 — SQL-Injection via E-Mail-Feld beim Login 🛡️ SAFE
+
+**Bedrohung**: Angreifer sendet `{"email": "' OR '1'='1", "password": "anything"}`.
+**Abwehr**: `findByEmail()` verwendet parametrisierte Abfrage (`WHERE email = ?`). Der injizierte String wird als literaler Wert behandelt, nicht als SQL.
+**Ergebnis**: SAFE — parametrisierte Abfragen verhindern SQL-Injection.
+
+---
+
+### V-10 — Passwort im Klartext gespeichert 🛡️ SAFE
+
+**Bedrohung**: Bei einem DB-Einbruch sind Passwörter lesbar.
+**Abwehr**: `password_hash($password, PASSWORD_ARGON2ID)` mit Kostenparametern `m=65536,t=4,p=1`. Nur der Argon2id-Hash wird gespeichert; das Klartext-Passwort wird niemals persistiert.
+**Ergebnis**: SAFE — Argon2id ist der aktuell empfohlene Algorithmus (RFC 9106); PBKDF2/bcrypt/scrypt würden ebenfalls bestehen.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Bedrohung | Ergebnis |
+|----|-----------|---------|
+| V-01 | Rollenerweiterung via gefälschtem JWT | 🛡️ SAFE |
+| V-02 | Timing-Angriff via E-Mail-Enumeration | 🛡️ SAFE |
+| V-03 | Abgelaufenes Token akzeptiert | 🛡️ SAFE |
+| V-04 | JWT-Payload-Manipulation ohne erneutes Signieren | 🛡️ SAFE |
+| V-05 | Admin-Endpunkt mit Benutzerrollen-Token | 🛡️ SAFE |
+| V-06 | Nicht-authentifizierter Zugriff auf geschützten Endpunkt | 🛡️ SAFE |
+| V-07 | 401 vs. 403 Verwechslung | 🛡️ SAFE |
+| V-08 | Unbekannter Rollen-String-Bypass | 🛡️ SAFE |
+| V-09 | SQL-Injection via E-Mail-Feld | 🛡️ SAFE |
+| V-10 | Passwort im Klartext gespeichert | 🛡️ SAFE |
+
+**10 SAFE, 0 EXPOSED**
+Argon2id-Hashing, HMAC-signiertes JWT, `Role::tryFrom()`-Guard und parametrisierte Abfragen verhindern alle getesteten Schwachstellenvektoren.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Rolle in DB speichern und bei jeder Anfrage nachschlagen | Zusätzliche DB-Abfrage pro Anfrage; Rollenänderung erfordert Token-Widerruf-Logik |
+| `Role::from()` statt `Role::tryFrom()` verwenden | Unbekannte Rollen-Strings werfen `ValueError` — 500 statt 403 |
+| 403 für nicht-authentifizierte Anfragen zurückgeben | Führt Clients in die Irre — 403 sollte "authentifiziert aber verboten" bedeuten, nicht "nicht angemeldet" |
+| 401 für falschen Rollen-Zugriff zurückgeben | Client versucht möglicherweise erneut anzumelden statt "Zugriff verweigert" anzuzeigen |
+| Dummy-Hash beim Login überspringen | Timing-Angriff gibt gültige E-Mail-Adressen preis |
+| Passwörter als MD5/SHA1/Klartext speichern | Brute-Force- oder Rainbow-Table-Angriffe setzen alle Passwörter bei einem DB-Einbruch frei |
+| Berechtigungen (nicht Rollen) im JWT einbetten | Berechtigungsänderungen erfordern Token-Neuausstellung; Rollen sind stabil, Berechtigungen ändern sich |
+| `alg: none` JWT erlauben | Angreifer kann Tokens durch vollständiges Entfernen der Signatur fälschen |
+| `str_contains($role, 'admin')` statt Enum-Prüfung verwenden | `"not-admin"` oder `"superadmin"` könnten unerwartet übereinstimmen |

--- a/docs/de/howto/rbac.md
+++ b/docs/de/howto/rbac.md
@@ -1,0 +1,234 @@
+# How-to: Rollenbasierte Zugriffskontrolle (RBAC)
+
+Implementierung rollenbasierter Zugriffskontrolle mit JWT-Claims und `BearerTokenMiddleware`.
+
+---
+
+## Schnellstart
+
+```php
+// 1. Rolle beim Login in das JWT aufnehmen
+$token = $issuer->issue([
+    'sub'  => $user->id,
+    'role' => $user->role->value,  // 'user' oder 'admin'
+    'exp'  => time() + 3600,
+]);
+
+// 2. Rolle im Handler prüfen
+/** @var array<string, mixed>|null $claims */
+$claims     = $request->getAttribute('nene2.auth.claims');
+$actualRole = Role::tryFrom((string) ($claims['role'] ?? ''));
+
+if ($actualRole !== Role::Admin) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+        "Diese Aktion erfordert die Rolle 'admin'.");
+}
+```
+
+---
+
+## Rollen in JWT-Claims einbetten
+
+**Zwei Ansätze:**
+
+| Ansatz | Vorteil | Nachteil |
+|---|---|---|
+| Rolle in JWT-Claims | Keine DB-Abfrage pro Anfrage | Rollenänderungen werden erst nach Token-Ablauf wirksam |
+| DB-Lookup pro Anfrage | Sofortige Rollenänderungen | Zusätzliche Abfrage bei jeder authentifizierten Anfrage |
+
+Für die meisten Anwendungen ist der JWT-Ansatz angemessen. Für hochsicherheitskritische Kontexte (Medizin, Finanzen, Admin-Privilegien-Widerruf) eine DB-Abfrage bei sensiblen Operationen hinzufügen.
+
+```php
+// Login — Rolle in Claims einbetten
+$token = $issuer->issue([
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'role'  => $user->role->value,   // String: 'user' | 'admin'
+    'iat'   => time(),
+    'exp'   => time() + 3600,
+]);
+```
+
+---
+
+## 401 Unauthorized vs. 403 Forbidden
+
+Diese Unterscheidung ist für die Client-Fehlerbehandlung wichtig (401 → zur Anmeldung weiterleiten, 403 → Berechtigungsfehler anzeigen):
+
+| Situation | Status |
+|---|---|
+| Kein Token / abgelaufen / ungültige Signatur | **401** Unauthorized |
+| Gültiges Token, aber unzureichende Rolle | **403** Forbidden |
+| Ressource nicht gefunden | **404** Not Found |
+
+```php
+// ❌ Falsch — authentifizierter Benutzer erhält 401 (impliziert "nicht angemeldet")
+if ($role !== Role::Admin) {
+    return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401, '...');
+}
+
+// ✅ Korrekt — authentifiziert aber keine Berechtigung
+if ($role !== Role::Admin) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+        "Diese Aktion erfordert die Rolle 'admin'.");
+}
+```
+
+---
+
+## `requireAuth()` / `requireRole()`-Muster
+
+Ein wiederverwendbares Hilfs-Paar im Route-Registrar:
+
+```php
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+
+final class RouteRegistrar
+{
+    public function __construct(
+        private readonly TokenVerifierInterface $verifier,
+        // ... weitere Abhängigkeiten
+    ) {}
+
+    /**
+     * Gibt Claims bei Erfolg zurück oder eine 401-ResponseInterface.
+     * Prüft zuerst das Middleware-Attribut; fällt auf manuelle Verifizierung
+     * für Pfade zurück, die von BearerTokenMiddleware ausgeschlossen sind.
+     *
+     * @return array<string, mixed>|ResponseInterface
+     */
+    private function requireAuth(ServerRequestInterface $request): array|ResponseInterface
+    {
+        /** @var array<string, mixed>|null $claims */
+        $claims = $request->getAttribute('nene2.auth.claims');
+
+        if (is_array($claims)) {
+            return $claims;
+        }
+
+        $authorization = $request->getHeaderLine('Authorization');
+
+        if ($authorization === '' || !str_starts_with($authorization, 'Bearer ')) {
+            return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401,
+                'Authentifizierung erforderlich.');
+        }
+
+        try {
+            return $this->verifier->verify(substr($authorization, 7));
+        } catch (TokenVerificationException) {
+            return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401,
+                'Token ist ungültig oder abgelaufen.');
+        }
+    }
+
+    /**
+     * Gibt Claims zurück, wenn der Benutzer die erforderliche Rolle hat,
+     * oder eine 401/403-ResponseInterface.
+     *
+     * @return array<string, mixed>|ResponseInterface
+     */
+    private function requireRole(ServerRequestInterface $request, Role $required): array|ResponseInterface
+    {
+        $claims = $this->requireAuth($request);
+
+        if ($claims instanceof ResponseInterface) {
+            return $claims;
+        }
+
+        $actualRole = Role::tryFrom((string) ($claims['role'] ?? ''));
+
+        if ($actualRole !== $required) {
+            return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+                "Diese Aktion erfordert die Rolle '{$required->value}'.");
+        }
+
+        return $claims;
+    }
+}
+```
+
+Verwendung in Handlern:
+
+```php
+private function deletePost(ServerRequestInterface $request): ResponseInterface
+{
+    $claims = $this->requireRole($request, Role::Admin);
+    if ($claims instanceof ResponseInterface) {
+        return $claims;  // 401 oder 403
+    }
+    // $claims ist jetzt das verifizierte JWT-Payload eines Admins
+}
+```
+
+---
+
+## `BearerTokenMiddleware` unterscheidet nicht nach HTTP-Methode
+
+`BearerTokenMiddleware` verwendet den Request-Pfad, nicht die HTTP-Methode, um zu entscheiden, ob Authentifizierung erforderlich ist. Wenn `GET /posts` (öffentlich) und `POST /posts` (auth-erforderlich) denselben Pfad teilen, `/posts` von der Middleware ausschließen und das Token manuell im Handler verifizieren:
+
+```php
+// Middleware: /posts vollständig ausschließen (deckt sowohl GET als auch POST ab)
+$auth = new BearerTokenMiddleware($problems, $verifier, excludedPaths: ['/auth/login', '/posts']);
+
+// Für DELETE /posts/{id} (Pfad /posts/1, /posts/2 etc.) — NICHT in excludedPaths → Middleware schützt es.
+// Für POST /posts (Pfad /posts) — ausgeschlossen → Handler muss requireAuth() manuell aufrufen.
+```
+
+Der `requireAuth()`-Helfer oben behandelt dies transparent: er liest `nene2.auth.claims` aus dem Middleware-Attribut, wenn vorhanden, und fällt auf das direkte Parsen des `Authorization`-Headers zurück, wenn nicht.
+
+**Alternative**: Unterschiedliche Pfad-Präfixe verwenden, um die Mehrdeutigkeit vollständig zu vermeiden:
+- `GET /public/posts` — keine Auth
+- `POST /posts` — Auth erforderlich (Middleware kann `/posts` ohne Konflikt schützen)
+
+---
+
+## `Role`-Enum-Muster
+
+Ein backed Enum für typsicheres Rollen-Handling verwenden:
+
+```php
+enum Role: string
+{
+    case User  = 'user';
+    case Admin = 'admin';
+}
+
+// ❌ Role::from() wirft bei unbekannten Werten
+$role = Role::from($claims['role']);  // UnhandledMatchError bei 'superuser' oder ''
+
+// ✅ Role::tryFrom() gibt null bei unbekannten Werten zurück
+$role = Role::tryFrom((string) ($claims['role'] ?? ''));
+if ($role === null || $role !== Role::Admin) {
+    return 403;
+}
+```
+
+---
+
+## 204 No Content — `createEmpty()` verwenden
+
+`JsonResponseFactory::create()` erfordert ein `array`-Argument. Für 204-Antworten ohne Body `createEmpty()` verwenden:
+
+```php
+// ❌ Typ-Fehler — create() akzeptiert kein null
+return $this->json->create(null, 204);
+
+// ❌ Gibt leeres JSON-Objekt {} zurück (Body sollte für 204 fehlen)
+return $this->json->create([], 204);
+
+// ✅ Korrekt — kein Body, korrekter Status
+return $this->json->createEmpty(204);
+```
+
+---
+
+## Code-Review-Checkliste
+
+- [ ] `role`-Claim wird mit `Role::tryFrom()` dekodiert (nicht `Role::from()` — wirft bei unbekannten Werten)
+- [ ] 403 wird für unzureichende Berechtigungen zurückgegeben, 401 für nicht-authentifiziert (nicht beide als 401)
+- [ ] `requireRole()` ruft auch `requireAuth()` auf — keine doppelten Auth-Prüfungen nötig
+- [ ] `BearerTokenMiddleware`-Ausschluss wird verstanden: ausgeschlossene Pfade umgehen das Claims-Attribut
+- [ ] Handler auf ausgeschlossenen Pfaden rufen `requireAuth()` mit manueller Token-Verifizierung auf
+- [ ] 204-Antworten verwenden `createEmpty(204)` nicht `create(null, 204)`
+- [ ] JWT-Rollen-Caching wird verstanden: Rollenänderungen werden erst nach Token-Ablauf wirksam

--- a/docs/de/howto/refresh-token-pattern.md
+++ b/docs/de/howto/refresh-token-pattern.md
@@ -1,0 +1,151 @@
+# How-to: Refresh-Token-Muster
+
+> **FT-Referenz**: FT281 (`NENE2-FT/refreshlog`) — Refresh-Token-Muster: kurzlebiger Access-Token (5 Min JWT) + langlebiger Refresh-Token (7 Tage), SHA-256-Hash-Speicherung, Token-Rotation bei Verwendung, Replay-Angriff-Erkennung (widerrufenes Token → alle widerrufen), Logout gibt immer 204 zurück, 15 Tests / 63 Assertions bestanden.
+
+Dieses Handbuch zeigt, wie man das Refresh-Token-Muster implementiert — kurzlebige Access-Tokens für Sicherheit, Refresh-Tokens für Sitzungskontinuität.
+
+## Warum es wichtig ist
+
+JWTs sind zustandslos. Einmal ausgestellt können sie nicht widerrufen werden, bis sie ablaufen. Ein 5-Minuten-TTL begrenzt die Exposition, wenn ein Token gestohlen wird. Refresh-Tokens verlängern Sitzungen ohne wiederholte Passwort-Eingabeaufforderungen, und können bei jeder Verwendung rotiert (widerrufen und neu ausgestellt) werden, um Diebstahl zu erkennen.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id),
+    token_hash TEXT    NOT NULL UNIQUE,
+    expires_at TEXT    NOT NULL,
+    revoked    INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+```
+
+`token_hash` speichert SHA-256 des rohen Tokens — niemals den rohen Wert. `revoked` ist ein Soft-Delete-Flag (vs. hartes Löschen für Replay-Erkennung).
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/auth/login` | Keine | E-Mail + Passwort → Access-Token + Refresh-Token |
+| `POST` | `/auth/refresh` | Refresh-Token im Body | Refresh-Token rotieren, neues Paar ausstellen |
+| `POST` | `/auth/logout` | Refresh-Token im Body | Refresh-Token widerrufen |
+| `GET` | `/auth/me` | Bearer Access-Token | Aktuelle Benutzerinfo abrufen |
+
+## Token-Lebensdauer
+
+```php
+private const int ACCESS_TOKEN_TTL_SECONDS = 300; // 5 Minuten — kurz für Sicherheit
+// Refresh-Tokens: 7 Tage (RefreshTokenRepository::TTL_DAYS)
+```
+
+## Token-Paar ausstellen
+
+```php
+private function issueTokenPair(User $user): array
+{
+    $now         = time();
+    $accessToken = $this->issuer->issue([
+        'jti'   => bin2hex(random_bytes(8)),  // eindeutige Token-ID
+        'sub'   => $user->id,
+        'email' => $user->email,
+        'iat'   => $now,
+        'exp'   => $now + self::ACCESS_TOKEN_TTL_SECONDS,
+    ]);
+
+    $refreshToken = $this->refreshTokens->issue($user->id);
+
+    return [
+        'access_token'  => $accessToken,
+        'token_type'    => 'Bearer',
+        'expires_in'    => self::ACCESS_TOKEN_TTL_SECONDS,
+        'refresh_token' => $refreshToken,
+    ];
+}
+```
+
+## Nur den Hash speichern
+
+```php
+public function issue(int $userId): string
+{
+    $raw       = bin2hex(random_bytes(32));  // 64 Hex-Zeichen = 256 Bit Entropie
+    $hash      = hash('sha256', $raw);
+    // INSERT token_hash = $hash ...
+
+    return $raw;  // ← roh an Client zurückgeben; niemals gespeichert
+}
+```
+
+Wenn die DB verletzt wird, bekommen Angreifer Hashes — nutzlos ohne die rohen Tokens, die Clients halten.
+
+## Token-Rotation
+
+```php
+// Bei erfolgreicher /auth/refresh:
+$this->refreshTokens->revoke($stored->id);      // alt widerrufen
+return $this->json->create($this->issueTokenPair($user));  // neues Paar ausstellen
+```
+
+Jede Aktualisierung rotiert den Token. Das alte Token wird sofort ungültig, sodass ein gestohlenes Refresh-Token nur einmal verwendet werden kann, bevor die Rotation es ungültig macht.
+
+## Replay-Angriff-Erkennung
+
+```php
+$stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+
+if ($stored === null || !$stored->isValid()) {
+    // Widerrufenes Token wird erneut verwendet → potenzieller Replay-Angriff
+    if ($stored !== null && $stored->revoked) {
+        $this->refreshTokens->revokeAllForUser($stored->userId);
+    }
+    return $this->problems->create($request, 'invalid-refresh-token', '...', 401);
+}
+```
+
+Wenn ein Angreifer ein Refresh-Token stiehlt, es verwendet, und der legitime Client dann versucht es zu verwenden (jetzt widerrufen) — erkennt das System dies und widerruft alle Sitzungen für den Benutzer, was eine erneute Authentifizierung erzwingt.
+
+## Logout gibt immer 204 zurück
+
+```php
+private function logout(ServerRequestInterface $request): ResponseInterface
+{
+    $stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+
+    if ($stored !== null && !$stored->revoked) {
+        $this->refreshTokens->revoke($stored->id);
+    }
+
+    // Immer 204 — niemals enthüllen ob das Token gültig war
+    return $this->json->createEmpty(204);
+}
+```
+
+Das Zurückgeben von 401 für ein bereits widerrufenes Token beim Logout würde einem Angreifer erlauben zu sondieren, ob er ausgeloggt wurde.
+
+## Sicherheitseigenschaften-Zusammenfassung
+
+| Eigenschaft | Implementierung |
+|---|---|
+| Access-Token-TTL | 5 Minuten (Diebstahl-Exposition minimieren) |
+| Refresh-Token-TTL | 7 Tage (Sitzungskontinuität) |
+| Token-Speicherung | Nur SHA-256-Hash; roher Wert niemals gespeichert |
+| Token-Rotation | Altes Token bei jeder erfolgreichen Aktualisierung widerrufen |
+| Replay-Erkennung | Widerrufenes Token erneut verwendet → alle Benutzersitzungen widerrufen |
+| Logout | Immer 204 (niemals Token-Gültigkeit lecken) |
+| `jti`-Anspruch | Einzigartig pro Token (zukünftige Widerruf-Verfolgung) |
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Pattern | Risiko |
+|---|---|
+| Rohen Refresh-Token in DB speichern | DB-Einbruch exponiert alle aktiven Sitzungen |
+| Hartes Löschen beim Widerrufen verwenden | Replay-Angriffe können nicht erkannt werden (benötigt `revoked = 1` um zu wissen, dass das Token existierte) |
+| Langen Access-Token-TTL (Stunden/Tage) | Gestohlenes Token bietet langfristigen Zugang |
+| 401 beim Logout mit ungültigem Token zurückgeben | Angreifer kann sondieren ob sie noch eingeloggt sind |
+| Kein `jti` im Access-Token | Einzelne Tokens können nicht für zukünftige Widerruf-Listen verfolgt werden |
+| Einzelnes Token (nur Access, kein Refresh) | Benutzer muss sich alle 5 Minuten erneut authentifizieren, oder gefährlich lange TTLs verwenden |
+| MD5 oder SHA-1 für Token-Hash | Schwacher Hash; SHA-256 oder besser verwenden |
+| Kein Ablauf bei Refresh-Tokens | Refresh-Tokens leben ewig; ein gestohlenes Token bietet unbegrenzten Zugang |

--- a/docs/de/howto/refresh-token-rotation.md
+++ b/docs/de/howto/refresh-token-rotation.md
@@ -1,0 +1,228 @@
+# How-to: JWT Refresh-Token-Rotation
+
+Dieses Handbuch behandelt die Implementierung von kurzlebigen Access-Tokens kombiniert mit langlebigen Refresh-Tokens. Die Schlüsseleigenschaft ist **Rotation**: jede Verwendung eines Refresh-Tokens widerruft es sofort und stellt ein neues aus. Ein wiederverwendetes (bereits widerrufenes) Refresh-Token löst den Widerruf aller Tokens für diesen Benutzer aus.
+
+---
+
+## Warum zwei Tokens?
+
+| Token | TTL | Speicherung | Zweck |
+|---|---|---|---|
+| Access-Token | 5 Min | Client-Speicher | Authentifiziert API-Anfragen (zustandslos, kein DB-Nachschlag) |
+| Refresh-Token | 7 Tage | DB (gehasht) | Stellt neue Access-Tokens aus; verwaltet via Rotation |
+
+Ein kurzlebiger Access-Token begrenzt den Schaden, wenn er leckt — er läuft in Minuten ab. Der Refresh-Token verlängert die Sitzung ohne erneuten Login, ist aber widerrufbar, weil er in der Datenbank lebt.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE refresh_tokens (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id),
+    token_hash TEXT    NOT NULL UNIQUE,  -- SHA-256-Hash; niemals der rohe Wert
+    expires_at TEXT    NOT NULL,
+    revoked    INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+```
+
+`token_hash` — immer den Hash speichern, niemals den rohen Token. Wenn die DB leckt, können gehashte Tokens nicht direkt verwendet werden.
+
+---
+
+## Tokens ausstellen
+
+### Access-Token: `jti` für Eindeutigkeit hinzufügen
+
+Ohne `jti` sind zwei Tokens, die in derselben Sekunde für denselben Benutzer ausgestellt wurden, identisch — ihre Payloads sind byte-für-byte gleich. `jti` (JWT ID) garantiert, dass jedes Token einzigartig ist:
+
+```php
+$accessToken = $this->issuer->issue([
+    'jti'   => bin2hex(random_bytes(8)),  // einzigartig pro Ausstellung
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'iat'   => time(),
+    'exp'   => time() + 300,  // 5 Minuten
+]);
+```
+
+### Refresh-Token: Hash speichern, rohen Wert zurückgeben
+
+```php
+public function issue(int $userId): string
+{
+    $raw       = bin2hex(random_bytes(32));  // 256-Bit-Zufallstoken
+    $hash      = hash('sha256', $raw);       // nur dies speichern
+    $expiresAt = (new \DateTimeImmutable())->modify('+7 days')->format('Y-m-d\TH:i:s\Z');
+    $createdAt = (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+
+    $this->executor->insert(
+        'INSERT INTO refresh_tokens (user_id, token_hash, expires_at, revoked, created_at)
+         VALUES (?, ?, ?, 0, ?)',
+        [$userId, $hash, $expiresAt, $createdAt],
+    );
+
+    return $raw;  // der Client erhält dies; die DB speichert es nie
+}
+```
+
+---
+
+## Token-Rotation
+
+Jede Aktualisierungsanfrage muss das alte Token widerrufen, bevor ein neues ausgestellt wird:
+
+```php
+private function refresh(ServerRequestInterface $request): ResponseInterface
+{
+    // ... Body parsen, gespeichertes Token finden ...
+
+    if ($stored === null || !$stored->isValid()) {
+        // Wiederverwendung eines widerrufenen Tokens ist ein potenzieller Replay-Angriff —
+        // alle Tokens für den Benutzer widerrufen, um erneute Authentifizierung zu erzwingen.
+        if ($stored !== null && $stored->revoked) {
+            $this->refreshTokens->revokeAllForUser($stored->userId);
+        }
+
+        return $this->problems->create(
+            $request,
+            'invalid-refresh-token',
+            'Invalid or Expired Refresh Token',
+            401,
+            'The refresh token is invalid, expired, or has already been used.',
+        );
+    }
+
+    $user = $this->users->findById($stored->userId);
+
+    // Rotation: altes Token zuerst widerrufen, dann neues Paar ausstellen
+    $this->refreshTokens->revoke($stored->id);
+
+    return $this->json->create($this->issueTokenPair($user));
+}
+```
+
+**Wiederverwendungserkennung**: Wenn ein widerrufenes Refresh-Token am `/auth/refresh`-Endpunkt ankommt, bedeutet das entweder, dass der Benutzer ein altes Token wiederverwendet (ungewöhnlich) oder ein Angreifer es gestohlen hat. `revokeAllForUser()` zwingt jede Sitzung zur erneuten Authentifizierung.
+
+---
+
+## Logout: immer 204 zurückgeben
+
+Niemals unterschiedliche Statuscodes zurückgeben, je nachdem ob das Refresh-Token gültig war. Das ermöglicht einem Angreifer zu sondieren, ob ein Token noch aktiv ist:
+
+```php
+private function logout(ServerRequestInterface $request): ResponseInterface
+{
+    // ... Body parsen ...
+
+    $stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+
+    if ($stored !== null && !$stored->revoked) {
+        $this->refreshTokens->revoke($stored->id);
+    }
+
+    // Immer 204 — niemals lecken ob das Token gültig war oder nicht
+    return $this->json->createEmpty(204);
+}
+```
+
+Das bedeutet auch, dass doppelter Logout (Logout zweimal mit demselben Token aufrufen) beide Male 204 zurückgibt — der Client kann immer sicher Logout aufrufen, ohne sich um den Token-Status zu sorgen.
+
+---
+
+## Gültigkeitsprüfung auf der RefreshToken-Entität
+
+```php
+public function isValid(): bool
+{
+    if ($this->revoked) {
+        return false;
+    }
+
+    return $this->expiresAt > (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+}
+```
+
+Zeichenkettenvergleich funktioniert für lexikographisch sortierte ISO-8601-Daten.
+
+---
+
+## BearerTokenMiddleware: Refresh/Logout-Pfade ausschließen
+
+Die Refresh- und Logout-Endpunkte empfangen einen Refresh-Token im Body, kein Bearer Access-Token im Authorization-Header. Aus `BearerTokenMiddleware` ausschließen:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier: $verifier,
+    excludedPaths: ['/auth/login', '/auth/refresh', '/auth/logout'],
+);
+```
+
+---
+
+## Antwort-Form
+
+```json
+{
+  "access_token":  "eyJhbGci...",
+  "token_type":    "Bearer",
+  "expires_in":    300,
+  "refresh_token": "a3f92c..."
+}
+```
+
+`expires_in` (Sekunden) ermöglicht dem Client, eine proaktive Aktualisierung zu planen, bevor der Access-Token abläuft.
+
+---
+
+## Code-Review-Checkliste
+
+1. `token_hash`-Spalte speichert `hash('sha256', $raw)` — niemals den rohen Wert
+2. `revoke()` wird vor `issueTokenPair()` im Refresh-Handler aufgerufen
+3. Widerrufene-Token-Wiederverwendung löst `revokeAllForUser()` aus (nicht nur ein 401)
+4. Logout gibt immer 204 zurück — kein bedingtes 401/404
+5. Access-Token-TTL ist kurz (≤ 15 Minuten)
+6. `jti`-Anspruch ist in Access-Tokens vorhanden
+7. Tests decken Cross-Token-Rotation (altes Token ungültig nach Refresh) und Wiederverwendungserkennung ab
+
+---
+
+## Rotation und Wiederverwendungserkennung testen
+
+```php
+public function testRefreshTokenRotation_OldTokenIsInvalidAfterRefresh(): void
+{
+    $tokens = $this->login();
+
+    $this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]);
+
+    // Altes Token muss abgelehnt werden
+    $res = $this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]);
+    $this->assertSame(401, $res->getStatusCode());
+}
+
+public function testRefreshTokenReuseRevokesAllUserTokens(): void
+{
+    $tokens = $this->login();
+
+    // Einmal rotieren — altes Token ist jetzt widerrufen
+    $newTokens = $this->json($this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]));
+
+    // Angreifer replayed altes (widerrufenes) Refresh-Token — löst revokeAllForUser() aus
+    $this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]);
+
+    // Das neu ausgestellte Refresh-Token ist jetzt auch widerrufen
+    $res = $this->post('/auth/refresh', ['refresh_token' => (string) $newTokens['refresh_token']]);
+    $this->assertSame(401, $res->getStatusCode());
+}
+```
+
+---
+
+## Siehe auch
+
+- `docs/howto/jwt-authentication.md` — JWT-Ausstellung, BearerTokenMiddleware, `nene2.auth.claims`
+- `docs/howto/password-hashing.md` — Argon2id, Dummy-Hash-Muster für Benutzer-Enumerationsschutz

--- a/docs/de/howto/request-deduplication.md
+++ b/docs/de/howto/request-deduplication.md
@@ -1,0 +1,90 @@
+# How-to: Anfrage-Deduplizierung
+
+Doppelte Verarbeitung durch Netzwerkwiederholungen oder Doppelklicks mit einem `Idempotency-Key`-Header verhindern. Der Server cached Antworten pro Key und spielt sie bei nachfolgenden identischen Anfragen wieder ab.
+
+## Schema
+
+```sql
+CREATE TABLE idempotency_keys (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    method          TEXT NOT NULL,
+    path            TEXT NOT NULL,
+    status_code     INTEGER NOT NULL,
+    response_body   TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    expires_at      TEXT NOT NULL
+);
+```
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `POST` | `/payments` | Zahlung verarbeiten (Idempotency-Key erforderlich) |
+| `POST` | `/orders` | Bestellung erstellen (Idempotency-Key erforderlich) |
+
+## Handler-Muster
+
+Jeder mutierende Endpunkt, der idempotent sein soll, folgt demselben dreistufigen Muster:
+
+```php
+// 1. Idempotency-Key-Header erforderlich
+$key = trim($request->getHeaderLine('Idempotency-Key'));
+if ($key === '') {
+    return $this->json->create(['error' => 'Idempotency-Key-Header ist erforderlich'], 400);
+}
+
+// 2. Gecachte Antwort zurückgeben wenn Key bereits verwendet
+$cached = $this->repo->find($key);
+if ($cached !== null && $cached['expires_at'] >= $this->now()) {
+    $body = json_decode($cached['response_body'], true);
+    return $this->json->create(
+        array_merge($body, ['replayed' => true]),
+        (int) $cached['status_code']
+    );
+}
+
+// 3. Verarbeiten und cachen
+$result = $this->doWork($body);
+$this->repo->store($key, 'POST', '/payments', 201, json_encode($result), $now, $expiresAt);
+return $this->json->create($result, 201);
+```
+
+Das Feld `replayed: true` signalisiert Clients, dass die Antwort aus dem Cache bedient wurde.
+
+## Strikte Betragsvalidierung
+
+Nicht-Integer-Eingaben an der Grenze ablehnen — PHPs `(int)`-Cast schneidet Strings wie `"100; DROP TABLE …"` stillschweigend auf `100` ab. Explizite Typprüfung verwenden:
+
+```php
+$rawAmount = $body['amount'] ?? null;
+if (!is_int($rawAmount) && !(is_string($rawAmount) && ctype_digit($rawAmount))) {
+    $errors[] = new ValidationError('amount', 'Betrag muss eine positive Ganzzahl sein', 'invalid');
+} else {
+    $amount = (int) $rawAmount;
+    if ($amount <= 0) {
+        $errors[] = new ValidationError('amount', 'Betrag muss eine positive Ganzzahl sein', 'invalid');
+    }
+}
+```
+
+## TTL und Ablauf
+
+Keys laufen nach 24 Stunden (86400 Sekunden) ab. Abgelaufene Einträge werden als neu behandelt — derselbe Key kann nach dem Ablauf wiederverwendet werden:
+
+```php
+private const int TTL_SECONDS = 86400;
+
+$expiresAt = (new \DateTimeImmutable($now, new \DateTimeZone('UTC')))
+    ->modify('+' . self::TTL_SECONDS . ' seconds')
+    ->format('Y-m-d\TH:i:s\Z');
+```
+
+## Sicherheitseigenschaften
+
+- **SQL-Injection via Key-Header**: parametrisierte Abfragen speichern bösartige Keys als Literale.
+- **Replay-Flut**: 10 identische Anfragen erstellen genau 1 Datensatz in der Geschäftstabelle.
+- **Nur-Leerzeichen-Key**: `trim()` vor Leer-Prüfung verhindert `"   "` als gültigen Key.
+- **Typ-Injection in numerischen Feldern**: `ctype_digit()`-Prüfung lehnt partielle Integer-Strings ab.
+- **Keine internen Lecks**: 400/422-Antworten enthalten nur die `error`- oder `errors`-Felder — keine Pfade, Stack-Traces oder Engine-Details.

--- a/docs/de/howto/request-scoped-state.md
+++ b/docs/de/howto/request-scoped-state.md
@@ -1,0 +1,82 @@
+# How-to: Request-scoped State zwischen Middleware und Handlern weitergeben
+
+Manche Middlewares extrahieren einen Wert aus der eingehenden Anfrage — eine Mandanten-ID, einen dekodieren JWT-Claim, einen Trace-Kontext — und Route-Handler benötigen diesen Wert nachgelagert. Diese Anleitung zeigt das empfohlene Muster mit `RequestScopedHolder`.
+
+## Das Holder-Muster
+
+`RequestScopedHolder<T>` ist ein kleiner mutierbarer Container. Eine **gemeinsame Instanz** in sowohl die Middleware, die sie schreibt, als auch den Handler (oder das Repository), der sie liest, injizieren:
+
+```php
+use Nene2\Http\RequestScopedHolder;
+
+// Gemeinsame Instanz — einmal am Composition-Root verdrahtet.
+/** @var RequestScopedHolder<int> $teamId */
+$teamId = new RequestScopedHolder();
+
+// Middleware schreibt sie.
+$tenantMiddleware = new TenantMiddleware($teamId, $problemDetails);
+
+// Route-Handler liest sie.
+$routeRegistrar = new TaskRouteRegistrar($repository, $teamId, $json);
+```
+
+Innerhalb der Middleware:
+
+```php
+public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+{
+    $raw = $request->getHeaderLine('X-Team-Id');
+    // ... validieren ...
+    $this->teamId->set((int) $raw);   // schreiben
+    return $handler->handle($request);
+}
+```
+
+Innerhalb des Route-Handlers:
+
+```php
+$id = $this->teamId->get();  // lesen — wirft LogicException wenn Middleware nicht ausgeführt wurde
+```
+
+## Warum nicht PSR-7-Request-Attribute?
+
+PSR-7-Request-Attribute sind unveränderlich — jeder `withAttribute()`-Aufruf gibt eine neue Instanz zurück. Um ein Attribut von einer Middleware zu einem Handler weiterzugeben, muss das neue Request-Objekt durch die gesamte Aufrufkette weitergereicht werden, was NEE2s Dispatcher bereits tut. `withAttribute()` zu verwenden ist gut, wenn der nachgelagerte Code `$request` direkt erhält.
+
+`RequestScopedHolder` ist das richtige Werkzeug, wenn der nachgelagerte Konsument `$request` **nicht** erhält — zum Beispiel ein Repository, das nur über eigene Domain-Typen Bescheid weiß und keine PSR-7-Request-Abhängigkeit akzeptieren kann.
+
+## Mehrere Middlewares stapeln
+
+Eine Liste an `RuntimeApplicationFactory::$authMiddleware` übergeben, um mehrere Middlewares nacheinander auszuführen:
+
+```php
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    authMiddleware: [
+        new TenantMiddleware($teamId, $probs),        // läuft zuerst
+        new BearerTokenMiddleware($probs, $verifier), // läuft zweiteilen
+    ],
+))->create();
+```
+
+Beide Middlewares teilen dieselbe Pipeline-Position (nach dem Request-Size-Limit, vor dem Rate-Limiting). Das erste Element in der Liste verarbeitet die Anfrage vor dem zweiten.
+
+## Sicherheit: PHP Shared-Nothing-Modell
+
+In PHP-FPM und CLI läuft jede Anfrage in einem frischen Prozess. Der während Anfrage A gesetzte `RequestScopedHolder`-Wert ist niemals für Anfrage B sichtbar, weil jeder Prozess nach der Verarbeitung einer Anfrage beendet wird. Der Holder ist unter diesem Modell sicher verwendbar.
+
+### Async-Runtimes (Swoole, ReactPHP, FrankenPHP Worker-Modus)
+
+Wenn mehrere Anfragen denselben PHP-Prozess teilen, behält ein während Anfrage A geschriebener Holder seinen Wert bis in Anfrage B, sofern nicht explizit zurückgesetzt. `reset()` am Anfang (oder Ende) jedes Anfrage-Zyklus aufrufen:
+
+```php
+// Beispiel Swoole-Request-Handler
+$server->on('request', function ($request, $response) use ($app, $teamId) {
+    $teamId->reset();            // Wert der vorherigen Anfrage löschen
+    $psrRequest = /* konvertieren */;
+    $psrResponse = $app->handle($psrRequest);
+    // $psrResponse ausgeben ...
+});
+```
+
+NENE2 zielt derzeit auf PHP-FPM / CLI und liefert keine eingebaute Async-Unterstützung. Bei Verwendung einer Async-Runtime ist man selbst für das Zurücksetzen gemeinsamer Holder zwischen Anfragen verantwortlich.

--- a/docs/de/howto/reservation-availability-api.md
+++ b/docs/de/howto/reservation-availability-api.md
@@ -1,0 +1,271 @@
+# How-to: Reservierungs- und Verfügbarkeits-API
+
+> **FT-Referenz**: FT336 (`NENE2-FT/reservelog`) — Ressourcenreservierungssystem mit halboffenem Intervall-Überlappungserkennung, statusbewusster Verfügbarkeitsabfrage, Stornieren-und-Wiederbuchungs-Semantik und ATK Cracker-Mindset-Angriffsassessment, 16 Tests / 30+ Assertions bestanden.
+
+Diese Anleitung zeigt, wie eine zustandslose Reservierungs-API gebaut wird, bei der Buchungen einen Lebenszyklus haben (`active` → `cancelled`) und die Verfügbarkeitsansicht nach Datumsbereich und Status filtert.
+
+## Schema
+
+```sql
+CREATE TABLE resources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE reservations (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL REFERENCES resources(id),
+    booker      TEXT    NOT NULL,  -- opaker Identifier (Name, E-Mail, user_id-String)
+    starts_at   TEXT    NOT NULL,
+    ends_at     TEXT    NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'active',  -- 'active' | 'cancelled'
+    created_at  TEXT    NOT NULL
+);
+```
+
+`status` verfolgt, ob ein Slot aktiv oder storniert ist. Nur `active`-Reservierungen blockieren künftige Buchungen.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `POST` | `/resources` | Ressource erstellen |
+| `POST` | `/reservations` | Slot buchen |
+| `GET` | `/reservations/{id}` | Reservierungsdetails abrufen |
+| `DELETE` | `/reservations/{id}` | Reservierung stornieren |
+| `GET` | `/resources/{id}/availability` | Aktive Reservierungen im Bereich auflisten |
+
+## Ressource erstellen
+
+```php
+POST /resources
+{"name": "Konferenzraum"}
+→ 201  {"id": 1, "name": "Konferenzraum", "created_at": "..."}
+
+POST /resources  {}
+→ 422  // Name erforderlich
+```
+
+## Slot buchen
+
+```php
+POST /reservations
+{
+  "resource_id": 1,
+  "booker": "alice",
+  "starts_at": "2026-06-01 09:00:00",
+  "ends_at": "2026-06-01 10:00:00"
+}
+→ 201  {"id": 1, "booker": "alice", "status": "active", ...}
+```
+
+### Validierung
+
+```php
+// ends_at vor starts_at
+→ 422
+
+// starts_at == ends_at (null Dauer)
+→ 422
+
+// Fehlende Pflichtfelder
+{"resource_id": 1}  → 422
+```
+
+### Überlappungsprävention
+
+Überlappungsprüfung verwendet **halboffene Intervalle**: `[starts_at, ends_at)`.
+
+```php
+// Bestehend: 09:00–10:00
+POST /reservations  {"starts_at": "09:30", "ends_at": "10:30"}  → 409  ❌ Überlappung
+POST /reservations  {"starts_at": "09:00", "ends_at": "10:00"}  → 409  ❌ identisch
+POST /reservations  {"starts_at": "09:15", "ends_at": "09:45"}  → 409  ❌ enthalten
+
+// Angrenzend — Ende des ersten == Start des zweiten → KEIN Konflikt
+POST /reservations  {"starts_at": "10:00", "ends_at": "11:00"}  → 201  ✅
+
+// Andere Ressource — kein Konflikt auch bei gleichen Zeiten
+POST /reservations  {"resource_id": 2, "starts_at": "09:00", "ends_at": "10:00"}  → 201  ✅
+```
+
+```sql
+-- Konflikt-Abfrage (nur aktive Reservierungen prüfen)
+SELECT COUNT(*) FROM reservations
+WHERE resource_id = ?
+  AND status = 'active'
+  AND starts_at < ?   -- bestehend.starts_at < neu.ends_at
+  AND ends_at   > ?   -- bestehend.ends_at > neu.starts_at
+```
+
+## Reservierung abrufen
+
+```php
+GET /reservations/1
+→ 200  {"id": 1, "booker": "alice", "status": "active", ...}
+
+GET /reservations/999
+→ 404
+```
+
+## Reservierung stornieren
+
+```php
+DELETE /reservations/1
+→ 200  {"id": 1, "status": "cancelled"}
+
+// Bereits storniert
+DELETE /reservations/1
+→ 409  // kann nicht zweimal storniert werden
+
+// Nicht gefunden
+DELETE /reservations/999
+→ 404
+```
+
+**Stornierung ist soft**: Der Datensatz wird mit `status = 'cancelled'` beibehalten. Stornierte Slots werden für Wiederbuchungen freigegeben.
+
+```php
+// Nach Stornierung kann derselbe Slot wieder gebucht werden
+DELETE /reservations/1               → 200
+POST /reservations  {same slot...}   → 201  ✅ Slot ist frei
+```
+
+## Verfügbarkeitsansicht
+
+```php
+GET /resources/1/availability?from=2026-06-01&to=2026-06-02
+→ 200
+{
+  "reservations": [
+    {"id": 1, "booker": "alice", "starts_at": "2026-06-01 09:00:00", "ends_at": "2026-06-01 10:00:00"},
+    {"id": 2, "booker": "bob",   "starts_at": "2026-06-01 11:00:00", "ends_at": "2026-06-01 12:00:00"}
+  ]
+}
+
+// Stornierte Reservierungen werden NICHT eingeschlossen
+// Fehlende from/to-Parameter
+GET /resources/1/availability
+→ 422
+```
+
+---
+
+## ATK-Assessment — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Reservierung eines anderen Buchenden stornieren ⚠️ EXPOSED
+
+**Angriff**: Angreifer errät oder entdeckt eine Reservierungs-ID und sendet `DELETE /reservations/{id}`, um die Buchung eines anderen zu stornieren.
+**Ergebnis**: EXPOSED — Keine Authentifizierungsprüfung bei DELETE. Jeder Client, der eine Reservierungs-ID kennt, kann sie stornieren. Abhilfe: Authentifizierungstoken oder einen bei Buchungszeit ausgestellten geheimen Stornierungstoken erforderlich machen (ähnlich einem Terminbestätigungscode).
+
+---
+
+### ATK-02 — Doppelbuchung via schnelles Stornieren + Wiederbuchungs-Race 🚫 BLOCKED
+
+**Angriff**: Angreifer storniert eine Reservierung und übermittelt sie gleichzeitig neu, um den Slot exklusiv zu halten während andere blockiert sind.
+**Ergebnis**: BLOCKED — Stornierung setzt `status = 'cancelled'` und die Überlappungsabfrage filtert nach `status = 'active'`. DB-Zeilensperrung verhindert, dass gleichzeitiges Stornieren+Buchen einen inkonsistenten Zustand sieht. Der Slot wird sauber freigegeben bevor die nächste Buchung erfolgreich sein kann.
+
+---
+
+### ATK-03 — Überlappung injizieren um eine andere Buchung zu überschreiben 🚫 BLOCKED
+
+**Angriff**: Angreifer übermittelt eine Buchung mit `starts_at`, das genau mit der Grenze einer bestehenden Buchung übereinstimmt, in der Hoffnung, angrenzende Slots "zu absorbieren".
+**Ergebnis**: BLOCKED — Halboffene Intervallsemantik ist streng. `starts_at == existing.ends_at` ist angrenzend, nicht überlappend. Partielle Überlappungsinjektion wird durch die SQL-Konfliktabfrage erfasst.
+
+---
+
+### ATK-04 — SQL-Injection via `booker`-Feld 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `"booker": "alice'; DROP TABLE reservations--"`, um die DB zu korrumpieren.
+**Ergebnis**: BLOCKED — Alle Abfragen verwenden parametrisierte Anweisungen. `booker` wird als gebundener Wert eingefügt, niemals interpoliert.
+
+---
+
+### ATK-05 — Überlauf `resource_id` um nicht erreichbare Ressourcen zuzugreifen 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `resource_id: 9999999999999999999`, um die Validierung zu umgehen.
+**Ergebnis**: BLOCKED — `resource_id` wird als positive Ganzzahl validiert. Überlaufwerte → 422. Die Ressourcenexistenzprüfung gibt 404 für unbekannte IDs zurück, bevor Buchungslogik läuft.
+
+---
+
+### ATK-06 — Bereits stornierte Reservierung stornieren um Zustandsverwirrung zu verursachen 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `DELETE /reservations/1` zweimal, in der Hoffnung, dass der zweite Aufruf die Buchung reaktiviert oder den Status korrumpiert.
+**Ergebnis**: BLOCKED — Die zweite Stornierung gibt 409 Conflict zurück. Die Anwendung prüft `status = 'active'` vor dem Stornieren; `status = 'cancelled'`-Datensätze werden nicht modifiziert.
+
+---
+
+### ATK-07 — Verfügbarkeitsabfrage mit massivem Datumsbereich (DoS) ⚠️ EXPOSED
+
+**Angriff**: Angreifer sendet `GET /resources/1/availability?from=2000-01-01&to=2099-12-31`, um einen Hundert-Jahre-Dump zurückzugeben.
+**Ergebnis**: EXPOSED — Keine maximale Bereichsbegrenzung wird durchgesetzt. Ein großer Datumsbereich gibt alle Reservierungen in diesem Fenster zurück, was möglicherweise einen langsamen DB-Scan verursacht. Abhilfe: Das `to - from`-Fenster begrenzen (z.B. 31 Tage) und 422 zurückgeben wenn überschritten.
+
+---
+
+### ATK-08 — Slot in der Vergangenheit buchen 🚫 BLOCKED
+
+**Angriff**: Angreifer übermittelt `starts_at: "2020-01-01 00:00:00"`, um eine historische Reservierung zu erstellen und möglicherweise Berichte zu manipulieren.
+**Ergebnis**: BLOCKED — Der Server validiert `ends_at > starts_at`, erfordert aber standardmäßig nicht, dass `starts_at` in der Zukunft liegt. Für Produktionssysteme `starts_at >= now()`-Validierung hinzufügen, um vergangene Buchungen abzulehnen.
+
+---
+
+### ATK-09 — Ungültiges Datumsformat injizieren 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `"starts_at": "kein-datum"`, um die Vergleichslogik zu korrumpieren.
+**Ergebnis**: BLOCKED — Daten werden vor jeder DB-Operation gegen das erwartete Format validiert. Ungültige Formate geben 422 zurück.
+
+---
+
+### ATK-10 — Verfügbarkeit für nicht existierende Ressource 🚫 BLOCKED
+
+**Angriff**: Angreifer fragt `GET /resources/9999/availability?from=...&to=...` ab, in der Hoffnung, Daten zu lecken oder Auth zu umgehen.
+**Ergebnis**: BLOCKED — Ressourcenexistenz wird geprüft; unbekannte Ressource → 404.
+
+---
+
+### ATK-11 — Zu langes Buchender-Feld (Speichermissbrauch) ⚠️ EXPOSED
+
+**Angriff**: Angreifer übermittelt einen 1-MB-`booker`-String, um Speicher zu erschöpfen.
+**Ergebnis**: EXPOSED — Keine maximale Länge bei `booker` durchgesetzt. Abhilfe: Eine `MAX_BOOKER_LENGTH`-Konstante hinzufügen (z.B. 255 Zeichen) und 422 zurückgeben wenn überschritten.
+
+---
+
+### ATK-12 — Mehrfache Stornierungen um Slots für Flash-Buchungsangriff freizugeben 🚫 BLOCKED
+
+**Angriff**: Angreifer storniert viele Reservierungen gleichzeitig vor und bucht sie schnell wieder, um eine Ressource zu monopolisieren.
+**Ergebnis**: BLOCKED — Jedes Stornieren+Wiederbuchungs-Paar muss die Überlappungsabfrage bestehen. Die DB serialisiert Schreibvorgänge pro Zeile; gleichzeitige Versuche können nicht beide für denselben Slot gelingen.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|---------|
+| ATK-01 | Reservierung eines anderen stornieren | ⚠️ EXPOSED |
+| ATK-02 | Doppelbuchung via Stornieren + Wiederbuchungs-Race | 🚫 BLOCKED |
+| ATK-03 | Überlappungsinjektion um angrenzende Slots zu absorbieren | 🚫 BLOCKED |
+| ATK-04 | SQL-Injection via booker-Feld | 🚫 BLOCKED |
+| ATK-05 | Überlauf resource_id | 🚫 BLOCKED |
+| ATK-06 | Bereits storniert stornieren (Zustandsverwirrung) | 🚫 BLOCKED |
+| ATK-07 | Verfügbarkeitsabfrage mit riesigem Datumsbereich | ⚠️ EXPOSED |
+| ATK-08 | Slot in der Vergangenheit buchen | 🚫 BLOCKED |
+| ATK-09 | Ungültige Datumsformat-Injektion | 🚫 BLOCKED |
+| ATK-10 | Verfügbarkeit für nicht existierende Ressource | 🚫 BLOCKED |
+| ATK-11 | Buchender-Feld zu lang | ⚠️ EXPOSED |
+| ATK-12 | Flash-Buchungs-Monopolisierung | 🚫 BLOCKED |
+
+**9 BLOCKED, 3 EXPOSED** — Kritisch: Stornierung authentifizieren; Verfügbarkeits-Datumsbereich begrenzen; Buchender-Feld-Länge begrenzen.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Keine Auth bei DELETE /reservations/{id} | Jeder Client kann jede Buchung stornieren |
+| Stornierte Reservierungen hard-löschen | Slot-Historie geht verloren; Verfügbarkeitslücken erscheinen im Prüfungsprotokoll |
+| Kein Statusfilter in Überlappungsabfrage | Stornierte Slots blockieren neue Buchungen |
+| Geschlossene Intervalle bei Überlappungsprüfung | Angrenzende Slots (Ende = Start) werden fälschlicherweise als Konflikte abgelehnt |
+| Kein maximaler Datumsbereich bei Verfügbarkeit | Großer Bereich verursacht Full-Table-Scan |
+| `starts_at >= ends_at` akzeptieren | Null oder negative Dauer erzeugt Logikfehler |

--- a/docs/de/howto/resource-booking.md
+++ b/docs/de/howto/resource-booking.md
@@ -1,0 +1,155 @@
+# How-to: Ressourcenbuchungssystem
+
+## Übersicht
+
+Diese Anleitung behandelt den Aufbau einer Ressourcenbuchungs-API mit NENE2. Funktionen umfassen Kapazitätsdurchsetzung, Doppelbuchungsprävention, IDOR-Isolation pro Benutzer und Admin-Stornierung.
+
+**Referenzimplementierung**: `../NENE2-FT/bookinglog/`
+
+---
+
+## Schema-Design
+
+```sql
+CREATE TABLE IF NOT EXISTS resources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL UNIQUE,
+    capacity   INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bookings (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL,
+    user_id     INTEGER NOT NULL,
+    slot_date   TEXT    NOT NULL,   -- 'YYYY-MM-DD'
+    slot_hour   INTEGER NOT NULL,   -- 0-23
+    created_at  TEXT    NOT NULL,
+    cancelled   INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE CASCADE,
+    UNIQUE (resource_id, user_id, slot_date, slot_hour)
+);
+```
+
+Schlüsselconstraints:
+- `UNIQUE (resource_id, user_id, slot_date, slot_hour)` — eine Buchung pro Benutzer pro Slot.
+- `cancelled` Soft-Delete-Flag — Geschichte beibehalten während Wiederbuchungen ermöglicht werden.
+- Kapazität wird zur Abfragezeit geprüft (aktive Buchungen zählen vs. resource.capacity).
+
+---
+
+## Routentabelle
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `GET` | `/resources` | Keine | Alle Ressourcen auflisten |
+| `POST` | `/resources` | Admin | Ressource erstellen |
+| `POST` | `/bookings` | Benutzer | Slot buchen |
+| `GET` | `/bookings` | Benutzer | Eigene Buchungen auflisten |
+| `GET` | `/bookings/{id}` | Benutzer | Eine Buchung abrufen |
+| `DELETE` | `/bookings/{id}` | Benutzer/Admin | Buchung stornieren |
+
+---
+
+## Doppelbuchungsprävention
+
+Zuerst prüfen, ob der Benutzer diesen Slot bereits hat (Anwendungsebene):
+
+```php
+$stmt = $this->pdo->prepare(
+    'SELECT id FROM bookings WHERE resource_id = :rid AND user_id = :uid
+     AND slot_date = :d AND slot_hour = :h AND cancelled = 0'
+);
+$stmt->execute([...]);
+if ($stmt->fetch() !== false) {
+    return 'double_booking';
+}
+```
+
+Dann Kapazität prüfen:
+
+```php
+$count = $this->countSlotBookings($resourceId, $date, $hour);
+if ($count >= (int) $resource['capacity']) {
+    return 'capacity_full';
+}
+```
+
+---
+
+## IDOR-Isolation
+
+Benutzer können nur ihre eigenen Buchungen lesen/stornieren. 404 (nicht 403) zurückgeben, um die Existenz nicht preiszugeben:
+
+```php
+if (!$this->isAdmin($req) && (int) $booking['user_id'] !== $uid) {
+    return $this->problem(404, 'not-found', 'Buchung nicht gefunden.');
+}
+```
+
+---
+
+## Admin storniert ohne X-User-Id
+
+Admin kann jede Buchung ohne eigene Benutzer-ID stornieren:
+
+```php
+$isAdmin = $this->isAdmin($req);
+$uid     = $this->uid($req);
+if ($uid === null && !$isAdmin) {
+    return $this->problem(400, 'bad-request', 'X-User-Id erforderlich.');
+}
+$result = $this->repo->cancel($id, $uid ?? 0, $isAdmin);
+```
+
+---
+
+## Validierungsregeln
+
+| Feld | Regel |
+|---|---|
+| `resource_id` | `is_int()` + positiv |
+| `slot_date` | Regex `/\A\d{4}-\d{2}-\d{2}\z/` |
+| `slot_hour` | `is_int()` + 0–23 |
+| `capacity` | `is_int()` + positiv |
+| `name` | nicht-leerer String |
+
+---
+
+## HTTP-Statuscodes
+
+| Situation | Status |
+|---|---|
+| Ressource erstellt | 201 |
+| Buchung bestätigt | 201 |
+| Buchung gefunden / Liste | 200 |
+| Kein X-User-Id | 400 |
+| Ungültiger Feldtyp | 422 |
+| Ungültiges Datumsformat | 422 |
+| slot_hour außerhalb 0–23 | 422 |
+| Ressource nicht gefunden | 404 |
+| Buchung nicht gefunden | 404 |
+| Kein Admin-Key | 403 |
+| Eigene Buchung stornieren | 200 |
+| Buchung eines anderen stornieren | 403 |
+| Doppelbuchung | 409 |
+| Kapazität voll | 409 |
+
+---
+
+## Behandelte VULN-Muster
+
+| VULN | Muster | Abwehr |
+|---|---|---|
+| A | IDOR: Benutzer sieht andere Buchung | `WHERE user_id = :uid` + 404 |
+| B | Negative resource_id | `is_int() + > 0`-Prüfung |
+| C | null slot_hour (Mitternacht) | Bereich 0-23 erlaubt 0 |
+| D | SQL-Injection in slot_date | Regex-Validierung + parametrisierte Abfrage |
+| E | String resource_id Typ-Jonglage | `is_int()` strenge Prüfung |
+| F | Doppelbuchung | Existenzprüfung vor INSERT |
+| G | Kapazitätsüberlauf | COUNT vs. Kapazitätsprüfung |
+| H | Kein X-User-Id | 400 mit Meldung |
+| I | Buchung eines anderen Benutzers stornieren | `user_id`-Eigentümerprüfung → 403 |
+| J | Liste gibt Daten anderer Benutzer preis | `WHERE user_id = :uid` |
+| K | Admin storniert beliebige Buchung | `isAdmin` umgeht Eigentümerschaft |
+| L | slot_hour = 24 (außerhalb des Bereichs) | `$hour > 23` → 422 |

--- a/docs/de/howto/resource-reservation-booking.md
+++ b/docs/de/howto/resource-reservation-booking.md
@@ -1,0 +1,231 @@
+# How-to: Ressourcenreservierungs- und Buchungs-API
+
+> **FT-Referenz**: FT335 (`NENE2-FT/reservationlog`) — Ressourcen-Zeitfenster-Buchung mit halboffenem Intervall-Überlappungsprävention, user_id aus öffentlichen Antworten ausgeschlossen, Stornieren-IDOR-Schutz (403), Admin/Benutzer-Dual-Level-Zugriff, 30 Tests / 70+ Assertions bestanden.
+
+Diese Anleitung zeigt, wie ein Raum/Ressourcen-Buchungssystem gebaut wird: buchbare Ressourcen erstellen (Admin), Zeitfenster buchen (Benutzer), Überlappungen atomar verhindern und Benutzerprivatsphäre in öffentlichen Antworten schützen.
+
+## Schema
+
+```sql
+CREATE TABLE resources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE bookings (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL REFERENCES resources(id),
+    user_id     INTEGER NOT NULL,
+    starts_at   TEXT    NOT NULL,   -- ISO 8601 UTC
+    ends_at     TEXT    NOT NULL,
+    note        TEXT,               -- optional
+    created_at  TEXT    NOT NULL
+);
+```
+
+Daten werden als ISO 8601 UTC-Strings gespeichert (`2026-06-01T09:00:00Z`). Lexikographischer Vergleich ist für UTC-ISO-Strings korrekt.
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `POST` | `/resources` | Admin | Buchbare Ressource erstellen |
+| `POST` | `/resources/{id}/book` | Benutzer | Zeitfenster buchen |
+| `DELETE` | `/bookings/{id}` | Benutzer (Eigentümer) | Eigene Buchung stornieren |
+| `GET` | `/bookings` | Benutzer | Eigene Buchungen auflisten |
+| `GET` | `/resources/{id}/bookings` | Admin | Alle Buchungen für Ressource auflisten |
+
+## Ressource erstellen (Admin)
+
+```php
+POST /resources
+X-Admin-Key: admin-secret
+{"name": "Besprechungsraum 1"}
+→ 201  {"resource": {"id": 1, "name": "Besprechungsraum 1", "created_at": "..."}}
+
+// Kein Admin-Key
+POST /resources  {"name": "Raum"}
+→ 401
+
+POST /resources  X-Admin-Key: admin-secret  {"name": ""}
+→ 422  // Name erforderlich
+
+POST /resources  X-Admin-Key: admin-secret  {"name": "x".repeat(201)}
+→ 422  // Name zu lang (max 200 Zeichen)
+```
+
+## Zeitfenster buchen
+
+```php
+POST /resources/1/book
+X-User-Id: 101
+{"starts_at": "2026-06-01T09:00:00Z", "ends_at": "2026-06-01T10:00:00Z"}
+→ 201
+{
+  "booking": {
+    "id": 1,
+    "resource_id": 1,
+    "starts_at": "2026-06-01T09:00:00Z",
+    "ends_at": "2026-06-01T10:00:00Z",
+    "note": null,
+    "created_at": "..."
+    // user_id wird NICHT zurückgegeben — IDOR-Prävention
+  }
+}
+
+// Optionale Notiz
+POST /resources/1/book  X-User-Id: 101
+{"starts_at": "2026-06-01T09:00:00Z", "ends_at": "2026-06-01T10:00:00Z", "note": "Teammeeting"}
+→ 201  {"booking": {..., "note": "Teammeeting"}}
+```
+
+### Validierungsfehler
+
+```php
+// ends_at vor starts_at
+{"starts_at": "2026-06-01T10:00:00Z", "ends_at": "2026-06-01T09:00:00Z"}
+→ 422
+
+// starts_at == ends_at (Null-Dauer)
+{"starts_at": "2026-06-01T09:00:00Z", "ends_at": "2026-06-01T09:00:00Z"}
+→ 422
+
+// Fehlende starts_at
+{"ends_at": "2026-06-01T10:00:00Z"}
+→ 422
+
+// Fehlende X-User-Id
+POST /resources/1/book  (kein Header)
+→ 400
+
+// Null oder Überlauf X-User-Id
+X-User-Id: 0    → 400
+X-User-Id: 9999999999999999999  → 400
+
+// Unbekannte Ressource
+POST /resources/9999/book  X-User-Id: 101  {...}
+→ 404
+```
+
+## Überlappungsprävention — Halboffene Intervalle
+
+Slots sind **halboffen**: `[starts_at, ends_at)`. Das Ende einer Buchung und der Start der nächsten sind gleich, aber nicht überlappend.
+
+```php
+// 09:00–10:00 buchen
+POST /resources/1/book  {"starts_at": "09:00", "ends_at": "10:00"}  → 201
+
+// Überlappend — beginnt innerhalb bestehenden Slots
+POST /resources/1/book  {"starts_at": "10:00", "ends_at": "11:00"}  → 201  ✅ angrenzend, erlaubt
+
+// Überlappend — innen
+POST /resources/1/book  {"starts_at": "09:30", "ends_at": "11:00"}  → 409  ❌ Überlappung
+
+// Identischer Slot
+POST /resources/1/book  {"starts_at": "09:00", "ends_at": "10:00"}  → 409  ❌
+
+// Nicht überlappend auf gleicher Ressource
+POST /resources/1/book  {"starts_at": "14:00", "ends_at": "15:00"}  → 201  ✅
+
+// Gleicher Slot auf ANDERER Ressource — immer erlaubt
+POST /resources/2/book  {"starts_at": "09:00", "ends_at": "10:00"}  → 201  ✅
+```
+
+### Überlappungs-SQL-Abfrage
+
+```sql
+-- Konflikt erkennen: NOT (new.ends_at <= existing.starts_at OR new.starts_at >= existing.ends_at)
+SELECT COUNT(*) FROM bookings
+WHERE resource_id = ?
+  AND starts_at < ?   -- existing.starts_at < new.ends_at
+  AND ends_at   > ?   -- existing.ends_at > new.starts_at
+```
+
+Wenn count > 0, 409 Conflict zurückgeben.
+
+## Buchung stornieren (IDOR-Schutz)
+
+```php
+DELETE /bookings/1
+X-User-Id: 101
+→ 200  {"cancelled": true}
+
+// Falscher Benutzer → 403, NICHT 404
+DELETE /bookings/1
+X-User-Id: 102
+→ 403  // Benutzer 102 besitzt Buchung 1 nicht
+
+// Nicht gefunden → 404
+DELETE /bookings/9999
+X-User-Id: 101
+→ 404
+```
+
+**403 (nicht 404) bei falscher Benutzer-Stornierung zurückgeben** — 404 würde es Benutzern erlauben, die Buchungs-IDs anderer Benutzer zu erkunden. Die Buchung existiert; der Anfragende ist nicht der Eigentümer.
+
+```php
+// Nach Stornierung ist Slot frei
+DELETE /bookings/1  X-User-Id: 101  → 200
+POST /resources/1/book  X-User-Id: 102  {"starts_at": "09:00", "ends_at": "10:00"}  → 201
+```
+
+### ID-Validierung
+
+```php
+DELETE /bookings/0                    → 422  // Null ist ungültig
+DELETE /bookings/99999999999999999999 → 422  // Überlauf
+POST /resources/0/book  X-User-Id: 101 {...} → 422  // resource_id null ungültig
+```
+
+## Eigene Buchungen auflisten (Benutzer)
+
+```php
+GET /bookings
+X-User-Id: 101
+→ 200
+{
+  "total": 2,
+  "data": [
+    {"id": 1, "resource_id": 1, "starts_at": "...", "ends_at": "...", "note": null, "created_at": "..."}
+    // user_id ist NICHT enthalten
+  ]
+}
+
+// Buchungen anderer Benutzer werden nicht zurückgegeben
+// Benutzer 101 sieht nur seine eigenen Buchungen auch wenn Benutzer 102 Buchungen hat
+```
+
+## Ressourcenbuchungen auflisten (Admin)
+
+```php
+GET /resources/1/bookings
+X-Admin-Key: admin-secret
+→ 200
+{
+  "total": 2,
+  "data": [
+    {"id": 1, "user_id": 101, "starts_at": "2026-06-01T09:00:00Z", ...},  // user_id sichtbar
+    {"id": 2, "user_id": 102, "starts_at": "2026-06-01T14:00:00Z", ...}
+  ]
+}
+// Geordnet nach starts_at ASC
+
+GET /resources/1/bookings  (kein Admin-Key)  → 401
+GET /resources/9999/bookings  X-Admin-Key: key  → 404
+```
+
+Admin erhält `user_id` in der Antwort; öffentliche Benutzerendpunkte geben niemals `user_id` zurück.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Überlappungsprüfung: geschlossene Intervalle | Angrenzende Slots (Ende von A = Start von B) werden fälschlicherweise als überlappend abgelehnt |
+| `user_id` in öffentlichen Buchungsantworten zurückgeben | Gibt preis, wer jede Buchung besitzt, ermöglicht Benutzer-Enumeration |
+| 404 bei falscher Benutzer-Stornierung zurückgeben | Angreifer bestätigt, dass die Buchung existiert; 403 verwenden um Eigentümerschaft-Inkongruenz anzuerkennen |
+| `starts_at >= ends_at` akzeptieren | Buchungen mit Null oder negativer Dauer korrumpieren Verfügbarkeitsberechnungen |
+| Kein resource_id-Scoping in Überlappungsabfrage | Buchung von Benutzer A auf Ressource 1 blockiert Ressource 2 (Falsch-Konflikt) |
+| `user_id` aus Request-Body vertrauen | Angreifer macht Buchungen im Namen beliebiger Benutzer; Identität immer aus `X-User-Id`-Header lesen |

--- a/docs/de/howto/resource-reservation.md
+++ b/docs/de/howto/resource-reservation.md
@@ -1,0 +1,155 @@
+# How-to: Ressourcenreservierung / Zeitfenster-Buchungs-API
+
+Diese Anleitung zeigt, wie ein Zeitfenster-Buchungssystem mit Überlappungsprävention in NENE2 gebaut wird.
+Muster demonstriert durch das **reservationlog** Feldversuch (FT216).
+
+## Funktionen
+
+- Benannte Ressourcen erstellen (Besprechungsräume, Ausrüstung usw.) — nur Admin
+- Zeitfenster buchen mit automatischer Überlappungserkennung
+- Buchungen pro Ressource (Admin) oder pro Benutzer (selbst) auflisten
+- Buchungen mit Eigentümerverifizierung stornieren
+- Öffentliche Antworten schließen `user_id` aus (IDOR-Prävention)
+- Admin-Ansicht enthält `user_id` für Prüfung
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS resources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bookings (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL,
+    user_id     INTEGER NOT NULL,
+    starts_at   TEXT    NOT NULL,   -- ISO 8601 UTC
+    ends_at     TEXT    NOT NULL,   -- ISO 8601 UTC
+    note        TEXT,
+    created_at  TEXT    NOT NULL,
+    FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE CASCADE
+);
+
+-- Index für schnelle Überlappungsabfragen
+CREATE INDEX IF NOT EXISTS idx_bookings_resource_time
+    ON bookings (resource_id, starts_at, ends_at);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `POST` | `/resources` | Admin | Ressource erstellen |
+| `GET` | `/resources/{id}/bookings` | Admin | Alle Buchungen für Ressource auflisten |
+| `POST` | `/resources/{id}/book` | Benutzer | Zeitfenster buchen |
+| `GET` | `/bookings` | Benutzer | Eigene Buchungen auflisten |
+| `DELETE` | `/bookings/{id}` | Benutzer | Eigene Buchung stornieren |
+
+## Überlappungserkennung
+
+Zwei Zeitbereiche `[A.start, A.end)` und `[B.start, B.end)` überlappen sich wenn:
+
+```
+A.start < B.end AND A.end > B.start
+```
+
+Das behandelt korrekt alle Überlappungsfälle (enthält, überschneidet, identisch) während angrenzende Slots erlaubt werden (A.end = B.start ist OK — halboffene Intervallsemantik).
+
+```sql
+SELECT COUNT(*) FROM bookings
+WHERE resource_id = :rid
+  AND starts_at < :ends_at
+  AND ends_at   > :starts_at
+```
+
+```php
+public function book(int $resourceId, int $userId, string $startsAt, string $endsAt, ?string $note): ?Booking
+{
+    $overlap = $this->countOverlaps($resourceId, $startsAt, $endsAt, excludeId: null);
+    if ($overlap > 0) {
+        return null; // → 409 Conflict
+    }
+    // ... INSERT
+}
+```
+
+## Value Objects
+
+Readonly Value Objects für Domänenklarheit verwenden:
+
+```php
+final readonly class Booking
+{
+    public function __construct(
+        public int     $id,
+        public int     $resourceId,
+        public int     $userId,
+        public string  $startsAt,
+        public string  $endsAt,
+        public ?string $note,
+        public string  $createdAt,
+    ) {}
+
+    /** Öffentliche Ansicht: schließt user_id aus (IDOR-Prävention) */
+    public function toPublicArray(): array { ... }
+
+    /** Admin-Ansicht: enthält user_id für Prüfung */
+    public function toAdminArray(): array { ... }
+}
+```
+
+## IDOR-Prävention
+
+Buchungen exponieren öffentliche und Admin-Ansichten mit verschiedenen Feldern:
+
+```php
+// Benutzer: GET /bookings — öffentliche Ansicht (kein user_id)
+return $this->responseFactory->create([
+    'data'  => array_map(fn(Booking $b) => $b->toPublicArray(), $bookings),
+    'total' => count($bookings),
+]);
+
+// Admin: GET /resources/{id}/bookings — Admin-Ansicht (enthält user_id)
+return $this->responseFactory->create([
+    'data'  => array_map(fn(Booking $b) => $b->toAdminArray(), $bookings),
+    'total' => count($bookings),
+]);
+```
+
+Stornieren gibt 403 (nicht 404) zurück, wenn ein Benutzer versucht, die Buchung eines anderen zu stornieren, da die Buchungs-ID bereits sichtbar ist (keine versteckte Existenz):
+
+```php
+/** @return 'cancelled'|'not_found'|'not_owner' */
+public function cancel(int $id, int $userId): string
+{
+    $booking = $this->findBookingById($id);
+    if ($booking === null) return 'not_found';     // → 404
+    if ($booking->userId !== $userId) return 'not_owner'; // → 403
+    // DELETE ...
+    return 'cancelled'; // → 200
+}
+```
+
+## Sicherheitsmuster
+
+- **Admin fail-closed**: `if ($this->adminKey === '') return false;` vor `hash_equals()`
+- **`ctype_digit()`**: ReDoS-sichere Integer-Validierung für Pfad-IDs
+- **ISO 8601-Validierung**: Regex-Muster + lexikographischer Vergleich (funktioniert in UTC)
+- **Notizlängen-Guard**: `mb_strlen($note) > 500` gibt 422 zurück
+- **Kaskaden-Löschen**: `ON DELETE CASCADE` stellt sicher, dass Buchungen mit der Ressource entfernt werden
+
+## VULN + ATK-Assessment (FT216)
+
+Dieser FT besteht vollständige VULN-A bis VULN-L und ATK-01 bis ATK-12 Auswertungen:
+
+- **VULN-B**: Kein Mass Assignment — Ressourcen/Buchungsfelder werden explizit gebunden
+- **VULN-C**: Stornieren gibt 403 für falschen Eigentümer zurück; Ressourcen/Buchungssuchen verwenden typisierte IDs
+- **VULN-D**: Admin fail-closed — leerer Admin-Key gibt immer false zurück
+- **VULN-F**: ISO 8601-Regex verhindert Datetime-Injection
+- **VULN-G**: `ctype_digit()` sichert alle Integer-Pfadparameter ab
+- **ATK-01**: SQL-Injection durch parametrisierte Abfragen geblockt
+- **ATK-02/03**: Integer-Überlauf in IDs durch `strlen > 18`-Guard geblockt
+- **ATK-06**: Authentifizierungs-Bypass durch fail-closed Admin-Prüfung geblockt
+- **ATK-09**: Überlappungslogik verhindert korrekt Doppelbuchungen

--- a/docs/de/howto/scheduled-publish-article.md
+++ b/docs/de/howto/scheduled-publish-article.md
@@ -1,0 +1,126 @@
+# How-to: Geplante Artikel-Veröffentlichung
+
+> **FT-Referenz**: FT330 (`NENE2-FT/pubschedulelog`) — Artikel-Entwurf/Zeitplan/Veröffentlichung/Archiv-Lebenszyklus, nur-Eigentümer-Entwurfszugriff, öffentlich veröffentlichte Artikel, geplanter Veröffentlichungsauslöser, 34 Tests / 95 Assertions bestanden.
+
+Dieses Handbuch zeigt, wie man ein Artikelverwaltungssystem mit verzögerter Veröffentlichung aufbaut: Autoren schreiben Entwürfe, planen sie für einen zukünftigen Zeitpunkt, und ein Hintergrundjob (oder API-Aufruf) überführt sie in veröffentlicht.
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    author_id  INTEGER NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    status     TEXT    NOT NULL DEFAULT 'draft',   -- draft | scheduled | published | archived
+    publish_at TEXT,                               -- ISO-8601, NULL wenn nicht geplant
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+## Status-Übergänge
+
+```
+draft ──veröffentlichen──► published ──archivieren──► archived
+  │
+  └──planen──► scheduled ──(Zeit vergeht)──► published
+  │               │
+  │           unplanen
+  │               │
+  └───────────────┘
+```
+
+Nur erlaubte Übergänge — ungültige Übergänge geben 409 zurück.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST`  | `/articles` | Entwurf erstellen (`X-User-Id` erforderlich) |
+| `GET`   | `/articles/{id}` | Abrufen (Entwurf: nur Eigentümer; veröffentlicht: öffentlich) |
+| `PUT`   | `/articles/{id}` | Entwurf aktualisieren (`X-User-Id` erforderlich) |
+| `POST`  | `/articles/{id}/publish` | Sofort veröffentlichen |
+| `POST`  | `/articles/{id}/schedule` | Für zukünftigen Zeitpunkt planen |
+| `POST`  | `/articles/{id}/unschedule` | Zurück zu Entwurf |
+| `POST`  | `/articles/{id}/archive` | Veröffentlichten Artikel archivieren |
+| `GET`   | `/articles` | Auflisten (mit `?status=`-Filter) |
+| `POST`  | `/publish-due` | Geplante Artikel mit publish_at <= jetzt auslösen |
+
+## Entwurf erstellen
+
+```php
+POST /articles  X-User-Id: 1
+{"title": "Hallo", "body": "Welt"}
+→ 201  {"id": 1, "status": "draft", "author_id": 1}
+
+// Keine Auth → 401
+```
+
+## Sichtbarkeitsregeln
+
+```php
+// Entwurf: nur Eigentümer
+GET /articles/1  X-User-Id: 1  → 200   // Autor sieht eigenen Entwurf
+GET /articles/1  X-User-Id: 2  → 404   // anderer Benutzer kann Entwurf nicht sehen
+GET /articles/1               → 404   // keine Auth, Entwurf versteckt
+
+// Veröffentlicht: alle
+GET /articles/1               → 200   // öffentlich
+```
+
+## Veröffentlichen & Archivieren
+
+```php
+POST /articles/1/publish  X-User-Id: 1  → 200  {"status": "published"}
+POST /articles/1/archive  X-User-Id: 1  → 200  {"status": "archived"}
+
+// Kann Entwurf nicht archivieren
+POST /articles/1/archive  X-User-Id: 1  → 409
+```
+
+## Planen
+
+```php
+// Für 1 Stunde ab jetzt planen
+POST /articles/1/schedule  X-User-Id: 1
+{"publish_at": "2026-05-27T15:00:00+09:00"}
+→ 200  {"status": "scheduled", "publish_at": "2026-05-27T15:00:00+09:00"}
+
+// Vergangene Zeit → 422
+POST /articles/1/schedule  X-User-Id: 1
+{"publish_at": "2020-01-01T00:00:00Z"}
+→ 422
+
+// Unplanen → zurück zu Entwurf
+POST /articles/1/unschedule  X-User-Id: 1
+→ 200  {"status": "draft", "publish_at": null}
+```
+
+## Geplante Artikel auslösen
+
+Ein Cron-Job oder Admin-Endpunkt überführt alle geplanten Artikel mit `publish_at <= jetzt`:
+
+```php
+POST /publish-due
+→ 200  {"published_count": 3}
+```
+
+## Artikel auflisten
+
+```php
+GET /articles?status=published      → 200  // öffentlich, keine Auth nötig
+GET /articles?status=draft  X-User-Id: 1  → 200  // nur eigene Entwürfe
+```
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Pattern | Risiko |
+|---|---|
+| Entwurf für unauthentifizierten Benutzer anzeigen | Unveröffentlichte Inhalte lecken |
+| Planung in der Vergangenheit erlauben | Artikel würde "sofort" über den Auslöser-Job veröffentlicht, ohne Überprüfung zu umgehen |
+| Wanduhr now() im Test für Planungsauslöser verwenden | Tests werden zeitabhängig; vergangenes `publish_at` im Test per Force-Insert verwenden |
+| Hartes Löschen beim Archivieren | Prüfungspfad verloren gehen; Status-Feld verwenden |
+| Übergang von archiviert → veröffentlicht erlauben | Bringt entfernte Inhalte zurück; explizites Neu-Veröffentlichen erforderlich |

--- a/docs/de/howto/scheduled-reminders.md
+++ b/docs/de/howto/scheduled-reminders.md
@@ -1,0 +1,191 @@
+# How-to: Geplante Erinnerungs-API
+
+> **FT-Referenz**: FT235 (`NENE2-FT/reminderlog`) — Geplante Erinnerungs-API
+
+Demonstriert eine Erinnerungs-Planungs-API mit zeitzonenbewusster Zukunftsdatum-Validierung,
+leichter Pro-Anfrage-Benutzeridentifikation via Header, IDOR-Prävention durch
+eigentümerschafts-begrenzte Abfragen und einer 404/409-Unterscheidung beim Stornieren einer Erinnerung.
+
+---
+
+## Routen
+
+| Methode  | Pfad                        | Beschreibung                                           |
+|---------|-----------------------------|-------------------------------------------------------|
+| `POST`  | `/reminders`                | Erinnerung erstellen (zukünftiges `remind_at` erforderlich) |
+| `GET`   | `/reminders`                | Erinnerungen für Aufrufer auflisten (nach Status filterbar) |
+| `PATCH` | `/reminders/{id}/cancel`    | Ausstehende Erinnerung stornieren |
+
+Alle Routen erfordern den `X-User-Id`-Header.
+
+---
+
+## Leichte Benutzeridentifikation via Header
+
+Statt Bearer JWT verwendet diese API einen `X-User-Id`-Integer-Header als minimalen
+Authentifizierungs-/Identifikationsmechanismus:
+
+```php
+$userId = V::userId($request->getHeaderLine('X-User-Id'));
+
+if ($userId === null) {
+    return $this->responseFactory->create(
+        ['error' => 'X-User-Id header must be a positive integer.'],
+        401,
+    );
+}
+```
+
+`V::userId()` validiert den Header-Wert:
+
+```php
+public static function userId(string $header): ?int
+{
+    // ctype_digit('') === false — leere Zeichenkette bereits abgelehnt.
+    if (!ctype_digit($header) || strlen($header) > 18) {
+        return null;
+    }
+
+    $id = (int) $header;
+
+    return $id > 0 ? $id : null;
+}
+```
+
+Schlüsseleigenschaften:
+- `ctype_digit()` — ReDoS-immun, lehnt `0`, `-1`, `1.5`, `abc`, leere Zeichenkette ab.
+- `strlen > 18` — Überlauf-Guard vor `(int)`-Cast (PHP_INT_MAX hat 19 Stellen).
+- `$id > 0` — lehnt die geparste Integer-Null ab.
+
+---
+
+## Zukunftsdatum-Validierung (zeitzonenbewusst)
+
+`remind_at` muss ein gültiger ISO 8601-Datetime mit explizitem Timezone-Offset **und**
+muss streng in der Zukunft relativ zu jetzt sein:
+
+```php
+$now      = (new DateTimeImmutable())->format(DATE_ATOM);
+$remindAt = V::futureDatetime($rawRemindAt, $now);
+
+if ($remindAt === null) {
+    return $this->responseFactory->create(
+        ['error' => 'remind_at must be a valid ISO 8601 datetime with timezone offset and must be in the future.'],
+        422,
+    );
+}
+```
+
+`V::futureDatetime()` kombiniert zwei Prüfungen:
+
+```php
+public static function futureDatetime(mixed $raw, string $now): ?string
+{
+    $dt = self::isoDatetime($raw);   // Schritt 1: Format + Bereichsvalidierung
+
+    if ($dt === null) {
+        return null;
+    }
+
+    // Schritt 2: Zeitzonenbewusste Zukunftsprüfung
+    $dtObj  = DateTimeImmutable::createFromFormat(DATE_ATOM, $dt);
+    $nowObj = DateTimeImmutable::createFromFormat(DATE_ATOM, $now);
+
+    if ($dtObj === false || $nowObj === false) {
+        return null;
+    }
+
+    return $dtObj > $nowObj ? $dt : null;  // Objektvergleich normalisiert auf UTC
+}
+```
+
+---
+
+## IDOR-Prävention: Eigentümerschafts-begrenzte Suche
+
+Alle Operationen, die eine bestimmte Erinnerung berühren, verwenden `WHERE id = ? AND user_id = ?`:
+
+```php
+public function findForUser(int $id, int $userId): ?Reminder
+{
+    $stmt = $this->pdo->prepare('SELECT * FROM reminders WHERE id = ? AND user_id = ?');
+    $stmt->execute([$id, $userId]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    return is_array($row) ? $this->hydrate($row) : null;
+}
+```
+
+Wenn die Erinnerung einem anderen Benutzer gehört, gibt `findForUser()` `null` zurück — der Aufrufer
+erhält `404 Not Found`, ununterscheidbar von "Erinnerung existiert nicht". `403 Forbidden`
+zurückzugeben würde bestätigen, dass die ID existiert, was Enumeration-Informationen leckt.
+
+---
+
+## 404 vs 409: Zuerst-Abrufen-Stornieren
+
+Der Stornieren-Handler ruft die Erinnerung ab, bevor der Status geprüft wird. Dieser Zwei-Schritt-Ansatz
+ermöglicht den korrekten HTTP-Status für jeden Fehlerfall:
+
+```php
+// Zuerst abrufen, um 404 (nicht gefunden/falscher Eigentümer) von 409 (falscher Status) zu unterscheiden
+$reminder = $this->repository->findForUser($id, $userId);
+
+if ($reminder === null) {
+    return $this->responseFactory->create(['error' => 'Reminder not found.'], 404);
+}
+
+if ($reminder->status !== ReminderStatus::Pending) {
+    return $this->responseFactory->create(
+        ['error' => sprintf('Cannot cancel a reminder with status "%s".', $reminder->status->value)],
+        409,
+    );
+}
+
+$this->repository->cancel($id, $userId);
+```
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE reminders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    message    TEXT    NOT NULL,
+    remind_at  TEXT    NOT NULL,  -- ISO 8601 mit Timezone-Offset, as-is gespeichert
+    status     TEXT    NOT NULL DEFAULT 'pending',
+    created_at TEXT    NOT NULL,
+    CHECK (status IN ('pending', 'triggered', 'cancelled'))
+);
+
+CREATE INDEX idx_reminders_user   ON reminders (user_id, id);
+CREATE INDEX idx_reminders_status ON reminders (status, id);
+```
+
+---
+
+## Status-Enum
+
+```php
+enum ReminderStatus: string
+{
+    case Pending   = 'pending';
+    case Triggered = 'triggered';
+    case Cancelled = 'cancelled';
+}
+```
+
+Nur `pending`-Erinnerungen können storniert werden (`409` andernfalls). `triggered` wird durch
+einen Hintergrundjob gesetzt, wenn die Erinnerung auslöst — diese API enthält nicht den Auslöser-
+Endpunkt, der auf einem geplanten Task außerhalb des HTTP-Servers laufen würde.
+
+---
+
+## Verwandte Handbücher
+
+- [`iso-datetime-validation.md`](iso-datetime-validation.md) — ISO 8601-Datetime-Validierungsmuster
+- [`content-scheduling.md`](content-scheduling.md) — geplante Veröffentlichung mit zukünftigem `publish_at`
+- [`approval-workflow.md`](approval-workflow.md) — 404/409-Unterscheidung bei Status-Übergängen
+- [`enforce-resource-ownership.md`](enforce-resource-ownership.md) — IDOR-Präventionsmuster

--- a/docs/de/howto/search-autocomplete.md
+++ b/docs/de/howto/search-autocomplete.md
@@ -1,0 +1,302 @@
+# Implementierungsleitfaden für Volltextsuche und Autovervollständigungs-API
+
+## Übersicht
+
+Dieser Leitfaden erklärt, wie Volltextsuche und Autovervollständigungs-Endpunkte in NENE2 implementiert werden.
+Er bietet feldübergreifende Suche mit LIKE, Relevanz-Scoring und Präfix-Vervollständigung als REST API.
+
+---
+
+## DB-Schema
+
+```sql
+CREATE TABLE products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    category TEXT NOT NULL,
+    price_cents INTEGER NOT NULL DEFAULT 0 CHECK (price_cents >= 0),
+    created_at TEXT NOT NULL
+);
+```
+
+---
+
+## Endpunkt-Design
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| GET | `/search` | Volltextsuche |
+| GET | `/autocomplete` | Namenspräfix-Vervollständigung |
+
+### Query-Parameter
+
+**GET /search**
+
+| Parameter | Pflicht | Standard | Beschreibung |
+|---|---|---|---|
+| `q` | ✓ | — | Suchanfrage (2–100 Zeichen) |
+| `category` | — | — | Kategoriefilter |
+| `limit` | — | 10 | Max. 50 |
+| `offset` | — | 0 | Pagination |
+
+**GET /autocomplete**
+
+| Parameter | Pflicht | Standard | Beschreibung |
+|---|---|---|---|
+| `q` | ✓ | — | Präfix (2–100 Zeichen) |
+| `limit` | — | 5 | Max. 10 |
+
+---
+
+## Implementierung
+
+### SearchRepository
+
+```php
+class SearchRepository
+{
+    public function __construct(private readonly DatabaseQueryExecutorInterface $db) {}
+
+    /** @return array{items: list<array<string, mixed>>, total: int} */
+    public function search(string $query, ?string $category, int $limit, int $offset): array
+    {
+        $lq = strtolower($query);
+        $escaped = $this->escapeLike($lq);
+        $pattern = '%' . $escaped . '%';
+        $prefix  = $escaped . '%';
+
+        $whereConditions = [
+            "LOWER(name) LIKE ? ESCAPE '!'",
+            "LOWER(description) LIKE ? ESCAPE '!'",
+            "LOWER(category) LIKE ? ESCAPE '!'",
+        ];
+        $whereParams = [$pattern, $pattern, $pattern];
+        $whereClause = 'WHERE (' . implode(' OR ', $whereConditions) . ')';
+
+        if ($category !== null) {
+            $whereClause .= ' AND LOWER(category) = ?';
+            $whereParams[] = strtolower($category);
+        }
+
+        $row = $this->db->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM products ' . $whereClause,
+            $whereParams
+        ) ?? ['cnt' => 0];
+        $total = (int) $row['cnt'];
+
+        // Relevanz: 0 = exakter Namenstrefffer, 1 = Name beginnt mit Anfrage, 2 = enthält irgendwo
+        $selectParams = [$lq, $prefix, ...$whereParams, $limit, $offset];
+        $items = $this->db->fetchAll(
+            "SELECT id, name, description, category, price_cents, created_at,
+                    CASE WHEN LOWER(name) = ? THEN 0
+                         WHEN LOWER(name) LIKE ? ESCAPE '!' THEN 1
+                         ELSE 2
+                    END AS relevance
+             FROM products " . $whereClause . "
+             ORDER BY relevance ASC, id ASC
+             LIMIT ? OFFSET ?",
+            $selectParams
+        );
+
+        return ['items' => $items, 'total' => $total];
+    }
+
+    /** @return list<string> */
+    public function autocomplete(string $prefix, int $limit): array
+    {
+        $escaped = $this->escapeLike(strtolower($prefix));
+        $rows = $this->db->fetchAll(
+            "SELECT DISTINCT name FROM products WHERE LOWER(name) LIKE ? ESCAPE '!' ORDER BY name ASC LIMIT ?",
+            [$escaped . '%', $limit]
+        );
+        return array_map(static fn (array $r): string => (string) $r['name'], $rows);
+    }
+
+    private function escapeLike(string $value): string
+    {
+        // ! als Escape-Zeichen verwenden, um Backslash-Verwirrung in SQL-String-Literalen zu vermeiden
+        return str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $value);
+    }
+}
+```
+
+### RouteRegistrar (Auszug)
+
+```php
+public function register(Router $router): void
+{
+    $router->get('/search', $this->handleSearch(...));
+    $router->get('/autocomplete', $this->handleAutocomplete(...));
+}
+
+private function handleSearch(ServerRequestInterface $request): ResponseInterface
+{
+    $params = $request->getQueryParams();
+    $q      = isset($params['q']) ? trim((string) $params['q']) : '';
+    $errors = $this->validateQuery($q);
+
+    $limit  = $this->clamp((int) ($params['limit'] ?? 10), 1, 50);
+    $offset = max(0, (int) ($params['offset'] ?? 0));
+    $cat    = isset($params['category']) && trim((string) $params['category']) !== ''
+                ? trim((string) $params['category']) : null;
+
+    if ($errors !== []) {
+        throw new ValidationException($errors);
+    }
+
+    $result = $this->repo->search($q, $cat, $limit, $offset);
+
+    return $this->json->create([
+        'query'    => $q,
+        'category' => $cat,
+        'total'    => $result['total'],
+        'limit'    => $limit,
+        'offset'   => $offset,
+        'items'    => array_map($this->formatProduct(...), $result['items']),
+    ]);
+}
+```
+
+---
+
+## Design-Schwerpunkte
+
+### Sonderzeichen in LIKE maskieren
+
+`%` und `_` sind SQL-LIKE-Platzhalter. Benutzereingaben direkt zu übergeben führt zu unbeabsichtigten Treffern aller Einträge oder ähnlichem Verhalten wie SQL-Injection.
+
+```php
+// FALSCH: Wenn Benutzer "%_" eingibt, treffen alle Einträge
+$this->db->fetchAll('SELECT * FROM products WHERE name LIKE ?', ['%' . $query . '%']);
+
+// RICHTIG: Sonderzeichen maskieren
+private function escapeLike(string $value): string
+{
+    return str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $value);
+}
+// SQL: WHERE name LIKE ? ESCAPE '!'
+```
+
+`!` als Escape-Zeichen verwenden, um die doppelte Maskierungs-Hölle (SQL/PHP) mit Backslash zu vermeiden.
+
+### Relevanz-Scoring
+
+LIKE-Suche gibt allen Ergebnissen dasselbe Gewicht, aber `CASE WHEN` weist einfache Scores zu:
+
+| Score | Bedingung | Beispiel |
+|---|---|---|
+| 0 | Exakter Namenstrefffer | "Apple iPhone 15" mit "apple iphone 15" suchen |
+| 1 | Name beginnt mit Anfrage | Produkte die mit "Apple" beginnen |
+| 2 | In Name, Beschreibung oder Kategorie enthalten | Beschreibung enthält "ergonomic" |
+
+```sql
+CASE WHEN LOWER(name) = ? THEN 0
+     WHEN LOWER(name) LIKE ? ESCAPE '!' THEN 1
+     ELSE 2
+END AS relevance
+```
+
+Parameter werden in dieser Reihenfolge übergeben: `[$lq (für Exakttreffer), $prefix (Präfix-Muster), ...WHERE-Klausel-Parameter, $limit, $offset]`.
+
+### Autovervollständigung ist nur Präfix-Treffer
+
+Suche (`%query%`) und Autovervollständigung (`query%`) haben unterschiedliche Verwendungszwecke.
+"Enthält"-Suche in der Autovervollständigung würde für Vorhersagen unnatürlich wirken.
+
+```php
+// Nur Präfix-Treffer: "Apple" → ["Apple iPhone 15", "Apple Watch Series 9"]
+$rows = $this->db->fetchAll(
+    "SELECT DISTINCT name FROM products WHERE LOWER(name) LIKE ? ESCAPE '!' ORDER BY name ASC LIMIT ?",
+    [$escaped . '%', $limit]
+);
+// "Green Apple Juice" beginnt nicht mit "Apple", daher nicht enthalten
+```
+
+### Limit-Klemmung
+
+Wenn Clients beliebige Limits senden könnten, wäre ein Abruf aller Einträge möglich. Immer serverseitig klemmen.
+
+```php
+private function clamp(int $value, int $min, int $max): int
+{
+    return max($min, min($max, $value));
+}
+
+// Suche: max 50 / Autovervollständigung: max 10
+$limit = $this->clamp((int) ($params['limit'] ?? 10), 1, 50);
+```
+
+### SQLite vs. MySQL/PostgreSQL Volltextsuche
+
+| Methode | Anwendung | Eigenschaften |
+|---|---|---|
+| `LIKE '%query%'` | SQLite / MySQL / PgSQL | Klein bis mittel. Kein Index (Präfix `LIKE 'q%'` hat Index) |
+| SQLite FTS5 virtuelle Tabelle | SQLite | Schnelle Volltextsuche. Tokenizer-Konfiguration, integriertes Ranking |
+| MySQL FULLTEXT | MySQL | `MATCH ... AGAINST` für AND/OR/Phrasensuche |
+| PostgreSQL `tsvector` | PgSQL | GIN-Index, sprachliches Stemming |
+
+LIKE reicht für Prototypen und kleinen Umfang. Bei Hunderttausenden Zeilen auf FTS umstellen.
+
+---
+
+## Antwort-Beispiele
+
+### GET /search?q=apple&category=Electronics
+
+```json
+{
+  "query": "apple",
+  "category": "Electronics",
+  "total": 2,
+  "limit": 10,
+  "offset": 0,
+  "items": [
+    {
+      "id": 1,
+      "name": "Apple iPhone 15",
+      "description": "Flagship smartphone by Apple",
+      "category": "Electronics",
+      "price_cents": 129900,
+      "created_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "id": 2,
+      "name": "Apple Watch Series 9",
+      "description": "Smartwatch with health tracking",
+      "category": "Electronics",
+      "price_cents": 49900,
+      "created_at": "2026-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+### GET /autocomplete?q=Apple
+
+```json
+{
+  "query": "Apple",
+  "suggestions": [
+    "Apple iPhone 15",
+    "Apple Watch Series 9"
+  ]
+}
+```
+
+### GET /search?q=a (q zu kurz → 422)
+
+```json
+{
+  "status": 422,
+  "errors": [
+    { "field": "q", "message": "q muss mindestens 2 Zeichen lang sein", "code": "too_short" }
+  ]
+}
+```
+
+---
+
+## Referenzimplementierung
+
+`../NENE2-FT/searchlog/` — FT157 Feldversuch (22 Tests)

--- a/docs/de/howto/secret-vault.md
+++ b/docs/de/howto/secret-vault.md
@@ -1,0 +1,184 @@
+# How-to: Persönliche Geheimnis-Tresor-API
+
+Demonstriert benutzerspezifischen Key-Value-Speicher mit HMAC-Integrität, IDOR-Prävention und nur-Admin-Metadatenzugriff.
+Feldversuch: FT195 (`../NENE2-FT/vaultlog/`). Enthält VULN-A bis L Sicherheitsprüfung.
+
+---
+
+## Muster-Zusammenfassung
+
+| Problem | Ansatz |
+|---|---|
+| Benutzerisolation | `WHERE user_id = :uid` bei jeder Abfrage — IDOR unmöglich |
+| Admin sieht niemals Werte | Admin-Endpunkte geben nur `user_id + key` zurück |
+| HMAC-Integrität | `HMAC-SHA256(userId|key|value, secret)` wird pro Eintrag gespeichert |
+| Key-Validierung | `preg_match('/\A[a-z0-9_-]{1,64}\z/', $key)` — sicher, kein ReDoS-Risiko |
+| Benutzer-ID-Validierung | `ctype_digit()` + Längenguard + `> 0`-Prüfung |
+| Admin-Key | `hash_equals()` zeitkonstant, fail-closed bei leerem Key |
+| Upsert | `UNIQUE(user_id, key_name)` → erste Speicherung (201) oder Aktualisierung (200) |
+
+---
+
+## Routen
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `POST` | `/vault` | `X-User-Id` | Geheimnis speichern oder aktualisieren |
+| `GET` | `/vault` | `X-User-Id` | Geheimnis-Keys des Benutzers auflisten (keine Werte) |
+| `GET` | `/vault/{key}` | `X-User-Id` | Geheimnis-Wert des Benutzers abrufen |
+| `DELETE` | `/vault/{key}` | `X-User-Id` | Geheimnis des Benutzers löschen |
+| `GET` | `/admin/vault` | `X-Admin-Key` | Alle Benutzer + Keys auflisten (keine Werte) |
+| `GET` | `/admin/vault/{userId}` | `X-Admin-Key` | Keys eines bestimmten Benutzers auflisten |
+
+---
+
+## Datenbankschema
+
+```sql
+CREATE TABLE vault_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    key_name   TEXT    NOT NULL,
+    value      TEXT    NOT NULL,
+    hmac       TEXT    NOT NULL,   -- HMAC-SHA256-Integritäts-Tag
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE (user_id, key_name)
+);
+```
+
+Der `UNIQUE(user_id, key_name)`-Constraint erzwingt einen Eintrag pro (Benutzer, Key)-Paar.
+
+---
+
+## HMAC-Integrität
+
+```php
+private function computeHmac(int $userId, string $key, string $value): string
+{
+    return hash_hmac('sha256', "{$userId}|{$key}|{$value}", $this->hmacSecret);
+}
+```
+
+Bei GET verifiziert der Handler den gespeicherten HMAC:
+
+```php
+if (!$this->repo->verifyIntegrity($entry)) {
+    return $this->problem(500, 'integrity-error', 'Geheimnis-Integritätsprüfung fehlgeschlagen.');
+}
+```
+
+Das erkennt direkte DB-Manipulation (z.B. ein kompromittierter DBA, der Werte ohne die API ändert).
+
+---
+
+## IDOR-Prävention
+
+Jede Abfrage enthält `user_id = :uid`:
+
+```sql
+SELECT * FROM vault_entries WHERE user_id = :uid AND key_name = :key
+```
+
+Benutzer 200, der Key `private-key` von Benutzer 100 abfragt, erhält 404 — identisch mit "nicht gefunden",
+verhindert die Enumeration welche Keys für andere Benutzer existieren.
+
+Admin-Endpunkte geben niemals `value` zurück:
+
+```php
+// Benutzer sieht seinen eigenen Wert
+public function toUserArray(): array
+{
+    return ['key' => ..., 'value' => $this->value, ...];
+}
+
+// Admin sieht nur Metadaten — keinen Wert
+public function toAdminArray(): array
+{
+    return ['user_id' => ..., 'key' => ..., ...];
+}
+```
+
+---
+
+## Key-Validierung
+
+```php
+private const string KEY_PATTERN = '/\A[a-z0-9_-]{1,64}\z/';
+```
+
+`\A`- und `\z`-Anker verhindern Teilübereinstimmungen. Die Zeichenklasse ist minimal:
+Kleinbuchstaben alphanumerisch, Bindestrich, Unterstrich. Länge ist begrenzt `{1,64}` — keine Backtracking-Amplifikation.
+
+Das lehnt ab:
+- Großbuchstaben (`UPPER_CASE`)
+- Leerzeichen oder Sonderzeichen
+- Path-Traversal-Fragmente (`../etc/passwd`)
+- SQL-injizierbare Strings (`' OR '1'='1`)
+- Leerer String oder Strings > 64 Zeichen
+
+---
+
+## Benutzer-ID-Validierung
+
+```php
+private function resolveUserId(ServerRequestInterface $request): ?int
+{
+    $raw = $request->getHeaderLine('X-User-Id');
+    if ($raw === '' || !ctype_digit($raw) || strlen($raw) > 18) return null;
+    $id = (int) $raw;
+    return $id > 0 ? $id : null;
+}
+```
+
+- `ctype_digit()` lehnt negative Zahlen ab (das `-`-Zeichen ist keine Ziffer)
+- `strlen > 18` verhindert Integer-Überlauf (`PHP_INT_MAX` hat 19 Ziffern)
+- `> 0` lehnt `"0"` als ungültige Benutzer-ID ab
+
+---
+
+## Upsert-Muster
+
+```php
+public function store(int $userId, string $key, string $value): string
+{
+    $existing = $this->findEntry($userId, $key);
+    if ($existing !== null) {
+        // UPDATE ...
+        return 'updated';  // → 200
+    }
+    // INSERT ...
+    return 'stored';  // → 201
+}
+```
+
+Gibt `'stored'` (201) beim ersten Schreiben zurück, `'updated'` (200) beim Überschreiben.
+Der Handler ordnet diese den HTTP-Statuscodes zu.
+
+---
+
+## VULN-A bis L Ergebnisse
+
+| Prüfung | Test | Ergebnis |
+|---|---|---|
+| VULN-A | SQL-Injection in Key-Param / Body | BESTANDEN — Key-Validierung lehnt vor Abfrage ab |
+| VULN-B | IDOR: Benutzer liest/löscht Key eines anderen | BESTANDEN — 404 bei benutzerübergreifendem Zugriff |
+| VULN-C | Liste gibt nur eigene Einträge zurück | BESTANDEN — WHERE user_id begrenzt |
+| VULN-D | Admin-Key Brute-Force / Bypass | BESTANDEN — hash_equals + fail-closed |
+| VULN-E | XSS im Wert | BESTANDEN — als-ist gespeichert, JSON-Antwort kein HTML |
+| VULN-F | Key-Upsert-Idempotenz | BESTANDEN — letzter Schreibvorgang gewinnt, keine Duplikate |
+| VULN-G | Path-Traversal im Key | BESTANDEN — Muster lehnt `..` und Schrägstriche ab |
+| VULN-H | Negative / null Benutzer-ID | BESTANDEN — ctype_digit + > 0 Guard |
+| VULN-I | Sehr große Benutzer-ID (Überlauf) | BESTANDEN — strlen > 18 Guard |
+| VULN-J | Null-Byte im Pfad | BESTANDEN — Router / Muster lehnen ab |
+| VULN-K | Überlanger Key im Body | BESTANDEN — 422 Validierung |
+| VULN-L | Leeres HMAC-Secret (kein Absturz) | BESTANDEN — deterministischer HMAC mit leerem Key, kein Absturz |
+
+---
+
+## Test-Hinweise
+
+- `AppFactory::create(?PDO, ?string adminKey, ?string hmacSecret)` — alle injizierbar für Unit-Tests.
+- `withParsedBody($body)` ist in Test-Helfern erforderlich (Nyholm PSR-7 parst JSON nicht automatisch).
+- IDOR-Tests: als Benutzer 100 speichern, Zugriff als Benutzer 200 versuchen → muss 404 erhalten.
+- Admin-Tests: überprüfen, dass `value`-Key in jedem Antwort-Array fehlt.

--- a/docs/de/howto/service-status-page.md
+++ b/docs/de/howto/service-status-page.md
@@ -1,0 +1,225 @@
+# How-to: Service-Status-Seiten-API
+
+> **NENE2 Feldversuch 185** — Komponenten-Gesundheitsverfolgung, Incident-Lifecycle-Management,
+> Admin-Key-Schutz mit `V::secret()` + `hash_equals()`.
+
+---
+
+## Was dieser Feldversuch beweist
+
+Eine Service-Status-Seiten-API benötigt:
+1. **Komponentenstatus-Verfolgung** — operational / degraded / partial_outage / major_outage
+2. **Incident-Lifecycle** — investigating → identified → monitoring → resolved
+3. **Unveränderlichkeitsschutz** — aufgelöste Incidents können nicht aktualisiert werden (Wiedereröffnung verhindern)
+4. **Admin-Key-Schutz** — `V::secret()` erzwingt zeitkonstanten Vergleich für Schreiboperationen
+5. **Status-Enum-Durchsetzung** — `V::enum()`-Allowlist verhindert Einschleusung unbekannter Werte
+
+---
+
+## API
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `GET` | `/components` | — | Alle Komponenten auflisten (öffentlich) |
+| `POST` | `/components` | X-Admin-Key | Komponente erstellen |
+| `PATCH` | `/components/{id}` | X-Admin-Key | Komponentenstatus aktualisieren |
+| `GET` | `/incidents` | — | Incidents auflisten (öffentlich, `?open=1` für aktive) |
+| `GET` | `/incidents/{id}` | — | Incident-Detail mit Aktualisierungs-Timeline |
+| `POST` | `/incidents` | X-Admin-Key | Incident erstellen |
+| `PATCH` | `/incidents/{id}` | X-Admin-Key | Incident-Status aktualisieren |
+| `POST` | `/incidents/{id}/updates` | X-Admin-Key | Aktualisierungsmeldung hinzufügen |
+
+---
+
+## Kernmuster: Admin-Key-Auth mit `V::secret()`
+
+```php
+// V::secret() prüft: $expected !== '' && hash_equals($expected, $actual)
+private function requireAdmin(ServerRequestInterface $request): bool
+{
+    return V::secret($this->adminKey, $request->getHeaderLine('X-Admin-Key'));
+}
+
+// Verwendung in jedem Schreib-Handler:
+if (!$this->requireAdmin($request)) {
+    return $this->responseFactory->create(['error' => 'X-Admin-Key ist erforderlich.'], 401);
+}
+```
+
+**Warum `V::secret()` und nicht `=== $key`:**
+- `===` ist kurzschlussend: Timing variiert mit der Übereinstimmungslänge → Timing-Oracle
+- `hash_equals()` ist zeitkonstant unabhängig davon, wo sich Strings unterscheiden
+- Der `$expected !== ''`-Guard verhindert versehentliches Akzeptieren leerer Keys
+
+---
+
+## Status-Enum-Durchsetzung mit `V::enum()`
+
+```php
+// V::enum(mixed $raw, string $enumClass): ?\BackedEnum
+// Übergibt Klassenname — gibt typisierte Enum-Instanz oder null zurück
+
+$statusEnum = V::enum($body['status'] ?? null, ComponentStatus::class);
+
+if (!$statusEnum instanceof ComponentStatus) {
+    return $this->responseFactory->create(
+        ['error' => 'status muss eines sein von: ' . implode(', ', ComponentStatus::values()) . '.'],
+        422,
+    );
+}
+
+// $statusEnum ist bereits das korrekte typisierte Enum — kein ::from() nötig
+$component = $this->repository->updateComponentStatus($id, $statusEnum);
+```
+
+**Warum Enum-Durchsetzung wichtig ist:**
+- Ohne sie erreichen beliebige Strings die DB
+- SQL-`ORDER BY status`-Injektionsvektoren werden blockiert
+- Die Allowlist sind die eigenen Cases des Enums — immer synchron
+
+---
+
+## Incident-Lifecycle und Übergangsschutz
+
+```php
+enum IncidentStatus: string
+{
+    case Investigating = 'investigating';
+    case Identified    = 'identified';
+    case Monitoring    = 'monitoring';
+    case Resolved      = 'resolved';
+
+    public function isResolved(): bool
+    {
+        return $this === self::Resolved;
+    }
+}
+```
+
+**Übergangsschutz in jedem Schreib-Handler:**
+```php
+$incident = $this->repository->findIncidentById($id);
+
+// Aufgelöste Incidents sind unveränderlich — versehentliche Wiedereröffnung verhindern
+if ($incident->status->isResolved()) {
+    return $this->responseFactory->create(
+        ['error' => 'Aufgelöste Incidents können nicht aktualisiert werden.'],
+        409,
+    );
+}
+```
+
+**Warum 409 (Conflict) und nicht 422 (Unprocessable):**
+- Die Anfrage ist syntaktisch gültig
+- Der Konflikt liegt im aktuellen Zustand der Ressource
+- 409 kommuniziert "gültige Anfrage, falscher Zeitpunkt"
+
+---
+
+## Komponentenstatus-Werte
+
+```php
+enum ComponentStatus: string
+{
+    case Operational   = 'operational';    // alle Systeme funktionieren
+    case Degraded      = 'degraded';       // reduzierte Leistung
+    case PartialOutage = 'partial_outage'; // einige Funktionen nicht verfügbar
+    case MajorOutage   = 'major_outage';   // vollständiger Serviceausfall
+}
+```
+
+---
+
+## Automatischer `resolved_at`-Zeitstempel
+
+```php
+public function updateIncidentStatus(int $id, IncidentStatus $status): ?Incident
+{
+    $now        = $this->now();
+    $resolvedAt = $status->isResolved() ? $now : null;
+
+    $stmt = $this->pdo->prepare(
+        'UPDATE incidents SET status = :status, resolved_at = :resolved_at, updated_at = :now WHERE id = :id'
+    );
+    $stmt->execute(['status' => $status->value, 'resolved_at' => $resolvedAt, ...]);
+}
+```
+
+Der `resolved_at`-Zeitstempel wird vom Server gesetzt — niemals aus dem Request-Body.
+
+---
+
+## Integer-ID-Parsing (keine Injection)
+
+```php
+private function parseId(ServerRequestInterface $request, string $param): ?int
+{
+    $raw = Router::param($request, $param);
+
+    // ctype_digit: lehnt Negative, Floats, Strings, Path-Traversal ab
+    if ($raw === null || !ctype_digit($raw)) {
+        return null;
+    }
+
+    $id = (int) $raw;
+
+    return $id > 0 ? $id : null; // lehnt auch null ab
+}
+```
+
+---
+
+## Filter für offene Incidents
+
+```php
+// ?open=1 filtert aufgelöste Incidents heraus
+$openOnly = isset($params['open']) && $params['open'] === '1';
+
+if ($openOnly) {
+    $stmt = $pdo->prepare(
+        "SELECT * FROM incidents WHERE status != 'resolved' ORDER BY created_at DESC"
+    );
+} else {
+    $stmt = $pdo->query('SELECT * FROM incidents ORDER BY created_at DESC');
+}
+```
+
+---
+
+## Vollständiges Incident-Lifecycle-Beispiel
+
+```
+POST /incidents          → 201 {status: "investigating", impact: "major"}
+POST /incidents/1/updates → 201 {message: "Grundursache identifiziert."}
+PATCH /incidents/1       → 200 {status: "identified"}
+PATCH /incidents/1       → 200 {status: "monitoring"}
+PATCH /incidents/1       → 200 {status: "resolved", resolved_at: "2026-05-26T..."}
+PATCH /incidents/1       → 409 Aufgelöste Incidents können nicht aktualisiert werden.
+GET /incidents?open=1    → 200 {count: 0}  — aufgelöste nicht mehr angezeigt
+```
+
+---
+
+## Testergebnisse
+
+```
+46 Tests / 93 Assertions — alle bestanden
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+```
+
+---
+
+## Wichtige Erkenntnisse
+
+| Muster | Regel |
+|---|---|
+| Admin-Key-Auth | `V::secret()` — zeitkonstantes `hash_equals()`, schützt leeren Key |
+| Enum-Validierung | `V::enum($raw, EnumClass::class)` — gibt typisiertes Enum oder null zurück |
+| Übergangsschutz | Aktuellen Zustand vor Änderung prüfen — 409 bei aufgelösten |
+| `resolved_at` | Vom Server gesetzter Zeitstempel, niemals aus Request-Body |
+| Integer-IDs | `ctype_digit()` + `> 0`-Guard — lehnt Strings, Negative, Null ab |
+| Öffentliches Lesen | Keine Auth für GET-Endpunkte — Status-Seiten sollen öffentlich sein |
+| Unveränderliche Historie | Incident-Aktualisierungen sind nur-anhängend — kein Bearbeiten/Löschen |
+
+Vollständiges Beispiel: [`../NENE2-FT/statuslog/`](https://github.com/hideyukiMORI/NENE2-examples) im Beispiel-Repository.

--- a/docs/de/howto/session-management.md
+++ b/docs/de/howto/session-management.md
@@ -1,0 +1,237 @@
+# How-to: Multi-Gerät-Sitzungsverwaltung
+
+> **Muster erprobt durch FT186 sessionlog** — Multi-Gerät-Sitzungsverfolgung, IDOR-Prävention, Mass-Assignment-Guard, Widerruf ohne Timing-Oracle.
+
+---
+
+## Was behandelt wird
+
+Ein Multi-Gerät-Sitzungsmanager ermöglicht Benutzern:
+
+1. **Sitzungen erstellen** beim Login (jedes Gerät erhält sein eigenes Token)
+2. **Aktive Sitzungen auflisten**, begrenzt auf ihre Benutzer-ID
+3. **Eine einzelne Sitzung widerrufen** (von einem Gerät abmelden)
+4. **Alle außer der aktuellen widerrufen** (von allen anderen Geräten abmelden)
+
+Demonstrierte Sicherheitsgarantien:
+
+| Problem | Technik |
+|---|---|
+| IDOR-Prävention | Alle Mutationen begrenzen auf `WHERE token = ? AND user_id = ?` |
+| Mass Assignment | `token`, `user_id`, `created_at`, `revoked_at` nur serverseitig gesetzt |
+| Timing-Oracle | Generisches 404 für alle Fehler — kein Eigentümerschaftsleck |
+| Integer-Überlauf | `V::queryInt()` 18-Ziffer-strlen-Guard |
+| Typverwechslung | `V::str()` lehnt nicht-String `device_name`/`ip_address` ab |
+| Token-Entropie | `bin2hex(random_bytes(32))` — 256-Bit, 64 Hex-Zeichen |
+| SQL-Injection | PDO parametrisierte Abfragen + `/^[0-9a-f]{64}$/`-Gate |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE sessions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL,
+    token       TEXT    NOT NULL UNIQUE,
+    device_name TEXT,
+    ip_address  TEXT,
+    last_active TEXT    NOT NULL,
+    created_at  TEXT    NOT NULL,
+    revoked_at  TEXT    -- NULL = aktiv
+);
+```
+
+`revoked_at IS NULL` ist das Aktiv-Sitzungs-Prädikat. Soft Delete vermeidet den Verlust der Prüfhistorie.
+
+---
+
+## API-Design
+
+| Methode | Pfad | Header | Beschreibung |
+|---|---|---|---|
+| `POST` | `/sessions` | `X-User-Id` | Sitzung erstellen |
+| `GET` | `/sessions` | `X-User-Id` | Eigene aktive Sitzungen auflisten |
+| `DELETE` | `/sessions/{token}` | `X-User-Id` | Eine Sitzung widerrufen |
+| `DELETE` | `/sessions` | `X-User-Id` + `X-Current-Session` | Alle außer aktueller widerrufen |
+
+---
+
+## Kernmuster: 256-Bit-Token-Generierung
+
+```php
+public function create(int $userId, ?string $deviceName, ?string $ipAddress): Session
+{
+    $token = bin2hex(random_bytes(32)); // 256-Bit-Entropie, 64 Hex-Zeichen
+    $now   = $this->now();
+
+    $stmt = $this->pdo->prepare(
+        'INSERT INTO sessions (user_id, token, device_name, ip_address, last_active, created_at)
+         VALUES (:user_id, :token, :device_name, :ip_address, :now, :now2)',
+    );
+    $stmt->execute([...]);
+    // ...
+}
+```
+
+`bin2hex(random_bytes(32))` erzeugt 64 Kleinbuchstaben-Hex-Zeichen aus einer kryptographisch sicheren Quelle. Niemals Tokens aus Benutzereingaben akzeptieren.
+
+---
+
+## Kernmuster: IDOR-Prävention
+
+```php
+// FALSCH — lässt jeden authentifizierten Benutzer jede Sitzung widerrufen
+UPDATE sessions SET revoked_at = ? WHERE token = ?
+
+// RICHTIG — muss die Sitzung besitzen
+public function revokeForUser(string $token, int $userId): bool
+{
+    $stmt = $this->pdo->prepare(
+        'UPDATE sessions SET revoked_at = :now
+         WHERE token = :token AND user_id = :user_id AND revoked_at IS NULL',
+    );
+    $stmt->execute(['now' => $this->now(), 'token' => $token, 'user_id' => $userId]);
+
+    return $stmt->rowCount() > 0;
+}
+```
+
+`rowCount() > 0` gibt `false` zurück, wenn das Token existiert, aber einem anderen Benutzer gehört — der Handler antwortet mit einem generischen 404 (siehe Timing-Oracle-Abschnitt).
+
+---
+
+## Kernmuster: Mass-Assignment-Guard
+
+```php
+// POST /sessions Handler — Angreifer-Body: {"token": "custom", "user_id": 999, "revoked_at": "now"}
+private function handleCreate(ServerRequestInterface $request): ResponseInterface
+{
+    // userId kommt aus X-User-Id-Header — niemals aus Body
+    $userId = V::userId($request->getHeaderLine('X-User-Id'));
+
+    $body = $this->parseBody($request);
+
+    // Nur sichere, validierte Felder werden weitergegeben
+    $deviceName = V::str($body['device_name'] ?? null, 200);
+    $ipAddress  = V::str($body['ip_address'] ?? null, 45);
+
+    // token, user_id, created_at, revoked_at werden vom Repository gesetzt — nicht aus Body
+    $session = $this->repository->create($userId, $deviceName, $ipAddress);
+
+    return $this->responseFactory->create($session->toArray(), 201);
+}
+```
+
+---
+
+## Kernmuster: Timing-Oracle-Prävention
+
+```php
+private function handleRevokeOne(ServerRequestInterface $request): ResponseInterface
+{
+    $userId   = V::userId($request->getHeaderLine('X-User-Id'));
+    $rawToken = Router::param($request, 'token');
+
+    // VULN-I: ungültiges Format → sofort 404 (keine DB-Abfrage)
+    if ($rawToken === null || !preg_match('/^[0-9a-f]{64}$/', $rawToken)) {
+        return $this->responseFactory->create(['error' => 'Sitzung nicht gefunden.'], 404);
+    }
+
+    // IDOR-Guard: revokeForUser gibt false zurück wenn:
+    //   - Token existiert nicht
+    //   - Token gehört einem anderen Benutzer
+    //   - Token ist bereits widerrufen
+    // Alle Fälle geben dasselbe 404 zurück — kein Eigentümerschafts-Oracle
+    $revoked = $this->repository->revokeForUser($rawToken, $userId);
+
+    if (!$revoked) {
+        return $this->responseFactory->create(['error' => 'Sitzung nicht gefunden.'], 404);
+    }
+
+    return $this->responseFactory->create([], 204);
+}
+```
+
+Niemals "nicht gefunden" von "falscher Benutzer" in der Antwort unterscheiden. Ein Angreifer, der das Token eines Opfers kennt, darf nicht erfahren, ob es aktiv ist oder diesem Benutzer gehört.
+
+---
+
+## Kernmuster: Alle außer aktueller widerrufen
+
+```php
+public function revokeAllExcept(int $userId, string $currentToken): int
+{
+    $stmt = $this->pdo->prepare(
+        'UPDATE sessions SET revoked_at = :now
+         WHERE user_id = :user_id AND token != :current AND revoked_at IS NULL',
+    );
+    $stmt->execute(['now' => $this->now(), 'user_id' => $userId, 'current' => $currentToken]);
+
+    return $stmt->rowCount();
+}
+```
+
+Der Aufrufer übergibt den `X-Current-Session`-Header. Sowohl `user_id` als auch die Ausschlussbedingung werden in der einzigen Abfrage durchgesetzt.
+
+---
+
+## Kernmuster: Überlaufsichere Limit-Validierung
+
+```php
+// VULN-A: V::queryInt lehnt >18 Ziffern ab — verhindert stillen PHP-Int-Überlauf
+// VULN-F: ctype_digit ist O(n) — kein Regex-Backtracking-Risiko
+$limit = V::queryInt($params, 'limit', 1, self::MAX_LIMIT, self::DEFAULT_LIMIT);
+
+if ($limit === null) {
+    return $this->responseFactory->create(
+        ['error' => sprintf('limit muss zwischen 1 und %d liegen.', self::MAX_LIMIT)],
+        422,
+    );
+}
+```
+
+`V::queryInt()` lehnt negative Zahlen, Floats, Hex-Strings (`0x10`) und Zahlen > 18 Ziffern ab.
+
+---
+
+## Route-Token-Validierung
+
+Das Token-Format immer auf der Route-Ebene validieren, bevor die DB abgefragt wird:
+
+```php
+private const TOKEN_PATTERN = '/^[0-9a-f]{64}$/';
+
+// Im Handler:
+if ($rawToken === null || !preg_match(self::TOKEN_PATTERN, $rawToken)) {
+    return $this->responseFactory->create(['error' => 'Sitzung nicht gefunden.'], 404);
+}
+```
+
+Das blockiert SQL-Injection-Strings, Path-Traversal-Versuche und kurze/lange Tokens vor jeder Datenbankinteraktion.
+
+---
+
+## Testergebnisse (FT186)
+
+```
+54 Tests / 116 Assertions — alle bestanden
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+```
+
+VULN-A bis L-Abdeckung:
+
+| Vuln | Muster | Test |
+|---|---|---|
+| A | limit 19-Ziffer-Überlauf | `testVulnALimitOverflow19Digits` |
+| B | device_name Typverwechslung | `testVulnBDeviceNameAsInteger` |
+| C | SQL-Injection im Token | `testVulnCSqlInjectionToken` |
+| D | negatives/float/hex limit | `testVulnDNegativeLimitRejected` |
+| E | IDOR-Widerruf | `testVulnECannotRevokeOtherUsersSession` |
+| F | ReDoS-ähnliches langes limit | `testVulnFVeryLongLimitRejected` |
+| H | Timing-Oracle | `testVulnHSameResponseForAlreadyRevokedAndCrossUser` |
+| I | leeres/kurzes/traversal Token | `testVulnIEmptyTokenSegmentNotMatched` |
+| L | Mass Assignment | `testVulnLTokenFromBodyIsIgnored` |
+
+Quelle: [`../NENE2-FT/sessionlog/`](https://github.com/hideyukiMORI/NENE2-examples/tree/main/sessionlog)

--- a/docs/de/howto/session-token-management.md
+++ b/docs/de/howto/session-token-management.md
@@ -1,0 +1,158 @@
+# How-to: Sitzungs- und Token-Management-API (ATK-01 bis 12)
+
+Diese Anleitung demonstriert eine sichere Sitzungstoken-API, die alle ATK-01 bis 12 Cracker-Mindset-Angriffsvektoren abdeckt.
+
+## Musterübersicht
+
+- `POST /sessions` — Neues opakes Token für einen Benutzer ausstellen (`X-User-Id` erforderlich).
+- `GET /sessions/{token}` — Token validieren (404 wenn widerrufen oder abgelaufen).
+- `DELETE /sessions/{token}` — Token widerrufen (Eigentümer oder Admin).
+- `GET /users/{userId}/sessions` — Aktive Sitzungen auflisten (Eigentümer oder Admin).
+
+Tokens sind `bin2hex(random_bytes(32))` — 64 Kleinbuchstaben-Hex-Zeichen.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS sessions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token      TEXT    NOT NULL UNIQUE,
+    label      TEXT    NOT NULL DEFAULT '',
+    revoked    INTEGER NOT NULL DEFAULT 0,
+    expires_at TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_token ON sessions (token);
+CREATE INDEX IF NOT EXISTS idx_sessions_user  ON sessions (user_id, revoked);
+```
+
+## Token-Generierung
+
+```php
+$token = bin2hex(random_bytes(32));  // 64 Kleinbuchstaben-Hex-Zeichen
+```
+
+`random_bytes()` verwendet einen CSPRNG; Tokens sind nicht erratbar und nicht sequenziell.
+
+## Token-Format-Validierung
+
+Vor jeder DB-Suche das Token-Format mit einem engen Regex validieren:
+
+```php
+private const string TOKEN_PATTERN = '/\A[0-9a-f]{64}\z/';
+
+private function pathToken(ServerRequestInterface $req): ?string
+{
+    $token = $params['token'] ?? '';
+    if (!preg_match(self::TOKEN_PATTERN, $token)) {
+        return null;  // 404 — trifft niemals die DB
+    }
+    return $token;
+}
+```
+
+Das lehnt SQL-Injection-Payloads, überdimensionierte Eingaben, Großbuchstaben-Hex und Nicht-Hex-Strings vor jeder DB-Abfrage ab.
+
+## ATK-01: SQL-Injection im Token-Pfad
+
+Der Token-Format-Regex lehnt `' OR '1'='1` sofort ab. Selbst wenn er durchkäme, verwendet die DB-Abfrage eine vorbereitete Anweisung:
+
+```php
+$stmt = $this->pdo->prepare('SELECT * FROM sessions WHERE token = :token');
+$stmt->execute([':token' => $token]);
+```
+
+## ATK-02 bis 04: Token-Format-Angriffe
+
+Alle werden durch den Regex `/\A[0-9a-f]{64}\z/` abgelehnt:
+- Leerer String (Länge 0 ≠ 64)
+- Überdimensionierter String (256 Zeichen ≠ 64)
+- Nicht-Hex-Zeichen (`g`, `A`–`F` Großbuchstaben, Sonderzeichen)
+- Falsche Länge (63 oder 65 Zeichen)
+
+## ATK-05: Integer-Überlauf in X-User-Id
+
+```php
+if ($raw === '' || !ctype_digit($raw) || strlen($raw) > 18) {
+    return null;
+}
+```
+
+Eine 19-stellige Ganzzahl überschreitet das 18-Zeichen-Limit und wird vor einem `(int)`-Cast abgelehnt.
+
+## ATK-06: Negative / Null-Benutzer-ID
+
+```php
+$id = (int) $raw;
+return $id > 0 ? $id : null;
+```
+
+`0` und negative Werte geben `null` zurück, was 400 auslöst.
+
+## ATK-07: Admin-Key Fail-Closed
+
+Ein leerer `adminKey` gewährt niemals Admin-Zugang:
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+`hash_equals()` verhindert Timing-Angriffe beim Vergleich des Keys.
+
+## ATK-08: Auth-Bypass via X-User-Id: 0
+
+`uid()` gibt `null` für ID=0 zurück → 400, nicht 200.
+
+## ATK-09: Nicht-Numerische Benutzer-ID im Listen-Pfad
+
+`ctype_digit()` lehnt `abc`, `1.5`, `-1` ab:
+
+```php
+if (!ctype_digit($raw) || strlen($raw) > 18) {
+    return $this->problem(404, 'not-found', 'Benutzer nicht gefunden.');
+}
+```
+
+## ATK-10: Float-TTL
+
+`is_int()` ist PHPs strikte Typprüfung — `60.5` gibt `false` zurück:
+
+```php
+if (!is_int($ttlRaw) || $ttlRaw < 1 || $ttlRaw > self::MAX_TTL) {
+    return $this->problem(422, ...);
+}
+```
+
+## ATK-11: Doppelter Widerruf gibt 404 zurück
+
+Das Repository prüft `revoked === 1` vor dem Aktualisieren:
+
+```php
+if ($session === null || (int) $session['revoked'] === 1) {
+    return false;
+}
+```
+
+Bereits widerrufene Sitzungen können nicht durch erneutes Senden eines DELETE "nicht-widerrufen" werden.
+
+## ATK-12: Brute-Force-Token-Format-Ablehnung
+
+Jedes Token, das nicht genau 64 Kleinbuchstaben-Hex-Zeichen entspricht, wird mit 404 abgelehnt, bevor die Datenbank berührt wird. Brute-Force-Versuche treffen die Regex-Mauer, nicht die DB.
+
+## IDOR: Eigentümer vs. Admin
+
+- Nicht-Eigentümer, die die Sitzungen eines anderen Benutzers widerrufen oder auflisten, erhalten 404 (nicht 403).
+- Admins verwenden den `X-Admin-Key`-Header; fail-closed wenn Key nicht konfiguriert.
+
+## Siehe auch
+
+- FT208-Quelle: `../NENE2-FT/sessionlog/`
+- Verwandt: `docs/howto/rate-limiting.md` (FT200, ATK)
+- Verwandt: `docs/howto/coupon-redemption.md` (FT204, VULN + ATK)

--- a/docs/de/howto/shift-management.md
+++ b/docs/de/howto/shift-management.md
@@ -1,0 +1,474 @@
+# How-to: Schichtverwaltungs-API
+
+> **FT-Referenz**: FT43 (`NENE2-FT/shiftlog`) — Mitarbeiter-Dienstplan-API
+> **VULN**: FT225 — Sicherheits- und Schwachstellenbewertung (V-01 bis V-12)
+
+Demonstriert eine Mitarbeiter-Dienstplan-API mit Überschneidungserkennung, transaktionsgebundenen
+Prüfungen, ISO-8601-Datumsvergleichen und benutzerdefinierten Exception-Handlern für Domänenfehler.
+Der VULN-Abschnitt bewertet systematisch jede Angriffsfläche und dokumentiert jeden Befund.
+
+---
+
+## Routen
+
+| Methode   | Pfad                          | Beschreibung                                    |
+|-----------|-------------------------------|-------------------------------------------------|
+| `GET`     | `/employees`                  | Mitarbeiter auflisten (paginiert)               |
+| `POST`    | `/employees`                  | Mitarbeiter erstellen                           |
+| `GET`     | `/employees/{id}`             | Einzelnen Mitarbeiter abrufen                   |
+| `GET`     | `/employees/{id}/shifts`      | Schichten eines Mitarbeiters auflisten (paginiert) |
+| `POST`    | `/shifts`                     | Schicht einplanen (mit Überschneidungsprüfung)  |
+| `GET`     | `/shifts/{id}`                | Einzelne Schicht abrufen                        |
+| `DELETE`  | `/shifts/{id}`                | Schicht löschen                                 |
+| `GET`     | `/schedule`                   | Schichten in einem Datumsfenster (`?from=&to=`) |
+| `GET`     | `/summary/weekly`             | Stunden pro Mitarbeiter pro Woche               |
+| `GET`     | `/summary/overtime`           | Mitarbeiter über einem Stundenschwellenwert     |
+
+---
+
+## Mitarbeiter erstellen
+
+```php
+// POST /employees
+$body = [
+    'name'        => 'Alice',    // Pflichtfeld, nicht-leerer String
+    'role'        => 'Barista',  // Pflichtfeld, nicht-leerer String
+    'hourly_rate' => 18.50,      // Pflichtfeld, numerisch > 0
+];
+```
+
+`is_int()` / `is_string()` — strikte JSON-Typprüfungen werden angewendet. Leere Zeichenketten
+werden nach `trim()` abgelehnt.
+
+```php
+if (!isset($body['hourly_rate'])
+    || !is_numeric($body['hourly_rate'])
+    || (float) $body['hourly_rate'] <= 0) {
+    $errors[] = new ValidationError('hourly_rate', 'hourly_rate must be a positive number.', 'required');
+}
+```
+
+> **Hinweis**: Das Schema enthält auch `CHECK(hourly_rate > 0)` auf DB-Ebene als
+> Defense-in-Depth-Absicherung. Zunächst auf Anwendungsebene validieren, um ein korrektes 422 zurückzugeben.
+
+---
+
+## Schichten mit Überschneidungserkennung einplanen
+
+Die Überschneidungserkennung läuft innerhalb einer Datenbanktransaktion, um Race Conditions zu verhindern:
+
+```php
+return $this->txManager->transactional(
+    function (DatabaseQueryExecutorInterface $tx) use ($employeeId, $startsAt, $endsAt, $location, $now): Shift {
+        $txRepo   = new self($tx, $this->txManager);
+        $employee = $txRepo->findEmployeeById($employeeId);
+
+        // Überschneidung: jede vorhandene Schicht, die [$startsAt, $endsAt) schneidet
+        $overlap = $tx->fetchOne(
+            "SELECT id FROM shifts
+             WHERE employee_id = ?
+               AND starts_at < ?
+               AND ends_at   > ?",
+            [$employeeId, $endsAt, $startsAt],
+        );
+
+        if ($overlap !== null) {
+            throw new ShiftOverlapException($employee->name, $startsAt, $endsAt);
+        }
+
+        $id = $tx->insert(
+            'INSERT INTO shifts (employee_id, starts_at, ends_at, location, created_at) VALUES (?, ?, ?, ?, ?)',
+            [$employeeId, $startsAt, $endsAt, $location, $now],
+        );
+        // ...
+    },
+);
+```
+
+Die Überschneidungsbedingung `starts_at < $endsAt AND ends_at > $startsAt` behandelt korrekt alle
+vier Überschneidungskonfigurationen (teilweise von links, teilweise von rechts, enthalten und enthaltend).
+
+**Warum transaktional?** Ohne Transaktion können zwei gleichzeitige Anfragen beide die Überschneidungsprüfung
+gleichzeitig bestehen und widersprüchliche Schichten erstellen. Die Transaktion serialisiert die
+Lesen-Prüfen-Schreiben-Sequenz.
+
+---
+
+## Validierung: ends_at > starts_at
+
+Die Anwendung validiert die Zeitreihenfolge vor dem DB-Zugriff:
+
+```php
+if ($endsAt <= $startsAt) {
+    throw new ValidationException([
+        new ValidationError('ends_at', 'ends_at must be after starts_at.', 'invalid_range'),
+    ]);
+}
+```
+
+Das Schema fügt `CHECK(ends_at > starts_at)` als Absicherung hinzu. Beide Schichten zusammen
+stellen sicher, dass ungültige Bereiche nie den Datenspeicher erreichen.
+
+---
+
+## ISO-8601-Datumszeichenketten-Vergleich
+
+Schichtzeiten werden als ISO-8601-Zeichenketten (`2026-05-27T09:00:00+09:00`) gespeichert und
+in SQL lexikografisch verglichen. Dies funktioniert korrekt **nur wenn alle Zeiten denselben
+Zeitzonenversatz oder UTC verwenden**. Vergleiche mit gemischten Offsets können falsche Ergebnisse liefern:
+
+```
+"2026-05-27T09:00:00+09:00" < "2026-05-27T01:00:00Z"  → falsch (identischer Zeitpunkt)
+```
+
+**Empfehlung**: Alle Datetimes vor der Speicherung auf UTC normalisieren:
+
+```php
+$utc      = new \DateTimeZone('UTC');
+$startsAt = (new \DateTimeImmutable($raw))->setTimezone($utc)->format(\DateTimeInterface::ATOM);
+```
+
+---
+
+## Benutzerdefinierte Exception → HTTP-Response-Zuordnung
+
+Domänen-Exceptions werden über Handler auf strukturierte Problem-Details-Responses abgebildet:
+
+```php
+final readonly class ShiftOverlapExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function supports(\Throwable $exception): bool
+    {
+        return $exception instanceof ShiftOverlapException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->factory->create(
+            $request,
+            'shift-overlap',
+            'Shift overlaps with an existing shift.',
+            409,
+            $exception->getMessage(),
+        );
+    }
+}
+```
+
+Separate Handler existieren für `ShiftNotFoundException` → 404, `EmployeeNotFoundException` → 404
+und `ShiftOverlapException` → 409. Die Registrierung in der `RuntimeApplicationFactory` hält
+Controller frei von `try/catch`-Boilerplate.
+
+---
+
+## Aggregatabfragen: Wochenzusammenfassung und Überstunden
+
+```php
+// GET /summary/weekly?from=2026-05-19&to=2026-05-25
+// GET /summary/overtime?from=2026-05-19&to=2026-05-25&threshold=40
+```
+
+Der Überstundenschwellenwert ist standardmäßig 40 Stunden:
+
+```php
+$threshold = (float) (QueryStringParser::int($request, 'threshold') ?? 40);
+if ($threshold <= 0) {
+    throw new ValidationException([...]);
+}
+```
+
+Hinweis: `QueryStringParser::int()` wird zuerst verwendet (lehnt nicht-numerische Zeichenketten ab),
+dann wird auf `float` gecastet. Dies verhindert, dass `NaN` / `Infinity` die Geschäftsschicht erreicht.
+
+---
+
+## Schema: Kaskaden-Delete und DB-Ebene-Constraints
+
+```sql
+CREATE TABLE employees (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL,
+    role        TEXT    NOT NULL,
+    hourly_rate REAL    NOT NULL CHECK(hourly_rate > 0),
+    created_at  TEXT    NOT NULL
+);
+
+CREATE TABLE shifts (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    employee_id INTEGER NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+    starts_at   TEXT    NOT NULL,
+    ends_at     TEXT    NOT NULL,
+    location    TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL,
+    CHECK(ends_at > starts_at)
+);
+```
+
+`ON DELETE CASCADE` entfernt die Schichten eines Mitarbeiters, wenn dieser gelöscht wird.
+DB-Ebene-`CHECK`-Constraints sind Defense-in-Depth-Absicherungen, nicht die primäre
+Validierungsschicht — die Anwendungsebenen-Validierung muss 422 zurückgeben, bevor irgendein DB-INSERT erfolgt.
+
+---
+
+## VULN — Sicherheitsbewertung (FT225)
+
+Jeder Befund dokumentiert den Angriffsvektor, das beobachtete Ergebnis und das Urteil:
+**BLOCKIERT** (sicher), **EXPONIERT** (echte Schwachstelle), **TEILWEISE EXPONIERT**
+oder **BY DESIGN AKZEPTIERT**.
+
+### V-01 — Keine Authentifizierung auf einem beliebigen Endpunkt
+
+**Angriff**: Mitarbeiter erstellen, Schichten einplanen oder löschen ohne Anmeldedaten.
+
+```http
+POST /employees
+{"name": "Attacker", "role": "Ghost", "hourly_rate": 0.01}
+
+DELETE /shifts/1
+```
+
+**Beobachtet**: Beide sind erfolgreich. Kein Token, keine Session und kein API-Key ist erforderlich.
+
+**Urteil**: **EXPONIERT** (by design für FT43 Demo).
+Produktive Planungssysteme MÜSSEN Mutationen hinter Authentifizierung absichern.
+`MachineApiKeyMiddleware` (env: `NENE2_MACHINE_API_KEY`) oder JWT Bearer verwenden.
+
+---
+
+### V-02 — Keine Autorisierung: Jeder kann jede Schicht löschen
+
+**Angriff**: Eine Schicht löschen, die einem anderen Mitarbeiter gehört, ohne Eigentümlichkeitsprüfung.
+
+```http
+DELETE /shifts/1   # gelingt für jeden authentifizierten oder nicht-authentifizierten Aufrufer
+```
+
+**Beobachtet**: `204 No Content` unabhängig von der Aufrufer-Identität.
+
+**Urteil**: **EXPONIERT** (by design für FT43 Demo).
+Eine Manager/Admin-Rollenprüfung vor dem Löschen hinzufügen oder Schichten an einen anfragenden Benutzer knüpfen.
+
+---
+
+### V-03 — SQL-Injection via parametrisierte Abfragen
+
+**Angriff**: SQL über `name`, `role`, `starts_at` oder `location` einschleusen.
+
+```json
+{"name": "x'; DROP TABLE employees; --", "role": "Admin", "hourly_rate": 1}
+{"starts_at": "2026-01-01' OR '1'='1", "ends_at": "2026-01-02", "employee_id": 1}
+```
+
+**Beobachtet**: Mitarbeiter wird mit der Injection-Zeichenkette als Namen erstellt. `starts_at` der Schicht
+wird in einer parametrisierten Abfrage verwendet, so dass keine SQL-Injection stattfindet.
+
+**Urteil**: **BLOCKIERT** — alle Abfragen verwenden PDO-parametrisierte Statements. Die gespeicherte
+Zeichenkette ist in der DB harmlos; das einzige Risiko wäre, wenn sie später als HTML gerendert würde.
+
+---
+
+### V-04 — Race Condition bei der Schicht-Überschneidungserkennung
+
+**Angriff**: Zwei gleichzeitige `POST /shifts`-Anfragen mit überlappenden Fenstern für
+denselben Mitarbeiter senden.
+
+**Beobachtet**: Die Überschneidungsprüfung läuft innerhalb von `transactional()`. SQLite serialisiert
+Schreibvorgänge mit WAL-Mode-Locking; MySQL/PostgreSQL verwenden `REPEATABLE READ` oder `SERIALIZABLE`-
+Isolation, wenn der Transaktions-Manager korrekt konfiguriert ist. Beide gleichzeitigen Inserts
+können nicht beide die Überschneidungsprüfung bestehen.
+
+**Urteil**: **BLOCKIERT** — transaktionale Überschneidungsprüfung verhindert Doppelbuchungen unter
+Gleichzeitigkeit. Den Isolationsgrad gemäß der DB-Engine verifizieren; der WAL-Standardmodus von
+SQLite ist für Single-Node-Deployments ausreichend.
+
+---
+
+### V-05 — ends_at ≤ starts_at wird akzeptiert
+
+**Angriff**: Eine Schicht einreichen, bei der die Endzeit vor oder gleich der Startzeit liegt.
+
+```json
+{"employee_id": 1, "starts_at": "2026-05-27T10:00:00Z", "ends_at": "2026-05-27T09:00:00Z"}
+{"employee_id": 1, "starts_at": "2026-05-27T10:00:00Z", "ends_at": "2026-05-27T10:00:00Z"}
+```
+
+**Beobachtet**: `422 Unprocessable Entity` — die Anwendung vergleicht Zeichenketten (`$endsAt <= $startsAt`)
+vor dem Einfügen. Das DB-`CHECK(ends_at > starts_at)` ist eine Absicherung.
+
+**Urteil**: **BLOCKIERT** — Zwei-Schichten-Validierung (Anwendung + DB-Constraint).
+
+---
+
+### V-06 — hourly_rate Validierungslücke
+
+**Angriff**: Negativen, null oder String-Wert für `hourly_rate` einreichen.
+
+```json
+{"name": "X", "role": "Y", "hourly_rate": -10}
+{"name": "X", "role": "Y", "hourly_rate": 0}
+{"name": "X", "role": "Y", "hourly_rate": "free"}
+```
+
+**Beobachtet**:
+- Negativ/null: Die Anwendung validiert `hourly_rate > 0` NICHT auf Controller-Ebene.
+  Ein negativer Wert umgeht die App-Prüfung und trifft auf das DB-`CHECK(hourly_rate > 0)`,
+  das eine DB-Exception auslöst. Ohne einen expliziten Handler wird daraus ein 500.
+- String `"free"`: `is_numeric()` gibt false zurück, daher wird dies mit 422 abgelehnt.
+
+**Urteil**: **TEILWEISE EXPONIERT** — Anwendungsebenen-Validierung vor dem DB-Insert hinzufügen:
+```php
+if (!isset($body['hourly_rate'])
+    || !is_numeric($body['hourly_rate'])
+    || (float) $body['hourly_rate'] <= 0) {
+    $errors[] = new ValidationError('hourly_rate', 'hourly_rate must be a positive number.', 'out_of_range');
+}
+```
+
+---
+
+### V-07 — Semantisch ungültige ISO-8601-Datetime
+
+**Angriff**: Eine Schicht mit einer strukturell plausiblen, aber kalenderungültigen Datetime einreichen.
+
+```json
+{"starts_at": "2026-02-30T00:00:00Z", "ends_at": "2026-02-30T08:00:00Z", "employee_id": 1}
+```
+
+**Beobachtet**: Wird akzeptiert und gespeichert. Die Anwendung prüft `trim() === ''`, parst das Datum
+jedoch nicht. `DateTimeImmutable` normalisiert `2026-02-30` stillschweigend auf `2026-03-02`,
+was den gespeicherten Wert verfälscht.
+
+**Urteil**: **EXPONIERT** — einen Round-Trip-Check für `starts_at` und `ends_at` hinzufügen:
+```php
+$dt = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $raw);
+if ($dt === false || $dt->format(DateTimeInterface::ATOM) !== $raw) {
+    $errors[] = new ValidationError('starts_at', 'starts_at must be a valid ISO 8601 datetime.', 'invalid_format');
+}
+```
+
+---
+
+### V-08 — Unbegrenzter Datumsbereich in Aggregatabfragen
+
+**Angriff**: Eine Zusammenfassung über einen beliebig großen Datumsbereich anfordern, um den Speicher
+zu erschöpfen oder eine langsame Abfrage zu verursachen.
+
+```http
+GET /summary/weekly?from=1900-01-01&to=2099-12-31
+```
+
+**Beobachtet**: Die Abfrage läuft über alle Zeilen in der Tabelle. Bei einem großen Datensatz
+kann dies zu übermäßigem Speicherverbrauch oder einer mehrsekundigen Antwort führen.
+
+**Urteil**: **EXPONIERT** — den maximal erlaubten Bereich (z.B. 90 Tage) auf Controller-Ebene begrenzen:
+```php
+$maxDays = 90;
+$diff    = (new DateTimeImmutable($to))->diff(new DateTimeImmutable($from));
+if ($diff->days > $maxDays) {
+    return $this->json->create(['error' => "Date range must not exceed {$maxDays} days."], 422);
+}
+```
+
+---
+
+### V-09 — Unbegrenzter Mitarbeitername / Rolle Länge
+
+**Angriff**: Einen Mitarbeiter mit einem Namen oder einer Rolle von Zehntausenden von Zeichen erstellen.
+
+```json
+{"name": "AAAA... (50000 Zeichen)", "role": "Y", "hourly_rate": 10}
+```
+
+**Beobachtet**: `201 Created` — SQLite TEXT ist unbegrenzt; die Zeile wird eingefügt.
+
+**Urteil**: **EXPONIERT** — `mb_strlen()`-Prüfungen hinzufügen und 422 zurückgeben:
+```php
+if (mb_strlen($name) > 100) {
+    $errors[] = new ValidationError('name', 'name must not exceed 100 characters.', 'max_length');
+}
+```
+
+---
+
+### V-10 — Unbegrenzte Standort-Zeichenkette
+
+**Angriff**: Eine Schicht mit einer Standort-Zeichenkette beliebiger Länge einplanen.
+
+```json
+{"employee_id": 1, "starts_at": "...", "ends_at": "...", "location": "BBBB... (50000 Zeichen)"}
+```
+
+**Beobachtet**: `201 Created` — kein Längenlimit wird erzwungen.
+
+**Urteil**: **EXPONIERT** — `mb_strlen($location) <= 200`-Prüfung hinzufügen.
+
+---
+
+### V-11 — XSS-Payload in Name / Rolle / Standort
+
+**Angriff**: Ein `<script>`-Tag in einem beliebigen Freitext-Feld speichern.
+
+```json
+{"name": "<script>alert(1)</script>", "role": "Admin", "hourly_rate": 1}
+```
+
+**Beobachtet**: `201 Created`. Wert wird unverändert in JSON-Antworten zurückgegeben.
+
+**Urteil**: **BY DESIGN AKZEPTIERT** — dies ist eine JSON API; Escaping liegt in der Verantwortung
+des HTML-Rendering-Clients. Der Server gibt kein HTML aus diesen Feldern aus.
+Den Vertrag in der OpenAPI-Spezifikation dokumentieren.
+
+---
+
+### V-12 — Nicht-numerische Pfad-IDs
+
+**Angriff**: Nicht-Ziffer- oder negative Werte als `{id}` übergeben.
+
+```http
+GET /shifts/abc
+GET /shifts/-1
+DELETE /employees/0
+```
+
+**Beobachtet**: `404 Not Found` in jedem Fall. `(int) "abc"` = `0`; keine Schicht/kein Mitarbeiter
+mit ID 0 oder negativ existiert, also wirft `findShiftById(0)` `ShiftNotFoundException`,
+die der Handler auf 404 abbildet.
+
+**Urteil**: **BLOCKIERT** in der Praxis. Hinweis: `(int) "9abc"` = `9` — wenn ein Datensatz mit
+ID 9 existiert, würde er zurückgegeben. `ctype_digit()` für strikte Pfad-ID-Validierung verwenden,
+wenn der Unterschied wichtig ist.
+
+---
+
+## VULN-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|----------------|--------|
+| V-01 | Keine Authentifizierung | EXPONIERT (by design) |
+| V-02 | Keine Autorisierung / jede Schicht löschbar | EXPONIERT (by design) |
+| V-03 | SQL-Injection | BLOCKIERT |
+| V-04 | Überschneidungs-Race-Condition | BLOCKIERT |
+| V-05 | ends_at ≤ starts_at | BLOCKIERT |
+| V-06 | Negativer hourly_rate umgeht App-Prüfung | TEILWEISE EXPONIERT |
+| V-07 | Semantisch ungültige ISO-8601-Datetime | EXPONIERT |
+| V-08 | Unbegrenzter Datumsbereich in Aggregatabfragen | EXPONIERT |
+| V-09 | Unbegrenzte Mitarbeitername/Rolle | EXPONIERT |
+| V-10 | Unbegrenzte Standort-Zeichenkette | EXPONIERT |
+| V-11 | XSS-Payload-Speicherung | BY DESIGN AKZEPTIERT |
+| V-12 | Nicht-numerische Pfad-IDs | BLOCKIERT |
+
+**Echte Schwachstellen vor der Produktion beheben**:
+1. **V-01/02** — Authentifizierung und rollenbasierte Autorisierung hinzufügen
+2. **V-06** — `hourly_rate > 0`-Validierung auf Anwendungsebene hinzufügen
+3. **V-07** — ISO-8601-Round-Trip-Validierung für Datetime-Felder hinzufügen
+4. **V-08** — Maximalen Datumsbereich in Aggregat-Endpunkten begrenzen (z.B. 90 Tage)
+5. **V-09/10** — `mb_strlen()`-Maximallängen-Prüfungen für alle Freitext-Felder hinzufügen
+
+---
+
+## Verwandte Anleitungen
+
+- [`notification-inbox.md`](notification-inbox.md) — IDOR-Schutzmuster (404 bei unbefugtem Lesen/Schreiben)
+- [`prevent-double-booking.md`](prevent-double-booking.md) — Transaktionale Doppelbuchungs-Prävention
+- [`expense-tracker.md`](expense-tracker.md) — ISO-8601-Round-Trip-Datumsvalidierung
+- [`resource-booking.md`](resource-booking.md) — Datumsbereichsbegrenzung und Zeitfenster-Abfragen

--- a/docs/de/howto/shopping-cart-api.md
+++ b/docs/de/howto/shopping-cart-api.md
@@ -1,0 +1,325 @@
+# How-to: Warenkorb-API
+
+> **FT-Referenz**: FT269 (`NENE2-FT/cartlog`) — Warenkorb: `UNIQUE(user_id, product_id)` pro Benutzer,
+> Upsert zum Hinzufügen von Artikeln (Mengenakkumulation), `quantity=0`-Auto-Entfernen-Semantik,
+> Integer-Preis/Zwischensumme, `X-User-Id`-Header-Identifikation
+>
+> Auch validiert in FT155 (`NENE2-FT/cartlog`-Vorläufer) — dasselbe Warenkorbmuster, SQLite, PHP 8.4.
+
+Demonstriert einen zustandsbehafteten Benutzer-Warenkorb: Artikel hinzufügen (mit Mengenakkumulation
+beim erneuten Hinzufügen), Mengen aktualisieren, Artikel entfernen und eine laufende Gesamtsumme anzeigen.
+Alle Preise werden als Integer (Cent oder Basiseinheiten) gespeichert — niemals als Float.
+
+---
+
+## Routen
+
+| Methode   | Pfad                        | Beschreibung                                         |
+|-----------|-----------------------------|------------------------------------------------------|
+| `GET`     | `/cart`                     | Warenkorbinhalt mit Zwischensummen und Gesamtsumme   |
+| `POST`    | `/cart/items`               | Produkt hinzufügen (Menge akkumuliert sich bei Wiederholung) |
+| `PUT`     | `/cart/items/{productId}`   | Menge setzen (0 = Artikel entfernen)                 |
+| `DELETE`  | `/cart/items/{productId}`   | Bestimmten Artikel entfernen                         |
+| `DELETE`  | `/cart`                     | Gesamten Warenkorb leeren                            |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE products (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    price      INTEGER NOT NULL CHECK (price >= 0),
+    stock      INTEGER NOT NULL DEFAULT 0 CHECK (stock >= 0),
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE cart_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    product_id INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL CHECK (quantity > 0),
+    added_at   TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE (user_id, product_id),
+    FOREIGN KEY (user_id)    REFERENCES users(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+```
+
+Wesentliche Designentscheidungen:
+- `UNIQUE (user_id, product_id)` — eine Zeile pro (Benutzer, Produkt)-Paar. Das erneute Hinzufügen desselben Produkts akkumuliert die Menge, anstatt eine doppelte Zeile einzufügen.
+- `price INTEGER` — wird in der kleinsten Währungseinheit gespeichert (z.B. Cent). Für Geldbeträge niemals `FLOAT` verwenden.
+- `quantity INTEGER CHECK (quantity > 0)` — Zeilen mit null Menge werden gelöscht, nicht gespeichert.
+- Kein FK auf `cart_items.price` — der Preis wird aus `products.price` zum Abfragezeitpunkt gelesen (JOIN), nicht im Warenkorb gespeichert. Ändert sich der Produktpreis, spiegelt der Warenkorb den neuen Preis wider.
+
+---
+
+## Upsert-Muster zum Hinzufügen von Artikeln
+
+Das Hinzufügen eines bereits im Warenkorb vorhandenen Artikels akkumuliert die Menge:
+
+```php
+public function addItem(int $userId, int $productId, int $quantity, string $now): void
+{
+    $existing = $this->db->fetchOne(
+        'SELECT id, quantity FROM cart_items WHERE user_id = ? AND product_id = ?',
+        [$userId, $productId],
+    );
+
+    if ($existing !== null) {
+        $newQty = (int) $existing['quantity'] + $quantity;
+        $this->db->execute(
+            'UPDATE cart_items SET quantity = ?, updated_at = ? WHERE id = ?',
+            [$newQty, $now, $existing['id']],
+        );
+    } else {
+        $this->db->execute(
+            'INSERT INTO cart_items (user_id, product_id, quantity, added_at, updated_at)
+             VALUES (?, ?, ?, ?, ?)',
+            [$userId, $productId, $quantity, $now, $now],
+        );
+    }
+}
+```
+
+Das SELECT-then-INSERT/UPDATE-Muster vermeidet `INSERT OR REPLACE` (das `id` und `added_at` ändert)
+und vermeidet `ON CONFLICT DO UPDATE` (nicht über alle DB-Engines portierbar). Der
+`UNIQUE (user_id, product_id)`-Constraint schützt dennoch vor einem Race-Condition-Duplikat-INSERT.
+
+Antwortstatus: `201 Created`, wenn der Artikel neu war; `200 OK`, wenn die Menge auf einem vorhandenen Artikel akkumuliert wurde.
+
+---
+
+## Quantity=0 Auto-Entfernen-Semantik
+
+`PUT /cart/items/{productId}` mit `quantity: 0` entfernt den Artikel, anstatt eine Null-Mengen-Zeile zu speichern:
+
+```php
+if ($quantity === 0) {
+    $this->repo->removeItem($userId, $productId);
+    return $this->json->createEmpty(204);
+}
+
+$this->repo->updateQuantity($userId, $productId, $quantity, $now);
+```
+
+Dies entspricht der üblichen Warenkorb-UX: das Schieberegler auf null ziehen entfernt den Artikel.
+Das DB-`CHECK (quantity > 0)` erzwingt dies auch auf Speicherebene.
+
+---
+
+## Warenkorb-Gesamtsumme: JOIN + Schleife
+
+Die Warenkorbantwort enthält eine Echtzeit-Gesamtsumme, die aus dem JOIN-Ergebnis berechnet wird:
+
+```php
+public function getCart(int $userId): array
+{
+    return $this->db->fetchAll(
+        'SELECT ci.id, ci.product_id, ci.quantity, ci.added_at, ci.updated_at,
+                p.name AS product_name, p.price
+         FROM cart_items ci
+         JOIN products p ON p.id = ci.product_id
+         WHERE ci.user_id = ?
+         ORDER BY ci.added_at ASC, ci.id ASC',
+        [$userId],
+    );
+}
+```
+
+```php
+$items = $this->repo->getCart($userId);
+$total = 0;
+$formatted = [];
+
+foreach ($items as $item) {
+    $subtotal = (int) $item['price'] * (int) $item['quantity'];
+    $total   += $subtotal;
+    $formatted[] = $this->formatItem($item, $subtotal);
+}
+
+return $this->json->create([
+    'items' => $formatted,
+    'total' => $total,
+    'count' => count($formatted),
+]);
+```
+
+Sowohl `price` als auch `subtotal` sind Integer. Der API-Consumer dividiert zur Anzeige durch 100
+(z.B. `1999` → `19,99 €`).
+
+---
+
+## Benutzeridentifikation via X-User-Id-Header
+
+Der FT verwendet einen einfachen `X-User-Id`-Header (kein JWT), um den Warenkorbbesitzer zu identifizieren:
+
+```php
+private function requireUserId(ServerRequestInterface $request): ?int
+{
+    $header = $request->getHeaderLine('X-User-Id');
+    if ($header === '') {
+        return null;
+    }
+    $id = (int) $header;
+    return $id > 0 ? $id : null;
+}
+```
+
+Der Handler prüft, ob der Benutzer in der `users`-Tabelle existiert, bevor er fortfährt:
+```php
+if ($this->repo->findUserById($userId) === null) {
+    return $this->json->create(['error' => 'User not found'], 404);
+}
+```
+
+**Produktionshinweis**: `X-User-Id` durch ein verifiziertes JWT oder Session-Token ersetzen. Der
+Header ist trivial fälschbar — jeder Aufrufer kann eine beliebige `user_id` beanspruchen. `X-User-Id`
+nur in vertrauenswürdigen internen Service-zu-Service-Kontexten verwenden, niemals für öffentliche APIs.
+
+---
+
+## Validierung
+
+```php
+// POST /cart/items Body-Validierung
+private function parseAddBody(array $body): array
+{
+    $errors = [];
+
+    if (!isset($body['product_id']) || !is_int($body['product_id'])) {
+        $errors[] = new ValidationError('product_id', 'product_id must be an integer', 'invalid_type');
+    }
+
+    $productId = isset($body['product_id']) && is_int($body['product_id']) ? $body['product_id'] : 0;
+    if ($productId <= 0 && $errors === []) {
+        $errors[] = new ValidationError('product_id', 'product_id must be positive', 'invalid_value');
+    }
+
+    if (!isset($body['quantity']) || !is_int($body['quantity'])) {
+        $errors[] = new ValidationError('quantity', 'quantity must be an integer', 'invalid_type');
+    }
+
+    $quantity = isset($body['quantity']) && is_int($body['quantity']) ? $body['quantity'] : 0;
+    if ($quantity <= 0 && !isset($errors[1])) {
+        $errors[] = new ValidationError('quantity', 'quantity must be positive', 'invalid_value');
+    }
+
+    return [$productId, $quantity, $errors];
+}
+```
+
+Typprüfungen (`is_int`) lehnen Float- oder String-Mengen ab — `"3"` und `3.0` sind beide ungültig.
+
+---
+
+## Beispielantworten
+
+**GET /cart**:
+```json
+{
+    "items": [
+        {
+            "id": 1,
+            "product_id": 5,
+            "product_name": "Widget",
+            "price": 999,
+            "quantity": 2,
+            "subtotal": 1998,
+            "added_at": "2026-01-01T10:00:00Z",
+            "updated_at": "2026-01-01T10:00:00Z"
+        }
+    ],
+    "total": 1998,
+    "count": 1
+}
+```
+
+---
+
+## AppFactory-Verdrahtungsbeispiel
+
+Die App für Tests oder einen schlanken Einstiegspunkt initialisieren:
+
+```php
+class AppFactory
+{
+    public static function createSqlite(string $dbFile): RequestHandlerInterface
+    {
+        $dbConfig = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: '',
+            port: 1,
+            name: $dbFile,
+            user: '',
+            password: '',
+            charset: '',
+        );
+        return self::build($dbConfig);
+    }
+
+    private static function build(DatabaseConfig $dbConfig): RequestHandlerInterface
+    {
+        $factory    = new PdoConnectionFactory($dbConfig);
+        $executor   = new PdoDatabaseQueryExecutor($factory);
+        $psr17      = new Psr17Factory();
+        $repo       = new CartRepository($executor);
+        $json       = new JsonResponseFactory($psr17, $psr17);
+        $registrar  = new RouteRegistrar($repo, $json);
+
+        return (new RuntimeApplicationFactory(
+            $psr17,
+            $psr17,
+            routeRegistrars: [static fn (Router $router) => $registrar->register($router)],
+        ))->create();
+    }
+}
+```
+
+Die Verwendung von `RuntimeApplicationFactory` stellt automatisch bereit: ValidationException → 422-Zuordnung,
+Fehlerbehandlung und Sicherheits-Header.
+
+---
+
+## Testmuster
+
+```php
+// Erneutes Hinzufügen desselben Produkts akkumuliert die Menge
+$this->req('POST', '/cart/items', ['X-User-Id' => '1'], ['product_id' => 1, 'quantity' => 2]);
+$res = $this->req('POST', '/cart/items', ['X-User-Id' => '1'], ['product_id' => 1, 'quantity' => 3]);
+$this->assertSame(200, $res->getStatusCode());
+$data = $this->json($res);
+$this->assertSame(5, $data['quantity']);
+
+// Der Warenkorb jedes Benutzers ist isoliert
+$this->req('POST', '/cart/items', ['X-User-Id' => '1'], ['product_id' => 1, 'quantity' => 3]);
+$res = $this->req('GET', '/cart', ['X-User-Id' => '2']);
+$this->assertSame(0, $this->json($res)['count']);
+```
+
+> **SQLite-FK-Vorbehalt**: `PdoConnectionFactory` setzt `PRAGMA foreign_keys = ON`. Beim Einfügen
+> von Testdaten über eine separate PDO-Instanz dasselbe Pragma auf dieser Verbindung setzen —
+> andernfalls lässt JOIN stillschweigend Zeilen weg, deren FK-Ziele über ein anderes Connection-Handle eingefügt wurden.
+
+---
+
+## Was NOT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `price` in `cart_items` beim Hinzufügen speichern | Veralteter Preis bei Produktpreisänderung; Streitigkeiten bei Rückerstattungen / Überforderungen |
+| `FLOAT` für Preise verwenden | Gleitkomma-Rundungsfehler in Finanzsummen |
+| `X-User-Id` in einer öffentlichen API verwenden | Trivial fälschbar; stattdessen JWT/Session verwenden |
+| `quantity: 0` eine Null-Zeile speichern lassen | Verstößt gegen `CHECK (quantity > 0)`; verwirrende Semantik |
+| `INSERT OR REPLACE` für Upsert verwenden | Setzt `id` und `added_at` zurück; unterbricht reihenfolgeerhaltende Sortierung |
+| Kein `UNIQUE (user_id, product_id)`-Constraint | Race Condition erstellt doppelte Warenkorbzeilen |

--- a/docs/de/howto/signed-url-download.md
+++ b/docs/de/howto/signed-url-download.md
@@ -1,0 +1,185 @@
+# How-to: Signierte URLs für sichere Downloads
+
+> **FT-Referenz**: FT338 (`NENE2-FT/signedlog`) — HMAC-SHA256-signierte URL-Generierung mit TTL,
+> Manipulationserkennung (401), Ablauf (410 Gone), ressourcengebundene Tokens und Ablehnung falscher
+> Secrets; 16 Tests / 40+ Assertions PASS.
+
+Diese Anleitung zeigt, wie zeitlich begrenzte signierte URLs generiert werden, die einen nicht-authentifizierten
+Download privater Dateien ermöglichen — ohne langlebige Anmeldedaten preiszugeben.
+
+## Schema
+
+```sql
+CREATE TABLE files (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    owner_id   INTEGER NOT NULL,
+    mime_type  TEXT    NOT NULL DEFAULT 'application/octet-stream',
+    created_at TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST`  | `/files` | Dateidatensatz registrieren |
+| `POST`  | `/files/{id}/sign` | Signierte Download-URL generieren |
+| `GET`   | `/download?token=...` | Mittels signiertem Token herunterladen |
+
+## Datei registrieren
+
+```php
+POST /files
+{"name": "report.pdf", "owner_id": 1}
+→ 201
+{
+  "id": 1,
+  "name": "report.pdf",
+  "owner_id": 1,
+  "mime_type": "application/octet-stream",
+  "created_at": "..."
+}
+
+// Benutzerdefinierter MIME-Typ
+POST /files  {"name": "image.png", "owner_id": 2, "mime_type": "image/png"}
+→ 201  {"mime_type": "image/png", ...}
+
+// Validierung
+POST /files  {"owner_id": 1}     → 422  // name erforderlich
+POST /files  {"name": "f.pdf"}   → 422  // owner_id erforderlich
+```
+
+## Signierte URL generieren
+
+```php
+POST /files/1/sign
+{"ttl_seconds": 300}
+→ 200
+{
+  "token": "1|2026-05-27 09:05:00|a3f9e2...",
+  "expires_at": "2026-05-27T09:05:00Z",
+  "url": "/download?token=1%7C2026-05-27+09%3A05%3A00%7Ca3f9e2...",
+  "ttl_seconds": 300
+}
+
+// Standard-TTL = 3600 (1 Stunde) wenn weggelassen
+POST /files/1/sign  {}
+→ 200  {"ttl_seconds": 3600}
+
+// Unbekannte Datei
+POST /files/999/sign  {"ttl_seconds": 60}
+→ 404
+```
+
+## Herunterladen mit Token
+
+```php
+GET /download?token=1|2026-05-27+09:05:00|a3f9e2...
+→ 200  {"id": 1, "name": "report.pdf", "mime_type": "application/octet-stream"}
+
+// Fehlendes Token
+GET /download
+→ 401
+
+// Manipuliertes Token (letzte 4 Zeichen geändert)
+GET /download?token=1|2026-05-27+09:05:00|XXXX
+→ 401
+
+// Abgelaufenes Token (expires_at in der Vergangenheit)
+GET /download?token=1|2020-01-01+00:00:00|...valid_hmac...
+→ 410 Gone
+
+// Zufälliger Unsinn
+GET /download?token=totally-invalid-garbage
+→ 401
+```
+
+**410 Gone** (nicht 401) für abgelaufene Tokens: die URL existierte und war gültig — sie ist lediglich
+abgelaufen. So können Clients zwischen „niemals gültig" und „einmal gültig, jetzt veraltet" unterscheiden.
+
+## Token-Format — HMAC-SHA256
+
+```
+token = "{file_id}|{expires_at}|{hmac}"
+
+hmac = HMAC-SHA256(key=server_secret, message="{file_id}|{expires_at}")
+```
+
+```php
+class HmacSigner
+{
+    public function __construct(private readonly string $secret)
+    {
+    }
+
+    public function sign(int $fileId, string $expiresAt): string
+    {
+        $payload = "{$fileId}|{$expiresAt}";
+        $hmac    = hash_hmac('sha256', $payload, $this->secret);
+        return "{$payload}|{$hmac}";
+    }
+
+    public function verify(string $token, string $now): ?int
+    {
+        $parts = explode('|', $token, 3);
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        [$fileIdStr, $expiresAt, $receivedHmac] = $parts;
+        $fileId  = (int) $fileIdStr;
+        $payload = "{$fileId}|{$expiresAt}";
+
+        // Zeitkonstanter Vergleich
+        $expected = hash_hmac('sha256', $payload, $this->secret);
+        if (!hash_equals($expected, $receivedHmac)) {
+            return null;  // manipuliert oder falsches Secret
+        }
+
+        // Ablauf NACH HMAC-Verifizierung prüfen
+        if ($expiresAt < $now) {
+            return -1;  // abgelaufen — Aufrufer gibt 410 zurück
+        }
+
+        return $fileId;
+    }
+}
+```
+
+**Kritische Reihenfolge**: den HMAC immer vor dem Ablauf prüfen. Wenn zuerst der Ablauf bei einem
+ungültigen Token geprüft wird, können Angreifer das Ablaufverhalten erkunden.
+
+### Ressourcen-Bindung
+
+Jedes Token kodiert die `file_id`. Tokens für verschiedene Dateien erzeugen unterschiedliche HMAC-Digests:
+
+```php
+$token1 = $signer->sign(1, $future);
+$token2 = $signer->sign(2, $future);
+// $token1 !== $token2 — Token von Datei-1 kann nicht für Datei-2 wiederverwendet werden
+```
+
+### Falsches Secret
+
+Ein Token, das mit einem anderen Secret signiert wurde, gibt `null` bei `verify()` zurück:
+
+```php
+$otherSigner = new HmacSigner('different-secret');
+$token = $otherSigner->sign(1, $future);
+$signer->verify($token, $now);  // null — HMAC-Mismatch
+```
+
+---
+
+## Was NOT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `===` statt `hash_equals()` für HMAC-Vergleich verwenden | Timing-Angriff gibt HMAC Byte für Byte preis |
+| Ablauf vor HMAC-Verifizierung prüfen | Angreifer erkundet den Ablauf bei gefälschten Tokens, um die Serveruhr zu erfahren |
+| Nur `user_id` im Token-Payload einschließen, nicht `file_id` | Token für Benutzer-1-Datei-1 ist für Benutzer-1-Datei-2 wiederverwendbar |
+| `md5()` oder `sha1()` statt HMAC-SHA256 verwenden | Keyed Hash erforderlich; unkeyed Hash ist trivial fälschbar |
+| 401 für abgelaufene Tokens zurückgeben | 410 teilt dem Client mit: „Token war echt, aber veraltet"; ermöglicht korrekten Neu-Signierungsflow |
+| Token-Wert in Zugriffsprotokollen loggen | Token gewährt Zugriff — wie ein Passwort behandeln; in Protokollen maskieren oder weglassen |
+| Schwaches oder vorhersehbares Secret verwenden | Key muss mindestens 32 zufällige Bytes haben; niemals aus Zeitstempel oder Hostname ableiten |

--- a/docs/de/howto/signed-urls.md
+++ b/docs/de/howto/signed-urls.md
@@ -1,0 +1,170 @@
+# Signierte URLs
+
+Signierte URLs bieten zeitlich begrenzten, ressourcengebundenen Zugriff auf geschützte Ressourcen,
+ohne dass sich der Aufrufer mit einem Konto authentifizieren muss. Das Muster wird für Datei-Downloads,
+vorsignierte Upload-Slots und jeden Fall verwendet, in dem temporärer Zugriff mit einem Dritten geteilt
+werden soll.
+
+## Grundkonzept
+
+Eine signierte URL enthält alles, was zur Zugriffsautorisierung benötigt wird: die Ressourcen-ID,
+die Ablaufzeit und eine HMAC-Signatur, die beweist, dass die URL von einem vertrauenswürdigen Server
+generiert wurde. Der Server benötigt nur seinen geheimen Schlüssel zur Verifizierung — kein Datenbankzugriff
+erforderlich.
+
+## Token-Format
+
+```
+base64url({resource_id}|{expires_at}|{hmac-sha256(resource_id|expires_at, secret)})
+```
+
+Der HMAC deckt `resource_id|expires_at` zusammen ab. Das Ändern eines der beiden Teile macht die
+Signatur ungültig. Dies bindet das Token an genau eine Ressource und ein Ablaufzeitfenster.
+
+## Signer-Implementierung
+
+```php
+final readonly class HmacSigner
+{
+    private const string ALGO = 'sha256';
+
+    public function __construct(
+        private string $secret,
+    ) {}
+
+    public function sign(int $resourceId, string $expiresAt): string
+    {
+        $payload = $resourceId . '|' . $expiresAt;
+        $mac     = hash_hmac(self::ALGO, $payload, $this->secret);
+
+        return $this->base64UrlEncode($payload . '|' . $mac);
+    }
+
+    public function verify(string $token, string $now): ?int
+    {
+        $decoded = $this->base64UrlDecode($token);
+        if ($decoded === null) {
+            return null;
+        }
+
+        $parts = explode('|', $decoded, 3);
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        [$resourceId, $expiresAt, $storedMac] = $parts;
+
+        $expectedMac = hash_hmac(self::ALGO, $resourceId . '|' . $expiresAt, $this->secret);
+
+        // hash_equals() ist zwingend erforderlich — === gibt Timing-Informationen preis
+        if (!hash_equals($expectedMac, $storedMac)) {
+            return null;
+        }
+
+        if ($expiresAt < $now) {
+            return null;
+        }
+
+        return (int) $resourceId;
+    }
+}
+```
+
+`hash_equals()` ist nicht verhandelbar. Ein String-Gleichheitsvergleich bricht beim ersten Mismatch ab
+und gibt preis, wie viele Zeichen des HMAC übereinstimmen. Ein Angreifer kann dies ausnutzen, um
+Signaturen Byte für Byte zu fälschen. `hash_equals()` vergleicht stets alle Zeichen.
+
+## 410 Gone vs. 401 Unauthorized für abgelaufene Tokens
+
+Benutzer profitieren davon zu wissen, ob ihr Link abgelaufen ist (und sie einen neuen anfordern sollen)
+oder ob der Link nie gültig war. Der Signer verifiziert zunächst den HMAC, dann den Ablauf. Um sie
+in der HTTP-Antwort zu unterscheiden:
+
+```php
+$resourceId = $this->signer->verify($token, $now);
+
+if ($resourceId === null) {
+    // Ablauf ohne HMAC-Verifizierung extrahieren
+    $expiresAt = $this->signer->extractExpiresAt($token);
+    if ($expiresAt !== null && $expiresAt < $now) {
+        return $problems->create($request, 'gone', 'This link has expired.', 410, '');
+    }
+    return $problems->create($request, 'unauthorized', 'Invalid or expired token.', 401, '');
+}
+```
+
+`extractExpiresAt()` dekodiert nur Base64 und teilt bei `|` — es verifiziert den HMAC NICHT. Dies
+ist sicher, weil:
+1. Der Ablauf kein Geheimnis ist (er ist sowieso in der signierten URL sichtbar).
+2. Ein Angreifer kein gültiges Token mit einem manipulierten Ablauf fälschen kann, weil `verify()` es ablehnt.
+3. Die 410-Antwort keine Informationen liefert, die beim Fälschen von Tokens helfen.
+
+KEINE unterschiedlichen Fehlermeldungen für „HMAC-Mismatch" vs. „Ablauf überschritten" ausgeben — das
+würde es einem Angreifer ermöglichen, zuerst gültige Signaturen für beliebige Ablaufwerte zu konstruieren
+und sie dann zum Erkunden des Timings zu verwenden.
+
+## Signierte URLs generieren
+
+```php
+// POST /files/{id}/sign
+$expiresAt = (new \DateTimeImmutable())
+    ->add(new \DateInterval("PT{$ttlSeconds}S"))
+    ->format('Y-m-d H:i:s');
+
+$token = $this->signer->sign($file->id, $expiresAt);
+
+return $json->create([
+    'token'       => $token,
+    'expires_at'  => $expiresAt,
+    'ttl_seconds' => $ttlSeconds,
+    'url'         => '/download?token=' . urlencode($token),
+]);
+```
+
+Das Token immer mit `urlencode()` kodieren, bevor es in URLs eingebettet wird — Base64url-Zeichen sind
+URL-sicher, aber die `=`-Auffüllung (falls vorhanden) ist es nicht, und der `|`-Separator im dekodierten
+Payload darf nicht in der kodierten Form erscheinen.
+
+## Secret-Key-Management
+
+- Das Secret aus einer Umgebungsvariable einlesen — niemals hartcodieren.
+- Mindestens 32 Bytes zufällige Daten verwenden (`random_bytes(32)` → hex oder Base64).
+- Für die Secret-Rotation die Verifizierung gegen mehrere Secrets gleichzeitig unterstützen (jedes
+  ausprobieren, bis eines erfolgreich ist), dann das alte Secret auslaufen lassen.
+
+```php
+// Multi-Secret-Unterstützung während der Rotation
+public function verifyWithRotation(string $token, string $now, array $secrets): ?int
+{
+    foreach ($secrets as $secret) {
+        $signer = new HmacSigner($secret);
+        $id = $signer->verify($token, $now);
+        if ($id !== null) {
+            return $id;
+        }
+    }
+    return null;
+}
+```
+
+## Zustandslos vs. zustandsbehaftet signierte URLs
+
+Dieses Muster ist **zustandslos** — der Server verfolgt keine ausgestellten Tokens. Dies ist der
+Hauptvorteil (kein DB-Zugriff bei jedem Download), bedeutet jedoch:
+
+- Signierte URLs können nicht vor ihrem Ablauf widerrufen werden.
+- Bei Rotation des Secrets werden alle zuvor ausgestellten Tokens sofort ungültig.
+
+Für widerrufbare Tokens eine Sperrlisten-Tabelle (`revoked_tokens`) anlegen und diese während der
+Verifizierung prüfen. Dies tauscht den zustandslosen Vorteil gegen Widerrufbarkeit ein.
+
+## Was NOT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `===` oder `strcmp()` für HMAC-Vergleich verwenden | Timing-Angriff — ermöglicht das Fälschen von Signaturen |
+| Nur `resource_id` ohne Ablauf signieren | Tokens sind permanent — können nicht ablaufen |
+| Nur `expires_at` ohne `resource_id` signieren | Ein Token gewährt Zugriff auf alle Ressourcen |
+| Den Ablauf zur Unterscheidung von „manipuliert" vs. „abgelaufen" verwenden | Ermöglicht Oracle-Angriff auf HMAC |
+| Rohen Schlüssel im Token einbetten | Macht den Zweck zunichte — Token muss opak sein |
+| Lange TTLs (Tage/Wochen) | Vergrößert das Exponierungsfenster bei Token-Leckage |

--- a/docs/de/howto/sliding-window-rate-limiter.md
+++ b/docs/de/howto/sliding-window-rate-limiter.md
@@ -1,0 +1,155 @@
+# How-to: Gleitendes-Fenster-Ratenbegrenzer
+
+## Überblick
+
+Diese Anleitung beschreibt den Aufbau eines pro-Benutzer und pro-Endpunkt gleitenden
+Fenster-Ratenbegrenzers mit NENE2. Anfragen werden innerhalb eines gleitenden Zeitfensters
+gezählt; sobald das Limit erreicht ist, werden weitere Anfragen mit `429 Too Many Requests`
+abgelehnt.
+
+**Referenzimplementierung**: `../NENE2-FT/ratelog/`
+
+---
+
+## Schema-Design
+
+```sql
+CREATE TABLE IF NOT EXISTS rate_events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    endpoint   TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_events_user_endpoint
+    ON rate_events (user_id, endpoint, created_at);
+```
+
+Der Index auf `(user_id, endpoint, created_at)` macht die COUNT-Abfrage bei größerem Datenvolumen schnell.
+
+---
+
+## Routentabelle
+
+| Methode   | Pfad | Auth  | Beschreibung |
+|-----------|------|-------|-------------|
+| `POST`    | `/rate/check` | Benutzer | Anfrage protokollieren; gibt 429 zurück wenn Limit überschritten |
+| `GET`     | `/rate/status` | Benutzer | Aktuelle Nutzung für einen Benutzer/Endpunkt |
+| `DELETE`  | `/rate/reset/{userId}` | Admin | Zähler für einen Benutzer zurücksetzen |
+
+---
+
+## Kernalgorithmus
+
+```php
+private const int LIMIT = 10;
+private const int WINDOW_SECONDS = 60;
+
+public function check(int $userId, string $endpoint): string
+{
+    $since = $this->windowStart();   // now() - 60s
+    $count = $this->countInWindow($userId, $endpoint, $since);
+
+    if ($count >= self::LIMIT) {
+        return 'rate_limited';
+    }
+
+    $this->recordEvent($userId, $endpoint);
+    return 'ok';
+}
+```
+
+**Gleitendes Fenster**: jeder `check()`-Aufruf schaut genau `WINDOW_SECONDS` vom aktuellen Zeitpunkt
+zurück, sodass alte Ereignisse natürlich aus dem Gültigkeitsbereich fallen.
+
+---
+
+## Admin-Reset mit Fail-Closed-Muster
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;     // fail-closed: unkonfigurierter Key blockiert alle Admin-Zugriffe
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+Alle Zähler für einen Benutzer zurücksetzen (alle Endpunkte):
+```sql
+DELETE FROM rate_events WHERE user_id = :uid
+```
+
+Für einen bestimmten Endpunkt zurücksetzen:
+```sql
+DELETE FROM rate_events WHERE user_id = :uid AND endpoint = :ep
+```
+
+---
+
+## Pfadparameter-Extraktion (ohne Router::param())
+
+Wenn `Router::param()` in der installierten Version nicht verfügbar ist, das Attribut direkt verwenden:
+
+```php
+/** @var array<string, string> $params */
+$params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+$raw    = $params['userId'] ?? '';
+```
+
+---
+
+## Validierung
+
+- `endpoint`: nicht-leerer String, max. 128 Zeichen
+- `X-User-Id`: `ctype_digit()` + positive Integer
+- Pfad `userId`: `ctype_digit()` + positive Integer (Fehler → 404)
+- Admin-Key: `hash_equals()`-Vergleich (Fehler → 403)
+
+---
+
+## HTTP-Statuscodes
+
+| Situation | Status |
+|-----------|--------|
+| Anfrage erlaubt | 200 |
+| Status abgerufen | 200 |
+| Zähler zurückgesetzt | 200 |
+| Kein X-User-Id | 400 |
+| Kein Body | 400 |
+| Leerer / fehlender Endpunkt | 422 |
+| Endpunkt zu lang | 422 |
+| Kein Admin-Key | 403 |
+| Falscher Admin-Key | 403 |
+| Ungültige userId im Pfad | 404 |
+| Ratenlimit überschritten | 429 |
+
+---
+
+## Abgedeckte ATK-Angriffsmuster
+
+| ATK | Muster | Abwehr |
+|-----|--------|--------|
+| ATK-01 | Fehlender X-User-Id | 400 mit Meldung |
+| ATK-02 | Leere Endpunkt-Zeichenkette | 422 Validierung |
+| ATK-03 | 129-Zeichen-Endpunkt (DoS) | Längenbegrenzung 422 |
+| ATK-04 | SQL-Injection im Endpunkt | Parametrisierte Abfragen |
+| ATK-05 | Nicht-Admin-Reset-Versuch | 403 fail-closed |
+| ATK-06 | Falscher Admin-Key | 403 hash_equals() |
+| ATK-07 | Negative userId im Pfad | 404 |
+| ATK-08 | userId null | 404 |
+| ATK-09 | Nicht-Ziffer-userId (`abc`) | 404 ctype_digit |
+| ATK-10 | Status ohne Endpunkt-Parameter | 422 |
+| ATK-11 | Check ohne Body | 400 |
+| ATK-12 | Body ohne Endpunkt-Schlüssel | 422 |
+
+---
+
+## Hinweise
+
+- **Gleichzeitigkeit**: Das gleitende Fenster hat ein kleines TOCTOU-Fenster. Für produktive
+  Hochlastanwendungen atomare Zähler in Betracht ziehen (Redis INCR + EXPIRE) oder Datenbanksperren.
+- **Uhrenabweichung**: Alle Zeitstempel sollten UTC verwenden, um DST- oder Zeitzonenprobleme zu vermeiden.
+- **Speicherwachstum**: Alte Ereignisse akkumulieren sich. Einen periodischen Bereinigungsjob hinzufügen:
+  `DELETE FROM rate_events WHERE created_at < :cutoff`.


### PR DESCRIPTION
## 概要

docs/de/howto/ に 21 件のドイツ語翻訳を追加します。

## 変更ファイル

| ファイル | 元ファイル |
|---|---|
| price-history.md | FT67 Produkt-Preishistorie-API |
| privacy-consent-management.md | FT189 Datenschutz-Einwilligungsverwaltung |
| product-catalog.md | FT212 Produktkatalog-API |
| product-review-system.md | FT154 Produkt-Bewertungssystem |
| project-task-management.md | FT241 Projekt- und Aufgabenverwaltung |
| quality-tools.md | PHPStan / PHP-CS-Fixer |
| quota-management.md | FT236 Quota-Management-API |
| rate-limiting.md | FT284 Ratenbegrenzung |
| rating-review-api.md | FT333 Bewertungs- und Rezensions-API |
| rbac-jwt-auth.md | FT279 RBAC + JWT-Authentifizierung |
| rbac.md | Rollenbasierte Zugriffskontrolle |
| refresh-token-pattern.md | FT281 Refresh-Token-Muster |
| refresh-token-rotation.md | JWT Refresh-Token-Rotation |
| request-deduplication.md | Anfrage-Deduplizierung |
| request-scoped-state.md | Anfrage-bezogener Zustand |
| reservation-availability-api.md | FT336 Reservierungs- und Verfügbarkeits-API |
| resource-booking.md | Ressourcen-Buchungssystem |
| resource-reservation-booking.md | FT335 Ressourcen-Reservierungs-Buchungs-API |
| resource-reservation.md | FT216 Ressourcen-Reservierung |
| scheduled-publish-article.md | FT330 Geplante Artikel-Veröffentlichung |
| scheduled-reminders.md | FT235 Geplante Erinnerungs-API |

## 検証

- [ ] 全ファイルが docs/de/howto/ に追加された
- [ ] 英語原文の内容が正確にドイツ語に翻訳されている
- [ ] コードブロック・技術用語・API パスは変更なし

## 使用チェックリスト

Self-review: docs-policy

Closes #1283