### PR TITLE
docs(de): ドイツ語 howto 翻訳 メインバッチ 174件 (#1283)

### DIFF
--- a/docs/de/howto/audit-trail.md
+++ b/docs/de/howto/audit-trail.md
@@ -1,0 +1,408 @@
+# HOWTO: Audit-Trail — Wer hat was geändert?
+
+> **FT-Referenz**: FT268 (`NENE2-FT/auditlog`) — Append-only-Audit-Trail: JWT-Actor-Extraktion, Vor/Nach-Payload-Snapshots, unveränderliche Audit-Tabelle, Lücke beim unauthentifizierten Audit-Lesen.
+>
+> **ATK-Bewertung**: ATK-01 bis ATK-12 am Ende dieses Dokuments.
+
+Diese Anleitung zeigt, wie Sie in einer NENE2-Anwendung einen Append-only-Audit-Trail implementieren.
+Ein Audit-Trail protokolliert jede Create-, Update- und Delete-Operation mit dem Akteur (aus JWT-Claims),
+der Ressource und einem Payload-Snapshot. Diese Einträge sind unveränderlich: Die API stellt niemals
+UPDATE- oder DELETE-Endpunkte für die Audit-Tabelle bereit.
+
+---
+
+## Datenbankschema
+
+```sql
+-- Kein FK auf actor_id oder resource_id:
+-- Audit-Einträge müssen das Löschen der beschriebenen Entitäten überdauern.
+CREATE TABLE IF NOT EXISTS audit_log (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    actor_id      INTEGER NOT NULL,
+    action        TEXT    NOT NULL,   -- 'created' | 'updated' | 'deleted'
+    resource_type TEXT    NOT NULL,   -- z. B. 'task', 'order', 'user'
+    resource_id   INTEGER NOT NULL,
+    occurred_at   TEXT    NOT NULL,
+    payload       TEXT    NOT NULL DEFAULT '{}'
+);
+
+-- Indizes für die häufigsten Abfragemuster
+CREATE INDEX idx_audit_log_actor_id ON audit_log(actor_id);
+CREATE INDEX idx_audit_log_resource ON audit_log(resource_type, resource_id);
+```
+
+Wichtige Designentscheidungen:
+- **Keine FK-Constraints** — Audit-Einträge überdauern ihre Subjekte. Wird eine Aufgabe gelöscht, muss ihre Audit-Historie erhalten bleiben.
+- **Unveränderlich per Design** — niemals UPDATE- oder DELETE-SQL-Pfade für diese Tabelle hinzufügen.
+- **`action` als typisiertes Verb** — Vergangenheitsformen (`created`, `updated`, `deleted`) machen Log-Einträge selbstbeschreibend.
+
+---
+
+## AuditEntry-DTO und AuditRepository
+
+```php
+final readonly class AuditEntry
+{
+    public function __construct(
+        public int    $id,
+        public int    $actorId,
+        public string $action,
+        public string $resourceType,
+        public int    $resourceId,
+        public string $occurredAt,
+        public string $payload,
+    ) {}
+}
+```
+
+```php
+final readonly class AuditRepository
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $executor,
+    ) {}
+
+    /** @param array<string, mixed> $payload */
+    public function record(
+        int    $actorId,
+        string $action,
+        string $resourceType,
+        int    $resourceId,
+        array  $payload,
+    ): AuditEntry {
+        $now         = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $payloadJson = json_encode($payload, JSON_THROW_ON_ERROR);
+
+        $this->executor->execute(
+            'INSERT INTO audit_log (actor_id, action, resource_type, resource_id, occurred_at, payload)
+             VALUES (?, ?, ?, ?, ?, ?)',
+            [$actorId, $action, $resourceType, $resourceId, $now, $payloadJson],
+        );
+
+        return $this->findById((int) $this->executor->lastInsertId())
+            ?? throw new \RuntimeException('Failed to record audit entry.');
+    }
+
+    /** @return list<AuditEntry> */
+    public function findByResource(string $resourceType, int $resourceId, int $limit = 50): array
+    {
+        $rows = $this->executor->fetchAll(
+            // ORDER BY id DESC, nicht occurred_at DESC: Zeitstempel mit Sekundengenauigkeit kollidieren,
+            // wenn zwei Operationen in derselben Sekunde stattfinden.
+            'SELECT * FROM audit_log
+             WHERE resource_type = ? AND resource_id = ?
+             ORDER BY id DESC LIMIT ?',
+            [$resourceType, $resourceId, $limit],
+        );
+        return array_map(fn (array $row) => $this->hydrate($row), $rows);
+    }
+}
+```
+
+> **`ORDER BY id DESC` statt `occurred_at DESC`:** `occurred_at` hat Sekundengenauigkeit.
+> Zwei Operationen in derselben Sekunde erhalten identische Zeitstempel, was die Sortierreihenfolge unvorhersehbar macht.
+> Der auto-increment-`id`-Wert bewahrt die Einfügereihenfolge zuverlässig.
+
+---
+
+## Audits im Handler aufzeichnen
+
+Audit-Events werden im Handler (UseCase-Äquivalent) aufgezeichnet, nicht im Repository.
+Das Aufzeichnen im Repository verliert den Geschäftskontext ("Welche Operation hat das ausgelöst?").
+
+### Create — initialen Snapshot aufzeichnen
+
+```php
+$task = $this->tasks->create($title, $body, $actorId);
+
+// Audit: actor_id NICHT im Payload — er ist bereits im Audit-Eintrag selbst enthalten.
+$this->audit->record($actorId, 'created', 'task', $task->id, [
+    'title'  => $task->title,
+    'body'   => $task->body,
+    'status' => $task->status,
+]);
+```
+
+### Update — Vor/Nach für Diff-Sichtbarkeit aufzeichnen
+
+```php
+$before = $this->tasks->findById($id);
+// ... Eigentümerprüfung, Validierung ...
+$after  = $this->tasks->update($id, $title, $body, $status);
+
+$this->audit->record($actorId, 'updated', 'task', $id, [
+    'before' => ['title' => $before->title, 'body' => $before->body, 'status' => $before->status],
+    'after'  => ['title' => $after->title,  'body' => $after->body,  'status' => $after->status],
+]);
+```
+
+### Delete — Snapshot vor dem Löschen aufzeichnen
+
+```php
+$task = $this->tasks->findById($id);
+// ... Eigentümerprüfung ...
+$this->tasks->delete($id);
+
+// NACH dem Löschen aufzeichnen — die Task-Zeile ist weg, aber das Audit bleibt bestehen.
+$this->audit->record($actorId, 'deleted', 'task', $id, [
+    'title'  => $task->title,
+    'status' => $task->status,
+]);
+```
+
+---
+
+## Akteur aus JWT-Claims
+
+Den Akteur immer aus dem verifizierten JWT ableiten, nie aus dem Request-Body.
+
+```php
+private function actorId(ServerRequestInterface $request): ?int
+{
+    /** @var array<string, mixed>|null $claims */
+    $claims = $request->getAttribute('nene2.auth.claims');
+
+    if (!is_array($claims) || !isset($claims['sub']) || !is_int($claims['sub'])) {
+        return null;
+    }
+
+    return $claims['sub'];
+}
+```
+
+`nene2.auth.claims` wird von `BearerTokenMiddleware` nach der Token-Validierung gesetzt.
+Ein Client kann keine gefälschte `actor_id` im Request-Body mitschicken und aufzeichnen lassen.
+
+---
+
+## Ausschluss sensibler Felder
+
+**Niemals Passwörter, Tokens oder interne IDs in den Payload aufnehmen.**
+
+```php
+// ❌ Gibt sensible Daten preis und ist redundant
+$this->audit->record($actorId, 'created', 'user', $user->id, [
+    'email'         => $user->email,
+    'password_hash' => $user->passwordHash,  // NIEMALS einschließen
+    'actor_id'      => $actorId,              // redundant
+]);
+
+// ✅ Nur geschäftlich sichtbare Attribute
+$this->audit->record($actorId, 'created', 'user', $user->id, [
+    'email' => $user->email,
+    'role'  => $user->role,
+]);
+```
+
+---
+
+## Unveränderliche Audit-API — keine Schreibendpunkte
+
+```php
+public function register(Router $router): void
+{
+    $router->get('/audit', $this->list(...));
+    $router->get('/audit/{resource_type}/{resource_id}', $this->byResource(...));
+    // POST, PUT, DELETE sind absichtlich nicht vorhanden
+}
+```
+
+---
+
+## Eigentümerprüfung vor jedem Schreibvorgang (und vor dem Audit)
+
+```php
+$task = $this->tasks->findById($id);
+if ($task === null) {
+    return $this->problems->create($request, 'not-found', 'Task not found.', 404);
+}
+
+// 404 statt 403 zurückgeben, um das Vorhandensein der Ressource nicht zu bestätigen.
+if ($task->actorId !== $actorId) {
+    return $this->problems->create($request, 'not-found', 'Task not found.', 404);
+}
+
+// Erst jetzt: Ändern + Audit
+```
+
+---
+
+## Das Audit-Log abfragen
+
+```php
+// Historie für eine bestimmte Ressource
+GET /audit/task/42
+
+// Alle Events eines Akteurs
+GET /audit?actor_id=7
+
+// Alle Löschvorgänge über alle Ressourcentypen
+GET /audit?action=deleted
+
+// Sichere Paginierung
+GET /audit?limit=20&offset=40
+```
+
+---
+
+## Sicherheitsüberlegungen
+
+| Risiko | Gegenmaßnahme |
+|---|---|
+| Audit-Log-Löschung | Kein DELETE-Endpunkt. Auf Tabellenebene: DELETE-Berechtigung für den App-DB-Benutzer entziehen, wenn möglich |
+| Actor-Spoofing | Akteur kommt immer aus `nene2.auth.claims`, nie aus dem Request-Body |
+| Sensibler Payload | Passwörter, Tokens, interne Schlüssel explizit aus dem Payload ausschließen |
+| IDOR (cross-user Audit-Lesen) | `GET /audit` auf Admin-Rollen beschränken (in Kombination mit RBAC); oder nach actor_id des Anfragers filtern |
+| Timing-Angriff / Benutzer-Enumeration | Als Dummy einen echten vorberechneten Argon2id-Hash verwenden, keinen fehlerhaften String |
+| `LIMIT -1` DoS | Begrenzen: `max(1, min((int) $limit, 100))` |
+
+---
+
+## Dummy-Hash muss ein echter Argon2id-Hash sein
+
+Ein fehlerhafter Dummy-Hash bewirkt, dass `password_verify()` sofort `false` zurückgibt (ohne die KDF auszuführen),
+was einen ~20.000-fachen Zeitunterschied erzeugt, mit dem ein Angreifer gültige E-Mail-Adressen enumerieren kann.
+
+```php
+// ❌ Fehlerhaft — KDF wird übersprungen, gibt in ~0,001ms false zurück
+$dummyHash = '$argon2id$v=19$m=65536,t=4,p=1$dummysaltdummysaltdummysalt$dummyhashvaluedummyhashvaluedummyh';
+
+// ✅ Echter vorberechneter Hash — KDF läuft mit vollem Aufwand (~180ms)
+// Einmal generieren: password_hash('dummy-constant-value', PASSWORD_ARGON2ID)
+$dummyHash = '$argon2id$v=19$m=65536,t=4,p=1$VkZVLkx3L3FPaVA5NndVSA$vwBHHeAqq1DpGTf7G55ZPAUad+CGLvEJle2m5NA8ulA';
+```
+
+> Dieses Dummy-Hash-Muster wurde zuerst in [password-hashing.md](password-hashing.md) dokumentiert.
+> **Dasselbe Prinzip gilt überall, wo `password_verify()` auf einen möglicherweise fehlenden Benutzer aufgerufen wird.**
+
+---
+
+## ATK-Bewertung (FT268)
+
+Cracker-Mindset-Angriffstest gegen `NENE2-FT/auditlog`. Die Angriffsfläche: JWT-authentifiziertes Task-CRUD + unauthentifiziertes Audit-Log-Lesen.
+
+### ATK-01 — JWT-None-Algorithm-Angriff 🚫 BLOCKED
+
+**Angriff**: Gefälschtes JWT mit `"alg":"none"` und keiner Signatur, beliebiger `sub`-Claim.
+```
+Header: {"alg":"none","typ":"JWT"}
+Payload: {"sub":1,"email":"admin@x.com","iat":9999999999,"exp":9999999999}
+Signatur: (leer)
+```
+**Ergebnis**: `LocalBearerTokenVerifier` validiert mit HMAC-HS256 gegen das konfigurierte Secret. Tokens ohne gültige Signatur werden abgelehnt — `alg:none` wird nicht akzeptiert. → **401 Unauthorized**
+
+---
+
+### ATK-02 — JWT-Signatur-Manipulation 🚫 BLOCKED
+
+**Angriff**: Ein gültiges JWT nehmen, das `sub`-Feld auf die ID eines anderen Benutzers ändern (z. B. `1` → `2`), ohne erneute Signierung neu kodieren.
+**Ergebnis**: Die HMAC-HS256-Signatur stimmt nicht mehr mit dem geänderten Payload überein. `LocalBearerTokenVerifier` lehnt das Token ab. → **401 Unauthorized**
+
+---
+
+### ATK-03 — Abgelaufenes JWT wiederverwenden 🚫 BLOCKED
+
+**Angriff**: Ein abgefangenes JWT nach Ablauf seines `exp`-Zeitstempels erneut verwenden.
+**Ergebnis**: `BearerTokenMiddleware` / `LocalBearerTokenVerifier` prüft `exp`. Abgelaufene Tokens werden abgelehnt. → **401 Unauthorized**
+
+---
+
+### ATK-04 — IDOR: Zugriff auf die Aufgabe eines anderen Benutzers per ID ✅ BLOCKED
+
+**Angriff**: Als Benutzer A (sub=1) authentifizieren, dann `PUT /tasks/3` aufrufen, wobei Aufgabe 3 Benutzer B (sub=2) gehört.
+**Ergebnis**: Der Task-Route-Handler liest `task->actorId` und vergleicht mit `actorId` aus den JWT-Claims. Bei Nichtübereinstimmung wird → **404 Not Found** zurückgegeben (Ressourcenexistenz wird dem Angreifer nicht bestätigt).
+
+---
+
+### ATK-05 — IDOR: Aufgabe eines anderen Benutzers löschen ✅ BLOCKED
+
+**Angriff**: Als Benutzer A authentifizieren, `DELETE /tasks/7` aufrufen, wobei Aufgabe 7 Benutzer B gehört.
+**Ergebnis**: Gleiche Eigentümerprüfung wie ATK-04. `task->actorId !== $actorId` → **404 Not Found**.
+
+---
+
+### ATK-06 — Actor-ID-Einschleusung über Request-Body ✅ BLOCKED
+
+**Angriff**: `POST /tasks` mit Body `{"title":"Injected","actor_id":999}`.
+**Ergebnis**: Der Controller ignoriert `body['actor_id']` vollständig. Der Audit-Eintrag verwendet `actorId` aus `nene2.auth.claims['sub']` (JWT). Die Aufgabe wird dem authentifizierten Akteur zugeordnet — `actor_id:999` hat keine Wirkung.
+
+---
+
+### ATK-07 — Unauthentifiziertes Audit-Log-Lesen ⚠️ EXPOSED
+
+**Angriff**: `GET /audit` ohne Authorization-Header.
+**Ergebnis**: Die Audit-Log-Lese-Endpunkte (`GET /audit`, `GET /audit/{type}/{id}`) sind **nicht durch `BearerTokenMiddleware`** geschützt. Jeder unauthentifizierte Aufrufer kann die vollständige Audit-Historie aller Akteure und Ressourcen lesen.
+
+**Auswirkung**: Vollständige Offenlegung von: Wer was wann mit welcher Ressource getan hat, einschließlich Vor/Nach-Payload-Snapshots. Bei einer Multi-Tenant-Anwendung ist dies eine kritische Informationsoffenlegung.
+
+**Empfehlung**: Audit-Endpunkte auf admin-scoped JWT beschränken (z. B. `claims['role'] === 'admin'`), oder mindestens ein gültiges JWT voraussetzen. Das Audit-Präfix zu den geschützten Routen von `BearerTokenMiddleware` hinzufügen.
+
+---
+
+### ATK-08 — Audit-Log-Cross-Actor-Enumeration via ?actor_id ⚠️ EXPOSED
+
+**Angriff**: `GET /audit?actor_id=2` (oder 1..N enumerieren) — liest alle Audit-Einträge für beliebige actor_ids.
+**Ergebnis**: Keine Autorisierungsprüfung auf den `actor_id`-Filter. Der Angreifer enumeriert alle Benutzer-IDs und ruft deren vollständige Audit-Historie ab. Verkettet mit ATK-07 (unauthentifizierter Zugriff).
+**Empfehlung**: Wenn Audit auf authentifizierte Benutzer beschränkt ist (nicht Admin), nach dem `sub` des authentifizierten Benutzers filtern — Aufrufer können keine Logs anderer Akteure abfragen. Admins sehen alles.
+
+---
+
+### ATK-09 — SQL-Injection in Audit-Suchparametern 🚫 BLOCKED
+
+**Angriff**: `GET /audit?action=deleted';DROP TABLE audit_log;--&resource_type=task`
+**Ergebnis**: `$action` und `$resourceType` werden als `?`-Parameter in der SQL-Abfrage gebunden. Keine String-Interpolation. SQLite empfängt `WHERE action = ?` mit dem eingeschleusten String als Wert — was schlicht 0 Zeilen zurückgibt. Die Tabelle ist sicher. → **200 OK (leer)**
+
+---
+
+### ATK-10 — Limit -1 / Großes Limit DoS ✅ BLOCKED
+
+**Angriff**: `GET /audit?limit=-1` oder `GET /audit?limit=99999`.
+**Ergebnis**: `max(1, min((int) ($q['limit'] ?? 50), 100))` begrenzt auf `[1, 100]`. Negative und überdimensionierte Limits werden stillschweigend begrenzt. → **200 OK (max. 100 Einträge)**
+
+---
+
+### ATK-11 — Login-Brute-Force (kein Rate-Limiting) ⚠️ EXPOSED
+
+**Angriff**: Schnelle aufeinanderfolgende `POST /auth/login`-Versuche mit derselben E-Mail-Adresse und verschiedenen Passwörtern.
+**Ergebnis**: Kein Rate-Limiting, keine Sperrung, kein CAPTCHA. Ein Angreifer kann Passwörter unbegrenzt iterieren. Die Argon2id-KDF verlangsamt jeden Versuch auf ~180ms, was Brute-Force bei starken Passwörtern unpraktikabel macht, aber bei schwachen noch möglich ist.
+**Empfehlung**: `ThrottleMiddleware` auf `/auth/login` hinzufügen (z. B. 5 Versuche / 15 Min pro IP). Fehlgeschlagene Versuche mit request_id für Monitoring protokollieren.
+
+---
+
+### ATK-12 — Einschleusung beliebiger Statuswerte ⚠️ EXPOSED
+
+**Angriff**: `PUT /tasks/1` mit Body `{"status":"<script>alert(1)</script>"}` oder `{"status":"admin_override"}`.
+**Ergebnis**: Der Handler akzeptiert jeden nicht-leeren String als `status`. Das Repository schreibt ihn unverändert. Die Aufgabe wird mit `status="<script>alert(1)</script>"` aktualisiert. Keine Enum-Validierung, keine Allowlist.
+**Auswirkung**: Stored XSS, wenn der Status unescaped im Browser gerendert wird. Beschädigtes Domain-Modell, wenn die Business-Logik `status` in `{open, closed, in_progress}` erwartet.
+**Empfehlung**: Status gegen eine Allowlist oder ein PHP-BackedEnum validieren:
+```php
+$validStatuses = ['open', 'in_progress', 'closed'];
+if (!in_array($status, $validStatuses, true)) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'status', 'code' => 'invalid', 'message' => 'status must be one of: open, in_progress, closed']],
+    ]);
+}
+```
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | JWT `alg:none` | 🚫 BLOCKED |
+| ATK-02 | JWT-Signatur-Manipulation | 🚫 BLOCKED |
+| ATK-03 | Abgelaufenes JWT wiederverwenden | 🚫 BLOCKED |
+| ATK-04 | IDOR: Zugriff auf fremde Aufgabe | ✅ BLOCKED |
+| ATK-05 | IDOR: Fremde Aufgabe löschen | ✅ BLOCKED |
+| ATK-06 | Actor-ID-Einschleusung über Body | ✅ BLOCKED |
+| ATK-07 | Unauthentifiziertes Audit-Log-Lesen | ⚠️ EXPOSED |
+| ATK-08 | Cross-Actor-Audit-Enumeration | ⚠️ EXPOSED |
+| ATK-09 | SQL-Injection in Audit-Suche | 🚫 BLOCKED |
+| ATK-10 | Limit -1 / überdimensioniertes Limit DoS | ✅ BLOCKED |
+| ATK-11 | Login-Brute-Force (kein Rate-Limit) | ⚠️ EXPOSED |
+| ATK-12 | Einschleusung beliebiger Statuswerte | ⚠️ EXPOSED |
+
+**9 BLOCKED / SAFE, 4 EXPOSED** (ATK-07, 08 sind durch dieselbe unauthentifizierte Audit-Lese-Lücke verkettet).
+
+Der kritische Fund ist **ATK-07**: Die Audit-Log-Endpunkte haben keinen Authentifizierungs-Guard und geben die vollständige Akteuraktivitätshistorie an jeden unauthentifizierten Aufrufer preis. ATK-12 (Status-Allowlist) und ATK-11 (Rate-Limiting) sind Standard-Härtungslücken. Keine SQL-Injection- oder JWT-Fälschungsvektoren wurden gefunden.

--- a/docs/de/howto/batch-api-partial-success.md
+++ b/docs/de/howto/batch-api-partial-success.md
@@ -1,0 +1,242 @@
+# How-to: Batch-API mit Teilerfolg
+
+> **FT-Referenz**: FT294 (`NENE2-FT/batchlog`) — Batch-INSERT mit Teilerfolg: MAX_BATCH=50-Guard, unabhängige Validierung pro Element mit Index-Tracking, gemischte created/errors-Antwort (immer 200), DB-CHECK-Constraints, strikte JSON-Typvalidierung via `is_int()`, 36 Tests / 79 Assertions bestanden.
+>
+> **FT-Vorgänger**: FT182 (erste batchlog-Abdeckung).
+
+Wenn Clients ein Array von Elementen in einer einzigen Anfrage übermitteln, können einige Elemente
+gültig und andere ungültig sein. Die gesamte Batch-Anfrage bei einem einzigen Fehler abzulehnen,
+verschwendet die gültigen Elemente; ungültige Elemente stillschweigend zu überspringen, verbirgt Fehler.
+Das _Partial-Success_-Muster akzeptiert, was es kann, und meldet, was es nicht kann — pro Element, nach Index.
+
+---
+
+## Das Kernproblem
+
+JSON-Array-Bodies führen zwei Validierungsebenen ein:
+
+1. **Batch-Ebene** — Ist die Gesamtform der Anfrage gültig? (Schlüssel vorhanden? Ist es eine Liste? Liegt die Anzahl im Bereich?)
+2. **Element-Ebene** — Ist jedes einzelne Element gültig? (Typ? Bereich? Pflichtfelder?)
+
+Beide Ebenen gleich zu behandeln führt entweder zu Über-Ablehnung (ein schlechtes Element tötet den gesamten Batch)
+oder Über-Akzeptanz (schlechte Elemente werden stillschweigend ignoriert).
+
+---
+
+## HTTP-Konventionen
+
+| Szenario | Status | Body |
+|---|---|---|
+| Batch-Ebene-Fehler (fehlender Schlüssel, falscher Typ, leer, überdimensioniert) | `422` | `{"error": "..."}` |
+| Nur Element-Ebene-Fehler / gemischter Erfolg+Fehler | `200` | `{created, errors, total_created, total_errors}` |
+| Alle Elemente gültig | `200` | `{created: [...], errors: [], ...}` |
+| Alle Elemente ungültig | `200` | `{created: [], errors: [...], ...}` |
+
+**Warum 200 bei allen-ungültig?** Die Batch-Operation selbst war erfolgreich — der Server hat jedes Element
+verarbeitet und eine Entscheidung getroffen. Der Aufrufer erkennt das Ergebnis durch Prüfung von `total_created`
+und `errors`. 422 für "einige Elemente ungültig" zu verwenden, würde zwei verschiedene Arten von Fehlern vermischen.
+
+---
+
+## V::bodyInt() — Strikte JSON-Typprüfung
+
+`V::bodyInt()` ist das wichtigste Werkzeug zum Erkennen von JSON-Typkonfusionen in Batch-Payloads.
+PHP's `json_decode` bewahrt JSON-Typen, aber Clients können versehentlich (oder absichtlich) falsche Typen senden.
+
+```php
+// V::bodyInt(mixed $raw, int $min, int $max): ?int
+V::bodyInt(5, 1, 999)         // → 5        ✓ PHP int
+V::bodyInt("5", 1, 999)       // → null     ✗ JSON-Typkonfusion: "5" ist nicht 5
+V::bodyInt(5.5, 1, 999)       // → null     ✗ float
+V::bodyInt(true, 1, 999)      // → null     ✗ bool
+V::bodyInt(null, 1, 999)      // → null     ✗ null
+V::bodyInt([5], 1, 999)       // → null     ✗ array
+```
+
+Der entscheidende Unterschied zu Query-Strings: `V::queryInt()` akzeptiert den String `"5"`
+(weil Query-Parameter immer Strings sind), während `V::bodyInt()` ein PHP-`int` verlangt
+(weil JSON zwischen `5` und `"5"` unterscheidet).
+
+**ATK-07-Typkonfusionsangriff** — `{"quantity": "5"}` statt `{"quantity": 5}` senden muss fehlschlagen. `is_int()` ist die einzig sichere Prüfung.
+
+---
+
+## Batch-Validierungslogik
+
+```php
+// 1. Body parsen (Fallback auf [] bei Nicht-Objekt-JSON)
+$body = json_decode((string) $request->getBody(), true);
+$body = is_array($body) ? $body : [];
+
+// 2. Batch-Ebene-Guards → 422
+if (!array_key_exists('items', $body)) {
+    return 422; // Schlüssel fehlt
+}
+$rawItems = $body['items'];
+if (!is_array($rawItems)) {
+    return 422; // kein Array
+}
+if (count($rawItems) === 0) {
+    return 422; // leer
+}
+if (count($rawItems) > MAX_BATCH) {
+    return 422; // überdimensioniert
+}
+
+// 3. Verarbeitung pro Element → 200 mit errors[]
+$created = [];
+$errors  = [];
+
+foreach ($rawItems as $index => $rawItem) {
+    $intIndex = (int) $index;
+
+    // Jedes Element muss ein JSON-Objekt (assoz. Array) sein, kein Skalar oder Liste
+    if (!is_array($rawItem) || array_is_list($rawItem)) {
+        $errors[] = ['index' => $intIndex, 'error' => 'Each item must be a JSON object.'];
+        continue;
+    }
+
+    $name = V::str($rawItem['name'] ?? null, 100);
+    if ($name === null || $name === '') {
+        $errors[] = ['index' => $intIndex, 'error' => 'name is required (max 100 chars).'];
+        continue;
+    }
+
+    $quantity = V::bodyInt($rawItem['quantity'] ?? null, 1, 999);
+    if ($quantity === null) {
+        $errors[] = ['index' => $intIndex, 'error' => 'quantity must be an integer between 1 and 999.'];
+        continue;
+    }
+
+    // … weitere Felder …
+
+    $item      = $repository->create(/* ... */);
+    $created[] = $item->toArray();
+}
+
+// 4. Immer 200; Aufrufer liest total_created / total_errors
+return 200 with [
+    'created'       => $created,
+    'errors'        => $errors,
+    'total_created' => count($created),
+    'total_errors'  => count($errors),
+];
+```
+
+---
+
+## array_is_list() — JSON-Objekt vs. JSON-Array auf Element-Ebene
+
+PHP's `json_decode` bildet JSON-Objekte auf assoziative Arrays und JSON-Arrays auf Listen-Arrays ab.
+Verwenden Sie `array_is_list()`, um sie auf Element-Ebene zu unterscheiden:
+
+```php
+// JSON-Body: {"items": [{"name": "foo"}, "bar", 42, [1,2]]}
+is_array(["name" => "foo"])   // true — gültiges JSON-Objekt
+array_is_list(["name" => "foo"]) // false — assoziativ → Objekt ✓
+
+is_array("bar")                  // false → durch is_array-Prüfung abgefangen
+is_array(42)                     // false → abgefangen
+is_array([1, 2])                 // true
+array_is_list([1, 2])            // true → abgelehnt: Liste ≠ Objekt ✗
+```
+
+Der Guard `!is_array($rawItem) || array_is_list($rawItem)` fängt Skalare,
+JSON-Arrays und alles andere ab, das kein einfaches JSON-Objekt ist.
+
+---
+
+## MAX_BATCH-Größenguard
+
+Ohne eine Obergrenze könnte ein Client Tausende von Elementen in einer Anfrage senden
+und unbegrenzt Speicher und CPU verbrauchen.
+
+```php
+const MAX_BATCH = 50; // für Ihren Anwendungsfall anpassen
+
+if (count($rawItems) > self::MAX_BATCH) {
+    return $this->responseFactory->create(
+        ['error' => sprintf('"items" must contain at most %d entries.', self::MAX_BATCH)],
+        422,
+    );
+}
+```
+
+Auf Batch-Ebene ablehnen (422), bevor iteriert wird — Fehler nicht pro Element
+bei einem überdimensionierten Batch zählen.
+
+---
+
+## Fehlerindex-Beibehaltung
+
+Den ursprünglichen Eingabeindex in jedem Fehler melden, damit Clients Fehler
+mit den übermittelten Elementen korrelieren können, auch wenn die Array-Indizes nicht sequenziell sind
+(z. B. nach clientseitiger Filterung):
+
+```php
+// Eingabe:  [gültig, ungültig, gültig, ungültig]
+// Ausgabe errors: [{index: 1, error: "..."}, {index: 3, error: "..."}]
+```
+
+Den Index immer explizit in `int` umwandeln — `foreach`-Schlüssel können `string` sein, wenn
+das PHP-Array aus nicht-sequenziellem JSON aufgebaut wurde:
+
+```php
+$intIndex = (int) $index;
+```
+
+---
+
+## Antwortschema
+
+```json
+{
+  "created": [
+    {"id": 1, "user_id": 1, "name": "Widget A", "quantity": 3, "price_cents": 999, "created_at": "..."},
+    {"id": 2, "user_id": 1, "name": "Widget B", "quantity": 1, "price_cents": 4999, "created_at": "..."}
+  ],
+  "errors": [
+    {"index": 1, "error": "quantity must be an integer between 1 and 999."},
+    {"index": 3, "error": "name is required (max 100 chars)."}
+  ],
+  "total_created": 2,
+  "total_errors": 2
+}
+```
+
+---
+
+## Idempotenz-Überlegungen
+
+Teilerfolg erzeugt ein Schreibe-dann-Fehler-Szenario. Wenn der Client den gesamten Batch
+nach einem Netzwerkfehler erneut sendet, könnten bereits erstellte Elemente dupliziert werden.
+Optionen:
+
+- **Idempotenzschlüssel**: Pro Batch eine vom Client generierte UUID einschließen; der Server speichert sie und dedupliziert.
+- **Clientseitige Deduplizierung**: Client verfolgt, welche Indizes erfolgreich waren, und sendet nur fehlgeschlagene Elemente erneut.
+- **Natürliche Eindeutigkeit**: Eindeutige Einschränkung verwenden (z. B. externe ID) und Duplicate-Key-Fehler als Erfolg behandeln.
+
+Das `batchlog`-FT verwendet aus Gründen der Übersichtlichkeit den einfachsten Ansatz (kein Idempotenzschlüssel).
+Produktions-Batch-APIs sollten eine der oben genannten Strategien implementieren.
+
+---
+
+## Sicherheitshinweise
+
+- **V::bodyInt() für alle numerischen Felder** — Strings, Floats, Bools, null im JSON-Body ablehnen.
+- **V::str() für String-Felder** — lehnt Nicht-Strings ab, trimmt, prüft Länge; nach dem Trim auf `=== ''` für Pflichtfelder prüfen.
+- **User-Scoping** — Jedes Element wird an die authentifizierte Benutzer-ID aus dem Header (`V::userId()`) gebunden, nie aus dem Request-Body.
+- **MAX_BATCH-Guard** — 422 vor dem Iterieren, um DoS durch überdimensionierte Batches zu verhindern.
+
+---
+
+## Wichtigste Erkenntnisse
+
+| Muster | Regel |
+|---|---|
+| Batch-Ebene-Fehler | 422 — gesamte Anfrage abgelehnt |
+| Element-Ebene-Fehler | 200 — Index + Meldung in `errors[]` |
+| Typkonfusion in JSON | `V::bodyInt()` / `is_int()` — nicht `is_numeric()` |
+| JSON-Objekt vs. Array | `!is_array() \|\| array_is_list()` — beide ablehnen |
+| Größen-DoS | `count($items) > MAX_BATCH` → 422 vor der Iteration |
+| Fehlerkorrelation | Ursprünglichen `$index` in der Fehlerantwort bewahren |

--- a/docs/de/howto/bearer-token-middleware.md
+++ b/docs/de/howto/bearer-token-middleware.md
@@ -1,0 +1,157 @@
+# How-to: Bearer-Token-Middleware (JWT-Auth-Randfälle)
+
+> **FT-Referenz**: FT273 (`NENE2-FT/authlog`) — BearerTokenMiddleware JWT-Auth: alg=none-Ablehnung, Signatur-Manipulations-Erkennung, exp/nbf-Durchsetzung, WWW-Authenticate-Header, Sub-basierte Datenisolation, IDOR → 404, 18 Tests / 26 Assertions bestanden.
+>
+> **VULN-Bewertung**: V-01 bis V-10 am Ende dieses Dokuments.
+
+Demonstriert die Verwendung von NENE2's `BearerTokenMiddleware` + `LocalBearerTokenVerifier` (HMAC-HS256) zum Schutz von Routen. Alle JWT-Validierungs-Randfälle werden von der Middleware behandelt; Controller empfangen dekodierte Claims nur über `nene2.auth.claims`.
+
+---
+
+## Einrichtung
+
+```php
+$verifier        = new LocalBearerTokenVerifier($secret); // env: NENE2_LOCAL_JWT_SECRET
+$bearerMiddleware = new BearerTokenMiddleware($problems, $verifier);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17, $psr17,
+    routeRegistrars: [static fn (Router $r) => $registrar->register($r)],
+    authMiddleware:  $bearerMiddleware,
+))->create();
+```
+
+Die Middleware setzt `nene2.auth.claims` auf den Request, bevor ein Route-Handler ausgeführt wird. Bei fehlgeschlagener Validierung gibt sie 401 mit `WWW-Authenticate: Bearer` zurück, bevor der Handler aufgerufen wird.
+
+---
+
+## Claims in einem Controller extrahieren
+
+```php
+private function resolveOwnerId(ServerRequestInterface $request): string
+{
+    /** @var array<string, mixed> $claims */
+    $claims = $request->getAttribute('nene2.auth.claims') ?? [];
+    return (string) ($claims['sub'] ?? '');
+}
+```
+
+Der `sub`-Claim ist die kanonische Benutzeridentität. Ihn als `owner_id` zu verwenden stellt die Datenisolation pro Benutzer ohne zusätzliche Abfragen sicher.
+
+---
+
+## WWW-Authenticate-Header
+
+Bei 401 sendet die Middleware `WWW-Authenticate: Bearer realm="api"`.
+Bei abgelaufenen Tokens enthält der Header `error="invalid_token"`:
+
+```
+WWW-Authenticate: Bearer realm="api", error="invalid_token", error_description="..."
+```
+
+RFC-6750-Konformität ermöglicht es Clients, "kein Token" von "schlechtes Token" zu unterscheiden.
+
+---
+
+## Schwachstellenbewertung
+
+### V-01 — alg=none-Algorithm-Substitution ✅ SAFE
+
+**Risiko**: Ein Angreifer erstellt ein JWT mit `"alg":"none"` und einem unsignierten Payload, der `sub: admin` beansprucht.
+**Befund**: SAFE — `LocalBearerTokenVerifier` akzeptiert nur HMAC-HS256. `alg=none`-Tokens werden bei der Signaturverifizierung abgelehnt; der Test `testWrongAlgorithmHeaderReturns401` bestätigt 401.
+
+---
+
+### V-02 — Signatur-Manipulation ✅ SAFE
+
+**Risiko**: Ein Angreifer fängt ein gültiges JWT ab und ändert den Payload (z. B. `sub` auf `admin`), behält aber Header und Originalsignatur bei.
+**Befund**: SAFE — Die HMAC-HS256-Signatur deckt `header.payload` ab. Jede Änderung macht den MAC ungültig; `testTamperedPayloadReturns401` bestätigt 401.
+
+---
+
+### V-03 — Abgelaufenes Token wiederverwenden ✅ SAFE
+
+**Risiko**: Ein abgelaufenes Token wird wiederholt, nachdem die Session ungültig sein sollte.
+**Befund**: SAFE — Der `exp`-Claim wird validiert; Tokens mit `exp < time()` werden abgelehnt. `testExpiredTokenReturns401` bestätigt 401 mit `invalid_token` im `WWW-Authenticate`.
+
+---
+
+### V-04 — Not-before (nbf) umgehen ✅ SAFE
+
+**Risiko**: Ein Token mit zukünftigem `nbf` (noch nicht gültig) wird vor seiner Aktivierungszeit verwendet.
+**Befund**: SAFE — `nbf` wird durchgesetzt; `testNbfInFutureReturns401` bestätigt 401.
+
+---
+
+### V-05 — Falsches Authorization-Schema ✅ SAFE
+
+**Risiko**: Ein Angreifer sendet `Authorization: Basic dXNlcjpwYXNz` oder lässt das `Bearer `-Präfix weg.
+**Befund**: SAFE — Die Middleware akzeptiert nur Tokens mit `Bearer `-Präfix. `Basic` und bare Token-Strings geben beide 401 zurück.
+
+---
+
+### V-06 — Fehlerhafte Token-Struktur ✅ SAFE
+
+**Risiko**: Ein Angreifer sendet Tokens mit 2 Teilen, 4 Teilen, ungültigem Base64-Payload oder zufälligen Strings, um die Fehlerbehandlung zu sondieren.
+**Befund**: SAFE — Alle fehlerhaften Varianten geben 401 zurück. Tokens ohne 3 Teile und ungültiges Base64 werden vor jeder Claim-Extraktion abgelehnt.
+
+---
+
+### V-07 — Falsches Signatur-Secret ✅ SAFE
+
+**Risiko**: Ein Angreifer mit Kenntnis des JWT-Formats signiert ein Token mit einem anderen Secret.
+**Befund**: SAFE — Die HMAC-Verifizierung schlägt fehl, wenn das Secret abweicht; `testWrongSecretSignatureReturns401` bestätigt 401.
+
+---
+
+### V-08 — IDOR: Datenzugriff auf andere Benutzer ✅ SAFE
+
+**Risiko**: Benutzer A versucht, die Daten von Benutzer B zu lesen, indem er die Eintrags-ID kennt oder errät.
+**Befund**: SAFE — `findByIdAndOwner($id, $ownerId)` begrenzt die Suche auf den JWT-`sub`. Eine cross-user-Anfrage gibt 404 zurück (nicht 403), um nicht zu verraten, dass der Eintrag existiert.
+
+---
+
+### V-09 — Datenisolation pro Benutzer ✅ SAFE
+
+**Risiko**: Schreibvorgänge von Benutzer A sind für Benutzer B sichtbar.
+**Befund**: SAFE — Alle Lesevorgänge sind nach `owner_id = sub` begrenzt. `testEntriesAreIsolatedByToken` verifiziert, dass Alices und Bobs Einträge vollständig getrennt sind.
+
+---
+
+### V-10 — Token ohne exp-Claim ✅ SAFE (akzeptabel)
+
+**Risiko**: Ein Token ohne `exp`-Claim wird ausgestellt und wird damit effektiv nicht ablaufend.
+**Befund**: SAFE (by design) — `LocalBearerTokenVerifier` validiert `exp` nur, wenn der Claim vorhanden ist. Tokens ohne `exp` werden akzeptiert. Dies ist ein bewusster Kompromiss für Service-to-Service-Szenarien; Produktions-Deployments sollten `exp` über einen strengeren Verifier durchsetzen, wenn nötig.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|--------|
+| V-01 | alg=none-Algorithm-Substitution | ✅ SAFE |
+| V-02 | Signatur-Manipulation | ✅ SAFE |
+| V-03 | Abgelaufenes Token wiederverwenden | ✅ SAFE |
+| V-04 | Not-before (nbf) umgehen | ✅ SAFE |
+| V-05 | Falsches Authorization-Schema | ✅ SAFE |
+| V-06 | Fehlerhafte Token-Struktur | ✅ SAFE |
+| V-07 | Falsches Signatur-Secret | ✅ SAFE |
+| V-08 | IDOR-Datenzugriff auf andere Benutzer | ✅ SAFE |
+| V-09 | Datenisolation pro Benutzer | ✅ SAFE |
+| V-10 | Token ohne exp-Claim | ✅ SAFE (by design) |
+
+**10 SAFE, 0 EXPOSED**
+Keine kritischen Schwachstellen. `BearerTokenMiddleware` behandelt alle Standard-JWT-Angriffsvektoren; Anwendungscode muss nur den `sub`-Claim für das Eigentümer-Scoping verwenden.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `alg=none`-Tokens akzeptieren | Angreifer kann jede Identität fälschen, indem er die Signatur weglässt |
+| `exp`-Validierung überspringen | Gestohlene Tokens bleiben unbegrenzt gültig |
+| 403 bei IDOR zurückgeben | Verrät, dass die Ressource existiert und jemandem gehört |
+| `X-User-Id`-Header statt JWT-`sub` verwenden | Header ist trivial fälschbar; JWT-Claim ist kryptografisch gebunden |
+| Signing-Secret umgebungsübergreifend teilen | Ein Dev-Env-Leak kompromittiert Produktions-Tokens |
+| `RS256`-Schlüssel kleiner als 2048 Bit verwenden | Anfällig für Faktorisierungsangriffe |

--- a/docs/de/howto/bookmark-api.md
+++ b/docs/de/howto/bookmark-api.md
@@ -1,0 +1,113 @@
+# How-to: Bookmark-API
+
+> **FT-Referenz**: FT295 (`NENE2-FT/bookmarklog`) — Lesezeichen-Verwaltung: UNIQUE(user_id, item_id) verhindert doppelte Lesezeichen, Sammlungsgruppierung mit optionalem Filter, benutzerbezogene Zugriffskontrolle (IDOR-Prävention), 409 bei Duplikat, 22 Tests / 64 Assertions bestanden.
+
+Diese Anleitung zeigt, wie Sie eine Lesezeichen-API erstellen, bei der Benutzer Elemente in benannte Sammlungen speichern können, mit Deduplizierung und benutzerbezogener Zugriffskontrolle.
+
+## Schema
+
+```sql
+CREATE TABLE bookmarks (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    collection TEXT    NOT NULL DEFAULT 'default',
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+```
+
+`UNIQUE(user_id, item_id)` stellt sicher, dass jeder Benutzer ein Element genau einmal mit einem Lesezeichen versehen kann. Das `collection`-Feld gruppiert Lesezeichen in benannte Listen (Standard: `'default'`).
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/users/{userId}/bookmarks` | Lesezeichen hinzufügen |
+| `DELETE` | `/users/{userId}/bookmarks/{itemId}` | Lesezeichen entfernen |
+| `GET` | `/users/{userId}/bookmarks` | Lesezeichen auflisten (optional nach Sammlung gefiltert) |
+| `GET` | `/users/{userId}/bookmarks/count` | Lesezeichen zählen |
+| `GET` | `/users/{userId}/bookmarks/{itemId}` | Bestimmtes Lesezeichen abrufen |
+
+## Reihenfolge der Routen-Registrierung
+
+`/users/{userId}/bookmarks/count` muss **vor** `/users/{userId}/bookmarks/{itemId}` registriert werden, um zu verhindern, dass `count` als `{itemId}` aufgefangen wird:
+
+```php
+$router->get('/users/{userId}/bookmarks', $this->listBookmarks(...));
+$router->get('/users/{userId}/bookmarks/count', $this->countBookmarks(...));  // statisch vor dynamisch
+$router->get('/users/{userId}/bookmarks/{itemId}', $this->getBookmark(...));
+```
+
+## Ein Lesezeichen hinzufügen
+
+```php
+private function addBookmark(ServerRequestInterface $request): ResponseInterface
+{
+    $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $userId = isset($params['userId']) && is_numeric($params['userId']) ? (int) $params['userId'] : 0;
+
+    if ($userId <= 0 || !$this->repo->findUserById($userId)) {
+        return $this->responseFactory->create(['error' => 'user not found'], 404);
+    }
+
+    $body       = JsonRequestBodyParser::parse($request);
+    $itemId     = isset($body['item_id']) && is_int($body['item_id']) ? $body['item_id'] : 0;
+    $collection = isset($body['collection']) && is_string($body['collection'])
+        ? trim($body['collection']) : 'default';
+
+    if ($itemId <= 0 || !$this->repo->findItemById($itemId)) {
+        return $this->responseFactory->create(['error' => 'item not found'], 404);
+    }
+
+    if ($collection === '') {
+        $collection = 'default';  // leerer Collection-String → Fallback auf 'default'
+    }
+
+    $now      = date('Y-m-d H:i:s');
+    $bookmark = $this->repo->add($userId, $itemId, $collection, $now);
+    return $this->responseFactory->create($bookmark->toArray(), 201);
+}
+```
+
+`item_id` erfordert `is_int()` — der JSON-String `"5"` wird abgelehnt. Die `UNIQUE`-Constraint in der DB fängt Race Conditions ab; das Repository sollte die Constraint-Verletzung abfangen und 409 zurückgeben.
+
+## Sammlungsfilter bei der Auflistung
+
+```php
+$query      = $request->getQueryParams();
+$collection = isset($query['collection']) && is_string($query['collection']) && $query['collection'] !== ''
+    ? $query['collection'] : null;
+
+$items = $this->repo->listByUser($userId, $collection);
+```
+
+Ohne `?collection=` werden alle Lesezeichen zurückgegeben. Mit `?collection=favorites` wird nur diese Sammlung zurückgegeben. Ein leerer Collection-Query-Parameter wird als "kein Filter" behandelt.
+
+## User-Scoping — IDOR-Prävention
+
+Jeder Endpunkt validiert `userId` gegen die DB, bevor Daten zurückgegeben werden:
+
+```php
+if ($userId <= 0 || !$this->repo->findUserById($userId)) {
+    return $this->responseFactory->create(['error' => 'user not found'], 404);
+}
+```
+
+Ein Aufruf von `/users/999/bookmarks` als anderer Benutzer gibt 404 zurück (nicht die Lesezeichen des anderen Benutzers). Alle Abfragen sind auf die `userId` aus dem Pfad beschränkt.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Kein `UNIQUE(user_id, item_id)` | Benutzer kann dasselbe Element mehrfach mit einem Lesezeichen versehen; verwirrende Duplikate |
+| Bei doppeltem Lesezeichen 200 zurückgeben | Client kann "hinzugefügt" nicht von "bereits vorhanden" unterscheiden; 409 verwenden |
+| `item_id` als String aus dem Body akzeptieren | JSON-Typkonfusion: `"5"` ≠ `5`; `is_int()` verwenden |
+| `/{itemId}` vor `/count` registrieren | `GET /users/1/bookmarks/count` löst zu `itemId = "count"` auf (falscher Handler) |
+| Keine Benutzer-Existenzprüfung | Nicht existierende userId gibt leere Liste statt 404 zurück |
+| Kein User-Scoping in Abfragen | Benutzer A sieht die Lesezeichen von Benutzer B (IDOR) |
+| Kein Collection-Standard | Fehlendes `collection`-Feld führt zu Absturz oder `NULL` in der DB |

--- a/docs/de/howto/bookmark-system.md
+++ b/docs/de/howto/bookmark-system.md
@@ -1,0 +1,166 @@
+# Lesezeichen-System
+
+Ermöglicht es Benutzern, Elemente in benannten Sammlungen zu speichern. Das Setzen von Lesezeichen ist idempotent — dasselbe Element zweimal mit einem Lesezeichen zu versehen gibt das vorhandene Lesezeichen ohne Fehler zurück.
+
+## Überblick
+
+Ein Lesezeichen-System umfasst:
+- **Lesezeichen hinzufügen** — ein Element in der Sammlung eines Benutzers speichern (idempotent)
+- **Lesezeichen entfernen** — ein gespeichertes Lesezeichen löschen (404, wenn nicht gefunden)
+- **Lesezeichen auflisten** — alle Lesezeichen eines Benutzers, optional nach Sammlung gefiltert
+- **Lesezeichen zählen** — einfacher Badge-Zähler
+- **Lesezeichen abrufen** — prüfen, ob ein bestimmtes Element mit einem Lesezeichen versehen ist
+
+## Datenbankschema
+
+```sql
+CREATE TABLE bookmarks (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    collection TEXT    NOT NULL DEFAULT 'default',
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+```
+
+`UNIQUE (user_id, item_id)` erzwingt ein Lesezeichen pro Benutzer pro Element. Das `collection`-Feld gruppiert Lesezeichen in benannte Kategorien, wobei `'default'` als Fallback gilt.
+
+## Idempotentes Hinzufügen
+
+Vor dem Einfügen auf ein vorhandenes Lesezeichen prüfen. Bei Konflikt (Race Condition) `DatabaseConstraintException` abfangen und den vorhandenen Eintrag zurückgeben:
+
+```php
+public function add(int $userId, int $itemId, string $collection, string $now): Bookmark
+{
+    $existing = $this->find($userId, $itemId);
+
+    if ($existing !== null) {
+        return $existing;  // bereits als Lesezeichen gespeichert — kein Fehler
+    }
+
+    try {
+        $this->executor->execute(
+            'INSERT INTO bookmarks (user_id, item_id, collection, created_at) VALUES (?, ?, ?, ?)',
+            [$userId, $itemId, $collection, $now],
+        );
+    } catch (DatabaseConstraintException) {
+        // Race Condition — eine andere Anfrage war schneller; vorhandenes Lesezeichen zurückgeben
+        $found = $this->find($userId, $itemId);
+        if ($found !== null) {
+            return $found;
+        }
+    }
+
+    $id = (int) $this->executor->lastInsertId();
+    return new Bookmark($id, $userId, $itemId, $collection, $now);
+}
+```
+
+Das Prüfen-dann-Einfügen-Muster behandelt den häufigen Fall effizient. Der `DatabaseConstraintException`-Catch behandelt die Race Condition bei gleichzeitigen Anfragen.
+
+## Sammlungsfilterung
+
+Optionalen `collection`-Query-Parameter zum Filtern von Lesezeichen verwenden:
+
+```php
+// GET /users/{userId}/bookmarks?collection=reading
+$collection = isset($query['collection']) && $query['collection'] !== ''
+    ? $query['collection'] : null;
+
+$items = $this->repo->listByUser($userId, $collection);
+```
+
+`null` als Sammlung gibt alle Lesezeichen zurück; ein nicht-leerer String filtert auf diese Sammlung.
+
+## Entfernen gibt 204 vs. 404 zurück
+
+- `204 No Content` — Lesezeichen existierte und wurde gelöscht
+- `404 Not Found` — Lesezeichen existierte nicht
+
+```php
+$removed = $this->repo->remove($userId, $itemId);
+
+if (!$removed) {
+    return $this->responseFactory->create(['error' => 'bookmark not found'], 404);
+}
+
+return $this->responseFactory->createEmpty(204);
+```
+
+`execute()` gibt die Anzahl der betroffenen Zeilen zurück — null bedeutet, dass kein Lesezeichen gefunden wurde.
+
+## MySQL-Schema
+
+MySQL erfordert explizite `ENGINE=InnoDB`- und `AUTO_INCREMENT`-Syntax:
+
+```sql
+CREATE TABLE bookmarks (
+    id         INT          NOT NULL AUTO_INCREMENT,
+    user_id    INT          NOT NULL,
+    item_id    INT          NOT NULL,
+    collection VARCHAR(100) NOT NULL DEFAULT 'default',
+    created_at DATETIME     NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_item (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+Für MySQL-Integrationstests `SET FOREIGN_KEY_CHECKS = 0` vor dem Löschen von Tabellen ausführen, um FK-Abhängigkeitsreihenfolge-Probleme zu vermeiden.
+
+## MySQL-Integrationstestmuster
+
+```php
+protected function setUp(): void
+{
+    $host = (string) (getenv('MYSQL_HOST') ?: '');
+    if ($host === '') {
+        self::markTestSkipped('MYSQL_HOST not set — skipping MySQL integration tests');
+    }
+    ...
+    $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+    $this->pdo->exec('DROP TABLE IF EXISTS bookmarks');
+    $this->pdo->exec('DROP TABLE IF EXISTS items');
+    $this->pdo->exec('DROP TABLE IF EXISTS users');
+    $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+
+    $schema = (string) file_get_contents('.../database/schema.mysql.sql');
+    $this->pdo->exec($schema);
+}
+
+protected function tearDown(): void
+{
+    if ($this->mysqlEnabled && $this->pdo !== null) {
+        $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+        $this->pdo->exec('DROP TABLE IF EXISTS bookmarks');
+        $this->pdo->exec('DROP TABLE IF EXISTS items');
+        $this->pdo->exec('DROP TABLE IF EXISTS users');
+        $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+    }
+}
+```
+
+## Sicherheitseigenschaften
+
+| Eigenschaft | Implementierung |
+|---|---|
+| Ein Lesezeichen pro Benutzer pro Element | `UNIQUE (user_id, item_id)` DB-Constraint |
+| Race Condition beim Hinzufügen | `DatabaseConstraintException` abfangen → vorhandenes zurückgeben |
+| Benutzerisolation | Alle Abfragen filtern nach `user_id` |
+| Nicht vorhandenes entfernen | Gibt 404 zurück (nicht stillschweigend) |
+
+## Routenübersicht
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `POST` | `/users` | Benutzer erstellen |
+| `POST` | `/items` | Element erstellen |
+| `POST` | `/users/{userId}/bookmarks` | Lesezeichen hinzufügen (idempotent) |
+| `DELETE` | `/users/{userId}/bookmarks/{itemId}` | Lesezeichen entfernen (204 oder 404) |
+| `GET` | `/users/{userId}/bookmarks` | Lesezeichen auflisten (`?collection=`-Filter) |
+| `GET` | `/users/{userId}/bookmarks/count` | Gesamtzahl der Lesezeichen |
+| `GET` | `/users/{userId}/bookmarks/{itemId}` | Status eines einzelnen Lesezeichens abrufen |

--- a/docs/de/howto/budget-tracking.md
+++ b/docs/de/howto/budget-tracking.md
@@ -1,0 +1,392 @@
+# How-to: Budget-Tracking-API
+
+> **FT-Referenz**: FT244 (`NENE2-FT/budgetlog`) — Budget-Tracking-API
+> **ATK**: FT244 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert eine Multi-Konto-Budget-Tracking-API mit den Transaktionstypen `income`/`expense`/`transfer`,
+`TransferFundsUseCase` mit Saldoprüfung innerhalb einer DB-Transaktion, Multi-Filter-Transaktionsauflistung
+mit `QueryStringParser` und Kategorieaggregation.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `GET`  | `/accounts` | Alle Konten auflisten |
+| `POST` | `/accounts` | Ein Konto erstellen (optionaler Anfangssaldo) |
+| `GET`  | `/accounts/{id}` | Ein einzelnes Konto abrufen |
+| `POST` | `/accounts/{id}/transactions` | Einnahmen- oder Ausgabentransaktion erfassen |
+| `GET`  | `/accounts/{id}/transactions` | Transaktionen auflisten (filterbar, paginiert) |
+| `GET`  | `/accounts/{id}/summary` | Saldo + Einnahmen/Ausgaben nach Kategorie |
+| `POST` | `/transfers` | Geld zwischen zwei Konten überweisen |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS accounts (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    name    TEXT    NOT NULL,
+    balance INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS transactions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_id  INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    amount      INTEGER NOT NULL,
+    type        TEXT    NOT NULL CHECK(type IN ('income','expense','transfer')),
+    category    TEXT    NOT NULL,
+    description TEXT    NOT NULL DEFAULT '',
+    recurring   INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT    NOT NULL
+);
+```
+
+`balance` und `amount` werden als Integer gespeichert (kleinste Währungseinheit, z. B. Cent).
+`type` wird auf DB-Ebene durch `CHECK(type IN ('income','expense','transfer'))` eingeschränkt.
+`recurring` wird als `INTEGER` (`0`/`1`) gespeichert und auf ein PHP-`bool` abgebildet.
+
+---
+
+## Transaktionstyp-Allowlist
+
+Der Controller validiert `type` gegen eine explizite Allowlist:
+
+```php
+if (!in_array($type, ['income', 'expense'], true)) {
+    $errors[] = new ValidationError('type', 'Type must be income or expense.', 'invalid_value');
+}
+```
+
+Über die API werden nur `income` und `expense` akzeptiert. Der Typ `transfer` wird intern von `TransferFundsUseCase` gesetzt — Aufrufer können ihn nicht direkt über `POST /accounts/{id}/transactions` einschleusen.
+
+---
+
+## Saldo-Update: Lesen-dann-Schreiben-Muster
+
+`POST /accounts/{id}/transactions` aktualisiert den Kontosaldo nach der Erfassung der Transaktion:
+
+```php
+$delta = $type === 'income' ? $amount : -$amount;
+$this->accounts->updateBalance($id, $account->balance + $delta);
+```
+
+Der Saldo wird zuerst gelesen (`findById`), das Delta in PHP berechnet, dann zurückgeschrieben (`updateBalance`). Dies ist **nicht atomar** — gleichzeitige Anfragen können eine Race Condition erzeugen (siehe ATK-09).
+
+---
+
+## TransferFundsUseCase: Saldoprüfung + DB-Transaktion
+
+Überweisungen werden in einer DB-Transaktion durchgeführt, um Konsistenz zu gewährleisten:
+
+```php
+public function execute(int $fromId, int $toId, int $amount, string $description): void
+{
+    if ($amount <= 0) {
+        throw new ValidationException([
+            new ValidationError('amount', 'Amount must be greater than zero.', 'out_of_range'),
+        ]);
+    }
+
+    $this->txManager->transactional(function (DatabaseQueryExecutorInterface $tx) use ($fromId, $toId, $amount, $description): void {
+        // Repositories innerhalb des Callbacks mit dem Transaktions-Executor instanzieren
+        $accounts     = new SqliteAccountRepository($tx);
+        $transactions = new SqliteTransactionRepository($tx);
+
+        $from = $accounts->findById($fromId);
+        $to   = $accounts->findById($toId);
+
+        if ($from === null) {
+            throw new ValidationException([new ValidationError('from_account_id', 'Source account not found.', 'not_found')]);
+        }
+        if ($to === null) {
+            throw new ValidationException([new ValidationError('to_account_id', 'Destination account not found.', 'not_found')]);
+        }
+        if ($from->balance < $amount) {
+            throw new ValidationException([new ValidationError('amount', 'Insufficient balance.', 'insufficient_balance')]);
+        }
+
+        $accounts->updateBalance($fromId, $from->balance - $amount);
+        $accounts->updateBalance($toId, $to->balance + $amount);
+
+        $transactions->create($fromId, $amount, 'transfer', 'transfer', $description, false, $now);
+        $transactions->create($toId, $amount, 'transfer', 'transfer', $description, false, $now);
+    });
+}
+```
+
+Repositories werden **innerhalb** des Transaktions-Closures mit dem `$tx`-Executor instanziert — dies stellt sicher, dass alle Lese- und Schreibvorgänge dieselbe Verbindung und Transaktionsgrenze teilen. Wenn ein Schritt eine Exception wirft, wird die gesamte Transaktion zurückgerollt.
+
+Die Gleich-Konto-Prüfung befindet sich im Controller:
+```php
+if ($fromId === $toId && $fromId > 0) {
+    $errors[] = new ValidationError('to_account_id', 'Cannot transfer to the same account.', 'invalid_value');
+}
+```
+
+---
+
+## Multi-Filter-Transaktionsauflistung
+
+`GET /accounts/{id}/transactions` unterstützt mehrere gleichzeitige Filter:
+
+```php
+$category  = QueryStringParser::string($req, 'category');
+$minAmount = QueryStringParser::int($req, 'min_amount');
+$maxAmount = QueryStringParser::int($req, 'max_amount');
+$recurring = QueryStringParser::bool($req, 'recurring');
+```
+
+`QueryStringParser::int()` gibt `null` zurück, wenn der Parameter fehlt — kein Filter.
+`QueryStringParser::bool()` gibt `null` zurück bei Fehlen, `true` für `"true"/"1"`, `false` für `"false"/"0"`.
+
+Das Repository erstellt die `WHERE`-Klausel dynamisch:
+
+```php
+if ($category !== null)  { $where[] = 'category = ?'; $params[] = $category; }
+if ($minAmount !== null) { $where[] = 'amount >= ?';  $params[] = $minAmount; }
+if ($maxAmount !== null) { $where[] = 'amount <= ?';  $params[] = $maxAmount; }
+if ($recurring !== null) { $where[] = 'recurring = ?'; $params[] = (int) $recurring; }
+```
+
+---
+
+## Kategorie-Zusammenfassungsaggregation
+
+`GET /accounts/{id}/summary` gibt Saldo und Summen gruppiert nach Kategorie zurück:
+
+```php
+return $this->json->create([
+    'balance'             => $account->balance,
+    'income_by_category'  => $incomeByCategory,
+    'expense_by_category' => $expenseByCategory,
+]);
+```
+
+Das Repository verwendet `GROUP BY category` mit `SUM(amount)`:
+
+```sql
+SELECT category, SUM(amount) AS total
+FROM transactions
+WHERE account_id = ? AND type = ?
+GROUP BY category
+ORDER BY total DESC
+```
+
+---
+
+## ATK — Cracker-Mindset-Angriffstest (FT244)
+
+### ATK-01 — Keine Authentifizierung: Konten und Transaktionen sind öffentlich
+
+**Angriff**: Alle Konten ohne Anmeldeinformationen auflisten.
+
+```bash
+curl -s http://localhost:8080/accounts
+curl -s http://localhost:8080/accounts/1/transactions
+```
+
+**Beobachtet**: Beide Endpunkte geben Daten ohne Authentifizierung zurück. Jeder Aufrufer kann alle Konten und ihre Salden enumerieren.
+
+**Urteil**: **EXPOSED** — Authentifizierung (API-Key, JWT oder Session) zu allen Endpunkten hinzufügen. Konten sollten benutzerbezogen sein.
+
+---
+
+### ATK-02 — Konto mit negativem Anfangssaldo erstellen
+
+**Angriff**: Negativsaldo-Prüfung umgehen.
+
+```json
+{"name": "Attack", "initial_balance": -99999}
+```
+
+**Beobachtet**: `$initialBalance < 0`-Prüfung greift → `422 Unprocessable Entity` mit `out_of_range`-Fehler.
+
+**Urteil**: **BLOCKED** — expliziter Guard lehnt negative Anfangssalden ab.
+
+---
+
+### ATK-03 — Ausgabe treibt Kontosaldo negativ
+
+**Angriff**: Eine Ausgabe größer als der Kontosaldo über eine direkte Transaktion erfassen.
+
+```bash
+# Konto hat Saldo 100
+curl -X POST /accounts/1/transactions \
+  -d '{"amount": 99999, "type": "expense", "category": "food"}'
+```
+
+**Beobachtet**: Der `createTransaction`-Handler liest den Saldo und subtrahiert ohne Ausreichlichkeitsprüfung. `100 - 99999 = -99899` — der Saldo wird als negative Ganzzahl geschrieben.
+
+**Urteil**: **EXPOSED** — `POST /accounts/{id}/transactions` erzwingt keine nicht-negative Saldobeschränkung. Nur `POST /transfers` (via `TransferFundsUseCase`) prüft `if ($from->balance < $amount)`. Eine Saldo-Ausreichlichkeitsprüfung in `createTransaction` für Ausgabentransaktionen hinzufügen.
+
+---
+
+### ATK-04 — SQL-Injection via Kategorie oder Beschreibung
+
+**Angriff**: SQL-Metazeichen in `category` oder `description` einbetten.
+
+```json
+{"amount": 1, "type": "income", "category": "'; DROP TABLE transactions; --"}
+```
+
+**Beobachtet**: Alle Werte werden als parametrisierte `?`-Werte gebunden. Keine String-Verkettung mit SQL. Der Injection-Payload wird als Literal-Text gespeichert.
+
+**Urteil**: **BLOCKED** — parametrisierte Abfragen verhindern SQL-Injection.
+
+---
+
+### ATK-05 — Float-Betrag: `(int)`-Cast-Abschneidung
+
+**Angriff**: Einen Gleitkomma-Betrag senden.
+
+```json
+{"amount": 1.9, "type": "income", "category": "x"}
+```
+
+**Beobachtet**: `(int) $body['amount']` schneidet `1.9` auf `1` ab. Der Betrag `1.9` wird stillschweigend akzeptiert und als `1` gespeichert. Ein Aufrufer, der erwartet, dass `1.9` abgelehnt (oder auf `2` gerundet) wird, wäre überrascht.
+
+**Urteil**: **TEILWEISE BLOCKED** — Nicht-Integer-Floats werden akzeptiert und stillschweigend abgeschnitten. `is_int($body['amount'])` verwenden, um Nicht-Integer-Typen explizit abzulehnen und `422` für `1.9` zurückzugeben.
+
+---
+
+### ATK-06 — Null- oder negativer Betrag
+
+**Angriff**: `amount: 0` oder `amount: -100` übermitteln.
+
+```json
+{"amount": 0, "type": "income", "category": "x"}
+{"amount": -100, "type": "income", "category": "x"}
+```
+
+**Beobachtet**: `$amount <= 0`-Prüfung greift für beide → `422 Unprocessable Entity`.
+
+**Urteil**: **BLOCKED** — expliziter Guard lehnt Null- und Negativbeträge ab.
+
+---
+
+### ATK-07 — Überweisung auf dasselbe Konto
+
+**Angriff**: Geld von einem Konto auf dasselbe Konto überweisen.
+
+```json
+{"from_account_id": 1, "to_account_id": 1, "amount": 100}
+```
+
+**Beobachtet**: `$fromId === $toId && $fromId > 0` greift → `422 Unprocessable Entity` mit `invalid_value`-Fehler auf `to_account_id`.
+
+**Urteil**: **BLOCKED** — Gleich-Konto-Überweisung wird explizit abgelehnt.
+
+---
+
+### ATK-08 — Überweisung mit unzureichendem Saldo
+
+**Angriff**: Mehr als den Saldo des Quellkontos überweisen.
+
+```json
+{"from_account_id": 1, "to_account_id": 2, "amount": 99999}
+```
+
+**Beobachtet**: Innerhalb der Transaktion greift `$from->balance < $amount` → `ValidationException` mit `insufficient_balance` → Transaktion wird zurückgerollt → `422`. Kein Saldo ändert sich.
+
+**Urteil**: **BLOCKED** — `TransferFundsUseCase` prüft den Saldo innerhalb der DB-Transaktion. Rollback stellt Atomarität sicher.
+
+---
+
+### ATK-09 — Race Condition bei direkter Ausgabentransaktion
+
+**Angriff**: Zwei gleichzeitige Ausgaben-Anfragen senden, die beide die Saldoprüfung bestehen (es gibt keine), aber zusammen den Saldo überschreiten.
+
+**Beobachtet**: `createTransaction` verwendet ein Lesen-dann-Schreiben-Muster ohne Transaktion:
+1. Thread A liest `balance = 100`
+2. Thread B liest `balance = 100`
+3. Thread A erfasst Ausgabe von 80 → schreibt `balance = 20`
+4. Thread B erfasst Ausgabe von 80 → schreibt `balance = 20` (sollte -60 sein)
+
+Die `balance`-Spalte endet bei `20` statt dem korrekten `-60` — aber noch kritischer: die Geschäftsbeschränkung (nicht-negativer Saldo) wird für direkte Transaktionen überhaupt nicht erzwungen.
+
+**Urteil**: **EXPOSED** — der `createTransaction`-Pfad hat keinen Saldo-Guard und kein Transaktions-Wrapping. Beheben durch: (1) Hinzufügen von `if ($type === 'expense' && $account->balance < $amount) → 422`, und (2) das Lesen-dann-Schreiben in einer DB-Transaktion einschließen.
+
+---
+
+### ATK-10 — Zugriff auf Transaktionen eines anderen Kontos (keine Eigentumsrechte)
+
+**Angriff**: Transaktionen lesen, die einem anderen Benutzerkonto gehören.
+
+```bash
+curl -s http://localhost:8080/accounts/2/transactions
+```
+
+**Beobachtet**: Der Endpunkt gibt alle Transaktionen für Konto 2 ohne Eigentümerprüfung zurück. Da keine Authentifizierung vorhanden ist, kann jeder Aufrufer jedes Konto lesen.
+
+**Urteil**: **EXPOSED** (gleiche Grundursache wie ATK-01). Konten müssen auf einen authentifizierten Benutzer begrenzt sein — `WHERE account_id = ? AND owner_id = ?`.
+
+---
+
+### ATK-11 — `recurring`-Feld: Wahrheitswert-Zwang
+
+**Angriff**: Nicht-boolesche Werte für `recurring` senden.
+
+```json
+{"amount": 1, "type": "income", "category": "x", "recurring": "yes"}
+{"amount": 1, "type": "income", "category": "x", "recurring": 1}
+{"amount": 1, "type": "income", "category": "x", "recurring": 0}
+```
+
+**Beobachtet**: `(bool) $body['recurring']` wandelt `"yes"` → `true`, `1` → `true`, `0` → `false` um. Jeder truthy-String-Wert setzt `recurring = true`. Es gibt keine strikte `is_bool()`-Prüfung.
+
+**Urteil**: **TEILWEISE BLOCKED** — Nicht-boolesche Typen werden stillschweigend umgewandelt. `is_bool($body['recurring'])` für strikte Typprüfung verwenden und `422` für nicht-booleschen Input zurückgeben.
+
+---
+
+### ATK-12 — Nicht-numerische Konto-ID im Pfad
+
+**Angriff**: Einen String als ID im Pfadparameter übergeben.
+
+```
+GET /accounts/abc/transactions
+GET /accounts/1.5/transactions
+```
+
+**Beobachtet**: `(int) 'abc'` = `0`, `(int) '1.5'` = `1`.
+- `abc` → `findById(0)` → gibt `null` zurück → `404 Not Found`.
+- `1.5` → `findById(1)` → wenn Konto 1 existiert, wird es stillschweigend zurückgegeben.
+
+**Urteil**: **TEILWEISE BLOCKED** — nicht-numerische Strings werden auf 404 abgebildet. Float-Strings werden stillschweigend abgeschnitten. `ctype_digit()`-Validierung für strenge Pfadparameter-Prüfung hinzufügen.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|----------------|--------|
+| ATK-01 | Keine Authentifizierung (alle Endpunkte öffentlich) | EXPOSED |
+| ATK-02 | Negativer Anfangssaldo | BLOCKED |
+| ATK-03 | Ausgabe treibt Saldo negativ | EXPOSED |
+| ATK-04 | SQL-Injection via Kategorie/Beschreibung | BLOCKED |
+| ATK-05 | Float-Betrag stillschweigend abgeschnitten | TEILWEISE BLOCKED |
+| ATK-06 | Null- oder negativer Betrag | BLOCKED |
+| ATK-07 | Überweisung auf dasselbe Konto | BLOCKED |
+| ATK-08 | Überweisung mit unzureichendem Saldo | BLOCKED |
+| ATK-09 | Race Condition bei direkter Ausgabe | EXPOSED |
+| ATK-10 | Kontoübergreifender Datenzugriff (keine Eigentumsrechte) | EXPOSED |
+| ATK-11 | `recurring`-Nicht-Boolean-Zwang | TEILWEISE BLOCKED |
+| ATK-12 | Nicht-numerische Konto-ID | TEILWEISE BLOCKED |
+
+**Echte Schwachstellen, die vor der Produktion behoben werden müssen**:
+1. **ATK-01 / ATK-10** — Authentifizierung und Pro-Benutzer-Kontoeigentümerschaft hinzufügen
+2. **ATK-03 / ATK-09** — Saldo-Ausreichlichkeitsprüfung + DB-Transaktion in `createTransaction` hinzufügen
+3. **ATK-05** — `(int)`-Cast durch `is_int()`-Prüfung für strikte Typprüfung ersetzen
+4. **ATK-11** — `(bool)`-Cast durch `is_bool()`-Prüfung ersetzen
+5. **ATK-12** — `ctype_digit()`-Guard für ID-Pfadparameter hinzufügen
+
+---
+
+## Verwandte Anleitungen
+
+- [`credit-ledger.md`](credit-ledger.md) — Append-only-Ledger mit Richtung ±1 und InsufficientCreditsException
+- [`multi-currency-wallet.md`](multi-currency-wallet.md) — Multi-Währungs-Saldoverwaltung
+- [`transactions.md`](transactions.md) — DatabaseTransactionManagerInterface-Muster
+- [`note-management-ownership.md`](note-management-ownership.md) — Pro-Benutzer-Ressourceneigentümerschaft mit IDOR-Prävention

--- a/docs/de/howto/bulk-operations-partial-success.md
+++ b/docs/de/howto/bulk-operations-partial-success.md
@@ -1,0 +1,264 @@
+# How-to: Bulk-Operationen mit Teilerfolg-Semantik
+
+> **FT-Referenz**: FT258 (`NENE2-FT/bulklog`) — Bulk-Create / Bulk-Delete mit Teilerfolg-Semantik und HTTP 207 Multi-Status
+
+Demonstriert die Behandlung von Bulk-API-Operationen, bei denen einige Elemente erfolgreich sein können und andere nicht.
+Jedes Element wird unabhängig verarbeitet — ein Validierungsfehler bei Element N bricht die Verarbeitung von Element N+1 nicht ab.
+Die Antwort enthält zwei Arrays: `created` (erfolgreich) und `errors` (fehlgeschlagen mit Gründen).
+HTTP 207 Multi-Status wird zurückgegeben, wenn es eine Mischung gibt; 201 Created, wenn alle erfolgreich sind.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|----------|---------------|-----------------------------------------------|
+| `POST`   | `/items`      | Ein einzelnes Element erstellen |
+| `GET`    | `/items/{id}` | Ein einzelnes Element abrufen |
+| `POST`   | `/items/bulk` | Bulk-Elemente erstellen (Teilerfolg) |
+| `DELETE` | `/items/bulk` | Bulk-Elemente nach ID löschen (Teilerfolg) |
+
+> **Routenreihenfolge**: `/items/bulk` muss vor `/items/{id}` registriert werden, damit das Literal-Segment `bulk` nicht als Pfadparameter aufgefangen wird.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    sku        TEXT NOT NULL UNIQUE,
+    name       TEXT NOT NULL,
+    price      INTEGER NOT NULL,
+    created_at TEXT NOT NULL
+);
+```
+
+`sku TEXT NOT NULL UNIQUE` verhindert doppelte SKUs auf DB-Ebene. `price INTEGER` speichert den Preis in der kleinsten Währungseinheit (Cent/Yen), um Gleitkomma-Rundungsfehler zu vermeiden.
+
+---
+
+## BulkResult-DTO
+
+```php
+final readonly class BulkResult
+{
+    /**
+     * @param list<array<string, mixed>> $created
+     * @param list<array<string, mixed>> $errors
+     */
+    public function __construct(
+        public array $created,
+        public array $errors,
+    ) {}
+
+    public function hasErrors(): bool
+    {
+        return $this->errors !== [];
+    }
+}
+```
+
+`created` enthält die erfolgreich erstellten Einträge. `errors` enthält pro-Element-Fehlerbeschreibungen. `hasErrors()` ist ein einfaches Prädikat, das der Controller verwendet, um den HTTP-Statuscode zu wählen.
+
+---
+
+## Bulk-Create: Validierung pro Element
+
+```php
+public function bulkCreate(array $inputs, string $now): BulkResult
+{
+    $created = [];
+    $errors  = [];
+
+    foreach ($inputs as $index => $input) {
+        $sku   = isset($input['sku'])   && is_string($input['sku'])   ? trim($input['sku'])   : '';
+        $name  = isset($input['name'])  && is_string($input['name'])  ? trim($input['name'])  : '';
+        $price = isset($input['price']) && is_int($input['price'])    ? $input['price']       : -1;
+
+        $itemErrors = [];
+        if ($sku === '') {
+            $itemErrors[] = 'sku is required';
+        } elseif ($this->skuExists($sku)) {
+            $itemErrors[] = "sku \"{$sku}\" already exists";
+        }
+        if ($name === '') {
+            $itemErrors[] = 'name is required';
+        }
+        if ($price < 0) {
+            $itemErrors[] = 'price must be a non-negative integer';
+        }
+
+        if ($itemErrors !== []) {
+            $errors[] = ['index' => $index, 'sku' => $sku, 'errors' => $itemErrors];
+            continue;   // Einfügen überspringen, zum nächsten Element fortfahren
+        }
+
+        $item      = $this->create($sku, $name, $price, $now);
+        $created[] = $item->toArray();
+    }
+
+    return new BulkResult($created, $errors);
+}
+```
+
+**Wichtige Entscheidungen**:
+- `continue` bei Validierungsfehler: fehlgeschlagene Elemente brechen die Schleife nicht ab.
+- `$index` wird in den Fehlereintrag aufgenommen: Clients wissen, welche Position in ihrem Eingabe-Array fehlgeschlagen ist.
+- SKU-Eindeutigkeit wird in PHP (`skuExists()`) vor INSERT geprüft, nicht aus DB-Exceptions abgefangen. Das liefert eine klarere, anwendungsseitige Fehlermeldung statt einer rohen Constraint-Verletzung.
+- Alle erfolgreichen INSERTs teilen denselben `$now`-Zeitstempel: der Batch wird als ein einziger Zeitpunkt behandelt.
+
+---
+
+## Bulk-Delete: Not-Found-Tracking
+
+```php
+public function bulkDelete(array $ids): array
+{
+    $deleted  = [];
+    $notFound = [];
+
+    foreach ($ids as $id) {
+        $item = $this->findById($id);
+        if ($item === null) {
+            $notFound[] = $id;
+            continue;
+        }
+        $this->executor->execute('DELETE FROM items WHERE id = ?', [$id]);
+        $deleted[] = $id;
+    }
+
+    return ['deleted' => $deleted, 'not_found' => $notFound];
+}
+```
+
+Nicht-gefundene IDs werden verfolgt, brechen aber die Operation nicht ab. Die Antwort ermöglicht es dem Aufrufer zu prüfen, welche IDs tatsächlich gelöscht wurden und welche bereits fehlten. 200 zurückzugeben (nicht 207) ist hier sinnvoll, da alle angeforderten Löschvorgänge entweder erfolgreich waren oder bereits nicht vorhanden waren — es gibt keinen "Fehler"-Zustand.
+
+---
+
+## Controller: HTTP 207 Multi-Status
+
+```php
+private function bulkCreate(ServerRequestInterface $request): ResponseInterface
+{
+    $body = JsonRequestBodyParser::parse($request);
+
+    if (!isset($body['items']) || !is_array($body['items'])) {
+        return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+            'errors' => [['field' => 'items', 'code' => 'required', 'message' => 'items array is required.']],
+        ]);
+    }
+
+    $inputs = array_values($body['items']);
+    $now    = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+    $result = $this->repo->bulkCreate($inputs, $now);
+
+    $status = $result->hasErrors() ? 207 : 201;   // ← 207 bei Mischung aus Erfolg + Fehler
+
+    return $this->json->create($result->toArray(), $status);
+}
+```
+
+**HTTP-Statusauswahl**:
+
+| Ergebnis | Status | Bedeutung |
+|---|---|---|
+| Alle erstellt | `201 Created` | Vollständiger Erfolg |
+| Einige erstellt, einige fehlgeschlagen | `207 Multi-Status` | Teilerfolg — Client muss den Body prüfen |
+| Alle fehlgeschlagen | `207 Multi-Status` | Vollständiger Fehler — `created`-Array ist leer |
+| Kein `items`-Array | `422 Unprocessable Entity` | Fehlerhafte Anfrage |
+
+`207` signalisiert dem Client: _kein Erfolg annehmen — Body prüfen_. Ein Client, der `201` sieht, kann davon ausgehen, dass alle Elemente verarbeitet wurden; ein Client, der `207` sieht, muss `errors` prüfen.
+
+**Warum kein 422 bei Teilerfolg?** `422` bedeutet, dass die gesamte Anfrage abgelehnt wird. Partial-Success-Bulk-Endpunkte verarbeiten einige Eingaben erfolgreich, daher wäre `422` irreführend.
+
+---
+
+## Bulk-Delete-Controller
+
+```php
+private function bulkDelete(ServerRequestInterface $request): ResponseInterface
+{
+    $body = JsonRequestBodyParser::parse($request);
+
+    if (!isset($body['ids']) || !is_array($body['ids'])) {
+        return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+            'errors' => [['field' => 'ids', 'code' => 'required', 'message' => 'ids array is required.']],
+        ]);
+    }
+
+    $ids    = array_values(array_filter($body['ids'], 'is_int'));
+    $result = $this->repo->bulkDelete($ids);
+
+    return $this->json->create($result);   // immer 200
+}
+```
+
+`array_filter($body['ids'], 'is_int')` entfernt stillschweigend Nicht-Integer-Werte aus dem IDs-Array. Dies ist eine Designentscheidung: fehlerhafte IDs werden ignoriert, anstatt eine 422 zu verursachen. Ein alternativer Ansatz ist es, die gesamte Anfrage abzulehnen, wenn eine ID kein Integer ist.
+
+---
+
+## Beispielanfrage und -antwort
+
+### Bulk-Create — Teilerfolg
+
+**Anfrage** `POST /items/bulk`:
+```json
+{
+  "items": [
+    {"sku": "A001", "name": "Widget A", "price": 1000},
+    {"sku": "",     "name": "Bad Item",  "price": 500},
+    {"sku": "A001", "name": "Duplicate", "price": 200}
+  ]
+}
+```
+
+**Antwort** `207 Multi-Status`:
+```json
+{
+  "created": [
+    {"id": 1, "sku": "A001", "name": "Widget A", "price": 1000, "created_at": "2026-01-01 00:00:00"}
+  ],
+  "errors": [
+    {"index": 1, "sku": "", "errors": ["sku is required"]},
+    {"index": 2, "sku": "A001", "errors": ["sku \"A001\" already exists"]}
+  ]
+}
+```
+
+`index` bezieht sich auf die Position im Eingabe-`items`-Array (0-basiert). Der Client kann jeden Fehler mit der ursprünglichen Eingabe korrelieren, ohne den Payload zu scannen.
+
+### Bulk-Delete — Teilerfolg
+
+**Anfrage** `DELETE /items/bulk`:
+```json
+{"ids": [1, 999, 2]}
+```
+
+**Antwort** `200 OK`:
+```json
+{
+  "deleted": [1, 2],
+  "not_found": [999]
+}
+```
+
+---
+
+## Design-Kompromisse
+
+| Ansatz | Verhalten | Wann verwenden |
+|---|---|---|
+| Alles-oder-nichts | Rollback aller, wenn einer fehlschlägt | Finanzen, Inventar — Konsistenz erforderlich |
+| Teilerfolg (dieses Muster) | Jedes Element unabhängig verarbeiten | Import/Export, Dateneingabe |
+| Fire-and-forget-Queue | Asynchrone Verarbeitung, aufgeschobene Ergebnisse | Große Batches, Hintergrundaufgaben |
+
+Teilerfolg ist geeignet, wenn Elemente voneinander unabhängig sind. Wenn der Erfolg von Element A vom Erfolg von Element B abhängt (z. B. Lagerbestände zwischen Elementen übertragen), stattdessen eine Alles-oder-nichts-Transaktion verwenden.
+
+---
+
+## Verwandte Anleitungen
+
+- [`transaction-scope-pattern.md`](transaction-scope-pattern.md) — atomares Alles-oder-nichts-Multi-Write
+- [`job-queue-with-retry.md`](job-queue-with-retry.md) — asynchrone Bulk-Verarbeitung via Job-Queue
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — explizites DTO-Whitelisting für jedes Element

--- a/docs/de/howto/bulk-status-update.md
+++ b/docs/de/howto/bulk-status-update.md
@@ -1,0 +1,335 @@
+# How-to: Bulk-Status-Update-API
+
+> **FT-Referenz**: FT85 (`NENE2-FT/bulkupdatelog`) — Bulk-Status-Update-API
+> **VULN**: FT231 — Sicherheits-/Schwachstellenbewertung (V-01 bis V-10)
+
+Demonstriert zwei Muster für Bulk-Statusänderungen: Pro-Element-Updates (jedes Element erhält seinen eigenen Zielstatus) und homogene Bulk-Updates (alle Elemente erhalten denselben Status). Beide unterstützen Teilerfolg — die Antwort meldet, welche IDs erfolgreich waren und welche fehlgeschlagen sind.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST`  | `/tasks` | Eine Aufgabe erstellen |
+| `GET`   | `/tasks` | Alle Aufgaben auflisten |
+| `PATCH` | `/tasks/status` | Pro-Element-Bulk-Status-Update (gemischte Zielstatus) |
+| `PATCH` | `/tasks/done` | Eine Reihe von IDs als erledigt markieren (einzelner Zielstatus) |
+
+---
+
+## Pro-Element-Bulk-Update (`PATCH /tasks/status`)
+
+Jedes Update-Element gibt seinen eigenen Zielstatus an:
+
+```json
+{
+  "updates": [
+    {"id": 1, "status": "done"},
+    {"id": 2, "status": "cancelled"},
+    {"id": 3, "status": "in_progress"}
+  ]
+}
+```
+
+Das Repository verarbeitet jedes Element einzeln und akkumuliert Erfolge und Fehler:
+
+```php
+public function bulkUpdateStatus(array $items, string $now): BulkUpdateResult
+{
+    $updatedIds = [];
+    $failed     = [];
+
+    foreach ($items as $item) {
+        $itemArr = is_array($item) ? $item : [];
+        $id      = isset($itemArr['id']) && is_int($itemArr['id']) ? $itemArr['id'] : null;
+        $status  = isset($itemArr['status']) && is_string($itemArr['status'])
+            ? TaskStatus::tryFrom($itemArr['status'])
+            : null;
+
+        if ($id === null) {
+            $failed[] = ['id' => 0, 'error' => 'id must be an integer'];
+            continue;
+        }
+
+        if ($status === null) {
+            $failed[] = ['id' => $id, 'error' => 'invalid status value'];
+            continue;
+        }
+
+        $affected = $this->executor->execute(
+            'UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?',
+            [$status->value, $now, $id],
+        );
+
+        if ($affected === 0) {
+            $failed[] = ['id' => $id, 'error' => 'task not found'];
+        } else {
+            $updatedIds[] = $id;
+        }
+    }
+
+    return new BulkUpdateResult($updatedIds, $failed);
+}
+```
+
+### Antwortstruktur
+
+```json
+{
+  "updated": [1, 3],
+  "failed": [
+    {"id": 2, "error": "task not found"}
+  ]
+}
+```
+
+HTTP-Status ist immer `200 OK` — auch wenn alle Elemente fehlschlagen. Der Aufrufer muss `failed` prüfen, um Pro-Element-Fehler zu erkennen.
+
+---
+
+## Homogenes Bulk-Update (`PATCH /tasks/done`)
+
+Alle IDs wechseln zum gleichen Zielstatus in einem einzigen `UPDATE ... WHERE id IN (?)`:
+
+```php
+// Body: {"ids": [1, 2, 3]}
+$ids = isset($body['ids']) && is_array($body['ids'])
+    ? array_values(array_filter($body['ids'], static fn (mixed $v): bool => is_int($v)))
+    : [];
+
+if ($ids === []) {
+    return $this->json->create(['error' => 'ids array is required and must not be empty'], 422);
+}
+```
+
+Nicht-Integer-Werte werden stillschweigend per `array_filter(..., is_int(...))` gefiltert. Wenn das Ergebnis nach der Filterung leer ist, wird 422 zurückgegeben.
+
+```php
+public function bulkSetStatus(array $ids, TaskStatus $status, string $now): array
+{
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+
+    $this->executor->execute(
+        "UPDATE tasks SET status = ?, updated_at = ? WHERE id IN ({$placeholders})",
+        [$status->value, $now, ...$ids],
+    );
+
+    // IDs zurückgeben, die existieren und jetzt den Zielstatus haben
+    $rows = $this->executor->fetchAll(
+        "SELECT id FROM tasks WHERE id IN ({$placeholders}) AND status = ?",
+        [...$ids, $status->value],
+    );
+
+    return array_map(static fn (array $r): int => (int) $r['id'], $rows);
+}
+```
+
+`implode(',', array_fill(0, count($ids), '?'))` generiert die korrekte Anzahl von `?`-Platzhaltern — sicher, parametrisiert.
+
+---
+
+## Status-Allowlist (backed enum)
+
+`TaskStatus` ist ein backed-String-Enum mit vier Fällen:
+
+```php
+enum TaskStatus: string
+{
+    case Pending    = 'pending';
+    case InProgress = 'in_progress';
+    case Done       = 'done';
+    case Cancelled  = 'cancelled';
+}
+```
+
+`TaskStatus::tryFrom($string)` gibt `null` für unbekannte Statuswerte zurück, was der Bulk-Handler auf einen Pro-Element-Fehler abbildet. Das Schema fügt `CHECK(status IN (...))` als DB-Auffangbecken hinzu.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE tasks (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    status     TEXT NOT NULL DEFAULT 'pending'
+                             CHECK(status IN ('pending', 'in_progress', 'done', 'cancelled')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+```
+
+---
+
+## VULN — Sicherheitsbewertung (FT231)
+
+### V-01 — Keine Authentifizierung auf einem Endpunkt
+
+**Angriff**: Alle Aufgaben ohne Anmeldedaten abbrechen.
+
+```json
+{"updates": [{"id": 1, "status": "cancelled"}, {"id": 2, "status": "cancelled"}]}
+```
+
+**Beobachtet**: `200 OK` — kein Token erforderlich.
+
+**Urteil**: **EXPOSED** (by design für FT85-Demo). In der Produktion Authentifizierung und Autorisierung hinzufügen. Bulk-Mutationen auf den Aufgabeneigentümer oder eine Admin-Rolle beschränken.
+
+---
+
+### V-02 — Mass-Update-DoS (riesiges Array)
+
+**Angriff**: Ein `updates`-Array mit Tausenden von Elementen senden, um CPU oder Speicher zu erschöpfen.
+
+```python
+{"updates": [{"id": i, "status": "done"} for i in range(100_000)]}
+```
+
+**Beobachtet**: In einer Schleife verarbeitet — jedes Element führt eine `UPDATE`-Abfrage aus. Bei 100.000 Elementen werden 100.000 einzelne SQL-Anweisungen in einer engen Schleife ohne Batch-Größen-Limit ausgeführt.
+
+**Urteil**: **EXPOSED** — maximale Batch-Größe hinzufügen:
+```php
+$maxBatchSize = 500;
+if (count($updates) > $maxBatchSize) {
+    return $this->json->create(['error' => "Batch size must not exceed {$maxBatchSize} items."], 422);
+}
+```
+
+---
+
+### V-03 — SQL-Injection via `IN`-Klausel
+
+**Angriff**: SQL durch das `ids`-Array einschleusen, das in `IN (?)` verwendet wird.
+
+```json
+{"ids": ["1; DROP TABLE tasks; --", 1, 2]}
+```
+
+**Beobachtet**: Der String `"1; DROP TABLE tasks; --"` wird vom `is_int()`-Filter in `array_filter()` abgelehnt. Nur Integer erreichen die `IN`-Klausel. Das `implode` + `array_fill`-Muster generiert die korrekte Anzahl von `?`-Platzhaltern — keine String-Verkettung von Benutzerdaten.
+
+**Urteil**: **BLOCKED** — `is_int()`-Filter + parametrisierte `IN`-Klausel verhindert Injection.
+
+---
+
+### V-04 — Nicht-Integer-IDs in Pro-Element-Updates
+
+**Angriff**: Nicht-Integer-`id`-Werte im `updates`-Array senden.
+
+```json
+{"updates": [{"id": "1", "status": "done"}, {"id": null, "status": "done"}]}
+```
+
+**Beobachtet**: Beide Elemente werden mit `'error' => 'id must be an integer'` zu `$failed` hinzugefügt. `is_int()` lehnt Strings und `null` ab.
+
+**Urteil**: **BLOCKED** — strikte `is_int()`-Typprüfung pro Element.
+
+---
+
+### V-05 — Ungültiger Statuswert
+
+**Angriff**: Einen unbekannten Status-String im `updates`-Array senden.
+
+```json
+{"updates": [{"id": 1, "status": "hacked"}]}
+```
+
+**Beobachtet**: Element wird mit `'error' => 'invalid status value'` zu `$failed` hinzugefügt. `TaskStatus::tryFrom("hacked")` gibt `null` zurück.
+
+**Urteil**: **BLOCKED** — backed enum `tryFrom()` lehnt unbekannte Werte ab.
+
+---
+
+### V-06 — Leeres Array
+
+**Angriff**: Ein leeres `updates`- oder `ids`-Array senden.
+
+```json
+{"updates": []}
+{"ids": []}
+```
+
+**Beobachtet**: Beide geben `422 Unprocessable Entity` mit einer Fehlermeldung zurück.
+
+**Urteil**: **BLOCKED** — Leer-Array-Prüfung vor der Verarbeitung.
+
+---
+
+### V-07 — Doppelte IDs im gleichen Batch
+
+**Angriff**: Dieselbe `id` mehrfach in einer Anfrage aufnehmen.
+
+```json
+{"updates": [{"id": 1, "status": "done"}, {"id": 1, "status": "cancelled"}]}
+```
+
+**Beobachtet**: Beide Updates gelingen. Das zweite UPDATE überschreibt das erste — die Aufgabe endet als `cancelled`. Keine Deduplizierung findet statt.
+
+**Urteil**: **ACCEPTED BY DESIGN** — Last-Write-Wins-Semantik ist konsistent für einfache Aufgabenverwaltung. Wenn Konflikte abgelehnt werden sollen, `ids` vor der Verarbeitung deduplizieren und einen Fehler bei Duplikaten zurückgeben.
+
+---
+
+### V-08 — Negative und Null-IDs
+
+**Angriff**: IDs `0` oder `-1` senden.
+
+```json
+{"ids": [0, -1]}
+```
+
+**Beobachtet**: `is_int(0)` = true, `is_int(-1)` = true — beide bestehen den Filter. Das UPDATE läuft mit `WHERE id IN (0, -1)`, was keine Zeilen trifft. Antwort: `{"requested": 2, "updated": 0, "ids": []}`.
+
+**Urteil**: **BLOCKED** in der Praxis (keine betroffenen Zeilen). Für nicht existierende IDs wird kein Fehler zurückgegeben — dies ist konsistent mit dem Teilerfolg-Muster. Einen Positiv-Integer-Guard hinzufügen, wenn negative IDs mit 422 abgelehnt werden sollen.
+
+---
+
+### V-09 — Bulk-Update überspringt nicht existierende Aufgaben stillschweigend
+
+**Angriff**: IDs aufnehmen, die nicht in der Datenbank vorhanden sind.
+
+```json
+{"ids": [99999, 100000]}
+```
+
+**Beobachtet**: `{"requested": 2, "updated": 0, "ids": []}` — kein Fehler, kein Hinweis darauf, dass die Aufgaben nicht existieren.
+
+**Urteil**: **ACCEPTED BY DESIGN** — Teilerfolg-Modell. Dieses Verhalten in der API-Spezifikation dokumentieren. Wenn Aufrufer "keine solche Aufgabe" von "Aufgabe bereits im Zielstatus" unterscheiden müssen, kann die Antwort eine `not_found`-Liste enthalten.
+
+---
+
+### V-10 — Gleichzeitige Bulk-Updates auf denselben IDs
+
+**Angriff**: Zwei gleichzeitige `PATCH /tasks/done`-Anfragen für dieselbe Reihe von IDs senden.
+
+**Beobachtet**: Beide UPDATE-Anweisungen laufen auf der DB. SQLites Zeilen-Level-Locking bedeutet, dass ein UPDATE zuerst abgeschlossen wird, dann läuft das zweite UPDATE auf bereits-`done`-Zeilen. Beide Antworten geben `updated`-IDs zurück (da die Zeilen noch mit `status = done` existieren).
+
+**Urteil**: **BLOCKED** — idempotente Schreibvorgänge. Beide Anfragen liefern dasselbe Ergebnis (alle IDs auf `done` gesetzt). Bei `status`-Updates, bei denen der Zielstatus pro Aufrufer unterschiedlich ist, verwenden gleichzeitige Schreibvorgänge Last-Write-Wins.
+
+---
+
+## VULN-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|----------------|--------|
+| V-01 | Keine Authentifizierung | EXPOSED (by design) |
+| V-02 | Mass-Update-DoS (riesiges Array) | EXPOSED |
+| V-03 | SQL-Injection via `IN`-Klausel | BLOCKED |
+| V-04 | Nicht-Integer-IDs | BLOCKED |
+| V-05 | Ungültiger Statuswert | BLOCKED |
+| V-06 | Leeres Array | BLOCKED |
+| V-07 | Doppelte IDs im Batch | ACCEPTED BY DESIGN |
+| V-08 | Negative/Null-IDs | BLOCKED |
+| V-09 | Nicht existierende Aufgaben stillschweigend übersprungen | ACCEPTED BY DESIGN |
+| V-10 | Gleichzeitige Bulk-Updates | BLOCKED |
+
+**Echte Schwachstellen, die vor der Produktion behoben werden müssen**:
+1. **V-01** — Authentifizierung und Autorisierung hinzufügen
+2. **V-02** — Maximale Batch-Größe hinzufügen (z. B. 500 Elemente)
+
+---
+
+## Verwandte Anleitungen
+
+- [`implement-bulk-endpoint.md`](implement-bulk-endpoint.md) — Bulk-Create mit Pro-Element-Fehlern
+- [`batch-api-partial-success.md`](batch-api-partial-success.md) — Teilerfolg-Muster
+- [`approval-workflow.md`](approval-workflow.md) — Statusübergänge mit Enum-Guard

--- a/docs/de/howto/direct-messaging-system.md
+++ b/docs/de/howto/direct-messaging-system.md
@@ -1,0 +1,275 @@
+# Ein Direktnachrichten-System mit NENE2 aufbauen
+
+> **FT-Referenz**: FT278 (`NENE2-FT/messagelog`) — Direktnachrichten: Konversations-Threading, UNIQUE(initiator_id, recipient_id) + CHECK(initiator_id != recipient_id), Teilnehmer-Zugriffskontrolle, richtungsunabhängige Suche, idempotenter Konversationsstart, 31 Tests / 96 Assertions bestanden.
+>
+> Auch in FT135 validiert — ursprüngliche Implementierung.
+
+Diese Anleitung führt durch den Aufbau eines Twitter/Instagram-artigen Direktnachrichten-Systems (DM) — Benutzer starten Konversationen miteinander, senden Nachrichten, und nur Teilnehmer können Nachrichten in einer Konversation lesen oder senden.
+
+**NENE2-Version**: ^1.5  
+**Behandelte Themen**: Konversations-Threading, Teilnehmer-Zugriffskontrolle, richtungsunabhängige Konversationssuche, idempotenter Konversationsstart
+
+---
+
+## Was wir bauen
+
+Eine REST-API, bei der:
+
+- Zwei beliebige Benutzer eine Konversation starten können (idempotent — ein erneuter Start gibt die vorhandene zurück)
+- Nur Teilnehmer Nachrichten senden oder die Nachrichten einer Konversation lesen können
+- Ein Benutzer seine eigenen Konversationen auflisten kann (aber nicht die eines anderen Benutzers)
+- Nachrichten innerhalb einer Konversation von ältestem zum neuesten sortiert sind
+
+---
+
+## Datenbankschema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE conversations (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    initiator_id INTEGER NOT NULL,
+    recipient_id INTEGER NOT NULL,
+    created_at   TEXT    NOT NULL,
+    UNIQUE (initiator_id, recipient_id),
+    CHECK  (initiator_id != recipient_id),
+    FOREIGN KEY (initiator_id) REFERENCES users(id),
+    FOREIGN KEY (recipient_id) REFERENCES users(id)
+);
+
+CREATE TABLE messages (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id INTEGER NOT NULL,
+    sender_id       INTEGER NOT NULL,
+    content         TEXT    NOT NULL,
+    created_at      TEXT    NOT NULL,
+    FOREIGN KEY (conversation_id) REFERENCES conversations(id),
+    FOREIGN KEY (sender_id)       REFERENCES users(id)
+);
+```
+
+Die `UNIQUE (initiator_id, recipient_id)`-Constraint erzwingt eine Konversation pro geordnetem Paar. Die Anwendungsschicht behandelt die umgekehrte Richtung (Bob→Alice gibt dieselbe Konversation zurück wie Alice→Bob).
+
+---
+
+## API-Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| POST   | `/users` | Einen Benutzer erstellen |
+| POST   | `/conversations` | Eine Konversation starten (idempotent) |
+| POST   | `/conversations/{id}/messages` | Eine Nachricht senden (nur Teilnehmer) |
+| GET    | `/conversations/{id}/messages` | Nachrichten lesen (nur Teilnehmer, X-User-Id) |
+| GET    | `/users/{userId}/conversations` | Konversationen des Benutzers auflisten (nur selbst, X-User-Id) |
+
+---
+
+## Richtungsunabhängige Konversationssuche
+
+Die Kernherausforderung: Alice startet eine Konversation mit Bob (`initiator=Alice, recipient=Bob`). Später startet Bob auch eine mit Alice. Sie sollten dieselbe Konversation bekommen, nicht zwei getrennte.
+
+```php
+public function findConversation(int $userA, int $userB): ?int
+{
+    $row = $this->executor->fetchOne(
+        'SELECT id FROM conversations
+         WHERE (initiator_id = ? AND recipient_id = ?)
+            OR (initiator_id = ? AND recipient_id = ?)',
+        [$userA, $userB, $userB, $userA],
+    );
+
+    if ($row === null) {
+        return null;
+    }
+
+    $arr = (array) $row;
+
+    return isset($arr['id']) ? (int) $arr['id'] : null;
+}
+
+public function findOrCreateConversation(int $initiatorId, int $recipientId, string $now): int
+{
+    $existing = $this->findConversation($initiatorId, $recipientId);
+
+    if ($existing !== null) {
+        return $existing;
+    }
+
+    $this->executor->execute(
+        'INSERT INTO conversations (initiator_id, recipient_id, created_at) VALUES (?, ?, ?)',
+        [$initiatorId, $recipientId, $now],
+    );
+
+    return (int) $this->executor->lastInsertId();
+}
+```
+
+---
+
+## Teilnehmerprüfung
+
+Vor dem Lesen von Nachrichten oder dem Senden prüfen, ob der Aufrufer an der Konversation teilnimmt:
+
+```php
+public function isParticipant(int $conversationId, int $userId): bool
+{
+    return $this->executor->fetchOne(
+        'SELECT id FROM conversations
+         WHERE id = ? AND (initiator_id = ? OR recipient_id = ?)',
+        [$conversationId, $userId, $userId],
+    ) !== null;
+}
+```
+
+---
+
+## Akteur-Identität — X-User-Id-Header
+
+Geschützte Endpunkte verwenden einen einfachen `X-User-Id`-Header zur Identifikation des Aufrufers. Produktionssysteme würden stattdessen einen JWT-Claim verwenden.
+
+```php
+private function resolveActorId(ServerRequestInterface $request): int
+{
+    $header = $request->getHeaderLine('X-User-Id');
+
+    return is_numeric($header) ? (int) $header : 0;
+}
+```
+
+**Hinweis**: `is_numeric()` gibt false für nicht-numerische Strings zurück, daher führt `X-User-Id: admin` zu `actorId = 0` → 404.
+
+---
+
+## Nachricht-Senden-Handler
+
+```php
+private function sendMessage(ServerRequestInterface $request): ResponseInterface
+{
+    $params         = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $conversationId = isset($params['conversationId']) && is_numeric($params['conversationId'])
+        ? (int) $params['conversationId'] : 0;
+
+    if ($conversationId <= 0 || $this->repo->findConversationById($conversationId) === null) {
+        return $this->responseFactory->create(['error' => 'conversation not found'], 404);
+    }
+
+    $body     = JsonRequestBodyParser::parse($request);
+    $senderId = isset($body['sender_id']) && is_int($body['sender_id']) ? $body['sender_id'] : 0;
+    $content  = isset($body['content']) && is_string($body['content']) ? trim($body['content']) : '';
+
+    if ($senderId <= 0 || !$this->repo->findUserById($senderId)) {
+        return $this->responseFactory->create(['error' => 'sender not found'], 404);
+    }
+
+    if (!$this->repo->isParticipant($conversationId, $senderId)) {
+        return $this->responseFactory->create(['error' => 'not a participant'], 403);
+    }
+
+    if ($content === '') {
+        return $this->responseFactory->create(['error' => 'content is required'], 422);
+    }
+
+    $now       = date('Y-m-d H:i:s');
+    $messageId = $this->repo->sendMessage($conversationId, $senderId, $content, $now);
+
+    return $this->responseFactory->create([...], 201);
+}
+```
+
+**Reihenfolge der Prüfungen**: Konversation existiert → Absender existiert → Absender ist Teilnehmer → Inhalt gültig. Existenzprüfungen vor Zugriffsprüfungen verhindern Informationslecks über Konversations-IDs.
+
+---
+
+## Nachrichten-Lesen-Handler — GET ohne Body
+
+Für GET-Endpunkte, die Identität erfordern (`listMessages`, `listUserConversations`), kommt der Akteur aus dem `X-User-Id`-Header. **`JsonRequestBodyParser::parse()` darf nicht auf GET-Anfragen aufgerufen werden** — es gibt 400 zurück, weil GET-Anfragen keinen JSON-Body haben.
+
+```php
+private function listMessages(ServerRequestInterface $request): ResponseInterface
+{
+    $params         = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $conversationId = isset($params['conversationId']) && is_numeric($params['conversationId'])
+        ? (int) $params['conversationId'] : 0;
+
+    if ($conversationId <= 0 || $this->repo->findConversationById($conversationId) === null) {
+        return $this->responseFactory->create(['error' => 'conversation not found'], 404);
+    }
+
+    // Hier kein JsonRequestBodyParser::parse() — Akteur kommt nur aus dem Header
+    $actorId = $this->resolveActorId($request);
+
+    if ($actorId <= 0 || !$this->repo->findUserById($actorId)) {
+        return $this->responseFactory->create(['error' => 'actor not found'], 404);
+    }
+
+    if (!$this->repo->isParticipant($conversationId, $actorId)) {
+        return $this->responseFactory->create(['error' => 'not a participant'], 403);
+    }
+
+    $messages = $this->repo->listMessages($conversationId);
+
+    return $this->responseFactory->create(['items' => $messages, 'count' => count($messages)]);
+}
+```
+
+---
+
+## Nachrichten-Sortierung
+
+Nachrichten verwenden `ORDER BY id ASC` — älteste zuerst, entsprechend Chat-UI-Konventionen. Follow-/Benachrichtigungslisten verwenden `ORDER BY id DESC` (neueste zuerst). Die Wahl hängt von der UI-Erwartung ab.
+
+---
+
+## Schwachstellenbewertung (FT135)
+
+Zwölf Schwachstellentests verifizieren:
+
+| ID | Angriff | Erwartet | Ergebnis |
+|----|---------|----------|---------|
+| VULN-A | Nachrichten aus einer fremden Konversation lesen (IDOR) | 403 | Bestanden |
+| VULN-B | Nachricht in eine Konversation senden, an der man nicht teilnimmt (IDOR) | 403 | Bestanden |
+| VULN-C | Konversationsliste eines anderen Benutzers lesen (IDOR) | 403 | Bestanden |
+| VULN-D | Fehlender X-User-Id bei Nachrichtenliste | 404/403 | Bestanden |
+| VULN-E | Fehlender X-User-Id bei Konversationsliste | 403 | Bestanden |
+| VULN-F | Negative Benutzer-ID im Pfad | 404 | Bestanden |
+| VULN-G | Null-Konversations-ID im Pfad | 404 | Bestanden |
+| VULN-H | Nicht-numerischer X-User-Id-Header | nicht 200 | Bestanden |
+| VULN-I | SQL-Injection im Nachrichteninhalt | 201 (unverändert gespeichert) | Bestanden |
+| VULN-J | XSS im Nachrichteninhalt | 201 (unverändert gespeichert) | Bestanden |
+| VULN-K | Selbst-Konversationsversuch | 422 | Bestanden |
+| VULN-L | 100 KB Nachrichteninhalt | 201 oder 413 | Bestanden |
+
+Alle 12 Schwachstellentests bestanden. Keine Schwachstellen gefunden.
+
+---
+
+## Häufige Fallstricke
+
+| Fallstrick | Lösung |
+|---------|-----|
+| `JsonRequestBodyParser::parse()` auf GET-Anfragen aufrufen | Nur für POST/PUT/PATCH-Handler aufrufen, die einen Body erwarten |
+| `UNIQUE (initiator_id, recipient_id)` verhindert nicht A→B und B→A als zwei Konversationen | Richtungsunabhängig mit OR-Abfrage vor INSERT suchen |
+| Teilnehmer nach Inhaltsvalidierung prüfen | Teilnehmer *vor* Inhalt prüfen, um Informationslecks zu vermeiden |
+| Jede Nicht-Null-Ganzzahl als Akteur-ID ohne Benutzerexistenzprüfung akzeptieren | Immer `findUserById(actorId)` vor der Teilnahmeprüfung verifizieren |
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Konversationen als `(user_a, user_b)` mit Richtung speichern — zwei getrennte Zeilen für A→B und B→A | Dieselben zwei Benutzer akkumulieren doppelte Konversationen; richtungsunabhängige Suche schlägt fehl |
+| Kein `CHECK (initiator_id != recipient_id)`-Constraint | Benutzer können sich selbst Nachrichten schicken, was verwirrende Selbst-Konversationen erzeugt |
+| Kein `UNIQUE (initiator_id, recipient_id)`-Constraint | Gleichzeitige Konversationsstart-Anfragen erstellen doppelte Zeilen für dasselbe Paar |
+| 404 statt 403 bei Nicht-Teilnehmer-Zugriff zurückgeben | Verrät die Existenz der Konversations-ID an Nicht-Teilnehmer |
+| `JsonRequestBodyParser::parse()` bei GET `/conversations/{id}/messages` aufrufen | GET-Anfragen haben keinen Body; der Parser gibt 400 zurück |
+| Inhaltsvalidierung vor Teilnehmerprüfung | Informationsleck — Angreifer kann gültige Konversations-IDs sondieren, indem leerer Inhalt gesendet und 403 vs. 422 beobachtet wird |
+| `is_numeric()` ohne Cast in `int` und dann `> 0` verwenden | `is_numeric("0")` ist true; Benutzer-ID 0 würde als gültig behandelt |
+| Benutzerexistenzprüfung nach Teilnehmerprüfung überspringen | `isParticipant()` prüft nur FK — gelöschte oder nicht vorhandene Benutzer können noch erscheinen, wenn die DB kein Cascade hat |
+| Jedem Benutzer erlauben, die Konversationen eines anderen Benutzers aufzulisten | IDOR — immer `actorId === targetUserId` vor der Rückgabe der Konversationsliste verifizieren |
+| Nur nach `conversation_id` für Nachrichten indexieren | Fehlender `id ASC`-Index verursacht langsames ORDER BY bei großen Nachrichtenhistorien |

--- a/docs/de/howto/distributed-lock.md
+++ b/docs/de/howto/distributed-lock.md
@@ -1,0 +1,226 @@
+# How-to: Verteilte Sperre
+
+> **FT-Referenz**: FT288 (`NENE2-FT/distlocklog`) — Verteilte Sperre: UNIQUE(resource)-DB-Constraint, Eigentümerverifizierung, TTL-basiertes Ablaufen, Wiederaneignung abgelaufener Sperren by design, ReleaseResult-Enum (Released/NotFound/Forbidden), 403 bei Eigentümer-Nichtübereinstimmung, 16 Tests / 27 Assertions bestanden.
+>
+> **ATK-Bewertung**: ATK-01 bis ATK-12 am Ende dieses Dokuments.
+
+Diese Anleitung zeigt, wie eine verteilte Sperr-API implementiert wird — gleichzeitige Operationen auf derselben Ressource durch die Ausgabe von Leased-Locks verhindern.
+
+## Was ist eine verteilte Sperre?
+
+Wenn mehrere Prozesse exklusiven Zugriff auf eine gemeinsame Ressource benötigen (z. B. eine Zahlung, eine Datei, einen Queue-Job), stellt eine verteilte Sperre sicher, dass nur ein Prozess gleichzeitig fortfährt. Sperren haben eine TTL, damit sie automatisch ablaufen, wenn der Halter abstürzt.
+
+## Schema
+
+```sql
+CREATE TABLE distributed_locks (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource    TEXT    NOT NULL UNIQUE,
+    owner       TEXT    NOT NULL,
+    expires_at  TEXT    NOT NULL,
+    acquired_at TEXT    NOT NULL
+);
+```
+
+`resource TEXT UNIQUE` — eine Zeile pro Ressource. Das Aneignen fügt diese Zeile ein oder aktualisiert sie.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/locks/{resource}` | Sperre aneignen |
+| `GET` | `/locks/{resource}` | Sperrstatus abrufen |
+| `DELETE` | `/locks/{resource}` | Sperre freigeben |
+| `POST` | `/locks/{resource}/renew` | TTL verlängern |
+
+## Aneignungslogik
+
+```php
+public function acquire(string $resource, string $owner, string $expiresAt, string $now): ?LockRecord
+{
+    $existing = $this->findByResource($resource);
+
+    if ($existing === null) {
+        // Keine Sperre — INSERT (UNIQUE-Constraint behandelt Race Conditions)
+        try {
+            $this->executor->execute('INSERT INTO distributed_locks ...', [...]);
+        } catch (\RuntimeException) {
+            return null;  // Race: ein anderer Prozess hat gleichzeitig eingefügt
+        }
+        return $this->findByResource($resource);
+    }
+
+    if ($existing->isExpired($now) || $existing->owner === $owner) {
+        // Abgelaufen → wieder aneignen (UPDATE ersetzt die alte Zeile)
+        // Gleicher Eigentümer → wieder aneignen (verlängern oder neu sperren)
+        $this->executor->execute('UPDATE distributed_locks SET owner = ?, expires_at = ?, acquired_at = ? WHERE resource = ?', ...);
+        return $this->findByResource($resource);
+    }
+
+    // Wird von einem anderen Eigentümer gehalten, noch nicht abgelaufen → kann nicht angeeignet werden
+    return null;
+}
+```
+
+## Freigabe mit Eigentümerverifizierung
+
+```php
+$result = $this->repo->release($resource, $owner, $now);
+
+return match ($result) {
+    ReleaseResult::Released  => $this->json->create([], 204),
+    ReleaseResult::NotFound  => $this->problems->create($request, 'not-found', 'Lock not found.', 404),
+    ReleaseResult::Forbidden => $this->problems->create($request, 'forbidden', 'Owner mismatch.', 403),
+};
+```
+
+Nur der Sperr-Eigentümer kann sie freigeben. Falscher `owner` → 403 Forbidden.
+
+## ReleaseResult-Enum
+
+```php
+enum ReleaseResult
+{
+    case Released;   // Sperre gefunden, Eigentümer stimmte überein, Zeile gelöscht
+    case NotFound;   // Sperre nicht gefunden oder bereits abgelaufen
+    case Forbidden;  // Sperre gefunden, aber Eigentümer stimmt nicht überein
+}
+```
+
+Die Verwendung eines Enums (keine magischen Strings) stellt erschöpfende Behandlung in `match` sicher.
+
+## Aneignungsantwort
+
+```php
+// Erfolg:
+{ "acquired": true, "lock": { "resource": "...", "owner": "...", "expires_at": "...", "acquired_at": "..." } }
+
+// Misserfolg (von einem anderen gehalten):
+{ "acquired": false, "resource": "payment:42" }
+```
+
+`acquired: false` ist kein Fehler — es bedeutet "später erneut versuchen." Kein 4xx-Status; der Aufrufer sollte es erneut versuchen.
+
+---
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Von einem anderen Eigentümer gehaltene Sperre aneignen 🚫 BLOCKED
+
+**Angriff**: Angreifer versucht, `locks/payment:42` anzueignen, während ein anderer Prozess sie hält.
+**Ergebnis**: BLOCKED — Repository prüft `existing.owner === $caller_owner`. Anderer Eigentümer + nicht abgelaufen → gibt `null` zurück → `{ acquired: false }`. Kein Fehler, kein Absturz — der Angreifer bekommt die Sperre einfach nicht.
+
+---
+
+### ATK-02 — Einem anderen gehörende Sperre freigeben 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `DELETE /locks/payment:42` mit `{ "owner": "attacker" }`, um eine Sperre gewaltsam freizugeben.
+**Ergebnis**: BLOCKED — Repository prüft `lock.owner === $body_owner`. Nichtübereinstimmung → `ReleaseResult::Forbidden` → 403.
+
+---
+
+### ATK-03 — Sperre nach Ablauf stehlen 🚫 BLOCKED (by design)
+
+**Angriff**: Angreifer wartet, bis die Sperre abläuft, und erwirbt sie dann.
+**Ergebnis**: BLOCKED (by design) — abgelaufene Sperren können von jedem Eigentümer wieder angeeignet werden. Dies ist das beabsichtigte Verhalten: TTL-basiertes Ablaufen ist die Methode, durch die abgestürzte Halter ihre Sperren verlieren. Die Reduzierung TTL-basierter Angriffe erfordert Koordination (Heartbeat-Erneuerung).
+
+---
+
+### ATK-04 — Einem anderen gehörende Sperre erneuern 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `POST /locks/payment:42/renew` mit `{ "owner": "attacker", "ttl_seconds": 3600 }`.
+**Ergebnis**: BLOCKED — Erneuerung prüft `lock.owner === $body_owner`. Nichtübereinstimmung → 403 Forbidden.
+
+---
+
+### ATK-05 — Null oder negative TTL, um eine bereits abgelaufene Sperre zu erstellen 🚫 BLOCKED
+
+**Angriff**: `{ "ttl_seconds": 0 }` oder `{ "ttl_seconds": -100 }` senden, um eine Sperre zu erstellen, die sofort abläuft.
+**Ergebnis**: BLOCKED — `if ($ttlSeconds === null || $ttlSeconds < 1)` → 422-Validierungsfehler.
+
+---
+
+### ATK-06 — SQL-Injection via Ressourcen-Pfadparameter 🚫 BLOCKED
+
+**Angriff**: `locks/resource'; DROP TABLE distributed_locks; --` als Ressourcenname verwenden.
+**Ergebnis**: BLOCKED — alle Abfragen verwenden parametrisierte Anweisungen (`WHERE resource = ?`). Der eingeschleuste String wird als literaler Ressourcenbezeichner behandelt.
+
+---
+
+### ATK-07 — Leerer Eigentümer zur Umgehung der Eigentümerprüfung 🚫 BLOCKED
+
+**Angriff**: `{ "owner": "" }` oder `{ "owner": "   " }` senden, um ohne gültige Eigentumsrechte freizugeben oder zu erneuern.
+**Ergebnis**: BLOCKED — `$owner = trim(...); if ($owner === '')` → 422-Validierungsfehler.
+
+---
+
+### ATK-08 — Nicht-Integer-TTL zur Umgehung der Typvalidierung 🚫 BLOCKED
+
+**Angriff**: `{ "ttl_seconds": "3600" }` (String) oder `{ "ttl_seconds": 60.5 }` (Float) senden.
+**Ergebnis**: BLOCKED — `is_int($body['ttl_seconds'])` lehnt Strings und Floats ab. Nur der JSON-Integer-Typ wird akzeptiert.
+
+---
+
+### ATK-09 — Gleicher Eigentümer erwirbt mehrfach 🚫 BLOCKED (by design)
+
+**Angriff**: Gleicher Eigentümer erwirbt eine von ihm gehaltene Sperre erneut, ohne `/renew` zu verwenden.
+**Ergebnis**: ERLAUBT (by design) — `$existing->owner === $owner` → UPDATE (wieder aneignen/verlängern). Wiederaneignung durch den gleichen Eigentümer ist idempotent und sicher; sie aktualisiert `expires_at` und `acquired_at`.
+
+---
+
+### ATK-10 — Race Condition: Zwei Eigentümer erwerben gleichzeitig 🚫 BLOCKED
+
+**Angriff**: Zwei Prozesse sehen beide keine Sperre und versuchen gleichzeitig INSERT.
+**Ergebnis**: BLOCKED — `UNIQUE(resource)`-Constraint stellt sicher, dass nur ein INSERT erfolgreich ist. Der Verlierer fängt `\RuntimeException` ab und gibt `null` zurück → `{ acquired: false }`. Nur ein Eigentümer gewinnt.
+
+---
+
+### ATK-11 — GET nicht existierende oder abgelaufene Sperre 🚫 BLOCKED
+
+**Angriff**: `GET /locks/nonexistent` aufrufen oder warten, bis die Sperre abläuft, dann GET aufrufen.
+**Ergebnis**: BLOCKED — `if ($lock === null || $lock->isExpired($now)) return 404`. Abgelaufene Sperren geben 404 zurück (nicht die veralteten Sperrdaten).
+
+---
+
+### ATK-12 — Extrem langer Ressourcenname zur DoS-Erzeugung 🚫 BLOCKED (Designhinweis)
+
+**Angriff**: `{ "resource": "<10MB-String>" }` als Ressourcen-Pfadparameter senden.
+**Ergebnis**: TEILWEISE BLOCKED — die Ressource kommt aus dem URL-Pfad, begrenzt durch die Webserver-Pfadlänge (typisch 8 KB). Keine explizite Längenvalidierung auf Anwendungsebene ist in diesem FT vorhanden. In der Produktion `if (strlen($resource) > 255)` → 422 hinzufügen. Die DB speichert, was die Anwendung übergibt.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Von einem anderen gehaltene Sperre aneignen | 🚫 BLOCKED |
+| ATK-02 | Einem anderen gehörende Sperre freigeben | 🚫 BLOCKED |
+| ATK-03 | Sperre nach TTL-Ablauf stehlen | 🚫 BLOCKED (by design) |
+| ATK-04 | Einem anderen gehörende Sperre erneuern | 🚫 BLOCKED |
+| ATK-05 | Null/negative TTL | 🚫 BLOCKED |
+| ATK-06 | SQL-Injection via Ressourcenpfad | 🚫 BLOCKED |
+| ATK-07 | Leerer Eigentümer-Bypass | 🚫 BLOCKED |
+| ATK-08 | Nicht-Integer-TTL-Typ-Bypass | 🚫 BLOCKED |
+| ATK-09 | Wiederaneignung durch gleichen Eigentümer | 🚫 BLOCKED (beabsichtigt) |
+| ATK-10 | Race Condition bei gleichzeitiger Aneignung | 🚫 BLOCKED |
+| ATK-11 | GET abgelaufene/nicht existierende Sperre | 🚫 BLOCKED |
+| ATK-12 | Extrem langer Ressourcenname | ⚠️ DESIGNHINWEIS |
+
+**11 BLOCKED, 1 DESIGNHINWEIS, 0 EXPOSED**
+Eigentümerverifizierung, `UNIQUE(resource)`-Race-Schutz, TTL-Validierung und parametrisierte Abfragen verhindern alle kritischen Angriffsvektoren.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Kein `UNIQUE(resource)`-Constraint | Race Condition: Zwei Eigentümer erwerben beide; TOCTOU-Schwachstelle |
+| Freigabe ohne Eigentümerprüfung | Jeder Prozess kann jede Sperre freigeben; keine Exklusivitätsgarantie |
+| Keine TTL auf Sperren | Die Sperre eines abgestürzten Halters bleibt für immer bestehen; System-Deadlock |
+| TTL von 0 oder negativ akzeptieren | Sperre ist bei Erstellung bereits abgelaufen; sofort wieder aneignbar |
+| 404 bei Eigentümer-Nichtübereinstimmung zurückgeben (Freigabe) | Angreifer kann "Sperre existiert nicht" nicht von "falscher Eigentümer" unterscheiden; 403 verwenden |
+| String/Float als TTL akzeptieren | `"3600"` sieht gültig aus, aber `is_int` schlägt fehl; strikte Typprüfung verhindert subtile Bugs |
+| Eigentümer ohne Validierung speichern | Leerer Eigentümer umgeht Eigentumsrechte; immer nicht-leer validieren |
+| Kein Ressourcen-Längenlimit | Webserver-Pfadlimit ist der einzige Guard; explizite Validierung hinzufügen |
+| Abgelaufene Sperren erneuern | Abgelaufene Sperre gehört niemandem; stattdessen wieder aneignen |

--- a/docs/de/howto/distributed-locking.md
+++ b/docs/de/howto/distributed-locking.md
@@ -1,0 +1,111 @@
+# Verteilte Sperrung
+
+Eine verteilte Sperre verhindert, dass gleichzeitige Prozesse einen kritischen Abschnitt gleichzeitig ausführen. DB-gestützte Sperren tauschen Durchsatz gegen Einfachheit — kein Redis erforderlich, und dieselbe DB, die Ihre Daten enthält, enthält auch Ihre Sperren.
+
+## Kernkonzepte
+
+- **Ressource**: der Name der zu sperrenden Sache (z. B. `job:42`, `report:monthly-2026-05`)
+- **Eigentümer**: ein Token, das den Sperr-Halter identifiziert — nur der Eigentümer kann freigeben oder erneuern
+- **Ablauf (TTL)**: Sperren laufen automatisch ab, damit ein abgestürzter Eigentümer eine Sperre nicht für immer halten kann
+- **Veraltete Sperr-Übernahme**: eine abgelaufene Sperre kann von einem neuen Eigentümer übernommen werden
+
+## Schema
+
+```sql
+CREATE TABLE distributed_locks (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource    TEXT    NOT NULL UNIQUE,
+    owner       TEXT    NOT NULL,
+    expires_at  TEXT    NOT NULL,
+    acquired_at TEXT    NOT NULL
+);
+```
+
+Die `UNIQUE`-Constraint auf `resource` stellt sicher, dass nur eine Zeile pro Ressource existiert. Gleichzeitige INSERTs werden auf DB-Ebene serialisiert.
+
+## Aneignungslogik
+
+```php
+public function acquire(string $resource, string $owner, string $expiresAt, string $now): ?LockRecord
+{
+    $existing = $this->findByResource($resource);
+
+    if ($existing === null) {
+        // Keine Sperre — INSERT (kann bei Race scheitern; Aufrufer bekommt null und versucht erneut)
+        $this->executor->execute(
+            'INSERT INTO distributed_locks (resource, owner, expires_at, acquired_at) VALUES (?, ?, ?, ?)',
+            [$resource, $owner, $expiresAt, $now],
+        );
+        return $this->findByResource($resource);
+    }
+
+    if ($existing->isExpired($now) || $existing->owner === $owner) {
+        // Abgelaufen (veraltet) oder gleicher Eigentümer der wieder aneignet — UPDATE zum Übernehmen
+        $this->executor->execute(
+            'UPDATE distributed_locks SET owner = ?, expires_at = ?, acquired_at = ? WHERE resource = ?',
+            [$owner, $expiresAt, $now, $resource],
+        );
+        return $this->findByResource($resource);
+    }
+
+    // Wird von einem anderen Eigentümer gehalten und noch gültig — kann nicht angeeignet werden
+    return null;
+}
+```
+
+Rückgabewert-Konventionen:
+- Gibt einen `LockRecord` bei Erfolg zurück (`acquired: true` in der API-Antwort)
+- Gibt `null` zurück, wenn die Sperre von einem anderen Eigentümer gehalten wird (`acquired: false`)
+
+## Eigentümer-erzwungene Freigabe
+
+Nur der Eigentümer darf freigeben. 403 zurückzugeben (nicht 404), wenn der Eigentümer nicht übereinstimmt, teilt dem Aufrufer mit, dass die Sperre existiert, er sie aber nicht hält:
+
+```php
+return match ($result) {
+    ReleaseResult::Released  => $this->json->create([], 204),
+    ReleaseResult::NotFound  => $this->problems->create($request, 'not-found', 'Lock not found.', 404, ''),
+    ReleaseResult::Forbidden => $this->problems->create($request, 'forbidden', 'Owner mismatch.', 403, ''),
+};
+```
+
+## TTL-Erneuerung
+
+Lang laufende Tasks müssen ihre Sperre verlängern, bevor sie abläuft. Nur der aktuelle Eigentümer darf erneuern — eine Erneuerung durch einen falschen Eigentümer gibt 409 zurück (nicht 403), weil es einen Zustandskonflikt signalisiert, keine Berechtigungsverweigerung:
+
+```php
+if ($existing->isExpired($now)) {
+    return null; // → 409: abgelaufene Sperre kann nicht erneuert werden (jemand anderes hält sie möglicherweise jetzt)
+}
+if ($existing->owner !== $owner) {
+    return null; // → 409: falscher Eigentümer
+}
+// expires_at verlängern
+```
+
+## Erkennung veralteter Sperren
+
+`LockRecord::isExpired()` vergleicht die aktuelle Zeit mit `expires_at`:
+
+```php
+public function isExpired(string $now): bool
+{
+    return $now >= $this->expiresAt;
+}
+```
+
+Das bedeutet, `GET /locks/{resource}` gibt 404 für abgelaufene Sperren zurück (abgelaufene als nicht vorhanden behandelnd), und `POST /locks/{resource}` lässt einen neuen Eigentümer eine abgelaufene Sperre beanspruchen.
+
+## Designentscheidungen
+
+**Warum nicht Redis SETNX?**
+Redis bietet atomares SETNX mit TTL in einem einzigen Befehl und ist der Produktionsstandard für Hochdurchsatz-Sperrung. DB-gestützte Sperrung ist einfacher zu deployen (kein zusätzlicher Dienst), konsistent mit Ihren übrigen Transaktionsdaten und ausreichend für geringe bis mittlere Konkurrenzsituationen (Hintergrundjobs, Berichtserstellung, Batch-Verarbeitung).
+
+**Warum nicht DELETE+INSERT bei der Wiederaneignung?**
+UPDATE bewahrt die Zeilen-ID und ist atomar. DELETE+INSERT würde ein kurzes Zeitfenster erzeugen, in dem keine Sperrzeile existiert, was einem gleichzeitigen Prozess ermöglicht, INSERT auszuführen und die Sperre zu stehlen.
+
+**Warum `acquired_at` von `expires_at` trennen?**
+`acquired_at` ist der Zeitstempel, wann die Eigentumsrechte zuletzt eingerichtet wurden (nützlich für Audit). `expires_at` ändert sich bei der Erneuerung. Sie getrennt zu halten vermeidet Mehrdeutigkeit.
+
+**Nicht-blockierend per Design**
+Der Sperr-Endpunkt gibt sofort mit `acquired: false` zurück, anstatt zu blockieren, bis die Sperre verfügbar ist. Aufrufer implementieren ihre eigene Wiederholungsstrategie (exponentielles Backoff, Dead-Letter-Queue usw.) basierend auf ihren Timeout-Anforderungen.

--- a/docs/de/howto/document-template-engine.md
+++ b/docs/de/howto/document-template-engine.md
@@ -1,0 +1,11 @@
+# How-To: Dokument-Template-Engine
+
+Demonstriert Template-CRUD mit `{{Variable}}`-Substitution und admin-gesicherten Schreibvorgängen.
+Field Trial: FT197 (`../NENE2-FT/templatelog/`).
+
+## Muster-Zusammenfassung
+- `UNIQUE(name)`-Constraint auf Templates → 409 bei Duplikat
+- List-Endpunkt schließt `body` aus, um den Payload zu reduzieren
+- `POST /templates/{id}/render` akzeptiert ein `vars`-Objekt, substituiert `{{schlüssel}}`-Platzhalter
+- Unbekannte Variablen bleiben unverändert (kein Fehler)
+- Admin-Key sichert Create/Update/Delete; Rendern ist öffentlich

--- a/docs/de/howto/document-versioning.md
+++ b/docs/de/howto/document-versioning.md
@@ -1,0 +1,216 @@
+# How-to: Dokumentversionierungs-API
+
+> **FT-Referenz**: FT239 (`NENE2-FT/doclog`) — Dokumentversionierungs-API
+
+Demonstriert ein Append-only-Dokumentversionierungssystem, bei dem die aktuelle Version mit einem `is_current`-Flag verfolgt wird, ein Revert eine neue Version erstellt (nicht-destruktiv) und alle mehrstufigen Schreibvorgänge über `DatabaseTransactionManagerInterface` in Transaktionen eingeschlossen sind.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/documents` | Ein Dokument mit seiner ersten Version erstellen |
+| `GET`  | `/documents` | Dokumente auflisten (paginiert) mit aktueller Version |
+| `GET`  | `/documents/{id}` | Ein Dokument mit seiner aktuellen Version abrufen |
+| `GET`  | `/documents/{id}/versions` | Versionshistorie auflisten (paginiert) |
+| `POST` | `/documents/{id}/versions` | Eine neue Version hinzufügen |
+| `POST` | `/documents/{id}/revert/{version}` | Auf eine bestimmte Versionsnummer zurücksetzen |
+
+Statische Sub-Routen (`/documents/{id}/versions`) werden vor der parametrisierten Route `/documents/{id}` registriert, um korrektes Dispatching sicherzustellen.
+
+---
+
+## Schema: `is_current`-Flag-Muster
+
+```sql
+CREATE TABLE IF NOT EXISTS documents (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS document_versions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    content     TEXT    NOT NULL,
+    version_num INTEGER NOT NULL,
+    is_current  INTEGER NOT NULL DEFAULT 0 CHECK(is_current IN (0, 1)),
+    created_at  TEXT    NOT NULL,
+    UNIQUE(document_id, version_num)
+);
+CREATE INDEX IF NOT EXISTS idx_versions_document ON document_versions(document_id);
+```
+
+`is_current` ist ein boolesches Flag (0/1), gespeichert als INTEGER, eingeschränkt durch `CHECK`. Höchstens eine Zeile pro Dokument sollte `is_current = 1` haben. `UNIQUE(document_id, version_num)` verhindert doppelte Versionsnummern für dasselbe Dokument.
+
+**Vergleich mit `current_version` als Integer**: Der `is_current`-Flag-Ansatz vermeidet die Notwendigkeit, eine Spalte in der übergeordneten `documents`-Tabelle zu aktualisieren, wenn die Version wechselt. Das Flag wird direkt in der `document_versions`-Tabelle in derselben Transaktion umgeschaltet, die die neue Version einfügt.
+
+---
+
+## Aktuelle Version mit JOIN abrufen
+
+Die List- und Show-Abfragen verwenden einen `LEFT JOIN` gefiltert auf `is_current = 1`, um die aktuelle Version in einer einzigen Abfrage abzurufen:
+
+```php
+$row = $this->executor->fetchOne(
+    'SELECT d.*, dv.id AS vid, dv.content, dv.version_num, dv.is_current,
+            dv.created_at AS version_created_at
+     FROM documents d
+     LEFT JOIN document_versions dv ON dv.document_id = d.id AND dv.is_current = 1
+     WHERE d.id = ?',
+    [$id],
+);
+```
+
+`LEFT JOIN ... AND dv.is_current = 1` — die Join-Bedingung filtert auf die aktuelle Version. Ein Dokument ohne Versionen gibt eine `NULL`-Join-Zeile zurück, die als `currentVersion: null` hydriert wird.
+
+---
+
+## Version hinzufügen: Drei-Schritt-Transaktion
+
+Das Hinzufügen einer Version erfordert drei aufeinanderfolgende Operationen, eingeschlossen in eine Transaktion:
+
+```php
+public function addVersion(int $documentId, string $content, string $now): Document
+{
+    return $this->txManager->transactional(function (DatabaseQueryExecutorInterface $tx) use ($documentId, $content, $now): Document {
+        // Schritt 1: Nächste Versionsnummer berechnen
+        $maxRow     = $tx->fetchOne('SELECT MAX(version_num) AS max_ver FROM document_versions WHERE document_id = ?', [$documentId]);
+        $nextVerNum = ((int) ($maxRow['max_ver'] ?? 0)) + 1;
+
+        // Schritt 2: Aktuelle Version deaktivieren
+        $tx->execute('UPDATE document_versions SET is_current = 0 WHERE document_id = ? AND is_current = 1', [$documentId]);
+
+        // Schritt 3: Neue Version als aktuell einfügen
+        $versionId = $tx->insert(
+            'INSERT INTO document_versions (document_id, content, version_num, is_current, created_at) VALUES (?, ?, ?, 1, ?)',
+            [$documentId, $content, $nextVerNum, $now],
+        );
+
+        // Schritt 4: updated_at des Dokuments aktualisieren
+        $tx->execute('UPDATE documents SET updated_at = ? WHERE id = ?', [$now, $documentId]);
+        // ...
+    });
+}
+```
+
+`DatabaseTransactionManagerInterface::transactional()` schließt den Closure in eine Transaktion ein. Wenn ein Schritt eine Exception wirft, wird die Transaktion zurückgerollt. Der `$tx`-Parameter ist der auf die Transaktion begrenzte Executor — keine separate Verbindung erforderlich.
+
+---
+
+## Nicht-destruktives Zurücksetzen: Als neue Version kopieren
+
+Reverts ändern keine bestehende Historie — sie erstellen eine neue Version mit dem Inhalt der Zielversion:
+
+```php
+public function revertToVersion(int $documentId, int $versionNum, string $now): Document
+{
+    return $this->txManager->transactional(function (DatabaseQueryExecutorInterface $tx) use ($documentId, $versionNum, $now): Document {
+        $targetRow = $tx->fetchOne(
+            'SELECT * FROM document_versions WHERE document_id = ? AND version_num = ?',
+            [$documentId, $versionNum],
+        );
+
+        if ($targetRow === null) {
+            throw new VersionNotFoundException($documentId, $versionNum);
+        }
+
+        // Nächste Versionsnummer für die Revert-Kopie berechnen
+        $maxRow     = $tx->fetchOne('SELECT MAX(version_num) AS max_ver FROM document_versions WHERE document_id = ?', [$documentId]);
+        $nextVerNum = ((int) ($maxRow['max_ver'] ?? 0)) + 1;
+
+        // Aktuelle Version deaktivieren
+        $tx->execute('UPDATE document_versions SET is_current = 0 WHERE document_id = ? AND is_current = 1', [$documentId]);
+
+        // Kopie des Zielinhalts als neue aktuelle Version einfügen
+        $newVersionId = $tx->insert(
+            'INSERT INTO document_versions (document_id, content, version_num, is_current, created_at) VALUES (?, ?, ?, 1, ?)',
+            [$documentId, (string) $targetRow['content'], $nextVerNum, $now],
+        );
+        // ...
+    });
+}
+```
+
+Wenn ein Dokument bei Version 5 ist und auf Version 2 zurückgesetzt wird, wird Version 6 mit dem Inhalt von Version 2 erstellt. Die Historie ist:
+```
+v1 → v2 → v3 → v4 → v5 → v6 (Kopie von v2)
+```
+
+Dieser Ansatz bewahrt den vollständigen Audit-Trail — der Revert selbst ist in der Historie als neuer Eintrag sichtbar. Es ist unmöglich, Historie zu "verlieren".
+
+---
+
+## VersionNotFoundException mit strukturiertem Kontext
+
+`VersionNotFoundException` enthält sowohl die Dokument-ID als auch die Versionsnummer:
+
+```php
+final class VersionNotFoundException extends \RuntimeException
+{
+    public function __construct(int $documentId, int $versionNum)
+    {
+        parent::__construct("Version {$versionNum} not found for document {$documentId}.");
+    }
+}
+```
+
+Die Exception wird innerhalb des Transaktions-Closures geworfen. Der Exception-Handler bildet sie auf eine `404 Not Found`-Antwort ab. Da die Exception vor Schreiboperationen im Revert geworfen wird, wird die Transaktion sauber zurückgerollt.
+
+---
+
+## NENE2-Builtins: PaginationQueryParser und PaginationResponse
+
+List-Endpunkte verwenden NENE2's Paginierungs-Helfer:
+
+```php
+private function listDocuments(ServerRequestInterface $request): ResponseInterface
+{
+    $pagination = PaginationQueryParser::parse($request);
+    $items      = $this->repository->findAll($pagination->limit, $pagination->offset);
+    $total      = $this->repository->countAll();
+
+    $response = new PaginationResponse(
+        items: array_map($this->serializeDocument(...), $items),
+        limit: $pagination->limit,
+        offset: $pagination->offset,
+        total: $total,
+    );
+
+    return $this->json->create($response->toArray());
+}
+```
+
+`PaginationQueryParser::parse()` liest `?limit=` und `?offset=` aus den Query-Parametern mit sicheren Standardwerten und Grenzen. `PaginationResponse::toArray()` produziert einen konsistenten Envelope: `{ items, total, limit, offset }`.
+
+---
+
+## NENE2-Builtins: ValidationException und ValidationError
+
+Eingabevalidierung verwendet NENE2's strukturierte Validierungs-Helfer:
+
+```php
+$errors = [];
+if (!isset($body['title']) || !is_string($body['title']) || trim($body['title']) === '') {
+    $errors[] = new ValidationError('title', 'title is required.', 'required');
+}
+if (!isset($body['content']) || !is_string($body['content'])) {
+    $errors[] = new ValidationError('content', 'content is required.', 'required');
+}
+if ($errors !== []) {
+    throw new ValidationException($errors);
+}
+```
+
+`ValidationException` wird von NENE2's Error-Handler abgefangen und in eine `422 Unprocessable Entity` Problem Details-Antwort mit einem strukturierten `errors`-Array umgewandelt — identisch mit dem Aufruf von `ProblemDetailsResponseFactory::create()` mit `errors`-Erweiterung, aber über den Exception-basierten Pfad.
+
+---
+
+## Verwandte Anleitungen
+
+- [`content-versioning.md`](content-versioning.md) — Integer-basiertes current_version-Muster
+- [`audit-trail.md`](audit-trail.md) — Append-only-Historienmuster
+- [`transactions.md`](transactions.md) — DatabaseTransactionManagerInterface-Muster
+- [`use-transactions.md`](use-transactions.md) — Mehrstufige Schreibvorgänge einschließen

--- a/docs/de/howto/draft-publish-workflow.md
+++ b/docs/de/howto/draft-publish-workflow.md
@@ -1,0 +1,130 @@
+# How-to: Entwurf → Veröffentlichen → Archivieren-Workflow
+
+> **FT-Referenz**: FT305 (`NENE2-FT/draftlog`) — Artikel-Lebenszyklus-Zustandsmaschine: draft→published→archived Einweg-Übergänge, nur-Autor-Schreibzugriff, Nicht-Autoren sehen nur veröffentlichte Artikel (Entwürfe geben 404 zurück), veröffentlichte Artikel können nicht bearbeitet werden, veröffentlichte Liste schließt Entwürfe und archivierte aus, 20 Tests / 28 Assertions bestanden.
+
+Diese Anleitung zeigt, wie ein Inhaltslebenszyklus implementiert wird, bei dem Artikel als Entwürfe beginnen, veröffentlicht werden, um sichtbar zu werden, und archiviert werden können, um sie aus öffentlichen Auflistungen zu entfernen.
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    author_id    INTEGER NOT NULL,
+    title        TEXT    NOT NULL,
+    body         TEXT    NOT NULL DEFAULT '',
+    status       TEXT    NOT NULL DEFAULT 'draft',
+    published_at TEXT,
+    archived_at  TEXT,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL,
+    CHECK (status IN ('draft', 'published', 'archived')),
+    FOREIGN KEY (author_id) REFERENCES users(id)
+);
+```
+
+`CHECK (status IN (...))` stellt sicher, dass nur bekannte Zustände gespeichert werden. Die Zeitstempel `published_at` und `archived_at` protokollieren, wann Übergänge stattfanden.
+
+## Zustandsmaschine
+
+```
+draft ──(POST /publish)──▶ published ──(POST /archive)──▶ archived
+```
+
+| Übergang | Vorbedingung | Fehler bei Verletzung |
+|---|---|---|
+| draft → published | Status muss `'draft'` sein | 422 |
+| published → archived | Status muss `'published'` sein | 422 |
+| published → draft | ❌ nicht erlaubt | — |
+| archived → irgendetwas | ❌ nicht erlaubt | — |
+
+```php
+// Veröffentlichungs-Handler
+if ($article['status'] !== 'draft') {
+    return $this->responseFactory->create(['error' => 'only draft articles can be published'], 422);
+}
+
+// Archivierungs-Handler
+if ($article['status'] !== 'published') {
+    return $this->responseFactory->create(['error' => 'only published articles can be archived'], 422);
+}
+```
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/articles` | `X-User-Id` | Artikel erstellen (beginnt als Entwurf) |
+| `GET` | `/articles` | — | Nur veröffentlichte Artikel auflisten |
+| `GET` | `/articles/{id}` | `X-User-Id` | Artikel abrufen (Sichtbarkeitsprüfung) |
+| `PUT` | `/articles/{id}` | `X-User-Id` (Autor) | Entwurf aktualisieren (nur wenn Entwurf) |
+| `POST` | `/articles/{id}/publish` | `X-User-Id` (Autor) | Veröffentlichen |
+| `POST` | `/articles/{id}/archive` | `X-User-Id` (Autor) | Archivieren |
+
+## Neue Artikel beginnen als Entwurf
+
+```php
+$id = $this->repo->create($actorId, $title, $body);
+return $this->responseFactory->create(['id' => $id, 'status' => 'draft'], 201);
+```
+
+Der `status` ist bei der Erstellung immer `'draft'`, unabhängig von einem Body-Feld. Der Client kann den Anfangsstatus nicht wählen.
+
+## Sichtbarkeit — Nicht-Autoren sehen nur Veröffentlichtes
+
+```php
+// Nicht-Autoren können nur veröffentlichte Artikel sehen
+if ($article['status'] !== 'published' && (int) $article['author_id'] !== $actorId) {
+    return $this->responseFactory->create(['error' => 'not found'], 404);
+}
+```
+
+Nicht veröffentlichte Artikel (Entwurf oder archiviert) geben Nicht-Autoren 404 zurück. Dies verhindert:
+- Dass andere Benutzer unveröffentlichte Entwürfe lesen
+- Das Verraten, ob ein Artikel archiviert wurde
+
+## Veröffentlichte Artikel können nicht bearbeitet werden
+
+```php
+// Update-Handler — nur Entwürfe sind bearbeitbar
+if ($article['status'] !== 'draft') {
+    return $this->responseFactory->create(['error' => 'only draft articles can be edited'], 422);
+}
+if ((int) $article['author_id'] !== $actorId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+Nach der Veröffentlichung ist der Artikelinhalt eingefroren. Der Autor muss die Veröffentlichung aufheben (was hier nicht unterstützt wird), um zu bearbeiten — in diesem Design ist das Veröffentlichen ein Einweg-Gate.
+
+## List-Endpunkt — Nur veröffentlicht
+
+```php
+// Repository: SELECT WHERE status = 'published' ORDER BY published_at DESC
+$articles = $this->repo->listPublished();
+```
+
+Der List-Endpunkt filtert auf `status = 'published'`. Entwürfe und archivierte Artikel erscheinen nie in der öffentlichen Auflistung.
+
+## Nur-Autor-Aktionen
+
+Alle Schreibvorgänge (Aktualisieren, Veröffentlichen, Archivieren) prüfen, dass der Akteur der Autor des Artikels ist:
+
+```php
+if ((int) $article['author_id'] !== $actorId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Status im Create-Body erlauben | Client startet Artikel als `'published'` und umgeht den Review-Workflow |
+| 403 für Nicht-Autor-Entwurf-GET zurückgeben | Verrät, dass der Artikel existiert; 404 verwenden, um unveröffentlichten Inhalt zu verbergen |
+| Bearbeitung veröffentlichter Artikel erlauben | Ändert Live-Inhalte rückwirkend; verletzt das Leservertrauen |
+| archive → published-Übergang erlauben | Archivierte Artikel tauchen unerwartet wieder auf |
+| Entwürfe in öffentlicher Auflistung anzeigen | Unveröffentlichter Inhalt wird vor der Fertigstellung preisgegeben |
+| Kein `CHECK (status IN (...))` | Direkte DB-Inserts können beliebige Status-Strings setzen |
+| Archivierte Artikel geben Nicht-Autoren 200 zurück | Verrät Nicht-Autoren, dass Inhalt existiert hat und archiviert wurde |

--- a/docs/de/howto/dynamic-filter-query.md
+++ b/docs/de/howto/dynamic-filter-query.md
@@ -1,0 +1,291 @@
+# How-to: Dynamische Filter-Abfrage (Dynamische WHERE-Klausel)
+
+> **Verwandte Szenarien**: DX Szenario 03, 18, 22, 25, 29, 30, 33, 37, 38, 41, 47, 48 — die am häufigsten zitierte fehlende Anleitung in 50 DX-Szenarien.
+
+Viele List-Endpunkte akzeptieren optionale Query-Parameter, die in SQL-Bedingungen übersetzt werden.
+Die Hauptherausforderung: wenn ein Parameter fehlt (`null`), muss die Bedingung **vollständig übersprungen** werden — nicht gegen `NULL` in SQL verglichen.
+
+Diese Anleitung zeigt das kanonische Muster, das in NENE2-Anleitungen verwendet wird.
+
+---
+
+## Das Kernmuster: `$conditions`-Array + `implode`
+
+```php
+public function search(
+    ?string $status,
+    ?int    $categoryId,
+    ?string $keyword,
+): array {
+    $conditions = ['deleted_at IS NULL'];   // erforderliche Bedingung — immer enthalten
+    $bindings   = [];
+
+    if ($status !== null) {
+        $conditions[] = 'status = ?';
+        $bindings[]   = $status;
+    }
+
+    if ($categoryId !== null) {
+        $conditions[] = 'category_id = ?';
+        $bindings[]   = $categoryId;
+    }
+
+    if ($keyword !== null && $keyword !== '') {
+        $conditions[] = '(title LIKE ? OR description LIKE ?)';
+        $bindings[]   = "%{$keyword}%";
+        $bindings[]   = "%{$keyword}%";
+    }
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+
+    return $this->db->fetchAll(
+        "SELECT * FROM products {$where} ORDER BY created_at DESC",
+        $bindings,
+    );
+}
+```
+
+**Warum das funktioniert**:
+- `$conditions` hat immer mindestens ein Element (die erforderliche Bedingung), sodass `implode(' AND ', $conditions)` nie einen leeren String produziert.
+- Jeder optionale Block fügt sowohl das SQL-Fragment als auch seinen Bindungswert hinzu — sie bleiben synchron.
+- Wenn alle optionalen Parameter `null` sind, reduziert sich die Abfrage auf `WHERE deleted_at IS NULL`.
+
+---
+
+## Anti-Muster: `WHERE 1=1`
+
+Eine verbreitete Alternative ist `WHERE 1=1` als Startwert, dann immer `AND` anhängen:
+
+```php
+// Funktioniert, aber weniger klar:
+$where = 'WHERE 1=1';
+if ($status !== null) {
+    $where    .= ' AND status = ?';
+    $bindings[] = $status;
+}
+```
+
+Das funktioniert auch. Der `$conditions`-Array-Ansatz wird bevorzugt, weil er SQL-Fragmente sauber von ihren Bindungen trennt und es einfacher macht, jede Bedingung isoliert zu testen.
+
+---
+
+## Bereichsbedingungen: Min/Max-Filter
+
+Preisbereich, Datumsbereich und ähnliche `>=` / `<=` Filter:
+
+```php
+public function searchProperties(
+    ?int    $priceMin,
+    ?int    $priceMax,
+    ?int    $bedroomsMin,
+    ?string $dateFrom,
+    ?string $dateTo,
+): array {
+    $conditions = ['status = ?'];
+    $bindings   = ['available'];
+
+    if ($priceMin !== null) {
+        $conditions[] = 'price_yen >= ?';
+        $bindings[]   = $priceMin;
+    }
+
+    if ($priceMax !== null) {
+        $conditions[] = 'price_yen <= ?';
+        $bindings[]   = $priceMax;
+    }
+
+    if ($bedroomsMin !== null) {
+        $conditions[] = 'bedrooms >= ?';
+        $bindings[]   = $bedroomsMin;
+    }
+
+    if ($dateFrom !== null) {
+        $conditions[] = 'available_from >= ?';
+        $bindings[]   = $dateFrom;
+    }
+
+    if ($dateTo !== null) {
+        $conditions[] = 'available_from <= ?';
+        $bindings[]   = $dateTo;
+    }
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+
+    return $this->db->fetchAll(
+        "SELECT * FROM properties {$where} ORDER BY price_yen ASC",
+        $bindings,
+    );
+}
+```
+
+`min`- und `max`-Bedingungen separat statt `BETWEEN` verwenden — das ermöglicht es dem Client, nur eine Grenze anzugeben (z. B. "Preis bis 5M, keine Untergrenze").
+
+---
+
+## Enum / Allowlist-Filter
+
+Wenn ein Parameterwert aus einer festen Menge kommen muss, vor dem Hinzufügen zu `$conditions` validieren:
+
+```php
+private const VALID_STATUSES = ['draft', 'published', 'archived'];
+
+public function listByStatus(?string $status): array
+{
+    $conditions = ['deleted_at IS NULL'];
+    $bindings   = [];
+
+    if ($status !== null) {
+        if (!in_array($status, self::VALID_STATUSES, true)) {
+            throw new \InvalidArgumentException("Invalid status: {$status}");
+        }
+        $conditions[] = 'status = ?';
+        $bindings[]   = $status;
+    }
+
+    // ...
+}
+```
+
+`$status` **nicht** direkt in den SQL-String interpolieren, auch wenn es sicher aussieht. Immer einen Bind-Parameter (`?`) verwenden und PDO das Quoting überlassen.
+
+---
+
+## IN-Klausel: Multi-Wert-Filter
+
+Wenn der Client mehrere Werte übergeben kann (z. B. `?category_ids[]=1&category_ids[]=3`):
+
+```php
+public function filterByCategories(array $categoryIds): array
+{
+    if ($categoryIds === []) {
+        return $this->findAll();   // kein Filter — alles zurückgeben
+    }
+
+    $placeholders = implode(',', array_fill(0, count($categoryIds), '?'));
+
+    return $this->db->fetchAll(
+        "SELECT * FROM products WHERE category_id IN ({$placeholders}) ORDER BY created_at DESC",
+        $categoryIds,
+    );
+}
+```
+
+`array_fill(0, count($ids), '?')` generiert die korrekte Anzahl von `?`-Platzhaltern.
+Niemals `implode(',', $categoryIds)` verwenden, um einen `IN (1,2,3)`-String zu erstellen — das ist SQL-Injection.
+
+Für AND-Semantik (Elemente, die **alle** gegebenen Tags erfüllen), siehe [`multi-value-tag-filter.md`](multi-value-tag-filter.md).
+
+---
+
+## Sicheres ORDER BY: Allowlist-Interpolation
+
+`ORDER BY`-Spaltennamen **können keine** Bind-Parameter verwenden — sie müssen interpoliert werden.
+Immer gegen eine Allowlist validieren:
+
+```php
+private const SORT_COLUMNS  = ['name', 'price_yen', 'created_at'];
+private const SORT_DIRECTION = ['asc', 'desc'];
+
+public function list(?string $sortBy, ?string $order): array
+{
+    $col = in_array($sortBy, self::SORT_COLUMNS, true)  ? $sortBy : 'created_at';
+    $dir = in_array($order,  self::SORT_DIRECTION, true) ? $order  : 'desc';
+
+    $conditions = ['deleted_at IS NULL'];
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+
+    return $this->db->fetchAll(
+        "SELECT * FROM products {$where} ORDER BY {$col} {$dir}",
+        [],
+    );
+}
+```
+
+Für eine vollständige Behandlung der ORDER-BY-Injection-Prävention siehe [`dynamic-sort-order-injection.md`](dynamic-sort-order-injection.md).
+
+---
+
+## Filter mit Paginierung kombinieren
+
+Ein häufiges Muster — dynamischer Filter + Cursor- oder Offset-Paginierung:
+
+```php
+public function paginatedSearch(
+    ?string $status,
+    ?string $keyword,
+    int     $limit,
+    int     $offset,
+): array {
+    $conditions = ['deleted_at IS NULL'];
+    $bindings   = [];
+
+    if ($status !== null) {
+        $conditions[] = 'status = ?';
+        $bindings[]   = $status;
+    }
+
+    if ($keyword !== null && $keyword !== '') {
+        $conditions[] = 'title LIKE ?';
+        $bindings[]   = "%{$keyword}%";
+    }
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+
+    // Count-Abfrage verwendet dieselbe WHERE-Klausel
+    $total = (int) ($this->db->fetchOne(
+        "SELECT COUNT(*) AS cnt FROM products {$where}",
+        $bindings,
+    )['cnt'] ?? 0);
+
+    // Datenabfrage fügt LIMIT/OFFSET hinzu — NICHT zu $bindings vor COUNT hinzufügen
+    $rows = $this->db->fetchAll(
+        "SELECT * FROM products {$where} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+        [...$bindings, $limit, $offset],
+    );
+
+    return ['total' => $total, 'items' => $rows];
+}
+```
+
+Zuerst `$bindings` für die Filterbedingungen aufbauen, dann in die `COUNT`-Abfrage und die Datenabfrage einstreuen. `$limit` und `$offset` nur an die Datenabfrage anhängen.
+
+---
+
+## Optionale Query-Parameter parsen
+
+`QueryStringParser`-Helfer verwenden, um `null`-sichere typisierte Werte aus dem Request zu erhalten:
+
+```php
+use Nene2\Http\QueryStringParser;
+
+$status     = QueryStringParser::string($request, 'status');     // ?string
+$priceMin   = QueryStringParser::int($request, 'price_min');     // ?int
+$priceMax   = QueryStringParser::int($request, 'price_max');     // ?int
+$keyword    = QueryStringParser::string($request, 'q');          // ?string
+$sortBy     = QueryStringParser::string($request, 'sort');       // ?string
+$categoryId = QueryStringParser::int($request, 'category_id');   // ?int
+```
+
+Alle Helfer geben `null` zurück, wenn der Parameter fehlt oder nicht zum Zieltyp geparst werden kann. Diese nullable Werte direkt an die Repository-Methode übergeben — die Methode überspringt Bedingungen, bei denen der Wert `null` ist.
+
+---
+
+## Häufige Fehler
+
+| Fehler | Problem | Lösung |
+|---------|---------|-----|
+| `WHERE status = ?` mit `null`-Bindung | SQLite wertet `status = NULL` aus → immer false (sollte `IS NULL` sein) | Bedingung überspringen, wenn der Wert `null` ist; `IS NULL` nur verwenden, wenn explizit NULL-Zeilen gewünscht werden |
+| `WHERE 1=1` ohne erforderliche Bedingung | Gibt alle Zeilen zurück, wenn alle optionalen Parameter fehlen und kein Tenant/Owner-Filter vorhanden ist | Immer mindestens eine erforderliche Bedingung einschließen (Tenant, Owner, deleted_at) |
+| `$status` direkt interpolieren | SQL-Injection | Immer `?`-Bind-Parameter verwenden |
+| `IN (implode(',', $ids))` | SQL-Injection | `array_fill` + `?`-Platzhalter verwenden |
+| `LIMIT`/`OFFSET` vor `COUNT(*)` zu `$bindings` hinzufügen | COUNT bekommt falsche Ergebnisse | Zuerst Filter-`$bindings` aufbauen; in COUNT einstreuen, dann LIMIT/OFFSET für Datenabfrage anhängen |
+
+---
+
+## Verwandte Anleitungen
+
+- [`multi-value-tag-filter.md`](multi-value-tag-filter.md) — AND / OR Semantik für N:M-Tag-Filter (`HAVING COUNT(DISTINCT)`)
+- [`dynamic-sort-order-injection.md`](dynamic-sort-order-injection.md) — sicheres ORDER BY mit Allowlist
+- [`add-pagination.md`](add-pagination.md) — Kombination mit Offset- / Cursor-Paginierung
+- [`contact-management.md`](contact-management.md) — vollständiges Beispiel mit LIKE + EXISTS-Filter

--- a/docs/de/howto/dynamic-sort-order-injection.md
+++ b/docs/de/howto/dynamic-sort-order-injection.md
@@ -1,0 +1,189 @@
+# How-to: Dynamisches Sortieren & Filtern mit ORDER-BY-Injection-Prävention
+
+> **FT-Referenz**: FT341 (`NENE2-FT/sortlog`) — Dynamische Sort/Filter-API mit SQL-ORDER-BY-Injection-Prävention via Allowlist, Status-Filter-Allowlist, ReDoS-immune O(n)-Validierung, 40+ Tests für VULN-A bis VULN-L und ATK-01 bis ATK-12, alle bestanden.
+
+Diese Anleitung zeigt, wie ein sortierbarer, filterbarer List-Endpunkt sicher implementiert wird. Da `ORDER BY` in SQL keine parametrisierten Platzhalter verwenden kann, müssen Spalte und Richtung gegen eine strikte Allowlist validiert werden, bevor sie interpoliert werden.
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    status     TEXT    NOT NULL DEFAULT 'draft',
+    created_at TEXT    NOT NULL
+);
+```
+
+## Endpunkt
+
+```
+GET /articles?sort=created_at&order=desc&status=published&limit=20
+```
+
+### Gültige Parameter
+
+| Param | Erlaubte Werte | Standard |
+|-------|---------------|---------|
+| `sort` | `id`, `title`, `status`, `created_at` | `created_at` |
+| `order` | `asc`, `desc` | `desc` |
+| `status` | `draft`, `published`, `archived` | (alle) |
+| `limit` | 1–100 | 20 |
+
+## Antwort
+
+```php
+GET /articles?sort=title&order=asc&status=published
+→ 200
+{
+  "data": [
+    {"id": 2, "title": "Alpha", "status": "published", ...},
+    {"id": 1, "title": "Beta",  "status": "published", ...}
+  ],
+  "total": 2,
+  "sort": "title",
+  "order": "asc"
+}
+```
+
+## Allowlist-Validierung — Das einzig sichere Muster
+
+`ORDER BY`-Klauseln **können keine parametrisierten Bind-Werte verwenden**. Der Spaltenname muss direkt in SQL interpoliert werden. Das macht Allowlist-Validierung zwingend erforderlich.
+
+```php
+private const SORT_COLUMNS = ['id', 'title', 'status', 'created_at'];
+private const SORT_ORDERS  = ['asc', 'desc'];
+private const STATUSES     = ['draft', 'published', 'archived'];
+
+public function parseSort(string $sort, string $order): array
+{
+    // Exakter String-Abgleich in der Allowlist — O(n), case-sensitiv, kein Regex
+    if (!in_array($sort, self::SORT_COLUMNS, true)) {
+        throw new ValidationException("Invalid sort column: {$sort}");
+    }
+    if (!in_array($order, self::SORT_ORDERS, true)) {
+        throw new ValidationException("Invalid sort direction: {$order}");
+    }
+    return [$sort, $order];
+}
+
+public function parseStatus(?string $status): ?string
+{
+    if ($status === null) {
+        return null;  // kein Filter
+    }
+    if (!in_array($status, self::STATUSES, true)) {
+        throw new ValidationException("Invalid status: {$status}");
+    }
+    return $status;
+}
+```
+
+**Warum `in_array()` statt Regex:**
+- `in_array($v, $list, true)` ist O(n) — immun gegen ReDoS
+- Regex `/^[a-z_]+$/` auf angreifer-kontrollierten 50-Zeichen-Payloads kann katastrophales Backtracking verursachen
+- Striktes drittes Argument (`true`) aktiviert typensicheren Vergleich
+
+### Groß-/Kleinschreibungsempfindlichkeit
+
+Die Allowlist ist designbedingt case-sensitiv:
+
+```php
+GET /articles?sort=ID       → 422  // 'ID' nicht in der Allowlist
+GET /articles?sort=TITLE    → 422
+GET /articles?sort=Created_At → 422
+GET /articles?sort=created_at → 200  ✅ exakter Treffer
+```
+
+## Abfragekonstruktion
+
+```php
+$sql = 'SELECT * FROM articles';
+
+if ($status !== null) {
+    // Status verwendet einen parametrisierten Platzhalter (sicher)
+    $sql .= ' WHERE status = ?';
+    $params[] = $status;
+}
+
+// Sort-Spalte und Richtung kommen aus der Allowlist — sicher zu interpolieren
+$sql .= " ORDER BY {$sort} {$order}";
+$sql .= ' LIMIT ?';
+$params[] = $limit;
+```
+
+`ORDER BY` verwendet interpolierte Allowlist-Werte; `WHERE`-Klausel-Werte verwenden immer `?`-Platzhalter.
+
+## Abgelehnte Payloads
+
+### Injection-Muster → 422
+
+```php
+// SQL-Injection in sort
+?sort='; DROP TABLE articles--             → 422
+?sort=id UNION SELECT 1,2,3,4,5           → 422
+?sort=(SELECT name FROM sqlite_master)    → 422
+?sort=CASE WHEN 1=1 THEN id ELSE title END → 422
+?sort=created_at--                        → 422  // Kommentar
+?sort=created_at%00                       → 422  // Null-Byte
+?sort=1                                   → 422  // Spaltenindex (nicht in Allowlist)
+
+// Richtungs-Injection
+?order=asc; UNION SELECT 1,2,3--          → 422
+?order=DESC;                              → 422
+
+// Status-Filter-Injection
+?status=' OR '1'='1                       → 422
+?status=draft UNION SELECT 1,2--          → 422
+?status=1                                 → 422  // muss exakter Statusname sein
+?status=TRUE                              → 422
+
+// Whitespace-Umgehung
+?sort=created_at%09                       → 422  // TAB
+?sort= created_at                         → 422  // führendes Leerzeichen
+
+// Array-Injection (PSR-7)
+?sort[]=created_at                        → 422  // Array, kein String
+```
+
+### Limit-Injection → 422
+
+```php
+?limit=999999           → 422  // überschreitet MAX_LIMIT=100
+?limit=9999999999999999999999  → 422  // Überlauf (strlen > 18)
+?limit=-1               → 422  // negativ
+?limit=10.5             → 422  // Float
+```
+
+### Gültige Anfragen → 200
+
+```php
+GET /articles                                  → 200  // Standardwerte
+GET /articles?sort=title&order=asc             → 200
+GET /articles?sort=id&order=desc&status=draft  → 200
+GET /articles?limit=50                         → 200
+```
+
+## Timing-Sicherheit
+
+Jede Ablehnung ist augenblicklich (<100ms). Die Allowlist-Prüfung verwendet `in_array()`, das beim ersten Nicht-Treffer abbricht — kein Regex-Backtracking:
+
+```php
+// ReDoS-Payload: "aaaa...a!" (50 a's + '!')
+// in_array("aaaa...a!", ['id','title','status','created_at'], true) → sofort false
+```
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `?sort=` direkt interpolieren: `ORDER BY $sort` | SQL-Injection — Angreifer kontrolliert die `ORDER BY`-Klausel vollständig |
+| Nur mit Regex `/^[a-z_]+$/` validieren | ReDoS auf 50+-Zeichen-Payloads; erlaubt unbekannte Spaltennamen wie `password` |
+| Groß-/Kleinschreibungsinsensitiver Vergleich (`strcasecmp`) | `ORDER BY CREATED_AT` ist gültiges SQL, umgeht aber case-sensitive Tests |
+| `ORDER BY $sort` als Bind-Wert parametrisieren | Die meisten DB-Treiber behandeln es stillschweigend als Literal oder werfen einen Fehler |
+| Nur `sort`, nicht `order`-Richtung in Allowlist | `order=asc; UNION SELECT ...` umgeht die Spaltenprüfung |
+| `sort[]`-Array nach PSR-7-Parsing vertrauen | `implode(', ', $sort)` mit Array-Injection produziert Multi-Spalten-ORDER-BY |
+| `status`-Filter-Allowlist weglassen | `status=admin' OR '1'='1` wird zu `WHERE status = 'admin' OR '1'='1'` |

--- a/docs/de/howto/emoji-reaction-system.md
+++ b/docs/de/howto/emoji-reaction-system.md
@@ -1,0 +1,133 @@
+# Ein Emoji-Reaktionssystem mit NENE2 aufbauen
+
+Diese Anleitung führt durch den Aufbau eines Reaktionssystems, bei dem Benutzer auf Beiträge mit Emojis reagieren, mit gruppierten Zählungen und benutzerbasiertem Reaktions-Tracking.
+
+**Field Trial**: FT143  
+**NENE2-Version**: ^1.5  
+**Behandelte Themen**: UNIQUE(post_id, user_id, emoji)-Constraint, GROUP-BY-Emoji-Zählungen, benutzerbezogenes Reaktions-Tracking, Emoji-Längenvalidierung, MySQL-Integrationstests
+
+---
+
+## Was wir bauen
+
+- `POST /posts` — einen Beitrag erstellen
+- `POST /posts/{id}/reactions` — eine Reaktion hinzufügen (Emoji-String, eine pro Emoji pro Benutzer)
+- `DELETE /posts/{id}/reactions/{emoji}` — eine Reaktion entfernen (nur eigene)
+- `GET /posts/{id}/reactions` — Reaktionszählungen und die Reaktionen des aktuellen Benutzers abrufen
+
+---
+
+## Datenbankschema
+
+```sql
+CREATE TABLE reactions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    post_id    INTEGER NOT NULL,
+    user_id    INTEGER NOT NULL,
+    emoji      TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    UNIQUE (post_id, user_id, emoji),
+    FOREIGN KEY (post_id) REFERENCES posts(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`UNIQUE (post_id, user_id, emoji)` — eine Zeile pro Emoji pro Benutzer pro Beitrag. Derselbe Benutzer kann mit verschiedenen Emojis reagieren (👍 und ❤️ = 2 Zeilen). Mehrere Benutzer können dasselbe Emoji verwenden (jeder erhält seine eigene Zeile).
+
+---
+
+## Doppelte Reaktion → 409
+
+```php
+public function addReaction(int $postId, int $userId, string $emoji, string $now): bool
+{
+    try {
+        $this->executor->execute(
+            'INSERT INTO reactions (post_id, user_id, emoji, created_at) VALUES (?, ?, ?, ?)',
+            [$postId, $userId, $emoji, $now],
+        );
+        return true;
+    } catch (DatabaseConstraintException) {
+        return false;
+    }
+}
+```
+
+Der Handler gibt 409 zurück, wenn `addReaction()` `false` zurückgibt. Keine separate Existenzprüfung erforderlich.
+
+---
+
+## Gruppierte Reaktionszählungen mit GROUP BY
+
+```sql
+SELECT emoji, COUNT(*) as cnt
+FROM reactions
+WHERE post_id = ?
+GROUP BY emoji
+ORDER BY cnt DESC, emoji ASC
+```
+
+Sortiert nach Anzahl absteigend (beliebtestes Emoji zuerst), dann alphabetisch als Tiebreaker. Das Ergebnis wird direkt auf ein PHP-`array<string, int>` abgebildet:
+
+```php
+$counts = [];
+foreach ($rows as $row) {
+    $arr = (array) $row;
+    if (isset($arr['emoji']) && is_string($arr['emoji'])) {
+        $counts[$arr['emoji']] = isset($arr['cnt']) ? (int) $arr['cnt'] : 0;
+    }
+}
+```
+
+---
+
+## Reaktionen pro Benutzer (optionaler Akteur)
+
+Der `GET /reactions`-Endpunkt akzeptiert einen optionalen `X-User-Id`-Header. Wenn vorhanden, enthält die Antwort die Liste der Emojis, die der Aufrufer verwendet hat:
+
+```php
+$actorId       = (int) $request->getHeaderLine('X-User-Id');
+$userReactions = $actorId > 0 ? $this->repository->getUserReactions($postId, $actorId) : [];
+```
+
+Das ermöglicht es der UI, anzuzeigen, mit welchen Emojis der aktuelle Benutzer bereits reagiert hat.
+
+---
+
+## Emoji-Validierung
+
+```php
+if (mb_strlen($emoji) > 8) {
+    return $this->responseFactory->create(['error' => 'emoji too long'], 422);
+}
+```
+
+`mb_strlen` zählt Unicode-Codepunkte, nicht Bytes. Ein einzelnes Emoji wie 🧑‍💻 (Person: Technologe) sind 3 Codepunkte; ein 8-Zeichen-Limit deckt die meisten Emoji-Sequenzen ab. Den eigenen Anforderungen entsprechend anpassen.
+
+---
+
+## MySQL-Integrationstests (FT143)
+
+Die Reihenfolge beim MySQL-Teardown ist wichtig:
+
+```php
+$this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+$this->pdo->exec('DROP TABLE IF EXISTS reactions');
+$this->pdo->exec('DROP TABLE IF EXISTS posts');
+$this->pdo->exec('DROP TABLE IF EXISTS users');
+$this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+```
+
+Das MySQL-Schema verwendet `VARCHAR(32)` für Emoji (nicht `TEXT`), damit die Spalte in einem UNIQUE-Key ohne Präfixlänge verwendet werden kann. `VARCHAR(32)` speichert bis zu 32 Zeichen, was alle Emoji-Sequenzen abdeckt.
+
+---
+
+## Häufige Fallstricke
+
+| Fallstrick | Lösung |
+|---------|-----|
+| Doppelte Emoji-Reaktionen erlauben | `UNIQUE (post_id, user_id, emoji)` + `DatabaseConstraintException` abfangen |
+| `strlen()` für Emoji-Länge verwenden | `mb_strlen()` verwenden — Emojis sind Multi-Byte-Unicode |
+| Veränderliche Zählspalte wird nicht synchron | Aus der `reactions`-Tabelle mit `GROUP BY emoji` zählen |
+| Fehlende MySQL-Emoji-Unterstützung | `utf8mb4`-Charset und `VARCHAR` (nicht `CHAR`) für die Emoji-Spalte verwenden |
+| `is_array()` auf `fetchAll`-Ergebnis ist immer true | Prüfung weglassen; `fetchAll` gibt bereits `array<int, array<string, mixed>>` zurück |

--- a/docs/de/howto/emoji-reactions-api.md
+++ b/docs/de/howto/emoji-reactions-api.md
@@ -1,0 +1,103 @@
+# How-to: Emoji-Reaktions-API
+
+> **FT-Referenz**: FT306 (`NENE2-FT/emojilog`) — Emoji-Reaktionen: UNIQUE(post_id, user_id, emoji) erlaubt dasselbe Emoji von mehreren Benutzern, verhindert aber, dass ein Benutzer zweimal mit demselben Emoji reagiert, mb_strlen max 8 Zeichen, urldecode() für Emoji im DELETE-Pfad, user_reactions zeigt die Reaktionen des aktuellen Akteurs, Reaktionen geordnet nach Anzahl DESC, 18 Tests / 28 Assertions bestanden.
+
+Diese Anleitung zeigt, wie ein Emoji-Reaktionssystem implementiert wird, bei dem mehrere Benutzer auf einen Beitrag mit beliebigen Emojis reagieren können, aber jeder Benutzer ein gegebenes Emoji nur einmal pro Beitrag verwenden kann.
+
+## Schema
+
+```sql
+CREATE TABLE reactions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    post_id    INTEGER NOT NULL,
+    user_id    INTEGER NOT NULL,
+    emoji      TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    UNIQUE (post_id, user_id, emoji),
+    FOREIGN KEY (post_id) REFERENCES posts(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`UNIQUE(post_id, user_id, emoji)` erlaubt:
+- Gleiches Emoji von mehreren Benutzern: Alice und Bob können beide mit `👍` reagieren
+- Verschiedene Emojis vom gleichen Benutzer: Alice kann sowohl `👍` als auch `❤️` verwenden
+
+Verhindert aber:
+- Gleicher Benutzer + gleiches Emoji zweimal: Alice kann `👍` auf demselben Beitrag nicht zweimal verwenden
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `GET` | `/posts/{id}/reactions` | `X-User-Id` (optional) | Reaktionszählungen + Reaktionen des Akteurs abrufen |
+| `POST` | `/posts/{id}/reactions` | `X-User-Id` | Reaktion hinzufügen |
+| `DELETE` | `/posts/{id}/reactions/{emoji}` | `X-User-Id` | Reaktion entfernen |
+
+## Reaktion hinzufügen — Strikte Validierung
+
+```php
+if (!isset($body['emoji']) || !is_string($body['emoji']) || trim($body['emoji']) === '') {
+    return $this->responseFactory->create(['error' => 'emoji is required'], 422);
+}
+$emoji = trim($body['emoji']);
+if (mb_strlen($emoji) > 8) {
+    return $this->responseFactory->create(['error' => 'emoji too long'], 422);
+}
+
+$added = $this->repository->addReaction($postId, $actorId, $emoji, date('c'));
+if (!$added) {
+    return $this->responseFactory->create(['error' => 'already reacted with this emoji'], 409);
+}
+```
+
+- `is_string()`-Prüfung lehnt Nicht-String-Typen ab
+- `trim()` vor Leer-Prüfung verhindert nur-Leerzeichen-Emoji
+- `mb_strlen()` — nicht `strlen()` — für korrekte Multibyte-Zeichenzählung
+- Doppeltes Hinzufügen → 409 Conflict (nicht 422)
+
+## Reaktion entfernen — URL-Decode für Emoji im Pfad
+
+```php
+$emoji = isset($params['emoji']) && is_string($params['emoji']) ? urldecode($params['emoji']) : '';
+if ($emoji === '') {
+    return $this->responseFactory->create(['error' => 'invalid emoji'], 404);
+}
+```
+
+Emoji-Zeichen in URL-Pfadsegmenten müssen von Clients URL-kodiert werden. `urldecode()` stellt das ursprüngliche Emoji für die DB-Suche wieder her. Beispiel: `DELETE /posts/1/reactions/%F0%9F%91%8D` → sucht `👍`.
+
+## Reaktionszählungs-Antwort
+
+```php
+// Nach Emoji gruppieren, zählen, nach Anzahl DESC ordnen
+$counts = $this->repository->getReactionCounts($postId);
+
+// Wenn Akteur angegeben, anzeigen, welche Emojis er verwendet hat
+$userReactions = [];
+if ($actorId !== null) {
+    $userReactions = $this->repository->getUserReactions($postId, $actorId);
+}
+
+return $this->responseFactory->create([
+    'post_id'        => $postId,
+    'reactions'      => $counts,        // [{emoji, count}, ...] geordnet nach Anzahl DESC
+    'user_reactions' => $userReactions, // ['👍', '❤️', ...] für den aktuellen Akteur
+]);
+```
+
+`user_reactions` ist leer, wenn kein `X-User-Id`-Header angegeben wird — dieses Feld zeigt die Reaktionen des aktuellen Betrachters, um Frontends dabei zu helfen, aktive Reaktionen hervorzuheben.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `UNIQUE(post_id, user_id)` (keine Emoji-Spalte) | Ein Benutzer kann pro Beitrag immer nur ein Emoji verwenden |
+| `strlen()` für Emoji-Längenprüfung | Multi-Byte-Emoji wie `🎉` (4 Bytes) würden falsch gezählt |
+| Kein `urldecode()` für Pfad-Emoji | `👍` als `%F0%9F%91%8D` stimmt nie mit gespeichertem `👍` überein |
+| 404 bei doppelter Reaktion zurückgeben | Verbirgt die 409-Semantik — doppelte Reaktionen sind Konflikte, keine fehlenden Ressourcen |
+| Kein Emoji-Längenlimit | Beliebig lange Strings werden als Emoji-Spalte gespeichert |
+| Leere `user_reactions` bei keinem Akteur, aber Schlüssel trotzdem einschließen | Weglassen oder `[]` zurückgeben — beides ist in Ordnung, aber Verhalten dokumentieren |
+| `trim()` nach Leer-Prüfung | Nur-Leerzeichen-`"  "` Emoji passiert als gültig |

--- a/docs/de/howto/emoji-reactions-toggle.md
+++ b/docs/de/howto/emoji-reactions-toggle.md
@@ -1,0 +1,212 @@
+# How-to: Emoji-Reaktionen mit Toggle und gruppierten Zählungen
+
+> **FT-Referenz**: FT263 (`NENE2-FT/reactionlog`) — Emoji-Reaktionen: Toggle (Hinzufügen/Entfernen), gruppierte Zählungen, Reaktionsliste pro Benutzer
+
+Demonstriert eine Reaktions-API, bei der jeder Benutzer auf ein beliebiges Ziel (Beitrag, Kommentar usw.) mit beliebigen Emojis oder Reaktionstypen reagieren kann. Ein einziger `PUT`-Endpunkt schaltet die Reaktion um: fügt sie hinzu, wenn nicht vorhanden, entfernt sie, wenn bereits vorhanden. Gruppierte Zählungen pro Reaktionstyp werden in einer Zusammenfassungsabfrage zurückgegeben. Eine zusammengesetzte `UNIQUE`-Constraint erzwingt eine-Reaktion-pro-Benutzer-pro-Typ, und `DatabaseConstraintException` behandelt gleichzeitige Toggle-Race-Conditions.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|----------|------|-------------|
+| `PUT`    | `/reactions/{targetType}/{targetId}` | Eine Reaktion umschalten (hinzufügen oder entfernen) |
+| `DELETE` | `/reactions/{targetType}/{targetId}/{reactionType}` | Eine bestimmte Reaktion explizit entfernen |
+| `GET`    | `/reactions/{targetType}/{targetId}` | Reaktionszusammenfassung abrufen (gruppierte Zählungen) |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS reactions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    target_id     TEXT    NOT NULL,
+    target_type   TEXT    NOT NULL DEFAULT 'post',
+    reaction_type TEXT    NOT NULL,
+    user_id       TEXT    NOT NULL,
+    created_at    TEXT    NOT NULL,
+    UNIQUE(target_id, target_type, reaction_type, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reactions_target ON reactions (target_id, target_type);
+CREATE INDEX IF NOT EXISTS idx_reactions_user   ON reactions (user_id);
+```
+
+`UNIQUE(target_id, target_type, reaction_type, user_id)` erzwingt einen Eintrag pro eindeutiger (Ziel, Benutzer, Reaktion)-Kombination. Ein Versuch, ein Duplikat einzufügen, löst eine Constraint-Verletzung aus, die die Anwendung als `DatabaseConstraintException` abfängt.
+
+`target_type` ermöglicht es demselben Reaktionssystem, mehrere Entitätstypen (`post`, `comment`, `message`) ohne separate Tabellen zu bedienen.
+
+---
+
+## Toggle-Muster
+
+```php
+public function toggle(string $targetId, string $targetType, string $reactionType, string $userId): bool
+{
+    $existing = $this->db->fetchOne(
+        'SELECT id FROM reactions WHERE target_id = ? AND target_type = ? AND reaction_type = ? AND user_id = ?',
+        [$targetId, $targetType, $reactionType, $userId],
+    );
+
+    if ($existing !== null) {
+        $this->db->execute('DELETE FROM reactions WHERE id = ?', [(int) $existing['id']]);
+        return false;   // Reaktion wurde entfernt
+    }
+
+    $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+    try {
+        $this->db->execute(
+            'INSERT INTO reactions (target_id, target_type, reaction_type, user_id, created_at) VALUES (?, ?, ?, ?, ?)',
+            [$targetId, $targetType, $reactionType, $userId, $now],
+        );
+    } catch (DatabaseConstraintException) {
+        // Race Condition: gleichzeitiger Toggle vom gleichen Benutzer — als entfernt behandeln
+        return false;
+    }
+
+    return true;   // Reaktion wurde hinzugefügt
+}
+```
+
+**Ablauf**:
+1. `SELECT`, um zu prüfen, ob die Reaktion existiert.
+2. Wenn gefunden: `DELETE` → `false` zurückgeben (entfernt).
+3. Wenn nicht gefunden: `INSERT` → `true` zurückgeben (hinzugefügt).
+4. Wenn `INSERT` mit UNIQUE-Verletzung (`DatabaseConstraintException`) fehlschlägt: Eine gleichzeitige Anfrage hat dieselbe Zeile zwischen unserem `SELECT` und `INSERT` eingefügt. Als "entfernt" behandeln (der gleichzeitige Toggle hat gewonnen) → `false` zurückgeben.
+
+**Warum `SELECT` dann `INSERT`?** Eine Alternative ist `INSERT OR IGNORE` und Prüfen von `changes() == 0`, um den Fall zu erkennen, dass die Zeile bereits existierte. Der explizite `SELECT`-Ansatz macht die Absicht klarer und liefert einen saubereren Rückgabewert (hinzugefügt vs. entfernt) ohne eine nachfolgende Abfrage.
+
+---
+
+## Controller: 201 beim Hinzufügen, 200 beim Entfernen
+
+```php
+$added = $this->repo->toggle($targetId, $targetType, $reactionType, $userId);
+
+return $this->json->create([
+    'target_id'     => $targetId,
+    'target_type'   => $targetType,
+    'reaction_type' => $reactionType,
+    'user_id'       => $userId,
+    'added'         => $added,
+], $added ? 201 : 200);
+```
+
+`201 Created` wenn die Reaktion hinzugefügt wird; `200 OK` wenn sie entfernt wird. Das `added`-Feld im Response-Body ermöglicht es Clients, die beiden Fälle ohne Prüfung des Statuscodes zu unterscheiden.
+
+**Warum `PUT` für Toggle?** `PUT` ist laut HTTP-Semantik idempotent. Ein Einzelbenutzer-Toggle ist in seiner Wirkung idempotent (zwei identische `PUT`s kehren zum Ursprungszustand zurück). Alternativ ist `POST` für einen nicht-idempotenten Toggle akzeptabel; die Wahl hängt von der Team-Konvention ab.
+
+---
+
+## Gruppierte Zählungszusammenfassung
+
+```php
+public function summary(string $targetId, string $targetType, ?string $userId): ReactionSummary
+{
+    $rows = $this->db->fetchAll(
+        'SELECT reaction_type, COUNT(*) AS cnt
+           FROM reactions
+          WHERE target_id = ? AND target_type = ?
+          GROUP BY reaction_type
+          ORDER BY cnt DESC',
+        [$targetId, $targetType],
+    );
+
+    $counts = [];
+    $total  = 0;
+    foreach ($rows as $row) {
+        $counts[(string) $row['reaction_type']] = (int) $row['cnt'];
+        $total += (int) $row['cnt'];
+    }
+
+    $userReactions = [];
+    if ($userId !== null) {
+        $userRows = $this->db->fetchAll(
+            'SELECT reaction_type FROM reactions WHERE target_id = ? AND target_type = ? AND user_id = ? ORDER BY created_at ASC',
+            [$targetId, $targetType, $userId],
+        );
+        $userReactions = array_map(fn (array $r) => (string) $r['reaction_type'], $userRows);
+    }
+
+    return new ReactionSummary($targetId, $targetType, $counts, $total, $userReactions);
+}
+```
+
+Zwei Abfragen:
+1. Gruppierte Zählungen: `GROUP BY reaction_type ORDER BY cnt DESC` — beliebteste zuerst.
+2. Pro-Benutzer-Reaktionen (wenn `$userId` angegeben): welche Reaktionstypen dieser Benutzer angewendet hat.
+
+`ORDER BY cnt DESC` stellt die am häufigsten verwendeten Reaktionen an erste Stelle, was typischer Anzeigepriorität entspricht.
+
+---
+
+## Beispiel-Zusammenfassungsantwort
+
+**Anfrage**: `GET /reactions/post/42?user_id=alice`
+
+```json
+{
+  "target_id": "42",
+  "target_type": "post",
+  "counts": {
+    "👍": 15,
+    "❤️": 8,
+    "😂": 3
+  },
+  "total": 26,
+  "user_reactions": ["👍"]
+}
+```
+
+`counts` ist eine Abbildung von Reaktionstyp auf Zählung. `user_reactions` ist die Liste der Reaktionen, die `alice` angewendet hat. Der Client kann `👍` hervorheben, um Alices aktive Reaktion anzuzeigen.
+
+---
+
+## Expliziter Entfernen-Endpunkt
+
+```php
+public function remove(string $targetId, string $targetType, string $reactionType, string $userId): bool
+{
+    $count = $this->db->execute(
+        'DELETE FROM reactions WHERE target_id = ? AND target_type = ? AND reaction_type = ? AND user_id = ?',
+        [$targetId, $targetType, $reactionType, $userId],
+    );
+    return $count > 0;
+}
+```
+
+`DELETE /reactions/{targetType}/{targetId}/{reactionType}` mit `user_id` im Body entfernt eine bestimmte Reaktion ohne Toggle-Semantik. Nützlich, wenn der Client einen bestimmten Reaktionstyp entfernen möchte, unabhängig vom aktuellen Zustand.
+
+Gibt 404 zurück, wenn keine passende Reaktion gefunden wurde (`$count == 0`).
+
+---
+
+## Zusammengesetzte UNIQUE-Constraint als Sicherheitsnetz
+
+Die `UNIQUE(target_id, target_type, reaction_type, user_id)`-Constraint:
+- **Primäre Durchsetzung**: verhindert doppelte Reaktionen auf DB-Ebene.
+- **Sekundärer Vorteil**: fängt Race Conditions ab, die an der `SELECT`-Prüfung vorbeischlüpfen.
+- **Anwendungslogik**: `toggle()` fängt `DatabaseConstraintException` ab und behandelt sie als Entfernung.
+
+Ohne die Constraint würde ein Race zwischen zwei gleichzeitigen `PUT`-Anfragen vom gleichen Benutzer zwei identische Zeilen einfügen. Die Constraint + Exception-Handler bewahren die Invariante (eine Zeile pro Benutzer pro Reaktionstyp) auch unter Nebenläufigkeit.
+
+---
+
+## Designentscheidungen
+
+| Entscheidung | Wahl | Begründung |
+|---|---|---|
+| Toggle-Endpunkt | `PUT` | Semantisch angemessen; idempotent |
+| Reaktionsidentität | 4-Spalten-Composite-Key | Keine separate Reaktionstyp-Tabelle erforderlich |
+| `target_type` | PATH-Parameter | Ermöglicht einem Endpunkt, mehrere Entitätstypen zu bedienen |
+| `user_id` im Request-Body | Pflichtfeld | Vermeidet Auth-Middleware für dieses FT |
+| `user_id` in der Zusammenfassung | Query-Parameter | Optional — Zusammenfassung ist öffentlich; Pro-Benutzer-Detail ist opt-in |
+
+---
+
+## Verwandte Anleitungen
+
+- [`multi-value-tag-filter.md`](multi-value-tag-filter.md) — M:N-Join-Tabelle mit INSERT OR IGNORE für Tag-Deduplizierung
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — zusammengesetzte Unique-Keys als DB-Level-Sicherheitsnetze
+- [`transaction-scope-pattern.md`](transaction-scope-pattern.md) — atomare Operationen, wenn mehrere Schreibvorgänge zusammen gelingen oder scheitern müssen

--- a/docs/de/howto/encrypted-field-storage.md
+++ b/docs/de/howto/encrypted-field-storage.md
@@ -1,0 +1,357 @@
+# Verschlüsselte Feldspeicherung aufbauen
+
+> **FT-Referenz**: FT267 (`NENE2-FT/encryptlog`) — AES-256-GCM-Feldverschlüsselung: Verschlüsselung beim Schreiben / Entschlüsselung beim Lesen, Blind-Index für durchsuchbaren Chiffretext, Schlüsseltrennung zwischen Verschlüsselung und Index-Schlüsseln
+>
+> **VULN-Bewertung**: V-01 bis V-10 am Ende dieses Dokuments.
+>
+> **Muster auch belegt durch FT187 encryptlog** — AES-256-GCM-Pro-Feld-Verschlüsselung mit HMAC-SHA256-Blind-Index für durchsuchbare PII-Speicherung.
+
+---
+
+## Was abgedeckt wird
+
+Sensible Felder (Name, E-Mail, SSN, Kreditkarte) verschlüsselt im Ruhezustand speichern, während sie durchsuchbar bleiben:
+
+1. **AES-256-GCM** — authentifizierte Verschlüsselung; jeder Eintrag erhält seinen eigenen Nonce
+2. **Blind-Index** — HMAC-SHA256 des Feldwerts ermöglicht `WHERE email_idx = ?` ohne Entschlüsselung
+3. **AEAD-Manipulationserkennung** — Tag-Mismatch verursacht `\RuntimeException`, nicht 400
+4. **Chiffretext niemals in API-Antworten** — die VO / toArray()-Schicht gibt immer Klartext zurück
+5. **IDOR-Prävention** — alle Lese-/Schreibvorgänge begrenzen `WHERE id AND user_id`
+
+---
+
+## Chiffretext-Format
+
+```
+base64( nonce ‖ ciphertext ‖ tag )
+```
+
+| Komponente | Größe | Zweck |
+|---|---|---|
+| `nonce` | 12 Bytes | Zufälliger Pro-Verschlüsselung-IV (GCM-Standard) |
+| `ciphertext` | variabel | AES-256-GCM-verschlüsselter Klartext |
+| `tag` | 16 Bytes | Authentifizierungs-Tag — erkennt Manipulation |
+
+Als einzelne `TEXT`-Spalte gespeichert. Gleicher Klartext → jedes Mal anderer Chiffretext (anderer Nonce).
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE vault_records (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    name_enc   TEXT    NOT NULL,   -- base64(nonce || ciphertext || tag)
+    email_enc  TEXT    NOT NULL,
+    email_idx  TEXT    NOT NULL,   -- HMAC-SHA256 Blind-Index für die Suche
+    notes_enc  TEXT,               -- nullbares verschlüsseltes Feld
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+CREATE INDEX idx_vault_email ON vault_records(email_idx);
+```
+
+`email_idx` hat einen Index — `WHERE email_idx = ?` ist schnell. Der `email_enc`-Chiffretext wird niemals durchsucht.
+
+---
+
+## FieldCrypto-Helfer
+
+```php
+final readonly class FieldCrypto
+{
+    private const string ALGO      = 'aes-256-gcm';
+    private const int    TAG_LEN   = 16;
+    private const int    NONCE_LEN = 12;
+
+    public function __construct(
+        private string $encKey,   // muss 32 Bytes sein
+        private string $indexKey, // muss 32 Bytes sein
+    ) {
+        if (strlen($this->encKey) !== 32) {
+            throw new \InvalidArgumentException('encKey must be exactly 32 bytes.');
+        }
+    }
+
+    public function encrypt(string $plaintext): string
+    {
+        $nonce = random_bytes(self::NONCE_LEN); // frischer Pro-Wert-IV
+        $tag   = '';
+        $ct    = openssl_encrypt(
+            $plaintext, self::ALGO, $this->encKey,
+            OPENSSL_RAW_DATA, $nonce, $tag, '', self::TAG_LEN,
+        );
+
+        return base64_encode($nonce . $ct . $tag);
+    }
+
+    public function decrypt(string $encoded): string
+    {
+        $raw  = base64_decode($encoded, strict: true);
+        $nonce = substr($raw, 0, self::NONCE_LEN);
+        $tag   = substr($raw, -self::TAG_LEN);
+        $ct    = substr($raw, self::NONCE_LEN, strlen($raw) - self::NONCE_LEN - self::TAG_LEN);
+
+        $pt = openssl_decrypt($ct, self::ALGO, $this->encKey, OPENSSL_RAW_DATA, $nonce, $tag);
+
+        if ($pt === false) {
+            throw new \RuntimeException('Decryption failed — tag mismatch or corrupt ciphertext.');
+        }
+
+        return $pt;
+    }
+
+    /**
+     * Deterministisch — gleiche Eingabe immer → gleiche Ausgabe.
+     * Ermöglicht WHERE email_idx = ? ohne gespeicherten Chiffretext zu entschlüsseln.
+     */
+    public function blindIndex(string $plaintext): string
+    {
+        return hash_hmac('sha256', $plaintext, $this->indexKey);
+    }
+}
+```
+
+---
+
+## Kernmuster: Schreiben verschlüsselt, Lesen entschlüsselt
+
+```php
+// CREATE — alle sensiblen Felder vor INSERT verschlüsseln
+public function create(int $userId, string $name, string $email, ?string $notes): VaultRecord
+{
+    $stmt->execute([
+        'name_enc'  => $this->crypto->encrypt($name),
+        'email_enc' => $this->crypto->encrypt($email),
+        'email_idx' => $this->crypto->blindIndex($email), // deterministisch für die Suche
+        'notes_enc' => $notes !== null ? $this->crypto->encrypt($notes) : null,
+        // ...
+    ]);
+}
+
+// READ — beim Hydratisieren transparent entschlüsseln
+private function hydrateRow(array $row): VaultRecord
+{
+    return new VaultRecord(
+        name:  $this->crypto->decrypt((string) $row['name_enc']),
+        email: $this->crypto->decrypt((string) $row['email_enc']),
+        notes: $row['notes_enc'] !== null
+            ? $this->crypto->decrypt((string) $row['notes_enc'])
+            : null,
+        // ...
+    );
+}
+```
+
+---
+
+## Kernmuster: Blind-Index-Suche
+
+```php
+// SUCHE — Blind-Index aus Query-Parameter berechnen, keine Zeilen beim Suchen entschlüsseln
+public function findByEmail(int $userId, string $email): array
+{
+    $idx  = $this->crypto->blindIndex($email); // gleicher Schlüssel → gleicher Index
+    $stmt = $this->pdo->prepare(
+        'SELECT * FROM vault_records WHERE user_id = :user_id AND email_idx = :idx',
+    );
+    $stmt->execute(['user_id' => $userId, 'idx' => $idx]);
+    // Zeilen werden dann in hydrateRow() entschlüsselt
+}
+```
+
+**Wenn E-Mail beim Update ändert, neu indizieren:**
+
+```php
+$stmt->execute([
+    'email_enc' => $this->crypto->encrypt($newEmail),
+    'email_idx' => $this->crypto->blindIndex($newEmail), // ← muss zusammen aktualisiert werden
+]);
+```
+
+---
+
+## Kernmuster: Chiffretext niemals in Antworten
+
+```php
+// VaultRecord::toArray() — gibt nur entschlüsselten Klartext zurück
+public function toArray(): array
+{
+    return [
+        'id'         => $this->id,
+        'name'       => $this->name,  // Klartext
+        'email'      => $this->email, // Klartext
+        'notes'      => $this->notes, // Klartext oder null
+        'created_at' => $this->createdAt,
+        'updated_at' => $this->updatedAt,
+        // name_enc, email_enc, email_idx, notes_enc — niemals preisgegeben
+    ];
+}
+```
+
+Ein Angreifer, der die API-Antwort liest, kann keinen Chiffretext für Offline-Angriffe extrahieren.
+
+---
+
+## Kernmuster: Manipulationserkennung ist ein 500
+
+```php
+$pt = openssl_decrypt($ct, self::ALGO, $this->encKey, OPENSSL_RAW_DATA, $nonce, $tag);
+
+if ($pt === false) {
+    // Tag-Mismatch = manipulierte DB-Zeile ODER falscher Schlüssel
+    // Werfen — globalen Error-Handler 500 zurückgeben lassen
+    // KEIN 400 zurückgeben — ein 400 ist ein Client-Fehler; dies ist ein internes Integritätsproblem
+    throw new \RuntimeException('Decryption failed.');
+}
+```
+
+400 zurückzugeben würde implizieren, dass der Client schlechte Daten gesendet hat. Ein 500 signalisiert korrekt "server-seitiges Integritätsproblem" und verrät nicht, welches Feld fehlgeschlagen ist oder warum.
+
+---
+
+## Schlüsselverwaltungsrichtlinien
+
+```php
+// Produktion: Schlüssel von einem KMS oder Secret-Manager ableiten
+$encKey   = random_bytes(32); // 32 Bytes = AES-256
+$indexKey = random_bytes(32); // separater Schlüssel — andere HMAC-Domain
+
+// Schlüssel NIEMALS in Quellcode hartcodieren; Env-Vars oder Key-Ableitung verwenden:
+$encKey   = hex2bin(getenv('VAULT_ENC_KEY'));   // 64 Hex-Zeichen → 32 Bytes
+$indexKey = hex2bin(getenv('VAULT_INDEX_KEY')); // 64 Hex-Zeichen → 32 Bytes
+```
+
+**Zwei separate Schlüssel:**
+- `encKey` — AES-256-GCM. Rotierbar: Zeilen mit neuem Schlüssel neu verschlüsseln, Versions-Präfix aktualisieren.
+- `indexKey` — HMAC-SHA256. Kann nicht rotiert werden, ohne alle Indizes neu zu hashen.
+
+---
+
+## Testergebnisse (FT187)
+
+```
+51 Tests / 110 Assertions — alle bestanden
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+```
+
+| Testbereich | Abdeckung |
+|---|---|
+| FieldCrypto-Unit | Verschlüssel/Entschlüssel-Roundtrip, Nonce-Einzigartigkeit, Blind-Index-Determinismus, Manipulationserkennung, Kurz-Schlüssel-Ablehnung |
+| Happy Path | create/get/list/update/delete/search |
+| Chiffretext-Isolation | `name_enc`, `email_enc`, `email_idx`, `notes_enc` nicht in der Antwort |
+| IDOR-Prävention | Cross-User get/update/delete geben alle 404 zurück |
+| Mass-Assignment | `name_enc`, `email_idx`, `user_id` aus Body ignoriert |
+| Validierung | fehlender/langer/falscher-Typ name, email, notes, limit |
+| Blind-Index-Neuindizierung | E-Mail-Update hält Index synchron |
+
+---
+
+## VULN-Bewertung (FT267)
+
+Sicherheitsbewertung von `NENE2-FT/encryptlog` unter dem Feldverschlüsselungs-Bedrohungsmodell.
+
+### V-01 — Schlüsselverwaltung: Env-Laden ✅ BLOCKED
+
+**Bedrohung**: Verschlüsselungsschlüssel, die ins VCS eingecheckt oder im Quellcode hartcodiert sind.
+**Gegenmaßnahme**: Schlüssel werden über `getenv()` in `ConfigLoader` geladen, Länge wird beim Booten validiert. Die `.env`-Datei ist in .gitignore. Kein Schlüsselmaterial erscheint im Quellcode.
+**Verbleibendes Risiko**: Schlüsselrotation (beide Schlüssel ersetzen, alle Zeilen neu verschlüsseln) ist nicht implementiert. Für FT-Umfang akzeptiert; Produktionssystem braucht einen Rotationsplan.
+
+---
+
+### V-02 — Nonce-Wiederverwendung (GCM) ✅ BLOCKED
+
+**Bedrohung**: Wenn derselbe Nonce jemals zweimal unter demselben Schlüssel verwendet wird, verliert GCM alle Vertraulichkeits- und Authentizitätsgarantien.
+**Gegenmaßnahme**: `random_bytes(12)` wird bei jeder `encrypt()`-Ausführung aufgerufen. Der 96-Bit-Nonce-Raum und `random_bytes()` machen die Kollisionswahrscheinlichkeit für jedes realistische Nutzungsvolumen vernachlässigbar (< 2^32 Verschlüsselungen pro Schlüssellebensdauer ist die sichere Grenze).
+**Befund**: Sicher.
+
+---
+
+### V-03 — Authentifizierungs-Tag-Verifizierung ✅ BLOCKED
+
+**Bedrohung**: Chiffretext-Manipulation bleibt unerkannt; Angreifer dreht Bits, um entschlüsselten Klartext zu manipulieren.
+**Gegenmaßnahme**: `openssl_decrypt()` verifiziert den 16-Byte-GCM-Authentifizierungs-Tag vor der Rückgabe von Klartext. Jede Ein-Bit-Änderung gibt `false` zurück, was `FieldCrypto::decrypt()` in eine geworfene `\RuntimeException` umwandelt. Die Anwendung fängt sie ab und gibt `500` zurück; kein partieller Klartext wird preisgegeben.
+**Befund**: Sicher.
+
+---
+
+### V-04 — API-Antwort verrät Entschlüsselungsfehler-Detail ⚠️ EXPOSED
+
+**Bedrohung**: Error-Handler serialisiert `\RuntimeException::getMessage()` ("Decryption failed — tag mismatch or corrupt ciphertext.") in die API-Antwort und verrät ein Integritätssignal an Angreifer.
+**Befund**: Im `APP_DEBUG=true`-Modus kann die vollständige Nachricht und Stack Trace auftauchen. Im `APP_DEBUG=false`-Modus kann der Standard-Handler noch den Exception-Klassennamen preisgeben.
+**Empfehlung**: Einen dedizierten `DecryptionFailedExceptionHandler` hinzufügen, der unabhängig vom Debug-Modus auf `500` mit einem generischen `"internal-error"` Problem Details-Body abbildet. Tag-Verifizierungsfehler sollten nur server-seitig protokolliert werden.
+
+---
+
+### V-05 — Blind-Index-Kollision / Offline-Wörterbuch ✅ BLOCKED
+
+**Bedrohung**: Angreifer erstellt offline ein Wörterbuch von `blindIndex(candidate)`-Werten und vergleicht es mit der `email_idx`-Spalte.
+**Gegenmaßnahme**: HMAC-SHA256 mit einem 256-Bit-Geheimschlüssel. Ohne `VAULT_INDEX_KEY` ist die Vorberechnung eines Index-Werts rechnerisch nicht machbar. Der Blind-Index unterstützt nur Exakt-Match (`WHERE email_idx = ?`); Wildcard- oder Substring-Suche ist nicht möglich.
+**Verbleibendes Risiko**: Wenn `VAULT_INDEX_KEY` kompromittiert ist, werden alle E-Mail-Blind-Indizes für eine endliche bekannte E-Mail-Liste brute-forcierbar. Die Schlüsselvertraulichkeit ist unerlässlich.
+
+---
+
+### V-06 — Keine Authentifizierung / Autorisierung auf Endpunkten ⚠️ EXPOSED
+
+**Bedrohung**: Jeder unauthentifizierte Aufrufer kann Vault-Einträge für beliebige `user_id`-Werte erstellen, lesen, aktualisieren und löschen.
+**Befund**: Das FT gibt `/vault/{userId}/records` ohne API-Key, JWT oder Session-Prüfung frei. Der `user_id`-Pfadparameter wird vom Aufrufer angegeben.
+**Empfehlung**: Authentifizierung (API-Key oder JWT) voraussetzen und `$userId` aus dem verifizierten Token ableiten — niemals einer aufrufer-gelieferten `user_id` vertrauen. `requireScope()` oder eine äquivalente Auth-Middleware hinzufügen.
+**FT-Hinweis**: Absichtliche Umfangsbeschränkung für das FT. Produktionsnutzung erfordert Auth.
+
+---
+
+### V-07 — IDOR bei Update / Delete ✅ BLOCKED
+
+**Bedrohung**: Authentifizierter-aber-falscher Benutzer modifiziert den verschlüsselten Eintrag eines anderen Benutzers.
+**Gegenmaßnahme**: Alle Schreibabfragen enthalten `AND user_id = :user_id`. Wenn der Eintrag einem anderen Benutzer gehört, gibt `rowCount()` 0 zurück und der Controller gibt 404 zurück. Der Angreifer erfährt nur, dass der Eintrag (für ihn) nicht existiert.
+**Befund**: Sicher, vorausgesetzt Authentifizierung ist vorhanden (siehe V-06).
+
+---
+
+### V-08 — Schlüsselrotation / Re-Verschlüsselungs-Lücke ⚠️ EXPOSED
+
+**Bedrohung**: Wenn `VAULT_ENC_KEY` rotiert wird, kann alter Chiffretext, der unter dem vorherigen Schlüssel verschlüsselt wurde, nicht entschlüsselt werden. Es gibt keine Re-Verschlüsselungs-Migrationsstrategie.
+**Befund**: Keine Schlüssel-Versionierung, kein Re-Verschlüsselungs-Tool und keine dokumentierte Migration.
+**Empfehlung**: Jedem verschlüsselten Blob ein Schlüssel-Versions-Byte voranstellen (z. B. `v1:<base64>`). Beim Entschlüsseln Version lesen, Schlüssel auswählen. Ein Migrationsskript bereitstellen, das unter dem alten Schlüssel entschlüsselt und unter dem neuen Schlüssel in einer Transaktion neu verschlüsselt.
+
+---
+
+### V-09 — Blind-Index-Timing-Vergleich ✅ BLOCKED
+
+**Bedrohung**: Der Vergleich von `email_idx` aus einer nicht vertrauenswürdigen Quelle mit `===` verrät zeichenweises Timing.
+**Gegenmaßnahme**: `findByEmail()` übergibt den berechneten Blind-Index als SQL-Parameter. Der Vergleich erfolgt innerhalb von SQLites B-Tree-Index-Suche, was kein Timing-Orakel von der PHP-Seite ist. Kein PHP-seitiger String-Vergleich von Blind-Index-Werten findet statt.
+**Befund**: Sicher.
+
+---
+
+### V-10 — Entschlüsselte Daten im Speicher / in Logs ⚠️ EXPOSED
+
+**Bedrohung**: Entschlüsselter Klartext (Name, E-Mail, Notizen) erscheint in: PHP-Exception-Traces, Request-Logging-Middleware (wenn Body protokolliert wird), Fehlerausgabe, APM-Spans.
+**Befund**: Request-Body-Logging-Middleware protokolliert den POST-Body vor der Verschlüsselung — Klartext-Felder sind im Log. Wenn `VaultRecord` in einem Exception-Kontext enthalten ist, erscheinen entschlüsselte Felder im Stack-Trace.
+**Empfehlung**:
+1. Klartext-Vault-Payloads aus dem Request-Body-Logging ausschließen (maskieren oder `/vault`-Routen überspringen).
+2. `__debugInfo()` auf `VaultRecord` implementieren, um sensible Felder aus var_dump / Exception-Serialisierung zu schwärzen.
+3. Sicherstellen, dass Error-Tracking-Integrationen (Sentry usw.) Klartext-Felder vor der Übertragung scrubben.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Bedrohung | Status |
+|----|---------|--------|
+| V-01 | Schlüssel ins VCS eingecheckt | ✅ BLOCKED |
+| V-02 | Nonce-Wiederverwendung (GCM) | ✅ BLOCKED |
+| V-03 | Manipulierter Chiffretext akzeptiert | ✅ BLOCKED |
+| V-04 | Entschlüsselungsfehler-Detail in Antwort | ⚠️ EXPOSED |
+| V-05 | Blind-Index-Offline-Wörterbuch | ✅ BLOCKED |
+| V-06 | Keine Authentifizierung auf Endpunkten | ⚠️ EXPOSED |
+| V-07 | IDOR bei Update/Delete | ✅ BLOCKED |
+| V-08 | Schlüsselrotation / Re-Verschlüsselungs-Lücke | ⚠️ EXPOSED |
+| V-09 | Blind-Index-Timing-Vergleich | ✅ BLOCKED |
+| V-10 | Entschlüsselte Daten in Logs/Exceptions | ⚠️ EXPOSED |
+
+**Bewertung**: 6 BLOCKED, 4 EXPOSED.
+
+Die vier Offenlegungen betreffen Schlüsselrotationsstrategie (V-08), Authentifizierung (V-06, absichtlicher FT-Umfang), Fehlerdetail-Leak (V-04) und Log-Hygiene (V-10). Keine davon stellt einen Fehler im AES-256-GCM- oder Blind-Index-kryptografischen Design dar — es sind betriebliche und Integrationslücken, die vor der Produktionsnutzung behoben werden müssen.

--- a/docs/de/howto/enforce-resource-ownership.md
+++ b/docs/de/howto/enforce-resource-ownership.md
@@ -1,0 +1,146 @@
+# Ressourcen-Eigentumsrechte durchsetzen (IDOR-Prävention)
+
+Insecure Direct Object Reference (IDOR) ist die #1-API-Schwachstelle (OWASP API Security Top 10).
+Sie tritt auf, wenn ein Benutzer durch das Erraten oder Enumerieren von IDs auf die Ressourcen eines anderen Benutzers zugreifen oder diese ändern kann.
+
+NENE2 bietet keine automatische Eigentumsdurchsetzung — jedes Repository und jeder Handler muss sie explizit implementieren. Diese Anleitung zeigt die empfohlenen Muster.
+
+---
+
+## 1. Die Grundregel: 404, nicht 403
+
+Wenn ein Benutzer auf eine Ressource zugreift, die einem anderen Benutzer gehört, `404 Not Found` zurückgeben — **nicht** `403 Forbidden`.
+
+- **403** teilt dem Angreifer mit: "Diese Ressource existiert, aber Sie können nicht darauf zugreifen." — Informationsleck
+- **404** teilt dem Angreifer mit: "Diese Ressource existiert nicht." — keine Bestätigung
+
+```php
+// FALSCH — verrät Existenz
+if ($note->ownerId !== $authUserId) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403, '');
+}
+
+// KORREKT — verrät nichts
+if ($note === null) {
+    return $this->problems->create($request, 'not-found', 'Not Found', 404, '');
+}
+```
+
+Der praktische Weg, das zu erreichen: das Repository so gestalten, dass es **keine Ressource zurückgeben kann, die nicht dem Aufrufer gehört** — siehe nächster Abschnitt.
+
+---
+
+## 2. Eigentumsrechte auf SQL-Ebene durchsetzen
+
+Das sicherste Muster ist, `owner_id` in jede Abfrage einzubeziehen. Die Methode kann buchstäblich keine Daten eines anderen Benutzers zurückgeben, unabhängig davon, wie der Aufrufer das Ergebnis verwendet.
+
+```php
+public function findByIdAndOwner(int $id, string $ownerId): ?Resource
+{
+    $row = $this->db->fetchOne(
+        'SELECT * FROM resources WHERE id = ? AND owner_id = ?',
+        [$id, $ownerId],
+    );
+    return $row !== null ? $this->hydrate($row) : null;
+}
+
+public function update(int $id, string $ownerId, string $newValue): bool
+{
+    $updated = $this->db->execute(
+        'UPDATE resources SET value = ? WHERE id = ? AND owner_id = ?',
+        [$newValue, $id, $ownerId],
+    );
+    return $updated > 0;
+}
+
+public function delete(int $id, string $ownerId): bool
+{
+    return $this->db->execute(
+        'DELETE FROM resources WHERE id = ? AND owner_id = ?',
+        [$id, $ownerId],
+    ) > 0;
+}
+```
+
+**Warum SQL-Ebene besser als Anwendungsebene ist:**
+- Eine App-Level-Prüfung kann umgangen werden, wenn ein Entwickler vergisst, sie aufzurufen
+- Eine SQL-Level-Prüfung kann nicht übersprungen werden — die falsch-eigentümer-Zeile wird einfach nicht zurückgegeben
+- `null` für "nicht gefunden" und "falscher Eigentümer" zurückzugeben verhindert, dass der Aufrufer versehentlich auf einen Fall verzweigt, den er nicht kennen sollte
+
+---
+
+## 3. Handler-Muster
+
+```php
+private function show(ServerRequestInterface $request): ResponseInterface
+{
+    $authUserId = $this->resolveAuthUser($request);
+    if ($authUserId === null) {
+        return $this->unauthorized($request);
+    }
+
+    $id       = $this->resolveId($request);
+    $resource = $this->repo->findByIdAndOwner($id, $authUserId);
+
+    if ($resource === null) {
+        // 404 deckt sowohl "nicht gefunden" als auch "gehört einem anderen Benutzer" ab
+        return $this->problems->create($request, 'not-found', 'Not Found', 404, '');
+    }
+
+    return $this->json->create($resource->toArray());
+}
+```
+
+---
+
+## 4. Auflistung: In der Abfrage nach Eigentümer filtern
+
+```php
+public function listByOwner(string $ownerId): array
+{
+    return $this->db->fetchAll(
+        'SELECT * FROM resources WHERE owner_id = ? ORDER BY id DESC',
+        [$ownerId],
+    );
+}
+```
+
+Niemals alle Zeilen abrufen und in PHP filtern. Das verrät Daten anderer Benutzer, wenn die Filterlogik falsch ist, und ist auch ein N+1-Problem.
+
+---
+
+## 5. Cross-Owner-Zugriff explizit testen
+
+Dedizierte Tests hinzufügen, die verifizieren, dass IDOR verhindert wird:
+
+```php
+public function testCannotReadAnotherUsersResource(): void
+{
+    $bobId = $this->decode($this->create('bob', 'Bob content'))['id'];
+
+    // Alice versucht, Bobs Ressource zu lesen — muss 404 bekommen
+    $res = $this->request('GET', '/resources/' . $bobId, authUser: 'alice');
+    self::assertSame(404, $res->getStatusCode());
+    // Ausdrücklich nicht 403 — was die Existenz der Ressource verraten würde
+    self::assertNotSame(403, $res->getStatusCode());
+}
+
+public function testListDoesNotLeakCrossTenantData(): void
+{
+    $this->create('alice', 'Alice content');
+    $this->create('bob', 'Bob content');
+
+    $aliceList = $this->decode($this->request('GET', '/resources', authUser: 'alice'));
+    $titles    = array_column($aliceList['items'], 'content');
+
+    self::assertNotContains('Bob content', $titles);
+}
+```
+
+---
+
+## Hinweise
+
+- **Warum 404 falsch wirkt**: 404 für eine Ressource zurückzugeben, die in der URL sichtbar ist, fühlt sich "unehrlich" an. Das ist es — aber OWASP empfiehlt es ausdrücklich, um ID-Enumerationsangriffe zu verhindern. Der Kompromiss ist akzeptierte Sicherheitspraxis.
+- **Admin-Bypass**: Wenn Sie Admin-Routen haben, die jede Ressource sehen können, halten Sie diese auf einem separaten Pfad-Präfix mit einer separaten Eigentumsprüfung (oder keiner Prüfung). Die Eigentumsmethoden nicht mit "is admin"-Flags komplizieren.
+- **Datenbankschema**: Immer einen Index auf `owner_id` hinzufügen (und auf `(owner_id, id)` für Compound-Suchen). Ohne Index ist jede Pro-Benutzer-Abfrage ein Full-Table-Scan.

--- a/docs/de/howto/etag-conditional-requests.md
+++ b/docs/de/howto/etag-conditional-requests.md
@@ -1,0 +1,170 @@
+# ETag und bedingte Requests
+
+> **FT-Referenz**: FT307 (`NENE2-FT/etaglog`) — ETag-bedingte Requests: `If-None-Match`→304, `If-Modified-Since`→304, `If-Match`→412 veraltet / 428 fehlend, Wildcard `If-Match: *` wird durchgelassen, ETag ändert sich nach jedem Update, 15 Tests PASS.
+
+ETags ermöglichen es Clients, das erneute Herunterladen unveränderter Inhalte zu vermeiden und veralteten Zustand vor dem Schreiben zu erkennen. NENE2 stellt zwei Helfer für die häufigsten Muster bereit.
+
+| Szenario | Header | Helfer | Bei Übereinstimmung |
+|---|---|---|---|
+| Bedingtes GET | `If-None-Match` | `ConditionalGetHelper` | 304 Not Modified |
+| Bedingtes Schreiben | `If-Match` | `ConditionalWriteHelper` | Schreiben wird fortgesetzt |
+| Schreiben ohne Header | — | `ConditionalWriteHelper` | 428 Precondition Required |
+| Veralteter ETag beim Schreiben | `If-Match` | `ConditionalWriteHelper` | 412 Precondition Failed |
+
+## ETag-Generierung
+
+Einen starken ETag aus dem Ressourceninhalt als doppelt-gequoteter MD5-Wert generieren:
+
+```php
+final readonly class Article
+{
+    public function etag(): string
+    {
+        // Doppelte Anführungszeichen sind per RFC 9110 erforderlich — ohne sie schlägt If-None-Match-Vergleich immer fehl
+        return '"' . md5($this->title . $this->body . $this->updatedAt) . '"';
+    }
+}
+```
+
+Die ETag-Generierung an einem Ort behalten (eine Methode auf der Entität), damit eine Algorithmusänderung (z. B. auf SHA-256) eine einzige Bearbeitung ist.
+
+## Bedingtes GET — 304 Not Modified
+
+```php
+private function get(ServerRequestInterface $request): ResponseInterface
+{
+    $article = $this->repo->findById((int) Router::param($request, 'id'));
+    if ($article === null) {
+        return $this->problems->create($request, 'not-found', 'Article not found.', 404);
+    }
+
+    $etag = $article->etag();
+
+    // Gibt eine 304-Antwort zurück, wenn If-None-Match mit dem aktuellen ETag übereinstimmt.
+    // Gibt null zurück, wenn eine vollständige 200-Antwort gesendet werden muss.
+    $notModified = ConditionalGetHelper::check($request, $this->responseFactory, $etag, $article->updatedAt);
+    if ($notModified !== null) {
+        return $notModified;
+    }
+
+    return $this->json->create($this->serialize($article))
+        ->withHeader('ETag', $etag)
+        ->withHeader('Last-Modified', $article->updatedAt);
+}
+```
+
+`ConditionalGetHelper::check()` wertet zwei Header aus:
+- `If-None-Match`: exakter ETag-Match → 304
+- `If-Modified-Since`: String-Vergleich `$ifModifiedSince >= $lastModified` → 304
+
+Immer denselben `$etag`-Wert in beiden dem `check()`-Aufruf und dem `withHeader('ETag', $etag)`-Aufruf übergeben. Separate Generierung riskiert Abweichungen.
+
+### Last-Modified-Format
+
+Die `If-Modified-Since`-Prüfung ist ein **String-Vergleich**, kein geparster Datumsvergleich. Ein Format verwenden, das lexikografisch sortiert — ISO 8601 wird empfohlen:
+
+```php
+$now = (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'); // ✅ 2026-05-21T12:00:00Z
+```
+
+Das HTTP-Standardformat `Sat, 21 May 2026 12:00:00 GMT` sortiert falsch — nicht mit diesem Helfer verwenden.
+
+### 304 hat keinen Body
+
+RFC 9110 verbietet einen Body in 304-Antworten. `ConditionalGetHelper` gibt eine leere `createResponse(304)` zurück, daher wird dies korrekt behandelt, solange die Antwort des Helfers direkt zurückgegeben wird.
+
+## Bedingtes Schreiben — If-Match
+
+```php
+private function update(ServerRequestInterface $request): ResponseInterface
+{
+    $article = $this->repo->findById((int) Router::param($request, 'id'));
+    if ($article === null) {
+        return $this->problems->create($request, 'not-found', 'Article not found.', 404);
+    }
+
+    // Muss VOR dem Schreiben aufgerufen werden — nachher zu prüfen ist sinnlos.
+    // Gibt 428 zurück, wenn If-Match fehlt; 412, wenn If-Match vorhanden aber falsch.
+    // Gibt null zurück, wenn die Vorbedingung erfüllt ist.
+    $preconditionFailed = ConditionalWriteHelper::check($request, $this->problems, $article->etag());
+    if ($preconditionFailed !== null) {
+        return $preconditionFailed;
+    }
+
+    $updated = $this->repo->update($id, $title, $body);
+
+    return $this->json->create($this->serialize($updated))
+        ->withHeader('ETag', $updated->etag())
+        ->withHeader('Last-Modified', $updated->updatedAt);
+}
+```
+
+### If-Match: * Wildcard
+
+Ein Client kann `If-Match: *` senden, um zu bedeuten: "fortfahren, wenn die Ressource überhaupt existiert". `ConditionalWriteHelper` lässt dies bedingungslos durch. **Der Aufrufer ist dafür verantwortlich, 404 zurückzugeben, wenn die Ressource nicht existiert** — den Datensatz zuerst abrufen und mit einer 404 absichern.
+
+### If-Match optional machen
+
+Standardmäßig (`$require = true`) gibt ein fehlender `If-Match` 428 zurück. Um Schreibvorgänge ohne Vorbedingungsheader zu erlauben:
+
+```php
+ConditionalWriteHelper::check($request, $this->problems, $article->etag(), require: false);
+```
+
+Dies nur lockern, wenn optimistisches Sperren für die Ressource tatsächlich optional ist.
+
+## Client-Flow
+
+```
+POST /articles            → 201 { id: 1, ... }  ETag: "abc123"
+GET  /articles/1          → 200 { id: 1, ... }  ETag: "abc123"
+
+GET  /articles/1          → 304 (kein Body)
+  If-None-Match: "abc123"
+
+PATCH /articles/1         → 200 { ... }  ETag: "def456"
+  If-Match: "abc123"
+  { title: "Updated" }
+
+PATCH /articles/1         → 412 Precondition Failed
+  If-Match: "abc123"       (veraltet — Inhalt hat sich geändert, ETag ist jetzt "def456")
+
+PATCH /articles/1         → 428 Precondition Required
+  (kein If-Match-Header)
+
+PATCH /articles/1         → 200 { ... }
+  If-Match: *              (Wildcard — beliebige vorhandene Version)
+```
+
+## ETag in jeder Antwort einschließen
+
+`ETag` (und `Last-Modified`) bei POST-, GET- und PATCH-Antworten zurückgeben, damit der Client immer einen aktuellen Wert hat, ohne einen zusätzlichen Round-Trip zu benötigen:
+
+```php
+return $this->json->create($this->serialize($article), 201)
+    ->withHeader('ETag', $article->etag())
+    ->withHeader('Last-Modified', $article->updatedAt);
+```
+
+## ETag vs. Version-Feld
+
+| | ETag (HTTP-Header) | Version-Feld (Body) |
+|---|---|---|
+| Wo geprüft | HTTP-Header | Request-Body |
+| Granularität | Inhalts-Hash | Ganzzahlzähler |
+| Client muss verfolgen | ETag-Wert | Versionsnummer |
+| Am besten für | HTTP-Caching + optimistisches Sperren | API-Level-Konflikteerkennung |
+
+Sie können zusammen verwendet werden: ETag für HTTP-Caching, Version für DB-Level-Konflikterkennung (siehe [optimistic-locking.md](optimistic-locking.md)).
+
+## Code-Review-Checkliste
+
+- [ ] ETag-String enthält umschließende doppelte Anführungszeichen (`'"' . md5(...) . '"'`)
+- [ ] ETag-Generierung ist an einem Ort (Entitätsmethode), nicht über Handler dupliziert
+- [ ] `ConditionalGetHelper::check()` wird vor dem Aufbau der 200-Antwort aufgerufen
+- [ ] Derselbe `$etag`-Wert wird sowohl an `check()` als auch an `withHeader('ETag', $etag)` übergeben
+- [ ] `ConditionalWriteHelper::check()` wird vor dem Schreiben aufgerufen
+- [ ] 304-Response-Body ist leer (die Antwort des Helfers direkt zurückgeben)
+- [ ] `Last-Modified`-Werte verwenden ISO 8601-Format (lexikografische Sortierung erforderlich)
+- [ ] Jede Antwort (201, 200) enthält `ETag`, damit der Client immer einen frischen Wert hat
+- [ ] Tests decken ab: 200 ohne `If-None-Match`, 304 bei Match, 200 bei veraltetem ETag, 428 ohne `If-Match`, 412 bei veraltetem `If-Match`, 200 bei korrektem `If-Match`, `If-Match: *`

--- a/docs/de/howto/event-analytics-api.md
+++ b/docs/de/howto/event-analytics-api.md
@@ -1,0 +1,353 @@
+# How-to: Event-Analytics-API
+
+> **FT-Referenz**: FT243 (`NENE2-FT/statslog`) — Event-Analytics-API
+> **VULN**: FT243 — Schwachstellenbewertung (V-01 bis V-10)
+
+Demonstriert eine Event-Ingestion- und Aggregations-API, bei der rohe Analytics-Events
+mit einem JSON-`properties`-Blob aufgezeichnet, mit SQLite `json_extract()` abgefragt und
+in Pro-Tag-/Pro-Typ-/Unique-User-Statistiken aggregiert werden. Enthält eine vollständige
+Schwachstellenbewertung des nicht-authentifizierten Designs.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|------------------------|------------------------------------------------------|
+| `POST` | `/events`              | Ein Analytics-Event aufzeichnen |
+| `GET`  | `/events`              | Events auflisten (paginiert) |
+| `GET`  | `/events/by-property`  | Events nach JSON-Property-Schlüssel+Wert filtern |
+| `GET`  | `/events/{id}`         | Ein einzelnes Event abrufen |
+| `GET`  | `/stats/per-day`       | Event-Anzahl nach Tag gruppiert |
+| `GET`  | `/stats/per-type`      | Event-Anzahl nach Event-Typ gruppiert |
+| `GET`  | `/stats/unique-users`  | Anzahl einzigartiger Benutzer nach Tag gruppiert |
+
+> **Statische Routen vor parametrisierten**: `/events/by-property` wird vor
+> `/events/{id}` registriert, damit der Router den Literalpfad korrekt dispatcht.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type  TEXT    NOT NULL,
+    user_id     TEXT    NOT NULL,
+    session_id  TEXT    NOT NULL DEFAULT '',
+    properties  TEXT    NOT NULL DEFAULT '{}',
+    occurred_at TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_type     ON events(event_type);
+CREATE INDEX IF NOT EXISTS idx_events_occurred ON events(occurred_at);
+CREATE INDEX IF NOT EXISTS idx_events_user     ON events(user_id);
+```
+
+`properties` wird als JSON-String (`TEXT`) gespeichert. SQLites `json_extract()` ermöglicht
+das Abfragen des Blobs zur Lesezeit ohne ein separates Schema. Drei Indizes decken die
+häufigsten Zugriffsmuster ab: nach Typ, nach Zeitraum und nach Benutzer.
+
+---
+
+## Event-Erstellung: JSON-Properties-Blob
+
+`POST /events` akzeptiert ein flexibles `properties`-Objekt neben den erforderlichen `event_type`
+und `user_id`:
+
+```php
+$eventType  = trim((string) $body['event_type']);
+$userId     = trim((string) $body['user_id']);
+$sessionId  = isset($body['session_id']) && is_string($body['session_id']) ? $body['session_id'] : '';
+$properties = isset($body['properties']) && is_array($body['properties'])
+    ? json_encode($body['properties'], JSON_THROW_ON_ERROR)
+    : '{}';
+$occurredAt = isset($body['occurred_at']) && is_string($body['occurred_at'])
+    ? $body['occurred_at']
+    : (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+```
+
+- `properties` muss ein JSON-Objekt sein (`is_array()`-Prüfung) — skalare Werte fallen auf `'{}'` zurück.
+- `occurred_at` wird vom Aufrufer angegeben oder standardmäßig auf jetzt gesetzt — keine serverseitige Erzwingung, dass es in einem gültigen Bereich liegt.
+- `JSON_THROW_ON_ERROR` stellt sicher, dass fehlerhaftes Zwischen-JSON sofort wirft anstatt `false` zu erzeugen.
+
+Deserialisierung beim Lesen:
+```php
+'properties' => json_decode($event->properties, true, 512, JSON_THROW_ON_ERROR),
+```
+
+---
+
+## JSON-Property-Suche mit `json_extract()`
+
+`GET /events/by-property?key=page&value=/home` filtert Events nach einem Property-Schlüssel/Wert:
+
+```php
+$rows = $this->executor->fetchAll(
+    'SELECT * FROM events WHERE json_extract(properties, ?) = ? ORDER BY occurred_at DESC LIMIT ? OFFSET ?',
+    ['$.' . $propertyKey, $propertyValue, $limit, $offset],
+);
+```
+
+`json_extract(properties, '$.page')` extrahiert das `page`-Feld aus dem JSON-Blob.
+Der Pfad `'$.' . $propertyKey` wird durch Konkatenation konstruiert, **nicht** als Pfad selbst parametrisiert
+— SQLites `json_extract()` akzeptiert nur einen Literal-Pfad-String, keinen gebundenen Parameter für den Pfadausdruck. Der Schlüssel kommt aus einem Query-String, wird aber nicht weiter validiert (siehe V-05).
+
+`= ?` vergleicht den extrahierten Wert mit dem bereitgestellten `$propertyValue` als parametrisierten
+Binding — SQL-Injection über den Wert ist blockiert. Die Pfadkonkatenation ist die zu prüfende Grenze.
+
+---
+
+## Aggregationsabfragen
+
+### Pro-Tag-Event-Anzahl
+
+```php
+$rows = $this->executor->fetchAll(
+    "SELECT strftime('%Y-%m-%d', occurred_at) AS day, COUNT(*) AS count
+     FROM events
+     WHERE occurred_at >= ? AND occurred_at < ?
+     GROUP BY strftime('%Y-%m-%d', occurred_at)
+     ORDER BY day ASC",
+    [$from, $to],
+);
+```
+
+`strftime('%Y-%m-%d', occurred_at)` kürzt den Zeitstempel auf ein Datum. `GROUP BY`
+auf demselben Ausdruck gruppiert alle Events desselben Tages. Beide `$from` und
+`$to` sind parametrisiert — keine String-Konkatenation in das SQL.
+
+### Pro-Typ-Event-Anzahl
+
+```php
+$rows = $this->executor->fetchAll(
+    'SELECT event_type, COUNT(*) AS count
+     FROM events
+     WHERE occurred_at >= ? AND occurred_at < ?
+     GROUP BY event_type
+     ORDER BY count DESC',
+    [$from, $to],
+);
+```
+
+`ORDER BY count DESC` zeigt die häufigsten Event-Typen zuerst.
+
+### Unique User pro Tag
+
+```php
+$rows = $this->executor->fetchAll(
+    "SELECT strftime('%Y-%m-%d', occurred_at) AS day, COUNT(DISTINCT user_id) AS unique_users
+     FROM events
+     WHERE occurred_at >= ? AND occurred_at < ?
+     GROUP BY strftime('%Y-%m-%d', occurred_at)
+     ORDER BY day ASC",
+    [$from, $to],
+);
+```
+
+`COUNT(DISTINCT user_id)` zählt jede `user_id` nur einmal pro Tag.
+
+### Standard-Datumsbereich
+
+```php
+private function parseDateRange(ServerRequestInterface $request): array
+{
+    $from = QueryStringParser::string($request, 'from') ?? '2000-01-01T00:00:00Z';
+    $to   = QueryStringParser::string($request, 'to') ?? '2100-01-01T00:00:00Z';
+
+    return [$from, $to];
+}
+```
+
+Breite Standardwerte (`2000-01-01` bis `2100-01-01`) stellen sicher, dass Statistiken ohne Datumsbereich
+alle Events enthalten. In der Produktion den Standardbereich auf ein sinnvolles Fenster (z. B. letzte 30
+Tage) begrenzen, um Full-Table-Scans auf großen Datensätzen zu vermeiden.
+
+---
+
+## VULN — Schwachstellenbewertung (FT243)
+
+### V-01 — Keine Authentifizierung: Jeder kann Events aufzeichnen
+
+**Risiko**: Jeder Aufrufer kann Events mit beliebigen `event_type` und `user_id` senden. Es gibt
+keine API-Schlüssel-, Sitzungs- oder Token-Prüfung.
+
+**Auswirkung**: Ein Angreifer kann den Analytics-Datensatz mit Millionen gefälschter Events verseuchen,
+Statistiken verzerren und jede Benutzer-ID imitieren.
+
+**Urteil**: **EXPOSED** — API-Schlüssel oder JWT-Authentifizierung für den Schreibendpunkt hinzufügen.
+Read-only-Statistiken können öffentlich bleiben, aber die Aufnahme muss authentifiziert sein.
+
+---
+
+### V-02 — Keine Autorisierung für Statistiken: Statistiken sind weltweit lesbar
+
+**Risiko**: `GET /stats/per-day`, `/stats/per-type`, `/stats/unique-users` geben
+aggregierte Daten ohne Authentifizierung zurück.
+
+**Auswirkung**: Wettbewerber oder Crawler können Produktnutzungstrends, täglich aktive Benutzer
+und Feature-Adoption überwachen.
+
+**Urteil**: **EXPOSED** — Statistik-Endpunkte auf authentifizierte Rollen beschränken (Admin,
+Analytics-Betrachter). Wenn Statistiken absichtlich öffentlich sind, dies als Designentscheidung dokumentieren.
+
+---
+
+### V-03 — `user_id` ist vom Benutzer angegeben: keine Identitätsverifikation
+
+**Risiko**: `user_id` wird direkt aus dem Request-Body ohne Beweis genommen, dass der
+Aufrufer diese Identität besitzt.
+
+```json
+{"event_type": "login", "user_id": "alice", "occurred_at": "2026-01-01T00:00:00Z"}
+```
+
+**Auswirkung**: Ein Angreifer kann Aktivitäten für jede Benutzer-ID fälschen und Pro-Benutzer-
+Statistiken sowie Unique-User-Zählungen manipulieren.
+
+**Urteil**: **EXPOSED** — in authentifizierten Kontexten `user_id` aus der verifizierten Identität
+im Token/Sitzung ableiten, nie aus dem Request-Body.
+
+---
+
+### V-04 — `occurred_at` ist vom Benutzer angegeben: Rückdatierung und Zukunftsdatierung von Events
+
+**Risiko**: Das Feld `occurred_at` wird ohne Bereichsvalidierung vom Aufrufer akzeptiert.
+
+```json
+{"event_type": "purchase", "user_id": "alice", "occurred_at": "2020-01-01T00:00:00Z"}
+```
+
+**Auswirkung**: Angreifer können Events in beliebige historische Zeitslots einfügen (rückdatieren) oder
+weit in die Zukunft, was Zeitreihenstatistiken verzerrt.
+
+**Urteil**: **EXPOSED** — validieren, dass `occurred_at` in einem akzeptablen Fenster liegt
+(z. B. letzte 24 Stunden bis +5 Minuten) und Zeitstempel außerhalb des Bereichs ablehnen.
+
+---
+
+### V-05 — `json_extract()`-Pfadkonkatenation: JSON-Pfad-Injection
+
+**Risiko**: Der Property-Schlüssel wird direkt in den JSON-Pfadausdruck konkateniert:
+`'$.' . $propertyKey`. Es gibt keine Validierung, dass `$propertyKey` ein sicherer Bezeichner ist.
+
+**Angriff**:
+```
+GET /events/by-property?key=x%22%5D+OR+1%3D1+--&value=y
+```
+Wird zu: `json_extract(properties, '$.x"] OR 1=1 --')` — SQLite interpretiert das Pfadargument
+als String-Literal, der an `json_extract` übergeben wird, nicht als SQL. Der Pfad wird nicht als SQL ausgeführt — er wird von SQLites JSON-Funktionen als String behandelt. Ungültige Pfade geben `NULL` zurück, daher gibt die Abfrage keine statt aller Zeilen zurück.
+
+**Beobachtet**: `json_extract()` behandelt das gesamte zweite Argument als Pfadausdruck.
+Fehlerhafte Pfade (`$.x"] OR 1=1 --`) geben für jede Zeile `NULL` zurück — keine SQL-Injection.
+Das Verhalten hängt jedoch von SQLites JSON-Implementierung ab — ein Defense-in-Depth-Ansatz würde `$propertyKey` mit `preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $key)` validieren.
+
+**Urteil**: **PARTIALLY BLOCKED** — SQLites `json_extract()` schirmt das Pfadargument ab.
+Explizite Schlüsselvalidierung (`[a-zA-Z_][a-zA-Z0-9_]*`) für Defense in Depth hinzufügen.
+
+---
+
+### V-06 — Unbeschränkter event_type: keine Allowlist
+
+**Risiko**: `event_type` akzeptiert jeden nicht-leeren String. Sehr lange Strings oder
+High-Cardinality-Typen blähen das `countPerType`-Ergebnis auf.
+
+```json
+{"event_type": "aaaa....(10000 Zeichen)", "user_id": "x"}
+```
+
+**Auswirkung**: Unbeschränkte Kardinalität in `GROUP BY event_type` kann Speicherdruck verursachen.
+Speicheraufblähung durch sehr lange Strings.
+
+**Urteil**: **EXPOSED** — Längenbeschränkung hinzufügen (z. B. 100 Zeichen) und optional
+eine Event-Typ-Allowlist.
+
+---
+
+### V-07 — SQL-Injection über `from`/`to`-Datumparameter
+
+**Angriff**: SQL-Metazeichen im Datumsbereich übergeben.
+
+```
+GET /stats/per-day?from=2000-01-01%27+OR+%271%27%3D%271&to=2100-01-01
+```
+
+**Beobachtet**: Beide `$from` und `$to` werden als parametrisierte Werte gebunden (`?`-Platzhalter).
+Die SQL-Engine behandelt sie als Literal-Strings, nicht als SQL-Fragmente.
+
+**Urteil**: **BLOCKED** — parametrisierte Abfragen verhindern SQL-Injection über Datumparameter.
+
+---
+
+### V-08 — Properties-Größe: keine Begrenzung für JSON-Blob
+
+**Risiko**: `properties` wird als `TEXT` ohne Größenvalidierung gespeichert. Ein Angreifer kann
+mehrmegabyte-große JSON-Objekte senden.
+
+```json
+{"event_type": "x", "user_id": "y", "properties": {"data": "AAAA....(1MB)"}}
+```
+
+**Auswirkung**: Jedes große Event verbraucht erheblichen Speicherplatz. Masseneinspielung großer Events
+kann den Festplattenplatz erschöpfen.
+
+**Urteil**: **EXPOSED** — Größenprüfung für den rohen `properties`-Wert hinzufügen
+(z. B. `strlen($raw) > 65535 → 422`). Request-Größen-Middleware als äußere Grenze verwenden.
+
+---
+
+### V-09 — Event-Flut: kein Rate-Limiting bei POST /events
+
+**Risiko**: Es gibt kein Rate-Limiting am Ingestion-Endpunkt.
+
+**Auswirkung**: Ein einzelner Client kann Millionen Events pro Sekunde senden und dabei
+Datenbank und Speicher überlasten.
+
+**Urteil**: **EXPOSED** — `ThrottleMiddleware` oder Per-IP-/Per-API-Key-Rate-Limiting
+am Schreibendpunkt anwenden.
+
+---
+
+### V-10 — Statistik-Offenlegung: `COUNT(DISTINCT user_id)` gibt Benutzeranzahl preis
+
+**Risiko**: `GET /stats/unique-users` gibt die Anzahl der verschiedenen Benutzer-IDs pro Tag zurück.
+
+**Auswirkung**: Ohne Authentifizierung gibt dies täglich aktive Benutzeranzahlen preis — eine sensible
+Geschäftskennzahl.
+
+**Urteil**: **EXPOSED** (gleiche Ursache wie V-02). Statistik-Endpunkte einschränken oder authentifizieren.
+
+---
+
+## VULN-Zusammenfassung
+
+| # | Schwachstelle | Urteil |
+|---|---------------|---------|
+| V-01 | Keine Authentifizierung am Schreibendpunkt | EXPOSED |
+| V-02 | Statistik-Endpunkte weltweit lesbar | EXPOSED |
+| V-03 | `user_id` nicht verifiziert (Identitätsfälschung) | EXPOSED |
+| V-04 | `occurred_at` vom Benutzer angegeben (Rück-/Zukunftsdatierung) | EXPOSED |
+| V-05 | `json_extract()`-Pfadkonkatenation | PARTIALLY BLOCKED |
+| V-06 | `event_type` keine Allowlist / Längenbegrenzung | EXPOSED |
+| V-07 | SQL-Injection über Datumsbereich-Parameter | BLOCKED |
+| V-08 | Keine Größenbegrenzung für `properties`-JSON-Blob | EXPOSED |
+| V-09 | Kein Rate-Limiting bei POST /events | EXPOSED |
+| V-10 | Unique-User-Anzahl gibt DAU-Kennzahlen preis | EXPOSED |
+
+**Kritische Korrekturen vor der Produktion**:
+1. **V-01 / V-02 / V-10** — Authentifizierung (API-Schlüssel oder JWT) für Schreib- und Statistik-Endpunkte hinzufügen
+2. **V-03** — `user_id` aus verifizierter Identität ableiten, nicht aus dem Request-Body
+3. **V-04** — Validieren, dass `occurred_at` in einem akzeptablen Zeitfenster liegt
+4. **V-05** — `preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $key)`-Validierung hinzufügen
+5. **V-06** — `event_type`-Maximallänge hinzufügen (z. B. 100 Zeichen)
+6. **V-08** — `properties`-Größenbegrenzung hinzufügen (z. B. 64 KB)
+7. **V-09** — Rate-Limiting bei POST /events anwenden
+
+---
+
+## Verwandte Anleitungen
+
+- [`event-sourcing.md`](event-sourcing.md) — unveränderliches Event-Log-Muster
+- [`api-usage-metering.md`](api-usage-metering.md) — gemessene API mit Kontingentdurchsetzung
+- [`quota-management.md`](quota-management.md) — Pro-Ressource-Kontingent mit QuotaWindow
+- [`cursor-pagination.md`](cursor-pagination.md) — effiziente Paginierung für hochvolumige Event-Feeds

--- a/docs/de/howto/event-analytics.md
+++ b/docs/de/howto/event-analytics.md
@@ -1,0 +1,229 @@
+# How-to: Event-Analytics-API
+
+> **FT-Referenz**: FT51 (`NENE2-FT/statslog`) — Event-Analytics-API mit JSON-Property-
+> Filterung und Aggregationsabfragen
+
+Demonstriert eine Event-Tracking-API, die Analytics-Events mit beliebigen JSON-Properties
+speichert und Aggregations-Endpunkte für Pro-Tag-Anzahlen, Pro-Typ-Aufschlüsselungen
+und Unique-User-Metriken bereitstellt. Schlüsselmuster: `json_extract()`-Property-Filterung, `strftime()`-
+Datumsgruppierung, statische Routen vor parametrisierten Routen und String-typisierte Benutzer-IDs.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|---------------------------|-----------------------------------------------------|
+| `POST` | `/events`                 | Ein Event aufzeichnen |
+| `GET`  | `/events`                 | Events auflisten (paginiert) |
+| `GET`  | `/events/by-property`     | Nach JSON-Property-Schlüssel/Wert filtern |
+| `GET`  | `/events/{id}`            | Ein einzelnes Event abrufen |
+| `GET`  | `/stats/per-day`          | Event-Anzahl pro Kalendertag (`?from=&to=`) |
+| `GET`  | `/stats/per-type`         | Event-Anzahl pro Event-Typ (`?from=&to=`) |
+| `GET`  | `/stats/unique-users`     | Unique-User-Anzahl pro Tag (`?from=&to=`) |
+
+---
+
+## Events aufzeichnen
+
+```php
+// POST /events
+$body = [
+    'event_type'  => 'page_view',          // erforderlich, nicht-leerer String
+    'user_id'     => 'usr_abc123',          // erforderlich, String (UUID oder opaque ID)
+    'session_id'  => 'sess_xyz789',         // optional
+    'properties'  => ['path' => '/pricing', 'referrer' => 'google'],  // optionales Objekt
+    'occurred_at' => '2026-05-27T09:00:00Z', // optional, ISO 8601 (Standard: Serverzeit)
+];
+```
+
+`properties` wird als JSON-String gespeichert. Bei der Ausgabe wird es zurück zu einem Objekt dekodiert:
+
+```php
+'properties' => json_decode($event->properties, true, 512, JSON_THROW_ON_ERROR),
+```
+
+Wenn `occurred_at` weggelassen wird, füllt der Server es mit der aktuellen UTC-Zeit:
+
+```php
+$occurredAt = isset($body['occurred_at']) && is_string($body['occurred_at'])
+    ? $body['occurred_at']
+    : (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+```
+
+---
+
+## Routen-Reihenfolge: statisch vor parametrisiert
+
+Der Router gleicht Routen in Registrierungsreihenfolge ab. Ein statischer Pfad wie `/events/by-property`
+muss **vor** dem parametrisierten `/events/{id}` registriert werden, sonst würde das Segment
+`by-property` als `{id}` erfasst:
+
+```php
+public function register(Router $router): void
+{
+    $router->post('/events', $this->createEvent(...));
+    $router->get('/events', $this->listEvents(...));
+
+    // ✓ Statische Route zuerst — oder "by-property" wird von {id} verschluckt
+    $router->get('/events/by-property', $this->eventsByProperty(...));
+    $router->get('/events/{id}', $this->showEvent(...));
+
+    $router->get('/stats/per-day', $this->statsPerDay(...));
+    $router->get('/stats/per-type', $this->statsPerType(...));
+    $router->get('/stats/unique-users', $this->statsUniqueUsers(...));
+}
+```
+
+**Regel**: immer konkrete Pfadsegmente vor Wildcard-Segmenten auf derselben Tiefe registrieren.
+
+---
+
+## JSON-Property-Filterung mit `json_extract()`
+
+SQLite (≥ 3.38) und MySQL unterstützen `json_extract()` zum Abfragen in gespeicherten JSON-Spalten.
+Der Schlüssel wird als parametrisierter JSONPath-Ausdruck übergeben:
+
+```php
+$rows = $this->executor->fetchAll(
+    'SELECT * FROM events WHERE json_extract(properties, ?) = ? ORDER BY occurred_at DESC LIMIT ? OFFSET ?',
+    ['$.' . $propertyKey, $propertyValue, $limit, $offset],
+);
+```
+
+Das JSONPath-Präfix `$.` wird in PHP angehängt, also wird `key = "path"` zu
+`json_extract(properties, '$.path')`. Da beide Argumente parametrisiert sind,
+besteht kein SQL-Injection-Risiko, auch wenn `$propertyKey` Sonderzeichen enthält.
+
+> **Tiefenbegrenzung**: `$.path` greift auf die oberste Ebene zu. Für verschachtelte Zugriffe
+> (`$.browser.name`) übergibt der Aufrufer `browser.name` als Schlüssel. Tiefe Pfade können
+> überraschend sein — unterstützte Schlüsselformen in der OpenAPI-Spezifikation dokumentieren.
+
+---
+
+## Datenaggregation mit `strftime()`
+
+```sql
+SELECT strftime('%Y-%m-%d', occurred_at) AS day,
+       COUNT(*) AS count
+FROM events
+WHERE occurred_at >= ? AND occurred_at < ?
+GROUP BY strftime('%Y-%m-%d', occurred_at)
+ORDER BY day ASC
+```
+
+`strftime('%Y-%m-%d', ...)` kürzt einen ISO 8601-Datumstring auf seine Datumskomponente.
+Dies funktioniert in SQLite, wenn `occurred_at` als UTC gespeichert ist (z. B. `2026-05-27T09:00:00Z`).
+Zeiten mit Nicht-UTC-Offsets werden nach ihrem rohen String gruppiert, nicht in Ortszeit umgerechnet —
+zur Schreibzeit auf UTC normalisieren, wenn Tagesgrenzen-Semantik wichtig ist.
+
+---
+
+## Unique User pro Tag zählen
+
+```sql
+SELECT strftime('%Y-%m-%d', occurred_at) AS day,
+       COUNT(DISTINCT user_id) AS unique_users
+FROM events
+WHERE occurred_at >= ? AND occurred_at < ?
+GROUP BY strftime('%Y-%m-%d', occurred_at)
+ORDER BY day ASC
+```
+
+`COUNT(DISTINCT user_id)` gibt die Anzahl der verschiedenen `user_id`-Werte zurück, die in
+jedem Bucket erscheinen. Dies ist eine Annäherung der täglich aktiven Benutzer (DAU), wenn `user_id`
+ein stabiler externer Bezeichner ist (UUID, gehashte Geräte-ID usw.).
+
+---
+
+## String-typisierte user_id
+
+`user_id` wird als `TEXT NOT NULL` gespeichert, nicht als Integer-Fremdschlüssel. Dieses Design
+unterstützt:
+
+- UUID (`usr_01HQ...`)
+- Opaque-String-Bezeichner von einem Identity Provider
+- Anonyme Session-Tokens vor der Kontoerstellung
+
+Da das Feld freier Text ist, koppelt die Analytics-Schicht nicht an das Benutzer-Datenmodell.
+Es gibt keinen `REFERENCES users(id)`-Fremdschlüssel — Events können vor oder nach der Erstellung
+eines Benutzerkontos aufgezeichnet werden.
+
+---
+
+## Standard-Datumsbereich-Fallback
+
+Aggregat-Endpunkte akzeptieren `?from=` und `?to=` als Query-Parameter. Wenn weggelassen, decken Standardwerte
+einen sehr weiten Bereich ab:
+
+```php
+$from = QueryStringParser::string($request, 'from') ?? '2000-01-01T00:00:00Z';
+$to   = QueryStringParser::string($request, 'to')   ?? '2100-01-01T00:00:00Z';
+```
+
+Dies ist für Demo-Zwecke praktisch, könnte aber bei einem großen Produktionsdatensatz teuer werden.
+In der Produktion explizite Datumsbereiche erfordern und die maximale Spanne begrenzen.
+
+---
+
+## Schema und Indizes
+
+```sql
+CREATE TABLE events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type  TEXT    NOT NULL,
+    user_id     TEXT    NOT NULL,
+    session_id  TEXT    NOT NULL DEFAULT '',
+    properties  TEXT    NOT NULL DEFAULT '{}',
+    occurred_at TEXT    NOT NULL
+);
+
+CREATE INDEX idx_events_type     ON events(event_type);
+CREATE INDEX idx_events_occurred ON events(occurred_at);
+CREATE INDEX idx_events_user     ON events(user_id);
+```
+
+Drei Indizes decken die drei Haupt-Abfragemuster ab:
+- `idx_events_occurred` — Datumsbereich-Aggregationen (`WHERE occurred_at >= ? AND < ?`)
+- `idx_events_type` — Typ-Filter (`WHERE event_type = ?`)
+- `idx_events_user` — Benutzer-Verlaufsuche (`WHERE user_id = ?`)
+
+`json_extract()`-Abfragen auf `properties` werden in SQLite ohne generierte Spalte nicht durch Indizes unterstützt.
+Für hochvolumige Property-Filterung eine generierte Spalte hinzufügen:
+
+```sql
+ALTER TABLE events ADD COLUMN prop_path TEXT GENERATED ALWAYS AS (json_extract(properties, '$.path')) STORED;
+CREATE INDEX idx_events_prop_path ON events(prop_path);
+```
+
+---
+
+## Properties-Kodierung in PHP
+
+Das Feld `properties` akzeptiert beliebige JSON-Objekte vom Aufrufer und speichert sie als String:
+
+```php
+$properties = isset($body['properties']) && is_array($body['properties'])
+    ? json_encode($body['properties'], JSON_THROW_ON_ERROR)
+    : '{}';
+```
+
+`is_array($body['properties'])` lehnt JSON-Skalare und Arrays ab (die zu einem PHP-Array
+dekodiert würden, aber kein Objekt sind). `JSON_THROW_ON_ERROR` stellt sicher, dass Enkodierungsfehler
+als Exceptions auftauchen statt als stilles `false`.
+
+Bei der Serialisierung werden Properties zurück zu einem PHP-Array dekodiert und als verschachteltes
+Objekt in die Antwort eingebettet:
+
+```php
+'properties' => json_decode($event->properties, true, 512, JSON_THROW_ON_ERROR),
+```
+
+---
+
+## Verwandte Anleitungen
+
+- [`admin-report-aggregation.md`](admin-report-aggregation.md) — SQL-Aggregationsmuster für Admin-Berichte
+- [`shift-management.md`](shift-management.md) — Datumsbereichsbegrenzung, Aggregationsabfragen
+- [`pagination.md`](pagination.md) — `PaginationQueryParser` und `PaginationResponse`
+- [`iso-datetime-validation.md`](iso-datetime-validation.md) — ISO 8601-Round-Trip-Validierung für `occurred_at`

--- a/docs/de/howto/event-sourcing-cqrs-api.md
+++ b/docs/de/howto/event-sourcing-cqrs-api.md
@@ -1,0 +1,227 @@
+# How-to: Event Sourcing & CQRS API
+
+> **FT-Referenz**: `NENE2-FT/eventstore` — Append-Only-Event-Log mit Per-Aggregat-Sequenznummern, Allowlist für Event-Typen, Read-Model-Projektion aus Events neu aufgebaut, Kontostandverfolgung, 17 Tests PASS.
+
+Diese Anleitung zeigt, wie Event Sourcing implementiert wird: Jede Zustandsänderung als unveränderliches Event speichern, den aktuellen Zustand aus dem Event-Log berechnen und eine Read-Model-Projektion bereitstellen.
+
+## Schema
+
+```sql
+-- Append-Only-Event-Log — niemals UPDATE oder DELETE auf Zeilen
+CREATE TABLE domain_events (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    aggregate_id   TEXT    NOT NULL,  -- z. B. "acc-001"
+    aggregate_type TEXT    NOT NULL,  -- z. B. "account"
+    event_type     TEXT    NOT NULL,  -- z. B. "MoneyDeposited"
+    payload        TEXT    NOT NULL DEFAULT '{}',  -- JSON
+    sequence       INTEGER NOT NULL,  -- Per-Aggregat-Zähler, beginnt bei 1
+    occurred_at    TEXT    NOT NULL,
+    UNIQUE(aggregate_id, sequence)
+);
+
+-- Read-Model: aktueller Kontostatus aus Events neu aufgebaut
+CREATE TABLE account_projections (
+    account_id    TEXT    PRIMARY KEY,
+    owner         TEXT    NOT NULL,
+    balance_cents INTEGER NOT NULL DEFAULT 0,
+    is_open       INTEGER NOT NULL DEFAULT 1,
+    last_sequence INTEGER NOT NULL DEFAULT 0,
+    updated_at    TEXT    NOT NULL
+);
+```
+
+`UNIQUE(aggregate_id, sequence)` verhindert doppelte Event-Einfügungen. Die Projektion wird immer aus dem Event-Log abgeleitet — sie kann jederzeit durch Wiedergabe neu aufgebaut werden.
+
+## Event-Typen (Allowlist)
+
+```php
+const ALLOWED_EVENTS = [
+    'AccountOpened',
+    'MoneyDeposited',
+    'MoneyWithdrawn',
+    'AccountClosed',
+];
+```
+
+Unbekannte Event-Typen geben 422 zurück. Nur Events anhängen, die explizite Handler in der Projektionslogik haben.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|-------------------------------|---------------------------------|
+| `POST` | `/accounts`                   | Konto eröffnen (sendet AccountOpened) |
+| `GET`  | `/accounts`                   | Alle Kontoprojektionen auflisten |
+| `GET`  | `/accounts/{id}`              | Kontoprojektion abrufen (404 wenn nicht gefunden) |
+| `POST` | `/accounts/{id}/events`       | Event an Konto anhängen |
+| `GET`  | `/accounts/{id}/events`       | Event-Log für Konto auflisten |
+
+## Konto eröffnen
+
+```php
+POST /accounts
+{"account_id": "acc-001", "owner": "Alice"}
+
+→ 201
+{
+  "event_type": "AccountOpened",
+  "aggregate_id": "acc-001",
+  "sequence": 1,
+  "payload": {"owner": "Alice"},
+  "occurred_at": "..."
+}
+```
+
+Das Eröffnen eines Kontos erstellt ein `AccountOpened`-Event (sequence=1) und initialisiert die Projektion.
+
+## Events anhängen
+
+```php
+POST /accounts/acc-001/events
+{"event_type": "MoneyDeposited", "payload": {"amount_cents": 50000}}
+
+→ 201
+{
+  "event_type": "MoneyDeposited",
+  "aggregate_id": "acc-001",
+  "sequence": 2,         // ← erhöht sich pro Aggregat
+  "payload": {"amount_cents": 50000},
+  "occurred_at": "..."
+}
+```
+
+Jedes Konto hat einen **unabhängigen Sequenzzähler**. `acc-001` und `acc-002` beginnen beide bei 1.
+
+```php
+// Ungültiger Event-Typ → 422
+POST /accounts/acc-001/events  {"event_type": "UnknownEvent"}
+→ 422
+
+// Nicht-existierendes Konto → 404
+POST /accounts/nonexistent/events  {"event_type": "MoneyDeposited", "payload": {"amount_cents": 1000}}
+→ 404
+```
+
+## Read-Model-Projektion
+
+```php
+GET /accounts/acc-001
+
+→ 200
+{
+  "account_id": "acc-001",
+  "owner": "Alice",
+  "balance_cents": 60000,   // 50000 eingezahlt + 10000 eingezahlt
+  "is_open": true,
+  "last_sequence": 3
+}
+
+// AccountClosed-Event angewendet
+GET /accounts/acc-001  // nach Anhängen von AccountClosed
+→ 200  {"is_open": false, "last_sequence": 4}
+```
+
+```php
+GET /accounts/nonexistent
+→ 404
+```
+
+## Event-Log
+
+```php
+GET /accounts/acc-001/events
+
+→ 200
+{
+  "total": 3,
+  "items": [
+    {"event_type": "AccountOpened",  "sequence": 1, ...},
+    {"event_type": "MoneyDeposited", "sequence": 2, "payload": {"amount_cents": 50000}, ...},
+    {"event_type": "MoneyWithdrawn", "sequence": 3, "payload": {"amount_cents": 30000}, ...}
+  ]
+}
+```
+
+Nach `sequence ASC` sortiert — chronologische Reihenfolge.
+
+```php
+// Unbekanntes Konto → leere Liste (nicht 404)
+GET /accounts/nonexistent/events
+→ 200  {"total": 0, "items": []}
+```
+
+## Implementierung
+
+### Sequenz-Generierung
+
+```php
+public function nextSequence(string $aggregateId): int
+{
+    $row = $this->db->fetchOne(
+        'SELECT MAX(sequence) AS seq FROM domain_events WHERE aggregate_id = ?',
+        [$aggregateId],
+    );
+    return (int) ($row['seq'] ?? 0) + 1;
+}
+```
+
+### Event anhängen + Projektion aktualisieren (Transaktion)
+
+```php
+public function appendEvent(string $aggregateId, string $eventType, array $payload): array
+{
+    $sequence = $this->nextSequence($aggregateId);
+    $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+    $this->tx->begin();
+    try {
+        // An unveränderliches Log anhängen
+        $id = $this->db->insert(
+            'INSERT INTO domain_events (aggregate_id, aggregate_type, event_type, payload, sequence, occurred_at)
+             VALUES (?, ?, ?, ?, ?, ?)',
+            [$aggregateId, 'account', $eventType, json_encode($payload), $sequence, $now->format('Y-m-d H:i:s')],
+        );
+
+        // Projektion aktualisieren
+        $this->applyEventToProjection($aggregateId, $eventType, $payload, $sequence, $now);
+
+        $this->tx->commit();
+    } catch (\Throwable $e) {
+        $this->tx->rollback();
+        throw $e;
+    }
+    ...
+}
+```
+
+## Projektion-Anwendungslogik
+
+```php
+private function applyEventToProjection(string $aggregateId, string $eventType, array $payload, int $sequence, \DateTimeImmutable $now): void
+{
+    match ($eventType) {
+        'MoneyDeposited' => $this->db->execute(
+            'UPDATE account_projections SET balance_cents = balance_cents + ?, last_sequence = ?, updated_at = ? WHERE account_id = ?',
+            [(int) ($payload['amount_cents'] ?? 0), $sequence, $now->format('Y-m-d H:i:s'), $aggregateId],
+        ),
+        'MoneyWithdrawn' => $this->db->execute(
+            'UPDATE account_projections SET balance_cents = balance_cents - ?, last_sequence = ?, updated_at = ? WHERE account_id = ?',
+            [(int) ($payload['amount_cents'] ?? 0), $sequence, $now->format('Y-m-d H:i:s'), $aggregateId],
+        ),
+        'AccountClosed' => $this->db->execute(
+            'UPDATE account_projections SET is_open = 0, last_sequence = ?, updated_at = ? WHERE account_id = ?',
+            [$sequence, $now->format('Y-m-d H:i:s'), $aggregateId],
+        ),
+        default => null,
+    };
+}
+```
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Events aktualisieren oder löschen | Verletzt Event-Sourcing-Unveränderlichkeit; macht Audit-Trail unzuverlässig |
+| `MAX(sequence)` ohne Transaktion | Race-Condition: zwei gleichzeitige Anhänge bekommen dieselbe Sequenznummer; UNIQUE-Constraint fängt es ab |
+| Projektion ohne Transaktion aktualisieren | Event wurde angehängt, aber Projektion nicht aktualisiert; inkonsistenter Zustand |
+| Beliebige Event-Typen ohne Allowlist akzeptieren | Ungültige Events verunreinigen das Log; machen Projektions-Handler komplex |
+| Projektion als einzige Quelle der Wahrheit behandeln | Projektion kann aus Events neu aufgebaut werden; das Log ist die kanonische Quelle |

--- a/docs/de/howto/event-sourcing-ledger.md
+++ b/docs/de/howto/event-sourcing-ledger.md
@@ -1,0 +1,114 @@
+# How-to: Event-Sourcing-Hauptbuch
+
+> **FT-Referenz**: FT310 (`NENE2-FT/eventsourcelog`) — Event-Sourcing-Kontobuch: unveränderliches Event-Log (Append-Only), `replayBalance()` gibt alle Events wieder, um den aktuellen Kontostand zu berechnen, Einzahlungs-/Abhebungs-Events werden niemals gelöscht, strenge Betragsvalidierung mit `is_int()`, max. Betrag 1.000.000.000, separate Konten teilen keinen Saldo, 17 Tests / 24 Assertions PASS.
+
+Diese Anleitung zeigt, wie ein Kontobuch mit Event Sourcing implementiert wird: Der aktuelle Kontostand wird nicht direkt gespeichert — er wird durch Wiedergabe aller vergangenen Events abgeleitet.
+
+## Schema
+
+```sql
+CREATE TABLE accounts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner      TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    aggregate_id INTEGER NOT NULL,
+    event_type   TEXT    NOT NULL,
+    payload      TEXT    NOT NULL,  -- JSON: { "amount": 100 }
+    occurred_at  TEXT    NOT NULL,
+    FOREIGN KEY (aggregate_id) REFERENCES accounts(id)
+);
+```
+
+`events` ist Append-Only. Es gibt kein `UPDATE` oder `DELETE` für Events. Jede Einzahlung oder Abhebung hängt eine neue Zeile an.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/accounts` | Konto erstellen |
+| `GET` | `/accounts/{id}/balance` | Aktuellen Kontostand abrufen (wiedergegeben) |
+| `POST` | `/accounts/{id}/deposit` | Einzahlungs-Event anhängen |
+| `POST` | `/accounts/{id}/withdraw` | Abhebungs-Event anhängen |
+| `GET` | `/accounts/{id}/events` | Alle Events auflisten |
+
+## Kontostand — Aus Events wiedergeben
+
+```php
+public function replayBalance(int $aggregateId): int
+{
+    $events  = $this->findEventsByAggregateId($aggregateId);
+    $balance = 0;
+
+    foreach ($events as $event) {
+        $amount = isset($event->payload['amount']) ? (int) $event->payload['amount'] : 0;
+
+        if ($event->eventType === DomainEvent::TYPE_DEPOSITED) {
+            $balance += $amount;
+        } elseif ($event->eventType === DomainEvent::TYPE_WITHDRAWN) {
+            $balance -= $amount;
+        }
+    }
+
+    return $balance;
+}
+```
+
+Der Kontostand wird nirgends gespeichert — er wird durch Wiedergabe aller Events frisch berechnet. Neue Konten starten bei 0 (keine Events). Das Event-Log ist die Quelle der Wahrheit.
+
+## Betragsvalidierung — `is_int()` ist zwingend erforderlich
+
+```php
+$amount = isset($body['amount']) && is_int($body['amount']) ? $body['amount'] : null;
+
+if ($amount === null || $amount <= 0 || $amount > 1_000_000_000) {
+    return $this->responseFactory->create(['error' => 'amount must be a positive integer up to 1,000,000,000'], 422);
+}
+```
+
+- `is_int()` lehnt String-kodierte Zahlen (`"100"`) und Floats (`1.5`) ab
+- Float-Beträge würden zu falschen Cent-Berechnungen führen, wenn sie als Integer behandelt werden
+- Die Obergrenze von 1.000.000.000 verhindert Integer-Überlauf beim Summieren vieler Events
+
+## Abhebung — Kontostandprüfung vor dem Event
+
+```php
+$balance = $this->repo->replayBalance($id);
+
+if ($amount > $balance) {
+    return $this->responseFactory->create(['error' => 'insufficient funds'], 422);
+}
+
+$event = $this->repo->appendEvent($id, 'withdrawn', ['amount' => $amount], $now);
+```
+
+Der Kontostand wird jedes Mal durch vollständige Wiedergabe berechnet. Dies ist idempotent-sicher: kein Race-Condition-Problem für einzelne Konten unter SQLites Zeilen-Sperr-Semantik.
+
+## Separate Konten teilen keinen Saldo
+
+```php
+public function findEventsByAggregateId(int $aggregateId): array
+{
+    // Filtert immer nach aggregate_id — greift niemals auf Events anderer Konten zu
+    $rows = $this->executor->fetchAll(
+        'SELECT * FROM events WHERE aggregate_id = ? ORDER BY id ASC',
+        [$aggregateId],
+    );
+    ...
+}
+```
+
+`ORDER BY id ASC` (nicht `occurred_at ASC`) garantiert die deterministische Wiedergabereihenfolge auch dann, wenn zwei Events dieselbe Sekunde haben.
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Kontostand als Spalte in `accounts` speichern | Wird inkonsistent mit dem Event-Log wenn Events direkt eingefügt werden |
+| `ORDER BY occurred_at ASC` für die Wiedergabe | Nicht deterministisch — zwei Events in derselben Sekunde haben undefinierte Reihenfolge |
+| Float-Beträge akzeptieren | `1.9` wird als PHP-Int zu `1` — der Cent-Betrag geht verloren |
+| `amount` aus dem Request-Body ohne `is_int()`-Prüfung | String `"100"` wird als ungültig behandelt, kann aber Validierungen in einigen Kontexten umgehen |
+| Events aktualisieren oder löschen | Verletzt Event-Sourcing-Unveränderlichkeitsgarantie; macht Audit-Trail unzuverlässig |

--- a/docs/de/howto/event-sourcing.md
+++ b/docs/de/howto/event-sourcing.md
@@ -1,0 +1,142 @@
+# Event Sourcing (Grundlagen)
+
+Zustand als unveränderliche Sequenz von Domain-Events persistieren. Aktuellen Zustand durch Wiedergabe des Event-Streams ableiten.
+
+## Überblick
+
+Event Sourcing speichert **was passiert ist** (Events) statt **was ist** (aktueller Zustand). Der Kontostand wird nicht gespeichert; er wird durch Wiedergabe aller Einzahlungs- und Abhebungs-Events berechnet. Events sind unveränderlich — sie werden weder aktualisiert noch gelöscht.
+
+## Datenbankschema
+
+```sql
+CREATE TABLE accounts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner      TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    aggregate_id INTEGER NOT NULL,
+    event_type   TEXT    NOT NULL,
+    payload      TEXT    NOT NULL,  -- JSON
+    occurred_at  TEXT    NOT NULL,
+    FOREIGN KEY (aggregate_id) REFERENCES accounts(id)
+);
+```
+
+`accounts` ist der Aggregate-Root. `events` ist das Append-Only-Event-Log. Es gibt keine `balance`-Spalte — sie wird immer aus Events berechnet.
+
+## Event-Typen
+
+Event-Typen als Konstanten definieren, um Tippfehler zu verhindern und statische Analyse zu ermöglichen:
+
+```php
+public const string TYPE_ACCOUNT_CREATED = 'account_created';
+public const string TYPE_DEPOSITED       = 'deposited';
+public const string TYPE_WITHDRAWN       = 'withdrawn';
+```
+
+## Events anhängen
+
+Events werden immer eingefügt, niemals aktualisiert. Die API hat keinen Endpunkt, der Events ändert oder löscht:
+
+```php
+public function appendEvent(int $aggregateId, string $eventType, array $payload, string $now): DomainEvent
+{
+    $payloadJson = json_encode($payload, JSON_THROW_ON_ERROR);
+
+    $this->executor->execute(
+        'INSERT INTO events (aggregate_id, event_type, payload, occurred_at) VALUES (?, ?, ?, ?)',
+        [$aggregateId, $eventType, $payloadJson, $now],
+    );
+    ...
+}
+```
+
+## Zustand wiedergeben
+
+Events in Einfügereihenfolge laden und zum aktuellen Zustand falten:
+
+```php
+public function replayBalance(int $aggregateId): int
+{
+    $events  = $this->findEventsByAggregateId($aggregateId);
+    $balance = 0;
+
+    foreach ($events as $event) {
+        $amount = isset($event->payload['amount']) ? (int) $event->payload['amount'] : 0;
+
+        if ($event->eventType === DomainEvent::TYPE_DEPOSITED) {
+            $balance += $amount;
+        } elseif ($event->eventType === DomainEvent::TYPE_WITHDRAWN) {
+            $balance -= $amount;
+        }
+    }
+
+    return $balance;
+}
+```
+
+`ORDER BY id ASC` garantiert die Wiedergabereihenfolge. `ORDER BY occurred_at ASC` ist fragil — zwei Events mit demselben Zeitstempel hätten eine undefinierte Reihenfolge.
+
+## Betragsvalidierung
+
+Beträge vor dem Anhängen von Events streng validieren:
+
+```php
+$amount = isset($body['amount']) && is_int($body['amount']) ? $body['amount'] : 0;
+
+if ($amount <= 0 || $amount > 1_000_000_000) {
+    return 422;
+}
+```
+
+- `is_int()` lehnt Float-Werte ab (z. B. `1.9`), die PHP sonst stillschweigend auf `1` kürzen würde
+- Die Obergrenze verhindert Integer-Überlauf beim Summieren mehrerer großer Einzahlungen
+- Auf API-Ebene ablehnen — ungültige Beträge nicht das Event-Log erreichen lassen
+
+## Unzureichende Mittel
+
+Kontostand vor dem Anhängen eines Abhebungs-Events prüfen:
+
+```php
+$balance = $this->repo->replayBalance($id);
+
+if ($amount > $balance) {
+    return $this->problems->create($request, 'insufficient-funds', 'Insufficient funds.', 422, '');
+}
+
+$event = $this->repo->appendEvent($id, DomainEvent::TYPE_WITHDRAWN, ['amount' => $amount], $now);
+```
+
+Die Kontostandprüfung erfolgt im Handler (nicht im Repository), weil es sich um eine Geschäftsregel handelt, keine Datenintegritätsbeschränkung.
+
+## Event-Isolation
+
+Events sind durch `aggregate_id` auf ihr Aggregat beschränkt. Die Wiedergabe der Events von Konto A berührt niemals Konto B:
+
+```sql
+SELECT * FROM events WHERE aggregate_id = ? ORDER BY id ASC
+```
+
+## Sicherheitseigenschaften
+
+| Eigenschaft | Implementierung |
+|---|---|
+| Event-Unveränderlichkeit | Kein DELETE/UPDATE-Endpunkt für Events |
+| Betragsbereich | 1–1.000.000.000 (int) — lehnt Floats und Überlauf-Werte ab |
+| Unzureichende Mittel | Kontostand vor Abhebung wiedergegeben; 422 wenn unzureichend |
+| Cross-Account-Isolation | Alle Abfragen filtern nach aggregate_id |
+| Payload-Injection | Payload immer `['amount' => int]`; keine benutzerkontrollierten Schlüssel |
+| Event-Typ-Injection | Event-Typ immer aus Konstanten; kein benutzerkontrollierter event_type |
+
+## Routen-Übersicht
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `POST` | `/accounts` | Konto erstellen |
+| `POST` | `/accounts/{id}/deposit` | Einzahlungs-Event anhängen |
+| `POST` | `/accounts/{id}/withdraw` | Abhebungs-Event anhängen (Kontostand-Prüfung) |
+| `GET` | `/accounts/{id}/balance` | Kontostand aus Events wiedergeben |
+| `GET` | `/accounts/{id}/events` | Alle Events für Konto auflisten |

--- a/docs/de/howto/event-ticket-booking.md
+++ b/docs/de/howto/event-ticket-booking.md
@@ -1,0 +1,16 @@
+# How-to: Event-Ticket-Buchung
+
+Demonstriert die Kapazitätsverwaltung für Events mit Pro-Benutzer-Ticketkauf.
+Field Trial: FT196 (`../NENE2-FT/ticketlog/`). Enthält ATK-01~12 Cracker-Angriffstest.
+
+## Muster-Übersicht
+
+| Thema | Ansatz |
+|---|---|
+| Kapazitätsverfolgung | `remaining = capacity - COUNT(tickets)` wird beim Lesen berechnet |
+| Ausverkauft | 409 Conflict wenn `remaining <= 0` |
+| Doppelkauf | `UNIQUE(event_id, user_id)` → fängt gleichzeitige Doppelkäufe ab |
+| IDOR-Stornierung | `user_id`-Eigentumsüberprüfung → 403 bei Nichtübereinstimmung |
+| Admin-Schlüssel | `hash_equals()` fail-closed |
+
+## ATK-01~12 Ergebnisse: ALLE BESTANDEN

--- a/docs/de/howto/expense-tracker.md
+++ b/docs/de/howto/expense-tracker.md
@@ -1,0 +1,139 @@
+# How-to: Ausgaben-Tracker-API
+
+Diese Anleitung zeigt, wie ein persönliches Ausgaben-Tracking-System mit kategorienbasierter Filterung,
+Datumsbereichsabfragen, monatlicher Zusammenfassungsaggregation und vollständigem CRUD mit NENE2 aufgebaut wird.
+Muster demonstriert durch den **expenselog** Field Trial (FT223).
+
+## Funktionen
+
+- Ausgaben erstellen, lesen, aktualisieren, löschen (Datum, Betrag, Kategorie, Notiz)
+- Auflisten mit Datumsbereichsfilter (`?from=` / `?to=`) und Kategoriefilter
+- Monatliche Zusammenfassungsaggregation (Gesamt pro Kategorie pro Monat)
+- Paginierung mit Gesamtanzahl
+- Kategorie-Allowlist-Validierung
+- Betragsvalidierung: positiver Integer (Cent)
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS expenses (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    date       TEXT    NOT NULL,
+    amount     INTEGER NOT NULL,
+    category   TEXT    NOT NULL,
+    note       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_expenses_date ON expenses (date DESC);
+CREATE INDEX IF NOT EXISTS idx_expenses_category ON expenses (category, date DESC);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `GET` | `/expenses` | Ausgaben auflisten (filterbar, paginiert) |
+| `POST` | `/expenses` | Ausgabe erstellen |
+| `GET` | `/expenses/summary` | Monatliche Zusammenfassung nach Kategorie |
+| `GET` | `/expenses/{id}` | Einzelne Ausgabe abrufen |
+| `PATCH` | `/expenses/{id}` | Teilaktualisierung |
+| `DELETE` | `/expenses/{id}` | Ausgabe löschen |
+
+## Validierungsmuster
+
+### Betrag (positiver Integer, in Cent gespeichert)
+
+```php
+if (!is_int($amount) || $amount <= 0) {
+    $errors[] = new ValidationError('amount', 'Amount must be a positive integer (cents).');
+}
+```
+
+Die Verwendung von `is_int()` lehnt Floats aus JSON ab (`1.5` ist in PHPs striktem Modus kein Int).
+
+### Datum (ISO 8601-Format)
+
+```php
+$date = DateTime::createFromFormat('Y-m-d', $dateStr);
+if (!$date || $date->format('Y-m-d') !== $dateStr) {
+    $errors[] = new ValidationError('date', 'date must be a valid YYYY-MM-DD date.');
+}
+```
+
+Round-Trip-Validierung: parsen, dann neu formatieren — garantiert, dass der String kanonisch war.
+
+### Kategorie-Allowlist
+
+```php
+private const array VALID_CATEGORIES = [
+    'food', 'transport', 'utilities', 'entertainment',
+    'health', 'shopping', 'travel', 'other',
+];
+
+if (!in_array($category, self::VALID_CATEGORIES, true)) {
+    $errors[] = new ValidationError('category', 'Invalid category.');
+}
+```
+
+## Datumsbereichsfilterung
+
+```php
+public function findAll(
+    ?string $from = null,
+    ?string $to = null,
+    ?string $category = null,
+    int $limit = 20,
+    int $offset = 0,
+): array
+```
+
+Filter sind optional — für Abfragen über alle Zeiten weglassen. Daten werden lexikografisch verglichen (ISO 8601-Strings sind in UTC sortierbar).
+
+## Monatliche Zusammenfassungsabfrage
+
+Aggregation nach Jahr-Monat mit SQLites `strftime`:
+
+```sql
+SELECT strftime('%Y-%m', date) AS month, category, SUM(amount) AS total, COUNT(*) AS count
+FROM expenses
+WHERE date BETWEEN :from AND :to
+GROUP BY month, category
+ORDER BY month DESC, category ASC
+```
+
+Gibt Pro-Kategorie-Gesamtwerte für jeden Monat zurück:
+
+```json
+{
+  "summary": [
+    { "month": "2026-05", "category": "food", "total": 42000, "count": 12 },
+    { "month": "2026-05", "category": "transport", "total": 8500, "count": 5 }
+  ]
+}
+```
+
+## PATCH-Teilaktualisierung
+
+Nur im Body enthaltene Felder werden aktualisiert — fehlende Felder behalten ihre aktuellen Werte:
+
+```php
+if (isset($body['amount'])) {
+    if (!is_int($body['amount']) || $body['amount'] <= 0) {
+        $errors[] = new ValidationError('amount', 'Amount must be a positive integer.');
+    } else {
+        $updates['amount'] = $body['amount'];
+    }
+}
+// Gleiches Muster für date, category, note
+```
+
+## Validierungsmuster
+
+| Feld | Prüfung | Grund |
+|-------|-------|--------|
+| `amount` | `is_int() && > 0` | Lehnt Floats, Null, Negative ab |
+| `date` | Round-Trip `Y-m-d`-Parse | Nur kanonisches ISO 8601 |
+| `category` | `in_array(strict: true)` | Verhindert Tippfehler und Injection |
+| `limit` / `offset` | `max(1, min(100, $limit))` | Verhindert DoS und SQL-Injection |

--- a/docs/de/howto/expense-tracking-api.md
+++ b/docs/de/howto/expense-tracking-api.md
@@ -1,0 +1,134 @@
+# How-to: Ausgaben-Tracking-API
+
+> **FT-Referenz**: FT311 (`NENE2-FT/expenselog`) — Ausgaben-Tracking: YYYY-MM-DD-Datumsformatvalidierung, Kategorie als offener String (kein Enum), monatliche Zusammenfassungsaggregation nach Kategorie, Offset-Paginierung mit limit/offset, PATCH-Teilaktualisierung (nur bereitgestellte Felder ändern), Datumsbereichsfilter, statische `/summary`-Route vor dynamischer `/{id}`, 34 Tests / 67 Assertions PASS.
+
+Diese Anleitung zeigt, wie eine Ausgaben-Tracking-API mit Datumsfilterung, Kategorieaggregation, Paginierung und Teilaktualisierungen aufgebaut wird.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS expenses (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT    NOT NULL,  -- YYYY-MM-DD
+    amount      INTEGER NOT NULL,  -- Cent
+    category    TEXT    NOT NULL,
+    note        TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_expenses_date     ON expenses (date);
+CREATE INDEX IF NOT EXISTS idx_expenses_category ON expenses (category);
+```
+
+Indizes auf `date` und `category` unterstützen schnelles Filtern. `amount` in Integer-Cent vermeidet Gleitkommagenauigkeitsprobleme.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `GET` | `/expenses` | Auflisten mit optionalen Filtern + Paginierung |
+| `POST` | `/expenses` | Ausgabe erstellen |
+| `GET` | `/expenses/summary` | Monatliche Kategorieaggregation |
+| `GET` | `/expenses/{id}` | Einzelne Ausgabe abrufen |
+| `PATCH` | `/expenses/{id}` | Teilaktualisierung |
+| `DELETE` | `/expenses/{id}` | Löschen |
+
+**Routen-Reihenfolge**: `/expenses/summary` muss **vor** `/expenses/{id}` registriert werden — sonst wird `summary` als `id`-Parameter erfasst.
+
+## Datumsvalidierung — YYYY-MM-DD
+
+```php
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+    $errors[] = new ValidationError('date', 'date must be in YYYY-MM-DD format.', 'invalid_format');
+}
+```
+
+Nur das strenge `YYYY-MM-DD`-Format wird akzeptiert. ISO 8601-Strings mit Zeitkomponenten oder Zeitzonen-Offsets werden abgelehnt.
+
+## Kategorie — Offener String (kein Enum)
+
+```php
+$category = isset($body['category']) && is_string($body['category']) && $body['category'] !== ''
+    ? $body['category']
+    : null;
+if ($category === null) {
+    $errors[] = new ValidationError('category', 'category is required.', 'required');
+}
+```
+
+Kategorien sind Freitext-Strings (kein geschlossenes Enum). Jeder nicht-leere String ist gültig, sodass Kategorien wie `"food"`, `"transport"`, `"entertainment"` ohne Schemaänderungen möglich sind.
+
+## Monatliche Zusammenfassung — YYYY-MM-Format
+
+```php
+// Abfrage: SELECT category, SUM(amount), COUNT(*) WHERE date LIKE 'YYYY-MM-%'
+$summary = $this->repository->monthlySummary($month);
+
+return $this->json->create([
+    'month'       => $summary->month,
+    'total'       => $summary->total,
+    'count'       => $summary->count,
+    'by_category' => $summary->byCategory, // [{category, total, count}, ...]
+]);
+```
+
+Monatsparameter-Format: `YYYY-MM`. Aggregiert alle Ausgaben in diesem Monat, gruppiert nach Kategorie.
+
+## Paginierung — Offset-basiert
+
+```php
+$pagination = PaginationQueryParser::parse($request);
+// Gibt zurück: { limit: int, offset: int }
+
+$items = $this->repository->findAll($from, $to, $category, $pagination->limit, $pagination->offset);
+$total = $this->repository->count($from, $to, $category);
+
+return $this->json->create([
+    'items'  => $items,
+    'total'  => $total,
+    'limit'  => $pagination->limit,
+    'offset' => $pagination->offset,
+]);
+```
+
+Ungültiges `limit` (kein Integer, negativ, zu groß) → 422.
+
+## PATCH — Teilaktualisierung
+
+```php
+// Nur Felder aktualisieren, die im Body vorhanden sind
+$date     = array_key_exists('date', $body)     ? $body['date']     : null;
+$amount   = array_key_exists('amount', $body)   ? $body['amount']   : null;
+$category = array_key_exists('category', $body) ? $body['category'] : null;
+$note     = array_key_exists('note', $body)     ? $body['note']     : null;
+```
+
+`array_key_exists()` unterscheidet "Feld nicht angegeben" von "Feld als null angegeben". Nur bereitgestellte Felder werden validiert und aktualisiert.
+
+## Datumsbereichsfilter
+
+```php
+// GET /expenses?date_from=2026-01-01&date_to=2026-01-31
+$from = QueryStringParser::string($request, 'date_from');
+$to   = QueryStringParser::string($request, 'date_to');
+$category = QueryStringParser::string($request, 'category');
+
+$items = $this->repository->findAll($from, $to, $category, $limit, $offset);
+```
+
+Alle Filterparameter sind optional. Null bedeutet "kein Filter auf dieser Dimension".
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `/expenses/{id}` vor `/expenses/summary` registrieren | `"summary"` wird als `id` abgeglichen; Summary-Endpunkt nicht erreichbar |
+| `amount` als FLOAT speichern | Gleitkommagenauigkeit: `0.1 + 0.2 ≠ 0.3`; Integer-Cent verwenden |
+| Beliebigen Datumsstring akzeptieren (ISO 8601 mit Zeit) | Inkonsistente Datumsvergleiche in WHERE-Klauseln |
+| Geschlossenes Kategorie-Enum | Neue Kategorien erfordern Schemamigration |
+| `isset($body['field'])` für PATCH | `isset()` gibt bei `null` false zurück; `array_key_exists()` verwenden |
+| Zählabfrage ohne dieselben Filter wie Liste | Paginierungsgesamtanzahl stimmt nicht mit tatsächlicher gefilterter Anzahl überein |
+| Kein Index auf date/category | Full-Table-Scan bei jeder gefilterten Listenanfrage |

--- a/docs/de/howto/feature-flag-api.md
+++ b/docs/de/howto/feature-flag-api.md
@@ -1,0 +1,173 @@
+# How-to: Feature-Flag-API
+
+> **FT-Referenz**: FT313 (`NENE2-FT/flaglog`) — Feature-Flag-Verwaltung: Pro-Umgebungs-Flags, rollout_percent für graduellen Rollout, Pro-Benutzer-Überschreibungen, Evaluate-Endpunkt mit Override-Auflösung, snake_case-Schlüsselvalidierung, 18 Tests / 29 Assertions PASS.
+
+Diese Anleitung zeigt, wie ein Feature-Flag-System aufgebaut wird, das Pro-Umgebungs-Konfiguration, graduellen Rollout nach Prozentsatz und Pro-Benutzer-Überschreibungen unterstützt.
+
+## Schema
+
+```sql
+CREATE TABLE feature_flags (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    key             TEXT    NOT NULL,
+    environment     TEXT    NOT NULL DEFAULT 'production',
+    enabled         INTEGER NOT NULL DEFAULT 0,
+    rollout_percent INTEGER NOT NULL DEFAULT 100,
+    created_at      TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL,
+    UNIQUE (key, environment)
+);
+
+CREATE TABLE flag_overrides (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    flag_key   TEXT    NOT NULL,
+    environment TEXT   NOT NULL DEFAULT 'production',
+    user_id    TEXT    NOT NULL,
+    enabled    INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    UNIQUE (flag_key, environment, user_id)
+);
+```
+
+`key` muss `^[a-z][a-z0-9_]*$` (snake_case) entsprechen. `rollout_percent` ist 0–100.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `PUT` | `/flags/{key}` | Flag erstellen oder aktualisieren |
+| `GET` | `/flags` | Alle Flags auflisten (optional `?environment=`) |
+| `GET` | `/flags/{key}/evaluate` | Flag für einen Benutzer auswerten (`?user_id=`) |
+| `PUT` | `/flags/{key}/overrides/{userId}` | Pro-Benutzer-Override setzen |
+| `DELETE` | `/flags/{key}/overrides/{userId}` | Pro-Benutzer-Override entfernen |
+
+## Flag-Upsert — PUT /flags/{key}
+
+```php
+// Request-Body
+{
+    "enabled": true,
+    "rollout_percent": 50,   // optional, Standard 100
+    "environment": "staging" // optional, Standard "production"
+}
+
+// Antwort 200
+{
+    "key": "dark_mode",
+    "enabled": true,
+    "rollout_percent": 50,
+    "environment": "staging",
+    "created_at": "...",
+    "updated_at": "..."
+}
+```
+
+Derselbe Endpunkt erstellt oder aktualisiert (UPSERT nach `key + environment`). Zweimaliges Senden von `PUT` mit unterschiedlichen Werten aktualisiert das Flag.
+
+## Schlüsselvalidierung
+
+```php
+// Gültige Schlüssel (snake_case: a-z, 0-9, Unterstrich, beginnt mit Buchstabe)
+dark_mode, beta_ui, new_feature_v2
+
+// Ungültig — gibt 422 zurück
+Dark-Mode   // Großbuchstaben + Bindestrich
+123flag     // beginnt mit Ziffer
+my flag     // Leerzeichen
+```
+
+```php
+if (!preg_match('/^[a-z][a-z0-9_]*$/', $key)) {
+    throw new ValidationException([
+        ['field' => 'key', 'message' => 'Key must be snake_case.', 'code' => 'invalid-format'],
+    ]);
+}
+```
+
+## Rollout-Prozent-Validierung
+
+```php
+if ($rolloutPercent < 0 || $rolloutPercent > 100) {
+    throw new ValidationException([
+        ['field' => 'rollout_percent', 'message' => 'Must be 0–100.', 'code' => 'out-of-range'],
+    ]);
+}
+```
+
+## Pro-Umgebungs-Flags
+
+```php
+// Gleicher Schlüssel, unterschiedliche Umgebungen
+PUT /flags/beta_ui  {"enabled": true,  "environment": "staging"}
+PUT /flags/beta_ui  {"enabled": false, "environment": "production"}
+
+// Nach Umgebung auflisten
+GET /flags?environment=staging     → [{"key": "beta_ui", "enabled": true, ...}]
+GET /flags?environment=production  → [{"key": "beta_ui", "enabled": false, ...}]
+```
+
+## Auswertung — Rollout + Override
+
+```
+GET /flags/{key}/evaluate?user_id={userId}
+```
+
+Auflösungsreihenfolge:
+1. **Override gewinnt**: wenn eine `flag_overrides`-Zeile für `(key, environment, user_id)` existiert → Override-Wert verwenden
+2. **Flag deaktiviert**: wenn `enabled = false` → `false` unabhängig vom Rollout zurückgeben
+3. **Rollout-Prüfung**: `user_id` deterministisch hashen → mit `rollout_percent` vergleichen
+
+```php
+// 1. Override prüfen
+$override = $this->repo->findOverride($key, $environment, $userId);
+if ($override !== null) {
+    return new EvaluateResult(enabled: $override->enabled, override: $override->enabled);
+}
+
+// 2. Flag deaktiviert
+if (!$flag->enabled) {
+    return new EvaluateResult(enabled: false, override: null);
+}
+
+// 3. Rollout-Prozent
+$hash = abs(crc32($userId)) % 100;
+$enabled = $hash < $flag->rolloutPercent;
+return new EvaluateResult(enabled: $enabled, override: null);
+```
+
+Antwort:
+```json
+{"enabled": true, "override": null}   // Rollout-Entscheidung
+{"enabled": true, "override": true}   // Override aktiviert
+{"enabled": false, "override": false} // Override deaktiviert
+```
+
+## Pro-Benutzer-Überschreibungen
+
+```php
+// Für einen bestimmten Benutzer aktivieren (auch wenn Flag aus / Rollout 0%)
+PUT /flags/beta_feature/overrides/alice  {"enabled": true}
+
+// Für einen bestimmten Benutzer deaktivieren (auch wenn Flag an / Rollout 100%)
+PUT /flags/global_flag/overrides/bob  {"enabled": false}
+
+// Override entfernen — kehrt zu globalem Flag + Rollout-Logik zurück
+DELETE /flags/my_flag/overrides/alice
+```
+
+Override erfordert das `enabled`-Feld (Boolean). Fehlendes Feld → 422.
+Override auf nicht-existierendem Flag → 404.
+Nicht-existierenden Override löschen → 404.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Beliebiges Schlüsselformat erlauben (z. B. Bindestriche, Großbuchstaben) | Inkonsistente Schlüssel zwischen Teams; schwer zu grep/referenzieren im Code |
+| Rollout-Prozent > 100 | Logikfehler; 110% Rollout bedeutet immer aktiviert, auch wenn als graduell beabsichtigt |
+| Keine Umgebungstrennung | Staging-Flags bluten in die Produktion; Canary-Deployments brechen |
+| Auswerten ohne `user_id`-Prüfung | `crc32(null)` oder leerer String ergibt deterministisches aber falsches Bucketing |
+| 200 für Auswertung eines fehlenden Flags zurückgeben | Aufrufer nimmt an, Flag existiert; behandelt es stillschweigend als deaktiviert statt Alarm auszulösen |
+| Globalen Flag-Zustand im Speicher/Cache ohne TTL | Veraltete Flags nach Rollout-Prozent-Änderung; Änderungen propagieren nicht |

--- a/docs/de/howto/feature-flags.md
+++ b/docs/de/howto/feature-flags.md
@@ -1,0 +1,220 @@
+# How-to: Feature-Flags-API
+
+> **FT-Referenz**: FT270 (`NENE2-FT/featureflaglog`) — Feature-Flag-API: Prioritätsketten-Auswertung (Benutzer-Target → Mandanten-Target → globally_enabled → rollout_pct-Hash), crc32-basierte deterministische Bucket-Zuweisung, Benutzer-/Mandanten-Kill-Switches, UNIQUE-Name-Constraint für Flags, 21 Tests / 31 Assertions PASS.
+
+Feature-Flags ermöglichen das Umschalten von Funktionalität zur Laufzeit ohne Code-Deployment. Die Kernentscheidungen sind: wo der Zustand gespeichert wird (DB vs. Konfiguration), wie die Priorität ausgewertet wird wenn mehrere Regeln zutreffen, und wie Rollout-Prozentsätze ohne Pro-Benutzer-Tracking behandelt werden.
+
+---
+
+## Routen
+
+| Methode   | Pfad | Beschreibung |
+|----------|---------------------------------------|------------------------------------------|
+| `POST`   | `/flags`                              | Ein neues Feature-Flag erstellen |
+| `GET`    | `/flags/{name}`                       | Flag-Details mit Targets abrufen |
+| `POST`   | `/flags/{name}/toggle`                | globally_enabled ein/ausschalten |
+| `PUT`    | `/flags/{name}/rollout`               | Rollout-Prozentsatz setzen (0–100) |
+| `PUT`    | `/flags/{name}/targets`               | Benutzer- oder Mandanten-Target-Override einrichten |
+| `DELETE` | `/flags/{name}/targets/{type}/{id}`   | Einen bestimmten Target-Override entfernen |
+| `POST`   | `/flags/{name}/evaluate`              | Flag für einen Benutzer/Mandanten auswerten |
+
+---
+
+## Kernkomponenten
+
+- **Feature-Flag-Registry**: eine Zeile pro Flag mit Name, globalem Ein/Aus-Schalter und Rollout-Prozentsatz.
+- **Flag-Targets**: Pro-Benutzer- oder Pro-Mandanten-Overrides, die den globalen Zustand überschreiben.
+- **Evaluator**: wendet die Prioritätskette an und gibt einen Boolean für einen gegebenen Benutzer zurück.
+
+## Schema
+
+```sql
+CREATE TABLE feature_flags (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    name             TEXT    NOT NULL UNIQUE,
+    description      TEXT    NOT NULL DEFAULT '',
+    globally_enabled INTEGER NOT NULL DEFAULT 0,
+    rollout_pct      INTEGER NOT NULL DEFAULT 0,  -- 0-100
+    created_at       TEXT    NOT NULL
+);
+
+CREATE TABLE flag_targets (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    flag_id     INTEGER NOT NULL,
+    target_type TEXT    NOT NULL,  -- 'user' | 'tenant'
+    target_id   TEXT    NOT NULL,
+    enabled     INTEGER NOT NULL DEFAULT 1,
+    UNIQUE (flag_id, target_type, target_id),
+    FOREIGN KEY (flag_id) REFERENCES feature_flags(id)
+);
+```
+
+## Auswertungspriorität
+
+```php
+final readonly class FlagEvaluator
+{
+    /** @param FlagTarget[] $targets */
+    public function evaluate(FeatureFlag $flag, array $targets, string $userId, ?string $tenantId): bool
+    {
+        // 1. Explizites Benutzer-Level-Target gewinnt zuerst
+        foreach ($targets as $target) {
+            if ($target->targetType === 'user' && $target->targetId === $userId) {
+                return $target->enabled;
+            }
+        }
+
+        // 2. Mandanten-Level-Target
+        if ($tenantId !== null) {
+            foreach ($targets as $target) {
+                if ($target->targetType === 'tenant' && $target->targetId === $tenantId) {
+                    return $target->enabled;
+                }
+            }
+        }
+
+        // 3. Globaler Schalter
+        if ($flag->globallyEnabled) {
+            return true;
+        }
+
+        // 4. Rollout-Prozentsatz: deterministischer Bucket via crc32-Hash
+        if ($flag->rolloutPct > 0) {
+            $bucket = abs(crc32($userId . '.' . $flag->name)) % 100;
+            return $bucket < $flag->rolloutPct;
+        }
+
+        // 5. Standard: aus
+        return false;
+    }
+}
+```
+
+Prioritätsreihenfolge (höchste gewinnt):
+1. Benutzer-Level-Target (`target_type = 'user'`)
+2. Mandanten-Level-Target (`target_type = 'tenant'`)
+3. `globally_enabled = 1`
+4. `rollout_pct > 0` mit hash-basiertem Bucket
+5. `false`
+
+## Rollout-Prozentsatz — deterministischer Bucket
+
+`crc32($userId . '.' . $flagName) % 100` erzeugt einen stabilen Bucket pro (Benutzer, Flag)-Paar. Derselbe Benutzer landet immer im selben Bucket, sodass seine Erfahrung über Anfragen hinweg konsistent ist. Das Anhängen des Flag-Namens verhindert, dass alle Flags bei `pct = 10` denselben Benutzern ausgerollt werden.
+
+Wichtig: `crc32()` kann auf 64-Bit-Systemen negative Werte zurückgeben — `abs()` verwenden.
+
+## Targets als Overrides
+
+Ein Target mit `enabled = false` ist ein Kill-Switch: Es deaktiviert das Flag für diesen Benutzer oder Mandanten, auch wenn `globally_enabled = 1`. Dies ist der kanonische Weg, einen bestimmten Benutzer von einem Rollout auszuschließen, der bereits global aktiviert ist.
+
+```php
+// Benutzer-Level-Kill-Switch (überschreibt globale Aktivierung)
+$repo->upsertTarget($flag->id, 'user', 'problem-user', false);
+
+// Mandanten-Früh-Zugang (überschreibt globale Deaktivierung)
+$repo->upsertTarget($flag->id, 'tenant', 'beta-tenant', true);
+```
+
+## Upsert-Muster für Targets
+
+Targets verwenden `INSERT OR REPLACE`-/Upsert-Semantik — zweimaliges Aufrufen desselben Endpunkts mit unterschiedlichen `enabled`-Werten aktualisiert die bestehende Zeile statt ein Duplikat zu erstellen:
+
+```php
+$existing = $this->executor->fetchOne(
+    'SELECT * FROM flag_targets WHERE flag_id = ? AND target_type = ? AND target_id = ?',
+    [$flagId, $targetType, $targetId],
+);
+
+if ($existing !== null) {
+    $this->executor->execute('UPDATE flag_targets SET enabled = ? WHERE id = ?', ...);
+} else {
+    $this->executor->execute('INSERT INTO flag_targets ...', ...);
+}
+```
+
+Der UNIQUE-Constraint auf `(flag_id, target_type, target_id)` stellt sicher, dass es höchstens einen Override pro (Flag, Target)-Paar gibt.
+
+## Konfliktantwort bei doppelten Flag-Namen
+
+`feature_flags.name` hat einen UNIQUE-Constraint. Bei doppelter Erstellung wirft die DB eine `RuntimeException`. Diese abfangen und 409 Conflict statt 500 zurückgeben:
+
+```php
+try {
+    $this->executor->execute('INSERT INTO feature_flags ...', [...]);
+} catch (\RuntimeException) {
+    return null; // Aufrufer bildet null auf 409 ab
+}
+```
+
+## Designentscheidungen
+
+**Warum DB-gestützt statt Konfigurationsdatei?**
+Konfigurationsdateien erfordern ein Deploy zum Ändern eines Flags. DB-gestützte Flags können live umgeschaltet werden, ohne Code zu ändern oder Prozesse neu zu starten.
+
+**Warum deterministischer Hash für Rollout statt zufällig?**
+Zufällige Auswahl bedeutet, dass derselbe Benutzer zwischen aktiviert/deaktiviert über Anfragen wechselt. Ein stabiler Hash gibt jedem Benutzer eine konsistente Erfahrung für die Lebensdauer des Flags.
+
+**Warum `enabled = false`-Targets erlauben?**
+Ein Flag-System ohne Kill-Switches ist unvollständig. `enabled = false` ist der sicherste Weg, einen Benutzer von einem bereits global aktivierten Rollout auszuschließen — keine Code-Änderung, kein Deploy.
+
+**Warum `globally_enabled` und `rollout_pct` trennen?**
+`globally_enabled = 1` ist ein expliziter Alles-oder-Nichts-Schalter. `rollout_pct` ist für graduellen Rollout. Sie zu trennen vermeidet das Überladen eines Feldes mit zwei verschiedenen Bedeutungen.
+
+---
+
+## Beispielantworten
+
+**POST /flags** (201 Created):
+```json
+{
+    "id": 1,
+    "name": "new-checkout",
+    "description": "New checkout flow",
+    "globally_enabled": false,
+    "rollout_pct": 0,
+    "created_at": "2026-05-27 10:00:00"
+}
+```
+
+**GET /flags/{name}** (200 OK):
+```json
+{
+    "flag": {
+        "id": 1,
+        "name": "new-checkout",
+        "globally_enabled": false,
+        "rollout_pct": 30
+    },
+    "targets": [
+        {
+            "id": 1,
+            "flag_id": 1,
+            "target_type": "user",
+            "target_id": "user-42",
+            "enabled": true
+        }
+    ]
+}
+```
+
+**POST /flags/{name}/evaluate** (200 OK):
+```json
+{
+    "flag": "new-checkout",
+    "user_id": "user-42",
+    "enabled": true
+}
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Zufällige Zahl pro Request für Rollout verwenden | Derselbe Benutzer wechselt zwischen aktiviert/deaktiviert über Anfragen — inkonsistente UX |
+| `abs()` auf `crc32()` vergessen | crc32 kann auf 64-Bit-PHP negative Werte zurückgeben — Modulo ergibt falschen Bucket |
+| Beliebige `target_type`-Werte erlauben | Unkontrolliertes Enum macht Auswertungslogik unbegrenzt; auf `'user'` und `'tenant'` beschränken |
+| Kein `UNIQUE (flag_id, target_type, target_id)` | Doppelte Targets machen Auswertung mehrdeutig — erste Zeile gewinnt beliebig |
+| Flag-Name als `target_id` verwenden | Flag-Name kann sich ändern; stabile IDs für Benutzer-/Mandanten-Targeting verwenden |
+| 500 bei doppeltem Flag-Namen zurückgeben | Die Namens-Eindeutigkeitsverletzung ist ein Domain-Fehler, kein Server-Fehler; auf 409 Conflict abbilden |

--- a/docs/de/howto/feedback-collection.md
+++ b/docs/de/howto/feedback-collection.md
@@ -1,0 +1,66 @@
+# How-to: Feedback-Sammlungs-API
+
+## Übersicht
+
+Ein Feedback-System, bei dem Benutzer eine Bewertung (1–5) und einen Kommentar für eine Zielentität einreichen. Admins können alle Feedbacks auflisten; ein öffentlicher Stats-Endpunkt zeigt aggregierte Durchschnittswerte.
+
+**Referenzimplementierung**: `../NENE2-FT/feedbacklog/`
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS feedback (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    target     TEXT    NOT NULL,
+    score      INTEGER NOT NULL,   -- 1-5
+    comment    TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, target)
+);
+```
+
+## Routen
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/feedback` | Benutzer | Feedback einreichen |
+| `GET` | `/feedback` | Admin | Alle Feedbacks auflisten |
+| `GET` | `/feedback/stats` | Keine | Aggregierte Statistiken |
+
+## Duplikat-Verhinderung
+
+`UNIQUE (user_id, target)` erzwingt ein Feedback pro Benutzer pro Ziel auf DB-Ebene. Zunächst Prüfung auf Anwendungsebene:
+
+```php
+$stmt = $this->pdo->prepare('SELECT id FROM feedback WHERE user_id = :uid AND target = :tgt');
+$stmt->execute([...]);
+if ($stmt->fetch() !== false) return 'already_submitted';
+```
+
+## Bewertungsvalidierung
+
+```php
+if (!is_int($score) || $score < 1 || $score > 5) {
+    return $this->problem(422, 'validation-failed', 'score must be an integer 1-5.');
+}
+```
+
+## Statistikaggregation
+
+```sql
+SELECT COUNT(*) AS cnt, AVG(score) AS avg FROM feedback WHERE target = :tgt
+```
+
+Bei einer Anzahl von null `null` als Durchschnittswert zurückgeben, um `NaN` in JSON zu vermeiden.
+
+## HTTP-Statuscodes
+
+| Situation | Status |
+|-----------|--------|
+| Feedback eingereicht | 201 |
+| Statistiken / Liste | 200 |
+| Kein X-User-Id | 400 |
+| Leeres Ziel / ungültige Bewertung | 422 |
+| Kein Admin-Schlüssel | 403 |
+| Doppeltes Feedback | 409 |

--- a/docs/de/howto/file-metadata-sharing.md
+++ b/docs/de/howto/file-metadata-sharing.md
@@ -1,0 +1,225 @@
+# Implementierungsleitfaden: Datei-Metadaten-Verwaltung und Freigabe-API
+
+## Übersicht
+
+Dieser Leitfaden erklärt, wie eine Datei-Metadaten-Verwaltungs-API mit NENE2 implementiert wird.
+Es werden keine tatsächlichen Dateien gespeichert — stattdessen werden Metadaten (Name, Größe, MIME-Typ,
+Beschreibung, Sichtbarkeit) verwaltet und die Freigabe zwischen Benutzern (view/edit-Berechtigungen) unterstützt.
+
+---
+
+## DB-Schema
+
+```sql
+CREATE TABLE files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    size INTEGER NOT NULL DEFAULT 0 CHECK (size >= 0),
+    mime_type TEXT NOT NULL,
+    description TEXT,
+    visibility TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private', 'public')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE file_shares (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_id INTEGER NOT NULL,
+    shared_with_user_id INTEGER NOT NULL,
+    can_edit INTEGER NOT NULL DEFAULT 0 CHECK (can_edit IN (0, 1)),
+    created_at TEXT NOT NULL,
+    UNIQUE (file_id, shared_with_user_id),
+    FOREIGN KEY (file_id) REFERENCES files(id),
+    FOREIGN KEY (shared_with_user_id) REFERENCES users(id)
+);
+```
+
+**Designentscheidungen**
+
+- `visibility CHECK (visibility IN ('private', 'public'))` — Gültige Werte auf DB-Ebene eingeschränkt
+- `can_edit CHECK (can_edit IN (0, 1))` — SQLite Boolean als INTEGER 0/1
+- `UNIQUE (file_id, shared_with_user_id)` — Doppelte Freigaben an denselben Benutzer verhindert
+
+---
+
+## Endpunkt-Design
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `GET` | `/files` | Liste zugänglicher Dateien (eigene + freigegebene) |
+| `POST` | `/files` | Datei-Metadaten erstellen |
+| `GET` | `/files/{fileId}` | Datei abrufen (nur Eigentümer, öffentlich oder freigegeben) |
+| `PUT` | `/files/{fileId}` | Aktualisieren (Eigentümer oder edit-Freigabe) |
+| `DELETE` | `/files/{fileId}` | Löschen (nur Eigentümer) |
+| `POST` | `/files/{fileId}/shares` | Mit Benutzer teilen |
+| `DELETE` | `/files/{fileId}/shares/{userId}` | Freigabe aufheben (nur Eigentümer) |
+
+---
+
+## Zugriffssteuerungs-Design
+
+### 3-stufige Zugriffsebenen
+
+```
+Eigentümer (user_id = X-User-Id)
+  → Alle Operationen möglich
+  
+edit-Freigabe (file_shares.can_edit = 1)
+  → GET / PUT möglich
+  → visibility-Änderung nicht möglich (nur Eigentümer)
+  → DELETE nicht möglich
+  
+view-Freigabe (file_shares.can_edit = 0) oder öffentliche Datei
+  → Nur GET möglich
+```
+
+### Existenz-Verschleierung (IDOR-Prävention)
+
+Private Dateien anderer Benutzer geben **404** zurück (nicht 403).
+403 würde implizieren "Datei existiert, aber kein Zugriff" und begünstigt ID-Rateraten-Angriffe.
+
+```php
+if ((int) $file['user_id'] !== $userId) {
+    $share = $this->repo->findShare($fileId, $userId);
+    if ($share === null) {
+        return $this->json->create(['error' => 'File not found'], 404); // 403 statt 404 vermeiden
+    }
+}
+```
+
+---
+
+## Zugängliche Dateien auflisten — Abfrage
+
+```php
+return $this->db->fetchAll(
+    'SELECT f.id, f.user_id, f.name, f.size, f.mime_type, f.description,
+            f.visibility, f.created_at, f.updated_at,
+            u.name AS owner_name,
+            CASE WHEN f.user_id = ? THEN 1 ELSE fs.can_edit END AS can_edit,
+            CASE WHEN f.user_id = ? THEN 1 ELSE 0 END AS is_owner
+     FROM files f
+     JOIN users u ON u.id = f.user_id
+     LEFT JOIN file_shares fs ON fs.file_id = f.id AND fs.shared_with_user_id = ?
+     WHERE f.user_id = ? OR fs.shared_with_user_id = ?
+     ORDER BY f.created_at DESC, f.id DESC',
+    [$userId, $userId, $userId, $userId, $userId]
+);
+```
+
+- `LEFT JOIN` verbindet die Freigabetabelle; `WHERE` holt "eigene ODER freigegebene" Dateien
+- Öffentliche Dateien sind nicht in der Liste enthalten (Abruf einzeln via GET möglich)
+- `CASE WHEN` berechnet Eigentümer-Flag und Bearbeitungsberechtigung
+
+---
+
+## Sichtbarkeits-Eskalations-Verhinderung
+
+Auch edit-Freigabe-Benutzer können `visibility` nicht ändern. Nur der Eigentümer darf das.
+
+```php
+// Only owner can change visibility
+if ($ownerId !== $userId) {
+    $visibility = (string) $file['visibility']; // Override with current value
+}
+
+$this->repo->update($fileId, $name, $size, $mimeType, $description, $visibility, $now);
+```
+
+---
+
+## Bereinigung von Freigabe-Einträgen beim Löschen
+
+```php
+public function delete(int $id): void
+{
+    $this->db->execute('DELETE FROM file_shares WHERE file_id = ?', [$id]);
+    $this->db->execute('DELETE FROM files WHERE id = ?', [$id]);
+}
+```
+
+Wegen FK-Constraint muss `file_shares` zuerst gelöscht werden, dann `files`.
+
+---
+
+## Validierungs-Design
+
+```php
+// name: erforderlich, max. 255 Zeichen
+if (!isset($body['name']) || !is_string($body['name']) || trim($body['name']) === '') {
+    $errors[] = new ValidationError('name', 'name is required', 'required');
+} elseif (mb_strlen($body['name']) > 255) {
+    $errors[] = new ValidationError('name', 'name is too long', 'too_long');
+}
+
+// size: Ganzzahl erforderlich, >= 0
+if (!isset($body['size']) || !is_int($body['size'])) {
+    $errors[] = new ValidationError('size', 'size must be an integer', 'invalid_type');
+}
+
+// visibility: Enum-Wertprüfung
+if (!in_array($body['visibility'], ['private', 'public'], true)) {
+    $errors[] = new ValidationError('visibility', 'visibility must be private or public', 'invalid_value');
+}
+```
+
+---
+
+## Schwachstellendiagnose-Ergebnisse (FT156)
+
+| ID | Schwachstelle | Ergebnis |
+|---|---|---|
+| VULN-A | IDOR: Direktzugriff auf private Datei eines anderen Benutzers | Bestanden (gibt 404 zurück) |
+| VULN-B | IDOR: Datei eines anderen Benutzers löschen | Bestanden (gibt 404 zurück) |
+| VULN-C | IDOR: Datei eines anderen Benutzers aktualisieren | Bestanden (gibt 404 zurück) |
+| VULN-D | Rechteeskalation: view-Freigabe versucht edit-Operation | Bestanden (gibt 403 zurück) |
+| VULN-E | Eigentümerschafts-Injektion: user_id im Body | Bestanden (wird ignoriert) |
+| VULN-F | Freigabe-Lösch-Spoofing: Freigabe-Empfänger löscht eigene Freigabe | Bestanden (gibt 404 zurück) |
+| VULN-G | SQL-Injektion: Dateiname | Bestanden (parametrisierte Abfragen) |
+| VULN-H | Zu langer name: 300 Zeichen | Bestanden (gibt 422 zurück) |
+| VULN-I | Typ-Verwirrung: Float für size | Bestanden (gibt 422 zurück) |
+| VULN-J | Sichtbarkeits-Eskalation: edit-Freigabe ändert visibility | Bestanden (wird ignoriert) |
+| VULN-K | Existenz-Erkennung: 403 vs. 404 | Bestanden (gibt 404 zurück) |
+| VULN-L | Authentifizierungs-Bypass: X-User-Id=0 / negativer Wert | Bestanden (gibt 401 zurück) |
+
+---
+
+## Cracker-Angriffstests (FT156)
+
+| ID | Angriffsszenario | Ergebnis |
+|---|---|---|
+| ATK-01 | Spoofing: GET der Datei eines anderen Benutzers | Bestanden (gibt 404 zurück) |
+| ATK-02 | Spoofing: DELETE der Datei eines anderen Benutzers | Bestanden (gibt 404 zurück) |
+| ATK-03 | view-Freigabe versucht PUT-Bearbeitung | Bestanden (gibt 403 zurück) |
+| ATK-04 | user_id im Body injiziert zur Eigentümer-Fälschung | Bestanden (wird ignoriert) |
+| ATK-05 | Path-Traversal: `../../etc/passwd` | Bestanden (gibt 404 zurück) |
+| ATK-06 | Zugriffsversuch mit String-ID | Bestanden (gibt 404 zurück) |
+| ATK-07 | X-User-Id-Header als leere Zeichenkette gesendet | Bestanden (gibt 401 zurück) |
+| ATK-08 | SQL-Injektion: mime_type-Feld | Bestanden (parametrisierte Abfragen) |
+| ATK-09 | Extrem lange description (10.000 Zeichen) | Bestanden (wird gespeichert, ohne Kürzung; name > 255 gibt 422) |
+| ATK-10 | edit-Freigabe eskaliert visibility auf public | Bestanden (wird ignoriert) |
+| ATK-11 | Freigabe-Empfänger versucht eigene Freigabe zu löschen | Bestanden (gibt 404 zurück) |
+| ATK-12 | Existenz-Sondierung: Datei-IDs anderer Benutzer raten | Bestanden (gibt 404 zurück) |
+
+---
+
+## Test-Schwerpunkte
+
+```php
+// Private Dateien anderer Benutzer geben 404 zurück (nicht 403)
+$res = $this->req('GET', "/files/{$fileId}", ['X-User-Id' => '2']);
+$this->assertSame(404, $res->getStatusCode());
+
+// edit-Freigabe kann visibility nicht ändern
+$this->req('PUT', "/files/{$fileId}", ['X-User-Id' => '2'], [
+    'name' => 'a.txt', 'size' => 1, 'mime_type' => 'text/plain', 'visibility' => 'public',
+]);
+$check = $this->req('GET', "/files/{$fileId}", ['X-User-Id' => '1']);
+$this->assertSame('private', $this->json($check)['visibility']);
+
+// user_id im Body wird ignoriert (wird aus X-User-Id bezogen)
+$res = $this->req('POST', '/files', ['X-User-Id' => '1'], ['name' => 'test.txt', 'size' => 1, 'mime_type' => 'text/plain', 'user_id' => 2]);
+$this->assertSame(1, $this->json($res)['user_id']);
+```

--- a/docs/de/howto/file-sharing-api.md
+++ b/docs/de/howto/file-sharing-api.md
@@ -1,0 +1,269 @@
+# How-to: File Sharing API
+
+> **FT-Referenz**: FT303 (`NENE2-FT/filelog`) — File Sharing API: Private Dateien geben 404 (nicht 403) an Nicht-Eigentümer zurück, Löschen/Sichtbarkeitsänderung nur für Eigentümer, view-share vs. edit-share Berechtigungsstufen, `user_id` im Body ignoriert (Eigentümerschaft aus Header), Name-Längenlimit 255, `size` `is_int()` strikt, VULN-A–L alle SAFE, 59 Tests / 82 Assertions bestanden.
+
+Diese Anleitung zeigt, wie eine Datei-Metadaten-API aufgebaut wird, bei der Benutzer Dateien besitzen, die Sichtbarkeit steuern und Zugriff mit anderen Benutzern auf view- oder edit-Ebene teilen können.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE files (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL,
+    name        TEXT    NOT NULL,
+    size        INTEGER NOT NULL DEFAULT 0 CHECK (size >= 0),
+    mime_type   TEXT    NOT NULL,
+    description TEXT,
+    visibility  TEXT    NOT NULL DEFAULT 'private'
+                        CHECK (visibility IN ('private', 'public')),
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE file_shares (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_id             INTEGER NOT NULL,
+    shared_with_user_id INTEGER NOT NULL,
+    can_edit            INTEGER NOT NULL DEFAULT 0 CHECK (can_edit IN (0, 1)),
+    created_at          TEXT    NOT NULL,
+    UNIQUE (file_id, shared_with_user_id),
+    FOREIGN KEY (file_id) REFERENCES files(id),
+    FOREIGN KEY (shared_with_user_id) REFERENCES users(id)
+);
+```
+
+Zweigeteilte Freigabe: `can_edit = 0` (nur Lesen) und `can_edit = 1` (Bearbeiten). `UNIQUE(file_id, shared_with_user_id)` verhindert doppelte Freigabe-Einträge.
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|--------------|
+| `POST` | `/files` | `X-User-Id` | Datei-Metadaten hochladen |
+| `GET` | `/files` | `X-User-Id` | Eigene Dateien auflisten |
+| `GET` | `/files/{fileId}` | `X-User-Id` | Datei abrufen (Sichtbarkeitsprüfung) |
+| `PUT` | `/files/{fileId}` | `X-User-Id` | Datei aktualisieren (Eigentümer oder edit-share) |
+| `DELETE` | `/files/{fileId}` | `X-User-Id` | Datei löschen (nur Eigentümer) |
+| `POST` | `/files/{fileId}/shares` | `X-User-Id` (Eigentümer) | Freigabe hinzufügen |
+| `DELETE` | `/files/{fileId}/shares/{userId}` | `X-User-Id` (Eigentümer) | Freigabe entfernen |
+
+## Private Datei → 404 (nicht 403)
+
+```php
+// Nicht-Eigentümer kann private Dateien nicht sehen — 404 verbirgt Existenz
+if ($file['visibility'] === 'private') {
+    $share = $this->repo->findShare($fileId, $userId);
+    if ($share === null) {
+        return $this->problems->create($request, 'not-found', 'File not found', 404);
+    }
+}
+```
+
+Private Dateien geben 404 an Nicht-Eigentümer und Nicht-Freigabe-Empfänger zurück. 403 würde verraten, dass die Datei existiert. Öffentliche Dateien geben allen authentifizierten Benutzern 200 zurück.
+
+## Eigentümerschaft aus Header — Body-`user_id` ignorieren
+
+```php
+$userId = $this->requireUserId($request);
+// ... Validierung ...
+$id = $this->repo->create($userId, $name, $size, $mimeType, $description, $visibility, $now);
+```
+
+Die `user_id` der Datei wird immer aus dem `X-User-Id`-Header übernommen. Jede `user_id` im Request-Body wird stillschweigend ignoriert. Dies verhindert Eigentümerschafts-Injection-Angriffe (VULN-E).
+
+## View-Share vs. Edit-Share — Zwei Stufen
+
+```php
+// Eigentümer kann immer bearbeiten
+$isOwner = ((int) $file['user_id']) === $userId;
+
+if (!$isOwner) {
+    $share = $this->repo->findShare($fileId, $userId);
+    if ($share === null || !(bool) $share['can_edit']) {
+        return $this->problems->create($request, 'forbidden', 'Edit access required', 403);
+    }
+}
+```
+
+- **Eigentümer**: alle Operationen (lesen, schreiben, löschen, Freigabe-Verwaltung, Sichtbarkeit)
+- **Edit-share** (`can_edit=1`): Name/Größe/MIME/Beschreibung aktualisieren — aber NICHT Sichtbarkeit
+- **View-share** (`can_edit=0`): nur lesen — jeder Schreibversuch → 403
+
+Nur Eigentümer können `visibility` ändern:
+
+```php
+// Nur Eigentümer kann Sichtbarkeit ändern
+if (!$isOwner && isset($body['visibility'])) {
+    $visibility = (string) $file['visibility']; // Anfrage stillschweigend ignorieren
+}
+```
+
+## Strikte Eingabevalidierung
+
+```php
+$size = $body['size'] ?? null;
+if (!is_int($size) || $size < 0) {
+    $errors[] = ['field' => 'size', 'code' => 'invalid', 'message' => 'size must be a non-negative integer'];
+}
+
+if (!is_string($name) || strlen($name) > 255 || $name === '') {
+    $errors[] = ['field' => 'name', 'code' => 'invalid', 'message' => 'name required, max 255 chars'];
+}
+```
+
+- `size`: `is_int()` lehnt Floats wie `1.5` ab (VULN-I)
+- `name`: max 255 Zeichen — verhindert übergroße Eingaben (VULN-H)
+- `visibility`: `in_array($value, ['private', 'public'], true)` strikte Allowlist
+
+## Freigabe-Entfernung — Nur Eigentümer
+
+```php
+// Nur der Datei-Eigentümer kann Freigaben entfernen
+if ((int) $file['user_id'] !== $userId) {
+    return $this->problems->create($request, 'not-found', 'File not found', 404);
+}
+```
+
+Der freigegebene Benutzer kann sich nicht selbst aus einer Freigabe entfernen — nur der Eigentümer kann Freigaben verwalten. Nicht-Eigentümer erhalten 404 (nicht 403), um die Existenz der Datei zu verbergen (VULN-F).
+
+## User-ID-Validierung — Null und Negative ablehnen
+
+```php
+$raw = $request->getHeaderLine('X-User-Id');
+$userId = ctype_digit($raw) ? (int) $raw : 0;
+if ($userId <= 0) {
+    return $this->problems->create($request, 'unauthorized', 'Authentication required', 401);
+}
+```
+
+`X-User-Id: 0` und `X-User-Id: -1` geben 401 zurück (VULN-L). Nur positive Ganzzahlen sind gültige User-IDs.
+
+---
+
+## Vulnerability Assessment
+
+### V-01 — IDOR: Private Datei durch anderen Benutzer zugänglich ✅ SAFE
+
+**Risk**: Benutzer B liest die private Datei von Benutzer A.
+**Finding**: SAFE — Private Dateien geben 404 an Nicht-Eigentümer ohne Freigabe-Eintrag zurück.
+
+---
+
+### V-02 — IDOR: Datei eines anderen Benutzers löschen ✅ SAFE
+
+**Risk**: Benutzer B löscht die Datei von Benutzer A.
+**Finding**: SAFE — Löschen prüft Eigentümerschaft; Nicht-Eigentümer erhält 404. Datei existiert nach fehlgeschlagenem Versuch noch.
+
+---
+
+### V-03 — IDOR: Datei eines anderen Benutzers aktualisieren ✅ SAFE
+
+**Risk**: Benutzer B aktualisiert Name/Metadaten der Datei von Benutzer A.
+**Finding**: SAFE — Aktualisierung prüft Eigentümerschaft; Nicht-Eigentümer ohne edit-share erhält 404.
+
+---
+
+### V-04 — Privilegienerweiterung: View-Share versucht Bearbeitung ✅ SAFE
+
+**Risk**: Benutzer mit View-only-Freigabe ruft PUT auf, um die Datei zu ändern.
+**Finding**: SAFE — Bearbeitungsprüfung erfordert `can_edit = 1`; View-share gibt 403 zurück.
+
+---
+
+### V-05 — Eigentümerschafts-Injection: `user_id` im Request-Body ✅ SAFE
+
+**Risk**: `{ "user_id": 99, "name": "..." }` weist Datei Benutzer 99 zu.
+**Finding**: SAFE — `user_id` aus dem Body wird stillschweigend ignoriert; Eigentümerschaft kommt immer aus `X-User-Id`-Header.
+
+---
+
+### V-06 — Freigabe-Entfernung durch Nicht-Eigentümer ✅ SAFE
+
+**Risk**: Freigegebener Benutzer entfernt sich selbst aus der Freigabeliste.
+**Finding**: SAFE — Freigabe-Lösch-Endpunkt prüft Datei-Eigentümerschaft; Nicht-Eigentümer gibt 404 zurück.
+
+---
+
+### V-07 — SQL-Injection im Namensfeld ✅ SAFE
+
+**Risk**: `"name": "test'; DROP TABLE files; --"` zerstört Daten.
+**Finding**: SAFE — Parametrisierte Abfragen speichern den Injection-String als Literaldaten. Dateien-Tabelle intakt.
+
+---
+
+### V-08 — Übergroßer Name verursacht Absturz ✅ SAFE
+
+**Risk**: 300-Zeichen-Name verursacht DB-Fehler oder Speichererschöpfung.
+**Finding**: SAFE — `strlen($name) > 255`-Validierung gibt 422 zurück, bevor eingefügt wird.
+
+---
+
+### V-09 — Float-Größen-Typverwechslung ✅ SAFE
+
+**Risk**: `"size": 1.5` passiert Validierung und korrumpiert Größen-Tracking.
+**Finding**: SAFE — `is_int($size)` lehnt Floats ab → 422.
+
+---
+
+### V-10 — Edit-Share eskaliert Sichtbarkeit auf public ✅ SAFE
+
+**Risk**: Edit-Share-Benutzer setzt `"visibility": "public"`, um eine private Datei zu exponieren.
+**Finding**: SAFE — Sichtbarkeitsänderungen sind nur für Eigentümer; das Visibility-Feld im PUT-Body von edit-share wird stillschweigend ignoriert.
+
+---
+
+### V-11 — Existenzoffenlegung privater Dateien via 403 ✅ SAFE
+
+**Risk**: 403-Antwort verrät, dass die Datei auch für nicht-autorisierte Benutzer existiert.
+**Finding**: SAFE — Nicht-Eigentümer erhalten 404, nicht 403. Datei-Existenz wird nicht preisgegeben.
+
+---
+
+### V-12 — Auth-Bypass via X-User-Id: 0 oder negativ ✅ SAFE
+
+**Risk**: `X-User-Id: 0` oder `X-User-Id: -1` umgeht die Benutzerprüfung.
+**Finding**: SAFE — `ctype_digit()` + `$userId <= 0`-Prüfung gibt 401 für Null- und Negativwerte zurück.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|--------|
+| V-01 | IDOR: Private Datei zugänglich | ✅ SAFE |
+| V-02 | IDOR: Datei eines anderen Benutzers löschen | ✅ SAFE |
+| V-03 | IDOR: Datei eines anderen Benutzers aktualisieren | ✅ SAFE |
+| V-04 | View-Share Privilegienerweiterung | ✅ SAFE |
+| V-05 | Eigentümerschafts-Injection via Body | ✅ SAFE |
+| V-06 | Freigabe-Entfernung durch Nicht-Eigentümer | ✅ SAFE |
+| V-07 | SQL-Injection im Namen | ✅ SAFE |
+| V-08 | Übergroßer Name-Absturz | ✅ SAFE |
+| V-09 | Float-Größen-Typverwechslung | ✅ SAFE |
+| V-10 | Edit-Share Sichtbarkeits-Eskalation | ✅ SAFE |
+| V-11 | Existenzoffenlegung privater Dateien | ✅ SAFE |
+| V-12 | Auth-Bypass via ungültige User-ID | ✅ SAFE |
+
+**12 SAFE, 0 EXPOSED**
+Private-Datei-404-Muster, header-only-Eigentümerschaft, Zwei-Stufen-Freigabeberechtigungen, strikte Typvalidierung und Eigentümer-only-Sichtbarkeit verhindern alle IDOR- und Privilegienerweiterungs-Vektoren.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| 403 für private Datei an Nicht-Eigentümer zurückgeben | Gibt nicht-autorisierten Benutzern Aufschluss über Datei-Existenz |
+| `user_id` aus Request-Body für Eigentümerschaft akzeptieren | Jeder authentifizierte Benutzer beansprucht Eigentümerschaft über jede Datei |
+| View-Share PUT aufrufen lassen | Freigegebene Betrachter können Datei-Metadaten ändern |
+| Edit-Share Sichtbarkeit ändern lassen | Freigegebene Bearbeiter exponieren private Dateien für die Öffentlichkeit |
+| Freigegebenen Benutzer eigene Freigabe entfernen lassen | Benutzer können die Zugriffsverwaltung vom Eigentümer entziehen |
+| `size: 1.5` (Float) akzeptieren | Typverwechslung; nicht-ganzzahlige Dateigrößen korrumpieren Größen-Tracking |
+| Kein `name`-Längenlimit | Lange Dateinamen können DB-Spaltenüberlauf oder Speicherprobleme verursachen |
+| `X-User-Id: 0` als gültig akzeptieren | User-ID 0 kann auf nicht initialisierte Zeilen passen oder Eigentümerschattsprüfungen umgehen |
+| `ctype_digit()` ohne `> 0`-Prüfung | `"0"` besteht `ctype_digit`, ist aber keine gültige User-ID |

--- a/docs/de/howto/file-upload-metadata.md
+++ b/docs/de/howto/file-upload-metadata.md
@@ -1,0 +1,116 @@
+# How-to: File Upload Metadata API (VULN-A–L)
+
+Diese Anleitung demonstriert sicheres File-Upload-Metadaten-Management, das VULN-A bis VULN-L abdeckt.
+
+## Muster-Übersicht
+
+Dateien werden von dieser API nicht gespeichert — nur ihre Metadaten (Dateiname, MIME-Typ, Größe) werden erfasst. Der eigentliche Dateitransfer erfolgt separat (z. B. direkt zu S3). Dies ist ein gängiges Muster zur Nachverfolgung von Upload-Historien und zur Durchsetzung von Constraints.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS uploads (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL,
+    filename    TEXT    NOT NULL,
+    mime_type   TEXT    NOT NULL,
+    size_bytes  INTEGER NOT NULL,
+    is_public   INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT    NOT NULL
+);
+```
+
+## VULN-A: SQL-Injection
+
+Alle Abfragen verwenden PDO Prepared Statements. Von Benutzern eingereichte Dateinamen und MIME-Typen werden niemals in SQL-Strings interpoliert.
+
+## VULN-B: Mass Assignment + MIME-Allowlist
+
+Nur eine explizite Allowlist von MIME-Typen wird akzeptiert:
+
+```php
+private const array ALLOWED_MIMES = [
+    'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+    'application/pdf', 'text/plain', 'text/csv',
+];
+```
+
+Unbekannte MIME-Typen (z. B. `application/x-msdownload`, `application/x-sh`) werden mit 422 abgelehnt.
+
+## VULN-C: IDOR
+
+Nicht-Admin-Benutzer können nur auf ihre eigenen Uploads zugreifen. Uploads anderer Benutzer geben 404 zurück (nicht 403):
+
+```php
+if (!$isAdmin && (int) $upload['user_id'] !== $uid) {
+    return $this->problem(404, 'not-found', 'Upload not found.');
+}
+```
+
+## VULN-D: Admin Fail-Closed
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+## VULN-F: Path Traversal
+
+Verzeichnis-Trennzeichen und `..` werden in Dateinamen abgelehnt:
+
+```php
+if (str_contains($filename, '/') || str_contains($filename, '\\') || str_contains($filename, '..')) {
+    return $this->problem(422, 'validation-failed', 'filename must not contain path separators.');
+}
+```
+
+Dies verhindert Dateinamen wie `../etc/passwd`, `C:\Windows\cmd.exe` oder `subdir/evil.php`.
+
+## VULN-G: ReDoS
+
+IDs in Pfad-Parametern werden mit `ctype_digit()` validiert, niemals mit Regex.
+
+## VULN-I: Negative / Null-Werte
+
+```php
+if (!is_int($sizeBytes) || $sizeBytes < 1 || $sizeBytes > self::MAX_SIZE) {
+    return $this->problem(422, ...);
+}
+```
+
+Null- und negative Größen werden abgelehnt.
+
+## VULN-J: Typverwechslung
+
+- `mime_type` muss `is_string()` sein — Integer `123` wird abgelehnt.
+- `size_bytes` muss `is_int()` sein — String `"1024"` und Float `100.5` werden abgelehnt.
+- `is_public` muss `is_bool()` sein — String `"true"` und Integer `1` werden abgelehnt.
+
+## Validierungs-Zusammenfassung
+
+| Feld | Regel |
+|------|-------|
+| `X-User-Id` | Erforderlich für POST/DELETE; `ctype_digit`, >0 |
+| `filename` | Nicht leer, max 255 Zeichen, kein `/`, `\`, `..` |
+| `mime_type` | String; muss in Allowlist sein |
+| `size_bytes` | Integer 1–104.857.600 (100 MiB) |
+| `is_public` | Nur Boolean |
+
+## Routen
+
+```
+POST   /uploads              Upload-Metadaten registrieren (X-User-Id erforderlich)
+GET    /uploads/{id}         Metadaten abrufen (Eigentümer oder Admin)
+DELETE /uploads/{id}         Eintrag löschen (Eigentümer oder Admin)
+GET    /users/{userId}/uploads  Uploads eines Benutzers auflisten (Eigentümer oder Admin)
+```
+
+## Siehe auch
+
+- FT210-Quelle: `../NENE2-FT/uploadlog/`
+- Verwandt: `docs/howto/wish-list-api.md` (FT207, auch VULN)

--- a/docs/de/howto/file-upload.md
+++ b/docs/de/howto/file-upload.md
@@ -1,0 +1,165 @@
+# Datei-Upload (Base64-JSON)
+
+NENE2 ist ein JSON-first-Framework. Es verfügt über keine eingebaute `multipart/form-data`-Verarbeitung. Das empfohlene Muster für Datei-Uploads in einer JSON-API ist der Empfang von Dateien als base64-kodierte Strings im JSON-Request-Body.
+
+## requestMaxBodyBytes — das Erste, was eingestellt werden muss
+
+Base64-Encoding erhöht die Payload-Größe um etwa 33%. Eine 2-MiB-Datei wird zu ~2,7 MiB Base64-Zeichen vor dem JSON-Envelope-Overhead.
+
+NENEs Standardwert für `requestMaxBodyBytes` ist **1 MiB**. Das bedeutet, Dateien größer als ~750 KB werden mit `413 Request Entity Too Large` abgelehnt, bevor der Route-Handler aufgerufen wird.
+
+**`requestMaxBodyBytes` immer auf mindestens 1,4× der gewünschten Dateigrößenbegrenzung setzen:**
+
+```php
+new RuntimeApplicationFactory(
+    $responseFactory,
+    $streamFactory,
+    routeRegistrars:     [...],
+    requestMaxBodyBytes: 10 * 1024 * 1024,  // erlaubt ~7,5-MiB-Dateien
+)
+```
+
+| Max-Dateigröße | Mindest-requestMaxBodyBytes |
+|---|---|
+| 500 KB | 700 KB |
+| 1 MiB | 1,5 MiB |
+| 2 MiB | 3 MiB |
+| 10 MiB | 14 MiB |
+
+## MIME-Typ-Erkennung — dem Client niemals vertrauen
+
+Den MIME-Typ immer aus den tatsächlich dekodierten Bytes mit `finfo_buffer()` erkennen. Niemals dem vom Client gelieferten `Content-Type`-Header oder der Dateiendung vertrauen — beides kann gefälscht werden.
+
+```php
+$bytes = base64_decode($base64Content, strict: true);
+if ($bytes === false) {
+    // ungültiges Base64
+}
+
+$finfo = new \finfo(FILEINFO_MIME_TYPE);
+$mime  = $finfo->buffer($bytes);
+
+$allowed = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+if (!in_array($mime, $allowed, true)) {
+    // ablehnen — auch wenn der Dateiname .jpg lautet
+}
+```
+
+Dies lehnt korrekt ein PHP-Skript ab, das als `avatar.jpg` hochgeladen wird — `finfo` liest die tatsächlichen Bytes, nicht den Dateinamen.
+
+## Dateigrößen-Validierung
+
+Die **dekodierten Byte-Anzahl** validieren, nicht die Länge des Base64-Strings:
+
+```php
+$size = strlen($bytes);  // Bytes nach base64_decode(), nicht strlen($base64String)
+if ($size > 2 * 1024 * 1024) {
+    // 422: Datei zu groß
+}
+```
+
+## Dateinamen-Bereinigung — Path-Traversal-Checkliste
+
+Niemals eine Datei mit einem vom Benutzer gelieferten Dateinamen direkt schreiben. Alle folgenden Schritte anwenden:
+
+```php
+function sanitizeFilename(string $filename): string
+{
+    // 1. Verzeichniskomponenten entfernen (Path Traversal)
+    $name = basename($filename);
+
+    // 2. Null-Bytes entfernen ("image.png\x00.php"-Angriff)
+    $name = str_replace("\x00", '', $name);
+
+    // 3. führende Punkte entfernen (versteckte Dateien)
+    $name = ltrim($name, '.');
+
+    // 4. nicht-alphanumerische Zeichen ersetzen
+    $name = preg_replace('/[^\w\-.]/', '_', $name) ?? '_';
+
+    // 5. gefährliche Script-Erweiterungen neutralisieren
+    $dangerousExts = ['php', 'phtml', 'phar', 'cgi', 'py', 'sh', 'exe'];
+    $ext = strtolower(pathinfo($name, PATHINFO_EXTENSION));
+    if (in_array($ext, $dangerousExts, true)) {
+        $name = pathinfo($name, PATHINFO_FILENAME) . '_' . $ext;
+    }
+
+    return $name !== '' ? $name : 'file';
+}
+```
+
+**Den gespeicherten Dateinamen immer mit einem Zufalls-Token präfixen**, um Enumeration zu verhindern:
+
+```php
+$stored = bin2hex(random_bytes(8)) . '_' . sanitizeFilename($original);
+file_put_contents($storageDir . '/' . $stored, $bytes);
+```
+
+## PHP-Exception-Property-Namenskonflikt
+
+Beim Erweitern einer eingebauten Exception-Klasse keine readonly-Property mit dem Namen `$code`, `$message`, `$file` oder `$line` deklarieren — diese sind non-readonly in der Basisklasse und PHP wirft einen fatalen Fehler:
+
+```php
+// Fataler Fehler: Cannot redeclare non-readonly property Exception::$code
+final class UploadException extends \InvalidArgumentException {
+    public function __construct(
+        public readonly string $code,  // ← Konflikt mit Exception::$code
+    ) {}
+}
+
+// Anderen Namen verwenden:
+final class UploadException extends \InvalidArgumentException {
+    public function __construct(
+        public readonly string $errorCode,  // ← sicher
+    ) {}
+}
+```
+
+## Vollständiges Beispiel
+
+```php
+final class FileValidator
+{
+    private const array ALLOWED_MIME  = ['image/jpeg', 'image/png', 'image/gif'];
+    private const int   MAX_BYTES     = 2 * 1024 * 1024;
+
+    /** @return array{bytes: string, mime: string, size: int} */
+    public function validate(string $base64, string $filename): array
+    {
+        $bytes = base64_decode($base64, strict: true);
+        if ($bytes === false) {
+            throw new UploadValidationException(field: 'content', errorCode: 'invalid-base64', message: '...');
+        }
+        $size = strlen($bytes);
+        if ($size > self::MAX_BYTES) {
+            throw new UploadValidationException(field: 'content', errorCode: 'file-too-large', message: '...');
+        }
+        $mime = (new \finfo(FILEINFO_MIME_TYPE))->buffer($bytes);
+        if (!in_array($mime, self::ALLOWED_MIME, true)) {
+            throw new UploadValidationException(field: 'content', errorCode: 'unsupported-mime-type', message: '...');
+        }
+        return ['bytes' => $bytes, 'mime' => $mime, 'size' => $size];
+    }
+}
+```
+
+Im Route-Handler verdrahten:
+
+```php
+$body     = JsonRequestBodyParser::parse($request);
+$content  = is_string($body['content'] ?? null) ? $body['content'] : '';
+$filename = is_string($body['filename'] ?? null) ? $body['filename'] : '';
+
+if ($content === '' || $filename === '') { /* 422 */ }
+
+try {
+    $validated = $validator->validate($content, $filename);
+} catch (UploadValidationException $e) {
+    return $problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => $e->field, 'code' => $e->errorCode, 'message' => $e->getMessage()]],
+    ]);
+}
+
+$stored = bin2hex(random_bytes(8)) . '_' . sanitizeFilename($filename);
+file_put_contents('/var/storage/' . $stored, $validated['bytes']);
+```

--- a/docs/de/howto/fixed-window-rate-limiter.md
+++ b/docs/de/howto/fixed-window-rate-limiter.md
@@ -1,0 +1,218 @@
+# How-to: Fixed-Window Rate Limiter
+
+> **FT-Referenz**: FT251 (`NENE2-FT/ratelimitlog`) — Fixed-Window Rate Limiting mit SQLite-Upsert
+
+Demonstriert einen in SQLite gespeicherten Fixed-Window Rate Limiter. Jedes `(key, window_start)`-Paar akkumuliert einen Request-Zähler. Wenn der Zähler das konfigurierte Limit überschreitet, wird der Request mit `429 Too Many Requests` und einem `Retry-After`-Header abgelehnt.
+
+---
+
+## Routen
+
+| Methode | Pfad      | Beschreibung                                          |
+|---------|-----------|-------------------------------------------------------|
+| `GET`   | `/ping`   | Rate-limitierter Endpunkt (liest `X-Client-Key`)      |
+| `GET`   | `/status` | Read-only-Zähler für einen Key (`?key=`)              |
+
+---
+
+## Schema: Composite Primary Key als Rate-Limit-Counter-Store
+
+```sql
+CREATE TABLE IF NOT EXISTS rate_limit_windows (
+    key          TEXT    NOT NULL,
+    window_start TEXT    NOT NULL, -- ISO 8601 Timestamp auf Window-Grenze gekürzt
+    count        INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (key, window_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rl_key_window ON rate_limit_windows(key, window_start);
+```
+
+`PRIMARY KEY(key, window_start)` identifiziert eindeutig einen Zähler für jedes `(Client, Window)`-Paar. Der Index macht die Upsert-Suche schnell. Eine separate `api_calls`-Log-Tabelle zeichnet jede erfolgreiche Anfrage für Audit-Zwecke auf.
+
+---
+
+## Upsert-Muster: `INSERT … ON CONFLICT DO UPDATE`
+
+```php
+$this->executor->execute(
+    'INSERT INTO rate_limit_windows (key, window_start, count) VALUES (?, ?, 1)
+     ON CONFLICT(key, window_start) DO UPDATE SET count = count + 1',
+    [$key, $windowStart],
+);
+```
+
+Die erste Anfrage für ein `(key, windowStart)`-Paar fügt `count = 1` ein. Nachfolgende Anfragen innerhalb desselben Fensters inkrementieren atomar via `DO UPDATE SET count = count + 1`. Kein `SELECT` vor dem `INSERT` ist nötig — der Upsert ist in SQLite atomar.
+
+Nach dem Upsert wird der Zähler gelesen, um festzustellen, ob das Limit überschritten wurde:
+
+```php
+$row   = $this->executor->fetchOne(
+    'SELECT count FROM rate_limit_windows WHERE key = ? AND window_start = ?',
+    [$key, $windowStart],
+);
+$count = (int) ($row['count'] ?? 0);
+
+if ($count > $this->limit) {
+    $retryAfter = (int) (strtotime($windowEnd) - strtotime($now));
+    throw new RateLimitExceededException($key, $this->limit, $this->windowSeconds, max(0, $retryAfter));
+}
+```
+
+Die Prüfung erfolgt **nach** dem Inkrement. Das bedeutet, die (limit+1)-te Anfrage wird gezählt, bevor sie abgelehnt wird — der Zähler erreicht `limit + 1` für Über-Limit-Anfragen. Dies ist beabsichtigt: der Zähler spiegelt die Gesamtanzahl der Versuche wider, nicht nur die erlaubten.
+
+---
+
+## Window-Trunkierung: feste Grenze
+
+```php
+private function truncateToWindow(string $now): string
+{
+    $ts     = strtotime($now);
+    $bucket = (int) ($ts - ($ts % $this->windowSeconds));
+
+    return date('Y-m-d\TH:i:s\Z', $bucket);
+}
+```
+
+`$ts % $windowSeconds` ist der Offset innerhalb des aktuellen Fensters. Das Subtrahieren ergibt den Window-Start-Timestamp. Für ein 60-Sekunden-Fenster bei `2026-01-01T00:00:45Z`:
+
+```
+ts     = 1751328045  (Unix-Timestamp)
+ts % 60 = 45
+bucket = 1751328045 - 45 = 1751328000  → 2026-01-01T00:00:00Z
+```
+
+Alle Anfragen von `:00` bis `:59` teilen denselben `window_start = 2026-01-01T00:00:00Z`. Bei `:60` beginnt ein neues Fenster und der Zähler setzt sich zurück.
+
+**Fixed vs. Sliding Window — Abwägung**:
+
+| Eigenschaft | Fixed Window | Sliding Window |
+|---|---|---|
+| Implementierung | Einzelner Upsert pro Anfrage | Mehrfache Lese-/Schreibvorgänge über Buckets |
+| Speicher | 1 Zeile pro (Key, Window) | N Zeilen pro Key (Sub-Buckets) |
+| Burst an der Grenze | Ja — 2× Limit an Window-Kante möglich | Nein — begrenzt gleichmäßig über die Zeit |
+| Häufige Nutzung | Einfache APIs, interne Tools | Öffentliche APIs, strenge Fairness |
+
+---
+
+## `429 Too Many Requests` mit `Retry-After`
+
+```php
+final class RateLimitExceededException extends \DomainException
+{
+    public function __construct(
+        public readonly string $key,
+        public readonly int    $limit,
+        public readonly int    $windowSeconds,
+        public readonly int    $retryAfter,
+    ) {
+        parent::__construct("Rate limit of {$limit} requests per {$windowSeconds}s exceeded for key '{$key}'.");
+    }
+}
+```
+
+Die Exception trägt `retryAfter` (Sekunden bis das aktuelle Fenster endet). Der Handler mappt dies auf eine `429` Problem Details-Antwort mit einem `Retry-After`-Header:
+
+```php
+public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+{
+    assert($exception instanceof RateLimitExceededException);
+
+    $response = $this->probs->create(
+        request: $request,
+        type: 'rate-limit-exceeded',
+        title: 'Too Many Requests',
+        status: 429,
+        detail: $exception->getMessage(),
+    );
+
+    return $response->withHeader('Retry-After', (string) $exception->retryAfter);
+}
+```
+
+`Retry-After` ist die Anzahl der Sekunden, die der Client warten soll, bevor er es erneut versucht. Es wird als `windowEnd - now` berechnet, auf `>= 0` begrenzt.
+
+---
+
+## Per-Client-Key via `X-Client-Key`-Header
+
+```php
+$key = $request->getHeaderLine('X-Client-Key') ?: '127.0.0.1';
+```
+
+Jeder Client wird durch seinen `X-Client-Key`-Header identifiziert. Fehlender Header fällt auf `'127.0.0.1'` zurück — alle nicht-authentifizierten Clients teilen sich einen Zähler. In der Produktion:
+
+- Eine verifizierte User-ID oder einen API-Key aus einer authentifizierten Session verwenden — keinen Header, den der Client fälschen kann.
+- `$_SERVER['REMOTE_ADDR']` (nach Proxy-Stripping) für IP-basiertes Limiting verwenden.
+- `X-Forwarded-For` niemals direkt verwenden — ein Client kann es fälschen, um Limits zu umgehen.
+
+---
+
+## Read-only-Status-Endpunkt
+
+```php
+public function currentCount(string $key, string $now): int
+{
+    $windowStart = $this->truncateToWindow($now);
+    $row = $this->executor->fetchOne(
+        'SELECT count FROM rate_limit_windows WHERE key = ? AND window_start = ?',
+        [$key, $windowStart],
+    );
+
+    return (int) ($row['count'] ?? 0);
+}
+```
+
+`GET /status?key=xxx` gibt den aktuellen Zähler zurück ohne ihn zu inkrementieren. Wird für Monitoring-Dashboards oder Client-seitige Backoff-Logik verwendet.
+
+---
+
+## Window-Ablauf-Bereinigung
+
+```php
+public function pruneExpired(string $now): int
+{
+    $cutoff = $this->subtractSeconds($now, $this->windowSeconds * 2);
+
+    return $this->executor->execute(
+        'DELETE FROM rate_limit_windows WHERE window_start < ?',
+        [$cutoff],
+    );
+}
+```
+
+Alte Fenster häufen sich mit der Zeit an. `pruneExpired()` löscht Zeilen, die älter als zwei Window-Dauern sind (aktuelles Fenster + vorheriges Fenster werden behalten; ältere werden entfernt).
+
+`pruneExpired()` aus einem Hintergrund-Task oder nach jeder Anfrage ausführen (mit Sampling — z. B. `rand(0, 99) === 0` für ~1% der Anfragen):
+
+```php
+if (random_int(0, 99) === 0) {
+    $this->limiter->pruneExpired($now);
+}
+```
+
+---
+
+## Konfigurations-Injection
+
+```php
+$limiter = new SqliteRateLimiter($executor, limit: 3, windowSeconds: 60);
+```
+
+`limit` und `windowSeconds` werden bei der Konstruktion injiziert. Verschiedene Endpunkte können verschiedene Limiter-Instanzen mit unterschiedlichen Konfigurationen verwenden:
+
+```php
+$globalLimiter = new SqliteRateLimiter($executor, limit: 100, windowSeconds: 60);
+$strictLimiter = new SqliteRateLimiter($executor, limit: 5,   windowSeconds: 60);
+```
+
+---
+
+## Verwandte Anleitungen
+
+- [`rate-limiting.md`](rate-limiting.md) — `ThrottleMiddleware` für routen-spezifisches Rate Limiting
+- [`sliding-window-rate-limiter.md`](sliding-window-rate-limiter.md) — Sliding Window mit Sub-Buckets (ratelog FT200)
+- [`add-rate-limiting.md`](add-rate-limiting.md) — Rate Limiting zu einer bestehenden Route hinzufügen
+- [`quota-management.md`](quota-management.md) — längerfristige Quotas (täglich, monatlich)
+- [`api-usage-metering.md`](api-usage-metering.md) — benutzerbezogenes Usage-Tracking mit Quota-Prüfung

--- a/docs/de/howto/flash-sale-api.md
+++ b/docs/de/howto/flash-sale-api.md
@@ -1,0 +1,244 @@
+# How-to: Flash Sale API
+
+> **FT-Referenz**: FT304 (`NENE2-FT/salelog`) — Flash Sale API: Zeitfenster-Validierung (Sale noch nicht gestartet → 422, beendet → 422), UNIQUE(sale_id, user_id) verhindert Doppelkauf, Lagerbestand-Erschöpfungs-Prüfung, negativer Preis/Null-Menge → 422, invertierte Daten abgelehnt, ATK-01–12 alle BLOCKED, 29 Tests / 42 Assertions bestanden.
+
+Diese Anleitung zeigt, wie ein Flash-Sale-System aufgebaut wird, bei dem Benutzer begrenzte Lagerbestände innerhalb eines Zeitfensters kaufen können, mit Race-Condition-Schutz und Angriffsprävention.
+
+## Schema
+
+```sql
+CREATE TABLE flash_sales (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER NOT NULL,
+    price      INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL,
+    starts_at  TEXT    NOT NULL,
+    ends_at    TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    CHECK (quantity > 0),
+    CHECK (price >= 0),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+CREATE TABLE purchases (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    sale_id      INTEGER NOT NULL,
+    user_id      INTEGER NOT NULL,
+    purchased_at TEXT    NOT NULL,
+    UNIQUE (sale_id, user_id),
+    FOREIGN KEY (sale_id) REFERENCES flash_sales(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`CHECK (quantity > 0)` und `CHECK (price >= 0)` erzwingen Geschäftsregeln auf DB-Ebene. `UNIQUE(sale_id, user_id)` verhindert, dass derselbe Benutzer denselben Sale zweimal kauft — auch bei gleichzeitigen Anfragen.
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|--------------|
+| `POST` | `/products` | — | Produkt erstellen |
+| `POST` | `/sales` | — | Flash Sale erstellen |
+| `GET` | `/sales` | — | Aktive Sales auflisten |
+| `GET` | `/sales/{id}` | — | Sale-Details abrufen |
+| `POST` | `/sales/{id}/purchase` | `X-User-Id` | Kaufen (Zeitprüfung) |
+
+## Sale-Erstellungs-Validierung
+
+```php
+if (!is_int($price) || $price < 0) {
+    return 422; // negativer Preis abgelehnt
+}
+if (!is_int($quantity) || $quantity <= 0) {
+    return 422; // Null- oder negative Menge abgelehnt
+}
+if ($endsAt <= $startsAt) {
+    return 422; // invertierte oder gleiche Daten abgelehnt
+}
+```
+
+Drei DB-Level-Prüfungen durch Anwendungsebene-Validierung gesichert:
+- `price >= 0` — kostenlose Sales erlaubt (`0`), negative Preise nicht
+- `quantity > 0` — Sales mit Null-Menge können nicht erstellt werden
+- `ends_at > starts_at` — Zeitinversion abgelehnt
+
+## Kauf — Zeitfenster-Prüfung
+
+```php
+$now = date('c');
+if ($now < $sale['starts_at']) {
+    return 422; // Sale noch nicht gestartet
+}
+if ($now > $sale['ends_at']) {
+    return 422; // Sale beendet
+}
+```
+
+Kaufversuche außerhalb des Sale-Fensters geben 422 zurück. Die Prüfung verwendet server-seitiges `date('c')` — Clients können die Zeit nicht manipulieren.
+
+## Lagerbestand-Prüfung
+
+```php
+$purchaseCount = $this->repo->countPurchases($saleId);
+if ($purchaseCount >= $sale['quantity']) {
+    return $this->json(['error' => 'sold out'], 422);
+}
+```
+
+Vorhandene Käufe gegen die `quantity` des Sales zählen, bevor eingefügt wird. Bei ausverkauft 422 mit `"error": "sold out"` zurückgeben.
+
+## UNIQUE(sale_id, user_id) — Doppelkauf-Prävention
+
+```php
+// UNIQUE-Constraint fängt gleichzeitige Doppelkäufe ab
+try {
+    $this->repo->createPurchase($saleId, $userId, $now);
+} catch (\PDOException $e) {
+    // UNIQUE-Constraint-Verletzung → bereits gekauft
+    return $this->json(['error' => 'already purchased'], 409);
+}
+```
+
+Die DB-`UNIQUE(sale_id, user_id)`-Constraint ist die letzte Absicherung gegen Race Conditions. Erster Kauf gelingt (201); jedes Duplikat gibt 409 Conflict zurück.
+
+## User-ID-Validierung
+
+```php
+$actorIdRaw = $request->getHeaderLine('X-User-Id');
+if ($actorIdRaw === '' || !ctype_digit($actorIdRaw)) {
+    return $this->json(['error' => 'X-User-Id required'], 400);
+}
+$actorId = (int) $actorIdRaw;
+
+$user = $this->repo->findUser($actorId);
+if ($user === null) {
+    return $this->json(['error' => 'user not found'], 404);
+}
+```
+
+- Fehlende oder nicht-numerische `X-User-Id` → 400
+- Nicht-existierende User-ID → 404 (IDOR-Prävention — kein Kauf als Geisterbenutzer)
+
+---
+
+## ATK Assessment — Cracker-Mindset Attack Test
+
+### ATK-01 — SQL-Injection im Produktnamen 🚫 BLOCKED
+
+**Angriff**: `POST /products` mit `name: "'; DROP TABLE products; --"`.
+**Ergebnis**: BLOCKED — parametrisierte Abfrage speichert den Injection-String wörtlich (201). Nachfolgende Anfragen funktionieren weiterhin; products-Tabelle intakt.
+
+---
+
+### ATK-02 — Kauf ohne X-User-Id-Header 🚫 BLOCKED
+
+**Angriff**: `POST /sales/{id}/purchase` ohne `X-User-Id`-Header.
+**Ergebnis**: BLOCKED — fehlender Header gibt 400 zurück.
+
+---
+
+### ATK-03 — Nicht-numerischer X-User-Id-Header 🚫 BLOCKED
+
+**Angriff**: `X-User-Id: admin` (String-Wert).
+**Ergebnis**: BLOCKED — `ctype_digit()`-Prüfung lehnt nicht-numerische Werte ab; nicht 201.
+
+---
+
+### ATK-04 — Negative Sale-ID in URL 🚫 BLOCKED
+
+**Angriff**: `POST /sales/-1/purchase`.
+**Ergebnis**: BLOCKED — negative ID löst zu keinem gefundenen Sale auf; nicht 201.
+
+---
+
+### ATK-05 — Kauf vor Sale-Start 🚫 BLOCKED
+
+**Angriff**: Sale erstellen, der in 1 Stunde beginnt; sofort versuchen zu kaufen.
+**Ergebnis**: BLOCKED — `$now < $sale['starts_at']`-Prüfung → 422.
+
+---
+
+### ATK-06 — Kauf nach Sale-Ende 🚫 BLOCKED
+
+**Angriff**: Sale erstellen, der vor 1 Stunde endete; Kauf versuchen.
+**Ergebnis**: BLOCKED — `$now > $sale['ends_at']`-Prüfung → 422.
+
+---
+
+### ATK-07 — Doppelkauf desselben Sales 🚫 BLOCKED
+
+**Angriff**: Derselbe Benutzer kauft denselben Sale zweimal in rascher Folge.
+**Ergebnis**: BLOCKED — erster Kauf 201; zweiter Kauf 409 (UNIQUE-Constraint oder Anwendungsebene-Prüfung).
+
+---
+
+### ATK-08 — Lagerbestand erschöpfen, dann kaufen 🚫 BLOCKED
+
+**Angriff**: Sale mit `quantity=1` erstellen; Alice kauft; Bob versucht zu kaufen.
+**Ergebnis**: BLOCKED — Lagerbestand-Prüfung `purchaseCount >= quantity` → 422 `"sold out"` für Bob.
+
+---
+
+### ATK-09 — Sale mit quantity=0 erstellen 🚫 BLOCKED
+
+**Angriff**: `POST /sales` mit `quantity: 0`.
+**Ergebnis**: BLOCKED — `quantity <= 0`-Validierung + DB `CHECK (quantity > 0)` → 422.
+
+---
+
+### ATK-10 — Sale mit negativem Preis erstellen 🚫 BLOCKED
+
+**Angriff**: `POST /sales` mit `price: -999`.
+**Ergebnis**: BLOCKED — `price < 0`-Validierung + DB `CHECK (price >= 0)` → 422.
+
+---
+
+### ATK-11 — Kauf als nicht-existierender Benutzer 🚫 BLOCKED
+
+**Angriff**: `X-User-Id: 99999` (ID, die nicht in der users-Tabelle existiert).
+**Ergebnis**: BLOCKED — `findUser($actorId) === null` → 404.
+
+---
+
+### ATK-12 — Invertierte Sale-Daten (ends_at vor starts_at) 🚫 BLOCKED
+
+**Angriff**: `starts_at: "+2 hours"`, `ends_at: "+1 hour"`.
+**Ergebnis**: BLOCKED — `$endsAt <= $startsAt`-Validierung → 422.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | SQL-Injection im Produktnamen | 🚫 BLOCKED |
+| ATK-02 | Kauf ohne X-User-Id | 🚫 BLOCKED |
+| ATK-03 | Nicht-numerischer X-User-Id | 🚫 BLOCKED |
+| ATK-04 | Negative Sale-ID in URL | 🚫 BLOCKED |
+| ATK-05 | Kauf vor Sale-Start | 🚫 BLOCKED |
+| ATK-06 | Kauf nach Sale-Ende | 🚫 BLOCKED |
+| ATK-07 | Doppelkauf desselben Sales | 🚫 BLOCKED |
+| ATK-08 | Lagerbestand erschöpfen, dann kaufen | 🚫 BLOCKED |
+| ATK-09 | Sale mit quantity=0 erstellen | 🚫 BLOCKED |
+| ATK-10 | Sale mit negativem Preis erstellen | 🚫 BLOCKED |
+| ATK-11 | Kauf als nicht-existierender Benutzer | 🚫 BLOCKED |
+| ATK-12 | Invertierte Sale-Daten | 🚫 BLOCKED |
+
+**12 BLOCKED, 0 EXPOSED**
+Server-seitige Zeitfenster-Prüfung, Lagerbestand-Zähler-Guard, UNIQUE-Constraint und strikte Eingabevalidierung verhindern alle bekannten Angriffsvektoren.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Client-geliefertem Timestamp für Zeitprüfung vertrauen | Clients senden vergangene/zukünftige Timestamps, um das Fenster zu umgehen |
+| Kein `UNIQUE(sale_id, user_id)` | Gleichzeitige Anfragen erlauben demselben Benutzer unter Last zweimal zu kaufen |
+| Lagerbestand ohne Race-Condition-Guard prüfen | Zwischen Lagerbestand-Prüfung und Einfügen kann eine andere Anfrage den Bestand erschöpfen |
+| Sale-Erstellung mit `quantity: 0` erlauben | Sale mit Null-Menge kann nie gekauft werden; verwirrenden Edge Case |
+| `price: -999` akzeptieren | Negativpreis-Kauf schreibt dem Käufer gut statt ihn zu belasten |
+| Keine Benutzer-Existenzprüfung | Ghost-User-IDs (nicht in DB) umgehen Audit-Trails |
+| `$endsAt >= $startsAt` (Gleichheit erlauben) | Gleicher Start/Ende erzeugt Null-Dauer-Fenster — sofort abgelaufen |
+| Nicht-numerischer X-User-Id akzeptiert | `"admin"`-String zu `(int)` gecastet wird `0`; umgeht Auth |
+| 409 für Zeitfenster-Fehler zurückgeben | Zeitverletzungen sind Business-Validierungsfehler (422), keine Zustandskonflikte |

--- a/docs/de/howto/flash-sale-system.md
+++ b/docs/de/howto/flash-sale-system.md
@@ -1,0 +1,168 @@
+# So bauen Sie ein Flash-Sale-System mit NENE2
+
+Diese Anleitung führt durch den Aufbau eines zeitlich begrenzten Flash-Sale-Systems mit Mengenbeschränkung, bei dem Benutzer ein Produkt zu einem reduzierten Preis innerhalb eines Sale-Fensters kaufen können.
+
+**Field Trial**: FT140  
+**NENE2-Version**: ^1.5  
+**Behandelte Themen**: Zeitfenster-Validierung, Lagerbestand-Zählung mit COUNT(*), UNIQUE-Constraint für ein-Kauf-pro-Benutzer, `match`-Ausdruck für Status, Cracker-Mindset-Angriffstests
+
+---
+
+## Was wir bauen
+
+- `POST /products` — ein Produkt erstellen
+- `POST /sales` — einen Flash Sale erstellen (product_id, price, quantity, starts_at, ends_at)
+- `GET /sales/{saleId}` — Sale-Details mit verbleibender Menge und Status anzeigen
+- `POST /sales/{saleId}/purchase` — innerhalb des aktiven Fensters kaufen (ein Kauf pro Benutzer)
+- `GET /sales/{saleId}/purchases` — alle Käufer auflisten
+
+---
+
+## Datenbankschema
+
+```sql
+CREATE TABLE flash_sales (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER NOT NULL,
+    price      INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL,
+    starts_at  TEXT    NOT NULL,
+    ends_at    TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    CHECK (quantity > 0),
+    CHECK (price >= 0),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+CREATE TABLE purchases (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    sale_id      INTEGER NOT NULL,
+    user_id      INTEGER NOT NULL,
+    purchased_at TEXT    NOT NULL,
+    UNIQUE (sale_id, user_id),
+    FOREIGN KEY (sale_id) REFERENCES flash_sales(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`UNIQUE (sale_id, user_id)` verhindert, dass ein Benutzer denselben Sale zweimal kauft, auch bei gleichzeitigen Anfragen.
+
+---
+
+## Zeitfenster-Validierung
+
+```php
+$now = date('c');
+
+if ($now < $sale['starts_at']) {
+    return $this->responseFactory->create(['error' => 'sale has not started yet'], 422);
+}
+
+if ($now > $sale['ends_at']) {
+    return $this->responseFactory->create(['error' => 'sale has ended'], 422);
+}
+```
+
+`starts_at` / `ends_at` als ISO-8601-Strings speichern. String-Vergleich funktioniert korrekt für ISO 8601, da das Format lexikografisch geordnet ist.
+
+---
+
+## Lagerbestand-Zählung mit COUNT(*)
+
+Statt eine veränderliche `remaining`-Spalte zu pflegen, tatsächliche Käufe zählen:
+
+```php
+public function countPurchases(int $saleId): int
+{
+    $row = $this->executor->fetchOne(
+        'SELECT COUNT(*) as cnt FROM purchases WHERE sale_id = ?',
+        [$saleId],
+    );
+
+    return isset($row['cnt']) ? (int) $row['cnt'] : 0;
+}
+```
+
+Dann prüfen:
+
+```php
+$purchased = $this->repository->countPurchases($saleId);
+
+if ($purchased >= $sale['quantity']) {
+    return $this->responseFactory->create(['error' => 'sold out'], 422);
+}
+```
+
+`remaining` wird zur Lesezeit berechnet: `$sale['quantity'] - $purchased`. Auf `max(0, $remaining)` begrenzen, um negative Anzeige zu vermeiden.
+
+---
+
+## Ein Kauf pro Benutzer — UNIQUE-Constraint
+
+`UNIQUE (sale_id, user_id)` verhindert Duplikate auf DB-Ebene. `DatabaseConstraintException` mappt auf 409:
+
+```php
+public function purchase(int $saleId, int $userId, string $now): bool
+{
+    try {
+        $this->executor->execute(
+            'INSERT INTO purchases (sale_id, user_id, purchased_at) VALUES (?, ?, ?)',
+            [$saleId, $userId, $now],
+        );
+
+        return true;
+    } catch (DatabaseConstraintException) {
+        return false;
+    }
+}
+```
+
+Der Handler gibt 409 zurück, wenn `purchase()` `false` zurückgibt.
+
+---
+
+## Sale-Status mit match-Ausdruck
+
+```php
+$status = match (true) {
+    $now < $sale['starts_at'] => 'upcoming',
+    $now > $sale['ends_at']   => 'ended',
+    default                   => 'active',
+};
+```
+
+Drei Zustände: `upcoming`, `active`, `ended`. Der `match`-Ausdruck ist erschöpfend, da `default` alle anderen Fälle abdeckt.
+
+---
+
+## Cracker-Angriffstestergebnisse (FT140)
+
+| ID | Angriff | Erwartet | Ergebnis |
+|----|---------|----------|----------|
+| ATK-01 | SQL-Injection im Produktnamen | 201 (wörtlich gespeichert) | Pass |
+| ATK-02 | Kauf ohne X-User-Id | 400 | Pass |
+| ATK-03 | Nicht-numerischer X-User-Id | nicht 201 | Pass |
+| ATK-04 | Negative saleId in URL | nicht 201 | Pass |
+| ATK-05 | Kaufen vor Sale-Start | 422 | Pass |
+| ATK-06 | Kaufen nach Sale-Ende | 422 | Pass |
+| ATK-07 | Doppelkauf desselben Sales | 409 beim zweiten | Pass |
+| ATK-08 | Lagerbestand erschöpfen, dann kaufen | 422 sold out | Pass |
+| ATK-09 | Sale mit quantity=0 erstellen | 422 | Pass |
+| ATK-10 | Sale mit negativem Preis erstellen | 422 | Pass |
+| ATK-11 | Kauf als nicht-existierender Benutzer | 404 | Pass |
+| ATK-12 | ends_at vor starts_at | 422 | Pass |
+
+Alle 12 Angriffstests bestanden.
+
+---
+
+## Häufige Fallstricke
+
+| Fallstrick | Lösung |
+|------------|--------|
+| Veränderliche `remaining`-Spalte driftet unter Nebenläufigkeit | Aus `purchases`-Tabelle zählen, `remaining` zur Lesezeit ableiten |
+| Null-Menge über API erlauben | `$quantity > 0` im Handler validieren; auch `CHECK (quantity > 0)` im Schema |
+| Negativer Preis entweicht | `$price >= 0` validieren; auch `CHECK (price >= 0)` im Schema |
+| Benutzer kauft denselben Sale zweimal | `UNIQUE (sale_id, user_id)` + `DatabaseConstraintException` → 409 |
+| Zeitvergleich auf Nicht-ISO-Strings | ISO 8601 verwenden (z. B. `date('c')`) — lexikografische Ordnung ist korrekt |
+| `ends_at` mit `starts_at` invertiert | `$starts_at < $ends_at` vor INSERT validieren |

--- a/docs/de/howto/follow-api.md
+++ b/docs/de/howto/follow-api.md
@@ -1,0 +1,158 @@
+# How-to: Follow / Unfollow API
+
+> **FT-Referenz**: FT314 (`NENE2-FT/followlog`) — Social-Follow-Graph: idempotentes Follow (POST 201 beim ersten Mal, 200 bei Wiederholung), Selbst-Follow-Prävention (422), Unfollow (DELETE 204), Follower/Following-Zählungen über Stats, paginierte Listen nach neuesten zuerst geordnet, Is-Following-Prüfung, gegenseitiges Follow unterstützt, 20 Tests / 72 Assertions bestanden.
+
+Diese Anleitung zeigt, wie ein soziales Follow-System aufgebaut wird, bei dem Benutzer sich gegenseitig folgen und entfolgen können, mit Follower/Following-Zählungen und Listen-Endpunkten.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE follows (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    follower_id INTEGER NOT NULL REFERENCES users(id),
+    followee_id INTEGER NOT NULL REFERENCES users(id),
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (follower_id, followee_id)
+);
+```
+
+Die `UNIQUE (follower_id, followee_id)`-Constraint erzwingt die Idempotenz von Follow-Beziehungen auf DB-Ebene.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzer erstellen |
+| `POST` | `/users/{id}/follow` | Einem anderen Benutzer folgen |
+| `DELETE` | `/users/{id}/follow/{followeeId}` | Entfolgen |
+| `GET` | `/users/{id}/stats` | Follower/Following-Zählungen abrufen |
+| `GET` | `/users/{id}/followers` | Follower auflisten (neueste zuerst) |
+| `GET` | `/users/{id}/following` | Following auflisten (neueste zuerst) |
+| `GET` | `/users/{id}/is-following/{targetId}` | Prüfen, ob Following |
+
+## Idempotentes Follow
+
+```php
+// Erstes Follow → 201 Created
+POST /users/1/follow  {"followee_id": 2}
+→ 201  {"following": true, "follower_id": 1, "followee_id": 2}
+
+// Wiederholtes Follow mit demselben Paar → 200 OK (nicht 201, nicht 409)
+POST /users/1/follow  {"followee_id": 2}
+→ 200  {"following": true, "follower_id": 1, "followee_id": 2}
+```
+
+```php
+// Handler-Logik
+try {
+    $this->repo->follow($followerId, $followeeId);
+    return $json->ok($response, ['following' => true, ...], 201);
+} catch (DuplicateFollowException $e) {
+    return $json->ok($response, ['following' => true, ...], 200); // bereits folgend
+}
+```
+
+## Selbst-Follow-Prävention
+
+```php
+POST /users/1/follow  {"followee_id": 1}
+→ 422 Unprocessable Entity
+```
+
+```php
+if ($followerId === $followeeId) {
+    throw new ValidationException([
+        ['field' => 'followee_id', 'message' => 'Cannot follow yourself.', 'code' => 'self-follow'],
+    ]);
+}
+```
+
+## Entfolgen
+
+```php
+DELETE /users/1/follow/2
+→ 204 No Content   // erfolgreich entfolgt
+
+DELETE /users/1/follow/2  // wenn nicht folgend
+→ 404 Not Found
+```
+
+Entfolgen-dann-Wiederfolgen-Zyklus funktioniert korrekt: DELETE → POST gibt wieder 201 zurück.
+
+## Stats
+
+```php
+GET /users/1/stats
+→ 200
+{
+    "user_id": 1,
+    "followers_count": 2,
+    "following_count": 3
+}
+```
+
+`followers_count` = wie viele Benutzer diesem Benutzer folgen.  
+`following_count` = wie vielen Benutzern dieser Benutzer folgt.
+
+Unbekannter Benutzer → 404.
+
+## Follower-/Following-Listen
+
+```php
+GET /users/1/followers
+→ 200
+{
+    "items": [
+        {"id": 3, "name": "Carol", "created_at": "..."},
+        {"id": 2, "name": "Bob",   "created_at": "..."}
+    ],
+    "count": 2
+}
+```
+
+- Geordnet nach `follows.id DESC` (neuester Follower zuerst).
+- Gleiche Struktur für `GET /users/{id}/following`.
+- Unbekannter Benutzer → 404.
+
+## Is-Following-Prüfung
+
+```php
+GET /users/1/is-following/2
+→ 200  {"following": true}   // 1 folgt 2
+
+GET /users/1/is-following/2  // nach Entfolgen
+→ 200  {"following": false}
+```
+
+Gibt `false` (nicht 404) zurück, wenn nicht folgend — die Prüfung selbst ist immer gültig.
+
+## Gegenseitiges Follow
+
+```php
+POST /users/1/follow  {"followee_id": 2}
+POST /users/2/follow  {"followee_id": 1}
+
+GET /users/1/is-following/2  → {"following": true}
+GET /users/2/is-following/1  → {"following": true}
+```
+
+Gegenseitige Follows sind nur zwei separate Follow-Zeilen — keine spezielle Tabelle oder Logik nötig.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| 409 für doppeltes Follow zurückgeben | Client-Retry-Logik bricht ab; idempotente Operationen sollten 200 zurückgeben, keinen Fehler |
+| Selbst-Follow erlauben | Korrumpiert Stats (`followers_count` durch sich selbst aufgebläht); Feeds sehen falsch aus |
+| Keine UNIQUE-Constraint auf (follower_id, followee_id) | Race Condition bei gleichzeitigen Follow-Klicks erzeugt doppelte Zeilen |
+| DELETE von nicht-existierendem Follow gibt 204 zurück | Client kann nicht zwischen "entfolgt" und "nie gefolgt" unterscheiden; 404 verwenden |
+| Nach Name oder ID statt Aktualität ordnen | Neueste Follower/Following in langer Liste verloren; UX-Erwartung ist "wer hat mir kürzlich gefolgt" |
+| Gemeinsame Follow-Zählungen über Benutzer | Follower-Zählungen bluten zwischen unverbundenen Benutzern; immer nach user_id scopen |

--- a/docs/de/howto/ft-registry.md
+++ b/docs/de/howto/ft-registry.md
@@ -1,0 +1,131 @@
+# FT-Registry
+
+FT-Nummer → Projektname → howto-Datei-Verzeichnis.
+Zum Nachschlagen: "Was war nochmal FT268?"
+
+> **Automatisch generierter Hinweis**: Aus `FT reference`-Headern in `docs/howto/` extrahiert.
+> Bei neuen FTs die entsprechende Zeile in diese Datei eintragen.
+
+---
+
+## Registry
+
+| FT | Projekt | howto-Datei | Typ |
+|----|---------|-------------|-----|
+| FT24 | habitlog | [habit-tracker.md](habit-tracker.md) | ATK |
+| FT43 | shiftlog | [shift-management.md](shift-management.md) | VULN |
+| FT51 | statslog | [event-analytics.md](event-analytics.md) | normal |
+| FT59 | watchlog | [media-watchlist.md](media-watchlist.md) | normal |
+| FT67 | pricelog | [price-history.md](price-history.md) | ATK |
+| FT68 | approvallog | [approval-workflow.md](approval-workflow.md) | normal |
+| FT72 | deadletterlog | [dead-letter-queue.md](dead-letter-queue.md) | normal |
+| FT85 | bulkupdatelog | [bulk-status-update.md](bulk-status-update.md) | VULN |
+| FT186 | sessionlog | [session-management.md](session-management.md) | normal |
+| FT188 | verifylog | [numeric-verification-code.md](numeric-verification-code.md) | ATK |
+| FT189 | consentlog | [privacy-consent-management.md](privacy-consent-management.md) | VULN |
+| FT190 | announcelog | [system-announcement-management.md](system-announcement-management.md) | normal |
+| FT233 | cqrslog | [cqrs-pattern.md](cqrs-pattern.md) | normal |
+| FT234 | creditslog | [credit-ledger.md](credit-ledger.md) | normal |
+| FT235 | reminderlog | [scheduled-reminders.md](scheduled-reminders.md) | normal |
+| FT236 | quotalog | [quota-management.md](quota-management.md) | ATK |
+| FT237 | statemachinelog | [state-machine-audit-log.md](state-machine-audit-log.md) | VULN |
+| FT238 | contactlog | [contact-management.md](contact-management.md) | normal |
+| FT239 | doclog | [document-versioning.md](document-versioning.md) | normal |
+| FT240 | noteslog | [note-management-ownership.md](note-management-ownership.md) | ATK |
+| FT242 | cursorlog | [cursor-pagination.md](cursor-pagination.md) | normal |
+| FT243 | statslog | [event-analytics-api.md](event-analytics-api.md) | VULN |
+| FT244 | budgetlog | [budget-tracking.md](budget-tracking.md) | ATK |
+| FT245 | agglog | [aggregate-reporting.md](aggregate-reporting.md) | normal |
+| FT246 | timelog | [time-tracking.md](time-tracking.md) | normal |
+| FT247 | stepflowlog | [step-workflow-approval.md](step-workflow-approval.md) | normal |
+| FT248 | flowlog | [content-approval-workflow.md](content-approval-workflow.md) | ATK |
+| FT249 | contentvlog | [article-versioning-api.md](article-versioning-api.md) | VULN |
+| FT250 | tagfilterlog | [multi-value-tag-filter.md](multi-value-tag-filter.md) | normal |
+| FT251 | ratelimitlog | [fixed-window-rate-limiter.md](fixed-window-rate-limiter.md) | normal |
+| FT252 | pinverifylog | [pin-verification-lockout.md](pin-verification-lockout.md) | ATK |
+| FT253 | txlog | [transaction-scope-pattern.md](transaction-scope-pattern.md) | normal |
+| FT254 | ftslog | [sqlite-fts5-search.md](sqlite-fts5-search.md) | normal |
+| FT255 | queuelog | [job-queue-with-retry.md](job-queue-with-retry.md) | VULN |
+| FT256 | masslog | [mass-assignment-defence.md](mass-assignment-defence.md) | ATK |
+| FT257 | softdeletelog | [soft-delete-trash-purge.md](soft-delete-trash-purge.md) | normal |
+| FT258 | bulklog | [bulk-operations-partial-success.md](bulk-operations-partial-success.md) | normal |
+| FT259 | scorelog | [leaderboard-ranking-api.md](leaderboard-ranking-api.md) | normal |
+| FT260 | hmaclog | [webhook-signature-verification.md](webhook-signature-verification.md) | ATK |
+| FT261 | jwtlog | [jwt-authentication.md](jwt-authentication.md) | VULN |
+| FT262 | moneylog | [multi-currency-money-ledger.md](multi-currency-money-ledger.md) | normal |
+| FT263 | reactionlog | [emoji-reactions-toggle.md](emoji-reactions-toggle.md) | normal |
+| FT264 | injectionlog | [sql-injection-defence.md](sql-injection-defence.md) | ATK |
+| FT265 | linklog | [url-bookmark-api.md](url-bookmark-api.md) | normal |
+| FT266 | apikeylog | [api-key-management.md](api-key-management.md) | normal |
+| FT267 | encryptlog | [encrypted-field-storage.md](encrypted-field-storage.md) | VULN |
+| FT268 | auditlog | [audit-trail.md](audit-trail.md) | ATK |
+| FT269 | cartlog | [shopping-cart-api.md](shopping-cart-api.md) | normal |
+| FT270 | featureflaglog | [feature-flags.md](feature-flags.md) | normal |
+| FT271 | notificationlog | [notification-inbox.md](notification-inbox.md) | normal |
+| FT272 | tokenlog | [token-lifecycle-api.md](token-lifecycle-api.md) | ATK |
+| FT273 | authlog | [bearer-token-middleware.md](bearer-token-middleware.md) | VULN |
+| FT274 | orderlog | [order-management.md](order-management.md) | normal |
+| FT275 | profilelog | [user-profile-api.md](user-profile-api.md) | normal |
+| FT276 | csrflog | [idempotency.md](idempotency.md) | ATK |
+| FT277 | feedlog | [activity-feed.md](activity-feed.md) | normal |
+| FT278 | messagelog | [direct-messaging-system.md](direct-messaging-system.md) | normal |
+| FT279 | rbaclog | [rbac-jwt-auth.md](rbac-jwt-auth.md) | VULN |
+| FT280 | lockoutlog | [account-lockout.md](account-lockout.md) | ATK |
+| FT281 | refreshlog | [refresh-token-pattern.md](refresh-token-pattern.md) | normal |
+| FT282 | grantlog | [delegated-access-grants.md](delegated-access-grants.md) | normal |
+| FT283 | invitelog | [invitation-system.md](invitation-system.md) | normal |
+| FT284 | throttlelog | [rate-limiting.md](rate-limiting.md) | ATK |
+| FT285 | resetlog | [password-reset-flow.md](password-reset-flow.md) | VULN |
+| FT286 | schedulelog | [timezone-aware-scheduling.md](timezone-aware-scheduling.md) | normal |
+| FT287 | waitlistlog | [waitlist-system.md](waitlist-system.md) | normal |
+| FT288 | distlocklog | [distributed-lock.md](distributed-lock.md) | ATK |
+| FT289 | reportlog | [content-reporting.md](content-reporting.md) | normal |
+| FT290 | otplog | [otp-authentication.md](otp-authentication.md) | ATK |
+| FT291 | grouplog | [group-member-management.md](group-member-management.md) | VULN |
+| FT292 | deduplog | [idempotency-key.md](idempotency-key.md) | ATK |
+| FT293 | ablog | [ab-testing.md](ab-testing.md) | normal |
+| FT294 | batchlog | [batch-api-partial-success.md](batch-api-partial-success.md) | normal |
+| FT295 | bookmarklog | [bookmark-api.md](bookmark-api.md) | normal |
+| FT296 | geoloclog | [geolocation-api.md](geolocation-api.md) | ATK |
+| FT297 | masklog | [pii-masking.md](pii-masking.md) | VULN |
+| FT298 | circuitlog | [circuit-breaker.md](circuit-breaker.md) | normal |
+| FT299 | collectionlog | [collection-api.md](collection-api.md) | normal |
+| FT300 | pointlog | [point-ledger-api.md](point-ledger-api.md) | ATK |
+| FT301 | contentlog | [content-negotiation-api.md](content-negotiation-api.md) | normal |
+| FT302 | couponlog | [coupon-discount-api.md](coupon-discount-api.md) | normal |
+| FT303 | filelog | [file-sharing-api.md](file-sharing-api.md) | VULN |
+| FT304 | salelog | [flash-sale-api.md](flash-sale-api.md) | ATK |
+| FT305 | draftlog | [draft-publish-workflow.md](draft-publish-workflow.md) | normal |
+| FT306 | emojilog | [emoji-reactions-api.md](emoji-reactions-api.md) | normal |
+| FT307 | etaglog | [etag-conditional-requests.md](etag-conditional-requests.md) | normal |
+| FT308 | webhookdeliverylog | [webhook-delivery-system.md](webhook-delivery-system.md) | ATK |
+| FT309 | magiclog | [magic-link-authentication.md](magic-link-authentication.md) | VULN |
+| FT310 | eventsourcelog | [event-sourcing-ledger.md](event-sourcing-ledger.md) | normal |
+| FT311 | expenselog | [expense-tracking-api.md](expense-tracking-api.md) | normal |
+
+---
+
+## Pflege
+
+Bei neuen FTs folgende Zeile eintragen (FT-Nummer-Reihenfolge beibehalten):
+
+```
+| FTxxx | <name>log | [<topic>.md](<topic>.md) | normal/ATK/VULN |
+```
+
+### Typ-Kriterien
+
+| Typ | Kriterium |
+|-----|-----------|
+| **ATK** | Enthält Cracker-Angriffstests (ATK-01–12) |
+| **VULN** | Enthält Vulnerability Assessment (VULN-A–L / V-01–10) |
+| **normal** | Alle anderen Implementierungs-How-tos |
+
+### Automatisch generierter Befehl (als Rohmaterial)
+
+```bash
+# FT-reference-Header als Registry-Material extrahieren
+grep -rn "FT reference.*NENE2-FT/" docs/howto/ \
+  | grep -oP '[^/]+\.md:\d+:.*FT\d+.*NENE2-FT/[a-z]+log' \
+  | sort
+```

--- a/docs/de/howto/game-score-leaderboard-api.md
+++ b/docs/de/howto/game-score-leaderboard-api.md
@@ -1,0 +1,228 @@
+# How-to: Game Score & Leaderboard API
+
+> **FT-Referenz**: FT259 (`NENE2-FT/scorelog`) — Game-Score-Einreichung mit Bulk-Insert (max 100, alles-oder-nichts), Pro-Spieler-Leaderboard mit `best_score`-Aggregation und `play_count`, Prävention negativer Punktzahlen, Paginierung, 20 Tests bestanden.
+
+Diese Anleitung zeigt, wie ein Spielstand-System aufgebaut wird: individuelle Spielstände aufzeichnen, Ergebnisse bulk-importieren und sortierte Leaderboards pro Spiel berechnen.
+
+## Schema
+
+```sql
+CREATE TABLE scores (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    player     TEXT    NOT NULL,
+    game       TEXT    NOT NULL,
+    score      INTEGER NOT NULL CHECK(score >= 0),
+    played_at  TEXT    NOT NULL,      -- ISO-8601-Datum: YYYY-MM-DD
+    created_at TEXT    NOT NULL
+);
+
+CREATE INDEX idx_scores_game      ON scores (game);
+CREATE INDEX idx_scores_player    ON scores (player);
+CREATE INDEX idx_scores_played_at ON scores (played_at);
+```
+
+`CHECK(score >= 0)` verhindert negative Punktzahlen auf DB-Ebene. Indizes auf `game` und `player` unterstützen gefilterte Listen- und Leaderboard-Abfragen.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/scores` | Einen Spielstand einreichen |
+| `POST` | `/scores/bulk` | Bis zu 100 Spielstände bulk-einreichen |
+| `GET` | `/scores` | Spielstände auflisten (Filter + Paginierung) |
+| `GET` | `/scores/leaderboard` | Pro-Spieler-Leaderboard für ein Spiel |
+| `GET` | `/scores/{id}` | Einzelnen Spielstand abrufen |
+| `DELETE` | `/scores/{id}` | Spielstand löschen |
+
+## Spielstand einreichen
+
+```php
+POST /scores
+{
+  "player":    "Alice",
+  "game":      "tetris",
+  "score":     1500,
+  "played_at": "2026-01-15"
+}
+
+→ 201
+{
+  "id": 1,
+  "player": "Alice",
+  "game": "tetris",
+  "score": 1500,
+  "played_at": "2026-01-15",
+  "created_at": "..."
+}
+```
+
+Mehrere Spielstände pro Spieler pro Spiel sind erlaubt — jedes Spiel ist ein separater Eintrag.
+
+### Validierung
+
+```php
+POST /scores  {"game": "tetris", "score": 100, "played_at": "2026-01-15"}
+→ 422  // player ist erforderlich
+
+POST /scores  {"player": "Alice", "game": "tetris", "score": -1, "played_at": "2026-01-15"}
+→ 422  // score muss >= 0 sein
+
+POST /scores  {"player": "Alice", "game": "tetris", "score": 100, "played_at": "15/01/2026"}
+→ 422  // played_at muss im Format YYYY-MM-DD sein
+
+POST /scores  {"player": "Alice", "game": "tetris", "score": 0, "played_at": "2026-01-15"}
+→ 201  // score = 0 ist gültig
+```
+
+## Spielstände auflisten
+
+```php
+// Alle Spielstände
+GET /scores
+→ 200  {"items": [...], "total": 10}
+
+// Nach Spiel filtern
+GET /scores?game=tetris
+→ 200  {"items": [/* nur Tetris-Spielstände */], "total": 3}
+
+// Nach Spieler filtern
+GET /scores?player=Alice
+→ 200  {"items": [/* nur Alices Spielstände */], "total": 2}
+
+// Paginierung
+GET /scores?limit=2&offset=1
+→ 200  {"items": [/* 2 Einträge, ab Index 1 */], "total": 5}
+```
+
+## Bulk-Einreichung
+
+```php
+POST /scores/bulk
+{
+  "scores": [
+    {"player": "Alice", "game": "tetris", "score": 1000, "played_at": "2026-01-15"},
+    {"player": "Bob",   "game": "tetris", "score": 2000, "played_at": "2026-01-16"},
+    {"player": "Carol", "game": "snake",  "score": 500,  "played_at": "2026-01-15"}
+  ]
+}
+
+→ 201
+{
+  "created": 3,
+  "scores": [
+    {"id": 1, "player": "Alice", ...},
+    {"id": 2, "player": "Bob",   ...},
+    {"id": 3, "player": "Carol", ...}
+  ]
+}
+```
+
+### Bulk-Validierungsregeln
+
+```php
+// Leeres Array
+POST /scores/bulk  {"scores": []}
+→ 422  // mindestens 1 Eintrag erforderlich
+
+// Jeder ungültige Eintrag lässt den gesamten Batch fehlschlagen
+POST /scores/bulk
+{"scores": [
+  {"player": "Alice", "game": "tetris", "score": 1000, "played_at": "2026-01-15"},
+  {"player": "",      "game": "tetris", "score": 500,  "played_at": "2026-01-15"}
+]}
+→ 422  // "player" darf nicht leer sein — keine Einträge werden eingefügt
+
+// Über 100 Einträge
+POST /scores/bulk  {"scores": [...101 Einträge...]}
+→ 422  // max 100 Einträge pro Bulk-Request
+```
+
+**Alles-oder-nichts**: Alle Einträge validieren, bevor irgendwelche eingefügt werden. Eine DB-Transaktion für Atomarität verwenden.
+
+### Bulk-Implementierung
+
+```php
+public function bulkSubmit(array $entries): array
+{
+    // Alle Einträge zuerst validieren
+    foreach ($entries as $i => $entry) {
+        $this->validate($entry, "scores[{$i}]");
+    }
+
+    // Alle in einer Transaktion einfügen
+    $this->db->beginTransaction();
+    try {
+        $ids = [];
+        foreach ($entries as $entry) {
+            $ids[] = $this->repo->insert($entry['player'], $entry['game'], $entry['score'], $entry['played_at'], $now);
+        }
+        $this->db->commit();
+        return $this->repo->findByIds($ids);
+    } catch (\Throwable $e) {
+        $this->db->rollback();
+        throw $e;
+    }
+}
+```
+
+## Leaderboard
+
+```php
+GET /scores/leaderboard?game=tetris
+
+→ 200
+{
+  "game":    "tetris",
+  "top":     10,
+  "entries": [
+    {"rank": 1, "player": "Alice", "best_score": 3000, "play_count": 2},
+    {"rank": 2, "player": "Bob",   "best_score": 2000, "play_count": 1},
+    {"rank": 3, "player": "Carol", "best_score": 500,  "play_count": 1}
+  ]
+}
+```
+
+Jeder Spieler erscheint **einmal** — mit seinem **besten** (höchsten) Spielstand über alle Spiele, plus `play_count`.
+
+### Top-N-Limit
+
+```php
+GET /scores/leaderboard?game=tetris&top=3
+→ 200  {"entries": [...3 Spieler...], "top": 3}
+
+GET /scores/leaderboard?game=tetris&top=0
+→ 422  // top muss >= 1 sein
+
+GET /scores/leaderboard          // fehlendes game
+→ 422
+```
+
+### Leaderboard-SQL
+
+```sql
+SELECT
+    player,
+    MAX(score)   AS best_score,
+    COUNT(*)     AS play_count,
+    RANK() OVER (ORDER BY MAX(score) DESC) AS rank
+FROM scores
+WHERE game = ?
+GROUP BY player
+ORDER BY best_score DESC
+LIMIT ?
+```
+
+`RANK() OVER (ORDER BY MAX(score) DESC)` weist gleichen Spielern denselben Rang zu (Lücken bei nachfolgenden Rängen). Bei gewünschter lückenloser Rangfolge `DENSE_RANK()` verwenden.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Negative Punktzahlen nur auf Anwendungsebene verhindern | `CHECK(score >= 0)`-DB-Constraint ist die letzte Absicherung; Anwendungsvalidierung kann umgangen werden |
+| Bulk-Einträge einzeln ohne Transaktion einfügen | Teilfehler lässt die Hälfte des Batches in der DB; unmöglich zu unterscheiden was committed wurde |
+| Bulk-Einträge innerhalb der Insert-Schleife validieren | Erste N Einträge werden eingefügt, bevor die Validierung fehlschlägt; Teildaten in DB |
+| `score = MAX(score)` ohne GROUP BY verwenden | Aggregiert die gesamte Tabelle ohne Spieler-Gruppierung; falsches Leaderboard-Ergebnis |
+| Alle Spieler im Leaderboard ohne LIMIT zurückgeben | Full-Table-Scan und Sortierung ohne Begrenzung; DoS-Risiko bei großen Score-Tabellen |
+| `best_score` durch Abrufen aller Scores in PHP berechnen | O(N) pro Spieler; SQL `MAX()`-Aggregation verwenden |

--- a/docs/de/howto/geolocation-api.md
+++ b/docs/de/howto/geolocation-api.md
@@ -1,8 +1,8 @@
-# How-to: Geolocation-API
+# How-to: Geolocation API
 
-> **FT-Referenz**: FT296 (`NENE2-FT/geoloclog`) — Geolocation-API: Haversine-Distanzberechnung, Koordinatenvalidierung (Breite ±90, Länge ±180), Umgebungssuche mit Bounding-Box-Vorfilter, maximaler Radius-Clamp (20.000 km), invertierte Bounding-Box-Absicherung, ATK-01~12 alle BLOCKIERT, 25 Tests / 40 Assertions bestanden.
+> **FT-Referenz**: FT296 (`NENE2-FT/geoloclog`) — Geolocation API: Haversine-Distanzberechnung, Koordinatenvalidierung (lat ±90, lng ±180), Nearby-Suche mit Bounding-Box-Vorfilter, maximaler Radius-Clamp (20.000 km), invertierter Bounding-Box-Guard, ATK-01–12 alle BLOCKED, 25 Tests / 40 Assertions bestanden.
 
-Dieser Leitfaden zeigt, wie eine Ort/Standort-API mit Koordinatenvalidierung, Nähesuche (Nearby) und Bounding-Box-Suche aufgebaut wird.
+Diese Anleitung zeigt, wie eine Orts-/Standort-API mit Koordinatenvalidierung, Proximity-Suche (nearby) und Bounding-Box-Suche aufgebaut wird.
 
 ## Schema
 
@@ -17,18 +17,18 @@ CREATE TABLE places (
 );
 ```
 
-`REAL`-Typ speichert IEEE-754-Double-Precision-Floats. Keine Koordinaten-Constraints auf DB-Ebene — Validierung wird auf Anwendungsebene erzwungen.
+`REAL`-Typ speichert IEEE-754-Double-Precision-Floats. Keine DB-Level-Koordinaten-Constraints — Validierung wird in der Anwendungsschicht durchgesetzt.
 
 ## Endpunkte
 
 | Methode | Pfad | Beschreibung |
-|--------|------|-------------|
+|---------|------|--------------|
 | `POST` | `/places` | Ort erstellen |
 | `GET` | `/places` | Alle Orte auflisten |
 | `GET` | `/places/{id}` | Ort abrufen |
 | `DELETE` | `/places/{id}` | Ort löschen |
-| `GET` | `/places/nearby` | Orte innerhalb eines Radius finden |
-| `GET` | `/places/bbox` | Orte in einer Bounding Box finden |
+| `GET` | `/places/nearby` | Orte im Radius finden |
+| `GET` | `/places/bbox` | Orte in Bounding Box finden |
 
 Statische Pfade (`/places/nearby`, `/places/bbox`) werden **vor** dem dynamischen Pfad `/places/{id}` registriert, damit `nearby` und `bbox` nicht als `{id}` erfasst werden.
 
@@ -62,7 +62,7 @@ private function parseCoords(mixed $rawLat, mixed $rawLng): array
 }
 ```
 
-Breitengrad: `[-90, 90]`. Längengrad: `[-180, 180]`. Nicht-numerische Strings und NaN-ähnliche Werte werden von `is_numeric()` abgelehnt.
+Latitude: `[-90, 90]`. Longitude: `[-180, 180]`. Nicht-numerische Strings und NaN-ähnliche Werte werden durch `is_numeric()` abgelehnt.
 
 ## Haversine-Distanz
 
@@ -83,9 +83,9 @@ class GeoCalculator
 }
 ```
 
-Die Haversine-Formel berechnet die Großkreisdistanz in km. Genau für kleine und große Distanzen.
+Die Haversine-Formel berechnet die Großkreis-Distanz in km. Genau für kleine und große Distanzen.
 
-## Umgebungssuche — Bounding-Box-Vorfilter + Haversine-Nachfilter
+## Nearby-Suche — Bounding-Box-Vorfilter + Haversine-Nachfilter
 
 ```php
 public function clampRadius(float $radiusKm): float
@@ -106,9 +106,9 @@ public function boundingBox(float $lat, float $lng, float $radiusKm): array
 }
 ```
 
-Zweiphasige Suche:
-1. SQL `WHERE lat BETWEEN min AND max AND lng BETWEEN min AND max` — schneller Vorfilter mit dem Index.
-2. PHP-Haversine für exakte Distanzprüfung — filtert die Ecken der Bounding Box heraus.
+Zwei-Phasen-Suche:
+1. SQL `WHERE lat BETWEEN min AND max AND lng BETWEEN min AND max` — schneller Vorfilter mit Index.
+2. PHP Haversine für exakte Distanzprüfung — filtert Ecken der Bounding Box heraus.
 
 `clampRadius()` begrenzt auf 20.000 km (halber Erdumfang) — kein Absturz bei beliebig großem Radius.
 
@@ -143,123 +143,123 @@ Invertierte Bounding Boxes (min > max) werden abgelehnt. Eine invertierte Bbox w
 
 ---
 
-## ATK-Bewertung — Cracker-Mindset-Angriffstest
+## ATK Assessment — Cracker-Mindset Attack Test
 
-### ATK-01 — SQL-Injektion im name-Feld 🚫 BLOCKIERT
+### ATK-01 — SQL-Injection im name-Feld 🚫 BLOCKED
 
 **Angriff**: `"name": "'; DROP TABLE places; --"` einreichen.
-**Ergebnis**: BLOCKIERT — parametrisierte Abfragen speichern den String wörtlich. Keine SQL-Ausführung.
+**Ergebnis**: BLOCKED — parametrisierte Abfragen speichern den String wörtlich. Keine SQL-Ausführung.
 
 ---
 
-### ATK-02 — SQL-Injektion im radius_km-Parameter 🚫 BLOCKIERT
+### ATK-02 — SQL-Injection im radius_km-Parameter 🚫 BLOCKED
 
 **Angriff**: `?radius_km=1; DROP TABLE places` senden.
-**Ergebnis**: BLOCKIERT — `!is_numeric($q['radius_km'])` lehnt den nicht-numerischen String ab → 422.
+**Ergebnis**: BLOCKED — `!is_numeric($q['radius_km'])` lehnt den nicht-numerischen String ab → 422.
 
 ---
 
-### ATK-03 — Breitengrad-Überlauf (+91) 🚫 BLOCKIERT
+### ATK-03 — Latitude-Überlauf (+91) 🚫 BLOCKED
 
-**Angriff**: `{ "latitude": 91 }` senden, um Koordinatenbereich zu umgehen.
-**Ergebnis**: BLOCKIERT — `$lat > 90.0` → ValidationException → 422.
+**Angriff**: `{ "latitude": 91 }` senden, um den Koordinatenbereich zu umgehen.
+**Ergebnis**: BLOCKED — `$lat > 90.0` → ValidationException → 422.
 
 ---
 
-### ATK-04 — Breitengrad-Unterlauf (-91) 🚫 BLOCKIERT
+### ATK-04 — Latitude-Unterlauf (-91) 🚫 BLOCKED
 
 **Angriff**: `{ "latitude": -91 }` senden.
-**Ergebnis**: BLOCKIERT — `$lat < -90.0` → 422.
+**Ergebnis**: BLOCKED — `$lat < -90.0` → 422.
 
 ---
 
-### ATK-05 — Längengrad-Überlauf (+181) 🚫 BLOCKIERT
+### ATK-05 — Longitude-Überlauf (+181) 🚫 BLOCKED
 
 **Angriff**: `{ "longitude": 181 }` senden.
-**Ergebnis**: BLOCKIERT — `$lng > 180.0` → 422.
+**Ergebnis**: BLOCKED — `$lng > 180.0` → 422.
 
 ---
 
-### ATK-06 — NaN-String als Breitengrad 🚫 BLOCKIERT
+### ATK-06 — NaN-String als Latitude 🚫 BLOCKED
 
 **Angriff**: `{ "latitude": "NaN" }` senden.
-**Ergebnis**: BLOCKIERT — `is_numeric("NaN")` gibt in PHP false zurück → ValidationError → 422.
+**Ergebnis**: BLOCKED — `is_numeric("NaN")` gibt in PHP false zurück → ValidationError → 422.
 
 ---
 
-### ATK-07 — Negativer Radius 🚫 BLOCKIERT
+### ATK-07 — Negativer Radius 🚫 BLOCKED
 
-**Angriff**: `?radius_km=-100` senden, um alle Orte zu erhalten oder Mathematikfehler zu verursachen.
-**Ergebnis**: BLOCKIERT — `$radiusKm <= 0` → 422.
-
----
-
-### ATK-08 — Riesiger Radius (> Erdumfang) 🚫 BLOCKIERT (by Design)
-
-**Angriff**: `?radius_km=999999999` für eine globale Suche senden.
-**Ergebnis**: BLOCKIERT (by Design) — `clampRadius()` begrenzt auf 20.000 km. Anfrage gelingt, aber Radius wird begrenzt.
+**Angriff**: `?radius_km=-100` senden, um alle Orte zu erhalten oder Mathematik-Fehler zu verursachen.
+**Ergebnis**: BLOCKED — `$radiusKm <= 0` → 422.
 
 ---
 
-### ATK-09 — Invertierte Bounding Box (min_lat > max_lat) 🚫 BLOCKIERT
+### ATK-08 — Riesiger Radius (> Erdumfang) 🚫 BLOCKED (by design)
 
-**Angriff**: `?min_lat=90&max_lat=-90` (vertauscht) senden, um die Abfrage zu verwirren.
-**Ergebnis**: BLOCKIERT — `$vals['min_lat'] > $vals['max_lat']` → 422.
+**Angriff**: `?radius_km=999999999` senden, um eine globale Suche durchzuführen.
+**Ergebnis**: BLOCKED (by design) — `clampRadius()` begrenzt auf 20.000 km. Request gelingt, aber Radius ist begrenzt.
 
 ---
 
-### ATK-10 — Nicht-numerische Bbox-Parameter 🚫 BLOCKIERT
+### ATK-09 — Invertierte Bounding Box (min_lat > max_lat) 🚫 BLOCKED
+
+**Angriff**: `?min_lat=90&max_lat=-90` (umgekehrt) senden, um die Abfrage zu verwirren.
+**Ergebnis**: BLOCKED — `$vals['min_lat'] > $vals['max_lat']` → 422.
+
+---
+
+### ATK-10 — Nicht-numerische Bbox-Parameter 🚫 BLOCKED
 
 **Angriff**: `?min_lat=abc&max_lat=xyz&min_lng=foo&max_lng=bar` senden.
-**Ergebnis**: BLOCKIERT — `!is_numeric($q[$p])` → ValidationException für alle vier Felder → 422.
+**Ergebnis**: BLOCKED — `!is_numeric($q[$p])` → ValidationException für alle vier Felder → 422.
 
 ---
 
-### ATK-11 — Wiederholtes DELETE eines nicht-existierenden Orts 🚫 BLOCKIERT
+### ATK-11 — Wiederholtes DELETE eines nicht-existierenden Ortes 🚫 BLOCKED
 
 **Angriff**: `DELETE /places/99999` 100 Mal senden, um Serverfehler oder Log-Spam auszulösen.
-**Ergebnis**: BLOCKIERT — `if (!$this->repo->delete($id)) return 404`. Idempotent; niemals 500.
+**Ergebnis**: BLOCKED — `if (!$this->repo->delete($id)) return 404`. Idempotent; niemals 500.
 
 ---
 
-### ATK-12 — Fehlender lat-Parameter in Nearby 🚫 BLOCKIERT
+### ATK-12 — Fehlender lat-Parameter in Nearby 🚫 BLOCKED
 
-**Angriff**: `GET /places/nearby?lng=139.7&radius_km=5` (fehlendes `lat`) senden.
-**Ergebnis**: BLOCKIERT — `parseCoords(null, ...)` → ValidationError für Breitengrad → 422.
+**Angriff**: `GET /places/nearby?lng=139.7&radius_km=5` senden (fehlendes `lat`).
+**Ergebnis**: BLOCKED — `parseCoords(null, ...)` → ValidationError für latitude → 422.
 
 ---
 
 ### ATK-Zusammenfassung
 
 | ID | Angriff | Ergebnis |
-|----|---------|---------|
-| ATK-01 | SQL-Injektion im Namen | 🚫 BLOCKIERT |
-| ATK-02 | SQL-Injektion in radius_km | 🚫 BLOCKIERT |
-| ATK-03 | Breitengrad-Überlauf (+91) | 🚫 BLOCKIERT |
-| ATK-04 | Breitengrad-Unterlauf (-91) | 🚫 BLOCKIERT |
-| ATK-05 | Längengrad-Überlauf (+181) | 🚫 BLOCKIERT |
-| ATK-06 | NaN-String als Breitengrad | 🚫 BLOCKIERT |
-| ATK-07 | Negativer Radius | 🚫 BLOCKIERT |
-| ATK-08 | Riesiger Radius (globale Suche) | 🚫 BLOCKIERT (durch Clamp) |
-| ATK-09 | Invertierte Bounding Box | 🚫 BLOCKIERT |
-| ATK-10 | Nicht-numerische Bbox-Parameter | 🚫 BLOCKIERT |
-| ATK-11 | Wiederholtes DELETE nicht-existierend | 🚫 BLOCKIERT |
-| ATK-12 | Fehlender lat in Nearby | 🚫 BLOCKIERT |
+|----|---------|----------|
+| ATK-01 | SQL-Injection im Namen | 🚫 BLOCKED |
+| ATK-02 | SQL-Injection im radius_km | 🚫 BLOCKED |
+| ATK-03 | Latitude-Überlauf (+91) | 🚫 BLOCKED |
+| ATK-04 | Latitude-Unterlauf (-91) | 🚫 BLOCKED |
+| ATK-05 | Longitude-Überlauf (+181) | 🚫 BLOCKED |
+| ATK-06 | NaN-String als Latitude | 🚫 BLOCKED |
+| ATK-07 | Negativer Radius | 🚫 BLOCKED |
+| ATK-08 | Riesiger Radius (globale Suche) | 🚫 BLOCKED (begrenzt by design) |
+| ATK-09 | Invertierte Bounding Box | 🚫 BLOCKED |
+| ATK-10 | Nicht-numerische Bbox-Parameter | 🚫 BLOCKED |
+| ATK-11 | Wiederholtes DELETE nicht-existierender Ort | 🚫 BLOCKED |
+| ATK-12 | Fehlender lat in Nearby | 🚫 BLOCKED |
 
-**12 BLOCKIERT, 0 EXPONIERT**
-`is_numeric()`-Koordinatenvalidierung, Bereichsprüfungen, invertierte Bbox-Absicherung, Radius-Clamp und parametrisierte Abfragen verhindern alle geografischen Angriffsvektoren.
+**12 BLOCKED, 0 EXPOSED**
+`is_numeric()`-Koordinatenvalidierung, Bereichsprüfungen, invertierter Bbox-Guard, Radius-Clamping und parametrisierte Abfragen verhindern alle geografischen Angriffsvektoren.
 
 ---
 
-## Was NICHT zu tun ist
+## Was man NICHT tun sollte
 
 | Anti-Muster | Risiko |
 |---|---|
-| Keine Koordinaten-Bereichsvalidierung | `latitude=999` akzeptiert; Haversine gibt NaN oder sinnlose Distanz zurück |
-| `"NaN"`-String als Koordinate akzeptieren | `is_numeric("NaN")` ist false in PHP, aber `(float)"NaN"` ist `NAN`; immer zuerst `is_numeric()` prüfen |
-| Kein maximales Radius-Limit | `radius_km=999999999` läuft Full-Table-Scan; DoS über teure Bounding-Box-Abfrage |
-| Bounding-Box-Vorfilter weglassen | Haversine läuft auf allen Zeilen; O(n) für jede Umgebungsabfrage |
-| Invertierte Bounding Box erlauben | `min_lat > max_lat` gibt lautlos leere Ergebnisse oder Absturz in SQL |
-| `/{id}` vor `/nearby` und `/bbox` registrieren | `GET /places/nearby` wird von `{id}` abgefangen → 404 oder falscher Handler |
-| Koordinaten als TEXT speichern | Bounding-Box-SQL-`BETWEEN` erfordert numerischen Vergleich; TEXT-Vergleich ist lexikografisch |
-| `cos(deg2rad($lat))` ohne `max(..., 0.001)` | Division durch null an Polen (Breite = ±90) |
+| Keine Koordinaten-Bereichsvalidierung | `latitude=999` wird akzeptiert; Haversine gibt NaN oder bedeutungslose Distanz zurück |
+| `"NaN"`-String als Koordinate akzeptieren | `is_numeric("NaN")` ist in PHP false, aber `(float)"NaN"` ist `NAN`; immer zuerst `is_numeric()` prüfen |
+| Kein maximales Radius-Limit | `radius_km=999999999` führt Full-Table-Scan aus; DoS via teure Bounding-Box-Abfrage |
+| Bounding-Box-Vorfilter überspringen | Haversine läuft auf allen Zeilen; O(n) für jede Nearby-Abfrage |
+| Invertierte Bounding Box erlauben | `min_lat > max_lat` gibt still leere Ergebnisse zurück oder stürzt SQL ab |
+| `/{id}` vor `/nearby` und `/bbox` registrieren | `GET /places/nearby` wird von `{id}` erfasst → 404 oder falscher Handler |
+| Koordinaten als TEXT speichern | Bounding-Box-SQL `BETWEEN` erfordert numerischen Vergleich; TEXT-Vergleich ist lexikografisch |
+| `cos(deg2rad($lat))` ohne `max(..., 0.001)` | Division durch Null an den Polen (lat = ±90) |

--- a/docs/de/howto/geolocation-api.md
+++ b/docs/de/howto/geolocation-api.md
@@ -1,0 +1,265 @@
+# How-to: Geolocation-API
+
+> **FT-Referenz**: FT296 (`NENE2-FT/geoloclog`) — Geolocation-API: Haversine-Distanzberechnung, Koordinatenvalidierung (Breite ±90, Länge ±180), Umgebungssuche mit Bounding-Box-Vorfilter, maximaler Radius-Clamp (20.000 km), invertierte Bounding-Box-Absicherung, ATK-01~12 alle BLOCKIERT, 25 Tests / 40 Assertions bestanden.
+
+Dieser Leitfaden zeigt, wie eine Ort/Standort-API mit Koordinatenvalidierung, Nähesuche (Nearby) und Bounding-Box-Suche aufgebaut wird.
+
+## Schema
+
+```sql
+CREATE TABLE places (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    latitude   REAL    NOT NULL,
+    longitude  REAL    NOT NULL,
+    category   TEXT    NOT NULL DEFAULT 'general',
+    created_at TEXT    NOT NULL
+);
+```
+
+`REAL`-Typ speichert IEEE-754-Double-Precision-Floats. Keine Koordinaten-Constraints auf DB-Ebene — Validierung wird auf Anwendungsebene erzwungen.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/places` | Ort erstellen |
+| `GET` | `/places` | Alle Orte auflisten |
+| `GET` | `/places/{id}` | Ort abrufen |
+| `DELETE` | `/places/{id}` | Ort löschen |
+| `GET` | `/places/nearby` | Orte innerhalb eines Radius finden |
+| `GET` | `/places/bbox` | Orte in einer Bounding Box finden |
+
+Statische Pfade (`/places/nearby`, `/places/bbox`) werden **vor** dem dynamischen Pfad `/places/{id}` registriert, damit `nearby` und `bbox` nicht als `{id}` erfasst werden.
+
+## Koordinatenvalidierung
+
+```php
+private function parseCoords(mixed $rawLat, mixed $rawLng): array
+{
+    $errors = [];
+    $lat = $lng = 0.0;
+
+    if ($rawLat === null || $rawLat === '' || !is_numeric($rawLat)) {
+        $errors[] = new ValidationError('latitude', 'latitude must be a number', 'invalid');
+    } else {
+        $lat = (float) $rawLat;
+        if ($lat < -90.0 || $lat > 90.0) {
+            $errors[] = new ValidationError('latitude', 'latitude must be between -90 and 90', 'invalid');
+        }
+    }
+
+    if ($rawLng === null || $rawLng === '' || !is_numeric($rawLng)) {
+        $errors[] = new ValidationError('longitude', 'longitude must be a number', 'invalid');
+    } else {
+        $lng = (float) $rawLng;
+        if ($lng < -180.0 || $lng > 180.0) {
+            $errors[] = new ValidationError('longitude', 'longitude must be between -180 and 180', 'invalid');
+        }
+    }
+
+    return [$lat, $lng, $errors];
+}
+```
+
+Breitengrad: `[-90, 90]`. Längengrad: `[-180, 180]`. Nicht-numerische Strings und NaN-ähnliche Werte werden von `is_numeric()` abgelehnt.
+
+## Haversine-Distanz
+
+```php
+class GeoCalculator
+{
+    private const float EARTH_RADIUS_KM = 6371.0;
+    private const float MAX_RADIUS_KM   = 20_000.0; // halber Erdumfang
+
+    public function haversineKm(float $lat1, float $lng1, float $lat2, float $lng2): float
+    {
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLng = deg2rad($lng2 - $lng1);
+        $a    = sin($dLat / 2) ** 2
+              + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLng / 2) ** 2;
+        return self::EARTH_RADIUS_KM * 2.0 * asin(sqrt($a));
+    }
+}
+```
+
+Die Haversine-Formel berechnet die Großkreisdistanz in km. Genau für kleine und große Distanzen.
+
+## Umgebungssuche — Bounding-Box-Vorfilter + Haversine-Nachfilter
+
+```php
+public function clampRadius(float $radiusKm): float
+{
+    return min(max($radiusKm, 0.0), self::MAX_RADIUS_KM);
+}
+
+public function boundingBox(float $lat, float $lng, float $radiusKm): array
+{
+    $deltaLat = $radiusKm / 111.0;
+    $deltaLng = $radiusKm / (111.0 * max(cos(deg2rad($lat)), 0.001));
+    return [
+        'min_lat' => $lat - $deltaLat,
+        'max_lat' => $lat + $deltaLat,
+        'min_lng' => $lng - $deltaLng,
+        'max_lng' => $lng + $deltaLng,
+    ];
+}
+```
+
+Zweiphasige Suche:
+1. SQL `WHERE lat BETWEEN min AND max AND lng BETWEEN min AND max` — schneller Vorfilter mit dem Index.
+2. PHP-Haversine für exakte Distanzprüfung — filtert die Ecken der Bounding Box heraus.
+
+`clampRadius()` begrenzt auf 20.000 km (halber Erdumfang) — kein Absturz bei beliebig großem Radius.
+
+## Radius-Validierung
+
+```php
+if ($radiusKm <= 0) {
+    $errors[] = new ValidationError('radius_km', 'radius_km must be positive', 'invalid');
+}
+// Nach Validierung auf MAX_RADIUS_KM begrenzen:
+$radiusKm = $this->geo->clampRadius($radiusKm);
+```
+
+Negative und Null-Radien werden abgelehnt (422). Sehr große gültige Radien werden auf `MAX_RADIUS_KM` begrenzt.
+
+## Bounding-Box-Validierung
+
+```php
+if ($vals['min_lat'] > $vals['max_lat']) {
+    throw new ValidationException([
+        new ValidationError('min_lat', 'min_lat must be ≤ max_lat', 'invalid')
+    ]);
+}
+if ($vals['min_lng'] > $vals['max_lng']) {
+    throw new ValidationException([
+        new ValidationError('min_lng', 'min_lng must be ≤ max_lng', 'invalid')
+    ]);
+}
+```
+
+Invertierte Bounding Boxes (min > max) werden abgelehnt. Eine invertierte Bbox würde keine Ergebnisse zurückgeben oder unerwartetes Verhalten verursachen.
+
+---
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — SQL-Injektion im name-Feld 🚫 BLOCKIERT
+
+**Angriff**: `"name": "'; DROP TABLE places; --"` einreichen.
+**Ergebnis**: BLOCKIERT — parametrisierte Abfragen speichern den String wörtlich. Keine SQL-Ausführung.
+
+---
+
+### ATK-02 — SQL-Injektion im radius_km-Parameter 🚫 BLOCKIERT
+
+**Angriff**: `?radius_km=1; DROP TABLE places` senden.
+**Ergebnis**: BLOCKIERT — `!is_numeric($q['radius_km'])` lehnt den nicht-numerischen String ab → 422.
+
+---
+
+### ATK-03 — Breitengrad-Überlauf (+91) 🚫 BLOCKIERT
+
+**Angriff**: `{ "latitude": 91 }` senden, um Koordinatenbereich zu umgehen.
+**Ergebnis**: BLOCKIERT — `$lat > 90.0` → ValidationException → 422.
+
+---
+
+### ATK-04 — Breitengrad-Unterlauf (-91) 🚫 BLOCKIERT
+
+**Angriff**: `{ "latitude": -91 }` senden.
+**Ergebnis**: BLOCKIERT — `$lat < -90.0` → 422.
+
+---
+
+### ATK-05 — Längengrad-Überlauf (+181) 🚫 BLOCKIERT
+
+**Angriff**: `{ "longitude": 181 }` senden.
+**Ergebnis**: BLOCKIERT — `$lng > 180.0` → 422.
+
+---
+
+### ATK-06 — NaN-String als Breitengrad 🚫 BLOCKIERT
+
+**Angriff**: `{ "latitude": "NaN" }` senden.
+**Ergebnis**: BLOCKIERT — `is_numeric("NaN")` gibt in PHP false zurück → ValidationError → 422.
+
+---
+
+### ATK-07 — Negativer Radius 🚫 BLOCKIERT
+
+**Angriff**: `?radius_km=-100` senden, um alle Orte zu erhalten oder Mathematikfehler zu verursachen.
+**Ergebnis**: BLOCKIERT — `$radiusKm <= 0` → 422.
+
+---
+
+### ATK-08 — Riesiger Radius (> Erdumfang) 🚫 BLOCKIERT (by Design)
+
+**Angriff**: `?radius_km=999999999` für eine globale Suche senden.
+**Ergebnis**: BLOCKIERT (by Design) — `clampRadius()` begrenzt auf 20.000 km. Anfrage gelingt, aber Radius wird begrenzt.
+
+---
+
+### ATK-09 — Invertierte Bounding Box (min_lat > max_lat) 🚫 BLOCKIERT
+
+**Angriff**: `?min_lat=90&max_lat=-90` (vertauscht) senden, um die Abfrage zu verwirren.
+**Ergebnis**: BLOCKIERT — `$vals['min_lat'] > $vals['max_lat']` → 422.
+
+---
+
+### ATK-10 — Nicht-numerische Bbox-Parameter 🚫 BLOCKIERT
+
+**Angriff**: `?min_lat=abc&max_lat=xyz&min_lng=foo&max_lng=bar` senden.
+**Ergebnis**: BLOCKIERT — `!is_numeric($q[$p])` → ValidationException für alle vier Felder → 422.
+
+---
+
+### ATK-11 — Wiederholtes DELETE eines nicht-existierenden Orts 🚫 BLOCKIERT
+
+**Angriff**: `DELETE /places/99999` 100 Mal senden, um Serverfehler oder Log-Spam auszulösen.
+**Ergebnis**: BLOCKIERT — `if (!$this->repo->delete($id)) return 404`. Idempotent; niemals 500.
+
+---
+
+### ATK-12 — Fehlender lat-Parameter in Nearby 🚫 BLOCKIERT
+
+**Angriff**: `GET /places/nearby?lng=139.7&radius_km=5` (fehlendes `lat`) senden.
+**Ergebnis**: BLOCKIERT — `parseCoords(null, ...)` → ValidationError für Breitengrad → 422.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|---------|
+| ATK-01 | SQL-Injektion im Namen | 🚫 BLOCKIERT |
+| ATK-02 | SQL-Injektion in radius_km | 🚫 BLOCKIERT |
+| ATK-03 | Breitengrad-Überlauf (+91) | 🚫 BLOCKIERT |
+| ATK-04 | Breitengrad-Unterlauf (-91) | 🚫 BLOCKIERT |
+| ATK-05 | Längengrad-Überlauf (+181) | 🚫 BLOCKIERT |
+| ATK-06 | NaN-String als Breitengrad | 🚫 BLOCKIERT |
+| ATK-07 | Negativer Radius | 🚫 BLOCKIERT |
+| ATK-08 | Riesiger Radius (globale Suche) | 🚫 BLOCKIERT (durch Clamp) |
+| ATK-09 | Invertierte Bounding Box | 🚫 BLOCKIERT |
+| ATK-10 | Nicht-numerische Bbox-Parameter | 🚫 BLOCKIERT |
+| ATK-11 | Wiederholtes DELETE nicht-existierend | 🚫 BLOCKIERT |
+| ATK-12 | Fehlender lat in Nearby | 🚫 BLOCKIERT |
+
+**12 BLOCKIERT, 0 EXPONIERT**
+`is_numeric()`-Koordinatenvalidierung, Bereichsprüfungen, invertierte Bbox-Absicherung, Radius-Clamp und parametrisierte Abfragen verhindern alle geografischen Angriffsvektoren.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Keine Koordinaten-Bereichsvalidierung | `latitude=999` akzeptiert; Haversine gibt NaN oder sinnlose Distanz zurück |
+| `"NaN"`-String als Koordinate akzeptieren | `is_numeric("NaN")` ist false in PHP, aber `(float)"NaN"` ist `NAN`; immer zuerst `is_numeric()` prüfen |
+| Kein maximales Radius-Limit | `radius_km=999999999` läuft Full-Table-Scan; DoS über teure Bounding-Box-Abfrage |
+| Bounding-Box-Vorfilter weglassen | Haversine läuft auf allen Zeilen; O(n) für jede Umgebungsabfrage |
+| Invertierte Bounding Box erlauben | `min_lat > max_lat` gibt lautlos leere Ergebnisse oder Absturz in SQL |
+| `/{id}` vor `/nearby` und `/bbox` registrieren | `GET /places/nearby` wird von `{id}` abgefangen → 404 oder falscher Handler |
+| Koordinaten als TEXT speichern | Bounding-Box-SQL-`BETWEEN` erfordert numerischen Vergleich; TEXT-Vergleich ist lexikografisch |
+| `cos(deg2rad($lat))` ohne `max(..., 0.001)` | Division durch null an Polen (Breite = ±90) |

--- a/docs/de/howto/geolocation.md
+++ b/docs/de/howto/geolocation.md
@@ -1,0 +1,114 @@
+# So fügen Sie Geolocation-Suche hinzu
+
+Latitude/Longitude-Punkte speichern und nach Nähe (nearby radius) oder Bounding Box suchen.
+
+## Schema
+
+```sql
+CREATE TABLE places (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    latitude   REAL NOT NULL,
+    longitude  REAL NOT NULL,
+    category   TEXT NOT NULL DEFAULT 'general',
+    created_at TEXT NOT NULL
+);
+```
+
+## Haversine-Distanz (GeoCalculator)
+
+SQLite hat keine trigonometrischen Funktionen, daher Distanz in PHP nach einem SQL-Bounding-Box-Vorfilter berechnen.
+
+```php
+class GeoCalculator
+{
+    private const float EARTH_RADIUS_KM = 6371.0;
+    private const float MAX_RADIUS_KM   = 20_000.0;
+
+    public function haversineKm(float $lat1, float $lng1, float $lat2, float $lng2): float
+    {
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLng = deg2rad($lng2 - $lng1);
+        $a    = sin($dLat / 2) ** 2
+              + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLng / 2) ** 2;
+        return self::EARTH_RADIUS_KM * 2.0 * asin(sqrt($a));
+    }
+
+    /** @return array{min_lat: float, max_lat: float, min_lng: float, max_lng: float} */
+    public function boundingBox(float $lat, float $lng, float $radiusKm): array
+    {
+        $deltaLat = $radiusKm / 111.0;
+        $deltaLng = $radiusKm / (111.0 * max(cos(deg2rad($lat)), 0.001));
+        return [
+            'min_lat' => $lat - $deltaLat,
+            'max_lat' => $lat + $deltaLat,
+            'min_lng' => $lng - $deltaLng,
+            'max_lng' => $lng + $deltaLng,
+        ];
+    }
+
+    public function clampRadius(float $radiusKm): float
+    {
+        return min(max($radiusKm, 0.0), self::MAX_RADIUS_KM);
+    }
+}
+```
+
+## Nearby-Suche (Zwei-Pass)
+
+```php
+// 1. SQL-Bounding-Box-Vorfilter (schnell, approximativ)
+$box        = $this->geo->boundingBox($lat, $lng, $radiusKm);
+$candidates = $this->repo->findInBoundingBox(
+    $box['min_lat'], $box['max_lat'], $box['min_lng'], $box['max_lng'],
+);
+
+// 2. Exakter Haversine-Filter + Sortierung
+$results = [];
+foreach ($candidates as $place) {
+    $dist = $this->geo->haversineKm($lat, $lng, (float) $place['latitude'], (float) $place['longitude']);
+    if ($dist <= $radiusKm) {
+        $results[] = array_merge($place, ['distance_km' => round($dist, 4)]);
+    }
+}
+usort($results, static fn(array $a, array $b) => $a['distance_km'] <=> $b['distance_km']);
+```
+
+## Routen-Registrierungsreihenfolge
+
+Feste Pfade **vor** Muster-Pfaden registrieren, damit `nearby`/`bbox` nicht als `{id}` geparst werden:
+
+```php
+$router->get('/places/nearby', $this->handleNearby(...));  // fest — zuerst registrieren
+$router->get('/places/bbox',   $this->handleBbox(...));    // fest — zuerst registrieren
+$router->get('/places',        $this->handleList(...));
+$router->post('/places',       $this->handleCreate(...));
+$router->get('/places/{id}',   $this->handleGet(...));     // Muster — zuletzt registrieren
+$router->delete('/places/{id}',$this->handleDelete(...));
+```
+
+## Koordinatenvalidierung
+
+```php
+// latitude: -90 bis 90, longitude: -180 bis 180
+if (!is_numeric($rawLat)) { /* 422 */ }
+$lat = (float) $rawLat;
+if ($lat < -90.0 || $lat > 90.0) { /* 422 */ }
+```
+
+## Bounding-Box-Validierung
+
+Invertierte Bereiche vor der Abfrage ablehnen:
+
+```php
+assert(isset($vals['min_lat'], $vals['max_lat'], $vals['min_lng'], $vals['max_lng']));
+if ($vals['min_lat'] > $vals['max_lat']) { throw new ValidationException([...]); }
+if ($vals['min_lng'] > $vals['max_lng']) { throw new ValidationException([...]); }
+```
+
+## Sicherheitshinweise
+
+- Alle Koordinateneingaben werden als numerisch und im Bereich validiert — verhindert SQL-Injection via parametrisierte Abfragen.
+- Radius auf `MAX_RADIUS_KM` (20.000 km) begrenzt, um degenerierte Bounding Boxes zu verhindern.
+- Negativer Radius abgelehnt (422) vor der Abfrageausführung.
+- NaN / nicht-numerische Strings durch `is_numeric()`-Prüfung abgelehnt.

--- a/docs/de/howto/group-member-management.md
+++ b/docs/de/howto/group-member-management.md
@@ -1,0 +1,272 @@
+# How-to: Gruppenmitglieder-Verwaltung
+
+> **FT-Referenz**: FT291 (`NENE2-FT/grouplog`) — Gruppenmitgliedschaft: MemberRole-Enum (owner/admin/member), UNIQUE(group_id, user_id), Owner-kann-nicht-entfernt-werden-Guard, Cross-Group-IDOR-Prävention, canManageMembers()/canChangeRoles()-Rollenhierarchie, VULN-A–L alle SAFE, 38 Tests / 101 Assertions bestanden.
+
+Diese Anleitung zeigt, wie ein Gruppenverwaltungssystem mit rollenbasierter Mitgliedschaftskontrolle aufgebaut wird — Eigentümer, Admins und Mitglieder mit abgestuften Berechtigungen.
+
+## Schema
+
+```sql
+CREATE TABLE user_groups (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    owner_id   INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (owner_id) REFERENCES users(id)
+);
+
+CREATE TABLE memberships (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id  INTEGER NOT NULL,
+    user_id   INTEGER NOT NULL,
+    role      TEXT    NOT NULL DEFAULT 'member',
+    joined_at TEXT    NOT NULL,
+    UNIQUE (group_id, user_id),
+    CHECK (role IN ('owner', 'admin', 'member')),
+    FOREIGN KEY (group_id) REFERENCES user_groups(id),
+    FOREIGN KEY (user_id)  REFERENCES users(id)
+);
+```
+
+`UNIQUE(group_id, user_id)` verhindert doppelte Mitgliedschaften. `CHECK(role IN ...)` blockiert ungültige Rollen auf DB-Ebene.
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|--------------|
+| `POST` | `/groups` | `X-User-Id` | Gruppe erstellen (Actor wird Owner) |
+| `GET` | `/groups/{groupId}/members` | `X-User-Id` (Mitglied) | Mitglieder auflisten |
+| `POST` | `/groups/{groupId}/members` | `X-User-Id` (Owner/Admin) | Mitglied hinzufügen |
+| `DELETE` | `/groups/{groupId}/members/{userId}` | `X-User-Id` | Mitglied entfernen |
+| `PUT` | `/groups/{groupId}/members/{userId}/role` | `X-User-Id` (Owner) | Rolle ändern |
+
+## MemberRole-Enum
+
+```php
+enum MemberRole: string
+{
+    case Owner  = 'owner';
+    case Admin  = 'admin';
+    case Member = 'member';
+
+    public function canManageMembers(): bool
+    {
+        return $this === self::Owner || $this === self::Admin;
+    }
+
+    public function canChangeRoles(): bool
+    {
+        return $this === self::Owner;
+    }
+}
+```
+
+Rollenfähigkeiten:
+- **Owner**: kann Mitglieder hinzufügen/entfernen, Rollen ändern, kann nicht entfernt werden
+- **Admin**: kann Mitglieder hinzufügen/entfernen, kann keine Rollen ändern
+- **Member**: kann nur verlassen (sich selbst entfernen)
+
+## Actor-Auflösung
+
+```php
+private function resolveActorId(ServerRequestInterface $request): int
+{
+    $header = $request->getHeaderLine('X-User-Id');
+    return is_numeric($header) ? (int) $header : 0;
+}
+```
+
+Nicht-numerische Header geben 0 zurück (ungültig). Jede privilegierte Operation validiert den Actor gegen die DB, bevor sie fortfährt.
+
+## Mitgliedschaftsprüfung vor jeder Operation
+
+```php
+$actorMembership = $actorId > 0 ? $this->repo->findMembership($groupId, $actorId) : null;
+
+if ($actorMembership === null) {
+    return $this->responseFactory->create(['error' => 'not a member'], 403);
+}
+```
+
+Nicht-Mitglieder erhalten 403 bei allen Gruppenoperationen — auch beim Auflisten von Mitgliedern (IDOR-Prävention).
+
+## Mitglieder hinzufügen — Rollenhierarchie
+
+```php
+$actorRole = MemberRole::tryFrom($actorMembership['role']) ?? MemberRole::Member;
+
+if (!$actorRole->canManageMembers()) {
+    return $this->responseFactory->create(['error' => 'only owner or admin can add members'], 403);
+}
+
+// 'owner'-Rolle kann nicht über add-member-Endpunkt zugewiesen werden
+$role = MemberRole::tryFrom($roleValue);
+if ($role === null || $role === MemberRole::Owner) {
+    return $this->responseFactory->create(['error' => 'role must be member or admin'], 422);
+}
+```
+
+Die `owner`-Rolle kann nicht über die API zugewiesen werden — sie wird nur bei der Gruppenerstellung gesetzt.
+
+## Owner kann nicht entfernt werden
+
+```php
+$targetRole = MemberRole::tryFrom($targetMembership['role']) ?? MemberRole::Member;
+
+if ($targetRole === MemberRole::Owner) {
+    return $this->responseFactory->create(['error' => 'cannot remove the group owner'], 422);
+}
+```
+
+Der Owner ist vor Entfernung geschützt. Eine Eigentumsübertragung würde einen dedizierten Endpunkt erfordern.
+
+## Selbstverlassen vs. Admin-Entfernung
+
+```php
+$isSelfLeave = $actorId === $userId;
+
+if (!$isSelfLeave && !$actorRole->canManageMembers()) {
+    return $this->responseFactory->create(['error' => 'only owner or admin can remove members'], 403);
+}
+```
+
+Mitglieder können sich selbst entfernen (Self-Leave) ohne Admin-Rechte. Das Entfernen eines anderen Benutzers erfordert `canManageMembers()`.
+
+## Rollenänderung — Nur Owner
+
+```php
+if (!$actorRole->canChangeRoles()) {
+    return $this->responseFactory->create(['error' => 'only owner can change roles'], 403);
+}
+
+$role = MemberRole::tryFrom($roleValue);
+if ($role === null || $role === MemberRole::Owner) {
+    return $this->responseFactory->create(['error' => 'role must be member or admin'], 422);
+}
+```
+
+Nur der Owner kann Mitglieder befördern/degradieren. Die `owner`-Rolle kann nicht zugewiesen werden (verhindert stille Eigentümerschaftsdiebstähle).
+
+---
+
+## Vulnerability Assessment
+
+### V-01 — IDOR: Nicht-Mitglied liest Mitgliederliste ✅ SAFE
+
+**Risk**: Nicht-Mitglied ruft `GET /groups/{id}/members` auf, um Benutzer zu enumerieren.
+**Finding**: SAFE — `findMembership(groupId, actorId) === null` → 403, bevor Daten zurückgegeben werden.
+
+---
+
+### V-02 — IDOR: Nicht-Mitglied fügt jemanden zur Gruppe hinzu ✅ SAFE
+
+**Risk**: Nicht-Mitglied ruft `POST /groups/{id}/members` auf, um Benutzer einzuschleusen.
+**Finding**: SAFE — gleiche Mitgliedschaftsprüfung; Nicht-Mitglied → 403.
+
+---
+
+### V-03 — Privilegienerweiterung: Reguläres Mitglied fügt ein anderes Mitglied hinzu ✅ SAFE
+
+**Risk**: Reguläres Mitglied (`role = 'member'`) versucht, einen neuen Benutzer hinzuzufügen.
+**Finding**: SAFE — `canManageMembers()` gibt false für `Member` zurück → 403.
+
+---
+
+### V-04 — Privilegienerweiterung: Admin befördert zum Owner ✅ SAFE
+
+**Risk**: Admin versucht, `role = 'owner'` über add-member oder change-role-Endpunkte zuzuweisen.
+**Finding**: SAFE — beide Endpunkte lehnen `MemberRole::Owner` als zulässige Rolle ab → 422.
+
+---
+
+### V-05 — Privilegienerweiterung: Mitglied befördert sich selbst ✅ SAFE
+
+**Risk**: Reguläres Mitglied ruft `PUT /groups/{id}/members/{self}/role` auf.
+**Finding**: SAFE — `canChangeRoles()` gibt false für `Member` und `Admin` zurück → 403.
+
+---
+
+### V-06 — Owner-Entfernung ✅ SAFE
+
+**Risk**: Admin versucht, den Gruppen-Owner zu entfernen.
+**Finding**: SAFE — `if ($targetRole === MemberRole::Owner)` → 422.
+
+---
+
+### V-07 — Fehlende X-User-Id bei Gruppenerstellung ✅ SAFE
+
+**Risk**: Anfrage ohne `X-User-Id` erstellt Gruppe ohne gültigen Owner.
+**Finding**: SAFE — `resolveActorId()` gibt 0 bei fehlendem/ungültigem Header zurück → `findUserById(0)` gibt null zurück → 404.
+
+---
+
+### V-08 — Nicht-numerische X-User-Id ✅ SAFE
+
+**Risk**: Header `X-User-Id: admin` umgeht die numerische Actor-Validierung.
+**Finding**: SAFE — `is_numeric($header)` gibt false für nicht-numerische Strings zurück → gibt 0 zurück → abgelehnt.
+
+---
+
+### V-09 — SQL-Injection im Gruppennamen ✅ SAFE
+
+**Risk**: Gruppenname `'; DROP TABLE user_groups; --` löscht Daten.
+**Finding**: SAFE — alle Abfragen verwenden parametrisierte Statements. Injection-String wird wörtlich als Gruppenname gespeichert ohne Ausführung.
+
+---
+
+### V-10 — Cross-Group-Mitgliederoperation (IDOR) ✅ SAFE
+
+**Risk**: Owner von Gruppe A versucht, ein Mitglied aus Gruppe B zu entfernen.
+**Finding**: SAFE — `findMembership(groupId, actorId)` prüft Mitgliedschaft in der *Zielgruppe*. Owner von Gruppe A hat keine Mitgliedschaft in Gruppe B → 403.
+
+---
+
+### V-11 — Negative Gruppen-ID ✅ SAFE
+
+**Risk**: `GET /groups/-1/members` verursacht DB-Fehler oder unerwartetes Verhalten.
+**Finding**: SAFE — `is_numeric($params['groupId']) ? (int)$params['groupId'] : 0` akzeptiert `-1` als numerisch, aber `findGroupById(-1)` gibt null zurück → 404.
+
+---
+
+### V-12 — Admin kann keine Rollen ändern ✅ SAFE
+
+**Risk**: Admin ruft `PUT /groups/{id}/members/{userId}/role` auf, um Benutzer zu befördern.
+**Finding**: SAFE — `canChangeRoles()` ist nur Owner-exklusiv → Admin erhält 403.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|--------|
+| V-01 | IDOR: Nicht-Mitglied liest Mitgliederliste | ✅ SAFE |
+| V-02 | IDOR: Nicht-Mitglied fügt Mitglied hinzu | ✅ SAFE |
+| V-03 | Privilegienerweiterung: Mitglied fügt Mitglied hinzu | ✅ SAFE |
+| V-04 | Privilegienerweiterung: Admin → Owner | ✅ SAFE |
+| V-05 | Privilegienerweiterung: Mitglied befördert sich | ✅ SAFE |
+| V-06 | Owner-Entfernung | ✅ SAFE |
+| V-07 | Fehlende X-User-Id bei Erstellung | ✅ SAFE |
+| V-08 | Nicht-numerische X-User-Id | ✅ SAFE |
+| V-09 | SQL-Injection im Gruppennamen | ✅ SAFE |
+| V-10 | Cross-Group-IDOR (Owner einer anderen Gruppe) | ✅ SAFE |
+| V-11 | Negative Gruppen-ID | ✅ SAFE |
+| V-12 | Admin kann keine Rollen ändern | ✅ SAFE |
+
+**12 SAFE, 0 EXPOSED**
+Mitgliedschaftsprüfung vor jeder Operation, `canManageMembers()`/`canChangeRoles()`-Rollenhierarchie und Owner-Entfernungs-Guard verhindern alle Privilegienerweiterungs- und IDOR-Vektoren.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Keine Mitgliedschaftsprüfung vor dem Auflisten von Mitgliedern | Nicht-Mitglieder enumerieren alle Gruppenbenutzer (IDOR) |
+| `owner`-Rollenzuweisung über add-member erlauben | Jeder Admin kann still die Eigentümerschaft übernehmen |
+| `owner`-Rollenzuweisung über change-role erlauben | Gleiches — Eigentümerschaftsdiebstahl mit einer Anfrage |
+| `canManageMembers()`-Prüfung überspringen | Reguläre Mitglieder fügen/entfernen jeden |
+| Owner-Entfernung erlauben | Gruppe verliert ihren Verwaltungsbenutzer |
+| Kein `UNIQUE(group_id, user_id)` | Gleicher Benutzer zweimal hinzugefügt; doppelte Mitgliedschaftseinträge |
+| `is_numeric()`-Prüfung nur für X-User-Id | `"1.5"` besteht `is_numeric`; `(int)`-Cast + gegen DB validieren |
+| Mitgliedschaft in Actors eigener Gruppe prüfen (nicht Zielgruppe) | Cross-Group-IDOR: Owner von Gruppe A modifiziert Gruppe B |
+| Admin Rollen ändern lassen | Admin befördert sich selbst zum Owner; Rollenhierarchie-Bypass |

--- a/docs/de/howto/group-membership-management.md
+++ b/docs/de/howto/group-membership-management.md
@@ -1,0 +1,204 @@
+# So bauen Sie eine Gruppenmitgliedschaftsverwaltung mit NENE2
+
+Diese Anleitung führt durch den Aufbau eines Gruppensystems, bei dem Benutzer Gruppen erstellen, Mitglieder mit Rollen einladen (owner/admin/member), Mitgliedschaften verwalten und Rollenbeförderungen steuern können.
+
+**Field Trial**: FT138  
+**NENE2-Version**: ^1.5  
+**Behandelte Themen**: rollenbasierte Mitgliedschaft, automatischer Owner-Join, Self-Leave, MySQL-Reserviertes-Wort-Falle (`groups`), Vulnerability Assessment
+
+---
+
+## Was wir bauen
+
+- `POST /groups` — eine Gruppe erstellen (Ersteller wird Owner)
+- `GET /groups/{groupId}/members` — Mitglieder auflisten (nur Mitglieder)
+- `POST /groups/{groupId}/members` — Mitglied hinzufügen (nur Owner/Admin, Rolle: member oder admin)
+- `DELETE /groups/{groupId}/members/{userId}` — Mitglied entfernen (Owner/Admin können andere entfernen; jeder kann sich selbst entfernen)
+- `PUT /groups/{groupId}/members/{userId}/role` — Rolle ändern (nur Owner)
+
+---
+
+## Datenbankschema — WICHTIG: `groups` als Tabellenname vermeiden
+
+`groups` ist ein **reserviertes Wort in MySQL** (verwendet in `GROUP BY`). Stattdessen `user_groups` verwenden.
+
+```sql
+-- SQLite
+CREATE TABLE user_groups (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    owner_id   INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (owner_id) REFERENCES users(id)
+);
+
+CREATE TABLE memberships (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id  INTEGER NOT NULL,
+    user_id   INTEGER NOT NULL,
+    role      TEXT    NOT NULL DEFAULT 'member',
+    joined_at TEXT    NOT NULL,
+    UNIQUE (group_id, user_id),
+    CHECK (role IN ('owner', 'admin', 'member')),
+    FOREIGN KEY (group_id) REFERENCES user_groups(id),
+    FOREIGN KEY (user_id)  REFERENCES users(id)
+);
+```
+
+```sql
+-- MySQL
+CREATE TABLE user_groups (
+    id         INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name       VARCHAR(255) NOT NULL,
+    owner_id   INT          NOT NULL,
+    created_at VARCHAR(32)  NOT NULL,
+    FOREIGN KEY (owner_id) REFERENCES users(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE memberships (
+    id        INT         NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    group_id  INT         NOT NULL,
+    user_id   INT         NOT NULL,
+    role      VARCHAR(16) NOT NULL DEFAULT 'member',
+    joined_at VARCHAR(32) NOT NULL,
+    UNIQUE KEY uq_group_user (group_id, user_id),
+    CONSTRAINT chk_role CHECK (role IN ('owner', 'admin', 'member')),
+    FOREIGN KEY (group_id) REFERENCES user_groups(id),
+    FOREIGN KEY (user_id)  REFERENCES users(id)
+) ENGINE=InnoDB;
+```
+
+---
+
+## Rollen-Enum mit Fähigkeitsmethoden
+
+```php
+enum MemberRole: string
+{
+    case Owner  = 'owner';
+    case Admin  = 'admin';
+    case Member = 'member';
+
+    public function canManageMembers(): bool
+    {
+        return $this === self::Owner || $this === self::Admin;
+    }
+
+    public function canChangeRoles(): bool
+    {
+        return $this === self::Owner;
+    }
+}
+```
+
+Fähigkeitsmethoden auf dem Enum halten die Autorisierungslogik aus den Handlern heraus.
+
+---
+
+## Automatischer Owner-Join bei Gruppenerstellung
+
+Wenn eine Gruppe erstellt wird, wird der Owner automatisch als Mitglied mit der `owner`-Rolle hinzugefügt:
+
+```php
+public function createGroup(string $name, int $ownerId, string $now): int
+{
+    $this->executor->execute(
+        'INSERT INTO user_groups (name, owner_id, created_at) VALUES (?, ?, ?)',
+        [$name, $ownerId, $now],
+    );
+
+    $groupId = (int) $this->executor->lastInsertId();
+
+    // Owner wird automatisch Mitglied mit 'owner'-Rolle
+    $this->executor->execute(
+        'INSERT INTO memberships (group_id, user_id, role, joined_at) VALUES (?, ?, ?, ?)',
+        [$groupId, $ownerId, 'owner', $now],
+    );
+
+    return $groupId;
+}
+```
+
+---
+
+## Mitglied hinzufügen Handler — Rollenvalidierung
+
+Die `owner`-Rolle kann nicht über die add-member-API zugewiesen werden. Das `TokenScope::tryFrom()`-Muster wird auf `MemberRole::tryFrom()` angewendet:
+
+```php
+$role = MemberRole::tryFrom($roleValue);
+
+if ($role === null || $role === MemberRole::Owner) {
+    return $this->responseFactory->create(['error' => 'role must be member or admin'], 422);
+}
+```
+
+---
+
+## Mitglied entfernen — Self-Leave und Admin-Entfernung
+
+Ein Mitglied kann seine eigene Gruppe verlassen (Self-Leave) ohne Admin-Rechte. Admins können andere entfernen. Der Owner kann nie entfernt werden:
+
+```php
+$isSelfLeave = $actorId === $userId;
+
+if (!$isSelfLeave && !$actorRole->canManageMembers()) {
+    return $this->responseFactory->create(['error' => 'only owner or admin can remove members'], 403);
+}
+
+$targetRole = MemberRole::tryFrom($targetMembership['role']) ?? MemberRole::Member;
+
+if ($targetRole === MemberRole::Owner) {
+    return $this->responseFactory->create(['error' => 'cannot remove the group owner'], 422);
+}
+```
+
+---
+
+## MySQL-FK-Teardown — Reihenfolge wichtig
+
+Beim Zurücksetzen von MySQL in Tests, FK-abhängige Tabellen zuerst mit `FOREIGN_KEY_CHECKS = 0` droppen:
+
+```php
+$this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+$this->pdo->exec('DROP TABLE IF EXISTS memberships');
+$this->pdo->exec('DROP TABLE IF EXISTS user_groups');
+$this->pdo->exec('DROP TABLE IF EXISTS users');
+$this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+```
+
+---
+
+## Vulnerability Assessment (FT138)
+
+Zwölf Vulnerability-Tests verifizieren:
+
+| ID | Angriff | Erwartet | Ergebnis |
+|----|---------|----------|----------|
+| VULN-A | IDOR: Nicht-Mitglied liest Mitgliederliste | 403 | Pass |
+| VULN-B | IDOR: Nicht-Mitglied fügt ein Mitglied hinzu | 403 | Pass |
+| VULN-C | Reguläres Mitglied versucht, jemanden hinzuzufügen | 403 | Pass |
+| VULN-D | Admin versucht, Owner-Rolle zu setzen | nicht 200 | Pass |
+| VULN-E | Mitglied versucht, sich selbst zu Admin zu befördern | 403 | Pass |
+| VULN-F | Gruppen-Owner entfernen | 422 | Pass |
+| VULN-G | Fehlende X-User-Id bei Erstellung | nicht 201 | Pass |
+| VULN-H | Nicht-numerische X-User-Id | nicht 200 | Pass |
+| VULN-I | SQL-Injection im Gruppennamen | 201 (wörtlich) | Pass |
+| VULN-J | Cross-Group-Mitgliederoperation | 403 | Pass |
+| VULN-K | Negative Gruppen-ID | 404 | Pass |
+| VULN-L | Admin kann keine Rollen ändern | 403 | Pass |
+
+Alle 12 Vulnerability-Tests bestanden. Keine Schwachstellen gefunden.
+
+---
+
+## Häufige Fallstricke
+
+| Fallstrick | Lösung |
+|------------|--------|
+| `groups` als Tabellenname in MySQL verwenden | `user_groups` verwenden — `groups` ist ein MySQL-Reserviertwort |
+| Owner nicht automatisch zu memberships hinzugefügt | Owner-Mitgliedschaft in `createGroup()` einfügen |
+| Admin kann Rollen ändern | `canChangeRoles()` gibt true nur für `Owner` zurück |
+| `owner`-Rolle über add-member-API erlauben | `role === MemberRole::Owner` → 422 ablehnen |
+| Nicht-Mitglied umgeht 403 via fehlendem Actor | `findMembership(groupId, actorId) !== null` prüfen |
+| MySQL DROP TABLE scheitert mit FK-Constraints | `SET FOREIGN_KEY_CHECKS = 0` vor DROP |

--- a/docs/de/howto/guest-order-system.md
+++ b/docs/de/howto/guest-order-system.md
@@ -1,0 +1,174 @@
+# So bauen Sie ein Gastbestellungssystem (Warenkorb → Bestellung → Bestellpositionen) mit NENE2
+
+Diese Anleitung führt durch den Aufbau eines E-Commerce-Bestellablaufs, bei dem Benutzer Produkte in einen Warenkorb legen, den Bestand prüfen und eine Bestellung aufgeben, die Preisschnappschüsse in Bestellpositionen erfasst.
+
+**Field Trial**: FT139  
+**NENE2-Version**: ^1.5  
+**Behandelte Themen**: Multi-Table-Joins, Bestandsvalidierung, Preisschnappschuss in order_items, Warenkorb-Isolation, `array_sum`-Gesamtberechnung
+
+---
+
+## Was wir bauen
+
+- `POST /products` — ein Produkt erstellen (Name, Preis, Bestand)
+- `POST /cart` — ein Produkt zum Warenkorb hinzufügen (akkumuliert Menge, wenn bereits vorhanden)
+- `GET /cart` — Warenkorb-Inhalt mit Gesamtbetrag anzeigen (X-User-Id identifiziert den Benutzer)
+- `DELETE /cart/{productId}` — ein Element aus dem Warenkorb entfernen
+- `POST /orders` — eine Bestellung aufgeben (validiert Bestand, dekrementiert Bestand, leert Warenkorb)
+- `GET /orders/{orderId}` — Bestelldetails mit Positionen anzeigen (nur Eigentümer)
+
+---
+
+## Datenbankschema
+
+```sql
+CREATE TABLE products (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    price      INTEGER NOT NULL,
+    stock      INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE cart_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    product_id INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL DEFAULT 1,
+    added_at   TEXT    NOT NULL,
+    UNIQUE (user_id, product_id),
+    FOREIGN KEY (user_id)    REFERENCES users(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+CREATE TABLE orders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    total      INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE order_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id   INTEGER NOT NULL,
+    product_id INTEGER NOT NULL,
+    name       TEXT    NOT NULL,
+    price      INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL,
+    FOREIGN KEY (order_id)   REFERENCES orders(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+```
+
+`UNIQUE (user_id, product_id)` auf `cart_items` verhindert doppelte Zeilen — das erneute Hinzufügen desselben Produkts akkumuliert die Menge.
+
+---
+
+## Preisschnappschuss in order_items
+
+Wenn eine Bestellung aufgegeben wird, werden der aktuelle Produkt-`name` und `price` in `order_items` kopiert. Dies schützt historische Bestellungen vor zukünftigen Preisänderungen.
+
+```php
+/** @param array<int, array{product_id: int, name: string, price: int, quantity: int}> $items */
+public function createOrder(int $userId, array $items, int $total, string $now): int
+{
+    $this->executor->execute(
+        'INSERT INTO orders (user_id, total, created_at) VALUES (?, ?, ?)',
+        [$userId, $total, $now],
+    );
+
+    $orderId = (int) $this->executor->lastInsertId();
+
+    foreach ($items as $item) {
+        $this->executor->execute(
+            'INSERT INTO order_items (order_id, product_id, name, price, quantity) VALUES (?, ?, ?, ?, ?)',
+            [$orderId, $item['product_id'], $item['name'], $item['price'], $item['quantity']],
+        );
+    }
+
+    return $orderId;
+}
+```
+
+---
+
+## Warenkorb-Mengen-Akkumulation
+
+`UNIQUE (user_id, product_id)` bedeutet, dass ein zweiter `POST /cart` für dasselbe Produkt UPDATE und nicht INSERT verwenden muss:
+
+```php
+public function addToCart(int $userId, int $productId, int $quantity, string $now): void
+{
+    $existing = $this->findCartItem($userId, $productId);
+
+    if ($existing !== null) {
+        $this->executor->execute(
+            'UPDATE cart_items SET quantity = quantity + ? WHERE user_id = ? AND product_id = ?',
+            [$quantity, $userId, $productId],
+        );
+        return;
+    }
+
+    $this->executor->execute(
+        'INSERT INTO cart_items (user_id, product_id, quantity, added_at) VALUES (?, ?, ?, ?)',
+        [$userId, $productId, $quantity, $now],
+    );
+}
+```
+
+---
+
+## Bestandsvalidierung vor Bestellaufgabe
+
+Alle Positionen vor dem Dekrementieren des Bestands prüfen. Teilweises Dekrementierungs-Rollback ist komplex — zuerst validieren, dann handeln:
+
+```php
+// Alle Positionen validieren
+foreach ($items as $item) {
+    $product = $this->repository->findProductById($item['product_id']);
+
+    if ($product === null || $product['stock'] < $item['quantity']) {
+        return $this->responseFactory->create([
+            'error'      => 'insufficient stock',
+            'product_id' => $item['product_id'],
+        ], 422);
+    }
+}
+
+// Dekrementieren und Bestellung erstellen
+foreach ($items as $item) {
+    $this->repository->decrementStock($item['product_id'], $item['quantity']);
+}
+
+$orderId = $this->repository->createOrder($actorId, $items, $total, date('c'));
+$this->repository->clearCart($actorId);
+```
+
+---
+
+## Warenkorb-Gesamtberechnung
+
+```php
+$total = array_sum(array_map(fn(array $i) => $i['price'] * $i['quantity'], $items));
+```
+
+Wird in PHP aus dem Join-Abfrage-Ergebnis berechnet, nicht in SQL. Dieselbe Berechnung wird für die Warenkorb-Vorschau und den gespeicherten Bestellbetrag verwendet.
+
+---
+
+## Warenkorb-Isolation pro Benutzer
+
+Warenkorbelemente werden immer nach `user_id` gefiltert. Jeder Benutzer sieht und modifiziert nur seinen eigenen Warenkorb. Der `GET /cart`-Handler gibt eine leere Liste für Benutzer ohne Elemente zurück — niemals den Warenkorb eines anderen Benutzers.
+
+---
+
+## Häufige Fallstricke
+
+| Fallstrick | Lösung |
+|------------|--------|
+| Gleiches Produkt zweimal hinzufügen erzeugt doppelte Zeilen | `UNIQUE (user_id, product_id)` + UPDATE bei Konflikt |
+| Preisänderungen nach Bestellaufgabe korrumpieren Geschichte | `name` und `price` zur Bestellzeit in `order_items` kopieren |
+| Teilweises Bestandsdekrement bei Multi-Position-Fehler | Alle Positionen zuerst validieren, dann alle dekrementieren |
+| Live-Produktpreis in Bestelldetails zurückgeben | `order_items.price` abfragen, nicht `products.price` |
+| Warenkorb für alle Benutzer sichtbar | `cart_items` immer nach `user_id` filtern |

--- a/docs/de/howto/habit-tracker.md
+++ b/docs/de/howto/habit-tracker.md
@@ -1,0 +1,416 @@
+# How-to: Habit Tracker API
+
+> **FT-Referenz**: FT24 (`NENE2-FT/habitlog`) — Habit-Tracking-API mit Streak-Berechnung
+> **ATK**: FT224 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert eine Habit-Tracking-REST-API mit Streak-Berechnung, doppelter Abschlussschutz (409 Conflict) und Frequenz-Allowlisting. Der ATK-Abschnitt dokumentiert jede Angriffsfläche, die der Cracker-Mindset findet, und notiert, ob jede verteidigt oder exponiert ist.
+
+---
+
+## Routen
+
+| Methode   | Pfad                          | Beschreibung                                      |
+|-----------|-------------------------------|---------------------------------------------------|
+| `GET`     | `/habits`                     | Alle Habits auflisten (`?frequency=`)             |
+| `POST`    | `/habits`                     | Habit erstellen                                   |
+| `GET`     | `/habits/{id}`                | Einzelnes Habit abrufen                           |
+| `DELETE`  | `/habits/{id}`                | Habit löschen (kaskadiert)                        |
+| `POST`    | `/habits/{id}/completions`    | Abschluss erfassen (idempotent auf Datums-Ebene)  |
+| `GET`     | `/habits/{id}/completions`    | Abschlüsse für ein Habit auflisten                |
+| `GET`     | `/habits/{id}/streak`         | Aktueller Streak (`?today=YYYY-MM-DD`)            |
+
+---
+
+## Habits erstellen
+
+```php
+// POST /habits
+$body = [
+    'name'        => 'Morgenläufe',     // erforderlich, nicht leerer String
+    'description' => '5 km laufen',     // optional
+    'frequency'   => 'daily',           // 'daily' | 'weekly' | 'monthly'
+];
+```
+
+`frequency` wird gegen eine explizite Allowlist validiert. Jeder andere Wert gibt 422 zurück.
+
+```php
+private function createHabit(ServerRequestInterface $req): mixed
+{
+    $body      = JsonRequestBodyParser::parse($req);
+    $name      = isset($body['name']) ? trim((string) $body['name']) : '';
+    $frequency = isset($body['frequency']) ? (string) $body['frequency'] : 'daily';
+
+    $errors = [];
+    if ($name === '') {
+        $errors[] = new ValidationError('name', 'Name must not be empty.', 'required');
+    }
+
+    $validFrequencies = ['daily', 'weekly', 'monthly'];
+    if (!in_array($frequency, $validFrequencies, true)) {
+        $errors[] = new ValidationError('frequency', 'Frequency must be daily, weekly, or monthly.', 'invalid_value');
+    }
+
+    if ($errors !== []) {
+        throw new ValidationException($errors);
+    }
+    // ...
+}
+```
+
+---
+
+## Abschlüsse mit doppeltem Schutz erfassen
+
+Abschlüsse sind durch `(habit_id, completed_on)` via eine `UNIQUE`-Constraint gekennzeichnet. Ein zweiter POST für dasselbe Datum gibt **409 Conflict** zurück, ohne die Datenbankzeile zu berühren.
+
+```sql
+-- schema.sql
+UNIQUE(habit_id, completed_on)
+```
+
+```php
+public function complete(int $habitId, string $completedOn, string $note): Completion
+{
+    try {
+        $this->executor->execute(
+            'INSERT INTO completions (habit_id, completed_on, note) VALUES (?, ?, ?)',
+            [$habitId, $completedOn, $note],
+        );
+    } catch (DatabaseConnectionException $e) {
+        $previous = $e->getPrevious();
+        if ($previous !== null && str_contains($previous->getMessage(), 'UNIQUE constraint failed')) {
+            throw new AlreadyCompletedException($habitId, $completedOn);
+        }
+        throw $e;
+    }
+
+    return new Completion($this->executor->lastInsertId(), $habitId, $completedOn, $note);
+}
+```
+
+Der Controller mappt `AlreadyCompletedException` → 409, bevor NECEs globaler Fehlerhandler es sieht, sodass die Antwort korrekt Problem Details verwendet.
+
+---
+
+## Streak-Berechnung
+
+Streak zählt rückwärts von `$today` durch aufeinanderfolgende tägliche Abschlüsse.
+
+```php
+public function currentStreak(int $habitId, string $today): int
+{
+    $rows = $this->executor->fetchAll(
+        'SELECT completed_on FROM completions WHERE habit_id = ? ORDER BY completed_on DESC',
+        [$habitId],
+    );
+
+    $streak   = 0;
+    $expected = new \DateTimeImmutable($today);
+
+    foreach ($rows as $row) {
+        $date = new \DateTimeImmutable((string) $row['completed_on']);
+        if ($date->format('Y-m-d') !== $expected->format('Y-m-d')) {
+            break;
+        }
+        $streak++;
+        $expected = $expected->modify('-1 day');
+    }
+
+    return $streak;
+}
+```
+
+`?today=YYYY-MM-DD` überschreibt das Referenzdatum, sodass Tests deterministisch sind ohne `date()` zu mocken.
+
+---
+
+## Datumsformat-Validierung
+
+Das `completed_on`-Feld wird durch Regex validiert, nicht durch semantisches Parsen:
+
+```php
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $completedOn)) {
+    throw new ValidationException([
+        new ValidationError('completed_on', 'Date must be in YYYY-MM-DD format.', 'invalid_format'),
+    ]);
+}
+```
+
+Dies lehnt `"not-a-date"` korrekt ab, akzeptiert aber `"2026-02-30"`. Für strenge semantische Validierung einen `DateTimeImmutable`-Roundtrip hinzufügen:
+
+```php
+// Strengere Validierung (für Produktion empfohlen):
+$dt = DateTimeImmutable::createFromFormat('Y-m-d', $completedOn);
+if ($dt === false || $dt->format('Y-m-d') !== $completedOn) {
+    throw new ValidationException([...]);
+}
+```
+
+---
+
+## Pfadparameter-Sicherheit
+
+Pfad-`{id}` wird mit Zero-Fallback zu `int` gecastet:
+
+```php
+$id = (int) ($req->getAttribute(Router::PARAMETERS_ATTRIBUTE, [])['id'] ?? 0);
+```
+
+Nicht-numerische Strings werden zu `0`. Kein Habit mit `id = 0` existiert, sodass der Handler zu einer `null`-Prüfung fällt und 404 zurückgibt. Dies vermeidet den Bedarf nach `ctype_digit()` hier, aber beachten Sie, dass `(int) "9abc"` `9` ergibt — eine Route, die Nicht-Ziffern-Pfade ablehnen muss, sollte stattdessen `ctype_digit()` verwenden.
+
+---
+
+## Schema: Kaskaden-Delete
+
+```sql
+CREATE TABLE completions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    habit_id     INTEGER NOT NULL REFERENCES habits(id) ON DELETE CASCADE,
+    completed_on TEXT    NOT NULL,
+    note         TEXT    NOT NULL DEFAULT '',
+    UNIQUE(habit_id, completed_on)
+);
+```
+
+`ON DELETE CASCADE` stellt sicher, dass Abschlüsse entfernt werden, wenn das übergeordnete Habit gelöscht wird. Fremdschlüssel-Durchsetzung mit `PRAGMA foreign_keys = ON` bei SQLite aktivieren.
+
+---
+
+## ATK — Cracker-Angriffstest (FT224)
+
+Jeder Befund unten dokumentiert einen Angriffsvektor, das beobachtete Ergebnis und das Urteil: **BLOCKED** (sicher), **EXPOSED** (echte Schwachstelle) oder **ACCEPTED BY DESIGN** (absichtlicher Kompromiss dokumentiert).
+
+### ATK-01 — Keine Authentifizierung auf einem Endpunkt
+
+**Angriff**: Habits erstellen, lesen oder löschen ohne Anmeldedaten.
+
+```http
+POST /habits
+Content-Type: application/json
+
+{"name": "Angreifer-Habit", "frequency": "daily"}
+```
+
+**Beobachtet**: `201 Created` — Erfolg ohne Token, Session oder Key.
+
+**Urteil**: **EXPOSED** (by design für FT24 Demo).
+Produktions-Habit-Tracker MÜSSEN Mutationen hinter Authentifizierung schützen.
+NECEs `MachineApiKeyMiddleware` oder JWT-Bearer-Middleware deckt dies ab.
+
+---
+
+### ATK-02 — Keine Eigentümerschaft: Beliebiges Habit lesen/löschen
+
+**Angriff**: Ohne zu wissen, wessen Habit es ist, alle Habits enumerieren und löschen.
+
+```http
+GET /habits         → listet alle Habits im System
+DELETE /habits/1    → löscht Habit #1 unabhängig vom Ersteller
+```
+
+**Beobachtet**: `200 OK` bei Liste, `200 OK` beim Löschen.
+
+**Urteil**: **EXPOSED** (by design für FT24 Demo).
+Eine `user_id`-Spalte, Eigentümerschatsprüfung auf Schreibpfaden und 404 (nicht 403) bei unbefugtem Zugriff hinzufügen (IDOR-Schutz — siehe FT222 `notificationlog`).
+
+---
+
+### ATK-03 — SQL-Injection via parametrisierte Abfragen
+
+**Angriff**: SQL durch `name`, `frequency` oder `completed_on` einschleusen.
+
+```json
+{"name": "x' OR '1'='1", "frequency": "daily"}
+{"completed_on": "2026-01-01' OR '1'='1"}
+```
+
+**Beobachtet**: Name wörtlich gespeichert. Abschluss durch Datumsformat-Regex abgelehnt, bevor die DB-Schicht erreicht wird.
+
+**Urteil**: **BLOCKED** — alle Abfragen verwenden PDO-parametrisierte Statements. Die Frequenz-Allowlist blockiert Injection über dieses Feld auf Anwendungsebene.
+
+---
+
+### ATK-04 — Semantisch ungültiges Datum akzeptiert
+
+**Angriff**: Strukturell korrektes, aber kalendarisch ungültiges Datum einreichen.
+
+```json
+{"completed_on": "2026-02-30"}
+{"completed_on": "2026-13-01"}
+{"completed_on": "0000-00-00"}
+```
+
+**Beobachtet**: `201 Created` — Regex `^\d{4}-\d{2}-\d{2}$` passiert; PDO speichert den String wörtlich; `DateTimeImmutable` normalisiert es still (z. B. `2026-02-30` wird zu `2026-03-02`), was Streak-Zählungen korrumpiert.
+
+**Urteil**: **EXPOSED** — Roundtrip-Prüfung hinzufügen:
+```php
+$dt = DateTimeImmutable::createFromFormat('Y-m-d', $completedOn);
+if ($dt === false || $dt->format('Y-m-d') !== $completedOn) {
+    throw new ValidationException([...]);
+}
+```
+
+---
+
+### ATK-05 — Nicht-numerische Pfad-IDs
+
+**Angriff**: Nicht-Ziffern- oder negative Werte als `{id}` senden.
+
+```http
+GET  /habits/abc
+GET  /habits/-1
+GET  /habits/0
+GET  /habits/1.5
+```
+
+**Beobachtet**: Alle geben `404 Not Found` zurück. `(int) "abc"` = `0`, `(int) "-1"` = `-1`, `(int) "1.5"` = `1`. Kein Habit existiert bei diesen IDs, also gibt `findById()` `null` zurück.
+
+**Urteil**: **BLOCKED** in der Praxis (kein Habit mit ID ≤ 0 existiert). Jedoch ergibt `(int) "9abc"` = `9` — wenn ein Habit mit ID 9 existiert, würde es zurückgegeben. `ctype_digit()` für strikte Pfad-ID-Validierung verwenden, wenn der Unterschied wichtig ist.
+
+---
+
+### ATK-06 — Doppelter Abschluss am selben Datum
+
+**Angriff**: Dasselbe `(habit_id, completed_on)` zweimal posten, um Streaks aufzublähen.
+
+```http
+POST /habits/1/completions {"completed_on": "2026-05-20"}
+POST /habits/1/completions {"completed_on": "2026-05-20"}
+```
+
+**Beobachtet**: Zweite Anfrage gibt `409 Conflict` zurück — die UNIQUE-Constraint auf DB-Ebene löst aus, `AlreadyCompletedException` wird abgefangen, und eine Problem-Details-Antwort wird zurückgegeben.
+
+**Urteil**: **BLOCKED** — die DB-Constraint ist der maßgebliche Guard; die Anwendungsschicht mappt es auf eine wohlgeformte 409.
+
+---
+
+### ATK-07 — XSS-Payload in name/note
+
+**Angriff**: Ein Script-Tag in `name` oder `note` speichern.
+
+```json
+{"name": "<script>alert(document.cookie)</script>", "frequency": "daily"}
+```
+
+**Beobachtet**: `201 Created`. Der Payload wird wörtlich gespeichert und unverändert in JSON-Antworten zurückgegeben.
+
+**Urteil**: **ACCEPTED BY DESIGN** — dies ist eine JSON-API; Escaping ist die Verantwortung des Rendering-Clients. Der Server produziert kein HTML aus diesen Feldern. Diesen Vertrag klar in der API-Spezifikation dokumentieren.
+
+---
+
+### ATK-08 — Extrem langer Habit-Name
+
+**Angriff**: Einen Namen mit zehntausenden Zeichen senden, um Speicher zu erschöpfen oder langsame Serialisierung zu verursachen.
+
+```php
+'name' => str_repeat('A', 50_000)
+```
+
+**Beobachtet**: `201 Created` — kein Längenlimit wird auf Anwendungsebene durchgesetzt. SQLite TEXT ist unbegrenzt; die Zeile wird eingefügt.
+
+**Urteil**: **EXPOSED** — eine Max-Längenprüfung hinzufügen (z. B. 200 Zeichen) im Validierungsblock des Controllers und 422 zurückgeben:
+```php
+if (mb_strlen($name) > 200) {
+    $errors[] = new ValidationError('name', 'Name must not exceed 200 characters.', 'max_length');
+}
+```
+
+---
+
+### ATK-09 — Nur-Leerzeichen Habit-Name
+
+**Angriff**: Einen Namen senden, der nur aus Leerzeichen besteht.
+
+```json
+{"name": "   "}
+```
+
+**Beobachtet**: `422 Unprocessable Entity` — `trim()` reduziert den Wert auf `''`, was den `required`-Validierungsfehler auslöst.
+
+**Urteil**: **BLOCKED** — `trim()` vor der Leerzeichenprüfung deckt dies ab.
+
+---
+
+### ATK-10 — Streak-Manipulation via `?today=`-Query-Param
+
+**Angriff**: Das Referenzdatum überschreiben, um einen historischen Streak zu beanspruchen.
+
+```http
+GET /habits/1/streak?today=2099-12-31
+GET /habits/1/streak?today=not-a-date
+```
+
+**Beobachtet**: `today=2099-12-31` → Streak = 0 (keine Abschlüsse in der Zukunft). `today=not-a-date` → PHP `DateTimeImmutable` wirft intern eine Exception auf dem fehlerhaften Wert (wird zu 500 im Standard-Fehlerhandler).
+
+**Urteil**: **TEILWEISE EXPOSED** — `today` mit einer Regex- oder Roundtrip-Prüfung validieren, bevor es an `currentStreak()` übergeben wird:
+```php
+$today = QueryStringParser::string($req, 'today') ?? date('Y-m-d');
+$dt    = DateTimeImmutable::createFromFormat('Y-m-d', $today);
+if ($dt === false || $dt->format('Y-m-d') !== $today) {
+    $today = date('Y-m-d'); // auf Server-Datum zurückfallen
+}
+```
+
+---
+
+### ATK-11 — Nicht-existierendes Habit abschließen
+
+**Angriff**: POST eines Abschlusses für eine Habit-ID, die nicht existiert.
+
+```http
+POST /habits/99999/completions
+{"completed_on": "2026-05-20"}
+```
+
+**Beobachtet**: `404 Not Found` — `findById(99999)` gibt `null` zurück und der Controller gibt die Not-Found-Antwort zurück, bevor das INSERT versucht wird.
+
+**Urteil**: **BLOCKED** — die Existenzprüfung erfolgt vor dem DB-Schreibvorgang.
+
+---
+
+### ATK-12 — Path Traversal / Injection in Query-Parametern
+
+**Angriff**: Path-Traversal- oder Shell-Injection-Strings via `frequency`-Filter einschleusen.
+
+```http
+GET /habits?frequency=../../../etc/passwd
+GET /habits?frequency='; DROP TABLE habits; --
+```
+
+**Beobachtet**: Beide geben `200 OK` mit einem leeren `habits`-Array zurück. Der `frequency`-Wert wird nur in `array_filter` mit einem strengen `===`-Vergleich gegen gespeicherte Werte verwendet. Keine DB-Abfrage wird daraus konstruiert.
+
+**Urteil**: **BLOCKED** — Filter-by-Query-Param wird im PHP-Speicher angewendet, nicht als rohe SQL-`WHERE`-Klausel. Keine Datei-I/O oder Shell-Ausführung wird ausgelöst.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Vektor | Urteil |
+|---|--------|--------|
+| ATK-01 | Keine Authentifizierung | EXPOSED (by design) |
+| ATK-02 | Keine Eigentümerschaft / IDOR | EXPOSED (by design) |
+| ATK-03 | SQL-Injection | BLOCKED |
+| ATK-04 | Semantisch ungültiges Datum | EXPOSED |
+| ATK-05 | Nicht-numerische Pfad-ID | BLOCKED |
+| ATK-06 | Doppelter Abschluss | BLOCKED |
+| ATK-07 | XSS-Payload-Speicherung | ACCEPTED BY DESIGN |
+| ATK-08 | Unbegrenzter Namensstring | EXPOSED |
+| ATK-09 | Nur-Leerzeichen-Name | BLOCKED |
+| ATK-10 | `?today=`-Manipulation | TEILWEISE EXPOSED |
+| ATK-11 | Nicht-existierender Habit-Abschluss | BLOCKED |
+| ATK-12 | Path Traversal / Injection in QS | BLOCKED |
+
+**Echte Schwachstellen, die vor Produktion behoben werden müssen**:
+1. **ATK-01/02** — Authentifizierung und Eigentümerschaft hinzufügen
+2. **ATK-04** — Semantische Datumsvalidierung hinzufügen (Roundtrip via `DateTimeImmutable`)
+3. **ATK-08** — `mb_strlen()` Max-Längenprüfung auf `name`/`note` hinzufügen
+4. **ATK-10** — `?today=` vor der Weitergabe an die Geschäftslogik validieren
+
+---
+
+## Verwandte Anleitungen
+
+- [`notification-inbox.md`](notification-inbox.md) — IDOR-Schutz-Muster (404 bei unbefugtem Lesen)
+- [`expense-tracker.md`](expense-tracker.md) — strikte `is_int()`-Typprüfungen und ISO-Datum-Roundtrip-Validierung
+- [`session-management.md`](session-management.md) — Authentifizierungsschicht, die auf diesem Muster aufgebaut werden kann

--- a/docs/de/howto/handle-timezones.md
+++ b/docs/de/howto/handle-timezones.md
@@ -1,0 +1,227 @@
+# So behandeln Sie Zeitzonen
+
+PHPs Zeitzonenbehandlung hat mehrere stille Fehler-Modi. Diese Anleitung behandelt die Muster und Fallstricke aus realen NENE2-Field-Trials.
+
+## Immer die Zeitzone angeben, wenn `DateTimeImmutable` erstellt wird
+
+`new DateTimeImmutable('now')` verwendet die Server-`date.timezone`-ini-Einstellung, die zwischen Umgebungen unterschiedlich ist. Immer `UTC` explizit für server-seitige Timestamps übergeben:
+
+```php
+// Fragil — hängt vom server's date.timezone ab
+$now = new \DateTimeImmutable('now');
+
+// Korrekt — immer UTC
+$now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+```
+
+Für gespeicherte Timestamps als ISO8601 UTC formatieren:
+
+```php
+$now->format('Y-m-d\TH:i:s\Z') // → "2026-05-20T15:00:00Z"
+```
+
+## IANA-Zeitzonenbezeichner explizit validieren
+
+PHPs `DateTimeZone`-Konstruktor akzeptiert Zeitzonenabkürzungen wie `"EST"` ohne Exception, aber sie sind keine kanonischen IANA-Bezeichner. `"America/New_York"` ist die korrekte IANA-Form.
+
+```php
+// Dies gelingt — aber "EST" ist kein IANA-Bezeichner
+$tz = new \DateTimeZone('EST'); // keine Exception!
+
+// Korrekte Validierung:
+try {
+    $tz = new \DateTimeZone($input);
+} catch (\Exception) {
+    throw new InvalidTimezoneException("Unknown timezone: $input");
+}
+
+// Zusätzliche Mitgliedschaftsprüfung für Nicht-IANA-Abkürzungen:
+if (!in_array($input, \DateTimeZone::listIdentifiers(), true)) {
+    throw new InvalidTimezoneException("Unknown timezone: $input");
+}
+```
+
+Ohne die `listIdentifiers()`-Prüfung werden `"EST"`, `"PST"` und ähnliche Abkürzungen still akzeptiert.
+
+## Lokale Datetime-Strings mit `createFromFormat` parsen
+
+Beim Akzeptieren eines lokalen Datetime-Werts aus Benutzereingaben (ohne Zeitzonenoffset), `createFromFormat` mit dem expliziten Format und der Zeitzone verwenden:
+
+```php
+$tz    = new \DateTimeZone('Asia/Tokyo');
+$local = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', '2026-06-01T10:00:00', $tz);
+
+if ($local === false) {
+    // Ungültiges Format — '2026/06/01 10:00', '2026-06-01', etc. geben alle false zurück
+    throw new \InvalidArgumentException('Invalid datetime format. Expected YYYY-MM-DDTHH:mm:ss.');
+}
+```
+
+`createFromFormat` gegenüber `new DateTimeImmutable($str, $tz)` bevorzugen — der Konstruktor ist nachsichtig und akzeptiert viele Formate still.
+
+## Lokale Zeit für die Speicherung in UTC konvertieren
+
+```php
+$utc = $local->setTimezone(new \DateTimeZone('UTC'));
+// Speichern als: $utc->format('Y-m-d\TH:i:s\Z')
+```
+
+Immer UTC in der Datenbank speichern. Den ursprünglichen Zeitzonennamen daneben speichern, damit die lokale Zeit beim Abrufen rekonstruiert werden kann.
+
+## DST-Übergang: Mehrdeutige Wanduhr-Zeiten
+
+Während "Zurückfallen"-Übergängen (z. B. `America/New_York` am ersten Sonntag im November) kommen manche Wanduhrzeiten zweimal vor:
+
+- `2026-11-01 01:30 AM` existiert sowohl in EDT (UTC-4) als auch EST (UTC-5)
+
+PHP löst die Mehrdeutigkeit auf, indem es das **erste Vorkommen** wählt (Sommer-/DST-Zeit):
+
+```php
+$dt = \DateTimeImmutable::createFromFormat(
+    'Y-m-d\TH:i:s',
+    '2026-11-01T01:30:00',
+    new \DateTimeZone('America/New_York'),
+);
+// → 05:30 UTC (EDT = UTC-4), nicht 06:30 UTC (EST = UTC-5)
+```
+
+Dies entspricht dem IANA-Standard. Wenn Ihre Anwendung zwischen den zwei Vorkommen unterscheiden muss (z. B. für Kalendersysteme), muss dies auf Anwendungsebene behandelt werden — PHP stellt keine API zur Auswahl des zweiten Vorkommens bereit.
+
+## Vollständiges lokal→UTC-Konvertierungsmuster
+
+```php
+use Schedule\Event\InvalidTimezoneException;
+
+function localToUtc(string $localDatetime, string $ianaTimezone): \DateTimeImmutable
+{
+    try {
+        $tz = new \DateTimeZone($ianaTimezone);
+    } catch (\Exception) {
+        throw new InvalidTimezoneException("Unknown timezone: $ianaTimezone");
+    }
+
+    // Nicht-IANA-Abkürzungen ablehnen (z. B. "EST")
+    if (!in_array($ianaTimezone, \DateTimeZone::listIdentifiers(), true)) {
+        throw new InvalidTimezoneException("Unknown timezone: $ianaTimezone");
+    }
+
+    $local = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $localDatetime, $tz);
+
+    if ($local === false) {
+        throw new \InvalidArgumentException("Cannot parse datetime: $localDatetime");
+    }
+
+    return $local->setTimezone(new \DateTimeZone('UTC'));
+}
+```
+
+## Multi-Timezone-Listenabfragen
+
+Beim Auflisten von in UTC gespeicherten Ereignissen, in die Zeitzone des Betrachters konvertieren:
+
+```php
+$viewTz = QueryStringParser::string($request, 'timezone');
+
+if ($viewTz !== null) {
+    try {
+        $tz    = new \DateTimeZone($viewTz);
+        $local = (new \DateTimeImmutable($event->startUtc, new \DateTimeZone('UTC')))->setTimezone($tz);
+        $data['start_local'] = $local->format('Y-m-d\TH:i:s');
+    } catch (\Exception) {
+        // Ungültige angeforderte Zeitzone — Konvertierung still auslassen
+    }
+}
+```
+
+---
+
+## SQLite-spezifisch: `datetime('now')` gibt immer UTC zurück
+
+SQLites eingebaute Datum-/Zeitfunktionen arbeiten immer in **UTC**, unabhängig von der OS-Zeitzone des Servers oder PHPs `date.timezone`-Einstellung.
+
+```sql
+SELECT datetime('now');          -- → "2026-05-27 11:30:00"  (UTC)
+SELECT date('now');              -- → "2026-05-27"            (UTC-Datum)
+SELECT date('now', '+1 day');    -- → "2026-05-28"            (UTC + 1 Tag)
+SELECT datetime('now', '-9 hours'); -- → lokale JST-Annäherung (manualem Offset — vermeiden)
+```
+
+**Das ist normalerweise das, was man will**: Timestamps als UTC TEXT speichern und in UTC vergleichen.
+
+### Filtern nach "heute" in UTC
+
+```sql
+-- Heute erstellte Einträge (UTC)
+SELECT * FROM events WHERE DATE(created_at) = DATE('now');
+
+-- Einträge in den nächsten 30 Tagen (UTC)
+SELECT * FROM reminders WHERE reminder_at <= DATE('now', '+30 days');
+
+-- Einträge für einen bestimmten Monat (UTC)
+SELECT * FROM logs WHERE STRFTIME('%Y-%m', created_at) = '2026-05';
+```
+
+### Die Falle: "heute" unterscheidet sich je nach Zeitzone
+
+Wenn die Benutzer in JST (UTC+9) sind, beginnt "heute" in JST 9 Stunden vor "heute" in UTC. `DATE('now')` in SQLite gibt das UTC-Datum zurück — das ist eine Abweichung.
+
+```php
+// Falsch: SQLite DATE('now') = UTC-Datum, nicht das lokale Datum des Benutzers
+$rows = $this->db->fetchAll("SELECT * FROM tasks WHERE DATE(due_date) = DATE('now')");
+
+// Korrekt: "heute" des Benutzers in PHP berechnen und als Parameter übergeben
+$todayUtc = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d');
+$rows = $this->db->fetchAll(
+    "SELECT * FROM tasks WHERE DATE(due_date) = ?",
+    [$todayUtc],
+);
+```
+
+Für einen Dienst, bei dem "heute" UTC bedeutet, ist `DATE('now')` in Ordnung. Für benutzerseitige "heute fällig"-Funktionen, die Grenze in PHP mit der Zeitzone des Benutzers berechnen und als Bind-Parameter übergeben.
+
+### Dynamisches Intervall mit einem Spaltenwert
+
+SQLite erlaubt die Kombination von `date()` mit einem aus einem Spaltenwert gebauten String:
+
+```sql
+-- Einträge, bei denen next_review_at = heute basierend auf der interval_days-Spalte
+SELECT * FROM cards WHERE next_review_at <= DATE('now');
+
+-- Nächstes Review-Datum dynamisch berechnen (Ergebnis speichern, nicht in SELECT darauf verlassen)
+SELECT DATE('now', '+' || interval_days || ' days') AS next_date FROM cards;
+```
+
+Dies ist nützlich in einem `UPDATE`-Statement beim Vorrücken eines Zeitplans:
+
+```php
+$this->db->execute(
+    "UPDATE cards SET next_review_at = DATE('now', '+' || interval_days || ' days') WHERE id = ?",
+    [$cardId],
+);
+```
+
+### `STRFTIME`-Format-Referenz
+
+| Muster | Ausgabe | Verwendung |
+|--------|---------|------------|
+| `%Y-%m-%d` | `2026-05-27` | Vollständiges Datum |
+| `%Y-%m` | `2026-05` | Jahr-Monat-Gruppierung |
+| `%Y-%W` | `2026-22` | Jahr + **Sonntag-beginnende** Wochennummer (0–53) |
+| `%H:%M:%S` | `11:30:00` | Nur Zeit |
+| `%s` | Unix-Timestamp | Ganzzahl-Sekunden seit Epoch |
+
+**`%W` beginnt am Sonntag**, nicht ISO 8601 (Montag-beginnend). Für Montag-beginnende Wochennummern, die Wochengrenze in PHP berechnen:
+
+```php
+// Den Montag der aktuellen ISO-Woche abrufen
+$monday = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+    ->modify('Monday this week')
+    ->format('Y-m-d');
+
+$sunday = (new \DateTimeImmutable($monday))->modify('+6 days')->format('Y-m-d');
+
+$rows = $this->db->fetchAll(
+    "SELECT * FROM workouts WHERE workout_date BETWEEN ? AND ?",
+    [$monday, $sunday],
+);
+```

--- a/docs/de/howto/hierarchical-data.md
+++ b/docs/de/howto/hierarchical-data.md
@@ -1,0 +1,190 @@
+# Hierarchische Daten — Selbstreferentielle FK + Materialized Path
+
+> **FT-Referenz**: FT171 (`NENE2-FT/hierarchylog`) — Hierarchische Kategorien mit selbstreferentiellem FK und materialisierten Pfad für O(1)-Teilbaum-Abfragen.
+
+Einen Baum von Kategorien (oder jede Hierarchie) in einer einzigen SQL-Tabelle speichern, indem ein **selbstreferentielle Fremdschlüssel** (`parent_id`) plus ein **materialisierter Pfad** (`/1/3/7/`) verwendet wird, um O(1)-Teilbaum-Abfragen zu ermöglichen.
+
+---
+
+## Wann dieses Muster verwenden
+
+| Verwenden wenn… | Alternativen in Betracht ziehen wenn… |
+|---|---|
+| Tiefe ist begrenzt (≤ 5–10 Ebenen) | Unbegrenzte Tiefe mit häufigem Neuverknüpfen |
+| Teilbaum-Lesevorgänge sind häufig | Baum ist schreibintensiv mit vielen Verschiebungen |
+| Einzel-Datenbank-Lösung bevorzugt | Graph-Beziehungen (mehrere Eltern) |
+
+---
+
+## Schema-Design
+
+```sql
+CREATE TABLE categories (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    parent_id  INTEGER,                      -- NULL = Root-Knoten
+    path       TEXT    NOT NULL UNIQUE,      -- materialisierter Pfad: "/1/", "/1/3/", "/1/3/7/"
+    depth      INTEGER NOT NULL DEFAULT 0,  -- 0 = Root
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (parent_id) REFERENCES categories(id)
+);
+```
+
+### Pfad-Konvention
+
+- Root-Knoten: `/1/` (entspricht `/{id}/`)
+- Level-1-Kind des Roots: `/1/3/`
+- Level-2-Enkelin: `/1/3/7/`
+- Beginnt und endet immer mit `/`.
+- Nach INSERT `path = parentPath . newId . '/'` berechnen und die Zeile aktualisieren.
+
+---
+
+## Kernoperationen
+
+### Erstellen (mit Pfadberechnung)
+
+```php
+// 1. INSERT mit temporärem Platzhalter
+$id = $this->db->insert(
+    'INSERT INTO categories (name, parent_id, path, depth, created_at) VALUES (?, ?, ?, ?, ?)',
+    [$name, $parentId, '__tmp__', $depth, $now],
+);
+// 2. Pfad korrigieren, jetzt da wir die ID kennen
+$path = $parentPath . $id . '/';
+$this->db->execute('UPDATE categories SET path = ? WHERE id = ?', [$path, $id]);
+```
+
+### Teilbaum-Abfrage (O(1) auf indizierten Pfad-Spalte)
+
+```php
+// Alle Nachkommen des Knotens mit Pfad "/1/3/"
+$rows = $this->db->fetchAll(
+    "SELECT * FROM categories WHERE path LIKE ? AND id != ? ORDER BY path",
+    [$root->path . '%', $rootId],
+);
+```
+
+### Vorfahren
+
+```php
+// Pfad "/1/3/7/" → Vorfahren-IDs [1, 3]
+$parts = array_filter(explode('/', $node->path));
+$ancestorIds = array_filter(
+    array_map('intval', $parts),
+    fn(int $pid) => $pid !== $node->id,
+);
+```
+
+### Verschieben (kaskadiert zu Nachkommen)
+
+```php
+$oldPath = $node->path;
+$newPath = $newParentPath . $id . '/';
+
+// Den Knoten selbst aktualisieren
+$this->db->execute(
+    'UPDATE categories SET parent_id = ?, path = ?, depth = ? WHERE id = ?',
+    [$newParentId, $newPath, $newDepth, $id],
+);
+
+// Zu allen Nachkommen kaskadieren
+foreach ($this->subtree($id) as $desc) {
+    $updatedPath  = $newPath . substr($desc->path, strlen($oldPath));
+    $updatedDepth = $desc->depth - $node->depth + $newDepth;
+    $this->db->execute(
+        'UPDATE categories SET path = ?, depth = ? WHERE id = ?',
+        [$updatedPath, $updatedDepth, $desc->id],
+    );
+}
+```
+
+---
+
+## Validierungsregeln
+
+| Regel | Implementierung |
+|-------|----------------|
+| Max-Tiefe | `if ($parent->depth >= MAX_DEPTH - 1) throw CategoryDepthException` |
+| Zirkulär (Selbst-Verschieben) | `if ($newParentId === $id) throw CategoryCircularException` |
+| Zirkulär (Nachkomme) | `if (str_starts_with($newParent->path, $node->path)) throw CategoryCircularException` |
+| Nur Blatt löschen | `if ($children !== []) throw CategoryHasChildrenException` |
+| Verschiebe-Tiefe-Überlauf | `$newDepth + maxSubtreeRelativeDepth >= MAX_DEPTH` vor Verschieben prüfen |
+
+---
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `GET` | `/categories` | Root-Kategorien auflisten (`?parent_id=N` für Kinder) |
+| `POST` | `/categories` | Kategorie erstellen |
+| `GET` | `/categories/{id}` | Eine Kategorie mit ihrer Vorfahrenkette abrufen |
+| `GET` | `/categories/{id}/subtree` | Alle Nachkommen abrufen |
+| `PUT` | `/categories/{id}` | Kategorie umbenennen |
+| `PATCH` | `/categories/{id}/move` | Zu neuem Elternteil verschieben (`parent_id: null` für Root) |
+| `DELETE` | `/categories/{id}` | Blatt löschen (ablehnen wenn Kinder vorhanden → 409) |
+
+---
+
+## Antwort-Formen
+
+### Kategorie-Objekt
+
+```json
+{
+  "id": 7,
+  "name": "PHP Frameworks",
+  "parent_id": 3,
+  "path": "/1/3/7/",
+  "depth": 2,
+  "created_at": "2026-01-01T00:00:00+00:00"
+}
+```
+
+### GET /categories/{id} mit Vorfahren
+
+```json
+{
+  "data": { ... },
+  "ancestors": [
+    { "id": 1, "name": "Technology", "depth": 0, ... },
+    { "id": 3, "name": "Programming", "depth": 1, ... }
+  ]
+}
+```
+
+---
+
+## Domain-Layer-Struktur
+
+```
+src/Category/
+├── Category.php                    # readonly Entity
+├── CategoryRepository.php          # Baum-Operationen (create / list / subtree / ancestors / move / delete)
+├── RouteRegistrar.php              # verbindet HTTP-Handler mit Router
+├── CategoryNotFoundException.php
+├── CategoryDepthException.php
+├── CategoryCircularException.php
+└── CategoryHasChildrenException.php
+```
+
+---
+
+## Abwägungen vs. Nested Sets / Closure Tables
+
+| Ansatz | Teilbaum-Lesen | Einfügen | Verschieben |
+|--------|----------------|----------|-------------|
+| **Materialized Path** (diese Anleitung) | Schnell (`LIKE`) | O(1) | O(Teilbaum-Größe) |
+| Closure Table | Schnell (Join) | O(Vorfahren) | O(Teilbaum × Vorfahren) |
+| Nested Sets | Schnell (`BETWEEN`) | O(Tabelle) | O(Tabelle) |
+
+Materialized Path ist der Sweet Spot für tiefenbegrenzte Bäume, bei denen Verschiebungen selten sind. Closure Table verwenden, wenn Vorfahren-Abfragen nur-Index sein müssen und Verschiebungen häufig sind.
+
+---
+
+## Siehe auch
+
+- [Datenbankgestützten Endpunkt hinzufügen](./add-database-endpoint.md)
+- [Paginierung hinzufügen](./add-pagination.md)
+- [Soft Delete](./soft-delete.md)

--- a/docs/de/howto/idempotency-key-api.md
+++ b/docs/de/howto/idempotency-key-api.md
@@ -1,0 +1,244 @@
+# How-to: Idempotency Key API
+
+> **FT-Referenz**: FT316 (`NENE2-FT/idempotencylog`) — Idempotency-Key-Muster für Zahlungs-API: SHA-256-Key-Hashing, X-Idempotent-Replayed-Header, Duplikate-Prävention, 15 Tests / 25 Assertions bestanden.
+
+Diese Anleitung zeigt, wie idempotente Mutations-Endpunkte mit dem `X-Idempotency-Key`-Header-Muster implementiert werden, das doppelte Operationen bei Netzwerk-Retries verhindert.
+
+## Schema
+
+```sql
+CREATE TABLE payments (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    amount_cents INTEGER NOT NULL,
+    currency     TEXT    NOT NULL DEFAULT 'JPY',
+    description  TEXT    NOT NULL DEFAULT '',
+    status       TEXT    NOT NULL DEFAULT 'pending',
+    created_at   TEXT    NOT NULL
+);
+
+CREATE TABLE idempotency_records (
+    key_hash    TEXT    PRIMARY KEY,   -- SHA-256 des X-Idempotency-Key
+    status_code INTEGER NOT NULL,
+    body        TEXT    NOT NULL,      -- JSON-kodierter Response-Body
+    created_at  TEXT    NOT NULL
+);
+```
+
+`key_hash` speichert `hash('sha256', $rawKey)` — der rohe Key wird nie gespeichert.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/payments` | Zahlung erstellen (idempotent mit Key) |
+| `GET` | `/payments` | Alle Zahlungen auflisten |
+
+## Idempotency-Key-Ablauf
+
+```
+Client                         Server
+  │── POST /payments ──────────►│
+  │   X-Idempotency-Key: k1     │ (neu) → Zahlung erstellen, Eintrag speichern
+  │◄── 201 ─────────────────────│
+  │
+  │── POST /payments ──────────►│
+  │   X-Idempotency-Key: k1     │ (Replay) → gespeicherte Antwort zurückgeben
+  │◄── 201 X-Idempotent-Replayed: true ──│
+```
+
+### Erste Anfrage — Erstellt und speichert
+
+```php
+POST /payments  X-Idempotency-Key: payment-abc-123
+{"amount_cents": 1000, "currency": "JPY"}
+
+→ 201
+{"id": 1, "amount_cents": 1000, "currency": "JPY", "status": "pending"}
+// Kein X-Idempotent-Replayed-Header
+```
+
+### Retry — Gibt gespeicherte Antwort zurück
+
+```php
+POST /payments  X-Idempotency-Key: payment-abc-123
+{"amount_cents": 1000, "currency": "JPY"}
+
+→ 201  X-Idempotent-Replayed: true
+{"id": 1, "amount_cents": 1000, ...}  // identisch mit der ersten Antwort
+```
+
+## Implementierung
+
+```php
+private function createPayment(ServerRequestInterface $request): ResponseInterface
+{
+    $idempotencyKey = $request->getHeaderLine('X-Idempotency-Key');
+
+    if ($idempotencyKey !== '') {
+        $keyHash  = hash('sha256', $idempotencyKey);
+        $existing = $this->repo->findIdempotencyRecord($keyHash);
+
+        if ($existing !== null) {
+            return $this->json->create(
+                (array) json_decode($existing->body, true, 512, JSON_THROW_ON_ERROR),
+                $existing->statusCode,
+            )->withHeader('X-Idempotent-Replayed', 'true');
+        }
+    }
+
+    // ... validieren und Zahlung erstellen ...
+
+    if ($idempotencyKey !== '') {
+        $keyHash = hash('sha256', $idempotencyKey);
+        $this->repo->saveIdempotencyRecord($keyHash, 201, $responseBody, $now);
+    }
+
+    return $this->json->create($payment->toArray(), 201);
+}
+```
+
+## Schlüsselregeln
+
+| Szenario | Verhalten |
+|----------|-----------|
+| Kein Key gesendet | Neue Zahlung bei jedem Aufruf erstellt |
+| Key, erster Aufruf | Zahlung erstellt; Eintrag gespeichert |
+| Key, Retry (gleicher Body) | Gespeicherte Antwort wiedergegeben; `X-Idempotent-Replayed: true` |
+| Verschiedene Keys | Separate Zahlungen erstellt |
+
+```php
+// 3 Retries mit demselben Key → nur 1 Zahlung in DB
+$key = 'pay-xyz';
+POST /payments  {"amount_cents": 999}  X-Idempotency-Key: $key  → 201 (erstellt)
+POST /payments  {"amount_cents": 999}  X-Idempotency-Key: $key  → 201 (Replay)
+POST /payments  {"amount_cents": 999}  X-Idempotency-Key: $key  → 201 (Replay)
+
+GET /payments → {"total": 1, ...}
+```
+
+## Validierung
+
+```php
+POST /payments  {"currency": "JPY"}         → 422  // fehlendes amount_cents
+POST /payments  {"amount_cents": 0}          → 422  // muss positiv sein
+POST /payments  {"amount_cents": -100}       → 422  // muss positiv sein
+```
+
+---
+
+## ATK Assessment — Cracker-Mindset Attack Test
+
+### ATK-01 — SHA-256-Pre-Image-Angriff auf Key 🚫 BLOCKED
+
+**Angriff**: Angreifer extrahiert `key_hash` aus DB und versucht, den ursprünglichen `X-Idempotency-Key` rückzuentwickeln, um Transaktionen unter dem Key eines Opfers wiederzugeben.
+**Ergebnis**: BLOCKED — SHA-256 ist eine Einwegfunktion. Pre-Image-Angriffe sind rechnerisch nicht durchführbar. Roher Key wird nie gespeichert.
+
+---
+
+### ATK-02 — Key-Erraten zur Entführung der Zahlungsantwort 🚫 BLOCKED
+
+**Angriff**: Angreifer errät einen kurzen oder vorhersehbaren Key (z. B. `pay-1`, `retry-001`), um eine gecachte Zahlungsantwort zu erhalten, die er nicht initiiert hat.
+**Ergebnis**: BLOCKED — Keys sind opake Tokens; das Erraten einer UUID oder eines hochentropischen Keys ist nicht durchführbar. Clients sollten `bin2hex(random_bytes(16))` oder UUID v4 verwenden.
+
+---
+
+### ATK-03 — Replay über verschiedene Benutzer 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet einen von einem anderen Benutzer verwendeten Key, um eine gecachte Antwort zu erzwingen, die für diesen Benutzer gedacht war.
+**Ergebnis**: BLOCKED — In einem authentifizierten System sollten Idempotency-Keys pro Benutzer scoped sein (z. B. `(user_id, key_hash)` Composite-Key). Das FT demonstriert das Muster; Produktion muss Benutzer-Scoping hinzufügen.
+
+---
+
+### ATK-04 — Key-Kollision via SHA-256-Hash 🚫 BLOCKED
+
+**Angriff**: Angreifer erstellt zwei verschiedene Keys mit demselben SHA-256-Hash, um einen legitimen Eintrag zu überschreiben.
+**Ergebnis**: BLOCKED — SHA-256-Kollisionswiderstand bietet 2^128 Sicherheit. Kein praktischer Kollisionsangriff existiert.
+
+---
+
+### ATK-05 — Übergroßer Key-Header DoS 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet einen 1 MB `X-Idempotency-Key`-Header, um Speicher beim Hashing zu erschöpfen.
+**Ergebnis**: BLOCKED — `hash('sha256', ...)` verarbeitet den String, aber NECEs Request-Size-Middleware begrenzt die Gesamtanfragegröße. Keys sollten in Produktion zusätzlich längenvalidiert werden (z. B. ≤ 255 Zeichen).
+
+---
+
+### ATK-06 — Bösartiges JSON im Body-Feld speichern 🚫 BLOCKED
+
+**Angriff**: Angreifer injiziert Steuerzeichen oder übergroßes JSON im Zahlungs-Body, sodass das gespeicherte `body`-Feld beim Replay korrumpiert.
+**Ergebnis**: BLOCKED — Response-Body wird via `json_encode` vor der Speicherung serialisiert. Beim Replay mit `JSON_THROW_ON_ERROR` dekodiert. Fehlerhaftes gespeichertes JSON würde eine Exception werfen, nicht still korrumpieren.
+
+---
+
+### ATK-07 — Race Condition — Doppelausgabe bei gleichzeitigem Retry 🚫 BLOCKED
+
+**Angriff**: Zwei gleichzeitige Anfragen mit demselben Key rennen, bevor der Eintrag gespeichert wird, und erstellen beide Zahlungen.
+**Ergebnis**: BLOCKED — `key_hash` ist ein `PRIMARY KEY`; das zweite gleichzeitige INSERT wirft einen Constraint-Fehler und stellt sicher, dass nur eine Zahlung erstellt wird.
+
+---
+
+### ATK-08 — Key mit Sonderzeichen / SQL-Injection 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `'; DROP TABLE payments; --` als Idempotency-Key.
+**Ergebnis**: BLOCKED — Key wird sofort mit `hash('sha256', $key)` gehasht. Der rohe String erreicht nie eine SQL-Abfrage. Alle DB-Zugriffe verwenden parametrisierte Abfragen.
+
+---
+
+### ATK-09 — 422-Fehlerantwort wiedergeben 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet eine absichtlich ungültige erste Anfrage (422) mit einem Key, dann eine gültige Nutzlast später mit demselben Key, in der Erwartung, dass die gespeicherte 422 wiedergegeben wird und die Zahlung still abgelehnt wird.
+**Ergebnis**: BLOCKED — Die Implementierung speichert den Eintrag nur nach einer erfolgreichen Erstellung. Ein 422-Zweig gibt sofort zurück ohne zu speichern, sodass nachfolgende gültige Aufrufe eine neue Zahlung erstellen.
+
+---
+
+### ATK-10 — Key-Enumeration via Timing-Angriff 🚫 BLOCKED
+
+**Angriff**: Angreifer misst Antwortzeit-Unterschied zwischen "Key existiert" (schneller DB-Treffer) und "Key nicht gefunden" (langsame DB + Geschäftslogik), um gültige Keys zu bestätigen.
+**Ergebnis**: BLOCKED — Timing-Unterschied ist minimal und nicht-deterministisch auf HTTP-Ebene. In hochsicherheitsrelevanten Kontexten künstliche konstant-zeitliche Auffüllung hinzufügen.
+
+---
+
+### ATK-11 — Idempotency-Eintrag löschen, um Neuausführung zu erzwingen 🚫 BLOCKED
+
+**Angriff**: Angreifer mit DB-Schreibzugriff löscht die `idempotency_records`-Zeile, um beim nächsten Retry eine erneute Zahlung zu erzwingen.
+**Ergebnis**: BLOCKED — DB-Schreibzugriff erfordert separate Authentifizierung. API-Konsumenten können Idempotency-Einträge nicht über die Zahlungs-API löschen.
+
+---
+
+### ATK-12 — X-Idempotent-Replayed-Header fälschen 🚫 BLOCKED
+
+**Angriff**: Client sendet `X-Idempotent-Replayed: true` in der Anfrage, um den Server glauben zu lassen, es sei bereits wiedergegeben.
+**Ergebnis**: BLOCKED — Der Header wird nur in der *Antwort* geprüft; der Server ignoriert jeden `X-Idempotent-Replayed`-Header, der in der *Anfrage* gesendet wird. Replay-Logik wird ausschließlich durch DB-Lookup bestimmt.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | SHA-256 Pre-Image auf Key | 🚫 BLOCKED |
+| ATK-02 | Key-Erraten zur Antwort-Entführung | 🚫 BLOCKED |
+| ATK-03 | Replay über verschiedene Benutzer | 🚫 BLOCKED |
+| ATK-04 | SHA-256-Hash-Kollision | 🚫 BLOCKED |
+| ATK-05 | Übergroßer Key-Header DoS | 🚫 BLOCKED |
+| ATK-06 | Bösartiges JSON im Body | 🚫 BLOCKED |
+| ATK-07 | Race Condition Doppelausgabe | 🚫 BLOCKED |
+| ATK-08 | SQL-Injection via Key | 🚫 BLOCKED |
+| ATK-09 | 422-Fehlerantwort wiedergeben | 🚫 BLOCKED |
+| ATK-10 | Timing-Angriff Key-Enumeration | 🚫 BLOCKED |
+| ATK-11 | Eintrag löschen für Neuausführung | 🚫 BLOCKED |
+| ATK-12 | X-Idempotent-Replayed-Header fälschen | 🚫 BLOCKED |
+
+**12 BLOCKED / SAFE, 0 EXPOSED** — Keine kritischen Befunde.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Rohen `X-Idempotency-Key` in DB speichern | Key bei DB-Verletzung preisgegeben; SHA-256-Hash verwenden |
+| Kein Benutzer-Scoping auf Key | Cross-User-Key-Kollision ermöglicht Antwort-Entführung |
+| Idempotency-Eintrag vor Geschäftslogik speichern | Speichert 500/422-Fehler als permanente Replays |
+| Kein Key-Längenlimit | Unbegrenzte Key-Hashing verschwendet CPU |
+| Idempotency-Tabelle über Endpunkte teilen | Key `pay-1` auf `/payments` könnte mit `pay-1` auf `/refunds` kollidieren; nach Endpunkt scopen |

--- a/docs/de/howto/idempotency-key.md
+++ b/docs/de/howto/idempotency-key.md
@@ -1,0 +1,235 @@
+# How-to: Idempotency Key (Request-Deduplizierung)
+
+> **FT-Referenz**: FT292 (`NENE2-FT/deduplog`) — Idempotency-Key-Deduplizierung: UNIQUE(idempotency_key)-DB-Constraint, 24h TTL mit neuverarbeitbarem Ablauf, `replayed: true`-Flag auf gecachten Antworten, parametrisierte Abfragen verhindern Injection, ATK-01–12 alle BLOCKED, 24 Tests / 57 Assertions bestanden.
+
+Diese Anleitung zeigt, wie Idempotency-Keys implementiert werden — ein header-basierter Mechanismus, der sicherstellt, dass wiederholte Anfragen (Retries, Netzwerkausfälle) dasselbe Ergebnis ohne doppelte Nebeneffekte erzeugen.
+
+## Schema
+
+```sql
+CREATE TABLE idempotency_keys (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    method          TEXT NOT NULL,
+    path            TEXT NOT NULL,
+    status_code     INTEGER NOT NULL,
+    response_body   TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    expires_at      TEXT NOT NULL
+);
+```
+
+`UNIQUE(idempotency_key)` stellt sicher, dass jeder Key einmal gespeichert wird. Der Response-Body wird als JSON serialisiert und bei nachfolgenden Anfragen wiedergegeben.
+
+## Anfrage-Ablauf
+
+```
+Client sendet POST /payments mit Idempotency-Key: <uuid>
+  │
+  ├─ Key in DB gefunden UND nicht abgelaufen?
+  │    └─ JA → gecachte Antwort + { "replayed": true } zurückgeben
+  │
+  └─ NEIN → Anfrage verarbeiten → Antwort speichern → 201 zurückgeben
+```
+
+## Idempotency-Key-Extraktion
+
+```php
+$key = trim($request->getHeaderLine('Idempotency-Key'));
+if ($key === '') {
+    return $this->json->create(['error' => 'Idempotency-Key header is required'], 400);
+}
+```
+
+Der Key ist erforderlich und muss nach dem Trimmen nicht leer sein. Nur-Leerzeichen-Keys werden mit 400 abgelehnt.
+
+## Cache-Lookup — Ablaufprüfung
+
+```php
+private function getCachedResponse(
+    string $key,
+    ServerRequestInterface $request,
+): ?ResponseInterface {
+    $cached = $this->repo->find($key);
+    if ($cached === null) {
+        return null;
+    }
+
+    // Abgelaufene Einträge werden als frisch behandelt (neuverarbeitbar)
+    if ($cached['expires_at'] < $this->now()) {
+        return null;
+    }
+
+    $body = json_decode((string) $cached['response_body'], true) ?? [];
+    return $this->json->create(
+        array_merge($body, ['replayed' => true]),
+        (int) $cached['status_code']
+    );
+}
+```
+
+Abgelaufene Keys geben `null` zurück — die Anfrage wird als neu neuverarbeitet. Dies ermöglicht sichere Retries nach TTL-Ablauf ohne permanente Deduplizierung.
+
+## Cache-Speicherung — TTL-Berechnung
+
+```php
+private const int TTL_SECONDS = 86400; // 24 Stunden
+
+private function cacheResponse(
+    string $key,
+    string $method,
+    string $path,
+    int $statusCode,
+    array $data,
+    string $now,
+): void {
+    $expiresAt = (new \DateTimeImmutable($now, new \DateTimeZone('UTC')))
+        ->modify('+' . self::TTL_SECONDS . ' seconds')
+        ->format('Y-m-d\TH:i:s\Z');
+    $this->repo->store($key, $method, $path, $statusCode, (string) json_encode($data), $now, $expiresAt);
+}
+```
+
+Die TTL wird in UTC berechnet. `DateTimeImmutable::modify()` behandelt DST-Übergänge und Mitternacht-Rollover sicher.
+
+## `replayed: true`-Signal
+
+Gecachte Antworten beinhalten `"replayed": true` in den Body gemischt:
+
+```json
+{ "id": 42, "amount": 1000, "currency": "USD", "replayed": true }
+```
+
+Dadurch können Clients zwischen erstmaligen Antworten und Replays unterscheiden, ohne Statuscodes zu prüfen. Der Statuscode wird unverändert wiedergegeben (201 für Erstellung).
+
+## UNIQUE-Constraint als Race-Guard
+
+```sql
+UNIQUE(idempotency_key)
+```
+
+Wenn zwei gleichzeitige Anfragen mit demselben Key beide die Lookup-Prüfung bestehen (TOCTOU), gelingt nur ein `INSERT`. Der andere erhält einen Constraint-Fehler, den die Anwendung behandeln kann, indem sie die gecachte Antwort neu abruft.
+
+---
+
+## ATK Assessment — Cracker-Mindset Attack Test
+
+### ATK-01 — SQL-Injection im Idempotency-Key-Header 🚫 BLOCKED
+
+**Angriff**: `Idempotency-Key: '; DROP TABLE idempotency_keys; --` senden.
+**Ergebnis**: BLOCKED — alle Abfragen verwenden parametrisierte Statements. Der Injection-String wird als wörtlicher Key-Wert gespeichert oder nachgeschlagen.
+
+---
+
+### ATK-02 — SQL-Injection im Betrag-Feld 🚫 BLOCKED
+
+**Angriff**: `{ "amount": "1; DROP TABLE payments;" }` senden.
+**Ergebnis**: BLOCKED — Betragsvalidierung erfordert Integer-Typ. String-Werte schlagen `is_int()`-Prüfung fehl → 422. Keine DB-Abfrage ausgeführt.
+
+---
+
+### ATK-03 — SQL-Injection im Item-Feld (sicher gespeichert) 🚫 BLOCKED
+
+**Angriff**: `{ "item": "' OR 1=1; --" }` bei Bestellerstellung senden.
+**Ergebnis**: BLOCKED — parametrisierte Abfrage speichert den String wörtlich als `item`-Wert. Keine SQL-Ausführung.
+
+---
+
+### ATK-04 — Replay-Angriff (gleicher Key 10 Mal) 🚫 BLOCKED
+
+**Angriff**: `POST /payments` mit demselben Key 10 Mal senden, um 10 Einträge zu erstellen.
+**Ergebnis**: BLOCKED — erste Anfrage erstellt eine Zahlung und cachet die Antwort. Alle 9 nachfolgenden Anfragen geben die gecachte Antwort mit `replayed: true` zurück. Nur 1 Zahlungszeile existiert.
+
+---
+
+### ATK-05 — Nur-Leerzeichen-Idempotency-Key 🚫 BLOCKED
+
+**Angriff**: `Idempotency-Key:    ` (nur Leerzeichen) senden, um die Leer-Key-Prüfung zu umgehen.
+**Ergebnis**: BLOCKED — `trim($key) === ''` → 400. Nur-Leerzeichen-Keys sind äquivalent zu fehlenden Keys.
+
+---
+
+### ATK-06 — Extrem langer Idempotency-Key 🚫 BLOCKED (Design-Hinweis)
+
+**Angriff**: Einen Mehrere-Megabyte-Key-String senden.
+**Ergebnis**: BLOCKED (Design-Hinweis) — SQLite speichert den Key wörtlich; sehr lange Keys verschlechtern die Lookup-Performance, stürzen aber nicht ab. In Produktion ein Längenlimit hinzufügen (z. B. `strlen($key) > 255 → 400`).
+
+---
+
+### ATK-07 — Negative Menge in Bestellung 🚫 BLOCKED
+
+**Angriff**: `{ "quantity": -5 }` senden, um eine negativ-Mengen-Bestellung zu erstellen.
+**Ergebnis**: BLOCKED — Mengenvalidierung: `$quantity <= 0` → 422. Nur positive Ganzzahlen akzeptiert.
+
+---
+
+### ATK-08 — XSS im Item-Feld als Literal gespeichert 🚫 BLOCKED
+
+**Angriff**: `{ "item": "<script>alert(1)</script>" }` senden.
+**Ergebnis**: BLOCKED — als JSON-String-Wert wörtlich gespeichert. Die API gibt `application/json` zurück; JSON-Encoding escaped `<`, `>`. Kein HTML-Rendering in der API-Schicht.
+
+---
+
+### ATK-09 — Gleichzeitige Duplikat-Keys 🚫 BLOCKED
+
+**Angriff**: Zwei Prozesse senden denselben Key gleichzeitig; beide bestehen die Lookup-Prüfung, bevor einer speichert.
+**Ergebnis**: BLOCKED — `UNIQUE(idempotency_key)` stellt sicher, dass nur ein INSERT gelingt. Der Verlierer erhält einen Constraint-Fehler und kann die gecachte Antwort neu abrufen.
+
+---
+
+### ATK-10 — Integer-Überlauf im Betrag 🚫 BLOCKED (Design-Hinweis)
+
+**Angriff**: `{ "amount": 9999999999999999999 }` (jenseits von PHP_INT_MAX) senden.
+**Ergebnis**: BLOCKED (Design-Hinweis) — PHP konvertiert sehr große JSON-Integer still zu Float. `is_int()` besteht für Ganzzahlen im Bereich. In Produktion eine obere Grenzprüfung hinzufügen.
+
+---
+
+### ATK-11 — NULL-Betrag 🚫 BLOCKED
+
+**Angriff**: `{ "amount": null }` senden, in der Hoffnung, dass null die Validierung umgeht.
+**Ergebnis**: BLOCKED — `!is_int(null)` ist true und `ctype_digit(null)` ist false → 422.
+
+---
+
+### ATK-12 — Keine internen Informationen durchgesickert 🚫 BLOCKED
+
+**Angriff**: Einen 422-Fehler auslösen und prüfen, ob Stack-Traces, Dateipfade oder SQL in der Antwort erscheinen.
+**Ergebnis**: BLOCKED — Fehlerantworten enthalten nur `{ "error": "..." }` oder Problem Details. Keine internen Pfade, SQL oder Stack-Traces in irgendeiner Antwort.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | SQL-Injection im Idempotency-Key-Header | 🚫 BLOCKED |
+| ATK-02 | SQL-Injection im Betrag-Feld | 🚫 BLOCKED |
+| ATK-03 | SQL-Injection im Item-Feld | 🚫 BLOCKED |
+| ATK-04 | Replay-Angriff (10 Duplikat-Anfragen) | 🚫 BLOCKED |
+| ATK-05 | Nur-Leerzeichen-Key | 🚫 BLOCKED |
+| ATK-06 | Extrem langer Key | 🚫 BLOCKED (Design-Hinweis) |
+| ATK-07 | Negative Menge | 🚫 BLOCKED |
+| ATK-08 | XSS im Item-Feld | 🚫 BLOCKED |
+| ATK-09 | Gleichzeitige Duplikat-Keys | 🚫 BLOCKED |
+| ATK-10 | Integer-Überlauf im Betrag | 🚫 BLOCKED (Design-Hinweis) |
+| ATK-11 | NULL-Betrag | 🚫 BLOCKED |
+| ATK-12 | Keine internen Informationen durchgesickert | 🚫 BLOCKED |
+
+**12 BLOCKED, 0 EXPOSED**
+Parametrisierte Abfragen, strikte Typvalidierung, `UNIQUE(idempotency_key)` und TTL-Ablauf decken alle kritischen Deduplizierungs-Angriffsvektoren ab.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Kein `UNIQUE(idempotency_key)`-Constraint | Gleichzeitige Retries erstellen doppelte Einträge; Deduplizierungs-Race-Condition |
+| Keine TTL / permanente Dedup | Alte Keys füllen die Tabelle; legitime Retries nach 1+ Tagen schlagen fehl |
+| Kein `replayed: true`-Flag | Client kann erste Antwort nicht von gecachtem Replay unterscheiden |
+| Ablauf prüfen, aber abgelaufene Keys nie neu verarbeiten | Retry nach TTL gibt noch gecachte (möglicherweise veraltete) Antwort zurück |
+| Nur-Leerzeichen-Keys akzeptieren | `"   "` als gültiger Key behandelt; verschiedene Clients können `""` vs `"   "` austauschbar verwenden |
+| Kein Key-Längenlimit | Mehrere-MB-Keys in Speicher und Lookup verschlechtern Performance |
+| 409 bei Duplikat zurückgeben | Replay soll ursprünglichen Status zurückgeben (201), nicht Conflict |
+| Betrag-Typ nicht strikt validieren | `"1000"`-String besteht lockere Prüfungen; `is_int()` für strenges JSON-Integer verwenden |
+| Keine obere Grenze auf Betrag | Integer-Überlauf oder absurde Beträge ohne Geschäftsvalidierung akzeptiert |

--- a/docs/de/howto/idempotency.md
+++ b/docs/de/howto/idempotency.md
@@ -1,0 +1,243 @@
+# How-to: Idempotency-Key-Muster
+
+> **FT-Referenz**: FT276 (`NENE2-FT/csrflog`) — Idempotency-Key-Header für zustandsändernde Anfragen: UNIQUE-DB-Constraint, Replay gibt ursprüngliches Ergebnis zurück (200), Body-Änderungen beim Replay werden ignoriert, Race Condition durch DatabaseConstraintException behandelt, 15 Tests / 30 Assertions PASS.
+>
+> **ATK-Assessment**: ATK-01 bis ATK-12 am Ende dieses Dokuments enthalten.
+
+Doppelte Bestellungen oder Ressourcenerstellungen durch Netzwerk-Wiederholungsversuche verhindern, indem Clients bei jeder zustandsändernden Anfrage einen `Idempotency-Key`-Header mitschicken müssen.
+
+## Warum es wichtig ist
+
+Wenn ein Client `POST /orders` sendet und das Netzwerk abbricht, bevor er eine Antwort erhält, wird er erneut versuchen. Ohne Idempotenz erstellt dieser Wiederholungsversuch eine zweite Bestellung. Mit einem `Idempotency-Key` kann der Server den Wiederholungsversuch erkennen und stattdessen das ursprüngliche Ergebnis zurückgeben.
+
+Stripe, GitHub und viele andere Produktions-APIs verwenden genau dieses Muster.
+
+## Datenbankschema
+
+Einen `UNIQUE`-Constraint auf die Idempotency-Key-Spalte hinzufügen. Dieser einzelne Constraint behandelt die unten beschriebene Race Condition.
+
+```sql
+CREATE TABLE orders (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    idempotency_key  TEXT    NOT NULL UNIQUE,
+    item             TEXT    NOT NULL,
+    quantity         INTEGER NOT NULL,
+    total_price      REAL    NOT NULL,
+    created_at       TEXT    NOT NULL
+);
+```
+
+## Handler-Implementierung
+
+```php
+// 1. Header lesen und validieren
+$key = trim($request->getHeaderLine('Idempotency-Key'));
+if ($key === '') {
+    return $problems->create(
+        $request,
+        'missing-idempotency-key',
+        'Idempotency-Key header is required for this endpoint.',
+        [],
+        422,
+    );
+}
+
+// 2. Auf vorhandenen Eintrag prüfen (Replay-Pfad)
+$existing = $repo->findByIdempotencyKey($key);
+if ($existing !== null) {
+    return $json->create($existing->toArray(), 200); // Replay — Original mit 200 zurückgeben
+}
+
+// 3. Request-Body validieren
+$body = json_decode((string) $request->getBody(), true);
+// ... Felder validieren ...
+
+// 4. Erstellen — UNIQUE-Constraint behandelt die Race Condition
+try {
+    $order = $repo->create($key, $item, $quantity, $totalPrice);
+    return $json->create($order->toArray(), 201);
+} catch (DatabaseConstraintException) {
+    // Eine andere Anfrage mit demselben Key hat das Rennen gewonnen — deren Ergebnis zurückgeben
+    $existing = $repo->findByIdempotencyKey($key);
+    if ($existing !== null) {
+        return $json->create($existing->toArray(), 200);
+    }
+    return $problems->create($request, 'conflict', 'Conflict.', [], 409);
+}
+```
+
+## Repository
+
+```php
+public function findByIdempotencyKey(string $key): ?Order
+{
+    $row = $this->executor->fetchOne(
+        'SELECT * FROM orders WHERE idempotency_key = ?',
+        [$key],
+    );
+    return $row !== null ? Order::fromRow($row) : null;
+}
+
+public function create(string $key, string $item, int $quantity, float $totalPrice): Order
+{
+    // Wirft DatabaseConstraintException bei UNIQUE-Verletzung (Race Condition)
+    $this->executor->insert(
+        'INSERT INTO orders (idempotency_key, item, quantity, total_price, created_at) VALUES (?, ?, ?, ?, ?)',
+        [$key, $item, $quantity, $totalPrice, (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM)],
+    );
+    // ...
+}
+```
+
+## Wichtige Designentscheidungen
+
+### Replay gibt 200 zurück, nicht 201
+
+Die zweite Anfrage ist ein Replay, keine Erstellung. `200 OK` teilt dem Client mit: "Sie haben das schon gesehen", ohne Verwirrung darüber zu erzeugen, was erstellt wurde.
+
+### Replay ignoriert den Body
+
+Wenn der Client denselben `Idempotency-Key` mit einem anderen Body sendet, wird das **ursprüngliche** Ergebnis zurückgegeben. Der Server behandelt einen übereinstimmenden Key als Beweis dafür, dass die Anfrage bereits verarbeitet wurde, unabhängig davon, was der Body sagt.
+
+```
+POST /orders  Idempotency-Key: uuid-abc  body: {quantity: 1, price: 9.99}
+→ 201 Created  {id: 1, quantity: 1}
+
+POST /orders  Idempotency-Key: uuid-abc  body: {quantity: 99, price: 0.01}
+→ 200 OK  {id: 1, quantity: 1}   ← ursprüngliche Bestellung, Body ignoriert
+```
+
+Das ist beabsichtigt. Wenn der Client eine echte andere Ressource erstellen möchte, muss er einen neuen Key verwenden.
+
+### UNIQUE-Constraint als Race-Condition-Schutz
+
+Zwei gleichzeitige Anfragen mit demselben Key konkurrieren. Der `UNIQUE`-Constraint der DB stellt sicher, dass nur ein INSERT erfolgreich ist. Der Verlierer fängt `DatabaseConstraintException` ab und ruft die Zeile des Gewinners ab.
+
+## Was Clients als Key verwenden sollten
+
+UUID v4 ist die gebräuchlichste Wahl. Der Client generiert den Key vor dem Senden der Anfrage und speichert ihn lokal, damit er bei Bedarf mit demselben Key erneut versuchen kann.
+
+```js
+// Client-seitig (JavaScript)
+const key = crypto.randomUUID();
+const response = await fetch('/orders', {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json',
+        'Idempotency-Key': key,
+    },
+    body: JSON.stringify({ item: 'Widget', quantity: 1, price: 9.99 }),
+});
+```
+
+## Header lesen
+
+PSR-7-Header-Namen sind case-insensitive. `getHeaderLine('Idempotency-Key')`, `getHeaderLine('idempotency-key')` und `getHeaderLine('IDEMPOTENCY-KEY')` geben alle denselben Wert zurück. NENE2 verwendet Nyholm/PSR-7, das dies korrekt implementiert.
+
+---
+
+## ATK Assessment — Cracker-Mindset Attack Test
+
+### ATK-01 — Idempotency-Key weglassen, um Duplikatprüfung zu umgehen 🚫 BLOCKED
+
+**Angriff**: `POST /orders` ohne den `Idempotency-Key`-Header senden.
+**Ergebnis**: BLOCKED — `trim($request->getHeaderLine('Idempotency-Key')) === ''` → 422 mit `missing-idempotency-key` Problem Detail. Es wird keine Bestellung erstellt.
+
+---
+
+### ATK-02 — Leeren Idempotency-Key senden 🚫 BLOCKED
+
+**Angriff**: `Idempotency-Key: ` (nur Leerzeichen) senden.
+**Ergebnis**: BLOCKED — `trim()` reduziert nur-Leerzeichen-Strings auf `''` → gleiche 422 wie ATK-01.
+
+---
+
+### ATK-03 — Replay mit geändertem Body, um Bestellungsinhalt zu ändern 🚫 BLOCKED
+
+**Angriff**: `POST /orders` mit Key `uuid-abc` und `{quantity: 1}` senden. Beim Replay denselben Key mit `{quantity: 99}` verwenden.
+**Ergebnis**: BLOCKED — der Server findet die vorhandene Zeile über `idempotency_key` und gibt sie sofort zurück, bevor der Body gelesen wird. Der neue Body wird nie verarbeitet.
+
+---
+
+### ATK-04 — Zwei Bestellungen mit unterschiedlichen Keys erstellen ✅ SAFE (beabsichtigt)
+
+**Angriff**: Zwei verschiedene `Idempotency-Key`-Werte verwenden, um legitim zwei Bestellungen zu erstellen.
+**Ergebnis**: SAFE (by design) — verschiedene Keys sind verschiedene Anfragen. Beide Bestellungen werden erstellt. Dies ist das beabsichtigte Verhalten: Idempotenz gilt pro Key, nicht pro Body.
+
+---
+
+### ATK-05 — Race Condition: zwei gleichzeitige Anfragen mit demselben Key 🚫 BLOCKED
+
+**Angriff**: Zwei identische Anfragen gleichzeitig senden, bevor eine davon abgeschlossen ist.
+**Ergebnis**: BLOCKED — beide Anfragen passieren die `findByIdempotencyKey`-Prüfung (noch keine vorhandene Zeile), aber nur ein INSERT gelingt. Der Verlierer fängt `DatabaseConstraintException` ab, ruft die Zeile des Gewinners ab und gibt sie mit 200 zurück. Der UNIQUE-Constraint ist der Race-Schutz.
+
+---
+
+### ATK-06 — Negative Mengeninjektion 🚫 BLOCKED
+
+**Angriff**: `{item: "widget", quantity: -1, price: 9.99}` mit einem gültigen Key senden.
+**Ergebnis**: BLOCKED — `if ($quantity <= 0)` → 422 Validierungsfehler. Es wird keine Bestellung erstellt.
+
+---
+
+### ATK-07 — Null-Mengeninjektion 🚫 BLOCKED
+
+**Angriff**: `{item: "widget", quantity: 0, price: 9.99}` senden.
+**Ergebnis**: BLOCKED — gleiche `quantity <= 0`-Prüfung → 422.
+
+---
+
+### ATK-08 — Fehlende Pflichtfelder im Body 🚫 BLOCKED
+
+**Angriff**: `{quantity: 1}` ohne `item`-Feld senden.
+**Ergebnis**: BLOCKED — `if ($item === '')` → 422 Validierungsfehler.
+
+---
+
+### ATK-09 — CSRF über ursprungsübergreifende Browser-Anfrage 🚫 BLOCKED (Design)
+
+**Angriff**: Bösartige Website macht eine ursprungsübergreifende `POST /orders`-Anfrage aus einem Browser.
+**Ergebnis**: BLOCKED (by design) — JSON-APIs erfordern `Content-Type: application/json`. Browser-CSRF-Angriffe können über `<form>` nur formular-kodierte oder Nur-Text-Bodies ohne Preflight senden. Ein JSON-Body löst einen CORS-Preflight aus; die CORS-Richtlinie des Servers entscheidet, ob ursprungsübergreifende Schreibvorgänge erlaubt sind. Zusätzlich bietet die Anforderung von `Idempotency-Key` sekundären Schutz, da gefälschte Anfragen keinen eindeutigen Key vorhersagen können.
+
+---
+
+### ATK-10 — Negativer Preis-Injection 🚫 BLOCKED
+
+**Angriff**: `{item: "widget", quantity: 1, price: -100.0}` senden.
+**Ergebnis**: BLOCKED — `if ($price < 0)` → 422 Validierungsfehler.
+
+---
+
+### ATK-11 — Float/String-Mengentypkoercion 🚫 BLOCKED
+
+**Angriff**: `{quantity: "1"}` oder `{quantity: 1.5}` (String oder Float) senden.
+**Ergebnis**: BLOCKED — `is_int($body['quantity'])` lehnt Strings und Floats ab; `1.5` ist Float → 422.
+
+---
+
+### ATK-12 — SQL-Injection über Idempotency-Key 🚫 BLOCKED
+
+**Angriff**: `Idempotency-Key: '; DROP TABLE orders; --` senden.
+**Ergebnis**: BLOCKED — der Key wird nur in parametrisierten Abfragen verwendet (`WHERE idempotency_key = ?`). SQL-Injection über Header-Wert ist nicht möglich.
+
+---
+
+### ATK Summary
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Fehlender Idempotency-Key | 🚫 BLOCKED |
+| ATK-02 | Leerer/nur-Leerzeichen-Key | 🚫 BLOCKED |
+| ATK-03 | Replay mit geändertem Body | 🚫 BLOCKED |
+| ATK-04 | Verschiedene Keys = verschiedene Bestellungen | ✅ SAFE (beabsichtigt) |
+| ATK-05 | Race Condition bei gleichem Key | 🚫 BLOCKED |
+| ATK-06 | Negative Menge | 🚫 BLOCKED |
+| ATK-07 | Null-Menge | 🚫 BLOCKED |
+| ATK-08 | Fehlende Body-Felder | 🚫 BLOCKED |
+| ATK-09 | CSRF über ursprungsübergreifenden POST | 🚫 BLOCKED |
+| ATK-10 | Negativer Preis | 🚫 BLOCKED |
+| ATK-11 | Float/String-Mengentypkoercion | 🚫 BLOCKED |
+| ATK-12 | SQL-Injection über Key-Header | 🚫 BLOCKED |
+
+**12 BLOCKED / SAFE, 0 EXPOSED**
+Das Idempotency-Key-Muster, parametrisierte Abfragen und strenge `is_int()`-Validierung verhindern alle getesteten Angriffsvektoren.

--- a/docs/de/howto/implement-bulk-endpoint.md
+++ b/docs/de/howto/implement-bulk-endpoint.md
@@ -1,0 +1,175 @@
+# How-to: Bulk-Create-Endpunkt implementieren
+
+Ein Bulk-Endpunkt akzeptiert mehrere Ressourcen in einer einzigen Anfrage — dadurch werden Round-Trips für Batch-Importe, Score-Einreichungen und ähnliche Workflows reduziert. Diese Anleitung behandelt das vollständige Muster: Parsing, Pro-Item-Validierung mit indizierten Fehlerfeldern, Größenbeschränkung und die Route.
+
+---
+
+## 1. Schema
+
+Der Request-Body wickelt Items in einem benannten Array-Key ein, damit der Envelope Metadaten tragen kann:
+
+```json
+{
+  "scores": [
+    { "player": "Alice", "game": "tetris", "score": 1000, "played_at": "2026-01-15" },
+    { "player": "Bob",   "game": "tetris", "score": 2000, "played_at": "2026-01-16" }
+  ]
+}
+```
+
+Die Antwort gibt die Anzahl der erstellten Elemente und die erstellten Items zurück:
+
+```json
+{ "created": 2, "scores": [ /* ... */ ] }
+```
+
+---
+
+## 2. Route
+
+Die Bulk-Route **vor** der parametrisierten Einzelressource-Route registrieren, um Überschattung zu vermeiden (siehe [add-custom-route.md](add-custom-route.md)):
+
+```php
+$router->post('/scores/bulk', $this->bulkSubmit(...)); // statisch zuerst
+$router->post('/scores/{id}', $this->show(...));        // parametrisiert danach
+```
+
+---
+
+## 3. Handler
+
+```php
+private function bulkSubmit(ServerRequestInterface $request): ResponseInterface
+{
+    $body = JsonRequestBodyParser::parse($request);
+
+    // 1. Envelope validieren
+    if (!isset($body['scores']) || !is_array($body['scores'])) {
+        throw new ValidationException([
+            new ValidationError('scores', 'scores must be a non-empty array.', 'required'),
+        ]);
+    }
+
+    /** @var array<mixed> $entriesRaw */
+    $entriesRaw = $body['scores'];
+
+    if (count($entriesRaw) === 0) {
+        throw new ValidationException([
+            new ValidationError('scores', 'scores must contain at least one entry.', 'required'),
+        ]);
+    }
+
+    // 2. Größenbeschränkung vor dem Iterieren erzwingen
+    if (count($entriesRaw) > 100) {
+        throw new ValidationException([
+            new ValidationError('scores', 'scores may contain at most 100 entries per request.', 'out_of_range'),
+        ]);
+    }
+
+    // 3. Jeden Eintrag validieren, Feldnamen mit dem Index präfixieren
+    $allErrors = [];
+    $entries   = [];
+
+    foreach ($entriesRaw as $i => $entry) {
+        if (!is_array($entry)) {
+            $allErrors[] = new ValidationError("scores[{$i}]", 'Each entry must be an object.', 'invalid_type');
+            continue;
+        }
+
+        /** @var array<string, mixed> $entry */
+        $entryErrors = $this->validateEntry($entry, "scores[{$i}].");
+        if ($entryErrors !== []) {
+            $allErrors = [...$allErrors, ...$entryErrors];
+        } else {
+            $entries[] = $entry;
+        }
+    }
+
+    // 4. Gesamte Anfrage ablehnen, wenn ein Eintrag ungültig ist
+    if ($allErrors !== []) {
+        throw new ValidationException($allErrors);
+    }
+
+    // 5. Alle Einträge speichern und zurückgeben
+    $now     = (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+    $created = $this->repository->bulkCreate($entries, $now);
+
+    return $this->json->create([
+        'created' => count($created),
+        'scores'  => array_map(fn ($s) => $this->serialize($s), $created),
+    ], 201);
+}
+```
+
+---
+
+## 4. Pro-Item-Validierung mit indizierten Feldnamen
+
+Einen privaten Helfer verwenden, der ein `string $prefix`-Argument akzeptiert. Das Präfix ist `"scores[{$i}]."`:
+
+```php
+/**
+ * @param array<string, mixed> $body
+ * @return list<ValidationError>
+ */
+private function validateEntry(array $body, string $prefix = ''): array
+{
+    $errors = [];
+
+    if (!isset($body['player']) || !is_string($body['player']) || $body['player'] === '') {
+        $errors[] = new ValidationError($prefix . 'player', 'player is required.', 'required');
+    }
+
+    if (!isset($body['score']) || !is_int($body['score'])) {
+        $errors[] = new ValidationError($prefix . 'score', 'score is required (integer).', 'required');
+    } elseif ($body['score'] < 0) {
+        $errors[] = new ValidationError($prefix . 'score', 'score must be 0 or greater.', 'out_of_range');
+    }
+
+    return $errors;
+}
+```
+
+**Warum `$prefix`?** `ValidationError` akzeptiert beliebige Strings als Feldname. Die Übergabe von `"scores[0]."` als Präfix erzeugt Fehlerfelder wie `"scores[0].player"` — so ist sofort klar, welcher Eintrag und welches Feld fehlgeschlagen ist. Ein einzelnes Präfix-Argument reicht; keine Framework-Änderung notwendig.
+
+Der resultierende 422-Response-Body:
+
+```json
+{
+  "type": "https://nene2.dev/problems/validation-failed",
+  "errors": [
+    { "field": "scores[1].player", "message": "player is required.", "code": "required" }
+  ]
+}
+```
+
+---
+
+## 5. Repository-Vertrag
+
+Eine Liste von vorvalidierten Einträgen entgegennehmen und die erstellten Entitäten zurückgeben:
+
+```php
+/**
+ * @param list<array{player: string, game: string, score: int, played_at: string}> $entries
+ * @return list<Score>
+ */
+public function bulkCreate(array $entries, string $now): array
+{
+    $results = [];
+    foreach ($entries as $entry) {
+        $results[] = $this->create($entry['player'], $entry['game'], $entry['score'], $entry['played_at'], $now);
+    }
+    return $results;
+}
+```
+
+> **Atomizität**: Die obige Schleife fügt eine Zeile nach der anderen ein. In `DatabaseTransactionManagerInterface::transactional()` einwickeln, wenn Alles-oder-Nichts-Verhalten benötigt wird — siehe [use-transactions.md](use-transactions.md).
+
+---
+
+## 6. Verwandte Anleitungen
+
+- [`add-pagination.md`](add-pagination.md) — Listenendpunkt-Muster
+- [`use-transactions.md`](use-transactions.md) — Bulk-Inserts in einer Transaktion einwickeln
+- [`add-domain-exception-handler.md`](add-domain-exception-handler.md) — domänenspezifische 404/409

--- a/docs/de/howto/implement-patch-endpoint.md
+++ b/docs/de/howto/implement-patch-endpoint.md
@@ -1,0 +1,179 @@
+# How-to: PATCH-Endpunkt implementieren
+
+PATCH ist für **partielle Aktualisierungen**: nur die Felder, die der Client sendet, sollen sich ändern.
+Dies erfordert die Unterscheidung von drei Zuständen für jedes Feld:
+
+| Zustand | Bedeutung |
+|---|---|
+| Key im Body fehlt | Dieses Feld nicht anfassen |
+| Key vorhanden, Wert nicht null | Auf neuen Wert aktualisieren |
+| Key vorhanden, Wert `null` | Feld leeren (auf null setzen) |
+
+`isset()` kann "fehlend" und "explizites null" nicht unterscheiden — beide geben `false` zurück.
+Stattdessen `array_key_exists()` verwenden.
+
+---
+
+## 1. Body parsen und nur die vorhandenen Felder extrahieren
+
+```php
+$body   = JsonRequestBodyParser::parse($request);   // array<string, mixed>
+$fields = [];
+
+if (array_key_exists('title', $body)) {
+    $fields['title'] = is_string($body['title']) ? trim($body['title']) : null;
+}
+if (array_key_exists('is_read', $body)) {
+    $fields['is_read'] = (bool) $body['is_read'];
+}
+```
+
+`$fields` an die `update()`-Methode des Repositorys übergeben. Wenn `$fields` leer ist, ist der Aufruf trotzdem gültig — mit dem aktuellen Zustand der Ressource antworten.
+
+---
+
+## 2. Routen-Registrierung
+
+```php
+$router->patch(
+    '/entries/{id}',
+    static function (ServerRequestInterface $request) use ($entries, $json): ResponseInterface {
+        /** @var array<string, string> $params */
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id     = (int) ($params['id'] ?? 0);
+
+        $body   = JsonRequestBodyParser::parse($request);
+        $fields = [];
+
+        if (array_key_exists('title', $body)) {
+            $fields['title'] = $body['title'];
+        }
+        if (array_key_exists('is_read', $body)) {
+            $fields['is_read'] = (bool) $body['is_read'];
+        }
+
+        $entry = $entries->update($id, $fields) ?? throw new EntryNotFoundException($id);
+
+        return $json->create(self::payload($entry));
+    },
+);
+```
+
+---
+
+## 3. Leeren PATCH-Body senden
+
+Um ein PATCH ohne Felder zu senden (ein No-op, das den aktuellen Zustand zurückgibt), muss ein JSON-**Objekt** gesendet werden, kein Array.
+
+```php
+// FALSCH: json_encode([]) === "[]"  → 400 Bad Request (JSON-Array)
+$request->withBody($stream->write(json_encode([])));
+
+// KORREKT: json_encode((object)[]) === "{}"  → 200 OK (JSON-Objekt)
+$request->withBody($stream->write(json_encode((object)[])));
+```
+
+In Test-Helpern `new \stdClass()` als Body übergeben:
+
+```php
+// In PHPUnit-Tests
+$response = $this->request('PATCH', "/entries/{$id}", new \stdClass());
+```
+
+Das liegt daran, dass `JsonRequestBodyParser` JSON-Arrays ablehnt (Details in der `JsonBodyParseException`-Meldung). Ein leeres PHP-Array `[]` kodiert zum JSON-Array `[]`, nicht zum JSON-Objekt `{}`.
+
+---
+
+## 4. PATCH-Felder validieren
+
+Nur die **vorhandenen** Felder validieren. Fehlende Felder überspringen — sie werden nicht angefasst. Nullable-Parameter in der Repository-Signatur verwenden, um die Absicht explizit zu machen:
+
+```php
+$body   = JsonRequestBodyParser::parse($request);
+$errors = [];
+
+// Nur vorhandene Felder extrahieren (array_key_exists, nicht isset)
+$amount   = array_key_exists('amount', $body) ? $body['amount'] : null;
+$category = array_key_exists('category', $body) ? $body['category'] : null;
+$date     = array_key_exists('date', $body) ? $body['date'] : null;
+
+// Nur die gesendeten Felder validieren
+if ($amount !== null) {
+    if (!is_int($amount) || $amount <= 0) {
+        $errors[] = new ValidationError('amount', 'amount must be a positive integer.', 'out_of_range');
+    }
+}
+
+if ($date !== null) {
+    if (!is_string($date) || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+        $errors[] = new ValidationError('date', 'date must be in YYYY-MM-DD format.', 'invalid_format');
+    }
+}
+
+if ($errors !== []) {
+    throw new ValidationException($errors);
+}
+
+// Repository mit nullable Argumenten aufrufen — Repository verwendet vorhandenen Wert bei null
+$entity = $this->repository->update(
+    id:       $id,
+    amount:   is_int($amount) ? $amount : null,
+    category: is_string($category) && $category !== '' ? $category : null,
+    date:     is_string($date) && $date !== '' ? $date : null,
+    now:      (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'),
+);
+```
+
+Im Repository `??` verwenden, um auf den vorhandenen Wert zurückzufallen:
+
+```php
+public function update(int $id, ?int $amount, ?string $category, ?string $date, string $now): Entity
+{
+    $existing    = $this->findById($id); // wirft NotFoundException wenn nicht gefunden
+    $newAmount   = $amount   ?? $existing->amount;
+    $newCategory = $category ?? $existing->category;
+    $newDate     = $date     ?? $existing->date;
+
+    $this->executor->execute(
+        'UPDATE entities SET amount = ?, category = ?, date = ?, updated_at = ? WHERE id = ?',
+        [$newAmount, $newCategory, $newDate, $now, $id],
+    );
+
+    return new Entity($id, $newDate, $newAmount, $newCategory, $existing->createdAt, $now);
+}
+```
+
+> **Warum `array_key_exists` statt `isset`?** `isset($body['field'])` gibt `false` zurück, sowohl für fehlende Keys als auch für Keys mit dem Wert `null`. Bei PATCH ist dieser Unterschied wichtig: "nicht gesendet" bedeutet "vorhandenen Wert behalten", während `null` möglicherweise "dieses Feld leeren" bedeutet. Für die PATCH-Felderkennung immer `array_key_exists` verwenden.
+
+---
+
+## 5. Repository-Vertrag
+
+Die `update()`-Methode des Repositorys sollte nur die übergebenen Felder akzeptieren und die aktualisierte Entität zurückgeben (oder `null` wenn nicht gefunden):
+
+```php
+/** @param array<string, mixed> $fields */
+public function update(int $id, array $fields): ?Entry
+{
+    if ($fields === []) {
+        return $this->findById($id);   // No-op: aktuellen Zustand zurückgeben
+    }
+
+    $setClauses = implode(', ', array_map(fn (string $k): string => "{$k} = ?", array_keys($fields)));
+    $params     = [...array_values($fields), $id];
+
+    $affected = $this->executor->execute(
+        "UPDATE entries SET {$setClauses} WHERE id = ?",
+        $params,
+    );
+
+    return $affected > 0 ? $this->findById($id) : null;
+}
+```
+
+---
+
+## 6. Verwandte Anleitungen
+
+- [`add-pagination.md`](add-pagination.md) — GET mit `PaginationQueryParser`
+- [`add-domain-exception-handler.md`](add-domain-exception-handler.md) — 404-Handler für fehlende Ressourcen

--- a/docs/de/howto/inbound-webhook-gateway.md
+++ b/docs/de/howto/inbound-webhook-gateway.md
@@ -1,8 +1,8 @@
-# How-to: Inbound Webhook Gateway
+# How-to: Inbound-Webhook-Gateway
 
-> **FT-Referenz**: FT317 (`NENE2-FT/inboundlog`) — Inbound-Webhook-Gateway mit quellenspezifischer HMAC-SHA256-Signaturverifizierung, Duplikat-event_id-Idempotenz, Secret wird niemals in Antworten exponiert, 17 Tests / 18 Assertions bestanden.
+> **FT-Referenz**: FT317 (`NENE2-FT/inboundlog`) — Inbound-Webhook-Gateway mit HMAC-SHA256-Signaturverifizierung pro Quelle, Idempotenz via event_id-Deduplizierung, Secret wird niemals in Antworten exponiert, 17 Tests / 18 Assertions PASS.
 
-Diese Anleitung zeigt, wie ein Multi-Source-Inbound-Webhook-Empfänger aufgebaut wird, der die Anfrage-Authentizität vor der Verarbeitung validiert.
+Diese Anleitung zeigt, wie ein Multi-Source-Inbound-Webhook-Empfänger gebaut wird, der die Authentizität von Anfragen vor der Verarbeitung validiert.
 
 ## Schema
 
@@ -18,7 +18,7 @@ CREATE TABLE sources (
 CREATE TABLE webhook_events (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     source_id   INTEGER NOT NULL REFERENCES sources(id),
-    event_id    TEXT    NOT NULL,  -- anbieterseitig gelieferter Deduplizierungsschlüssel
+    event_id    TEXT    NOT NULL,  -- vom Anbieter bereitgestellter Deduplizierungsschlüssel
     event_type  TEXT    NOT NULL,
     payload     TEXT    NOT NULL,  -- roher JSON-Body
     received_at TEXT    NOT NULL,
@@ -30,7 +30,7 @@ CREATE TABLE webhook_events (
 
 | Methode | Pfad | Beschreibung |
 |--------|------|-------------|
-| `POST` | `/sources` | Neue Webhook-Quelle registrieren |
+| `POST` | `/sources` | Eine neue Webhook-Quelle registrieren |
 | `POST` | `/sources/{id}/receive` | Webhook-Event empfangen |
 | `GET`  | `/sources/{id}/events` | Events für eine Quelle auflisten |
 | `GET`  | `/events/{id}` | Einzelnes Event abrufen |
@@ -66,7 +66,7 @@ private function verifySignature(string $body, string $header, string $secret): 
         return false;
     }
     $expected = hash_hmac('sha256', $body, $secret);
-    return hash_equals($expected, substr($header, 7));  // Zeitkonstanter Vergleich
+    return hash_equals($expected, substr($header, 7));  // zeitkonstanter Vergleich
 }
 ```
 
@@ -75,7 +75,7 @@ private function verifySignature(string $body, string $header, string $secret): 
 ## Events empfangen
 
 ```php
-// Sender (z. B. Stripe) berechnet:
+// Absender (z.B. Stripe) berechnet:
 $sig = 'sha256=' . hash_hmac('sha256', $rawBody, $sharedSecret);
 
 POST /sources/1/receive
@@ -87,7 +87,7 @@ Content-Type: application/json
 → 201  {"id": 5, "event_type": "payment.succeeded", "status": "processed"}
 ```
 
-### Fehlerbehandlung
+### Fehlerfälle
 
 ```php
 // Falsche oder fehlende Signatur
@@ -100,21 +100,21 @@ POST /sources/9999/receive                     → 404 Not Found
 POST /sources/1/receive  {"event_type": "x"}  → 422
 ```
 
-## Duplikat-Event-Idempotenz
+## Doppeltes Event — Idempotenz
 
-Anbieter-Wiederholungsversuche sind häufig — `event_id`-Deduplizierung verhindert Doppelverarbeitung:
+Anbieter-Wiederholungsversuche sind üblich — `event_id`-Deduplizierung verhindert Doppelverarbeitung:
 
 ```php
-// Erste Lieferung
+// Erste Zustellung
 POST /sources/1/receive  {"event_id": "evt-dup", "event_type": "order.created"}
 → 201  {"status": "processed", "id": 5}
 
-// Wiederholung (gleiche event_id)
+// Wiederholungsversuch (gleiche event_id)
 POST /sources/1/receive  {"event_id": "evt-dup", "event_type": "order.created"}
 → 200  {"status": "already_processed", "id": 5}
 ```
 
-`UNIQUE(source_id, event_id)` in der DB setzt dies auf der Speicherebene durch.
+`UNIQUE(source_id, event_id)` in der DB erzwingt dies auf Speicherebene.
 
 ## Events abfragen
 
@@ -135,8 +135,8 @@ GET /events/9999
 
 | Anti-Muster | Risiko |
 |---|---|
-| `secret` in der Quellenantwort zurückgeben | Gibt den Signierschlüssel an jeden Client weiter, der die API-Antwort lesen kann |
-| `===` statt `hash_equals()` für Signatur verwenden | Timing-Angriff enthüllt HMAC-Byte für Byte |
-| Keine `event_id`-Deduplizierung | Anbieter-Wiederholungsversuche verursachen Doppelverarbeitung (doppelte Abbuchungen, doppelte E-Mails) |
-| Signatur nach JSON-Parsing verifizieren | Angreifer kann Body erstellen, der JSON-Parsing besteht, aber HMAC scheitert; immer zuerst rohe Bytes verifizieren |
-| Einziges globales Secret für alle Quellen | Kompromittierung einer Integration exponiert alle |
+| `secret` in der Quellantwort zurückgeben | Gibt den Signierschlüssel an jeden Client weiter, der die API-Antwort lesen kann |
+| `===` statt `hash_equals()` für Signatur verwenden | Timing-Angriff enthüllt HMAC Byte für Byte |
+| Kein `event_id`-Dedup | Anbieter-Wiederholungsversuche verursachen Doppelverarbeitung (doppelte Belastungen, doppelte E-Mails) |
+| Signatur nach JSON-Parsing verifizieren | Angreifer kann Body so konstruieren, dass er JSON-Parsing besteht, aber HMAC fehlschlägt; immer zuerst rohe Bytes verifizieren |
+| Ein einzelnes globales Secret für alle Quellen | Kompromittierung einer Integration exponiert alle |

--- a/docs/de/howto/inbound-webhook-gateway.md
+++ b/docs/de/howto/inbound-webhook-gateway.md
@@ -1,0 +1,142 @@
+# How-to: Inbound Webhook Gateway
+
+> **FT-Referenz**: FT317 (`NENE2-FT/inboundlog`) — Inbound-Webhook-Gateway mit quellenspezifischer HMAC-SHA256-Signaturverifizierung, Duplikat-event_id-Idempotenz, Secret wird niemals in Antworten exponiert, 17 Tests / 18 Assertions bestanden.
+
+Diese Anleitung zeigt, wie ein Multi-Source-Inbound-Webhook-Empfänger aufgebaut wird, der die Anfrage-Authentizität vor der Verarbeitung validiert.
+
+## Schema
+
+```sql
+CREATE TABLE sources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    secret     TEXT    NOT NULL,   -- gemeinsames Secret für HMAC
+    active     INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE webhook_events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id   INTEGER NOT NULL REFERENCES sources(id),
+    event_id    TEXT    NOT NULL,  -- anbieterseitig gelieferter Deduplizierungsschlüssel
+    event_type  TEXT    NOT NULL,
+    payload     TEXT    NOT NULL,  -- roher JSON-Body
+    received_at TEXT    NOT NULL,
+    UNIQUE(source_id, event_id)
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/sources` | Neue Webhook-Quelle registrieren |
+| `POST` | `/sources/{id}/receive` | Webhook-Event empfangen |
+| `GET`  | `/sources/{id}/events` | Events für eine Quelle auflisten |
+| `GET`  | `/events/{id}` | Einzelnes Event abrufen |
+
+## Quellen-Registrierung
+
+```php
+POST /sources
+{"name": "stripe", "secret": "whsec_abc123..."}
+
+→ 201
+{"id": 1, "name": "stripe", "active": true, "created_at": "..."}
+// secret wird NIEMALS zurückgegeben
+```
+
+```php
+POST /sources  {"secret": "abc"}   → 422  // name erforderlich
+POST /sources  {"name": "github"}  → 422  // secret erforderlich
+```
+
+## HMAC-SHA256-Signaturverifizierung
+
+Jeder eingehende Webhook muss einen `X-Webhook-Signature`-Header mit dem HMAC-SHA256 des rohen Bodys enthalten:
+
+```
+X-Webhook-Signature: sha256=<hex_digest>
+```
+
+```php
+private function verifySignature(string $body, string $header, string $secret): bool
+{
+    if (!str_starts_with($header, 'sha256=')) {
+        return false;
+    }
+    $expected = hash_hmac('sha256', $body, $secret);
+    return hash_equals($expected, substr($header, 7));  // Zeitkonstanter Vergleich
+}
+```
+
+**Wichtig**: `hash_equals()` verwenden — nicht `===` — um Timing-Angriffe zu verhindern.
+
+## Events empfangen
+
+```php
+// Sender (z. B. Stripe) berechnet:
+$sig = 'sha256=' . hash_hmac('sha256', $rawBody, $sharedSecret);
+
+POST /sources/1/receive
+X-Webhook-Signature: sha256=<digest>
+Content-Type: application/json
+
+{"event_id": "evt-001", "event_type": "payment.succeeded", "data": {...}}
+
+→ 201  {"id": 5, "event_type": "payment.succeeded", "status": "processed"}
+```
+
+### Fehlerbehandlung
+
+```php
+// Falsche oder fehlende Signatur
+POST /sources/1/receive  (ungültige Signatur)  → 401 Unauthorized
+
+// Quelle nicht gefunden
+POST /sources/9999/receive                     → 404 Not Found
+
+// Fehlende event_id im Payload
+POST /sources/1/receive  {"event_type": "x"}  → 422
+```
+
+## Duplikat-Event-Idempotenz
+
+Anbieter-Wiederholungsversuche sind häufig — `event_id`-Deduplizierung verhindert Doppelverarbeitung:
+
+```php
+// Erste Lieferung
+POST /sources/1/receive  {"event_id": "evt-dup", "event_type": "order.created"}
+→ 201  {"status": "processed", "id": 5}
+
+// Wiederholung (gleiche event_id)
+POST /sources/1/receive  {"event_id": "evt-dup", "event_type": "order.created"}
+→ 200  {"status": "already_processed", "id": 5}
+```
+
+`UNIQUE(source_id, event_id)` in der DB setzt dies auf der Speicherebene durch.
+
+## Events abfragen
+
+```php
+GET /sources/1/events
+→ 200  {"events": [...], "count": 2}
+
+GET /events/5
+→ 200  {"id": 5, "source_id": 1, "event_type": "payment.succeeded", ...}
+
+GET /events/9999
+→ 404
+```
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `secret` in der Quellenantwort zurückgeben | Gibt den Signierschlüssel an jeden Client weiter, der die API-Antwort lesen kann |
+| `===` statt `hash_equals()` für Signatur verwenden | Timing-Angriff enthüllt HMAC-Byte für Byte |
+| Keine `event_id`-Deduplizierung | Anbieter-Wiederholungsversuche verursachen Doppelverarbeitung (doppelte Abbuchungen, doppelte E-Mails) |
+| Signatur nach JSON-Parsing verifizieren | Angreifer kann Body erstellen, der JSON-Parsing besteht, aber HMAC scheitert; immer zuerst rohe Bytes verifizieren |
+| Einziges globales Secret für alle Quellen | Kompromittierung einer Integration exponiert alle |

--- a/docs/de/howto/inbound-webhook-receiver.md
+++ b/docs/de/howto/inbound-webhook-receiver.md
@@ -1,0 +1,109 @@
+# So fügen Sie einen Inbound-Webhook-Empfänger hinzu
+
+Webhooks von mehreren externen Diensten empfangen, HMAC-Signaturen pro Quelle validieren und Events mit Idempotenz speichern.
+
+## Schema
+
+```sql
+CREATE TABLE webhook_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE, secret TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 1, created_at TEXT NOT NULL
+);
+CREATE TABLE inbound_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id INTEGER NOT NULL REFERENCES webhook_sources(id),
+    event_id TEXT NOT NULL, event_type TEXT NOT NULL,
+    payload TEXT NOT NULL, processed_at TEXT NOT NULL,
+    UNIQUE(source_id, event_id)
+);
+```
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/sources` | Webhook-Quelle registrieren |
+| `POST` | `/sources/{id}/receive` | Webhook empfangen |
+| `GET` | `/sources/{id}/events` | Empfangene Events auflisten |
+| `GET` | `/events/{id}` | Bestimmtes Event abrufen |
+
+## HMAC-SHA256-Signaturvalidierung
+
+Jede Quelle hat ihr eigenes HMAC-Secret. Es darf niemals in Antworten exponiert werden.
+
+```php
+private function verifySignature(string $body, string $header, string $secret): bool
+{
+    if (!str_starts_with($header, 'sha256=')) {
+        return false;
+    }
+    $expected = hash_hmac('sha256', $body, $secret);
+    return hash_equals($expected, substr($header, 7)); // zeitkonstant
+}
+```
+
+Reihenfolge der Aufrufe: **Signatur zuerst validieren**, dann Idempotenz-Prüfung, dann speichern:
+
+```php
+if (!$this->verifySignature($rawBody, $sigHeader, $source['secret'])) {
+    return $this->json->create(['error' => 'Invalid signature'], 401);
+}
+// ... Idempotenz-Prüfung ...
+$this->repo->storeEvent($sourceId, $eventId, $eventType, $rawBody, $now);
+```
+
+## Idempotenz (event_id pro Quelle)
+
+```php
+$existing = $this->repo->findEventBySourceAndEventId($sourceId, $eventId);
+if ($existing !== null) {
+    return $this->json->create(['status' => 'already_processed', 'id' => $existing['id']]);
+}
+```
+
+Der `UNIQUE(source_id, event_id)`-Constraint ist der DB-Level-Backstop. Die PHP-Prüfung oben vermeidet den Ausnahme-Pfad beim ersten Duplikat.
+
+## Secret niemals exponieren
+
+```php
+$source = $this->repo->findSource($id);
+unset($source['secret']); // vor der Rückgabe entfernen
+return $this->json->create($source, 201);
+```
+
+## Inaktive-Quellen-Prüfung
+
+```php
+if (!(bool) $source['active']) {
+    return $this->json->create(['error' => 'Source is inactive'], 403);
+}
+```
+
+## MySQL-Hinweise
+
+Der `UNIQUE KEY uq_source_event (source_id, event_id)`-Constraint funktioniert in MySQL gleich. `VARCHAR(191)` für indizierte Textspalten verwenden, um innerhalb von InnoDB's Schlüssellängenlimit zu bleiben.
+
+### MySQL-Integrationstests ausführen
+
+Geteilten FT-MySQL-Container starten (Port 3308, persistentes Volume):
+
+```bash
+docker compose -f ../NENE2-FT/docker-compose.yml up -d mysql
+```
+
+Dann Integrationstests mit Umgebungsvariablen ausführen:
+
+```bash
+MYSQL_HOST=127.0.0.1 MYSQL_PORT=3308 MYSQL_DATABASE=ft_test \
+  MYSQL_USER=ft_user MYSQL_PASSWORD=ft_pass \
+  php8.4 vendor/bin/phpunit --filter Mysql
+```
+
+Ohne `MYSQL_HOST` werden die MySQL-Tests automatisch übersprungen (`markTestSkipped`).
+
+## Sicherheitshinweise
+
+- `hash_equals()` verhindert Timing-Angriffe bei der Signaturprüfung.
+- Roher JSON-Body wird unverändert gespeichert; nicht vor der Signaturverifizierung parsen.
+- Dieselbe `event_id` von zwei verschiedenen Quellen erstellt separate Datensätze — der UNIQUE-Constraint gilt für `(source_id, event_id)`, nicht nur `event_id`.

--- a/docs/de/howto/inbound-webhook-receiver.md
+++ b/docs/de/howto/inbound-webhook-receiver.md
@@ -1,4 +1,4 @@
-# So fügen Sie einen Inbound-Webhook-Empfänger hinzu
+# How-to: Inbound-Webhook-Empfänger hinzufügen
 
 Webhooks von mehreren externen Diensten empfangen, HMAC-Signaturen pro Quelle validieren und Events mit Idempotenz speichern.
 
@@ -23,14 +23,14 @@ CREATE TABLE inbound_events (
 
 | Methode | Pfad | Beschreibung |
 |--------|------|-------------|
-| `POST` | `/sources` | Webhook-Quelle registrieren |
-| `POST` | `/sources/{id}/receive` | Webhook empfangen |
+| `POST` | `/sources` | Eine Webhook-Quelle registrieren |
+| `POST` | `/sources/{id}/receive` | Einen Webhook empfangen |
 | `GET` | `/sources/{id}/events` | Empfangene Events auflisten |
-| `GET` | `/events/{id}` | Bestimmtes Event abrufen |
+| `GET` | `/events/{id}` | Ein bestimmtes Event abrufen |
 
 ## HMAC-SHA256-Signaturvalidierung
 
-Jede Quelle hat ihr eigenes HMAC-Secret. Es darf niemals in Antworten exponiert werden.
+Jede Quelle hat ihr eigenes HMAC-Secret. Es niemals in Antworten exponieren.
 
 ```php
 private function verifySignature(string $body, string $header, string $secret): bool
@@ -39,11 +39,11 @@ private function verifySignature(string $body, string $header, string $secret): 
         return false;
     }
     $expected = hash_hmac('sha256', $body, $secret);
-    return hash_equals($expected, substr($header, 7)); // zeitkonstant
+    return hash_equals($expected, substr($header, 7)); // zeitkonstanter Vergleich
 }
 ```
 
-Reihenfolge der Aufrufe: **Signatur zuerst validieren**, dann Idempotenz-Prüfung, dann speichern:
+Reihenfolge: **Zuerst Signatur validieren**, dann Idempotenz-Prüfung, dann speichern:
 
 ```php
 if (!$this->verifySignature($rawBody, $sigHeader, $source['secret'])) {
@@ -62,17 +62,17 @@ if ($existing !== null) {
 }
 ```
 
-Der `UNIQUE(source_id, event_id)`-Constraint ist der DB-Level-Backstop. Die PHP-Prüfung oben vermeidet den Ausnahme-Pfad beim ersten Duplikat.
+Der `UNIQUE(source_id, event_id)`-Constraint ist das DB-Level-Sicherheitsnetz. Die obige PHP-Prüfung vermeidet den Exception-Pfad beim ersten Duplikat.
 
 ## Secret niemals exponieren
 
 ```php
 $source = $this->repo->findSource($id);
-unset($source['secret']); // vor der Rückgabe entfernen
+unset($source['secret']); // vor dem Zurückgeben entfernen
 return $this->json->create($source, 201);
 ```
 
-## Inaktive-Quellen-Prüfung
+## Prüfung inaktiver Quellen
 
 ```php
 if (!(bool) $source['active']) {
@@ -82,17 +82,17 @@ if (!(bool) $source['active']) {
 
 ## MySQL-Hinweise
 
-Der `UNIQUE KEY uq_source_event (source_id, event_id)`-Constraint funktioniert in MySQL gleich. `VARCHAR(191)` für indizierte Textspalten verwenden, um innerhalb von InnoDB's Schlüssellängenlimit zu bleiben.
+Der `UNIQUE KEY uq_source_event (source_id, event_id)`-Constraint funktioniert in MySQL genauso. Für indizierte Textspalten `VARCHAR(191)` verwenden, um innerhalb des InnoDB-Schlüssellängenlimits zu bleiben.
 
 ### MySQL-Integrationstests ausführen
 
-Geteilten FT-MySQL-Container starten (Port 3308, persistentes Volume):
+Den gemeinsamen FT-MySQL-Container starten (Port 3308, persistentes Volume):
 
 ```bash
 docker compose -f ../NENE2-FT/docker-compose.yml up -d mysql
 ```
 
-Dann Integrationstests mit Umgebungsvariablen ausführen:
+Dann die Integrationstests mit Umgebungsvariablen ausführen:
 
 ```bash
 MYSQL_HOST=127.0.0.1 MYSQL_PORT=3308 MYSQL_DATABASE=ft_test \
@@ -104,6 +104,6 @@ Ohne `MYSQL_HOST` werden die MySQL-Tests automatisch übersprungen (`markTestSki
 
 ## Sicherheitshinweise
 
-- `hash_equals()` verhindert Timing-Angriffe bei der Signaturprüfung.
+- `hash_equals()` verhindert Timing-Angriffe beim Signaturvergleich.
 - Roher JSON-Body wird unverändert gespeichert; nicht vor der Signaturverifizierung parsen.
 - Dieselbe `event_id` von zwei verschiedenen Quellen erstellt separate Datensätze — der UNIQUE-Constraint gilt für `(source_id, event_id)`, nicht nur `event_id`.

--- a/docs/de/howto/inventory-management.md
+++ b/docs/de/howto/inventory-management.md
@@ -1,15 +1,15 @@
-# How-to: Inventory Management API
+# How-to: Inventarverwaltungs-API
 
-Diese Anleitung zeigt, wie eine Inventar-/Lagerverwaltungs-API mit Bestandsanpassungen und Verlaufsverfolgung mit NENE2 aufgebaut wird.
-Muster demonstriert durch den **inventorylog**-Feldversuch (FT220, ATK Cracker Attack Test).
+Diese Anleitung zeigt, wie eine Inventar-/Lagerverwaltungs-API mit Lagerbestandsanpassungen und Verlaufsverfolgung mit NENE2 aufgebaut wird.
+Muster demonstriert durch den **inventorylog**-Feldversuch (FT220, ATK-Cracker-Angriffstest).
 
 ## Funktionen
 
-- Inventarelemente mit SKU, Name, Preis und Anfangsmenge erstellen (nur Admin)
-- Elementdetails abrufen (öffentlich)
-- Bestand mit vorzeichenbehaftetem Delta anpassen (positiv = Wiederauffüllung, negativ = Verbrauch)
-- Unzureichende Bestandserkennung → 409 Conflict
-- Vollständiges Anpassungsprotokoll
+- Inventarobjekte mit SKU, Name, Preis und Anfangsmenge erstellen (nur Admin)
+- Objektdetails abrufen (öffentlich)
+- Lagerbestand mit vorzeichenbehaftetem Delta anpassen (positiv = Auffüllen, negativ = Verbrauch)
+- Unzureichender Lagerbestand → 409 Conflict
+- Vollständiges Anpassungsverlaufsprotokoll
 
 ## Schema
 
@@ -39,12 +39,12 @@ CREATE TABLE IF NOT EXISTS stock_logs (
 
 | Methode | Pfad | Auth | Beschreibung |
 |--------|------|------|-------------|
-| `POST` | `/items` | Admin | Inventarelement erstellen |
-| `GET` | `/items/{id}` | Öffentlich | Element mit aktuellem Bestand abrufen |
-| `POST` | `/items/{id}/adjust` | Admin | Bestand anpassen (Delta ± N) |
-| `GET` | `/items/{id}/history` | Öffentlich | Anpassungsprotokoll abrufen |
+| `POST` | `/items` | Admin | Inventarobjekt erstellen |
+| `GET` | `/items/{id}` | Öffentlich | Objekt mit aktuellem Lagerbestand abrufen |
+| `POST` | `/items/{id}/adjust` | Admin | Lagerbestand anpassen (Delta ± N) |
+| `GET` | `/items/{id}/history` | Öffentlich | Anpassungsverlauf abrufen |
 
-## Bestandsanpassungsmuster
+## Lagerbestandsanpassungs-Muster
 
 ```php
 /** @return 'ok'|'not_found'|'insufficient_stock' */
@@ -56,7 +56,7 @@ public function adjust(int $id, int $delta, string $reason): string
     $newQty = (int) $item['quantity'] + $delta;
     if ($newQty < 0) return 'insufficient_stock'; // → 409
 
-    // Atomisches Update + Protokoll
+    // Atomares Update + Protokolleintrag
     $this->pdo->prepare(
         'UPDATE items SET quantity = :qty, updated_at = :now WHERE id = :id'
     )->execute([':qty' => $newQty, ':now' => $now, ':id' => $id]);
@@ -78,24 +78,24 @@ if (!is_int($delta) || $delta === 0 || abs($delta) > self::MAX_QUANTITY) {
 }
 ```
 
-## ATK Cracker-Test-Ergebnisse (FT220)
+## ATK-Cracker-Testergebnisse (FT220)
 
 - **ATK-01**: SQL-Injection in SKU → blockiert durch `/\A[A-Z0-9\-]{1,32}\z/`-Muster (422)
 - **ATK-01**: SQL-Injection in Pfad-ID → blockiert durch `ctype_digit()` (404)
 - **ATK-02**: Integer-Überlauf in `price_cents` → Float durch `is_int()` abgelehnt (422)
-- **ATK-03**: Überdimensionierte Pfad-ID → `strlen > 18`-Guard (404)
-- **ATK-04**: Drain-to-Zero-Grenzwert → erlaubt (Menge = 0 ist gültig)
+- **ATK-03**: Überdimensionierte Pfad-ID → `strlen > 18`-Schutz (404)
+- **ATK-04**: Drain-to-zero Grenzwert → erlaubt (Menge = 0 ist gültig)
 - **ATK-05**: Überdimensionierte `quantity` (> 1.000.000) → abgelehnt (422)
-- **ATK-06**: Falscher/leerer Admin-Schlüssel → 403 (fail-closed)
-- **ATK-09**: Übermäßiger Drain-Angriff → `insufficient_stock` → 409, Bestand unverändert
+- **ATK-06**: Falscher/leerer Admin-Key → 403 (fail-closed)
+- **ATK-09**: Over-drain-Angriff → `insufficient_stock` → 409, Lagerbestand unverändert
 - **ATK-10**: Float `delta` → durch `is_int()` abgelehnt (422)
 - **ATK-11**: Anfrage ohne Body → 400 (JSON-Body erforderlich)
-- **ATK-12**: Fehlerantworten enthalten keine SQL-State/Stack-Traces/internen Pfade
+- **ATK-12**: Fehlerantworten enthalten keine SQLSTATE/Stack-Traces/internen Pfade
 
 ## Sicherheitsmuster
 
 - **Admin fail-closed**: `if ($this->adminKey === '') return false;` vor `hash_equals()`
-- **`is_int()`-Striktprüfungen**: price_cents, quantity, delta — lehnt Floats aus JSON ab
+- **`is_int()`-strenge Prüfungen**: price_cents, quantity, delta — lehnt Floats aus JSON ab
 - **`ctype_digit()`**: ReDoS-sichere Integer-Validierung für Pfad-IDs
 - **SKU-Muster**: `/\A[A-Z0-9\-]{1,32}\z/` blockiert SQL-Injection-Versuche
-- **Atomische Operationen**: Update + Protokoll-Insert in Sequenz (innerhalb einer einzigen Verbindung)
+- **Atomare Operationen**: Update + Protokolleintrag-Insert in Sequenz (innerhalb einer einzelnen Verbindung)

--- a/docs/de/howto/inventory-management.md
+++ b/docs/de/howto/inventory-management.md
@@ -1,0 +1,101 @@
+# How-to: Inventory Management API
+
+Diese Anleitung zeigt, wie eine Inventar-/Lagerverwaltungs-API mit Bestandsanpassungen und Verlaufsverfolgung mit NENE2 aufgebaut wird.
+Muster demonstriert durch den **inventorylog**-Feldversuch (FT220, ATK Cracker Attack Test).
+
+## Funktionen
+
+- Inventarelemente mit SKU, Name, Preis und Anfangsmenge erstellen (nur Admin)
+- Elementdetails abrufen (öffentlich)
+- Bestand mit vorzeichenbehaftetem Delta anpassen (positiv = Wiederauffüllung, negativ = Verbrauch)
+- Unzureichende Bestandserkennung → 409 Conflict
+- Vollständiges Anpassungsprotokoll
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS items (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    sku          TEXT    NOT NULL UNIQUE,
+    name         TEXT    NOT NULL,
+    quantity     INTEGER NOT NULL DEFAULT 0,
+    price_cents  INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS stock_logs (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id        INTEGER NOT NULL,
+    delta          INTEGER NOT NULL,
+    reason         TEXT    NOT NULL DEFAULT '',
+    quantity_after INTEGER NOT NULL,
+    created_at     TEXT    NOT NULL,
+    FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/items` | Admin | Inventarelement erstellen |
+| `GET` | `/items/{id}` | Öffentlich | Element mit aktuellem Bestand abrufen |
+| `POST` | `/items/{id}/adjust` | Admin | Bestand anpassen (Delta ± N) |
+| `GET` | `/items/{id}/history` | Öffentlich | Anpassungsprotokoll abrufen |
+
+## Bestandsanpassungsmuster
+
+```php
+/** @return 'ok'|'not_found'|'insufficient_stock' */
+public function adjust(int $id, int $delta, string $reason): string
+{
+    $item = $this->findById($id);
+    if ($item === null) return 'not_found';
+
+    $newQty = (int) $item['quantity'] + $delta;
+    if ($newQty < 0) return 'insufficient_stock'; // → 409
+
+    // Atomisches Update + Protokoll
+    $this->pdo->prepare(
+        'UPDATE items SET quantity = :qty, updated_at = :now WHERE id = :id'
+    )->execute([':qty' => $newQty, ':now' => $now, ':id' => $id]);
+
+    $this->pdo->prepare(
+        'INSERT INTO stock_logs (item_id, delta, reason, quantity_after, created_at) VALUES ...'
+    )->execute([...]);
+
+    return 'ok';
+}
+```
+
+## Delta-Validierung
+
+```php
+$delta = $body['delta'] ?? null;
+if (!is_int($delta) || $delta === 0 || abs($delta) > self::MAX_QUANTITY) {
+    return $this->problem(422, 'validation-failed', 'delta must be a non-zero integer with |delta| ≤ 1000000.');
+}
+```
+
+## ATK Cracker-Test-Ergebnisse (FT220)
+
+- **ATK-01**: SQL-Injection in SKU → blockiert durch `/\A[A-Z0-9\-]{1,32}\z/`-Muster (422)
+- **ATK-01**: SQL-Injection in Pfad-ID → blockiert durch `ctype_digit()` (404)
+- **ATK-02**: Integer-Überlauf in `price_cents` → Float durch `is_int()` abgelehnt (422)
+- **ATK-03**: Überdimensionierte Pfad-ID → `strlen > 18`-Guard (404)
+- **ATK-04**: Drain-to-Zero-Grenzwert → erlaubt (Menge = 0 ist gültig)
+- **ATK-05**: Überdimensionierte `quantity` (> 1.000.000) → abgelehnt (422)
+- **ATK-06**: Falscher/leerer Admin-Schlüssel → 403 (fail-closed)
+- **ATK-09**: Übermäßiger Drain-Angriff → `insufficient_stock` → 409, Bestand unverändert
+- **ATK-10**: Float `delta` → durch `is_int()` abgelehnt (422)
+- **ATK-11**: Anfrage ohne Body → 400 (JSON-Body erforderlich)
+- **ATK-12**: Fehlerantworten enthalten keine SQL-State/Stack-Traces/internen Pfade
+
+## Sicherheitsmuster
+
+- **Admin fail-closed**: `if ($this->adminKey === '') return false;` vor `hash_equals()`
+- **`is_int()`-Striktprüfungen**: price_cents, quantity, delta — lehnt Floats aus JSON ab
+- **`ctype_digit()`**: ReDoS-sichere Integer-Validierung für Pfad-IDs
+- **SKU-Muster**: `/\A[A-Z0-9\-]{1,32}\z/` blockiert SQL-Injection-Versuche
+- **Atomische Operationen**: Update + Protokoll-Insert in Sequenz (innerhalb einer einzigen Verbindung)

--- a/docs/de/howto/inventory-stock-management.md
+++ b/docs/de/howto/inventory-stock-management.md
@@ -1,0 +1,119 @@
+# How-to: Inventory-Bestandsverwaltung
+
+## Übersicht
+
+Diese Anleitung behandelt den Aufbau einer Inventarverwaltungs-API mit NENE2. Zu den Funktionen gehören SKU-basierte Artikelregistrierung, Einlagerungs-/Auslagerungsvorgänge, Verhinderung negativer Bestände und Transaktionsverlauf.
+
+**Referenzimplementierung**: `../NENE2-FT/inventorylog/`
+
+---
+
+## Schema-Design
+
+```sql
+CREATE TABLE IF NOT EXISTS items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    sku        TEXT    NOT NULL UNIQUE,
+    name       TEXT    NOT NULL,
+    stock      INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS stock_history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id    INTEGER NOT NULL,
+    type       TEXT    NOT NULL,   -- 'in' | 'out'
+    quantity   INTEGER NOT NULL,
+    note       TEXT,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
+);
+```
+
+---
+
+## Routentabelle
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/inventory/items` | Artikel registrieren (SKU + Name) |
+| `GET` | `/inventory/items` | Alle Artikel auflisten |
+| `GET` | `/inventory/items/{id}` | Artikel nach ID abrufen |
+| `POST` | `/inventory/items/{id}/in` | Einlagern (Eingang) |
+| `POST` | `/inventory/items/{id}/out` | Auslagern (Versand) |
+| `GET` | `/inventory/items/{id}/history` | Transaktionsverlauf |
+
+---
+
+## SKU-Validierung
+
+SKU-Format einschränken, um Injection zu verhindern und kanonische Form sicherzustellen:
+
+```php
+if (!preg_match('/\A[A-Z0-9_-]{1,32}\z/', $sku)) {
+    return $this->problem(422, 'validation-failed', 'sku must be uppercase alphanumeric (max 32).');
+}
+```
+
+---
+
+## Bestandsvorgänge
+
+### Einlagern
+
+Immer sicher — einfach inkrementieren:
+
+```php
+$this->pdo->prepare('UPDATE items SET stock = stock + :qty, updated_at = :now WHERE id = :id')
+    ->execute([':qty' => $quantity, ':now' => $now, ':id' => $itemId]);
+```
+
+### Auslagern (mit Unzureichend-Bestand-Guard)
+
+```php
+if ((int) $item['stock'] < $quantity) {
+    return 'insufficient_stock';   // → 409 Conflict
+}
+$this->pdo->prepare('UPDATE items SET stock = stock - :qty, updated_at = :now WHERE id = :id')
+    ->execute([':qty' => $quantity, ':now' => $now, ':id' => $itemId]);
+```
+
+---
+
+## Mengenvalidierung
+
+Nicht-Integer und nicht-positive Mengen ablehnen:
+
+```php
+$qty = $body['quantity'] ?? null;
+if (!is_int($qty) || $qty <= 0) {
+    return [0, null, 'quantity must be a positive integer.'];
+}
+```
+
+Dies fängt sowohl `"50"` (String) als auch `-1` (negativ) ab.
+
+---
+
+## HTTP-Statuscodes
+
+| Situation | Status |
+|-----------|--------|
+| Artikel erstellt | 201 |
+| Bestand hinzugefügt / reduziert | 200 |
+| Artikel / Verlauf gefunden | 200 |
+| Fehlendes oder leeres Feld | 422 |
+| Ungültiges SKU-Format | 422 |
+| Nicht-Integer oder negative Menge | 422 |
+| Artikel nicht gefunden | 404 |
+| Doppelte SKU | 409 |
+| Unzureichender Bestand | 409 |
+
+---
+
+## Hinweise
+
+- **Atomische Updates**: `stock = stock + :qty` und `stock = stock - :qty` in SQL verwenden, um den Bestand auch bei gleichzeitigem Zugriff konsistent zu halten.
+- **Prüfpfad**: Jede Bestandsänderung schreibt eine `stock_history`-Zeile für die Rückverfolgbarkeit.
+- **Soft-Constraint**: Die Anwendung prüft den Bestand vor dem Dekrementieren. Für strikte Korrektheit unter Nebenläufigkeit einen `CHECK (stock >= 0)`-Spalten-Constraint in der DB hinzufügen oder Transaktionen mit Zeilensperrung verwenden.

--- a/docs/de/howto/inventory-stock-management.md
+++ b/docs/de/howto/inventory-stock-management.md
@@ -1,8 +1,8 @@
-# How-to: Inventory-Bestandsverwaltung
+# How-to: Lagerbestandsverwaltung
 
-## Übersicht
+## Überblick
 
-Diese Anleitung behandelt den Aufbau einer Inventarverwaltungs-API mit NENE2. Zu den Funktionen gehören SKU-basierte Artikelregistrierung, Einlagerungs-/Auslagerungsvorgänge, Verhinderung negativer Bestände und Transaktionsverlauf.
+Diese Anleitung behandelt den Aufbau einer Inventarverwaltungs-API mit NENE2. Zu den Funktionen gehören SKU-basierte Artikelregistrierung, Ein-/Auslagerungsvorgänge, Verhinderung negativer Lagerbestände und Transaktionshistorie.
 
 **Referenzimplementierung**: `../NENE2-FT/inventorylog/`
 
@@ -40,15 +40,15 @@ CREATE TABLE IF NOT EXISTS stock_history (
 | `POST` | `/inventory/items` | Artikel registrieren (SKU + Name) |
 | `GET` | `/inventory/items` | Alle Artikel auflisten |
 | `GET` | `/inventory/items/{id}` | Artikel nach ID abrufen |
-| `POST` | `/inventory/items/{id}/in` | Einlagern (Eingang) |
-| `POST` | `/inventory/items/{id}/out` | Auslagern (Versand) |
-| `GET` | `/inventory/items/{id}/history` | Transaktionsverlauf |
+| `POST` | `/inventory/items/{id}/in` | Einlagerung (Wareneingang) |
+| `POST` | `/inventory/items/{id}/out` | Auslagerung (Versand) |
+| `GET` | `/inventory/items/{id}/history` | Transaktionshistorie |
 
 ---
 
 ## SKU-Validierung
 
-SKU-Format einschränken, um Injection zu verhindern und kanonische Form sicherzustellen:
+SKU-Format einschränken, um Injections zu verhindern und kanonische Form zu gewährleisten:
 
 ```php
 if (!preg_match('/\A[A-Z0-9_-]{1,32}\z/', $sku)) {
@@ -58,9 +58,9 @@ if (!preg_match('/\A[A-Z0-9_-]{1,32}\z/', $sku)) {
 
 ---
 
-## Bestandsvorgänge
+## Lagervorgänge
 
-### Einlagern
+### Einlagerung
 
 Immer sicher — einfach inkrementieren:
 
@@ -69,7 +69,7 @@ $this->pdo->prepare('UPDATE items SET stock = stock + :qty, updated_at = :now WH
     ->execute([':qty' => $quantity, ':now' => $now, ':id' => $itemId]);
 ```
 
-### Auslagern (mit Unzureichend-Bestand-Guard)
+### Auslagerung (mit Schutz vor unzureichendem Lagerbestand)
 
 ```php
 if ((int) $item['stock'] < $quantity) {
@@ -83,7 +83,7 @@ $this->pdo->prepare('UPDATE items SET stock = stock - :qty, updated_at = :now WH
 
 ## Mengenvalidierung
 
-Nicht-Integer und nicht-positive Mengen ablehnen:
+Nicht-Integer- und nicht-positive Mengen ablehnen:
 
 ```php
 $qty = $body['quantity'] ?? null;
@@ -101,19 +101,19 @@ Dies fängt sowohl `"50"` (String) als auch `-1` (negativ) ab.
 | Situation | Status |
 |-----------|--------|
 | Artikel erstellt | 201 |
-| Bestand hinzugefügt / reduziert | 200 |
-| Artikel / Verlauf gefunden | 200 |
+| Lagerbestand hinzugefügt / reduziert | 200 |
+| Artikel / Historie gefunden | 200 |
 | Fehlendes oder leeres Feld | 422 |
 | Ungültiges SKU-Format | 422 |
-| Nicht-Integer oder negative Menge | 422 |
+| Nicht-Integer- oder negative Menge | 422 |
 | Artikel nicht gefunden | 404 |
-| Doppelte SKU | 409 |
-| Unzureichender Bestand | 409 |
+| Doppeltes SKU | 409 |
+| Unzureichender Lagerbestand | 409 |
 
 ---
 
 ## Hinweise
 
-- **Atomische Updates**: `stock = stock + :qty` und `stock = stock - :qty` in SQL verwenden, um den Bestand auch bei gleichzeitigem Zugriff konsistent zu halten.
-- **Prüfpfad**: Jede Bestandsänderung schreibt eine `stock_history`-Zeile für die Rückverfolgbarkeit.
-- **Soft-Constraint**: Die Anwendung prüft den Bestand vor dem Dekrementieren. Für strikte Korrektheit unter Nebenläufigkeit einen `CHECK (stock >= 0)`-Spalten-Constraint in der DB hinzufügen oder Transaktionen mit Zeilensperrung verwenden.
+- **Atomare Updates**: `stock = stock + :qty` und `stock = stock - :qty` in SQL verwenden, um den Saldo auch bei gleichzeitigem Zugriff konsistent zu halten.
+- **Audit-Trail**: Jede Lagerbestandsänderung schreibt eine `stock_history`-Zeile für die Nachverfolgbarkeit.
+- **Soft Constraint**: Die Anwendung prüft den Lagerbestand vor dem Dekrementieren. Für strenge Korrektheit unter Nebenläufigkeit einen `CHECK (stock >= 0)`-Spalten-Constraint in der DB hinzufügen oder Transaktionen mit Zeilensperrung verwenden.

--- a/docs/de/howto/invitation-referral.md
+++ b/docs/de/howto/invitation-referral.md
@@ -1,15 +1,15 @@
 # How-to: Einladungs-/Empfehlungs-API
 
-Diese Anleitung zeigt, wie ein tokenbasiertes Einladungssystem mit Ablauf und einmaliger Verwendung mit NENE2 aufgebaut wird.
+Diese Anleitung zeigt, wie ein tokenbasiertes Einladungssystem mit Ablaufdatum und Einmalnutzung mit NENE2 aufgebaut wird.
 Muster demonstriert durch den **invitelog**-Feldversuch (FT221).
 
 ## Funktionen
 
 - Einladungstoken generieren (`bin2hex(random_bytes(16))` = 32 Kleinbuchstaben-Hex-Zeichen)
 - Ablaufdatum pro Einladung festlegen (ISO 8601)
-- Einladung annehmen/verwenden (einmalig, verfolgt Eingeladenen)
-- Benutzerspezifische Einladungsliste (IDOR: nur Selbst kann ansehen)
-- Status-Lebenszyklus: `pending → used` (Ablauf wird bei Verwendung erkannt)
+- Einladung annehmen/nutzen (einmalig, verfolgt Eingeladenen)
+- Benutzerbezogene Einladungsliste (IDOR: nur Selbst kann einsehen)
+- Status-Lebenszyklus: `pending → used` (abgelaufen bei Nutzung erkannt)
 
 ## Schema
 
@@ -41,14 +41,14 @@ CREATE TABLE IF NOT EXISTS invitations (
 $token = bin2hex(random_bytes(16)); // 32 Kleinbuchstaben-Hex-Zeichen, kryptografisch sicher
 ```
 
-Token-Muster in Pfad-Parametern validiert:
+Token-Muster validiert in Pfadparametern:
 
 ```php
 /** Token: 32 Kleinbuchstaben-Hex-Zeichen (16 zufällige Bytes) */
 public const string TOKEN_PATTERN = '/\A[0-9a-f]{32}\z/';
 ```
 
-## Einmalige Verwendungslogik
+## Einmalnutzungs-Logik
 
 ```php
 /** @return 'ok'|'not_found'|'already_used'|'expired' */
@@ -59,7 +59,7 @@ public function use(string $token, int $inviteeId): string
     if ($inv['status'] === 'used') return 'already_used'; // → 409
     if ($inv['expires_at'] < $this->now()) return 'expired'; // → 409
 
-    // Als verwendet markieren + Eingeladenen erfassen
+    // Als genutzt markieren + Eingeladenen aufzeichnen
     $this->pdo->prepare(
         "UPDATE invitations SET status = 'used', invitee_id = :iid, used_at = :now WHERE token = :token"
     )->execute([...]);
@@ -70,7 +70,7 @@ public function use(string $token, int $inviteeId): string
 
 ## IDOR-Schutz
 
-Der Einladungslisten-Endpunkt erzwingt Selbst-Zugriff:
+Der Einladungslisten-Endpunkt erzwingt Nur-Selbst-Zugriff:
 
 ```php
 $callerUid = $this->uid($req);
@@ -79,12 +79,12 @@ if ($callerUid !== $targetUid) {
 }
 ```
 
-Der `GET /invitations/{token}`-Endpunkt verwendet den Token selbst als Secret — das Wissen des Tokens gewährt Zugriff. Dies ist das „Token = Capability"-Muster.
+Der `GET /invitations/{token}`-Endpunkt verwendet das Token selbst als Secret — das Wissen um das Token gewährt Zugriff. Dies ist das "Token = Fähigkeit"-Muster.
 
 ## Sicherheitsmuster
 
-- **`bin2hex(random_bytes(16))`**: Kryptografisch sicherer 128-Bit-Entropie-Token
-- **Token-Muster-Validierung**: `/\A[0-9a-f]{32}\z/` — blockiert SQL-Injection, überdimensionierte Token
+- **`bin2hex(random_bytes(16))`**: Kryptografisch sicheres Token mit 128-Bit-Entropie
+- **Token-Mustervalidierung**: `/\A[0-9a-f]{32}\z/` — blockiert SQL-Injection, überdimensionierte Token
 - **`ctype_digit()`**: ReDoS-sichere Integer-Validierung für Benutzer-ID-Pfadparameter
-- **ISO-8601-Ablaufvalidierung**: Regex-Muster + lexikografischer Vergleich (UTC)
-- **Ablauf bei Verwendung geprüft**: Nicht vorausgefiltert — Token-Lookup gibt Ergebnis zurück, dann wird Ablauf geprüft
+- **ISO 8601-Ablaufvalidierung**: Regex-Muster + lexikografischer Vergleich (UTC)
+- **Ablauf bei Nutzung geprüft**: Nicht vorgefilter — Token-Suche gibt Ergebnis zurück, dann wird Ablauf geprüft

--- a/docs/de/howto/invitation-referral.md
+++ b/docs/de/howto/invitation-referral.md
@@ -1,0 +1,90 @@
+# How-to: Einladungs-/Empfehlungs-API
+
+Diese Anleitung zeigt, wie ein tokenbasiertes Einladungssystem mit Ablauf und einmaliger Verwendung mit NENE2 aufgebaut wird.
+Muster demonstriert durch den **invitelog**-Feldversuch (FT221).
+
+## Funktionen
+
+- Einladungstoken generieren (`bin2hex(random_bytes(16))` = 32 Kleinbuchstaben-Hex-Zeichen)
+- Ablaufdatum pro Einladung festlegen (ISO 8601)
+- Einladung annehmen/verwenden (einmalig, verfolgt Eingeladenen)
+- Benutzerspezifische Einladungsliste (IDOR: nur Selbst kann ansehen)
+- Status-Lebenszyklus: `pending → used` (Ablauf wird bei Verwendung erkannt)
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS invitations (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    token       TEXT    NOT NULL UNIQUE,
+    inviter_id  INTEGER NOT NULL,
+    invitee_id  INTEGER,
+    status      TEXT    NOT NULL DEFAULT 'pending',
+    expires_at  TEXT    NOT NULL,
+    used_at     TEXT,
+    created_at  TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/invitations` | Benutzer | Einladung erstellen (gibt Token zurück) |
+| `GET` | `/invitations/{token}` | Öffentlich (Token = Secret) | Einladungsstatus abrufen |
+| `POST` | `/invitations/{token}/use` | Benutzer | Einladung annehmen |
+| `GET` | `/users/{userId}/invitations` | Benutzer (nur Selbst) | Eigene Einladungen auflisten |
+
+## Token-Generierung
+
+```php
+$token = bin2hex(random_bytes(16)); // 32 Kleinbuchstaben-Hex-Zeichen, kryptografisch sicher
+```
+
+Token-Muster in Pfad-Parametern validiert:
+
+```php
+/** Token: 32 Kleinbuchstaben-Hex-Zeichen (16 zufällige Bytes) */
+public const string TOKEN_PATTERN = '/\A[0-9a-f]{32}\z/';
+```
+
+## Einmalige Verwendungslogik
+
+```php
+/** @return 'ok'|'not_found'|'already_used'|'expired' */
+public function use(string $token, int $inviteeId): string
+{
+    $inv = $this->findByToken($token);
+    if ($inv === null) return 'not_found';
+    if ($inv['status'] === 'used') return 'already_used'; // → 409
+    if ($inv['expires_at'] < $this->now()) return 'expired'; // → 409
+
+    // Als verwendet markieren + Eingeladenen erfassen
+    $this->pdo->prepare(
+        "UPDATE invitations SET status = 'used', invitee_id = :iid, used_at = :now WHERE token = :token"
+    )->execute([...]);
+
+    return 'ok';
+}
+```
+
+## IDOR-Schutz
+
+Der Einladungslisten-Endpunkt erzwingt Selbst-Zugriff:
+
+```php
+$callerUid = $this->uid($req);
+if ($callerUid !== $targetUid) {
+    return $this->problem(404, 'not-found', 'User not found.');
+}
+```
+
+Der `GET /invitations/{token}`-Endpunkt verwendet den Token selbst als Secret — das Wissen des Tokens gewährt Zugriff. Dies ist das „Token = Capability"-Muster.
+
+## Sicherheitsmuster
+
+- **`bin2hex(random_bytes(16))`**: Kryptografisch sicherer 128-Bit-Entropie-Token
+- **Token-Muster-Validierung**: `/\A[0-9a-f]{32}\z/` — blockiert SQL-Injection, überdimensionierte Token
+- **`ctype_digit()`**: ReDoS-sichere Integer-Validierung für Benutzer-ID-Pfadparameter
+- **ISO-8601-Ablaufvalidierung**: Regex-Muster + lexikografischer Vergleich (UTC)
+- **Ablauf bei Verwendung geprüft**: Nicht vorausgefiltert — Token-Lookup gibt Ergebnis zurück, dann wird Ablauf geprüft

--- a/docs/de/howto/invitation-system.md
+++ b/docs/de/howto/invitation-system.md
@@ -1,0 +1,163 @@
+# How-to: Einladungssystem
+
+> **FT-Referenz**: FT283 (`NENE2-FT/invitelog`) — Einladungscode-System: 32-Zeichen-Hex-Token (128-Bit-Entropie), ISO 8601-Datums-/Zeit-Validierung, pending→used-Status-Lebenszyklus, match-Expression-Statuszuordnung, IDOR-geschützte Einladungsliste, 23 Tests / 47 Assertions PASS.
+
+Diese Anleitung zeigt, wie ein sicheres Einladungssystem aufgebaut wird — Einmaltokens generieren, die bei Einlösung Zugriff gewähren.
+
+## Anwendungsfall
+
+Ein Benutzer erstellt einen Einladungslink (Token) und teilt ihn. Der Empfänger löst das Token ein, um beizutreten. Jedes Token ist für die einmalige Nutzung gedacht und zeitlich begrenzt.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS invitations (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    token       TEXT    NOT NULL UNIQUE,
+    inviter_id  INTEGER NOT NULL,
+    invitee_id  INTEGER,
+    status      TEXT    NOT NULL DEFAULT 'pending',
+    expires_at  TEXT    NOT NULL,
+    used_at     TEXT,
+    created_at  TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_invitations_token ON invitations (token);
+CREATE INDEX IF NOT EXISTS idx_invitations_inviter ON invitations (inviter_id, id DESC);
+```
+
+Wichtige Punkte:
+- `token TEXT UNIQUE` — erzwingt ein Token pro Zeile auf DB-Ebene
+- `invitee_id` ist `NULL` bis zur Einlösung
+- `status` — `'pending'` | `'used'`
+- `used_at` — wird bei Einlösung gesetzt, liefert Audit-Zeitstempel
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/invitations` | `X-User-Id` | Einladung erstellen |
+| `GET` | `/invitations/{token}` | Keine | Einladung nach Token nachschlagen |
+| `POST` | `/invitations/{token}/use` | `X-User-Id` | Einladung einlösen |
+| `GET` | `/users/{userId}/invitations` | `X-User-Id` (nur Selbst) | Eigene Einladungen auflisten |
+
+## Token-Generierung
+
+```php
+/** Token: 32 Kleinbuchstaben-Hex-Zeichen (16 zufällige Bytes = 128-Bit-Entropie) */
+public const string TOKEN_PATTERN = '/\A[0-9a-f]{32}\z/';
+
+$token = bin2hex(random_bytes(16));
+```
+
+`random_bytes(16)` generiert kryptografisch sichere 128-Bit-Zufallsdaten. Die Hex-Darstellung besteht aus 32 Zeichen. Dies ist dasselbe Entropieniveau wie UUID v4 (122 nutzbare Bits).
+
+## expires_at-Validierung
+
+```php
+private const string ISO_DATE_PATTERN = '/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/';
+
+$expiresAt = trim((string) ($body['expires_at'] ?? ''));
+if (!preg_match(self::ISO_DATE_PATTERN, $expiresAt)) {
+    return $this->problem(422, 'validation-failed', 'expires_at must be ISO 8601 datetime.');
+}
+```
+
+Der Regex validiert nur das Format. Die Zeitzonenbehandlung (UTC vs. lokal) liegt in der Verantwortung der Anwendung — die Verwendung einer einheitlichen Zeitzone (z.B. UTC) vermeidet Grenzfälle.
+
+## Status-Lebenszyklus
+
+```
+pending → used (einseitig, irreversibel)
+```
+
+Nur `pending`-Einladungen können eingelöst werden. Einmal genutzt, ist die Einladung dauerhaft verbraucht.
+
+## Einlösung mit match-Expression
+
+```php
+$result = $this->repo->use($token, $uid);
+
+return match ($result) {
+    'not_found'    => $this->problem(404, 'not-found', 'Invitation not found.'),
+    'already_used' => $this->problem(409, 'conflict', 'Invitation already used.'),
+    'expired'      => $this->problem(409, 'conflict', 'Invitation has expired.'),
+    default        => $this->json(['message' => 'Invitation accepted.']),
+};
+```
+
+`match` ist erschöpfend (im Gegensatz zu `switch`): kein Fall-through, alle Fälle müssen behandelt werden. Das Repository gibt einen String-Ergebnistyp zurück; der Handler ordnet ihn sauber HTTP-Antworten zu.
+
+## Repository — Atomare Einlösung
+
+```php
+/** @return 'ok'|'not_found'|'already_used'|'expired' */
+public function use(string $token, int $inviteeId): string
+{
+    $inv = $this->findByToken($token);
+    if ($inv === null) {
+        return 'not_found';
+    }
+    if ($inv['status'] === 'used') {
+        return 'already_used';
+    }
+    // Ablauf prüfen
+    $now = $this->now();
+    if ($inv['expires_at'] < $now) {
+        return 'expired';
+    }
+
+    // Als genutzt markieren
+    $this->pdo->prepare('UPDATE invitations SET status = \'used\', invitee_id = ?, used_at = ? WHERE token = ?')
+        ->execute([$inviteeId, $now, $token]);
+
+    return 'ok';
+}
+```
+
+Die Prüf-dann-Aktualisieren-Sequenz ist eine potenzielle TOCTOU-Race-Condition bei gleichzeitigen Einlösungen desselben Tokens. Für die Produktion eine DB-Level-Transaktion oder `UPDATE WHERE status = 'pending'` verwenden und betroffene Zeilen prüfen.
+
+## IDOR — Einladungsliste
+
+Nur der Einladende kann seine eigenen Einladungen einsehen:
+
+```php
+$callerUid = $this->uid($req);
+if ($callerUid !== $targetUid) {
+    return $this->problem(404, 'not-found', 'User not found.');
+}
+```
+
+Gibt 404 zurück (nicht 403), um zu verbergen, ob der Zielbenutzer existiert.
+
+## X-User-Id-Header-Validierung
+
+```php
+private function uid(ServerRequestInterface $req): ?int
+{
+    $raw = $req->getHeaderLine('X-User-Id');
+    if ($raw === '' || !ctype_digit($raw) || strlen($raw) > 18) {
+        return null;
+    }
+    $id = (int) $raw;
+    return $id > 0 ? $id : null;
+}
+```
+
+`ctype_digit()` ist ReDoS-sicher; `strlen > 18` verhindert PHP-Int-Überlauf auf 64-Bit; `> 0` lehnt Benutzer-ID 0 ab.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Kurze/sequenzielle Token verwenden (4-stelliger PIN) | In Millisekunden per Brute-Force knackbar; mindestens 128-Bit-Zufall verwenden |
+| Token ohne `UNIQUE`-Constraint speichern | Doppeltes Token-Collision verursacht Verwirrung bei der Einlösung |
+| `status === 'pending'` mit losem Vergleich prüfen | PHP `'0' == false`; immer striktes `===` verwenden |
+| Keine Ablaufvalidierung bei Einlösung | Abgelaufene Einladungen bleiben dauerhaft einlösbar |
+| 403 bei Einladungslisten-IDOR-Prüfung zurückgeben | Enthüllt, dass Zielbenutzer existiert; 404 verwenden, um Enumeration zu verbergen |
+| Atomare Einlösung ohne Transaktion | Gleichzeitige Anfragen können beide `pending` sehen und beide erfolgreich sein — Doppeleinlösung |
+| Soft Delete (`deleted_at`) statt Status-Spalte | Status-Spalte ist selbstdokumentierend; `pending`/`used` ist klarer als null/nicht-null |
+| Beliebige Strings als `expires_at` akzeptieren | SQL-injectable wenn nicht parametrisiert; parametrisierte Abfrage + Formatvalidierung verwenden |
+| Status bei abgelaufenem Token auf `pending` zurücksetzen | Ermöglicht die Wiederverwendung von legitim abgelaufenen Tokens |

--- a/docs/de/howto/iso-datetime-validation.md
+++ b/docs/de/howto/iso-datetime-validation.md
@@ -1,0 +1,204 @@
+# How-to: ISO 8601-Datumszeit mit Zeitzone validieren
+
+Das Akzeptieren von benutzerkontrollierten Datums-/Zeit-Strings erfordert sorgfältige Validierung. Diese Anleitung behandelt die zwei wichtigsten Fallstricke: **PHP, das ungültige Zeitzonen-Offsets stillschweigend akzeptiert**, und **String-Vergleich, der über verschiedene Zeitzonen-Offsets hinweg fehlschlägt**.
+
+---
+
+## V::isoDatetime — Format-Validierung
+
+```php
+V::isoDatetime(mixed $raw): ?string
+```
+
+Validiert einen Datums-/Zeit-String im `±HH:MM`-Offset-Format:
+
+```
+✅ 2024-01-15T12:30:00+09:00   (JST)
+✅ 2024-06-01T00:00:00+00:00   (UTC)
+✅ 2024-12-31T23:59:59-05:00   (EST)
+✅ 2026-06-15T09:00:00-14:00   (UTC−14, Howland Island)
+✅ 2026-06-15T09:00:00+14:00   (UTC+14, Kiribati)
+
+❌ 2024-01-15                   (nur Datum, keine Zeit)
+❌ 2024-01-15T12:00:00Z         ('Z'-Suffix, kein ±HH:MM)
+❌ 2024-01-15T12:00:00          (kein Offset)
+❌ 2024-02-30T00:00:00+00:00   (30. Feb. existiert nicht)
+❌ 2024-13-01T00:00:00+00:00   (Monat 13 existiert nicht)
+❌ 2026-06-15T09:00:00+25:00   (ungültiger Offset — überschreitet +14:00)
+```
+
+### Implementierung
+
+```php
+public static function isoDatetime(mixed $raw): ?string
+{
+    if (!is_string($raw)) return null;
+
+    // Strikter Regex: ±HH:MM erforderlich, kein Z, keine bloße Zeit
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-])(\d{2}):(\d{2})$/', $raw, $m)) {
+        return null;
+    }
+
+    // Offset-Bereich validieren: gültige UTC-Offsets sind −14:00 … +14:00.
+    // PHPs DateTimeImmutable akzeptiert +25:00 und ähnliche ungültige Offsets stillschweigend.
+    $tzHours   = (int) $m[2];
+    $tzMinutes = (int) $m[3];
+    if ($tzHours > 14 || $tzMinutes > 59 || ($tzHours === 14 && $tzMinutes > 0)) {
+        return null;
+    }
+
+    // DateTimeImmutable bewahrt die Eingabe-Zeitzone — vermeidet strtotime + date()
+    // die stillschweigend in der lokalen Zeitzone des Servers neu formatieren.
+    $dt = DateTimeImmutable::createFromFormat(DATE_ATOM, $raw);
+    if ($dt === false) return null;
+
+    // Round-Trip-Vergleich fängt Überlaufdaten ab (30. Feb. rollt auf 1. Mär., usw.)
+    return $dt->format(DATE_ATOM) === $raw ? $raw : null;
+}
+```
+
+### Warum nicht `strtotime` + `date()`?
+
+```php
+// ❌ FALSCH — date() verwendet die lokale Zeitzone des Servers
+$ts = strtotime('2024-01-15T12:30:00+09:00');
+$canonical = date('c', $ts);
+// Wenn Server UTC ist: '2024-01-15T03:30:00+00:00' — Zeitzone verloren!
+```
+
+```php
+// ✅ KORREKT — DateTimeImmutable bewahrt den ursprünglichen Offset
+$dt = DateTimeImmutable::createFromFormat(DATE_ATOM, '2024-01-15T12:30:00+09:00');
+$dt->format(DATE_ATOM); // → '2024-01-15T12:30:00+09:00' ✓
+```
+
+---
+
+## V::futureDatetime — Zukunfts-Check über Zeitzonen hinweg
+
+```php
+V::futureDatetime(mixed $raw, string $now): ?string
+```
+
+Gibt den validierten String nur zurück, wenn die Datumszeit **strikt nach** `$now` liegt.
+
+### Der kritische Fehler: String-Vergleich schlägt über Zeitzonen fehl
+
+```php
+$now  = '2026-06-01T10:00:00+00:00';  // UTC 10:00
+
+// JST 18:00 = UTC 09:00 → 1 Stunde in der VERGANGENHEIT
+$pastJst = '2026-06-01T18:00:00+09:00';
+
+// ❌ FALSCH: String-Vergleich sagt Zukunft ("T18" > "T10")
+$pastJst > $now  // → TRUE   ← FALSCH! Es liegt in der Vergangenheit!
+
+// ✅ KORREKT: DateTimeImmutable-Vergleich normalisiert zuerst auf UTC
+$dtObj = new DateTimeImmutable('2026-06-01T18:00:00+09:00');  // UTC 09:00
+$nowObj = new DateTimeImmutable('2026-06-01T10:00:00+00:00');  // UTC 10:00
+$dtObj > $nowObj  // → FALSE ✓ (korrekt in der Vergangenheit)
+```
+
+Der umgekehrte Fehler tritt auch bei negativen Offsets auf:
+
+```php
+// EST 08:00 = UTC 13:00 → 3 Stunden in der ZUKUNFT
+$futureEst = '2026-06-01T08:00:00-05:00';
+
+// ❌ FALSCH: String-Vergleich sagt Vergangenheit ("T08" < "T10")
+$futureEst > $now  // → FALSE  ← FALSCH! Es liegt in der Zukunft!
+
+// ✅ KORREKT: Objekt-Vergleich
+$dtObj = new DateTimeImmutable('2026-06-01T08:00:00-05:00');  // UTC 13:00
+$dtObj > $nowObj  // → TRUE ✓ (korrekt in der Zukunft)
+```
+
+### Implementierung
+
+```php
+public static function futureDatetime(mixed $raw, string $now): ?string
+{
+    $dt = self::isoDatetime($raw);
+    if ($dt === null) return null;
+
+    $dtObj  = DateTimeImmutable::createFromFormat(DATE_ATOM, $dt);
+    $nowObj = DateTimeImmutable::createFromFormat(DATE_ATOM, $now);
+
+    if ($dtObj === false || $nowObj === false) return null;
+
+    // Objekt-Vergleich normalisiert beide auf UTC vor dem Vergleich.
+    return $dtObj > $nowObj ? $dt : null;
+}
+```
+
+### Verwendung in einem Routen-Handler
+
+```php
+private function handleCreate(ServerRequestInterface $request): ResponseInterface
+{
+    // ...
+    $rawRemindAt = $body['remind_at'] ?? null;
+
+    if (!is_string($rawRemindAt)) {
+        return $this->responseFactory->create(
+            ['error' => 'remind_at is required (ISO 8601 with timezone, e.g. 2026-06-01T09:00:00+09:00).'],
+            422,
+        );
+    }
+
+    // DateTimeImmutable für ein zeitzonenerhaltenes "now" verwenden
+    $now      = (new DateTimeImmutable())->format(DATE_ATOM);
+    $remindAt = V::futureDatetime($rawRemindAt, $now);
+
+    if ($remindAt === null) {
+        return $this->responseFactory->create(
+            ['error' => 'remind_at must be a valid ISO 8601 datetime with timezone and must be in the future.'],
+            422,
+        );
+    }
+
+    // $remindAt ist jetzt sicher zu speichern — der exakt eingereichte String, Zeitzone erhalten.
+    $reminder = $this->repository->create($userId, $message, $remindAt, $now);
+    // ...
+}
+```
+
+---
+
+## Zeitzonenerhaltung
+
+`remind_at` (oder jede vom Benutzer eingereichte Datumszeit) genau wie validiert speichern — nicht nach UTC konvertieren.
+
+```php
+// ✅ Den validierten String unverändert speichern
+'INSERT INTO reminders (remind_at, ...) VALUES (:remind_at, ...)'
+// mit :remind_at = '2026-06-15T09:00:00+09:00'
+
+// Unverändert in der API-Antwort zurückgeben
+$reminder->remindAt  // → '2026-06-15T09:00:00+09:00'
+```
+
+Dies respektiert die Absicht des Benutzers und vermeidet implizite Zeitzonenkonvertierung. Wenn die Anwendung UTC-Normalisierung für die SQL-Sortierung/-Vergleich benötigt, eine separate `remind_at_utc`-Spalte hinzufügen, die bei Schreibzeit berechnet wird.
+
+---
+
+## Validierte Eingaben → sicheres SQL
+
+Nach `V::isoDatetime()` / `V::futureDatetime()` ist der String sicher für die Einfügung über eine parametrisierte Abfrage. Niemals rohe Datums-/Zeit-Strings in SQL interpolieren.
+
+```php
+// ✅ Sicher — vorvalidiert, parametrisiert
+$stmt->execute(['remind_at' => $remindAt]);
+
+// ❌ Gefährlich — rohe Benutzereingabe interpoliert
+$sql = "INSERT INTO reminders (remind_at) VALUES ('{$_POST['remind_at']}')";
+```
+
+---
+
+## Verwandte Themen
+
+- FT181 — reminderlog: ISO 8601-Datums-/Zeit-Validierung & Zeitzone-bewusste API  
+- [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339) — Datum und Zeit im Internet  
+- [IANA Time Zone Database](https://www.iana.org/time-zones) — UTC-Offset-Referenz  
+- `docs/howto/json-merge-patch.md` — verwendet ebenfalls isoDatetime für created_at

--- a/docs/de/howto/job-queue-with-retry.md
+++ b/docs/de/howto/job-queue-with-retry.md
@@ -1,0 +1,326 @@
+# How-to: Hintergrund-Job-Queue mit Retry und Idempotenz
+
+> **FT-Referenz**: FT255 (`NENE2-FT/queuelog`) — Hintergrund-Job-Queue mit Retry und Idempotenz
+> **VULN**: FT255 — Schwachstellenanalyse (V-01 bis V-10)
+
+Demonstriert eine persistente Job-Queue auf SQLite-Basis. Jobs haben Prioritätsstufen, durchlaufen eine `pending → running → completed|failed`-Zustandsmaschine und unterstützen automatische Wiederholung bei Fehlschlag mit einem konfigurierbaren Wiederholungslimit. Ein Idempotenz-Key verhindert doppelte Job-Erstellung. Enthält eine vollständige Schwachstellenanalyse.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/jobs` | Job einreihen (optionaler Idempotenz-Key) |
+| `GET`  | `/jobs` | Jobs auflisten (nach Status filterbar) |
+| `GET`  | `/jobs/{id}` | Einen einzelnen Job abrufen |
+| `POST` | `/jobs/claim` | Worker beansprucht nächsten ausstehenden Job |
+| `POST` | `/jobs/{id}/complete` | Worker markiert Job als abgeschlossen |
+| `POST` | `/jobs/{id}/fail` | Worker markiert Job als fehlgeschlagen (mit Retry) |
+
+> **Routen-Reihenfolge**: `/jobs/claim` muss vor `/jobs/{id}` registriert werden, damit das Literalsegment `claim` nicht als Pfadparameter erfasst wird.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS jobs (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    type            TEXT    NOT NULL,
+    payload         TEXT    NOT NULL DEFAULT '{}',
+    priority        INTEGER NOT NULL DEFAULT 0,
+    status          TEXT    NOT NULL DEFAULT 'pending',
+    retry_count     INTEGER NOT NULL DEFAULT 0,
+    max_retries     INTEGER NOT NULL DEFAULT 3,
+    idempotency_key TEXT    UNIQUE,
+    claimed_at      TEXT,
+    worker_id       TEXT,
+    error           TEXT,
+    created_at      TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL
+);
+```
+
+`idempotency_key TEXT UNIQUE` erzwingt Einzigartigkeit auf DB-Ebene. `claimed_at`, `worker_id` und `error` sind nullable — nur gesetzt, wenn ein Job in den Zustand `running` oder `failed` wechselt.
+
+---
+
+## Priorität: numerisches Enum für SQL-Sortierung
+
+```php
+enum JobPriority: int
+{
+    case Low      = 0;
+    case Medium   = 10;
+    case High     = 20;
+    case Critical = 30;
+
+    public static function fromLabel(string $label): self
+    {
+        return match (strtolower($label)) {
+            'low' => self::Low, 'medium' => self::Medium,
+            'high' => self::High, 'critical' => self::Critical,
+            default => throw new \InvalidArgumentException("Unknown priority: {$label}"),
+        };
+    }
+}
+```
+
+Numerische Werte ermöglichen direkte `ORDER BY priority DESC`-Sortierung. Ein String-Enum würde einen `CASE`-Ausdruck oder eine Prioritätsnachschlagetabelle erfordern. Lücken zwischen den Werten (0, 10, 20, 30) erlauben das Einfügen zukünftiger Prioritätsstufen ohne Neunummerierung.
+
+---
+
+## Beanspruchen: Höchste-Priorität-FIFO
+
+```php
+public function claim(string $workerId, string $now): ?Job
+{
+    $rows = $this->executor->fetchAll(
+        "SELECT * FROM jobs WHERE status = 'pending' ORDER BY priority DESC, created_at ASC LIMIT 1",
+        [],
+    );
+    if ($rows === []) {
+        return null;
+    }
+
+    $id = (int) $rows[0]['id'];
+    $this->executor->execute(
+        "UPDATE jobs SET status = 'running', claimed_at = ?, worker_id = ?, updated_at = ? WHERE id = ?",
+        [$now, $workerId, $now, $id],
+    );
+
+    return $this->findById($id);
+}
+```
+
+`ORDER BY priority DESC, created_at ASC` wählt den Job mit der höchsten Priorität und bei gleicher Priorität den ältesten (FIFO). `LIMIT 1` stellt sicher, dass nur ein Job ausgewählt wird.
+
+Diese Beanspruchung ist **nicht-atomar** (siehe V-06). Für ein Einzelworker-Setup ist das akzeptabel. Für gleichzeitige Worker `BEGIN IMMEDIATE` von SQLite + `SELECT … LIMIT 1 FOR UPDATE` (MySQL) oder ein bedingtes UPDATE mit `status = 'pending' AND id = ?` mit `changes()`-Prüfung verwenden.
+
+---
+
+## Retry-Logik: Wiedereinreihen vs. Fehlschlag
+
+```php
+public function fail(int $id, string $error, string $now): ?Job
+{
+    $job = $this->findById($id);
+    if ($job === null || $job->status !== JobStatus::Running) {
+        return null;
+    }
+
+    if ($job->retryCount < $job->maxRetries) {
+        // Wiedereinreihen: auf pending zurücksetzen mit inkrementiertem retry_count
+        $this->executor->execute(
+            "UPDATE jobs SET status = 'pending', retry_count = retry_count + 1,
+             error = ?, claimed_at = NULL, worker_id = NULL, updated_at = ? WHERE id = ?",
+            [$error, $now, $id],
+        );
+    } else {
+        // Erschöpft: dauerhafter Fehlschlag
+        $this->executor->execute(
+            "UPDATE jobs SET status = 'failed', error = ?, updated_at = ? WHERE id = ?",
+            [$error, $now, $id],
+        );
+    }
+
+    return $this->findById($id);
+}
+```
+
+`retry_count < max_retries` prüft, ob der Job noch Wiederholungsversuche hat. Falls ja, kehrt der Job zu `pending` zurück (geleertes `claimed_at`/`worker_id`) und kann erneut beansprucht werden. Falls erschöpft, wechselt er in den terminalen Zustand `failed`.
+
+Bei Wiedereinreihung werden `claimed_at = NULL` und `worker_id = NULL` geleert, sodass der Job dem nächsten Worker, der ihn beansprucht, als frischer ausstehender Job erscheint.
+
+---
+
+## Idempotenz-Key: Deduplizierung bei Erstellung
+
+```php
+if ($idempotencyKey !== null) {
+    $existing = $this->repo->findByIdempotencyKey($idempotencyKey);
+    if ($existing !== null) {
+        return $this->json->create($existing->toArray(), 200);
+    }
+}
+
+$job = $this->repo->create($type, ..., $idempotencyKey, $maxRetries);
+return $this->json->create($job->toArray(), 201);
+```
+
+Wenn ein Job mit demselben `idempotency_key` bereits existiert, wird der vorhandene Job mit `200 OK` zurückgegeben, anstatt ein Duplikat zu erstellen. Ein neuer Job gibt `201 Created` zurück. Der `UNIQUE`-Constraint auf `idempotency_key` bietet einen zweiten Schutz gegen Race Conditions.
+
+---
+
+## Zustandsmaschine
+
+```
+pending ──(claim)──→ running ──(complete)──→ completed (terminal)
+                        │
+                        └──(fail, Retries verbleiben)──→ pending
+                        │
+                        └──(fail, Retries erschöpft)──→ failed (terminal)
+```
+
+`complete()` und `fail()` prüfen beide `status = Running` vor dem Übergang. Ein `null`-Rückgabe von beiden zeigt an, dass der Job nicht gefunden oder nicht im richtigen Zustand war, vom Controller auf `409 Conflict` abgebildet.
+
+---
+
+## VULN — Schwachstellenanalyse (FT255)
+
+### V-01 — Keine Authentifizierung: jeder Aufrufer kann Jobs einreihen, beanspruchen oder abschließen
+
+**Risiko**: Alle Endpunkte sind nicht authentifiziert.
+
+**Auswirkung**: Ein Angreifer kann beliebige Jobs mit beliebigem Typ und Payload einreihen, legitime Jobs beanspruchen, um echte Worker an der Verarbeitung zu hindern, und Jobs als abgeschlossen oder fehlgeschlagen markieren, ohne die tatsächliche Arbeit auszuführen.
+
+**Urteil**: **EXPOSED** — Authentifizierung hinzufügen. Worker-Endpunkte (`/jobs/claim`, `/jobs/{id}/complete`, `/jobs/{id}/fail`) sollten einen Worker-API-Key oder JWT erfordern. Das Einreihen sollte auf authentifizierte Produzenten beschränkt sein.
+
+---
+
+### V-02 — Job-Typ ist ein beliebiger String: keine Allowlist erzwungen
+
+**Risiko**: `type` akzeptiert beliebige nicht-leere Strings. Ein Angreifer kann Jobs mit Typen einreihen, die das System nicht behandelt (z.B. `"DROP TABLE"`, `"shutdown"`, `"admin_task"`).
+
+**Auswirkung**: Wenn der Worker basierend auf `type` dispatcht (z.B. `match($job->type) { ... }`), werden unbekannte Typen stillschweigend übersprungen oder lösen unerwartete Standard-Handler aus.
+
+**Urteil**: **EXPOSED** — `type` gegen eine Allowlist bekannter Job-Typen validieren. `422` für unbekannte Typen zurückgeben. Beispiel:
+
+```php
+if (!in_array($type, ['email', 'pdf', 'sync'], true)) {
+    return $this->problems->create($request, 'validation-failed', '...', 422, ...);
+}
+```
+
+---
+
+### V-03 — Prioritätsmanipulation: Angreifer setzt `critical`-Priorität
+
+**Angriff**: Job mit `"priority": "critical"` einreihen, um alle vorhandenen Jobs zu verdrängen.
+
+```json
+{"type": "spam", "payload": {}, "priority": "critical"}
+```
+
+**Beobachtet**: Die Anfrage gelingt mit `201`. Der Spam-Job befindet sich nun an vorderster Stelle der Queue und wird vor allen legitimen hochprioritären Jobs beansprucht.
+
+**Urteil**: **EXPOSED** — beschränken, wer hohe Prioritätsstufen setzen kann. Produzenten ohne erhöhtes Vertrauen sollten auf `low` oder `medium` beschränkt sein. `critical` von nicht-authentifizierten Aufrufern ablehnen.
+
+---
+
+### V-04 — Worker-ID-Spoofing: jeder kann mit beliebiger worker_id beanspruchen
+
+**Angriff**: Einen Claim mit `"worker_id": "legitimate-worker-1"` einreichen.
+
+**Beobachtet**: Der Claim gelingt — der Job wird der gefälschten Worker-ID zugewiesen. Der legitime Worker kann das nicht von seinen eigenen Claims unterscheiden.
+
+**Urteil**: **EXPOSED** — `worker_id` sollte von einer authentifizierten Identität abgeleitet werden (API-Key → Worker-Name), nicht vom Aufrufer geliefert. Worker-IDs vom Aufrufer niemals vertrauen.
+
+---
+
+### V-05 — Job-Zustandsübernahme: jeder Aufrufer kann jeden laufenden Job abschließen/fehlschlagen lassen
+
+**Angriff**: Einen Job abschließen oder fehlschlagen lassen, den ein anderer Worker beansprucht hat.
+
+```bash
+# Worker A beansprucht Job 1; Angreifer schließt ihn ab, bevor Worker A fertig ist:
+POST /jobs/1/complete
+```
+
+**Beobachtet**: `complete()` prüft nur `status = Running`. Keine Eigentumsprüfung verifiziert, dass der Aufrufer der Worker ist, der den Job beansprucht hat.
+
+**Urteil**: **EXPOSED** — eine `WHERE worker_id = $requestWorkerId`-Bedingung zu `complete()` und `fail()` hinzufügen. `409` zurückgeben, wenn der Worker den Job nicht besitzt.
+
+---
+
+### V-06 — Race Condition beim Claim: nicht-atomares SELECT + UPDATE
+
+**Risiko**: `claim()` führt `SELECT … LIMIT 1` dann `UPDATE … WHERE id = ?` durch. Zwei gleichzeitige Worker könnten denselben Job auswählen, bevor einer davon ihn aktualisiert.
+
+**Angriff**: Zwei Worker sehen Job 1 beide als `pending`, aktualisieren ihn beide auf `running`, führen den Job beide aus. Das zweite Update gewinnt die `worker_id`-Spalte, aber der Job wird zweimal ausgeführt.
+
+**Urteil**: **EXPOSED** — ein atomares Claim-Muster verwenden:
+```sql
+UPDATE jobs SET status='running', worker_id=?, claimed_at=?
+WHERE id = (SELECT id FROM jobs WHERE status='pending' ORDER BY priority DESC, created_at ASC LIMIT 1)
+  AND status = 'pending'
+```
+Dann `changes() = 1` prüfen. Bei SQLite verhindert `BEGIN IMMEDIATE`, dass gleichzeitige Reads dieselbe ausstehende Zeile sehen.
+
+---
+
+### V-07 — Payload-Größe: kein Limit für Job-Payload
+
+**Risiko**: `payload` akzeptiert beliebige JSON-Objekte ohne Größenvalidierung.
+
+**Auswirkung**: Ein mehrmegabyte-großer Payload verbraucht Speicher und Arbeitsspeicher, wenn der Job von Workern abgerufen oder in der Queue aufgelistet wird.
+
+**Urteil**: **EXPOSED** — eine Payload-Größenprüfung hinzufügen (z.B. `strlen($json) > 65536 → 422`). Request-Size-Middleware als äußeres Limit verwenden.
+
+---
+
+### V-08 — SQL-Injection über type oder payload
+
+**Angriff**: SQL-Metazeichen in `type`- oder `payload`-Felder einbetten.
+
+```json
+{"type": "'; DROP TABLE jobs; --", "payload": {}}
+```
+
+**Beobachtet**: Werte werden als parametrisierte `?`-Platzhalter gebunden. Die Injection wird als Literaltext in der Datenbank gespeichert; das SQL wird nie ausgeführt.
+
+**Urteil**: **BLOCKED** — parametrisierte Abfragen verhindern SQL-Injection.
+
+---
+
+### V-09 — Idempotenz-Key-Kollision: Angreifer errät einen legitimen Key
+
+**Angriff**: Den Idempotenz-Key eines legitimen Aufrufers erraten oder enumerieren und denselben Job mit einem anderen Payload einreichen.
+
+**Beobachtet**: Der vorhandene Job wird unverändert zurückgegeben. Die Anfrage des Angreifers erstellt KEINEN neuen Job — der `UNIQUE`-Constraint und die Anwendungsebenenprüfung verhindern beide. Der Angreifer erfährt, dass der Job existiert (via dem zurückgegebenen `200`), kann ihn aber nicht modifizieren.
+
+**Urteil**: **TEILWEISE BLOCKIERT** — doppelte Erstellung ist blockiert. Der Angreifer kann jedoch die Existenz von Jobs durch Sondierung von Idempotenz-Keys enumerieren. Lange zufällige Keys (z.B. UUID v4) verwenden, um Enumeration unpraktikabel zu machen. Die Antwort auf einen übereinstimmenden Key verrät, dass der Job existiert und seinen Status.
+
+---
+
+### V-10 — Fehlermeldungs-Offenlegung in fehlgeschlagenen Jobs
+
+**Risiko**: Worker-Fehlermeldungen von `POST /jobs/{id}/fail` werden in der `error`-Spalte gespeichert und in allen Listen-/Abrufantworten zurückgegeben.
+
+**Auswirkung**: Interne Fehlermeldungen (Stack-Traces, DB-Verbindungsstrings, interne Dateipfade), die von Workern eingereicht werden, sind für jeden Aufrufer von `GET /jobs` sichtbar.
+
+**Urteil**: **EXPOSED** — Fehlermeldungen vor der Speicherung bereinigen (sensible Details entfernen). Sichtbarkeit des `error`-Feldes in Listen-/Abrufantworten auf Admin-Rollen beschränken.
+
+---
+
+## VULN-Zusammenfassung
+
+| # | Schwachstelle | Urteil |
+|---|---------------|--------|
+| V-01 | Keine Authentifizierung auf irgendeinem Endpunkt | EXPOSED |
+| V-02 | Job-Typ: keine Allowlist | EXPOSED |
+| V-03 | Prioritätsmanipulation (kritische Jobs) | EXPOSED |
+| V-04 | Worker-ID-Spoofing | EXPOSED |
+| V-05 | Job-Zustandsübernahme (keine Eigentumsprüfung) | EXPOSED |
+| V-06 | Race Condition beim Claim (nicht-atomar) | EXPOSED |
+| V-07 | Payload-Größe: kein Limit | EXPOSED |
+| V-08 | SQL-Injection über type/payload | BLOCKED |
+| V-09 | Idempotenz-Key-Kollision / Enumeration | TEILWEISE BLOCKIERT |
+| V-10 | Fehlermeldungs-Offenlegung in Liste | EXPOSED |
+
+**Kritische Korrekturen vor Produktionseinsatz**:
+1. **V-01** — Authentifizierung für Produzenten und Worker hinzufügen (separate Authentifizierungsebenen)
+2. **V-02** — `type` gegen eine bekannte Allowlist validieren
+3. **V-03 / V-04 / V-05** — Worker-Identität von authentifizierter Session ableiten; `worker_id`-Eigentumsprüfung hinzufügen
+4. **V-06** — Atomaren Claim verwenden (`UPDATE … WHERE … AND status='pending'` + `changes() = 1`)
+5. **V-10** — Worker-Fehlermeldungen vor Speicherung bereinigen; Sichtbarkeit einschränken
+
+---
+
+## Verwandte Anleitungen
+
+- [`notification-queue.md`](notification-queue.md) — Benachrichtigungs-Queue-API (notiflog FT214)
+- [`idempotency.md`](idempotency.md) — Idempotenz-Key-Muster für POST-Anfragen
+- [`dead-letter-queue.md`](dead-letter-queue.md) — Dead-Letter-Queue mit Retry (deadletterlog FT72)
+- [`transactions.md`](transactions.md) — Queue-Operationen in Transaktionen einwickeln

--- a/docs/de/howto/job-queue.md
+++ b/docs/de/howto/job-queue.md
@@ -1,0 +1,172 @@
+# Hintergrund-Job-Queue mit Retry und Idempotenz
+
+Diese Anleitung behandelt die Implementierung einer persistenten Hintergrund-Job-Queue in NENE2-Anwendungen. Das Muster unterstützt Prioritätswarteschlangen, automatischen Retry mit Rückzählern und idempotente Job-Erstellung.
+
+## Kernkonzepte
+
+Eine Job-Queue entkoppelt Arbeit von HTTP-Request-Zyklen. Der HTTP-Handler reiht einen Job ein und kehrt sofort zurück; ein separater Worker-Prozess beansprucht und führt Jobs aus.
+
+Wichtige Zustände: `pending` → `running` → `completed` oder `failed` (mit automatischem Wiedereinreihen, wenn Wiederholungen verbleiben).
+
+## Schema-Design
+
+```sql
+CREATE TABLE IF NOT EXISTS jobs (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    type            TEXT    NOT NULL,
+    payload         TEXT    NOT NULL DEFAULT '{}',
+    priority        INTEGER NOT NULL DEFAULT 0,
+    status          TEXT    NOT NULL DEFAULT 'pending',
+    retry_count     INTEGER NOT NULL DEFAULT 0,
+    max_retries     INTEGER NOT NULL DEFAULT 3,
+    idempotency_key TEXT    UNIQUE,
+    claimed_at      TEXT,
+    worker_id       TEXT,
+    error           TEXT,
+    created_at      TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL
+);
+```
+
+`idempotency_key UNIQUE` wird auf Datenbankebene erzwungen, nicht nur auf Anwendungsebene. Das verhindert Race Conditions, bei denen zwei gleichzeitige HTTP-Anfragen beide die Anwendungsebenenprüfung bestehen und beide ein INSERT versuchen.
+
+## Job-Lebenszyklus
+
+```
+POST /jobs                  → pending (retry_count=0)
+POST /jobs/claim            → running (worker_id, claimed_at gesetzt)
+POST /jobs/{id}/complete    → completed
+POST /jobs/{id}/fail        → pending (retry_count+1) wenn Retries verbleiben
+                            → failed wenn retry_count >= max_retries
+```
+
+## Retry-Logik
+
+Wenn ein Worker `fail` aufruft, entscheidet das Repository, ob wiedereingereiht oder dauerhaft fehlgeschlagen wird:
+
+```php
+public function fail(int $id, string $error, string $now): ?Job
+{
+    $job = $this->findById($id);
+    if ($job === null || $job->status !== JobStatus::Running) {
+        return null;
+    }
+
+    if ($job->retryCount < $job->maxRetries) {
+        $this->executor->execute(
+            "UPDATE jobs SET status = 'pending', retry_count = retry_count + 1,
+             error = ?, claimed_at = NULL, worker_id = NULL, updated_at = ? WHERE id = ?",
+            [$error, $now, $id],
+        );
+    } else {
+        $this->executor->execute(
+            "UPDATE jobs SET status = 'failed', error = ?, updated_at = ? WHERE id = ?",
+            [$error, $now, $id],
+        );
+    }
+
+    return $this->findById($id);
+}
+```
+
+Das `error`-Feld speichert den **zuletzt aufgetretenen** Fehlergrund auch bei Wiedereinreihung, was Operatoren einen Diagnose-Trail auf dem Job-Datensatz gibt.
+
+## Idempotenz
+
+Einen `idempotency_key` beim Erstellen eines Jobs übergeben, um die Operation für Wiederholungsversuche vom HTTP-Client sicher zu machen:
+
+```http
+POST /jobs
+Content-Type: application/json
+
+{
+  "type": "send-invoice",
+  "payload": {"invoice_id": 42},
+  "idempotency_key": "invoice-42-send-2026-05"
+}
+```
+
+- Erster Aufruf: `201 Created` — Job wird erstellt.
+- Nachfolgende Aufrufe mit demselben Key: `200 OK` — vorhandener Job zurückgegeben, kein Duplikat erstellt.
+
+Der `UNIQUE`-Constraint der Datenbank auf `idempotency_key` ist das Sicherheitsnetz. Zuerst auf Anwendungsebene prüfen, um nicht primär auf Exception-Handling angewiesen zu sein:
+
+```php
+if ($idempotencyKey !== null) {
+    $existing = $this->repo->findByIdempotencyKey($idempotencyKey);
+    if ($existing !== null) {
+        return $this->json->create($existing->toArray(), 200);
+    }
+}
+$job = $this->repo->create(..., $idempotencyKey, $maxRetries);
+return $this->json->create($job->toArray(), 201);
+```
+
+## Prioritätswarteschlange
+
+Jobs werden nach Priorität DESC, dann created_at ASC (FIFO innerhalb einer Ebene) beansprucht:
+
+```sql
+SELECT * FROM jobs
+WHERE status = 'pending'
+ORDER BY priority DESC, created_at ASC
+LIMIT 1
+```
+
+Prioritätsstufen (Integer-Werte gespeichert, menschenlesbare Labels exponiert):
+
+| Label | Wert |
+|-------|------|
+| low | 0 |
+| medium | 10 |
+| high | 20 |
+| critical | 30 |
+
+## Worker-Muster
+
+Worker sind zustandslose Prozesse, die in einer Schleife arbeiten: beanspruchen → ausführen → abschließen oder fehlschlagen lassen.
+
+```
+Schleife:
+  job = POST /jobs/claim { worker_id: "worker-1" }
+  wenn job null ist → schlafen, fortfahren
+
+  versuchen:
+    ausführen(job.type, job.payload)
+    POST /jobs/{job.id}/complete {}
+  fehler abfangen:
+    POST /jobs/{job.id}/fail { error: error.message }
+```
+
+Worker identifizieren sich mit `worker_id`, damit Operatoren sehen können, welcher Worker einen Job hält, und blockierte Worker diagnostizieren können.
+
+## Blockierte-Job-Erkennung
+
+Jobs im `running`-Status mit einem `claimed_at`-Zeitstempel, der älter als ein Schwellenwert ist, sind blockiert (Worker abgestürzt). Ein Wartungsprozess sollte sie erkennen und wiedereinreihen:
+
+```sql
+UPDATE jobs
+SET status = 'pending', retry_count = retry_count + 1,
+    claimed_at = NULL, worker_id = NULL, updated_at = ?
+WHERE status = 'running'
+  AND claimed_at < ?             -- älter als Timeout-Schwellenwert
+  AND retry_count < max_retries
+```
+
+## max_retries=0 für nicht-wiederholbare Jobs
+
+Einige Jobs dürfen nicht wiederholt werden (z.B. Zahlungen, externe Webhooks, bei denen eine Wiederholung Schaden anrichten würde). Bei der Erstellung `max_retries: 0` setzen:
+
+```json
+{ "type": "charge-card", "max_retries": 0, "idempotency_key": "charge-order-99" }
+```
+
+Der erste `fail`-Aufruf überführt den Job sofort in den Zustand `failed`.
+
+## Designentscheidungen
+
+**Warum Retry-Logik im Repository, nicht im Worker?** Die Entscheidung zum Wiedereinreihen ist eine Datenschicht-Invariante (retry_count < max_retries), keine Geschäftslogik. Sie im Repository zu platzieren, hält Worker einfach und verhindert Inkonsistenz durch Worker, die die Prüfung unterschiedlich implementieren.
+
+**Warum `UNIQUE`-Constraint auf idempotency_key auf DB-Ebene?** Anwendungsebenenprüfungen haben Race Conditions unter gleichzeitigen Anfragen. Der DB-Constraint ist der maßgebliche Schutz; die Anwendungsebenenprüfung ist eine Optimierung, um nicht auf Exception-Handling angewiesen zu sein.
+
+**Warum Priorität als Integer speichern?** Ermöglicht das Hinzufügen von Zwischen-Prioritätsstufen später ohne Schema-Änderungen. Das menschenlesbare Label wird abgeleitet, nicht gespeichert.

--- a/docs/de/howto/json-merge-patch.md
+++ b/docs/de/howto/json-merge-patch.md
@@ -1,0 +1,202 @@
+# How-to: JSON Merge Patch & ETag Conflict Detection
+
+**FT178 — patchlog**
+
+Implementierung von PATCH (RFC 7396 JSON Merge Patch) und PUT-Semantik mit
+optimistischem Locking via ETag, Schutz unveränderlicher Felder und V.php-Integration.
+
+---
+
+## Das Problem mit PUT
+
+`PUT` ersetzt die gesamte Ressource. Clients müssen jedes Feld senden, auch die, die sie
+nicht geändert haben. Dies erzeugt:
+
+- **Race Conditions**: gleichzeitige Leser sehen beide Version 1, beide PUT, der letzte
+  gewinnt und verwirft stillschweigend die Änderungen des anderen.
+- **Bandbreitenverschwendung**: volles Payload auch bei Änderungen an einem einzigen Feld.
+- **Berechtigungsverwirrung**: Felder schreiben, die der Client nicht besitzt.
+
+`PATCH` mit **JSON Merge Patch (RFC 7396)** löst die ersten beiden; `ETag` /
+`If-Match` löst die Race Condition für sowohl PATCH als auch PUT.
+
+---
+
+## JSON Merge Patch-Semantik (RFC 7396)
+
+Das Patch-Dokument beschreibt Änderungen nach einer einfachen Regel:
+
+| Patch-Wert | Bedeutung |
+|------------|-----------|
+| `"neuer Wert"` | Feld auf diesen Wert setzen |
+| `null` | Feld zurücksetzen (löschen oder auf Standard zurücksetzen) |
+| *(Schlüssel abwesend)* | Feld unverändert lassen |
+
+```json
+// Dokument vor PATCH:
+{ "title": "Hello", "body": "World", "status": "draft" }
+
+// PATCH-Body:
+{ "title": "Goodbye", "status": null }
+
+// Ergebnis:
+{ "title": "Goodbye", "body": "World", "status": "draft" }
+//                              ^^^^^     ^^^^^^^^^^^^^^
+//                              unverändert  null → auf Standard zurücksetzen
+```
+
+### Unveränderliche Felder
+
+Manche Felder dürfen niemals via PATCH oder PUT modifizierbar sein:
+
+```php
+private const array IMMUTABLE_FIELDS = ['id', 'owner_id', 'version', 'created_at', 'updated_at'];
+
+$violations = array_intersect(array_keys($body), self::IMMUTABLE_FIELDS);
+
+if ($violations !== []) {
+    return $this->responseFactory->create(
+        ['error' => 'Fields are immutable: ' . implode(', ', $violations)],
+        422,
+    );
+}
+```
+
+### Leeres PATCH ist gültig (No-Op)
+
+RFC 7396 §3 erlaubt explizit einen leeren Patch `{}`:
+
+```php
+// Keine Schlüssel in $patch → UPDATE überspringen, aktuelles Dokument unverändert zurückgeben
+if ($patch === []) {
+    return $doc;  // No-Op; Version NICHT inkrementiert
+}
+```
+
+---
+
+## ETag und If-Match für optimistisches Locking
+
+### ETag-Format
+
+```php
+public function etag(): string
+{
+    return sprintf('"doc-%d-%d"', $this->id, $this->version);
+    // z. B. "doc-42-7"
+}
+```
+
+`ETag` bei jeder GET/PATCH/PUT-Antwort zurückgeben:
+
+```php
+return $this->responseFactory->create($doc->toArray())
+    ->withHeader('ETag', $doc->etag());
+```
+
+### Konflikterkennung
+
+```php
+$ifMatch = $request->getHeaderLine('If-Match');
+
+if ($ifMatch !== '' && $ifMatch !== $doc->etag()) {
+    return $this->responseFactory->create(
+        ['error' => 'Version conflict. Fetch the document and retry.'],
+        412,  // Precondition Failed
+    );
+}
+```
+
+**If-Match abwesend**: optimistisches Update ohne Konfliktprüfung (Last-Write-Wins).
+**If-Match vorhanden und übereinstimmend**: sicheres gleichzeitiges Update.
+**If-Match vorhanden aber veraltet**: 412 — Client muss neu laden und es erneut versuchen.
+
+### Versions-Inkrementierung in SQL
+
+Die Datenbank verwenden, um die Version atomar zu inkrementieren:
+
+```sql
+UPDATE documents
+SET title = ?, version = version + 1, updated_at = ?
+WHERE id = ? AND version = ?
+```
+
+Die `WHERE version = ?`-Klausel prüft das optimistische Lock auf DB-Ebene doppelt und
+verhindert, dass ein gleichzeitiger Schreibvorgang zwischen unserem Lesen und Schreiben einsickert.
+
+---
+
+## V.php-Integration
+
+FT178 ist das erste FT, das `Nene2\Validation\V` als geteiltes Utility verwendet:
+
+```php
+// Query-Parameter
+$page  = V::queryInt($params, 'page', 1, PHP_INT_MAX, 1);
+$limit = V::queryInt($params, 'limit', 1, 50, 20);
+
+// Auth-Header
+$ownerId = V::userId($request->getHeaderLine('X-User-Id'));
+
+// String-Felder (mit expliziten Längenbegrenzungen)
+$title = V::str($body['title'] ?? null, 200);
+
+// Enum-Validierung
+$status = V::enum($body['status'] ?? null, DocumentStatus::class);
+```
+
+### Die `?? ''`-Falle für optionale Body-Felder
+
+```php
+// ❌ FALSCH — umgeht V::str null-Rückgabe für überlanges Input
+$text = V::str($body['body'] ?? null, 10000) ?? '';
+
+// ✅ KORREKT — bei Vorhandensein validieren, bei Abwesenheit Standard verwenden
+$rawText = $body['body'] ?? null;
+if ($rawText !== null) {
+    $text = V::str($rawText, 10000);
+    if ($text === null) {
+        return $this->responseFactory->create(['error' => 'body too long'], 422);
+    }
+} else {
+    $text = '';
+}
+```
+
+`V::str(null, ...)` gibt `null` zurück, weil `null` kein String ist.
+`V::str(zu_langer_string, 10000)` gibt ebenfalls `null` zurück.
+`?? ''` zu verwenden kollabiert beide Fälle zu einem leeren String — und akzeptiert stillschweigend die überbreite Eingabe.
+
+---
+
+## Routenparameter-Extraktion
+
+Der NENE2-Router speichert Pfadparameter im `nene2.route.parameters`-Attribut,
+nicht als individuelle Request-Attribute:
+
+```php
+// ❌ FALSCH
+$id = $request->getAttribute('id');  // immer null für Pfadparameter
+
+// ✅ KORREKT
+$id = Router::param($request, 'id');  // liest aus nene2.route.parameters
+```
+
+---
+
+## Angriffs-Checkliste (ATK-01 bis ATK-12)
+
+| # | Test | Erwartung |
+|---|------|-----------|
+| ATK-01 | PATCH `{"id": 999}` | 422 — unveränderliches Feld |
+| ATK-02 | PATCH `{"owner_id": 99}` | 422 — unveränderliches Feld |
+| ATK-03 | PATCH `{"version": 999}` | 422 — unveränderliches Feld |
+| ATK-04 | PATCH `{"title": 42}` (Typ-Verwirrung) | 422 — V::str lehnt Nicht-String ab |
+| ATK-05 | PATCH durch Nicht-Eigentümer | 404 — IDOR-Schutz |
+| ATK-06 | If-Match veraltetes ETag | 412 — optimistischer Lock-Konflikt |
+| ATK-07 | PUT fehlender erforderlicher Titel | 422 |
+| ATK-08 | PATCH leeres `{}` | 200 — gültiger No-Op (RFC 7396 §3) |
+| ATK-09 | PATCH `{"status": null}` | 200 — auf Standard `draft` zurücksetzen |
+| ATK-10 | PATCH `{"status": 2}` (Typ-Verwirrung) | 422 — V::enum lehnt Nicht-String ab |
+| ATK-11 | PATCH `{"__proto__": {...}}` | 200 — unbekannter Schlüssel ignoriert, kein Absturz |
+| ATK-12 | `?limit=999999`, `?page=-1`, 20-stelliger Überlauf | 422 — V::queryInt-Guard |

--- a/docs/de/howto/jwt-authentication.md
+++ b/docs/de/howto/jwt-authentication.md
@@ -1,0 +1,332 @@
+# How-to: JWT-Authentifizierung
+
+> **FT-Referenz**: FT261 (`NENE2-FT/jwtlog`) — JWT-Authentifizierung mit Argon2id-Passwort-Hashing und BearerTokenMiddleware
+> **VULN**: FT261 — Schwachstellenanalyse (V-01 bis V-10)
+
+Ausstellen und Verifizieren von JWT Bearer-Token mit `LocalBearerTokenVerifier` und `BearerTokenMiddleware`.
+
+---
+
+## Schnellstart
+
+```php
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+
+$secret   = getenv('NENE2_LOCAL_JWT_SECRET') ?: throw new \RuntimeException('JWT secret not set');
+$verifier = new LocalBearerTokenVerifier($secret);
+
+// Alle Pfade außer /auth/login schützen
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier: $verifier,
+    excludedPaths: ['/auth/login'],
+);
+
+$app = (new RuntimeApplicationFactory($psr17, $psr17, authMiddleware: $authMiddleware, ...))->create();
+```
+
+---
+
+## Token ausstellen
+
+`LocalBearerTokenVerifier` implementiert sowohl `TokenIssuerInterface` als auch `TokenVerifierInterface` — eine Instanz behandelt beides.
+
+```php
+$now   = time();
+$token = $verifier->issue([
+    'sub'   => $user->id,       // Subjekt: Benutzer-Bezeichner (int oder string)
+    'email' => $user->email,    // benutzerdefinierter Claim
+    'iat'   => $now,            // ausgestellt-am (Unix-Zeitstempel — int)
+    'exp'   => $now + 3600,     // Ablauf (Unix-Zeitstempel — int, für Ablauferzwingung erforderlich)
+]);
+```
+
+**`exp` muss ein Unix-Zeitstempel (int) sein.** Das Übergeben eines Datumsstrings (`'2026-06-01'`) überspringt stillschweigend die Ablauferzwingung, weil `LocalBearerTokenVerifier` `is_int($claims['exp'])` prüft bevor er vergleicht.
+
+---
+
+## Claims in einem Handler lesen
+
+`BearerTokenMiddleware` speichert dekodierte Claims im `nene2.auth.claims`-Request-Attribut nach erfolgreicher Verifizierung:
+
+```php
+private function me(ServerRequestInterface $request): ResponseInterface
+{
+    /** @var array<string, mixed>|null $claims */
+    $claims = $request->getAttribute('nene2.auth.claims');
+
+    // Dieser Null-Guard sollte nicht ausgelöst werden — die Middleware hat bereits fehlende Token abgelehnt.
+    // Trotzdem einfügen für PHPStan Level 8 und defensive Klarheit.
+    if (!is_array($claims)) {
+        return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401);
+    }
+
+    return $this->json->create([
+        'id'    => $claims['sub'],
+        'email' => $claims['email'],
+    ]);
+}
+```
+
+Ebenfalls verfügbar: `$request->getAttribute('nene2.auth.credential_type')` gibt `'bearer'` zurück.
+
+---
+
+## Pfadschutz-Modi
+
+`BearerTokenMiddleware` unterstützt drei Modi — die erste nicht-leere Konfiguration gewinnt:
+
+| Konfiguration | Verhalten | Wann verwenden |
+|---|---|---|
+| `protectedPaths: ['/me', '/admin']` | Nur aufgelistete exakte Pfade sind geschützt | Öffentliche Pfade sind die Mehrheit |
+| `protectedPathPrefixes: ['/api/']` | Pfade, die mit Präfix beginnen, sind geschützt | Gesamten Teilbaum schützen |
+| `excludedPaths: ['/login', '/register']` | Alle Pfade außer aufgelisteten sind geschützt | Öffentliche Pfade sind die Minderheit |
+| (Standard — alle Arrays leer) | Jeder Pfad ist geschützt | Vollständig private API |
+
+```php
+// ✅ /auth/login ist öffentlich, alles andere erfordert ein Token
+new BearerTokenMiddleware($problems, $verifier, excludedPaths: ['/auth/login']);
+
+// ✅ Nur /auth/me ist geschützt
+new BearerTokenMiddleware($problems, $verifier, protectedPaths: ['/auth/me']);
+
+// ✅ Alle /api/-Pfade sind geschützt
+new BearerTokenMiddleware($problems, $verifier, protectedPathPrefixes: ['/api/']);
+
+// ⚠️  protectedPaths: [] ist NICHT "nichts schützen" — es deaktiviert den Allowlist-Modus
+//     und fällt durch zum nächsten Modus (Präfixe, dann Blockliste, dann protect-all).
+```
+
+---
+
+## `alg: none`-Angriff — bereits abgelehnt
+
+`LocalBearerTokenVerifier` prüft, dass `alg == 'HS256'` im Token-Header steht, bevor die Signatur verifiziert wird. Jeder andere Algorithmus — einschließlich `none` — wirft `TokenVerificationException`:
+
+```
+Token algorithm must be HS256.
+```
+
+Dies verhindert den klassischen `alg: none`-Bypass, bei dem ein Angreifer ein headerfreies Token ohne Signatur erstellt. Bei der Implementierung eines benutzerdefinierten Verifiers immer den erwarteten Algorithmus explizit erzwingen.
+
+---
+
+## Fehlerantworten
+
+`BearerTokenMiddleware` gibt 401 Problem Details zurück und fügt automatisch den `WWW-Authenticate`-Header hinzu (RFC 6750):
+
+```
+WWW-Authenticate: Bearer realm="NENE2", error="missing_token", error_description="No Bearer token was provided."
+```
+
+Mögliche `error`-Werte: `missing_token` (kein Header), `invalid_token` (falsches Schema, falsche Signatur, abgelaufen, `nbf` in der Zukunft, fehlerhaft).
+
+---
+
+## Secret-Verwaltung
+
+Das JWT-Secret niemals hardcoden. Aus einer Umgebungsvariablen lesen:
+
+```php
+// ❌ Hardcodiertes Secret — in der Versionskontrolle festgeschrieben
+$verifier = new LocalBearerTokenVerifier('my-secret');
+
+// ✅ Umgebungsvariable
+$secret   = (string) (getenv('NENE2_LOCAL_JWT_SECRET') ?: throw new \RuntimeException('JWT secret not configured'));
+$verifier = new LocalBearerTokenVerifier($secret);
+```
+
+In allen Umgebungen ein starkes zufälliges Secret verwenden. Für die Produktion eine bibliotheksgestützte Implementierung (`firebase/php-jwt`, `lcobucci/jwt`) anstelle von `LocalBearerTokenVerifier` verwenden — das „Local"-Präfix signalisiert seinen Gültigkeitsbereich.
+
+---
+
+## Token-Widerruf
+
+JWT ist zustandslos — es gibt kein eingebautes Widerruf. Token bleiben bis `exp` gültig. Wenn sofortiger Widerruf benötigt wird (z. B. Abmeldung, Passwortänderung):
+
+- Eine Token-Blockliste in Redis mit TTL entsprechend `exp` speichern
+- Oder kurzlebige Token (15 Minuten) mit Refresh-Token verwenden
+
+---
+
+## `authMiddleware`-Parametername
+
+Der benannte Parameter von `RuntimeApplicationFactory` ist `authMiddleware:`, nicht `middlewares:` oder `middleware:`:
+
+```php
+// ❌ Unbekannter benannter Parameter $middlewares
+new RuntimeApplicationFactory($psr17, $psr17, middlewares: [$authMiddleware]);
+
+// ✅ Korrekt
+new RuntimeApplicationFactory($psr17, $psr17, authMiddleware: $authMiddleware);
+```
+
+---
+
+## Code-Review-Checkliste
+
+- [ ] `exp`-Claim ist ein Unix-Zeitstempel (int), kein Datumsstring
+- [ ] JWT-Secret wird aus einer Umgebungsvariablen gelesen (nicht hardcodiert)
+- [ ] `LocalBearerTokenVerifier` wird nicht in der Produktion verwendet (Bibliotheksimplementierung verwenden)
+- [ ] `nene2.auth.claims`-Attribut wird vor der Verwendung auf Null geprüft
+- [ ] `excludedPaths` / `protectedPaths`-Modus-Wahl entspricht der Absicht
+- [ ] Token-Antwort enthält kein `password_hash` oder andere Secrets
+- [ ] `Authorization`-Header wird nicht protokolliert
+- [ ] 401 wird bei Auth-Fehlern zurückgegeben (nicht 404)
+
+---
+
+## Timing-Angriff-Schutz: Dummy-Hash für Benutzer-Enumeration
+
+Wenn eine E-Mail nicht gefunden wird, ist `$user === null`. Ohne einen Dummy-Hash würde der Code
+`password_verify()` vollständig überspringen — was die Antwort für unbekannte E-Mails merklich schneller macht.
+
+```php
+$user = $this->repo->findByEmail(trim($body['email']));
+
+// Immer password_verify ausführen — verhindert zeitbasierte Benutzer-Enumeration.
+$dummyHash   = '$argon2id$v=19$m=65536,t=4,p=1$dummysaltdummysaltdummysalt$dummyhashvaluedummyhashvaluedummyh';
+$hashToCheck = $user !== null ? $user->passwordHash : $dummyHash;
+
+// ⚠️  Reihenfolge wichtig: password_verify() VOR || $user === null
+// Kurzschluss-Auswertung würde password_verify() überspringen wenn $user zuerst geprüft würde.
+if (!password_verify($body['password'], $hashToCheck) || $user === null) {
+    return 401;  // gleicher Fehler unabhängig davon ob E-Mail unbekannt oder Passwort falsch
+}
+```
+
+---
+
+## VULN — Schwachstellenanalyse (FT261)
+
+### V-01 — Kein Brute-Force-Schutz auf Login
+
+**Risiko**: `POST /auth/login` hat kein Rate-Limiting.
+
+**Auswirkung**: Ein Angreifer kann unbegrenzte Login-Versuche einreichen. Argon2id ist absichtlich langsam (~100ms), aber ohne Rate-Limiting können verteilte Anfragen trotzdem Tausende von Passwörtern versuchen.
+
+**Urteil**: **EXPOSED** — `ThrottleMiddleware` auf `POST /auth/login` hinzufügen (z. B. 5 Req/min/IP). 429 mit `Retry-After` zurückgeben.
+
+---
+
+### V-02 — JWT-Secret-Stärke ist umgebungsabhängig
+
+**Risiko**: Wenn `NENE2_LOCAL_JWT_SECRET` leer oder schwach ist (`secret`, `test`), können HMAC-HS256-Token
+durch Brute-Force oder Raten kompromittiert werden. Ein gefälschtes Token mit Admin-Claims würde akzeptiert.
+
+**Urteil**: **EXPOSED** — Fail-closed-Startprüfung:
+```php
+if (strlen($jwtSecret) < 32) {
+    throw new \RuntimeException('NENE2_LOCAL_JWT_SECRET must be at least 32 random bytes.');
+}
+```
+
+---
+
+### V-03 — Kein Token-Widerruf
+
+**Risiko**: Ausgestellte JWTs bleiben bis `exp` gültig. Gestohlene Token oder Token von gelöschten
+Benutzern werden bis zu einer Stunde weiterhin akzeptiert.
+
+**Urteil**: **EXPOSED** — eine Token-Blockliste implementieren (z. B. `revoked_tokens(jti TEXT PK, revoked_at TEXT)`)
+oder kurzlebige Token (15 Min) mit Refresh-Token verwenden.
+
+---
+
+### V-04 — Kein Benutzerregistrierungs-Endpunkt
+
+**Risiko**: Kein `POST /auth/register`-Route existiert. Testbenutzer erfordern direkte DB-Einfügung und umgehen
+die von der Anwendung erzwungene Passwort-Hashing-Richtlinie.
+
+**Urteil**: **DESIGN-LÜCKE** — `POST /auth/register` mit E-Mail-Validierung und Argon2id-Hashing hinzufügen.
+
+---
+
+### V-05 — E-Mail-Groß-/Kleinschreibung: keine Normalisierung
+
+**Risiko**: `WHERE email = ?` ist groß-/kleinschreibungsabhängig. `USER@EXAMPLE.COM` und `user@example.com` sind
+verschiedene Lookups. Zwei Konten mit verschiedenen Groß-/Kleinschreibungen können koexistieren.
+
+**Urteil**: **EXPOSED** — E-Mail bei Registrierung und Login zu Kleinbuchstaben normalisieren (`strtolower()`).
+
+---
+
+### V-06 — Token-TTL: 1 Stunde kann für sensible APIs zu lang sein
+
+**Risiko**: `TOKEN_TTL_SECONDS = 3600`. Gestohlene Token bleiben bis zu einer Stunde gültig.
+
+**Urteil**: **DESIGN-ÜBERLEGUNG** — 1 Stunde ist für die meisten APIs akzeptabel. Für sensible Operationen
+kürzere TTLs (5–15 Min) mit Refresh-Token verwenden. TTL konfigurierbar machen.
+
+---
+
+### V-07 — `password_hash` ist nicht in JWT-Claims
+
+**Risiko**: Der `issue()`-Aufruf enthält nur `sub`, `email`, `iat`, `exp`.
+
+**Urteil**: **SAFE** — Claims sind minimal. Selbst wenn ein Token dekodiert wird (base64, nicht verschlüsselt),
+werden keine sensiblen internen Daten exponiert.
+
+---
+
+### V-08 — SQL-Injection via E-Mail
+
+**Angriff**: `{"email": "' OR '1'='1", "password": "x"}`
+
+**Beobachtet**: `WHERE email = ?` ist eine parametrisierte Abfrage. Die Injection wird als Literal-String
+behandelt. Kein Benutzer wird gefunden; 401 wird zurückgegeben.
+
+**Urteil**: **BLOCKED** — parametrisierte Abfragen verhindern SQL-Injection.
+
+---
+
+### V-09 — Keine E-Mail-Format-Validierung
+
+**Risiko**: Jeder nicht-leere String wird als E-Mail akzeptiert (z. B. `"not-an-email"`).
+
+**Auswirkung**: Verschwendete Argon2id-Berechnung; ungültige Benutzer in der DB; defekte Passwort-Reset-Abläufe.
+
+**Urteil**: **EXPOSED** — `filter_var($email, FILTER_VALIDATE_EMAIL)` bei Registrierung und Login hinzufügen.
+
+---
+
+### V-10 — Kein HTTPS-Erzwingung
+
+**Risiko**: JWT-Token und Passwörter werden im Klartext über HTTP übertragen.
+
+**Urteil**: **EXPOSED** — HTTPS in der Produktion erzwingen. `Strict-Transport-Security`-Header via
+`SecurityHeadersMiddleware` hinzufügen.
+
+---
+
+## VULN-Zusammenfassung
+
+| # | Schwachstelle | Urteil |
+|---|--------------|--------|
+| V-01 | Kein Brute-Force-Schutz | EXPOSED |
+| V-02 | JWT-Secret-Stärke (umgebungsabhängig) | EXPOSED |
+| V-03 | Kein Token-Widerruf | EXPOSED |
+| V-04 | Kein Registrierungsendpunkt | DESIGN-LÜCKE |
+| V-05 | E-Mail-Groß-/Kleinschreibung / keine Normalisierung | EXPOSED |
+| V-06 | Token-TTL 1 Stunde | DESIGN-ÜBERLEGUNG |
+| V-07 | password_hash nicht in JWT-Claims | SAFE |
+| V-08 | SQL-Injection via E-Mail | BLOCKED |
+| V-09 | Keine E-Mail-Format-Validierung | EXPOSED |
+| V-10 | Kein HTTPS-Erzwingung | EXPOSED |
+
+**Kritische Korrekturen vor der Produktion**:
+1. **V-01** — `ThrottleMiddleware` auf `POST /auth/login` (5 Req/min/IP)
+2. **V-02** — Fail-closed-JWT-Secret-Validierung beim Start (`strlen >= 32`)
+3. **V-03** — Token-Widerrufsliste oder kurze TTL + Refresh-Token
+4. **V-05** — E-Mail bei Registrierung und Login zu Kleinbuchstaben normalisieren
+5. **V-09** — `filter_var($email, FILTER_VALIDATE_EMAIL)` bei Registrierung
+
+---
+
+## Verwandte How-tos
+
+- [`pin-verification-lockout.md`](pin-verification-lockout.md) — Brute-Force-Sperre für PIN-Verifizierung
+- [`fixed-window-rate-limiter.md`](fixed-window-rate-limiter.md) — Rate-Limiting-Middleware
+- [`webhook-signature-verification.md`](webhook-signature-verification.md) — HMAC-SHA256 + zeitkonstanter Vergleich
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — explizites DTO-Whitelisting

--- a/docs/de/howto/jwt-authentication.md
+++ b/docs/de/howto/jwt-authentication.md
@@ -3,7 +3,7 @@
 > **FT-Referenz**: FT261 (`NENE2-FT/jwtlog`) — JWT-Authentifizierung mit Argon2id-Passwort-Hashing und BearerTokenMiddleware
 > **VULN**: FT261 — Schwachstellenanalyse (V-01 bis V-10)
 
-Ausstellen und Verifizieren von JWT Bearer-Token mit `LocalBearerTokenVerifier` und `BearerTokenMiddleware`.
+JWT-Bearer-Token mit `LocalBearerTokenVerifier` und `BearerTokenMiddleware` ausstellen und verifizieren.
 
 ---
 
@@ -35,20 +35,20 @@ $app = (new RuntimeApplicationFactory($psr17, $psr17, authMiddleware: $authMiddl
 ```php
 $now   = time();
 $token = $verifier->issue([
-    'sub'   => $user->id,       // Subjekt: Benutzer-Bezeichner (int oder string)
+    'sub'   => $user->id,       // subject: Benutzeridentifier (int oder string)
     'email' => $user->email,    // benutzerdefinierter Claim
-    'iat'   => $now,            // ausgestellt-am (Unix-Zeitstempel — int)
-    'exp'   => $now + 3600,     // Ablauf (Unix-Zeitstempel — int, für Ablauferzwingung erforderlich)
+    'iat'   => $now,            // issued-at (Unix-Zeitstempel — int)
+    'exp'   => $now + 3600,     // Ablauf   (Unix-Zeitstempel — int, erforderlich für Ablaufumsetzung)
 ]);
 ```
 
-**`exp` muss ein Unix-Zeitstempel (int) sein.** Das Übergeben eines Datumsstrings (`'2026-06-01'`) überspringt stillschweigend die Ablauferzwingung, weil `LocalBearerTokenVerifier` `is_int($claims['exp'])` prüft bevor er vergleicht.
+**`exp` muss ein Unix-Zeitstempel (int) sein.** Die Übergabe eines Datum-Strings (`'2026-06-01'`) überspringt stillschweigend die Ablaufumsetzung, da `LocalBearerTokenVerifier` `is_int($claims['exp'])` vor dem Vergleich prüft.
 
 ---
 
 ## Claims in einem Handler lesen
 
-`BearerTokenMiddleware` speichert dekodierte Claims im `nene2.auth.claims`-Request-Attribut nach erfolgreicher Verifizierung:
+`BearerTokenMiddleware` speichert dekodierte Claims im Request-Attribut `nene2.auth.claims` nach erfolgreicher Verifizierung:
 
 ```php
 private function me(ServerRequestInterface $request): ResponseInterface
@@ -56,8 +56,8 @@ private function me(ServerRequestInterface $request): ResponseInterface
     /** @var array<string, mixed>|null $claims */
     $claims = $request->getAttribute('nene2.auth.claims');
 
-    // Dieser Null-Guard sollte nicht ausgelöst werden — die Middleware hat bereits fehlende Token abgelehnt.
-    // Trotzdem einfügen für PHPStan Level 8 und defensive Klarheit.
+    // Diese null-Prüfung sollte nicht auslösen — die Middleware hat fehlende Tokens bereits abgelehnt.
+    // Trotzdem einschließen für PHPStan Level 8 und defensive Klarheit.
     if (!is_array($claims)) {
         return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401);
     }
@@ -73,14 +73,14 @@ Ebenfalls verfügbar: `$request->getAttribute('nene2.auth.credential_type')` gib
 
 ---
 
-## Pfadschutz-Modi
+## Pfadschutzmodi
 
 `BearerTokenMiddleware` unterstützt drei Modi — die erste nicht-leere Konfiguration gewinnt:
 
 | Konfiguration | Verhalten | Wann verwenden |
 |---|---|---|
 | `protectedPaths: ['/me', '/admin']` | Nur aufgelistete exakte Pfade sind geschützt | Öffentliche Pfade sind die Mehrheit |
-| `protectedPathPrefixes: ['/api/']` | Pfade, die mit Präfix beginnen, sind geschützt | Gesamten Teilbaum schützen |
+| `protectedPathPrefixes: ['/api/']` | Pfade, die mit Präfix beginnen, sind geschützt | Einen ganzen Teilbaum schützen |
 | `excludedPaths: ['/login', '/register']` | Alle Pfade außer aufgelisteten sind geschützt | Öffentliche Pfade sind die Minderheit |
 | (Standard — alle Arrays leer) | Jeder Pfad ist geschützt | Vollständig private API |
 
@@ -95,7 +95,7 @@ new BearerTokenMiddleware($problems, $verifier, protectedPaths: ['/auth/me']);
 new BearerTokenMiddleware($problems, $verifier, protectedPathPrefixes: ['/api/']);
 
 // ⚠️  protectedPaths: [] ist NICHT "nichts schützen" — es deaktiviert den Allowlist-Modus
-//     und fällt durch zum nächsten Modus (Präfixe, dann Blockliste, dann protect-all).
+//     und fällt auf den nächsten Modus zurück (Präfixe, dann Blockliste, dann alles schützen).
 ```
 
 ---
@@ -108,7 +108,7 @@ new BearerTokenMiddleware($problems, $verifier, protectedPathPrefixes: ['/api/']
 Token algorithm must be HS256.
 ```
 
-Dies verhindert den klassischen `alg: none`-Bypass, bei dem ein Angreifer ein headerfreies Token ohne Signatur erstellt. Bei der Implementierung eines benutzerdefinierten Verifiers immer den erwarteten Algorithmus explizit erzwingen.
+Das verhindert den klassischen `alg: none`-Bypass, bei dem ein Angreifer ein Header-loses Token ohne Signatur erstellt. Bei der Implementierung eines benutzerdefinierten Verifiers immer den erwarteten Algorithmus explizit erzwingen.
 
 ---
 
@@ -120,16 +120,16 @@ Dies verhindert den klassischen `alg: none`-Bypass, bei dem ein Angreifer ein he
 WWW-Authenticate: Bearer realm="NENE2", error="missing_token", error_description="No Bearer token was provided."
 ```
 
-Mögliche `error`-Werte: `missing_token` (kein Header), `invalid_token` (falsches Schema, falsche Signatur, abgelaufen, `nbf` in der Zukunft, fehlerhaft).
+Mögliche `error`-Werte: `missing_token` (kein Header), `invalid_token` (ungültiges Schema, ungültige Signatur, abgelaufen, `nbf` in der Zukunft, fehlerhaft).
 
 ---
 
 ## Secret-Verwaltung
 
-Das JWT-Secret niemals hardcoden. Aus einer Umgebungsvariablen lesen:
+Das JWT-Secret niemals hartcodieren. Es aus einer Umgebungsvariable lesen:
 
 ```php
-// ❌ Hardcodiertes Secret — in der Versionskontrolle festgeschrieben
+// ❌ Hartcodiertes Secret — in Versionsverwaltung committet
 $verifier = new LocalBearerTokenVerifier('my-secret');
 
 // ✅ Umgebungsvariable
@@ -137,13 +137,13 @@ $secret   = (string) (getenv('NENE2_LOCAL_JWT_SECRET') ?: throw new \RuntimeExce
 $verifier = new LocalBearerTokenVerifier($secret);
 ```
 
-In allen Umgebungen ein starkes zufälliges Secret verwenden. Für die Produktion eine bibliotheksgestützte Implementierung (`firebase/php-jwt`, `lcobucci/jwt`) anstelle von `LocalBearerTokenVerifier` verwenden — das „Local"-Präfix signalisiert seinen Gültigkeitsbereich.
+Ein starkes zufälliges Secret in allen Umgebungen verwenden. Für die Produktion eine bibliotheksbasierte Implementierung (`firebase/php-jwt`, `lcobucci/jwt`) statt `LocalBearerTokenVerifier` verwenden — das Präfix "Local" signalisiert seinen Anwendungsbereich.
 
 ---
 
 ## Token-Widerruf
 
-JWT ist zustandslos — es gibt kein eingebautes Widerruf. Token bleiben bis `exp` gültig. Wenn sofortiger Widerruf benötigt wird (z. B. Abmeldung, Passwortänderung):
+JWT ist zustandslos — es gibt keinen eingebauten Widerruf. Token bleiben bis `exp` gültig. Wenn sofortiger Widerruf benötigt wird (z.B. Logout, Passwortänderung):
 
 - Eine Token-Blockliste in Redis mit TTL entsprechend `exp` speichern
 - Oder kurzlebige Token (15 Minuten) mit Refresh-Token verwenden
@@ -166,21 +166,20 @@ new RuntimeApplicationFactory($psr17, $psr17, authMiddleware: $authMiddleware);
 
 ## Code-Review-Checkliste
 
-- [ ] `exp`-Claim ist ein Unix-Zeitstempel (int), kein Datumsstring
-- [ ] JWT-Secret wird aus einer Umgebungsvariablen gelesen (nicht hardcodiert)
+- [ ] `exp`-Claim ist ein Unix-Zeitstempel (int), kein Datum-String
+- [ ] JWT-Secret wird aus einer Umgebungsvariable gelesen (nicht hartcodiert)
 - [ ] `LocalBearerTokenVerifier` wird nicht in der Produktion verwendet (Bibliotheksimplementierung verwenden)
-- [ ] `nene2.auth.claims`-Attribut wird vor der Verwendung auf Null geprüft
-- [ ] `excludedPaths` / `protectedPaths`-Modus-Wahl entspricht der Absicht
+- [ ] `nene2.auth.claims`-Attribut wird vor Verwendung auf null geprüft
+- [ ] Wahl des Modus `excludedPaths` / `protectedPaths` entspricht der Absicht
 - [ ] Token-Antwort enthält kein `password_hash` oder andere Secrets
 - [ ] `Authorization`-Header wird nicht protokolliert
 - [ ] 401 wird bei Auth-Fehlern zurückgegeben (nicht 404)
 
 ---
 
-## Timing-Angriff-Schutz: Dummy-Hash für Benutzer-Enumeration
+## Timing-Angriffs-Schutz: Dummy-Hash für Benutzer-Enumeration
 
-Wenn eine E-Mail nicht gefunden wird, ist `$user === null`. Ohne einen Dummy-Hash würde der Code
-`password_verify()` vollständig überspringen — was die Antwort für unbekannte E-Mails merklich schneller macht.
+Wenn eine E-Mail nicht gefunden wird, ist `$user === null`. Ohne einen Dummy-Hash würde der Code `password_verify()` vollständig überspringen — was die Antwort für unbekannte E-Mails merklich schneller macht.
 
 ```php
 $user = $this->repo->findByEmail(trim($body['email']));
@@ -190,9 +189,9 @@ $dummyHash   = '$argon2id$v=19$m=65536,t=4,p=1$dummysaltdummysaltdummysalt$dummy
 $hashToCheck = $user !== null ? $user->passwordHash : $dummyHash;
 
 // ⚠️  Reihenfolge wichtig: password_verify() VOR || $user === null
-// Kurzschluss-Auswertung würde password_verify() überspringen wenn $user zuerst geprüft würde.
+// Kurzschlussauswertung würde password_verify() überspringen, wenn $user zuerst geprüft würde.
 if (!password_verify($body['password'], $hashToCheck) || $user === null) {
-    return 401;  // gleicher Fehler unabhängig davon ob E-Mail unbekannt oder Passwort falsch
+    return 401;  // gleicher Fehler, unabhängig davon, ob E-Mail unbekannt oder Passwort falsch ist
 }
 ```
 
@@ -200,22 +199,21 @@ if (!password_verify($body['password'], $hashToCheck) || $user === null) {
 
 ## VULN — Schwachstellenanalyse (FT261)
 
-### V-01 — Kein Brute-Force-Schutz auf Login
+### V-01 — Kein Brute-Force-Schutz bei Login
 
-**Risiko**: `POST /auth/login` hat kein Rate-Limiting.
+**Risiko**: `POST /auth/login` hat keine Rate-Begrenzung.
 
-**Auswirkung**: Ein Angreifer kann unbegrenzte Login-Versuche einreichen. Argon2id ist absichtlich langsam (~100ms), aber ohne Rate-Limiting können verteilte Anfragen trotzdem Tausende von Passwörtern versuchen.
+**Auswirkung**: Ein Angreifer kann unbegrenzte Anmeldeversuche einreichen. Argon2id ist absichtlich langsam (~100ms), aber ohne Rate-Begrenzung können verteilte Anfragen trotzdem Tausende von Passwörtern ausprobieren.
 
-**Urteil**: **EXPOSED** — `ThrottleMiddleware` auf `POST /auth/login` hinzufügen (z. B. 5 Req/min/IP). 429 mit `Retry-After` zurückgeben.
+**Urteil**: **EXPOSED** — `ThrottleMiddleware` auf `POST /auth/login` hinzufügen (z.B. 5 Req/Min/IP). 429 mit `Retry-After` zurückgeben.
 
 ---
 
 ### V-02 — JWT-Secret-Stärke ist umgebungsabhängig
 
-**Risiko**: Wenn `NENE2_LOCAL_JWT_SECRET` leer oder schwach ist (`secret`, `test`), können HMAC-HS256-Token
-durch Brute-Force oder Raten kompromittiert werden. Ein gefälschtes Token mit Admin-Claims würde akzeptiert.
+**Risiko**: Wenn `NENE2_LOCAL_JWT_SECRET` leer oder schwach ist (`secret`, `test`), können HMAC-HS256-Token per Brute-Force geknackt oder erraten werden. Ein gefälschtes Token mit Admin-Claims würde akzeptiert.
 
-**Urteil**: **EXPOSED** — Fail-closed-Startprüfung:
+**Urteil**: **EXPOSED** — fail-closed Startup-Prüfung:
 ```php
 if (strlen($jwtSecret) < 32) {
     throw new \RuntimeException('NENE2_LOCAL_JWT_SECRET must be at least 32 random bytes.');
@@ -226,18 +224,15 @@ if (strlen($jwtSecret) < 32) {
 
 ### V-03 — Kein Token-Widerruf
 
-**Risiko**: Ausgestellte JWTs bleiben bis `exp` gültig. Gestohlene Token oder Token von gelöschten
-Benutzern werden bis zu einer Stunde weiterhin akzeptiert.
+**Risiko**: Ausgestellte JWTs bleiben bis `exp` gültig. Gestohlene Token oder Token von gelöschten Benutzern werden bis zu 1 Stunde lang akzeptiert.
 
-**Urteil**: **EXPOSED** — eine Token-Blockliste implementieren (z. B. `revoked_tokens(jti TEXT PK, revoked_at TEXT)`)
-oder kurzlebige Token (15 Min) mit Refresh-Token verwenden.
+**Urteil**: **EXPOSED** — eine Token-Blockliste implementieren (z.B. `revoked_tokens(jti TEXT PK, revoked_at TEXT)`) oder kurzlebige Token (15 Min) mit Refresh-Token verwenden.
 
 ---
 
 ### V-04 — Kein Benutzerregistrierungs-Endpunkt
 
-**Risiko**: Kein `POST /auth/register`-Route existiert. Testbenutzer erfordern direkte DB-Einfügung und umgehen
-die von der Anwendung erzwungene Passwort-Hashing-Richtlinie.
+**Risiko**: Keine `POST /auth/register`-Route vorhanden. Testbenutzer erfordern direkte DB-Einfügung, was die Passwort-Hashing-Richtlinie der Anwendung umgeht.
 
 **Urteil**: **DESIGN-LÜCKE** — `POST /auth/register` mit E-Mail-Validierung und Argon2id-Hashing hinzufügen.
 
@@ -245,19 +240,17 @@ die von der Anwendung erzwungene Passwort-Hashing-Richtlinie.
 
 ### V-05 — E-Mail-Groß-/Kleinschreibung: keine Normalisierung
 
-**Risiko**: `WHERE email = ?` ist groß-/kleinschreibungsabhängig. `USER@EXAMPLE.COM` und `user@example.com` sind
-verschiedene Lookups. Zwei Konten mit verschiedenen Groß-/Kleinschreibungen können koexistieren.
+**Risiko**: `WHERE email = ?` ist case-sensitiv. `USER@EXAMPLE.COM` und `user@example.com` sind verschiedene Suchvorgänge. Zwei Konten mit unterschiedlicher Groß-/Kleinschreibung können koexistieren.
 
-**Urteil**: **EXPOSED** — E-Mail bei Registrierung und Login zu Kleinbuchstaben normalisieren (`strtolower()`).
+**Urteil**: **EXPOSED** — E-Mail bei Registrierung und Login in Kleinbuchstaben normalisieren (`strtolower()`).
 
 ---
 
-### V-06 — Token-TTL: 1 Stunde kann für sensible APIs zu lang sein
+### V-06 — Token-TTL: 1 Stunde ist möglicherweise zu lang für sensible APIs
 
 **Risiko**: `TOKEN_TTL_SECONDS = 3600`. Gestohlene Token bleiben bis zu einer Stunde gültig.
 
-**Urteil**: **DESIGN-ÜBERLEGUNG** — 1 Stunde ist für die meisten APIs akzeptabel. Für sensible Operationen
-kürzere TTLs (5–15 Min) mit Refresh-Token verwenden. TTL konfigurierbar machen.
+**Urteil**: **DESIGN-ERWÄGUNG** — 1 Stunde ist für die meisten APIs akzeptabel. Für sensible Operationen kürzere TTLs (5–15 Min) mit Refresh-Token verwenden. TTL konfigurierbar machen.
 
 ---
 
@@ -265,17 +258,15 @@ kürzere TTLs (5–15 Min) mit Refresh-Token verwenden. TTL konfigurierbar mache
 
 **Risiko**: Der `issue()`-Aufruf enthält nur `sub`, `email`, `iat`, `exp`.
 
-**Urteil**: **SAFE** — Claims sind minimal. Selbst wenn ein Token dekodiert wird (base64, nicht verschlüsselt),
-werden keine sensiblen internen Daten exponiert.
+**Urteil**: **SAFE** — Claims sind minimal. Selbst wenn ein Token dekodiert wird (base64, nicht verschlüsselt), werden keine sensiblen internen Daten exponiert.
 
 ---
 
-### V-08 — SQL-Injection via E-Mail
+### V-08 — SQL-Injection über E-Mail
 
 **Angriff**: `{"email": "' OR '1'='1", "password": "x"}`
 
-**Beobachtet**: `WHERE email = ?` ist eine parametrisierte Abfrage. Die Injection wird als Literal-String
-behandelt. Kein Benutzer wird gefunden; 401 wird zurückgegeben.
+**Beobachtet**: `WHERE email = ?` ist eine parametrisierte Abfrage. Die Injection wird als Literalstring behandelt. Kein Benutzer wird gefunden; 401 wird zurückgegeben.
 
 **Urteil**: **BLOCKED** — parametrisierte Abfragen verhindern SQL-Injection.
 
@@ -283,50 +274,49 @@ behandelt. Kein Benutzer wird gefunden; 401 wird zurückgegeben.
 
 ### V-09 — Keine E-Mail-Format-Validierung
 
-**Risiko**: Jeder nicht-leere String wird als E-Mail akzeptiert (z. B. `"not-an-email"`).
+**Risiko**: Beliebige nicht-leere Strings werden als E-Mail akzeptiert (z.B. `"not-an-email"`).
 
-**Auswirkung**: Verschwendete Argon2id-Berechnung; ungültige Benutzer in der DB; defekte Passwort-Reset-Abläufe.
+**Auswirkung**: Verschwendete Argon2id-Berechnung; ungültige Benutzer in der DB; unterbrochene Passwort-Reset-Flows.
 
 **Urteil**: **EXPOSED** — `filter_var($email, FILTER_VALIDATE_EMAIL)` bei Registrierung und Login hinzufügen.
 
 ---
 
-### V-10 — Kein HTTPS-Erzwingung
+### V-10 — Keine HTTPS-Erzwingung
 
 **Risiko**: JWT-Token und Passwörter werden im Klartext über HTTP übertragen.
 
-**Urteil**: **EXPOSED** — HTTPS in der Produktion erzwingen. `Strict-Transport-Security`-Header via
-`SecurityHeadersMiddleware` hinzufügen.
+**Urteil**: **EXPOSED** — HTTPS in der Produktion erzwingen. `Strict-Transport-Security`-Header über `SecurityHeadersMiddleware` hinzufügen.
 
 ---
 
 ## VULN-Zusammenfassung
 
 | # | Schwachstelle | Urteil |
-|---|--------------|--------|
+|---|---------------|--------|
 | V-01 | Kein Brute-Force-Schutz | EXPOSED |
 | V-02 | JWT-Secret-Stärke (umgebungsabhängig) | EXPOSED |
 | V-03 | Kein Token-Widerruf | EXPOSED |
-| V-04 | Kein Registrierungsendpunkt | DESIGN-LÜCKE |
+| V-04 | Kein Registrierungs-Endpunkt | DESIGN-LÜCKE |
 | V-05 | E-Mail-Groß-/Kleinschreibung / keine Normalisierung | EXPOSED |
-| V-06 | Token-TTL 1 Stunde | DESIGN-ÜBERLEGUNG |
+| V-06 | Token-TTL 1 Stunde | DESIGN-ERWÄGUNG |
 | V-07 | password_hash nicht in JWT-Claims | SAFE |
-| V-08 | SQL-Injection via E-Mail | BLOCKED |
+| V-08 | SQL-Injection über E-Mail | BLOCKED |
 | V-09 | Keine E-Mail-Format-Validierung | EXPOSED |
-| V-10 | Kein HTTPS-Erzwingung | EXPOSED |
+| V-10 | Keine HTTPS-Erzwingung | EXPOSED |
 
-**Kritische Korrekturen vor der Produktion**:
-1. **V-01** — `ThrottleMiddleware` auf `POST /auth/login` (5 Req/min/IP)
-2. **V-02** — Fail-closed-JWT-Secret-Validierung beim Start (`strlen >= 32`)
+**Kritische Korrekturen vor Produktionseinsatz**:
+1. **V-01** — `ThrottleMiddleware` auf `POST /auth/login` (5 Req/Min/IP)
+2. **V-02** — Fail-closed JWT-Secret-Validierung beim Start (`strlen >= 32`)
 3. **V-03** — Token-Widerrufsliste oder kurze TTL + Refresh-Token
-4. **V-05** — E-Mail bei Registrierung und Login zu Kleinbuchstaben normalisieren
+4. **V-05** — E-Mail bei Registrierung und Login in Kleinbuchstaben normalisieren
 5. **V-09** — `filter_var($email, FILTER_VALIDATE_EMAIL)` bei Registrierung
 
 ---
 
-## Verwandte How-tos
+## Verwandte Anleitungen
 
-- [`pin-verification-lockout.md`](pin-verification-lockout.md) — Brute-Force-Sperre für PIN-Verifizierung
+- [`pin-verification-lockout.md`](pin-verification-lockout.md) — Brute-Force-Sperrung für PIN-Verifizierung
 - [`fixed-window-rate-limiter.md`](fixed-window-rate-limiter.md) — Rate-Limiting-Middleware
 - [`webhook-signature-verification.md`](webhook-signature-verification.md) — HMAC-SHA256 + zeitkonstanter Vergleich
 - [`mass-assignment-defence.md`](mass-assignment-defence.md) — explizites DTO-Whitelisting

--- a/docs/de/howto/jwt-tenant-isolation.md
+++ b/docs/de/howto/jwt-tenant-isolation.md
@@ -1,0 +1,199 @@
+# How-to: JWT-Multi-Mandanten-Isolation
+
+> **FT-Referenz**: FT342 (`NENE2-FT/tenantlog`) — Multi-Mandanten-Notiz-API mit JWT-Bearer-Authentifizierung, tenant_id in Token-Claims eingebettet, strenge Abfrageeinschränkung pro Mandant, mandantenübergreifendes IDOR mit 404 blockiert, tenant_id wird niemals in Antworten exponiert, 13 Tests / 30+ Assertions PASS.
+
+Diese Anleitung zeigt, wie JWT-Token verwendet werden, um `tenant_id` als Claim zu tragen, alle Abfragen auf den authentifizierten Mandanten zu beschränken und mandantenübergreifenden Datenzugriff zu verhindern.
+
+## Schema
+
+```sql
+CREATE TABLE tenants (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE users (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id     INTEGER NOT NULL REFERENCES tenants(id),
+    email         TEXT    NOT NULL UNIQUE,
+    password_hash TEXT    NOT NULL,
+    created_at    TEXT    NOT NULL
+);
+
+CREATE TABLE notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id  INTEGER NOT NULL REFERENCES tenants(id),
+    user_id    INTEGER NOT NULL REFERENCES users(id),
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL
+);
+```
+
+## Authentifizierung
+
+```
+POST /auth/login  →  Bearer Token (JWT)
+Alle anderen Endpunkte → Authorization: Bearer <token>
+```
+
+### Login
+
+```php
+POST /auth/login
+{"email": "alice@acme.com", "password": "password"}
+→ 200  {"token": "eyJhbGci..."}
+
+// Falsche Anmeldedaten oder unbekannte E-Mail
+→ 401  {"type": ".../invalid-credentials", "detail": "Invalid email or password"}
+// Beide Fehler geben dieselbe Meldung zurück (Benutzer-Enumerations-Prävention)
+```
+
+### JWT-Claims
+
+```php
+// Token-Payload (dekodiert)
+{
+  "sub": 1,           // user_id
+  "tenant_id": 1,     // Mandant, zu dem der Benutzer gehört
+  "exp": 1748427600
+}
+```
+
+Der `tenant_id`-Claim ist die maßgebliche Quelle der Mandantenidentität — `tenant_id` aus dem Request-Body oder Headers niemals vertrauen.
+
+### Verifizierung
+
+```php
+$verifier = new LocalBearerTokenVerifier($secret);
+$claims   = $verifier->verify($token);
+// $claims['tenant_id'] ist die vertrauenswürdige Mandanteneinschränkung
+```
+
+Ein manipuliertes Token (ungültige Signatur) → 401.
+
+## Mandantenbezogene Endpunkte
+
+Alle Notizoperationen erfordern ein gültiges Bearer-Token. Die `tenant_id` wird aus den verifizierten JWT-Claims extrahiert.
+
+### Notiz erstellen
+
+```php
+POST /notes
+Authorization: Bearer <alice_token>
+{"title": "Alice Note", "body": "Acme content"}
+→ 201
+{
+  "id": 1,
+  "title": "Alice Note",
+  "body": "Acme content",
+  "created_at": "..."
+  // tenant_id wird NICHT zurückgegeben — wird niemals an Client durchgesickert
+}
+
+// Kein Token → 401
+// Ungültiges Token → 401
+```
+
+**`tenant_id` wird immer aus dem JWT-Claim genommen, nicht aus dem Request-Body.**
+
+### Notizen auflisten
+
+```php
+GET /notes
+Authorization: Bearer <alice_token>
+→ 200  [{"id": 1, "title": "Alice Note", ...}]
+
+// Bobs Token sieht nur Bobs Notizen — Alices Notizen erscheinen niemals
+GET /notes
+Authorization: Bearer <bob_token>
+→ 200  [{"id": 2, "title": "Bob Note", ...}]
+```
+
+```sql
+SELECT * FROM notes WHERE tenant_id = ? ORDER BY created_at DESC
+-- tenant_id aus JWT-Claims gebunden, niemals aus der Anfrage
+```
+
+### Notiz abrufen (IDOR-Prävention)
+
+```php
+// Alices Notiz
+GET /notes/1
+Authorization: Bearer <alice_token>
+→ 200  {"id": 1, "title": "Alice Note", ...}
+
+// Bob versucht, auf Alices Notiz zuzugreifen (Notiz-ID 1 gehört zu Mandant 1)
+GET /notes/1
+Authorization: Bearer <bob_token>
+→ 404  // NICHT 403 — verhindert mandantenübergreifende Existenz-Enumeration
+```
+
+**404 zurückgeben, nicht 403, für mandantenübergreifenden Zugriff.** Eine 403 enthüllt, dass die Ressource in einem anderen Mandanten existiert.
+
+### Notiz löschen
+
+```php
+DELETE /notes/1
+Authorization: Bearer <alice_token>
+→ 204
+
+// Mandantenübergreifendes Löschen
+DELETE /notes/1
+Authorization: Bearer <bob_token>
+→ 404  // Notiz bleibt intakt; Bobs Token kann sie nicht erreichen
+```
+
+## Implementierungsmuster
+
+```php
+// Middleware extrahiert und verifiziert JWT
+$claims = $verifier->verify($bearerToken);
+$request = $request->withAttribute('tenant_id', $claims['tenant_id']);
+$request = $request->withAttribute('user_id', $claims['sub']);
+
+// Controller liest aus Request-Attributen (niemals aus Body)
+$tenantId = (int) $request->getAttribute('tenant_id');
+
+// Repository beschränkt immer auf Mandant
+public function findById(int $id, int $tenantId): ?array
+{
+    $stmt = $this->db->prepare(
+        'SELECT id, title, body, created_at FROM notes WHERE id = ? AND tenant_id = ?'
+    );
+    $stmt->execute([$id, $tenantId]);
+    return $stmt->fetch() ?: null;
+}
+
+// Null-Rückgabe → 404-Antwort (niemals 403)
+if ($note === null) {
+    return $this->json->create(['error' => 'Not found'], 404);
+}
+```
+
+## Token-Manipulations-Ablehnung
+
+```php
+// Angreifer erstellt manuell ein Token mit einer anderen tenant_id
+$fakeToken = 'eyJhbGciOiJIUzI1NiJ9.tampered.invalidsignature';
+
+GET /notes/1
+Authorization: Bearer $fakeToken
+→ 401  // Signaturverifizierung schlägt fehl
+```
+
+Der Server lehnt jedes Token ab, dessen HMAC-SHA256-Signatur nicht mit dem Server-Secret übereinstimmt.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `tenant_id` aus Request-Body oder Query-Parametern lesen | Angreifer setzt `tenant_id=2`, um auf Daten eines anderen Mandanten zuzugreifen |
+| 403 bei mandantenübergreifendem Zugriff zurückgeben | Bestätigt, dass die Ressource in einem anderen Mandanten existiert — Informationsleck |
+| `tenant_id` in Notizantworten einschließen | Exponiert interne Mandantentopologie; für den Client nicht notwendig |
+| `AND tenant_id = ?` in Abfragen weglassen | Mandantenübergreifendes Leck — Angreifer mit gültigem Token sieht Daten aller Mandanten |
+| JWT-Secret in Konfiguration neben Daten speichern | Secret-Kompromittierung ermöglicht das Fälschen von Tokens für beliebige Mandanten |
+| `tenant_id` aus `X-Tenant-Id`-Header vertrauen | Header kann von jedem Client gesetzt werden; nur verifizierten JWT-Claims vertrauen |

--- a/docs/de/howto/leaderboard-ranking-api.md
+++ b/docs/de/howto/leaderboard-ranking-api.md
@@ -1,0 +1,277 @@
+# How-to: Bestenlisten-Ranking-API
+
+> **FT-Referenz**: FT332 (`NENE2-FT/ranklog`) — Bestenliste mit persönlicher Bestleistungsverfolgung pro Benutzer, absteigendes Ranking, eigene Rang-Abfrage, Score-Löschung und ATK-Cracker-Mindset-Angriffsbewertung, 19 Tests / 50+ Assertions PASS.
+
+Diese Anleitung zeigt, wie ein Multi-Bestenlisten-Rangsystem aufgebaut wird, das nur die persönliche Bestleistung pro Benutzer speichert, Rangpositionen zurückgibt und Self-Service-Score-Löschung ermöglicht.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL
+);
+
+CREATE TABLE leaderboards (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL UNIQUE
+);
+
+CREATE TABLE scores (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    leaderboard_id INTEGER NOT NULL REFERENCES leaderboards(id),
+    user_id        INTEGER NOT NULL REFERENCES users(id),
+    score          INTEGER NOT NULL,
+    submitted_at   TEXT    NOT NULL,
+    UNIQUE(leaderboard_id, user_id)   -- ein Bestleistungs-Score pro Benutzer pro Bestenliste
+);
+```
+
+`UNIQUE(leaderboard_id, user_id)` erzwingt einen Eintrag pro Benutzer — neue Einreichungen überschreiben nur, wenn der Score höher ist.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/leaderboards` | Bestenliste erstellen |
+| `POST` | `/leaderboards/{id}/scores` | Score einreichen |
+| `GET`  | `/leaderboards/{id}/rankings` | Vollständiges Ranking abrufen (absteigend) |
+| `GET`  | `/leaderboards/{id}/rankings/me` | Eigenen Rang abrufen |
+| `DELETE` | `/leaderboards/{id}/scores/{userId}` | Eigenen Score löschen |
+
+## Bestenliste erstellen
+
+```php
+POST /leaderboards
+{"name": "Global"}
+→ 201  {"id": 1, "name": "Global"}
+
+POST /leaderboards  {"name": ""}
+→ 422  // name erforderlich
+```
+
+## Score einreichen — Nur persönliche Bestleistung
+
+```php
+// Erste Einreichung
+POST /leaderboards/1/scores
+{"user_id": 1, "score": 1000}
+→ 200  {"new_best": true}
+
+// Besserer Score
+POST /leaderboards/1/scores
+{"user_id": 1, "score": 1200}
+→ 200  {"new_best": true}
+
+// Schlechterer Score — gespeicherter Wert wird NICHT aktualisiert
+POST /leaderboards/1/scores
+{"user_id": 1, "score": 800}
+→ 200  {"new_best": false}
+```
+
+Nur die persönliche Bestleistung wird gespeichert. Eine niedrigere Einreichung wird anerkannt, aber verworfen.
+
+```php
+// Negative Scores sind gültig (Strafen, Golf-Punktwertung usw.)
+POST /leaderboards/1/scores  {"user_id": 1, "score": -100}
+→ 200  {"new_best": true}
+
+// Fehler
+POST /leaderboards/1/scores  {"user_id": 9999, "score": 100}
+→ 404  // unbekannter Benutzer
+
+POST /leaderboards/9999/scores  {"user_id": 1, "score": 100}
+→ 404  // unbekannte Bestenliste
+
+POST /leaderboards/1/scores  {"user_id": 1}
+→ 422  // score-Feld fehlt
+```
+
+## Rankings abrufen
+
+```php
+GET /leaderboards/1/rankings
+→ 200
+{
+  "count": 3,
+  "items": [
+    {"rank": 1, "user_id": 2, "score": 500},
+    {"rank": 2, "user_id": 3, "score": 400},
+    {"rank": 3, "user_id": 1, "score": 300}
+  ]
+}
+
+// Auf Top N begrenzen
+GET /leaderboards/1/rankings?limit=2
+→ 200  {"count": 2, "items": [...]}  // nur Top 2
+```
+
+Rankings sind nach Score absteigend sortiert. `rank` ist 1-basiert.
+
+### SQL
+
+```sql
+SELECT
+  RANK() OVER (ORDER BY score DESC) AS rank,
+  user_id,
+  score
+FROM scores
+WHERE leaderboard_id = ?
+ORDER BY score DESC
+LIMIT ?
+```
+
+## Eigenen Rang abrufen
+
+```php
+GET /leaderboards/1/rankings/me
+X-User-Id: 1
+
+→ 200  {"rank": 2, "score": 300}
+
+// Noch nicht auf dieser Bestenliste
+GET /leaderboards/1/rankings/me
+X-User-Id: 99
+→ 404
+
+// Fehlender Akteur-Header
+GET /leaderboards/1/rankings/me
+→ 400
+```
+
+`X-User-Id`-Header identifiziert den anfragenden Benutzer. Fehlender oder ungültiger Header → 400.
+
+## Score löschen
+
+```php
+DELETE /leaderboards/1/scores/1
+X-User-Id: 1
+→ 204  (kein Body)
+
+// Bereits gelöscht / nie eingereicht
+DELETE /leaderboards/1/scores/1
+X-User-Id: 1
+→ 404
+```
+
+Nach der Löschung gibt `GET /rankings/me` für diesen Benutzer 404 zurück.
+
+---
+
+## ATK Assessment — Cracker-Mindset Attack Test
+
+### ATK-01 — Score für einen anderen Benutzer einreichen (Body-IDOR) ⚠️ EXPOSED
+
+**Angriff**: Angreifer sendet `{"user_id": 2, "score": 999999}`, um einen anderen Benutzer an die Spitze der Bestenliste zu schieben.
+**Ergebnis**: EXPOSED — Der Endpunkt verwendet `user_id` aus dem Request-Body, ohne zu verifizieren, dass der Akteur übereinstimmt. Eine Autorisierungsprüfung (`X-User-Id == body.user_id`) verhindert dies. Für Wettbewerbs-Bestenlisten `user_id` aus `X-User-Id` ableiten und das Body-Feld vollständig ignorieren.
+
+---
+
+### ATK-02 — Score eines anderen Benutzers löschen (IDOR auf DELETE) ✅ SAFE
+
+**Angriff**: Angreifer sendet `DELETE /leaderboards/1/scores/2` mit `X-User-Id: 1`, um den Score eines anderen Benutzers zu löschen.
+**Ergebnis**: SAFE — `DELETE /scores/{userId}` beschränkt die Suche auf den authentifizierten Akteur. Der Pfad `userId` wird gegen `X-User-Id` abgeglichen; eine Nichtübereinstimmung gibt 404 zurück. Nur Admin-Rollen sollten beliebige Benutzer-Scores löschen können.
+
+---
+
+### ATK-03 — Score-Integer-Überlauf 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `{"score": 9999999999999999999999}`, um den gespeicherten Integer zu überlaufen.
+**Ergebnis**: BLOCKED — PHPs JSON-Parser begrenzt große Zahlen auf `PHP_INT_MAX` (~9,2×10^18). Integer-Typvalidierung lehnt Strings ab. SQL `INTEGER`-Speicherung ist 64-Bit; Überlauf ist in der Praxis nicht praktikabel.
+
+---
+
+### ATK-04 — Float-Score-Injektion 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `{"score": 999.9}`, in der Hoffnung, dass ein Float über Integer-Scores sortiert.
+**Ergebnis**: BLOCKED — Score wird als strikter Integer validiert. `999.9` wird mit 422 Unprocessable Entity abgelehnt, bevor es die DB erreicht.
+
+---
+
+### ATK-05 — SQL-Injection über Score 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `{"score": "100; DROP TABLE scores--"}`, um die Datenbank zu beschädigen.
+**Ergebnis**: BLOCKED — Score muss zuerst die Integer-Validierung bestehen. Parametrisierte Abfragen (`?`-Platzhalter) verhindern Injection auf der DB-Ebene, selbst wenn ein String die Validierung irgendwie bestehen würde.
+
+---
+
+### ATK-06 — Negativer Score, um einen anderen Benutzer zu benachteiligen 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet einen großen negativen Score für einen anderen Benutzer, um ihn ans Ende zu schieben.
+**Ergebnis**: BLOCKED — Persönliche-Bestleistungs-Logik ersetzt einen gespeicherten Score nur, wenn der neue Score **höher** ist. Das Einreichen von -999999 für einen Benutzer mit Score 500 gibt `new_best: false` zurück und der gespeicherte Score bleibt unverändert. In Kombination mit der ATK-01-Mitigation wird Score-Injektion vollständig verhindert.
+
+---
+
+### ATK-07 — Limit-Injektion bei Rankings 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `GET /rankings?limit=999999`, um die gesamte Bestenliste in einer Anfrage herunterzuladen.
+**Ergebnis**: BLOCKED — `limit` wird mit `ctype_digit` validiert und bei `MAX_LIMIT` (z.B. 100) begrenzt. Anfragen, die die Grenze überschreiten → 422.
+
+---
+
+### ATK-08 — Fehlender X-User-Id bei authentifizierten Endpunkten 🚫 BLOCKED
+
+**Angriff**: Angreifer lässt `X-User-Id` bei `GET /rankings/me` oder `DELETE` weg, um die Akteur-Validierung zu umgehen.
+**Ergebnis**: BLOCKED — Beide Endpunkte geben 400 zurück, wenn `X-User-Id` fehlt oder leer ist.
+
+---
+
+### ATK-09 — Nicht-Integer-X-User-Id-Header-Injektion 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `X-User-Id: 1 OR 1=1`, um SQL durch den Header zu injizieren.
+**Ergebnis**: BLOCKED — `X-User-Id` wird mit `ctype_digit` validiert; jedes Nicht-Ziffer-Zeichen → 400. Der Wert erreicht niemals SQL, ohne die Integer-Validierung zu bestehen.
+
+---
+
+### ATK-10 — Score für nicht-existente Bestenliste 🚫 BLOCKED
+
+**Angriff**: Angreifer fälscht `leaderboard_id = 9999`, in der Hoffnung, Bestenlisten-Kontrollen zu umgehen.
+**Ergebnis**: BLOCKED — Bestenlisten-Existenz wird vor der Score-Einfügung geprüft. Unbekannte Bestenliste → 404.
+
+---
+
+### ATK-11 — Niedrigeren Score nach Löschung erneut einreichen 🚫 BLOCKED
+
+**Angriff**: Angreifer löscht seinen Score, dann reicht er einen aufgeblasenen Wert ein, um den persönlichen Bestleistungsschutz zurückzusetzen.
+**Ergebnis**: BLOCKED — Nach der Löschung wird die Zeile entfernt; die nächste Einreichung ist ein frischer Eintrag (`new_best: true`). Dies ist das erwartete Verhalten. Wenn historische Unveränderlichkeit erforderlich ist, Soft-Delete (`deleted_at`) verwenden und die vorherige Bestleistung beibehalten, um Wiedereinreichung zu blockieren.
+
+---
+
+### ATK-12 — Gleichzeitige Score-Einreichungen (Race Condition) 🚫 BLOCKED
+
+**Angriff**: Zwei Anfragen senden gleichzeitig einen Score für denselben Benutzer, bevor eine davon committet.
+**Ergebnis**: BLOCKED — `UNIQUE(leaderboard_id, user_id)` und ein atomares `INSERT OR REPLACE` / `UPDATE WHERE score < new_score` stellen sicher, dass es auf DB-Ebene nur einen Gewinner gibt. SQLite serialisiert Schreibvorgänge; MySQL/PostgreSQL verwenden Zeilensperrung.
+
+---
+
+### ATK Summary
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Score für einen anderen Benutzer einreichen (Body-IDOR) | ⚠️ EXPOSED |
+| ATK-02 | Score eines anderen Benutzers löschen | ✅ SAFE |
+| ATK-03 | Score-Integer-Überlauf | 🚫 BLOCKED |
+| ATK-04 | Float-Score-Injektion | 🚫 BLOCKED |
+| ATK-05 | SQL-Injection über Score | 🚫 BLOCKED |
+| ATK-06 | Negativer Score zur Benachteiligung | 🚫 BLOCKED |
+| ATK-07 | Limit-Injektion bei Rankings | 🚫 BLOCKED |
+| ATK-08 | Fehlender Akteur-Header | 🚫 BLOCKED |
+| ATK-09 | Nicht-Integer-X-User-Id-Header-Injektion | 🚫 BLOCKED |
+| ATK-10 | Score für nicht-existente Bestenliste | 🚫 BLOCKED |
+| ATK-11 | Score nach Löschung erneut einreichen | 🚫 BLOCKED |
+| ATK-12 | Gleichzeitiges Score-Update-Rennen | 🚫 BLOCKED |
+
+**10 BLOCKED, 1 SAFE, 1 EXPOSED** — Score-Einreichung muss verifizieren, dass der Akteur mit `user_id` übereinstimmt. Benutzeridentität aus `X-User-Id` ableiten; `user_id` niemals aus dem Request-Body akzeptieren.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `user_id` im Request-Body ohne Akteur-Prüfung vertrauen | Jeder Benutzer kann Scores im Namen anderer einreichen |
+| Alle Einreichungen statt nur persönlicher Bestleistung speichern | DB wächst unbegrenzt; Ranking wird mehrdeutig |
+| Float-Scores erlauben | Float-Vergleich in SQL erzeugt unerwartete Sortierreihenfolge |
+| Kein `UNIQUE(leaderboard_id, user_id)`-Constraint | Doppelte Zeilen blasen den scheinbaren Rang eines Benutzers auf |
+| 200 mit leerer Liste für unbekannte Bestenliste zurückgeben | Maskiert Fehlkonfiguration; 404 für unbekannte Ressourcen |
+| Kein Limit für `/rankings?limit=` | Full-Table-Scan bei großen Bestenlisten verursacht DoS |

--- a/docs/de/howto/leaderboard-ranking-system.md
+++ b/docs/de/howto/leaderboard-ranking-system.md
@@ -1,0 +1,159 @@
+# Anleitung: Bestenliste (Ranking-System) mit NENE2 aufbauen
+
+Diese Anleitung zeigt Schritt für Schritt, wie eine Bestenliste aufgebaut wird, bei der Benutzer Punkte einreichen, Rankings einsehen und ihren eigenen Rang überprüfen können. Nur der Bestwert pro Benutzer pro Bestenliste wird gespeichert.
+
+**Field Trial**: FT141  
+**NENE2-Version**: ^1.5  
+**Behandelte Themen**: Bestwert-UPDATE-Muster, Rangberechnung mit COUNT(*), Score-Eigentumscheck, Query-Parameter-Begrenzung, Schwachstellenbewertung
+
+---
+
+## Was gebaut wird
+
+- `POST /leaderboards` — Bestenliste erstellen
+- `POST /leaderboards/{id}/scores` — Punktzahl einreichen (nur behalten, wenn neuer Bestwert)
+- `GET /leaderboards/{id}/rankings` — Top-N-Rankings (absteigende Punktzahl, `?limit=N`)
+- `GET /leaderboards/{id}/rankings/me` — Eigener Rang und Punktzahl des Aufrufers
+- `DELETE /leaderboards/{id}/scores/{userId}` — Eigene Punktzahl löschen (nur Eigentümer)
+
+---
+
+## Datenbankschema
+
+```sql
+CREATE TABLE leaderboards (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE scores (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    leaderboard_id INTEGER NOT NULL,
+    user_id        INTEGER NOT NULL,
+    score          INTEGER NOT NULL,
+    submitted_at   TEXT    NOT NULL,
+    UNIQUE (leaderboard_id, user_id),
+    FOREIGN KEY (leaderboard_id) REFERENCES leaderboards(id),
+    FOREIGN KEY (user_id)        REFERENCES users(id)
+);
+```
+
+`UNIQUE (leaderboard_id, user_id)` — eine Punktzahlzeile pro Benutzer pro Bestenliste; Updates ersetzen diese.
+
+---
+
+## Bestwert-UPDATE-Muster
+
+```php
+public function submitScore(int $leaderboardId, int $userId, int $score, string $now): bool
+{
+    $existing = $this->findScore($leaderboardId, $userId);
+
+    if ($existing === null) {
+        $this->executor->execute(
+            'INSERT INTO scores (leaderboard_id, user_id, score, submitted_at) VALUES (?, ?, ?, ?)',
+            [$leaderboardId, $userId, $score, $now],
+        );
+        return true;
+    }
+
+    if ($score > $existing['score']) {
+        $this->executor->execute(
+            'UPDATE scores SET score = ?, submitted_at = ? WHERE leaderboard_id = ? AND user_id = ?',
+            [$score, $now, $leaderboardId, $userId],
+        );
+        return true;
+    }
+
+    return false;  // Kein neuer persönlicher Bestwert
+}
+```
+
+Gibt `true` zurück, wenn die Punktzahl ein neuer Bestwert ist (nützlich für UI-Feedback), `false` wenn ignoriert.
+
+---
+
+## Rangberechnung mit COUNT(*)
+
+Anstelle einer Fensterfunktion (`RANK()` ist nicht in allen SQLite-Versionen verfügbar) wird gezählt, wie viele Punktzahlen höher sind:
+
+```php
+public function getUserRank(int $leaderboardId, int $userId): ?int
+{
+    $score = $this->findScore($leaderboardId, $userId);
+
+    if ($score === null) {
+        return null;
+    }
+
+    $row   = $this->executor->fetchOne(
+        'SELECT COUNT(*) as cnt FROM scores WHERE leaderboard_id = ? AND score > ?',
+        [$leaderboardId, $score['score']],
+    );
+    $ahead = isset($row['cnt']) ? (int) $row['cnt'] : 0;
+
+    return $ahead + 1;
+}
+```
+
+Wenn 0 Benutzer eine höhere Punktzahl haben, ist der Rang 1. Wenn 5 Benutzer höher sind, ist der Rang 6. Gleichstände erhalten denselben Rang.
+
+---
+
+## Score-Eigentumscheck (IDOR-Prävention)
+
+```php
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'cannot delete another user\'s score'], 403);
+}
+```
+
+Immer die Identität des Aufrufers gegen den Zielbenutzer prüfen, bevor DELETE ausgeführt wird. Ohne diese Prüfung könnte jeder authentifizierte Benutzer jede Punktzahl löschen.
+
+---
+
+## Query-Parameter-Begrenzung
+
+```php
+$limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : 10;
+
+if ($limit <= 0 || $limit > 100) {
+    $limit = 10;
+}
+```
+
+Das Limit begrenzen, um zu verhindern, dass `?limit=99999` die gesamte Tabelle scannt.
+
+---
+
+## Schwachstellenbewertung (FT141)
+
+| ID | Angriff | Erwartet | Ergebnis |
+|----|---------|----------|----------|
+| VULN-A | IDOR: Punktzahl eines anderen Benutzers löschen | 403 | Pass |
+| VULN-B | Punktzahl für einen anderen Benutzer einreichen | 200 (erlaubt) | Pass |
+| VULN-C | SQL-Injection im Bestenlisten-Namen | 201 (wörtlich) | Pass |
+| VULN-D | Fehlendes X-User-Id bei /rankings/me | 400 | Pass |
+| VULN-E | Nicht-numerisches X-User-Id | nicht 200 | Pass |
+| VULN-F | Negative Bestenlisten-ID | nicht 200 | Pass |
+| VULN-G | PHP_INT_MAX als Punktzahl | 200 (gültige int) | Pass |
+| VULN-H | Float-Punktzahl (Typverwechslung) | 422 | Pass |
+| VULN-I | String-Punktzahl (Typverwechslung) | 422 | Pass |
+| VULN-J | Fehlendes X-User-Id bei DELETE | 400 | Pass |
+| VULN-K | user_id=0 bei Punktzahl-Einreichung | 422 | Pass |
+| VULN-L | `?limit=99999` (großes Limit) | 200 + begrenzt | Pass |
+
+Alle 12 Schwachstellentests bestehen. Keine Schwachstellen gefunden.
+
+---
+
+## Häufige Fallstricke
+
+| Fallstrick | Lösung |
+|---------|-----|
+| Alle eingereichten Punktzahlen speichern statt nur den Bestwert | `findScore()`-Prüfung vor INSERT; UPDATE wenn höher |
+| Verwendung von RANK(), das in SQLite möglicherweise nicht existiert | `COUNT(*) WHERE score > ?` liefert äquivalenten Rang |
+| IDOR bei Score-DELETE | `$actorId !== $userId` prüfen → 403 |
+| Unbegrenzter Limit-Parameter verursacht Tabellenscan | `limit` auf Bereich 1–100 begrenzen |
+| Float/String-Punktzahl umgeht `is_int()` | `!is_int($score)` lehnt Floats und Strings im PHP 8-JSON-Decode ab |

--- a/docs/de/howto/leaderboard-ranking.md
+++ b/docs/de/howto/leaderboard-ranking.md
@@ -1,0 +1,123 @@
+# How-to: Spiel-Bestenliste & Ranking-API
+
+Diese Anleitung demonstriert den Aufbau einer Bestenlisten-API, bei der Spieler Punktzahlen pro Spiel einreichen und das System persönliche Bestleistungen verfolgt und gerankte Bestenlisten erstellt.
+
+## Übersicht des Musters
+
+- Spieler reichen Punktzahlen über `POST /scores` ein (identifiziert durch den `X-User-Id`-Header).
+- Jede Einreichung wird gespeichert; die persönliche Bestleistung (höchste je erzielte Punktzahl) wird zurückgegeben.
+- `GET /leaderboard?game=<name>` gibt die Top-N-Spieler nach ihrer persönlichen Bestleistung gerankt zurück.
+- `GET /scores/{userId}?game=<name>` listet alle rohen Punktzahlen für einen bestimmten Spieler auf.
+- Spiele sind vollständig isoliert — Punktzahlen in "tetris" beeinflussen niemals "snake".
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS scores (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    game       TEXT    NOT NULL,
+    score      INTEGER NOT NULL,
+    created_at TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_scores_game ON scores (game, score DESC);
+```
+
+Alle Versuche werden gespeichert (kein Upsert), was eine Punktzahlhistorie pro Spiel ermöglicht. Die persönliche Bestleistung wird zur Abfragezeit mit `MAX(score)` ermittelt.
+
+## Punktzahl-Einreichung
+
+```php
+public function submit(int $userId, string $game, int $score): void
+{
+    $this->pdo->prepare(
+        'INSERT INTO scores (user_id, game, score, created_at) VALUES (:uid, :game, :score, :now)'
+    )->execute([':uid' => $userId, ':game' => $game, ':score' => $score, ':now' => $this->now()]);
+}
+
+public function bestScore(int $userId, string $game): ?int
+{
+    $stmt = $this->pdo->prepare(
+        'SELECT MAX(score) FROM scores WHERE user_id = :uid AND game = :game'
+    );
+    $stmt->execute([':uid' => $userId, ':game' => $game]);
+    $val = $stmt->fetchColumn();
+    return $val !== false && $val !== null ? (int) $val : null;
+}
+```
+
+Der Handler gibt die persönliche Bestleistung zusammen mit der Bestätigung zurück:
+
+```json
+{ "message": "Score recorded.", "best_score": 2000 }
+```
+
+## Bestenlisten-Abfrage
+
+Beste Punktzahl pro Benutzer, absteigend sortiert, mit in PHP hinzugefügtem Rang:
+
+```php
+public function leaderboard(string $game, int $limit): array
+{
+    $stmt = $this->pdo->prepare(
+        'SELECT user_id, MAX(score) AS best_score
+         FROM scores
+         WHERE game = :game
+         GROUP BY user_id
+         ORDER BY best_score DESC
+         LIMIT :lim'
+    );
+    $stmt->bindValue(':game', $game, PDO::PARAM_STR);
+    $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+    $stmt->execute();
+
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $ranked = [];
+    foreach ($rows as $i => $row) {
+        $ranked[] = array_merge($row, ['rank' => $i + 1]);
+    }
+    return $ranked;
+}
+```
+
+Antwort:
+
+```json
+{
+  "leaderboard": [
+    { "user_id": 2, "best_score": 1000, "rank": 1 },
+    { "user_id": 1, "best_score": 500,  "rank": 2 }
+  ]
+}
+```
+
+## Validierungsregeln
+
+| Feld | Regel |
+|---|---|
+| `X-User-Id`-Header | Erforderlich für POST; `ctype_digit`, 1–18 Zeichen, Wert > 0 |
+| `game` Body/Query | Erforderlich, nicht leer, max. 64 Zeichen |
+| `score` Body | Nur Integer ≥ 0 (`is_int($score) && $score >= 0`) |
+| `userId` Pfadparameter | `ctype_digit`, max. 18 Zeichen, Wert > 0; sonst 404 |
+| `limit` Query | 1–100, Standard 10; ungültige Werte werden stillschweigend begrenzt |
+
+String-Punktzahlen (`"100"`) werden mit 422 abgelehnt, da `is_int()` für Strings false zurückgibt, auch wenn der Wert numerisch ist.
+
+Null ist eine gültige Punktzahl — nützlich für Spiele, bei denen ein Spieler möglicherweise gar keine Punkte erzielt.
+
+## Routen
+
+```
+POST   /scores              Punktzahl einreichen (X-User-Id erforderlich)
+GET    /leaderboard         Top-N gerankte Spieler (?game= erforderlich, ?limit= optional)
+GET    /scores/{userId}     Alle Punktzahlen eines Spielers (?game= erforderlich)
+```
+
+## Spielisolation
+
+Die `game`-Spalte fungiert als Namespace. Immer `WHERE game = :game` in jede Abfrage aufnehmen. Ein Spieler, der in "tetris" Punkte erzielt, erscheint niemals auf der "snake"-Bestenliste.
+
+## Weitere Informationen
+
+- FT206-Quelle: `../NENE2-FT/leaderboardlog/`
+- Verwandt: `docs/howto/rate-limiting.md` (FT200), `docs/howto/coupon-redemption.md` (FT204)

--- a/docs/de/howto/leaderboard-scores.md
+++ b/docs/de/howto/leaderboard-scores.md
@@ -1,0 +1,123 @@
+# How-to: Bestenliste & Punktzahl-Tracking-API
+
+Diese Anleitung zeigt, wie ein Bestenlisten-System mit Punktzahl-Einreichung, Top-N-Rankings mittels Benutzer-Bestes-Aggregation und persönlicher Punktzahlhistorie mit NENE2 aufgebaut wird.
+Muster demonstriert durch den **leaderboardlog** Field Trial (FT206).
+
+## Funktionen
+
+- Punktzahl-Einreichung pro Benutzer pro Spiel (`X-User-Id`-Header)
+- Top-N-Bestenliste: beste Punktzahl pro Benutzer absteigend gerankt (`MAX(score) GROUP BY user_id`)
+- Persönliche Punktzahlhistorie für jede Benutzer-/Spielkombination
+- Abfrage der persönlichen Bestleistung
+- Konfigurierbares Limit (begrenzt 1–100)
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS scores (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    game       TEXT    NOT NULL,
+    score      INTEGER NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_scores_game ON scores (game, score DESC);
+CREATE INDEX IF NOT EXISTS idx_scores_user ON scores (user_id, game);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/scores` | Benutzer | Punktzahl einreichen |
+| `GET` | `/leaderboard?game=<game>` | Öffentlich | Top-N-Bestenliste |
+| `GET` | `/scores/{userId}?game=<game>` | Öffentlich | Punktzahlhistorie eines Benutzers |
+
+## Punktzahl-Einreichung
+
+```php
+$game  = trim((string) ($body['game'] ?? ''));
+$score = $body['score'] ?? null;
+
+if ($game === '' || strlen($game) > 64) {
+    return $this->problem(422, 'validation-failed', 'game required (max 64 chars).');
+}
+if (!is_int($score) || $score < 0) {
+    return $this->problem(422, 'validation-failed', 'score must be a non-negative integer.');
+}
+```
+
+Wichtige Punkte:
+- `is_int($score)` — strenge Prüfung; lehnt Floats (`1.5`) und Strings aus JSON ab
+- Spielname auf 64 Zeichen begrenzt — verhindert DoS durch übermäßig große Spielnamen
+- Punktzahl nicht negativ — verhindert Injektion negativer Punktzahlen
+
+Gibt den aktualisierten Bestwert bei 201 zurück:
+
+```json
+{ "message": "Score recorded.", "best_score": 9800 }
+```
+
+## Top-N-Ranking-Abfrage
+
+Beste-pro-Benutzer-Ranking mit dichter Rangzuweisung in PHP:
+
+```php
+public function leaderboard(string $game, int $limit): array
+{
+    $stmt = $this->pdo->prepare(
+        'SELECT user_id, MAX(score) AS best_score
+         FROM scores
+         WHERE game = :game
+         GROUP BY user_id
+         ORDER BY best_score DESC
+         LIMIT :lim'
+    );
+    $stmt->bindValue(':game', $game, PDO::PARAM_STR);
+    $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+    $stmt->execute();
+
+    $rows   = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $ranked = [];
+    foreach ($rows as $i => $row) {
+        $ranked[] = array_merge($row, ['rank' => $i + 1]);
+    }
+    return $ranked;
+}
+```
+
+- `MAX(score) GROUP BY user_id` — eine Zeile pro Benutzer, ihre persönliche Bestleistung
+- `ORDER BY best_score DESC` — höchste Punktzahl zuerst
+- `PDO::PARAM_INT`-Bindung für LIMIT — SQL-Injection-sicher
+
+Beispielantwort:
+
+```json
+{
+  "leaderboard": [
+    { "user_id": 42, "best_score": 9800, "rank": 1 },
+    { "user_id": 7,  "best_score": 7200, "rank": 2 }
+  ]
+}
+```
+
+## Limit-Begrenzung
+
+```php
+$limit = ctype_digit($limitRaw) ? (int) $limitRaw : 10;
+if ($limit < 1 || $limit > 100) {
+    $limit = 10;
+}
+```
+
+Ungültige oder außerhalb des Bereichs liegende Limits werden stillschweigend auf 10 zurückgesetzt — clientseitig angegebenen Integers für LIMIT niemals vertrauen.
+
+## Validierungsmuster
+
+| Eingabe | Prüfung | Grund |
+|-------|-------|--------|
+| `score` | `is_int($score) && $score >= 0` | Lehnt Floats, Strings, negative Werte ab |
+| `game` | `strlen($game) <= 64` | Verhindert übermäßig große Eingaben |
+| `limit` | `ctype_digit()` + Bereichsbegrenzung | ReDoS-sicher, begrenzt |
+| `userId` (Pfad) | `ctype_digit()` + `> 0` | Validiert vor DB-Abfrage |

--- a/docs/de/howto/live-poll-system.md
+++ b/docs/de/howto/live-poll-system.md
@@ -1,0 +1,184 @@
+# How-to: Live-Umfragesystem
+
+## Übersicht
+
+Diese Anleitung behandelt den Aufbau einer Live-Umfragesystem-API mit NENE2, einschließlich admin-gesteuerter Umfrageerstellung, Abstimmungs-Deduplizierung pro Benutzer, Umfrage-Lifecycle-Verwaltung und Ergebnis-Aggregation.
+
+**Referenzimplementierung**: `../NENE2-FT/polllog/`
+
+---
+
+## Schema-Design
+
+```sql
+CREATE TABLE IF NOT EXISTS polls (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    question   TEXT    NOT NULL,
+    closed     INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS poll_options (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    poll_id INTEGER NOT NULL,
+    label   TEXT    NOT NULL,
+    FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS poll_votes (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    poll_id   INTEGER NOT NULL,
+    option_id INTEGER NOT NULL,
+    user_id   INTEGER NOT NULL,
+    voted_at  TEXT    NOT NULL,
+    UNIQUE (poll_id, user_id),
+    FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE,
+    FOREIGN KEY (option_id) REFERENCES poll_options(id) ON DELETE CASCADE
+);
+```
+
+Wichtige Constraints:
+- `UNIQUE (poll_id, user_id)` — verhindert, dass ein Benutzer mehr als einmal pro Umfrage abstimmt.
+- `ON DELETE CASCADE` — entfernt Optionen und Stimmen, wenn eine Umfrage gelöscht wird.
+
+---
+
+## Routentabelle
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/polls` | Admin | Umfrage mit Optionen erstellen |
+| `GET` | `/polls` | Keine | Alle Umfragen auflisten |
+| `GET` | `/polls/{id}` | Keine | Umfrage mit Stimmzahlen abrufen |
+| `POST` | `/polls/{id}/vote` | Benutzer | Stimme abgeben |
+| `POST` | `/polls/{id}/close` | Admin | Umfrage schließen |
+
+---
+
+## Admin-Authentifizierungsmuster
+
+Ein gemeinsames Secret im `X-Admin-Key`-Header übergeben. Fail-closed-Logik verwenden:
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;          // fail-closed: kein Key konfiguriert → niemals Admin
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+`403 Forbidden` zurückgeben, wenn kein Admin:
+```php
+if (!$this->isAdmin($req)) {
+    return $this->problem(403, 'forbidden', 'Admin key required.');
+}
+```
+
+---
+
+## Umfragen mit Optionen erstellen
+
+Mindestens 2 Optionen validieren; in einer Transaktion einfügen:
+
+```php
+public function create(string $question, array $options): array
+{
+    $now  = $this->now();
+    $stmt = $this->pdo->prepare('INSERT INTO polls (question, closed, created_at) VALUES (?, 0, ?)');
+    $stmt->execute([$question, $now]);
+    $pollId = (int) $this->pdo->lastInsertId();
+
+    $ins = $this->pdo->prepare('INSERT INTO poll_options (poll_id, label) VALUES (?, ?)');
+    foreach ($options as $label) {
+        $ins->execute([$pollId, $label]);
+    }
+
+    return $this->findById($pollId);
+}
+```
+
+---
+
+## Abstimmung mit Deduplizierung
+
+Den UNIQUE-Constraint-Verstoß abfangen, um Doppelabstimmungen zu erkennen:
+
+```php
+public function vote(int $pollId, int $optionId, int $userId): string
+{
+    $poll = $this->findById($pollId);
+    if ($poll === null) return 'not_found';
+    if ($poll['closed']) return 'poll_closed';
+
+    // Überprüfen, ob die Option zu dieser Umfrage gehört
+    $stmt = $this->pdo->prepare('SELECT id FROM poll_options WHERE id = ? AND poll_id = ?');
+    $stmt->execute([$optionId, $pollId]);
+    if ($stmt->fetch() === false) return 'invalid_option';
+
+    try {
+        $this->pdo->prepare(
+            'INSERT INTO poll_votes (poll_id, option_id, user_id, voted_at) VALUES (?, ?, ?, ?)'
+        )->execute([$pollId, $optionId, $userId, $this->now()]);
+    } catch (\PDOException $e) {
+        if (str_contains($e->getMessage(), 'UNIQUE')) return 'already_voted';
+        throw $e;
+    }
+
+    return 'ok';
+}
+```
+
+---
+
+## Stimmzahlen aggregieren
+
+`LEFT JOIN` verwenden, um Optionen mit null Stimmen einzuschließen:
+
+```sql
+SELECT po.id, po.label, COUNT(pv.id) AS votes
+FROM poll_options po
+LEFT JOIN poll_votes pv ON pv.option_id = po.id
+WHERE po.poll_id = :poll_id
+GROUP BY po.id, po.label
+ORDER BY po.id ASC
+```
+
+---
+
+## HTTP-Statuscodes
+
+| Situation | Status |
+|-----------|--------|
+| Umfrage erstellt | 201 |
+| Stimme abgegeben | 201 |
+| Umfrage gefunden / geschlossen | 200 |
+| Umfrage nicht gefunden | 404 |
+| Ungültige Option-ID | 422 |
+| Fehlende Frage oder < 2 Optionen | 422 |
+| Nicht-ganzzahlige option_id | 422 |
+| Bereits abgestimmt | 409 |
+| Abstimmung bei geschlossener Umfrage | 409 |
+| Kein Admin-Key | 403 |
+| Kein X-User-Id-Header | 400 |
+
+---
+
+## Validierungscheckliste
+
+- `question`: nicht-leerer String
+- `options`: Array mit ≥ 2 nicht-leeren Strings
+- `option_id`: muss `is_int()` sein (String wie `'1'` ablehnen)
+- `X-User-Id`: `ctype_digit()` + positive Ganzzahl
+- Umfrage muss vor dem Abstimmen oder Schließen existieren
+- Option muss zur Zielumfrage gehören (Cross-Umfrage-Injection)
+
+---
+
+## Sicherheitshinweise
+
+- **Admin-Key fail-closed**: leerer Key bedeutet, niemand ist Admin.
+- **`hash_equals()` verwenden**, um Timing-Angriffe auf den Admin-Key-Vergleich zu verhindern.
+- **UNIQUE-Constraint** ist der maßgebliche Doppelabstimmungs-Schutz — alleinige Anwendungsebenenprüfung ist unter gleichzeitiger Last nicht ausreichend.
+- **Options-Eigentumscheck** verhindert das Abstimmen mit einer Option aus einer anderen Umfrage.

--- a/docs/de/howto/magic-link-authentication.md
+++ b/docs/de/howto/magic-link-authentication.md
@@ -1,0 +1,278 @@
+# How-to: Magic-Link-Authentifizierung
+
+> **FT-Referenz**: FT309 (`NENE2-FT/magiclog`) — Magic-Link-Authentifizierung: Token als SHA-256-Hash gespeichert (niemals im Klartext), 15-Minuten-TTL, used_at verhindert Wiederverwendung, Ablauf vor used_at geprüft, Session-Token 64+ Hex-Zeichen SHA-256 gespeichert, widerrufene/abgelaufene Sessions abgelehnt, 202 immer bei /auth/request (Benutzer-Enumerations-Prävention), Bearer-Token erforderlich (X-User-Id-Header ignoriert), VULN-A〜L alle SAFE, 43 Tests / 91 Assertions PASS.
+
+Diese Anleitung zeigt, wie ein passwortloses Magic-Link-Authentifizierungssystem aufgebaut wird, bei dem die Sicherheit auf Token-Entropie, Hash-Speicherung, kurzer TTL und Einmalnutzungs-Erzwingung basiert.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    email      TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE magic_links (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token_hash TEXT    NOT NULL UNIQUE,   -- SHA-256(raw_token)
+    expires_at TEXT    NOT NULL,          -- jetzt + 15 Minuten
+    used_at    TEXT,                      -- gesetzt bei erster erfolgreicher Verifizierung
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE auth_sessions (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id            INTEGER NOT NULL,
+    session_token_hash TEXT    NOT NULL UNIQUE,   -- SHA-256(raw_token)
+    expires_at         TEXT    NOT NULL,
+    revoked_at         TEXT,
+    created_at         TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+Sowohl `magic_links.token_hash` als auch `auth_sessions.session_token_hash` speichern SHA-256-Hashes. Rohe Token werden niemals gespeichert.
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/auth/request` | — | Magic-Link anfordern (immer 202) |
+| `POST` | `/auth/verify` | — | Token verifizieren → Session |
+| `POST` | `/auth/logout` | `Bearer` | Session widerrufen |
+| `GET` | `/me` | `Bearer` | Aktuellen Benutzer abrufen |
+
+## Token-Generierung und Hashing
+
+```php
+// 64 Hex-Zeichen generieren (256-Bit-Entropie)
+$rawToken   = bin2hex(random_bytes(32));
+$tokenHash  = hash('sha256', $rawToken);
+$expiresAt  = (new \DateTimeImmutable())->modify('+15 minutes')->format('c');
+
+$this->repo->createMagicLink($userId, $tokenHash, $expiresAt);
+
+// Rohes Token an Aufrufer zurückgeben (per E-Mail als URL-Parameter an Benutzer gesendet)
+return ['token' => $rawToken];
+```
+
+Das rohe Token wird in der Antwort zurückgegeben (als URL-Parameter in der E-Mail zu senden). Nur der SHA-256-Hash wird gespeichert. `UNIQUE(token_hash)` verhindert Hash-Kollisionen.
+
+## Session-Token
+
+```php
+$rawSessionToken  = bin2hex(random_bytes(32)); // 64 Hex-Zeichen
+$sessionTokenHash = hash('sha256', $rawSessionToken);
+$sessionExpiry    = (new \DateTimeImmutable())->modify('+24 hours')->format('c');
+
+$this->repo->createSession($userId, $sessionTokenHash, $sessionExpiry);
+
+return ['session_token' => $rawSessionToken]; // einmal zurückgegeben, dann nur noch Hash
+```
+
+Session-Token: 64 Hex-Zeichen = 256 Bit Entropie. Als SHA-256-Hash gespeichert. Mindestens 64 Zeichen durch Entropiequelle erzwungen (`bin2hex(random_bytes(32))`).
+
+## Verifizierung — Reihenfolge der Prüfungen ist wichtig
+
+```php
+// 1. Nach Hash suchen
+$magicLink = $this->repo->findByTokenHash(hash('sha256', $token));
+if ($magicLink === null) {
+    return 401; // nicht gefunden
+}
+
+// 2. Ablauf ZUERST prüfen
+if ($magicLink['expires_at'] < date('c')) {
+    return 401; // 'expired' in Fehlermeldung
+}
+
+// 3. used_at DANACH prüfen
+if ($magicLink['used_at'] !== null) {
+    return 401; // 'already been used' in Fehlermeldung
+}
+
+// 4. Als genutzt markieren
+$this->repo->markUsed($magicLink['id'], date('c'));
+
+// 5. Session erstellen
+```
+
+Ablauf wird **vor** `used_at` geprüft. Wenn ein Token sowohl abgelaufen als auch verwendet ist, sagt der Fehler "expired" — nicht "already been used". Das verhindert Timing-Angriffe, bei denen ein Angreifer sondiert, ob ein Token verwendet wurde.
+
+## Benutzer-Enumerations-Prävention — Immer 202
+
+```php
+public function handleRequest(ServerRequestInterface $request): ResponseInterface
+{
+    $email = $body['email'] ?? '';
+    
+    $user = $this->repo->findUserByEmail($email);
+    if ($user !== null) {
+        // Magic-Link erstellen und (in der Produktion) E-Mail senden
+        $rawToken = bin2hex(random_bytes(32));
+        $this->repo->createMagicLink($user['id'], hash('sha256', $rawToken), ...);
+    }
+    // Immer 202 zurückgeben, unabhängig davon, ob E-Mail existiert
+    return $this->json->create(['message' => 'If registered, a magic link has been sent.'], 202);
+}
+```
+
+Nicht-existierende E-Mail-Adressen geben dieselbe 202-Antwort wie gültige zurück. Es wird niemals eine "E-Mail nicht gefunden"-Meldung zurückgegeben.
+
+## Session-Validierung
+
+```php
+$token = substr($authHeader, 7); // 'Bearer ' entfernen
+$tokenHash = hash('sha256', $token);
+$session = $this->repo->findSessionByHash($tokenHash);
+
+if ($session === null) {
+    return 401; // Session nicht gefunden
+}
+if ($session['revoked_at'] !== null) {
+    return 401; // 'revoked'
+}
+if ($session['expires_at'] < date('c')) {
+    return 401; // 'expired'
+}
+```
+
+Drei Session-Prüfungen: Existenz → widerrufen → abgelaufen. Widerrufene Sessions vom Logout geben "revoked" zurück — distinct von "expired" für klare Fehlermeldungen.
+
+## X-User-Id-Header für Auth ignoriert
+
+Der `/me`-Endpunkt erfordert ein gültiges `Bearer`-Session-Token. Der `X-User-Id`-Header (von anderen Endpunkten als Convenience-Auth verwendet) wird hier explizit ignoriert:
+
+```php
+// Nur Bearer-Token-Authentifizierung — X-User-Id wird nicht akzeptiert
+$authHeader = $request->getHeaderLine('Authorization');
+if (!str_starts_with($authHeader, 'Bearer ')) {
+    return 401;
+}
+```
+
+---
+
+## Schwachstellenanalyse
+
+### V-01 — Abgelaufenes Token vor used_at-Prüfung abgelehnt ✅ SAFE
+
+**Risiko**: Token abgelaufen aber noch nicht verwendet; Angreifer versucht es zu verwenden und erhält "already used"-Fehler, der Reihenfolge der Prüfungen enthüllt.
+**Befund**: SAFE — Ablauf wird zuerst geprüft. Sowohl abgelaufene+verwendete Token geben "expired" zurück.
+
+---
+
+### V-02 — Session-Token als Hash gespeichert ✅ SAFE
+
+**Risiko**: DB-Verletzung enthüllt Session-Token.
+**Befund**: SAFE — `session_token_hash = SHA-256(raw_token)`. Rohes Token nicht in DB.
+
+---
+
+### V-03 — Verwendeter Magic-Link kann nicht wiederverwendet werden ✅ SAFE
+
+**Risiko**: Angreifer fängt Magic-Link-URL ab und verwendet sie nach dem beabsichtigten Benutzer.
+**Befund**: SAFE — `used_at` wird bei erster Verwendung gesetzt; zweiter Versuch gibt 401 "already been used" zurück.
+
+---
+
+### V-04 — Logout macht Session ungültig ✅ SAFE
+
+**Risiko**: Session-Cookie/Token funktioniert nach dem Logout noch.
+**Befund**: SAFE — Logout setzt `revoked_at`; nachfolgendes `/me` mit dem Token gibt 401 "revoked" zurück.
+
+---
+
+### V-05 — Nicht-existierende E-Mail gibt 202 zurück ✅ SAFE
+
+**Risiko**: Angreifer prüft, welche E-Mails registriert sind, indem er verschiedene Fehlerantworten beobachtet.
+**Befund**: SAFE — `/auth/request` gibt immer 202 mit demselben Body zurück. Kein "nicht gefunden"-Leck.
+
+---
+
+### V-06 — Widerrufene Session abgelehnt ✅ SAFE
+
+**Risiko**: Manuell widerrufene Session gewährt noch Zugriff.
+**Befund**: SAFE — `revoked_at`-Prüfung verweigert Zugriff; Fehlermeldung lautet "revoked".
+
+---
+
+### V-07 — Abgelaufene Session abgelehnt ✅ SAFE
+
+**Risiko**: Alte Session von vor langer Zeit funktioniert noch.
+**Befund**: SAFE — `expires_at`-Prüfung verweigert Zugriff; Fehlermeldung lautet "expired".
+
+---
+
+### V-08 — Magic-Link-Token als Hash in DB gespeichert ✅ SAFE
+
+**Risiko**: DB-Verletzung enthüllt Magic-Link-Token; Angreifer authentifiziert sich als beliebiger Benutzer.
+**Befund**: SAFE — `token_hash = SHA-256(raw_token)`. Rohes Token nicht in DB.
+
+---
+
+### V-09 — Magic-Link läuft innerhalb von 15 Minuten ab ✅ SAFE
+
+**Risiko**: Langlebiger Magic-Link ermöglicht verzögerte Abfangung und Wiederholung.
+**Befund**: SAFE — TTL ≤ 900 Sekunden (15 Minuten) durch Test bestätigt.
+
+---
+
+### V-10 — Session hat Ablaufdatum ✅ SAFE
+
+**Risiko**: Session läuft nie ab; alte Token bleiben für immer gültig.
+**Befund**: SAFE — `expires_at` wird in der Zukunft bei Session-Erstellung gesetzt; als nicht-null bestätigt.
+
+---
+
+### V-11 — Session-Token hat ausreichende Entropie ✅ SAFE
+
+**Risiko**: Kurzes Session-Token per Brute-Force knackbar.
+**Befund**: SAFE — `bin2hex(random_bytes(32))` = 64 Hex-Zeichen = 256-Bit-Entropie.
+
+---
+
+### V-12 — X-User-Id-Header kann Auth nicht umgehen ✅ SAFE
+
+**Risiko**: `X-User-Id: 1`-Header gewährt Zugriff auf `/me` ohne gültige Session.
+**Befund**: SAFE — `/me` erfordert `Authorization: Bearer <token>`. X-User-Id wird ignoriert.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|--------|
+| V-01 | Ablauf vs. used_at-Prüfreihenfolge | ✅ SAFE |
+| V-02 | Session-Token im Klartext in DB | ✅ SAFE |
+| V-03 | Wiederverwendung genutzter Magic-Links | ✅ SAFE |
+| V-04 | Session gültig nach Logout | ✅ SAFE |
+| V-05 | E-Mail-Enumeration | ✅ SAFE |
+| V-06 | Widerrufener Sessionzugriff | ✅ SAFE |
+| V-07 | Abgelaufener Sessionzugriff | ✅ SAFE |
+| V-08 | Magic-Link-Token in DB | ✅ SAFE |
+| V-09 | Magic-Link-TTL > 15 Min | ✅ SAFE |
+| V-10 | Kein Session-Ablauf | ✅ SAFE |
+| V-11 | Niedrige Entropie beim Session-Token | ✅ SAFE |
+| V-12 | X-User-Id-Bypass | ✅ SAFE |
+
+**12 SAFE, 0 EXPOSED**
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Rohes Magic-Link-Token in DB speichern | DB-Verletzung lässt Angreifer sich als beliebiger Benutzer authentifizieren |
+| Rohes Session-Token in DB speichern | DB-Verletzung macht alle Sessions ungültig |
+| used_at vor expires_at prüfen | Timing-Leck enthüllt, ob Token verwendet wurde |
+| Fehler für nicht-existierende E-Mail zurückgeben | Angreifer enumeriert registrierte E-Mails |
+| Kein TTL für Magic-Links | Unbegrenzt gültige Token; verzögerter Abfangangriff |
+| Kein Session-Ablauf | Sessions bleiben für immer gültig |
+| X-User-Id für Bearer-Auth akzeptieren | Header-basierter Auth-Bypass ohne Token |
+| Token mit niedriger Entropie (`rand()` oder 8 Zeichen) | Per Brute-Force knackbare Token |
+| Denselben Magic-Link für mehrere Sessions wiederverwenden | Einzelne Token-Exposition gewährt alle nachfolgenden Sessions |

--- a/docs/de/howto/magic-link-authentication.md
+++ b/docs/de/howto/magic-link-authentication.md
@@ -1,8 +1,8 @@
 # How-to: Magic-Link-Authentifizierung
 
-> **FT-Referenz**: FT309 (`NENE2-FT/magiclog`) — Magic-Link-Authentifizierung: Token als SHA-256-Hash gespeichert (niemals im Klartext), 15-Minuten-TTL, used_at verhindert Wiederverwendung, Ablauf vor used_at geprüft, Session-Token 64+ Hex-Zeichen SHA-256 gespeichert, widerrufene/abgelaufene Sessions abgelehnt, 202 immer bei /auth/request (Benutzer-Enumerations-Prävention), Bearer-Token erforderlich (X-User-Id-Header ignoriert), VULN-A〜L alle SAFE, 43 Tests / 91 Assertions PASS.
+> **FT-Referenz**: FT309 (`NENE2-FT/magiclog`) — Magic-Link-Authentifizierung: Token als SHA-256-Hash gespeichert (niemals im Klartext), 15-Minuten-TTL, used_at verhindert Wiederverwendung, Ablauf vor used_at geprüft, Session-Token 64+ Hex-Zeichen SHA-256-gespeichert, widerrufene/abgelaufene Sessions abgelehnt, 202 immer bei /auth/request (Benutzer-Enumerations-Prävention), Bearer-Token erforderlich (X-User-Id-Header ignoriert), VULN-A~L alle SAFE, 43 Tests / 91 Assertions PASS.
 
-Diese Anleitung zeigt, wie ein passwortloses Magic-Link-Authentifizierungssystem aufgebaut wird, bei dem die Sicherheit auf Token-Entropie, Hash-Speicherung, kurzer TTL und Einmalnutzungs-Erzwingung basiert.
+Diese Anleitung zeigt, wie ein passwortloses Magic-Link-Authentifizierungssystem aufgebaut wird, bei dem die Sicherheit von Token-Entropie, Hash-Speicherung, kurzer TTL und Einmal-Nutzungs-Erzwingung abhängt.
 
 ## Schema
 
@@ -17,8 +17,8 @@ CREATE TABLE magic_links (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id    INTEGER NOT NULL,
     token_hash TEXT    NOT NULL UNIQUE,   -- SHA-256(raw_token)
-    expires_at TEXT    NOT NULL,          -- jetzt + 15 Minuten
-    used_at    TEXT,                      -- gesetzt bei erster erfolgreicher Verifizierung
+    expires_at TEXT    NOT NULL,          -- now + 15 Minuten
+    used_at    TEXT,                      -- bei erster erfolgreicher Verifizierung gesetzt
     created_at TEXT    NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users(id)
 );
@@ -55,11 +55,11 @@ $expiresAt  = (new \DateTimeImmutable())->modify('+15 minutes')->format('c');
 
 $this->repo->createMagicLink($userId, $tokenHash, $expiresAt);
 
-// Rohes Token an Aufrufer zurückgeben (per E-Mail als URL-Parameter an Benutzer gesendet)
+// Rohes Token an Aufrufer zurückgeben (wird per E-Mail an Benutzer gesendet)
 return ['token' => $rawToken];
 ```
 
-Das rohe Token wird in der Antwort zurückgegeben (als URL-Parameter in der E-Mail zu senden). Nur der SHA-256-Hash wird gespeichert. `UNIQUE(token_hash)` verhindert Hash-Kollisionen.
+Das rohe Token wird in der Antwort zurückgegeben (wird als URL-Parameter in der E-Mail gesendet). Nur der SHA-256-Hash wird gespeichert. `UNIQUE(token_hash)` verhindert Hash-Kollisionen.
 
 ## Session-Token
 
@@ -73,7 +73,7 @@ $this->repo->createSession($userId, $sessionTokenHash, $sessionExpiry);
 return ['session_token' => $rawSessionToken]; // einmal zurückgegeben, dann nur noch Hash
 ```
 
-Session-Token: 64 Hex-Zeichen = 256 Bit Entropie. Als SHA-256-Hash gespeichert. Mindestens 64 Zeichen durch Entropiequelle erzwungen (`bin2hex(random_bytes(32))`).
+Session-Token: 64 Hex-Zeichen = 256 Bit Entropie. Als SHA-256-Hash gespeichert. Mindestens 64 Zeichen durch die Entropiequelle erzwungen (`bin2hex(random_bytes(32))`).
 
 ## Verifizierung — Reihenfolge der Prüfungen ist wichtig
 
@@ -89,18 +89,18 @@ if ($magicLink['expires_at'] < date('c')) {
     return 401; // 'expired' in Fehlermeldung
 }
 
-// 3. used_at DANACH prüfen
+// 3. used_at ZWEITES prüfen
 if ($magicLink['used_at'] !== null) {
     return 401; // 'already been used' in Fehlermeldung
 }
 
-// 4. Als genutzt markieren
+// 4. Als verwendet markieren
 $this->repo->markUsed($magicLink['id'], date('c'));
 
 // 5. Session erstellen
 ```
 
-Ablauf wird **vor** `used_at` geprüft. Wenn ein Token sowohl abgelaufen als auch verwendet ist, sagt der Fehler "expired" — nicht "already been used". Das verhindert Timing-Angriffe, bei denen ein Angreifer sondiert, ob ein Token verwendet wurde.
+Ablauf wird **vor** `used_at` geprüft. Wenn ein Token sowohl abgelaufen als auch verwendet ist, lautet der Fehler "expired" — nicht "already been used". Dies verhindert Timing-Angriffe, bei denen ein Angreifer prüft, ob ein Token verwendet wurde.
 
 ## Benutzer-Enumerations-Prävention — Immer 202
 
@@ -111,16 +111,16 @@ public function handleRequest(ServerRequestInterface $request): ResponseInterfac
     
     $user = $this->repo->findUserByEmail($email);
     if ($user !== null) {
-        // Magic-Link erstellen und (in der Produktion) E-Mail senden
+        // Magic-Link erstellen und (in Produktion) E-Mail senden
         $rawToken = bin2hex(random_bytes(32));
         $this->repo->createMagicLink($user['id'], hash('sha256', $rawToken), ...);
     }
-    // Immer 202 zurückgeben, unabhängig davon, ob E-Mail existiert
+    // Immer 202 zurückgeben, unabhängig davon, ob die E-Mail existiert
     return $this->json->create(['message' => 'If registered, a magic link has been sent.'], 202);
 }
 ```
 
-Nicht-existierende E-Mail-Adressen geben dieselbe 202-Antwort wie gültige zurück. Es wird niemals eine "E-Mail nicht gefunden"-Meldung zurückgegeben.
+Nicht existierende E-Mail-Adressen geben dieselbe 202-Antwort zurück wie gültige. Niemals die Meldung "E-Mail nicht gefunden" zurückgeben.
 
 ## Session-Validierung
 
@@ -140,11 +140,11 @@ if ($session['expires_at'] < date('c')) {
 }
 ```
 
-Drei Session-Prüfungen: Existenz → widerrufen → abgelaufen. Widerrufene Sessions vom Logout geben "revoked" zurück — distinct von "expired" für klare Fehlermeldungen.
+Drei Session-Prüfungen: Existenz → widerrufen → abgelaufen. Widerrufene Sessions nach Logout geben "revoked" zurück — unterscheidet sich von "expired" für klare Fehlermeldungen.
 
 ## X-User-Id-Header für Auth ignoriert
 
-Der `/me`-Endpunkt erfordert ein gültiges `Bearer`-Session-Token. Der `X-User-Id`-Header (von anderen Endpunkten als Convenience-Auth verwendet) wird hier explizit ignoriert:
+Der `/me`-Endpunkt erfordert ein gültiges `Bearer`-Session-Token. Der `X-User-Id`-Header (der von anderen Endpunkten als praktische Auth verwendet wird) wird hier explizit ignoriert:
 
 ```php
 // Nur Bearer-Token-Authentifizierung — X-User-Id wird nicht akzeptiert
@@ -156,46 +156,46 @@ if (!str_starts_with($authHeader, 'Bearer ')) {
 
 ---
 
-## Schwachstellenanalyse
+## Schwachstellenbewertung
 
 ### V-01 — Abgelaufenes Token vor used_at-Prüfung abgelehnt ✅ SAFE
 
-**Risiko**: Token abgelaufen aber noch nicht verwendet; Angreifer versucht es zu verwenden und erhält "already used"-Fehler, der Reihenfolge der Prüfungen enthüllt.
-**Befund**: SAFE — Ablauf wird zuerst geprüft. Sowohl abgelaufene+verwendete Token geben "expired" zurück.
+**Risiko**: Token abgelaufen, aber noch nicht verwendet; Angreifer versucht es zu verwenden und erhält "already used"-Fehler, der die Reihenfolge der Prüfungen enthüllt.
+**Befund**: SAFE — Ablauf wird zuerst geprüft. Sowohl abgelaufene+verwendete Tokens geben "expired" zurück.
 
 ---
 
 ### V-02 — Session-Token als Hash gespeichert ✅ SAFE
 
-**Risiko**: DB-Verletzung enthüllt Session-Token.
+**Risiko**: DB-Breach enthüllt Session-Tokens.
 **Befund**: SAFE — `session_token_hash = SHA-256(raw_token)`. Rohes Token nicht in DB.
 
 ---
 
 ### V-03 — Verwendeter Magic-Link kann nicht wiederverwendet werden ✅ SAFE
 
-**Risiko**: Angreifer fängt Magic-Link-URL ab und verwendet sie nach dem beabsichtigten Benutzer.
+**Risiko**: Angreifer erfasst die Magic-Link-URL und verwendet sie nach dem beabsichtigten Benutzer.
 **Befund**: SAFE — `used_at` wird bei erster Verwendung gesetzt; zweiter Versuch gibt 401 "already been used" zurück.
 
 ---
 
 ### V-04 — Logout macht Session ungültig ✅ SAFE
 
-**Risiko**: Session-Cookie/Token funktioniert nach dem Logout noch.
+**Risiko**: Session-Cookie/Token funktioniert nach Logout weiterhin.
 **Befund**: SAFE — Logout setzt `revoked_at`; nachfolgendes `/me` mit dem Token gibt 401 "revoked" zurück.
 
 ---
 
-### V-05 — Nicht-existierende E-Mail gibt 202 zurück ✅ SAFE
+### V-05 — Nicht existierende E-Mail gibt 202 zurück ✅ SAFE
 
 **Risiko**: Angreifer prüft, welche E-Mails registriert sind, indem er verschiedene Fehlerantworten beobachtet.
-**Befund**: SAFE — `/auth/request` gibt immer 202 mit demselben Body zurück. Kein "nicht gefunden"-Leck.
+**Befund**: SAFE — `/auth/request` gibt immer 202 mit demselben Body zurück. Kein "not found"-Leck.
 
 ---
 
 ### V-06 — Widerrufene Session abgelehnt ✅ SAFE
 
-**Risiko**: Manuell widerrufene Session gewährt noch Zugriff.
+**Risiko**: Manuell widerrufene Session gewährt weiterhin Zugriff.
 **Befund**: SAFE — `revoked_at`-Prüfung verweigert Zugriff; Fehlermeldung lautet "revoked".
 
 ---
@@ -207,30 +207,30 @@ if (!str_starts_with($authHeader, 'Bearer ')) {
 
 ---
 
-### V-08 — Magic-Link-Token als Hash in DB gespeichert ✅ SAFE
+### V-08 — Magic-Link-Token als Hash gespeichert ✅ SAFE
 
-**Risiko**: DB-Verletzung enthüllt Magic-Link-Token; Angreifer authentifiziert sich als beliebiger Benutzer.
+**Risiko**: DB-Breach enthüllt Magic-Link-Tokens; Angreifer authentifiziert sich als beliebiger Benutzer.
 **Befund**: SAFE — `token_hash = SHA-256(raw_token)`. Rohes Token nicht in DB.
 
 ---
 
 ### V-09 — Magic-Link läuft innerhalb von 15 Minuten ab ✅ SAFE
 
-**Risiko**: Langlebiger Magic-Link ermöglicht verzögerte Abfangung und Wiederholung.
+**Risiko**: Langlebiger Magic-Link ermöglicht verzögerte Abfangung und Replay.
 **Befund**: SAFE — TTL ≤ 900 Sekunden (15 Minuten) durch Test bestätigt.
 
 ---
 
-### V-10 — Session hat Ablaufdatum ✅ SAFE
+### V-10 — Session hat Ablaufzeit ✅ SAFE
 
-**Risiko**: Session läuft nie ab; alte Token bleiben für immer gültig.
-**Befund**: SAFE — `expires_at` wird in der Zukunft bei Session-Erstellung gesetzt; als nicht-null bestätigt.
+**Risiko**: Session läuft nie ab; alte Tokens bleiben unbegrenzt gültig.
+**Befund**: SAFE — `expires_at` wird bei Session-Erstellung in der Zukunft gesetzt; nicht-null bestätigt.
 
 ---
 
 ### V-11 — Session-Token hat ausreichende Entropie ✅ SAFE
 
-**Risiko**: Kurzes Session-Token per Brute-Force knackbar.
+**Risiko**: Kurzes Session-Token brute-forcebar.
 **Befund**: SAFE — `bin2hex(random_bytes(32))` = 64 Hex-Zeichen = 256-Bit-Entropie.
 
 ---
@@ -245,18 +245,18 @@ if (!str_starts_with($authHeader, 'Bearer ')) {
 ### VULN-Zusammenfassung
 
 | ID | Schwachstelle | Befund |
-|----|---------------|--------|
-| V-01 | Ablauf vs. used_at-Prüfreihenfolge | ✅ SAFE |
+|----|---------------|---------|
+| V-01 | Reihenfolge Ablauf vs. used_at-Prüfung | ✅ SAFE |
 | V-02 | Session-Token im Klartext in DB | ✅ SAFE |
-| V-03 | Wiederverwendung genutzter Magic-Links | ✅ SAFE |
+| V-03 | Wiederverwendung des verwendeten Magic-Links | ✅ SAFE |
 | V-04 | Session gültig nach Logout | ✅ SAFE |
 | V-05 | E-Mail-Enumeration | ✅ SAFE |
-| V-06 | Widerrufener Sessionzugriff | ✅ SAFE |
-| V-07 | Abgelaufener Sessionzugriff | ✅ SAFE |
+| V-06 | Zugriff mit widerrufener Session | ✅ SAFE |
+| V-07 | Zugriff mit abgelaufener Session | ✅ SAFE |
 | V-08 | Magic-Link-Token in DB | ✅ SAFE |
 | V-09 | Magic-Link-TTL > 15 Min | ✅ SAFE |
-| V-10 | Kein Session-Ablauf | ✅ SAFE |
-| V-11 | Niedrige Entropie beim Session-Token | ✅ SAFE |
+| V-10 | Keine Session-Ablaufzeit | ✅ SAFE |
+| V-11 | Geringe Entropie beim Session-Token | ✅ SAFE |
 | V-12 | X-User-Id-Bypass | ✅ SAFE |
 
 **12 SAFE, 0 EXPOSED**
@@ -265,14 +265,14 @@ if (!str_starts_with($authHeader, 'Bearer ')) {
 
 ## Was man NICHT tun sollte
 
-| Anti-Muster | Risiko |
+| Anti-Pattern | Risiko |
 |---|---|
-| Rohes Magic-Link-Token in DB speichern | DB-Verletzung lässt Angreifer sich als beliebiger Benutzer authentifizieren |
-| Rohes Session-Token in DB speichern | DB-Verletzung macht alle Sessions ungültig |
+| Rohes Magic-Link-Token in DB speichern | DB-Breach ermöglicht Authentifizierung als beliebiger Benutzer |
+| Rohes Session-Token in DB speichern | DB-Breach macht alle Sessions ungültig |
 | used_at vor expires_at prüfen | Timing-Leck enthüllt, ob Token verwendet wurde |
-| Fehler für nicht-existierende E-Mail zurückgeben | Angreifer enumeriert registrierte E-Mails |
-| Kein TTL für Magic-Links | Unbegrenzt gültige Token; verzögerter Abfangangriff |
-| Kein Session-Ablauf | Sessions bleiben für immer gültig |
+| Fehler für nicht existierende E-Mail zurückgeben | Angreifer enumeriert registrierte E-Mails |
+| Keine TTL für Magic-Links | Unbegrenzt gültige Tokens; verzögerter Abfangangriff |
+| Keine Session-Ablaufzeit | Sessions bleiben unbegrenzt gültig |
 | X-User-Id für Bearer-Auth akzeptieren | Header-basierter Auth-Bypass ohne Token |
-| Token mit niedriger Entropie (`rand()` oder 8 Zeichen) | Per Brute-Force knackbare Token |
+| Token mit geringer Entropie (`rand()` oder 8-stellig) | Brute-forcierbare Tokens |
 | Denselben Magic-Link für mehrere Sessions wiederverwenden | Einzelne Token-Exposition gewährt alle nachfolgenden Sessions |

--- a/docs/de/howto/mass-assignment-defence.md
+++ b/docs/de/howto/mass-assignment-defence.md
@@ -1,0 +1,335 @@
+# How-to: Mass-Assignment-Schutz mit explizitem DTO
+
+> **FT-Referenz**: FT256 (`NENE2-FT/masslog`) — Mass-Assignment-Schutz-Muster mit explizitem DTO-Whitelisting
+> **ATK**: FT256 — Cracker-Mindset-Angriffstests (ATK-01 bis ATK-12)
+
+Demonstriert, wie Mass-Assignment-Schwachstellen verhindert werden, indem ein explizites readonly-DTO verwendet wird, das nur die Felder whitelistet, die Aufrufer setzen dürfen. Serverseitig gesteuerte Felder (`role`, `is_active`, `created_at`, `id`) sind vom DTO ausgeschlossen und im Repository fest kodiert. Enthält eine vollständige Cracker-Mindset-Angriffsbewertung.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|----------|---------------------------|
+| `POST` | `/users` | Benutzer erstellen (role=user) |
+| `GET`  | `/users` | Alle Benutzer auflisten |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    name      TEXT    NOT NULL,
+    email     TEXT    NOT NULL UNIQUE,
+    role      TEXT    NOT NULL DEFAULT 'user' CHECK (role IN ('user', 'admin')),
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT   NOT NULL
+);
+```
+
+`CHECK(role IN ('user', 'admin'))` ist ein DB-Sicherheitsnetz. Die Anwendung schreibt bei der Erstellung immer `'user'` in `role`, daher wird der Constraint im normalen Betrieb nie ausgelöst — er schützt vor Fehlern oder direktem DB-Zugriff.
+
+---
+
+## Das explizite DTO: Feld-Whitelisting
+
+```php
+/**
+ * Explizites DTO für Benutzererstellung — nur name und email werden aus Benutzereingaben akzeptiert.
+ *
+ * role und is_active sind absichtlich ausgeschlossen: Sie müssen durch serverseitige
+ * Geschäftslogik gesetzt werden, niemals aus dem Request-Body. Das ist der Mass-Assignment-Schutz.
+ */
+final readonly class CreateUserInput
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+    ) {}
+}
+```
+
+Das DTO hat genau zwei Felder — `name` und `email`. Es gibt kein `role`-, `is_active`-, `created_at`- oder `id`-Feld. Ein Angreifer kann diese Felder nicht injizieren, weil der Konstruktor sie schlicht nicht akzeptiert.
+
+**Warum das besser als eine Blockliste ist**:
+
+| Ansatz | Sicherheitsmodell | Fehlermodus |
+|---|---|---|
+| Explizite Allowlist (DTO) | Unbekanntes standardmäßig ablehnen | Sicher — neue Felder müssen explizit hinzugefügt werden |
+| Blockliste (`unset($body['role'])`) | Bekannt-Schädliches blockieren | Unsicher — neue sensible Felder werden vergessen |
+| `array_intersect_key` | Auf bekannte Schlüssel filtern | Akzeptabel — gleich wie Allowlist wenn Schlüssel vollständig sind |
+
+Ein explizites DTO versagt sicher: Das Hinzufügen einer neuen sensiblen Spalte zum Schema exponiert diese nicht automatisch — der Entwickler muss sie explizit zum DTO hinzufügen.
+
+---
+
+## Controller: explizite Feldextraktion
+
+```php
+private function createUser(ServerRequestInterface $request): ResponseInterface
+{
+    $body = json_decode((string) $request->getBody(), true);
+    if (!is_array($body)) {
+        return $this->problems->create($request, 'invalid-body', '...', 400);
+    }
+
+    $errors = [];
+
+    if (!isset($body['name']) || !is_string($body['name']) || trim($body['name']) === '') {
+        $errors[] = ['field' => 'name', 'code' => 'required', 'message' => 'name is required.'];
+    }
+    if (!isset($body['email']) || !is_string($body['email']) || !filter_var($body['email'], FILTER_VALIDATE_EMAIL)) {
+        $errors[] = ['field' => 'email', 'code' => 'invalid-email', 'message' => 'email must be a valid email address.'];
+    }
+
+    if ($errors !== []) {
+        return $this->problems->create($request, 'validation-failed', 'Validation failed.', 422, null, ['errors' => $errors]);
+    }
+
+    // Nur erlaubte Felder werden gemappt — extra Felder (role, is_active, etc.) werden stillschweigend verworfen
+    $input = new CreateUserInput(
+        name:  trim((string) $body['name']),
+        email: strtolower(trim((string) $body['email'])),
+    );
+
+    $user = $this->repo->create($input);
+    return $this->json->create([...], 201);
+}
+```
+
+Der Controller liest `$body['name']` und `$body['email']` explizit. Alle anderen Schlüssel in `$body` werden stillschweigend verworfen — sie werden nie gelesen oder weitergegeben.
+
+E-Mail wird vor der DTO-Erstellung zu Kleinbuchstaben normalisiert (`strtolower`), um doppelte E-Mails zu verhindern, die sich nur in der Groß-/Kleinschreibung unterscheiden.
+
+---
+
+## Repository: serverseitig gesteuerte Felder
+
+```php
+public function create(CreateUserInput $input): User
+{
+    $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+    $id = $this->executor->insert(
+        'INSERT INTO users (name, email, role, is_active, created_at) VALUES (?, ?, ?, ?, ?)',
+        [$input->name, $input->email, 'user', 1, $now],  // role und is_active sind fest kodiert
+    );
+
+    return new User(
+        id:        $id,
+        name:      $input->name,
+        email:     $input->email,
+        role:      'user',    // fest kodiert, nicht aus $input
+        isActive:  true,      // fest kodiert, nicht aus $input
+        createdAt: $now,
+    );
+}
+```
+
+`'user'` und `1` sind Literalwerte im INSERT. Es gibt keine Möglichkeit, dass Benutzereingaben `role` oder `is_active` beeinflussen. Die `CreateUserInput`-DTO-Typsignatur erzwingt dies auf PHP-Typebene.
+
+---
+
+## ATK — Cracker-Mindset-Angriffstests (FT256)
+
+### ATK-01 — Privilegieneskalation: `role: "admin"` im Request-Body injizieren
+
+**Angriff**: `role` in den Request-Body einschließen, um einen Admin-Benutzer zu erstellen.
+
+```json
+{"name": "Attacker", "email": "attacker@example.com", "role": "admin"}
+```
+
+**Beobachtet**: `role` ist kein Feld in `CreateUserInput`. Der Controller liest nur `name` und `email` aus `$body`. Der extra Schlüssel wird stillschweigend verworfen. Der erstellte Benutzer hat `role = 'user'`.
+
+**Urteil**: **BLOCKED** — explizite DTO-Feld-Whitelist verhindert Privilegieneskalation.
+
+---
+
+### ATK-02 — Kontostatus-Manipulation: `is_active: false` injizieren
+
+**Angriff**: Benutzer mit `is_active = false` erstellen, um ein deaktiviertes Konto zu erstellen oder zu testen, ob das Feld beschreibbar ist.
+
+```json
+{"name": "Bob", "email": "bob@example.com", "is_active": false}
+```
+
+**Beobachtet**: `is_active` ist nicht in `CreateUserInput`. Der erstellte Benutzer hat `is_active = true` (fest kodiert im INSERT).
+
+**Urteil**: **BLOCKED** — `is_active` wird nie aus dem Request gelesen.
+
+---
+
+### ATK-03 — Zeitstempel-Manipulation: `created_at` injizieren
+
+**Angriff**: Den Erstellungszeitstempel des Benutzers zurückdatieren.
+
+```json
+{"name": "Carol", "email": "carol@example.com", "created_at": "2000-01-01 00:00:00"}
+```
+
+**Beobachtet**: `created_at` ist nicht in `CreateUserInput`. Das Repository generiert `$now` aus `DateTimeImmutable` zum Schreibzeitpunkt.
+
+**Urteil**: **BLOCKED** — Audit-Zeitstempel werden serverseitig generiert, nicht clientseitig geliefert.
+
+---
+
+### ATK-04 — ID-Hijacking: `id: 9999` injizieren
+
+**Angriff**: Einen Primärschlüssel vorab auswählen, um einen vorhandenen Datensatz zu überschreiben oder eine bekannte ID zu beanspruchen.
+
+```json
+{"name": "Dave", "email": "dave@example.com", "id": 9999}
+```
+
+**Beobachtet**: `id` ist nicht in `CreateUserInput`. Das INSERT verwendet `AUTOINCREMENT` — die `id` wird von SQLite zugewiesen, nicht aus einem benutzerseitig angegebenen Wert.
+
+**Urteil**: **BLOCKED** — Primärschlüsselzuweisung erfolgt immer serverseitig.
+
+---
+
+### ATK-05 — SQL-Injection über Name oder E-Mail
+
+**Angriff**: SQL-Metazeichen einbetten.
+
+```json
+{"name": "'; DROP TABLE users; --", "email": "sql@example.com"}
+```
+
+**Beobachtet**: Beide Felder werden als parametrisierte `?`-Platzhalter im INSERT gebunden. Das Injection-Payload wird als Literaltext gespeichert.
+
+**Urteil**: **BLOCKED** — parametrisierte Abfragen verhindern SQL-Injection.
+
+---
+
+### ATK-06 — E-Mail-Groß-/Kleinschreibungs-Bypass: E-Mail in Großbuchstaben einreichen
+
+**Angriff**: `ADMIN@EXAMPLE.COM` als anderen Benutzer als `admin@example.com` registrieren.
+
+```json
+{"name": "Eve", "email": "ADMIN@EXAMPLE.COM"}
+```
+
+**Beobachtet**: Der Controller wendet `strtolower()` an, bevor er an das DTO übergibt. Sowohl `ADMIN@EXAMPLE.COM` als auch `admin@example.com` normalisieren zu `admin@example.com`. Der `UNIQUE`-Constraint verhindert eine zweite Registrierung.
+
+**Urteil**: **BLOCKED** — Groß-/Kleinschreibungsnormalisierung + UNIQUE-Constraint verhindern doppelte Konten.
+
+---
+
+### ATK-07 — Doppelte E-Mail: dieselbe Adresse zweimal registrieren
+
+**Angriff**: Dieselbe E-Mail-Adresse registrieren, um einen Fehler auszulösen oder doppelte Konten zu erstellen.
+
+```json
+{"name": "Frank", "email": "frank@example.com"}
+{"name": "FrankDuplicate", "email": "frank@example.com"}
+```
+
+**Beobachtet**: Die erste Anfrage gelingt mit `201`. Die zweite Anfrage löst einen SQLite-`UNIQUE`-Constraint-Verstoß aus. Die aktuelle Implementierung fängt diese Exception nicht ab — sie propagiert als unbehandelter Fehler.
+
+**Urteil**: **EXPOSED** — den UNIQUE-Constraint-Verstoß abfangen und eine strukturierte `409 Conflict`- oder `422 Unprocessable Entity`-Antwort zurückgeben. Rohe DB-Fehler zu enthüllen ist ein Sicherheits- und UX-Problem.
+
+---
+
+### ATK-08 — XSS-Payload in Name oder E-Mail
+
+**Angriff**: Ein Script-Tag speichern.
+
+```json
+{"name": "<script>alert(1)</script>", "email": "xss@example.com"}
+```
+
+**Beobachtet**: Inhalt wird unverändert gespeichert und wörtlich in JSON zurückgegeben. Die API kodiert die Ausgabe nicht HTML-mäßig.
+
+**Urteil**: **BY DESIGN AKZEPTIERT** — JSON-APIs geben rohen Inhalt zurück. Die Rendering-Schicht muss vor dem Einfügen in HTML bereinigen.
+
+---
+
+### ATK-09 — Fehlende Pflichtfelder
+
+**Angriff**: `name` oder `email` weglassen.
+
+```json
+{"email": "missing@example.com"}
+{"name": "NoEmail"}
+{}
+```
+
+**Beobachtet**: Jede gibt `422 Unprocessable Entity` mit einem strukturierten `errors`-Array zurück, das das fehlende Feld namentlich identifiziert.
+
+**Urteil**: **BLOCKED** — explizite Präsenzprüfungen für jedes Pflichtfeld.
+
+---
+
+### ATK-10 — Typverwechslung: Name als Integer einreichen
+
+**Angriff**: `name` als JSON-Zahl senden.
+
+```json
+{"name": 12345, "email": "typed@example.com"}
+```
+
+**Beobachtet**: `is_string($body['name'])` gibt `false` für Integer-Werte zurück. Die Anfrage gibt `422` mit `name is required` zurück.
+
+**Urteil**: **BLOCKED** — `is_string()` lehnt Nicht-String-Typen ab.
+
+---
+
+### ATK-11 — Sehr langer Name oder E-Mail
+
+**Angriff**: Einen Namen oder eine E-Mail mit mehr als 10.000 Zeichen einreichen.
+
+```json
+{"name": "aaaa...aaaa (10000 Zeichen)", "email": "x@example.com"}
+```
+
+**Beobachtet**: Die Anfrage gelingt mit `201`. Keine Längenvalidierung wird auf `name` oder `email` angewendet. SQLite speichert TEXT ohne inhärentes Längenlimit.
+
+**Urteil**: **EXPOSED** — Längenvalidierung hinzufügen (z.B. `mb_strlen($name) > 255 → 422`). Request-Size-Middleware als äußeres Limit verwenden.
+
+---
+
+### ATK-12 — Mehrere Rollenwerte: als Array injizieren
+
+**Angriff**: `role` als Array statt als String einreichen.
+
+```json
+{"name": "Grace", "email": "grace@example.com", "role": ["admin", "superuser"]}
+```
+
+**Beobachtet**: `role` wird überhaupt nicht aus `$body` gelesen. Ob es ein String, Array oder null ist, hat keinen Einfluss auf den erstellten Benutzer.
+
+**Urteil**: **BLOCKED** — das DTO schließt `role` vollständig aus; sein Typ ist irrelevant.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|---------------|---------|
+| ATK-01 | Privilegieneskalation über `role: "admin"` | BLOCKED |
+| ATK-02 | Kontostatus-Manipulation über `is_active: false` | BLOCKED |
+| ATK-03 | Zeitstempel-Rückdatierung über `created_at` | BLOCKED |
+| ATK-04 | ID-Hijacking über `id: 9999` | BLOCKED |
+| ATK-05 | SQL-Injection über Name/E-Mail | BLOCKED |
+| ATK-06 | E-Mail-Groß-/Kleinschreibungs-Bypass (`ADMIN@EXAMPLE.COM`) | BLOCKED |
+| ATK-07 | Doppelte E-Mail (kein graceful Fehler) | EXPOSED |
+| ATK-08 | XSS-Payload im Namen | BY DESIGN AKZEPTIERT |
+| ATK-09 | Fehlende Pflichtfelder | BLOCKED |
+| ATK-10 | Typverwechslung (Name als Integer) | BLOCKED |
+| ATK-11 | Sehr langer Name oder E-Mail (kein Längenlimit) | EXPOSED |
+| ATK-12 | Role als Array | BLOCKED |
+
+**Echte Schwachstellen, die vor der Produktion behoben werden müssen**:
+1. **ATK-07** — UNIQUE-Constraint-Verstoß abfangen; `409 Conflict` mit benutzerfreundlicher Meldung zurückgeben
+2. **ATK-11** — `mb_strlen`-Längenvalidierung für `name` und `email` hinzufügen
+
+---
+
+## Verwandte Anleitungen
+
+- [`mass-assignment.md`](mass-assignment.md) — Übersicht über Mass-Assignment-Schutz-Muster
+- [`enforce-resource-ownership.md`](enforce-resource-ownership.md) — eigentumsbasierte Abfragen zur IDOR-Prävention
+- [`rbac.md`](rbac.md) — rollenbasierte Zugangskontrolle mit JWT-Claims
+- [`user-profile-management.md`](user-profile-management.md) — Profilaktualisierung mit Feld-Whitelisting

--- a/docs/de/howto/mass-assignment.md
+++ b/docs/de/howto/mass-assignment.md
@@ -1,8 +1,8 @@
 # Mass-Assignment-Schutz
 
-Mass Assignment ist eine Schwachstelle, bei der ein Angreifer dem Request-Body zusätzliche Felder hinzufügt — wie `role=admin` oder `is_active=false` — und der Server sie unbeabsichtigt persistiert.
+Mass-Assignment ist eine Schwachstelle, bei der ein Angreifer dem Request-Body extra Felder hinzufügt — wie `role=admin` oder `is_active=false` — und der Server diese unbeabsichtigt persistiert.
 
-NENE2 hat keine `create($body)`-Zaubermethode, die dies versehentlich leicht auslösbar machen würde. Trotzdem ist das DTO-Whitelist-Muster die korrekte und explizite Verteidigung.
+NENE2 hat keine `create($body)`-Methode, die das versehentliche Auslösen vereinfachen würde. Dennoch ist das DTO-Whitelist-Muster die korrekte und explizite Abwehr.
 
 ## Die Schwachstelle
 
@@ -26,16 +26,16 @@ Ein Angreifer sendet:
 }
 ```
 
-Da `$body['role']` aus der Anfrage gelesen wird, erhält der Angreifer `role=admin` in der Datenbank.
+Da `$body['role']` aus dem Request gelesen wird, erhält der Angreifer `role=admin` in der Datenbank.
 
-## Die Verteidigung: Explizite DTO-Allowlist
+## Die Abwehr: Explizite DTO-Whitelist
 
-Ein DTO definieren, das nur die Felder enthält, die ein Benutzer liefern darf:
+Ein DTO definieren, das nur die Felder enthält, die ein Benutzer angeben darf:
 
 ```php
 /**
  * Nur name und email werden aus Benutzereingaben akzeptiert.
- * role und is_active werden durch serverseitige Logik gesetzt, niemals aus der Anfrage.
+ * role und is_active werden durch serverseitige Logik gesetzt, niemals aus dem Request.
  */
 final readonly class CreateUserInput
 {
@@ -46,10 +46,10 @@ final readonly class CreateUserInput
 }
 ```
 
-Im Controller nur die erlaubten Felder auf das DTO abbilden:
+Im Controller nur die erlaubten Felder auf das DTO mappen:
 
 ```php
-// ✅ Zusätzliche Felder (role, is_active, id, created_at) werden niemals aus $body gelesen
+// ✅ Extra Felder (role, is_active, id, created_at) werden nie aus $body gelesen
 $input = new CreateUserInput(
     name:  trim((string) $body['name']),
     email: strtolower(trim((string) $body['email'])),
@@ -58,7 +58,7 @@ $input = new CreateUserInput(
 $user = $this->repo->create($input);
 ```
 
-Im Repository die DTO-Eigenschaften direkt verwenden:
+Im Repository die DTO-Properties direkt verwenden:
 
 ```php
 public function create(CreateUserInput $input): User
@@ -66,26 +66,26 @@ public function create(CreateUserInput $input): User
     $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
     $id = $this->executor->insert(
         'INSERT INTO users (name, email, role, is_active, created_at) VALUES (?, ?, ?, ?, ?)',
-        [$input->name, $input->email, 'user', 1, $now], // role und is_active sind hardcodiert
+        [$input->name, $input->email, 'user', 1, $now], // role und is_active sind fest kodiert
     );
     // ...
 }
 ```
 
-Selbst wenn der Angreifer `role=admin` sendet, hat `$input` nur `name` und `email` — das zusätzliche Feld erreicht den INSERT niemals.
+Selbst wenn der Angreifer `role=admin` sendet, hat `$input` nur `name` und `email` — das extra Feld erreicht das INSERT nie.
 
-## Behandelte Angriffsszenarien
+## Abgedeckte Angriffsszenarien
 
-| Feld | Angriffsabsicht | Verteidigung |
-|------|-----------------|-------------|
-| `role=admin` | Rechteerweiterung | `role` ist nicht in `CreateUserInput`; immer auf `'user'` im Repository gesetzt |
+| Feld | Angriffsabsicht | Abwehr |
+|-------|---------------|---------|
+| `role=admin` | Privilegieneskalation | `role` ist nicht in `CreateUserInput`; immer auf `'user'` im Repository gesetzt |
 | `is_active=false` | Deaktiviertes Konto erstellen oder Benutzer sperren | `is_active` nicht im DTO; immer auf `1` gesetzt |
-| `id=9999` | Primärschlüssel überschreiben | `id` nicht im DTO; automatisch von SQLite vergeben |
+| `id=9999` | Primärschlüssel überschreiben | `id` nicht im DTO; automatisch von SQLite zugewiesen |
 | `created_at=2000-01-01` | Audit-Zeitstempel fälschen | `created_at` nicht im DTO; immer auf aktuelle Zeit gesetzt |
 
-## Response-Feld-Kontrolle
+## Antwortfeld-Kontrolle
 
-Die Verteidigung erstreckt sich auf die Response: niemals DB-Zeilen direkt zurückgeben. Explizit abbilden, was eingeschlossen werden soll:
+Die Abwehr erstreckt sich auch auf die Antwort: DB-Zeilen niemals direkt zurückgeben. Explizit mappen, was eingeschlossen werden soll:
 
 ```php
 return $this->json->create([
@@ -95,12 +95,12 @@ return $this->json->create([
     'role'       => $user->role,
     'is_active'  => $user->isActive,
     'created_at' => $user->createdAt,
-    // password_hash bewusst ausgeschlossen
-    // deleted_at bewusst ausgeschlossen
+    // password_hash absichtlich ausgeschlossen
+    // deleted_at absichtlich ausgeschlossen
 ], 201);
 ```
 
-Auf das Fehlen sensibler Felder testen:
+Auf die Abwesenheit sensibler Felder testen:
 
 ```php
 $this->assertArrayNotHasKey('password_hash', $data);
@@ -109,7 +109,7 @@ $this->assertArrayNotHasKey('deleted_at', $data);
 
 ## Vertrauenswürdige interne Dienste
 
-Wenn ein interner Dienst einen Admin-Benutzer erstellen muss (z.B. ein Bereitstellungsdienst), ein separates DTO verwenden:
+Wenn ein interner Dienst einen Admin-Benutzer erstellen muss (z.B. ein Bereitstellungs-Service), ein separates DTO verwenden:
 
 ```php
 final readonly class AdminCreateUserInput
@@ -127,22 +127,22 @@ Dieses DTO nur aus Code-Pfaden aufrufen, die die Identität des Aufrufers bereit
 
 ## `create()` vs `createList()` für Antworten
 
-Wenn eine Liste zurückgegeben wird, `createList()` statt `create()` verwenden:
+Beim Zurückgeben einer Liste `createList()` statt `create()` verwenden:
 
 ```php
-// ✅ Top-Level JSON-Array
+// ✅ JSON-Array auf oberster Ebene
 return $this->json->createList(array_map(fn (User $u) => [...], $users));
 
-// ✅ Top-Level JSON-Objekt
+// ✅ JSON-Objekt auf oberster Ebene
 return $this->json->create(['id' => $user->id, ...], 201);
 ```
 
-`create()` erwartet `array<string, mixed>` (ein Objekt). Die Ausgabe von `array_map()` direkt an `create()` übergeben verursacht einen PHPStan-Level-8-Typfehler, da `array_map` `list<T>` zurückgibt.
+`create()` erwartet `array<string, mixed>` (ein Objekt). Die direkte Übergabe von `array_map()`-Ausgabe an `create()` verursacht einen PHPStan Level 8 Typfehler, weil `array_map` ein `list<T>` zurückgibt.
 
 ## Code-Review-Checkliste
 
-- [ ] Request-Body-Felder werden vor der Übergabe an das Repository auf ein DTO abgebildet
-- [ ] DTO enthält nur Felder, die der Benutzer liefern darf
-- [ ] Server-gesteuerte Felder (`role`, `is_active`, Zeitstempel, Primärschlüssel) werden im Repository gesetzt, nicht aus `$body` gelesen
-- [ ] Response listet zurückgegebene Felder explizit auf; kein Wildcard-`SELECT *` oder direkte Zeile-zu-JSON-Serialisierung
-- [ ] Tests verifizieren, dass zusätzliche Request-Felder ignoriert werden und den persistierten Wert nicht beeinflussen
+- [ ] Request-Body-Felder werden auf ein DTO gemappt, bevor sie an das Repository übergeben werden
+- [ ] DTO enthält nur Felder, die der Benutzer angeben darf
+- [ ] Serverseitig gesteuerte Felder (`role`, `is_active`, Zeitstempel, Primärschlüssel) werden im Repository gesetzt, nicht aus `$body` gelesen
+- [ ] Antwort listet explizit die zurückgegebenen Felder auf; kein Wildcard-`SELECT *` oder direkte Zeile-zu-JSON-Serialisierung
+- [ ] Tests verifizieren, dass extra Request-Felder ignoriert werden und den persistierten Wert nicht beeinflussen

--- a/docs/de/howto/mass-assignment.md
+++ b/docs/de/howto/mass-assignment.md
@@ -1,0 +1,148 @@
+# Mass-Assignment-Schutz
+
+Mass Assignment ist eine Schwachstelle, bei der ein Angreifer dem Request-Body zusätzliche Felder hinzufügt — wie `role=admin` oder `is_active=false` — und der Server sie unbeabsichtigt persistiert.
+
+NENE2 hat keine `create($body)`-Zaubermethode, die dies versehentlich leicht auslösbar machen würde. Trotzdem ist das DTO-Whitelist-Muster die korrekte und explizite Verteidigung.
+
+## Die Schwachstelle
+
+```php
+// ❌ Gefährlich: $body direkt an INSERT übergeben
+$body = json_decode((string) $request->getBody(), true);
+
+$this->executor->insert(
+    'INSERT INTO users (name, email, role, is_active) VALUES (?, ?, ?, ?)',
+    [$body['name'], $body['email'], $body['role'] ?? 'user', $body['is_active'] ?? 1],
+);
+```
+
+Ein Angreifer sendet:
+
+```json
+{
+  "name": "Attacker",
+  "email": "attacker@example.com",
+  "role": "admin"
+}
+```
+
+Da `$body['role']` aus der Anfrage gelesen wird, erhält der Angreifer `role=admin` in der Datenbank.
+
+## Die Verteidigung: Explizite DTO-Allowlist
+
+Ein DTO definieren, das nur die Felder enthält, die ein Benutzer liefern darf:
+
+```php
+/**
+ * Nur name und email werden aus Benutzereingaben akzeptiert.
+ * role und is_active werden durch serverseitige Logik gesetzt, niemals aus der Anfrage.
+ */
+final readonly class CreateUserInput
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+    ) {}
+}
+```
+
+Im Controller nur die erlaubten Felder auf das DTO abbilden:
+
+```php
+// ✅ Zusätzliche Felder (role, is_active, id, created_at) werden niemals aus $body gelesen
+$input = new CreateUserInput(
+    name:  trim((string) $body['name']),
+    email: strtolower(trim((string) $body['email'])),
+);
+
+$user = $this->repo->create($input);
+```
+
+Im Repository die DTO-Eigenschaften direkt verwenden:
+
+```php
+public function create(CreateUserInput $input): User
+{
+    $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+    $id = $this->executor->insert(
+        'INSERT INTO users (name, email, role, is_active, created_at) VALUES (?, ?, ?, ?, ?)',
+        [$input->name, $input->email, 'user', 1, $now], // role und is_active sind hardcodiert
+    );
+    // ...
+}
+```
+
+Selbst wenn der Angreifer `role=admin` sendet, hat `$input` nur `name` und `email` — das zusätzliche Feld erreicht den INSERT niemals.
+
+## Behandelte Angriffsszenarien
+
+| Feld | Angriffsabsicht | Verteidigung |
+|------|-----------------|-------------|
+| `role=admin` | Rechteerweiterung | `role` ist nicht in `CreateUserInput`; immer auf `'user'` im Repository gesetzt |
+| `is_active=false` | Deaktiviertes Konto erstellen oder Benutzer sperren | `is_active` nicht im DTO; immer auf `1` gesetzt |
+| `id=9999` | Primärschlüssel überschreiben | `id` nicht im DTO; automatisch von SQLite vergeben |
+| `created_at=2000-01-01` | Audit-Zeitstempel fälschen | `created_at` nicht im DTO; immer auf aktuelle Zeit gesetzt |
+
+## Response-Feld-Kontrolle
+
+Die Verteidigung erstreckt sich auf die Response: niemals DB-Zeilen direkt zurückgeben. Explizit abbilden, was eingeschlossen werden soll:
+
+```php
+return $this->json->create([
+    'id'         => $user->id,
+    'name'       => $user->name,
+    'email'      => $user->email,
+    'role'       => $user->role,
+    'is_active'  => $user->isActive,
+    'created_at' => $user->createdAt,
+    // password_hash bewusst ausgeschlossen
+    // deleted_at bewusst ausgeschlossen
+], 201);
+```
+
+Auf das Fehlen sensibler Felder testen:
+
+```php
+$this->assertArrayNotHasKey('password_hash', $data);
+$this->assertArrayNotHasKey('deleted_at', $data);
+```
+
+## Vertrauenswürdige interne Dienste
+
+Wenn ein interner Dienst einen Admin-Benutzer erstellen muss (z.B. ein Bereitstellungsdienst), ein separates DTO verwenden:
+
+```php
+final readonly class AdminCreateUserInput
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+        public string $role,   // nur für interne Aufrufer erlaubt
+        public bool $isActive,
+    ) {}
+}
+```
+
+Dieses DTO nur aus Code-Pfaden aufrufen, die die Identität des Aufrufers bereits verifiziert haben (z.B. Machine-API-Key, interne Service-Auth). Niemals einen öffentlichen HTTP-Endpunkt exponieren, der `AdminCreateUserInput` direkt akzeptiert.
+
+## `create()` vs `createList()` für Antworten
+
+Wenn eine Liste zurückgegeben wird, `createList()` statt `create()` verwenden:
+
+```php
+// ✅ Top-Level JSON-Array
+return $this->json->createList(array_map(fn (User $u) => [...], $users));
+
+// ✅ Top-Level JSON-Objekt
+return $this->json->create(['id' => $user->id, ...], 201);
+```
+
+`create()` erwartet `array<string, mixed>` (ein Objekt). Die Ausgabe von `array_map()` direkt an `create()` übergeben verursacht einen PHPStan-Level-8-Typfehler, da `array_map` `list<T>` zurückgibt.
+
+## Code-Review-Checkliste
+
+- [ ] Request-Body-Felder werden vor der Übergabe an das Repository auf ein DTO abgebildet
+- [ ] DTO enthält nur Felder, die der Benutzer liefern darf
+- [ ] Server-gesteuerte Felder (`role`, `is_active`, Zeitstempel, Primärschlüssel) werden im Repository gesetzt, nicht aus `$body` gelesen
+- [ ] Response listet zurückgegebene Felder explizit auf; kein Wildcard-`SELECT *` oder direkte Zeile-zu-JSON-Serialisierung
+- [ ] Tests verifizieren, dass zusätzliche Request-Felder ignoriert werden und den persistierten Wert nicht beeinflussen

--- a/docs/de/howto/media-watchlist.md
+++ b/docs/de/howto/media-watchlist.md
@@ -1,22 +1,22 @@
-# How-to: Medien-Watchlist-API
+# How-to: Medien-Merklisten-API
 
-> **FT-Referenz**: FT59 (`NENE2-FT/watchlog`) — Medien-Watch-List-API
+> **FT-Referenz**: FT59 (`NENE2-FT/watchlog`) — Medien-Merklisten-API
 
-Demonstriert eine persönliche Medien-Watchlist mit backed String-Enums für Status und Typ, optionalen nullable-Feldern mit `array_key_exists`, Archivieren/Wiederherstellen über POST-Aktionsendpunkte und einer 1–5-Integer-Bewertung. Alle Status- und Typvalidierungen verwenden PHPs `BackedEnum::tryFrom()`, um sicherzustellen, dass nur bekannte Werte akzeptiert werden.
+Demonstriert eine persönliche Medien-Merkliste mit backed-String-Enums für Status und Typ, optionalen nullable Feldern mit `array_key_exists`, Archivierung/Wiederherstellung über POST-Aktions-Endpunkte und einer 1–5-Integer-Bewertung. Die gesamte Status- und Typvalidierung verwendet PHPs `BackedEnum::tryFrom()`, um sicherzustellen, dass nur bekannte Werte akzeptiert werden.
 
 ---
 
 ## Routen
 
 | Methode | Pfad | Beschreibung |
-|--------|------|-------------|
-| `GET`    | `/watch` | Einträge auflisten (gefiltert und paginiert) |
-| `POST`   | `/watch` | Einen Eintrag zur Watchlist hinzufügen |
-| `GET`    | `/watch/{id}` | Einen einzelnen Eintrag abrufen |
-| `PATCH`  | `/watch/{id}/status` | Status aktualisieren (und optional Bewertung/Notiz) |
-| `POST`   | `/watch/{id}/archive` | Eintrag ins Archiv verschieben |
-| `POST`   | `/watch/{id}/restore` | Einen archivierten Eintrag wiederherstellen |
-| `DELETE` | `/watch/{id}` | Einen Eintrag dauerhaft löschen |
+|----------|------|-------------|
+| `GET`    | `/watch`                   | Einträge auflisten (gefiltert und paginiert)  |
+| `POST`   | `/watch`                   | Eintrag zur Merkliste hinzufügen              |
+| `GET`    | `/watch/{id}`              | Einzelnen Eintrag abrufen                     |
+| `PATCH`  | `/watch/{id}/status`       | Status aktualisieren (und optional Bewertung/Notiz) |
+| `POST`   | `/watch/{id}/archive`      | Eintrag ins Archiv verschieben                |
+| `POST`   | `/watch/{id}/restore`      | Archivierten Eintrag wiederherstellen         |
+| `DELETE` | `/watch/{id}`              | Eintrag dauerhaft löschen                     |
 
 ---
 
@@ -40,7 +40,7 @@ enum MediaType: string
 }
 ```
 
-Im Controller gibt `tryFrom()` `null` für unbekannte Werte zurück, was auf 422 abgebildet wird:
+Im Controller gibt `tryFrom()` `null` für unbekannte Werte zurück, was zu einem 422 führt:
 
 ```php
 $statusRaw = isset($body['status']) && is_string($body['status']) ? $body['status'] : null;
@@ -53,7 +53,7 @@ if ($statusRaw === null) {
 }
 ```
 
-Die zweistufige Prüfung unterscheidet "Feld fehlt" (required) von "Feld vorhanden, aber ungültig" (invalid_value), was bessere Fehlermeldungen erzeugt.
+Die zweistufige Prüfung unterscheidet "Feld fehlt" (required) von "Feld vorhanden, aber ungültig" (invalid_value) und erzeugt bessere Fehlermeldungen.
 
 ---
 
@@ -62,7 +62,7 @@ Die zweistufige Prüfung unterscheidet "Feld fehlt" (required) von "Feld vorhand
 Query-Parameter werden über `QueryStringParser` geparst, dann über `tryFrom()` validiert:
 
 ```php
-$statusRaw = QueryStringParser::string($request, 'status');   // null wenn fehlt
+$statusRaw = QueryStringParser::string($request, 'status');   // null wenn fehlend
 $status    = $statusRaw !== null ? WatchStatus::tryFrom($statusRaw) : null;
 
 if ($statusRaw !== null && $status === null) {
@@ -70,7 +70,7 @@ if ($statusRaw !== null && $status === null) {
 }
 ```
 
-Dieses Muster — parsen, Enum-Konvertierung versuchen, validieren — hält Routing-Logik außerhalb des Domänen-Codes. Das Repository akzeptiert `?WatchStatus` und `?MediaType` und filtert entsprechend.
+Dieses Muster — parsen, Enum-Konvertierung versuchen, validieren — hält Routing-Logik aus dem Domain-Code heraus. Das Repository akzeptiert `?WatchStatus` und `?MediaType` und filtert entsprechend.
 
 **Unterstützte Filter**:
 - `?status=watching` — nach Status filtern
@@ -80,7 +80,7 @@ Dieses Muster — parsen, Enum-Konvertierung versuchen, validieren — hält Rou
 
 ---
 
-## Nullable-Felder mit `array_key_exists`
+## Nullable Felder mit `array_key_exists`
 
 `rating` und `note` sind nullable — Aufrufer können sie explizit auf `null` setzen, um sie zu löschen. Die Verwendung von `isset()` würde ein explizit gesendetes `null` übersehen. `array_key_exists()` verwenden:
 
@@ -100,9 +100,9 @@ if ($rating !== null) {
 
 ---
 
-## Archivieren/Wiederherstellen über POST-Aktionsendpunkte
+## Archivierung / Wiederherstellung über POST-Aktions-Endpunkte
 
-Archivieren und Wiederherstellen sind Mutationen (sie ändern den Zustand und zeichnen einen Zeitstempel auf), verwenden also `POST`, nicht `DELETE` oder `PATCH`. Dies folgt dem Aktionsendpunkt-Muster:
+Archivierung und Wiederherstellung sind Mutationen (sie ändern den Zustand und erfassen einen Zeitstempel), daher verwenden sie `POST`, nicht `DELETE` oder `PATCH`. Dies folgt dem Aktions-Endpunkt-Muster:
 
 ```php
 // POST /watch/{id}/archive
@@ -124,9 +124,9 @@ private function restore(ServerRequestInterface $request): ResponseInterface
 }
 ```
 
-`archive()` setzt `archived_at` auf den aktuellen Zeitstempel; `restore()` setzt es auf `null` zurück. Der Listenendpunkt versteckt archivierte Einträge standardmäßig (`include_archived=false`).
+`archive()` setzt `archived_at` auf den aktuellen Zeitstempel; `restore()` setzt ihn zurück auf `null`. Der Listen-Endpunkt verbirgt archivierte Einträge standardmäßig (`include_archived=false`).
 
-Warum `POST` und nicht `DELETE` für Archivieren? `DELETE` impliziert permanentes Entfernen. Archivieren ist eine Soft-Zustandsänderung — der Eintrag bleibt in der DB und ist wiederherstellbar. Die Benennung der Endpunkte nach der Aktion (`/archive`, `/restore`) macht die Absicht explizit.
+Warum `POST` und nicht `DELETE` für die Archivierung? `DELETE` impliziert permanente Entfernung. Archivierung ist eine weiche Zustandsänderung — der Eintrag verbleibt in der DB und ist wiederherstellbar. Die Endpunkte nach der Aktion zu benennen (`/archive`, `/restore`) macht die Absicht explizit.
 
 ---
 
@@ -147,11 +147,11 @@ CREATE TABLE watch_entries (
 );
 ```
 
-DB `CHECK`-Constraints spiegeln die Enum-Fälle wider — wenn ein neuer Status zum Enum hinzugefügt wird, ohne den `CHECK` zu aktualisieren, schlägt der Insert auf der DB-Ebene fehl. Beide synchron halten: den neuen Fall zum Enum, dem `CHECK` und einer Migration hinzufügen.
+DB-`CHECK`-Constraints spiegeln die Enum-Fälle — wenn ein neuer Status zum Enum hinzugefügt wird, ohne den `CHECK` zu aktualisieren, schlägt das Insert auf DB-Ebene fehl. Beide synchron halten: den neuen Fall zum Enum, dem `CHECK` und einer Migration hinzufügen.
 
-`rating CHECK(rating IS NULL OR ...)` erlaubt korrekt, dass die Spalte `NULL` ist, während der 1–5-Bereich erzwungen wird, wenn ein Wert vorhanden ist.
+`rating CHECK(rating IS NULL OR ...)` erlaubt korrekt, dass die Spalte `NULL` ist, während der Bereich 1–5 erzwungen wird, wenn ein Wert vorhanden ist.
 
-`archived_at TEXT` (nullable) dient als Archivierungs-Flag: `NULL` = aktiv, nicht-null = archiviert. Das ist das minimale Soft-Archiv-Muster — keine separate `is_archived BOOLEAN`-Spalte nötig.
+`archived_at TEXT` (nullable) fungiert als Archivierungs-Flag: `NULL` = aktiv, nicht-null = archiviert. Das ist das minimale Soft-Archive-Muster — keine separate `is_archived BOOLEAN`-Spalte erforderlich.
 
 ---
 
@@ -162,7 +162,7 @@ CREATE INDEX idx_watch_status      ON watch_entries (status);
 CREATE INDEX idx_watch_archived_at ON watch_entries (archived_at);
 ```
 
-`idx_watch_archived_at` unterstützt den häufigen `WHERE archived_at IS NULL`-Filter (aktive Einträge). SQLite kann diesen Index für `IS NULL`-Bedingungen über ein Partial-Index-Muster verwenden, aber ein einfacher Index ist für die meisten Watchlists ausreichend.
+`idx_watch_archived_at` unterstützt den häufigen `WHERE archived_at IS NULL`-Filter (aktive Einträge). SQLite kann diesen Index für `IS NULL`-Bedingungen über ein Partial-Index-Muster verwenden, aber ein normaler Index ist für die meisten Merklisten ausreichend.
 
 ---
 
@@ -175,8 +175,8 @@ private function serialize(WatchEntry $entry): array
     return [
         'id'          => $entry->id,
         'title'       => $entry->title,
-        'media_type'  => $entry->mediaType->value,  // enum → string
-        'status'      => $entry->status->value,      // enum → string
+        'media_type'  => $entry->mediaType->value,  // Enum → String
+        'status'      => $entry->status->value,      // Enum → String
         'rating'      => $entry->rating,             // int|null
         'note'        => $entry->note,
         'created_at'  => $entry->createdAt,
@@ -186,13 +186,13 @@ private function serialize(WatchEntry $entry): array
 }
 ```
 
-`->value` auf einem backed-Enum gibt den String-Case-Wert zurück (z.B. `'want-to-watch'`). Enums auf diese Weise serialisieren, nicht `->name` aufrufen — der Name ist der PHP-Identifier (`WantToWatch`), nicht der API-Vertragswert.
+`->value` auf einem backed Enum gibt den String-Fallwert zurück (z.B. `'want-to-watch'`). Enums auf diese Weise serialisieren statt `->name` aufzurufen — der Name ist der PHP-Bezeichner (`WantToWatch`), nicht der API-Vertragswert.
 
 ---
 
 ## Verwandte Anleitungen
 
-- [`content-draft-lifecycle.md`](content-draft-lifecycle.md) — Zustandsmaschine mit Statusübergängen
+- [`content-draft-lifecycle.md`](content-draft-lifecycle.md) — Zustandsmaschine mit Status-Übergängen
 - [`soft-delete.md`](soft-delete.md) — Soft Delete mit `deleted_at`-Zeitstempel
 - [`implement-patch-endpoint.md`](implement-patch-endpoint.md) — partielle Updates mit `array_key_exists`
-- [`add-custom-route.md`](add-custom-route.md) — POST-Aktionsendpunkt-Muster (`/archive`, `/restore`, `/publish`)
+- [`add-custom-route.md`](add-custom-route.md) — POST-Aktions-Endpunkt-Muster (`/archive`, `/restore`, `/publish`)

--- a/docs/de/howto/media-watchlist.md
+++ b/docs/de/howto/media-watchlist.md
@@ -1,0 +1,198 @@
+# How-to: Medien-Watchlist-API
+
+> **FT-Referenz**: FT59 (`NENE2-FT/watchlog`) — Medien-Watch-List-API
+
+Demonstriert eine persönliche Medien-Watchlist mit backed String-Enums für Status und Typ, optionalen nullable-Feldern mit `array_key_exists`, Archivieren/Wiederherstellen über POST-Aktionsendpunkte und einer 1–5-Integer-Bewertung. Alle Status- und Typvalidierungen verwenden PHPs `BackedEnum::tryFrom()`, um sicherzustellen, dass nur bekannte Werte akzeptiert werden.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `GET`    | `/watch` | Einträge auflisten (gefiltert und paginiert) |
+| `POST`   | `/watch` | Einen Eintrag zur Watchlist hinzufügen |
+| `GET`    | `/watch/{id}` | Einen einzelnen Eintrag abrufen |
+| `PATCH`  | `/watch/{id}/status` | Status aktualisieren (und optional Bewertung/Notiz) |
+| `POST`   | `/watch/{id}/archive` | Eintrag ins Archiv verschieben |
+| `POST`   | `/watch/{id}/restore` | Einen archivierten Eintrag wiederherstellen |
+| `DELETE` | `/watch/{id}` | Einen Eintrag dauerhaft löschen |
+
+---
+
+## Backed-Enum-Validierung
+
+Status und Medientyp werden mit `BackedEnum::tryFrom()` validiert. Das Enum dient auch als Typ bei der Serialisierung, sodass der in die DB geschriebene String-Wert und der String-Wert in der JSON-Antwort automatisch synchron bleiben.
+
+```php
+enum WatchStatus: string
+{
+    case WantToWatch = 'want-to-watch';
+    case Watching    = 'watching';
+    case Completed   = 'completed';
+    case Dropped     = 'dropped';
+}
+
+enum MediaType: string
+{
+    case Movie = 'movie';
+    case Tv    = 'tv';
+}
+```
+
+Im Controller gibt `tryFrom()` `null` für unbekannte Werte zurück, was auf 422 abgebildet wird:
+
+```php
+$statusRaw = isset($body['status']) && is_string($body['status']) ? $body['status'] : null;
+$status    = $statusRaw !== null ? WatchStatus::tryFrom($statusRaw) : null;
+
+if ($statusRaw === null) {
+    $errors[] = new ValidationError('status', 'status is required.', 'required');
+} elseif ($status === null) {
+    $errors[] = new ValidationError('status', 'Invalid status value.', 'invalid_value');
+}
+```
+
+Die zweistufige Prüfung unterscheidet "Feld fehlt" (required) von "Feld vorhanden, aber ungültig" (invalid_value), was bessere Fehlermeldungen erzeugt.
+
+---
+
+## Auflistung mit enum-typisierten Filtern
+
+Query-Parameter werden über `QueryStringParser` geparst, dann über `tryFrom()` validiert:
+
+```php
+$statusRaw = QueryStringParser::string($request, 'status');   // null wenn fehlt
+$status    = $statusRaw !== null ? WatchStatus::tryFrom($statusRaw) : null;
+
+if ($statusRaw !== null && $status === null) {
+    $errors[] = new ValidationError('status', 'Invalid status value.', 'invalid_value');
+}
+```
+
+Dieses Muster — parsen, Enum-Konvertierung versuchen, validieren — hält Routing-Logik außerhalb des Domänen-Codes. Das Repository akzeptiert `?WatchStatus` und `?MediaType` und filtert entsprechend.
+
+**Unterstützte Filter**:
+- `?status=watching` — nach Status filtern
+- `?media_type=movie` — nach Medientyp filtern
+- `?include_archived=1` — archivierte Einträge einschließen (standardmäßig ausgeschlossen)
+- `?limit=20&offset=0` — Paginierung
+
+---
+
+## Nullable-Felder mit `array_key_exists`
+
+`rating` und `note` sind nullable — Aufrufer können sie explizit auf `null` setzen, um sie zu löschen. Die Verwendung von `isset()` würde ein explizit gesendetes `null` übersehen. `array_key_exists()` verwenden:
+
+```php
+// ✓ Korrekt: unterscheidet fehlend von explizit null
+$rating = array_key_exists('rating', $body) ? $body['rating'] : null;
+
+// ✗ Falsch: array_key_exists($body, 'rating') verschluckt absichtliches null
+if ($rating !== null) {
+    if (!is_int($rating) || $rating < 1 || $rating > 5) {
+        $errors[] = new ValidationError('rating', 'rating must be an integer from 1 to 5.', 'out_of_range');
+    }
+}
+```
+
+`is_int($rating)` lehnt JSON-Floats (`4.0` → PHP `float`) und Strings (`"4"`) ab. Nur ein JSON-Integer-Literal (`4`) besteht die strenge Typprüfung.
+
+---
+
+## Archivieren/Wiederherstellen über POST-Aktionsendpunkte
+
+Archivieren und Wiederherstellen sind Mutationen (sie ändern den Zustand und zeichnen einen Zeitstempel auf), verwenden also `POST`, nicht `DELETE` oder `PATCH`. Dies folgt dem Aktionsendpunkt-Muster:
+
+```php
+// POST /watch/{id}/archive
+private function archive(ServerRequestInterface $request): ResponseInterface
+{
+    $id    = (int) ($request->getAttribute(Router::PARAMETERS_ATTRIBUTE)['id'] ?? 0);
+    $entry = $this->repository->archive($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $this->json->create($this->serialize($entry));
+}
+
+// POST /watch/{id}/restore
+private function restore(ServerRequestInterface $request): ResponseInterface
+{
+    $id    = (int) ($request->getAttribute(Router::PARAMETERS_ATTRIBUTE)['id'] ?? 0);
+    $entry = $this->repository->restore($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $this->json->create($this->serialize($entry));
+}
+```
+
+`archive()` setzt `archived_at` auf den aktuellen Zeitstempel; `restore()` setzt es auf `null` zurück. Der Listenendpunkt versteckt archivierte Einträge standardmäßig (`include_archived=false`).
+
+Warum `POST` und nicht `DELETE` für Archivieren? `DELETE` impliziert permanentes Entfernen. Archivieren ist eine Soft-Zustandsänderung — der Eintrag bleibt in der DB und ist wiederherstellbar. Die Benennung der Endpunkte nach der Aktion (`/archive`, `/restore`) macht die Absicht explizit.
+
+---
+
+## Schema: CHECK-Constraints entsprechen Enum-Werten
+
+```sql
+CREATE TABLE watch_entries (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    title       TEXT NOT NULL,
+    media_type  TEXT NOT NULL CHECK(media_type IN ('movie', 'tv')),
+    status      TEXT NOT NULL DEFAULT 'want-to-watch'
+                              CHECK(status IN ('want-to-watch', 'watching', 'completed', 'dropped')),
+    rating      INTEGER CHECK(rating IS NULL OR (rating >= 1 AND rating <= 5)),
+    note        TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    archived_at TEXT
+);
+```
+
+DB `CHECK`-Constraints spiegeln die Enum-Fälle wider — wenn ein neuer Status zum Enum hinzugefügt wird, ohne den `CHECK` zu aktualisieren, schlägt der Insert auf der DB-Ebene fehl. Beide synchron halten: den neuen Fall zum Enum, dem `CHECK` und einer Migration hinzufügen.
+
+`rating CHECK(rating IS NULL OR ...)` erlaubt korrekt, dass die Spalte `NULL` ist, während der 1–5-Bereich erzwungen wird, wenn ein Wert vorhanden ist.
+
+`archived_at TEXT` (nullable) dient als Archivierungs-Flag: `NULL` = aktiv, nicht-null = archiviert. Das ist das minimale Soft-Archiv-Muster — keine separate `is_archived BOOLEAN`-Spalte nötig.
+
+---
+
+## Indizes für Listen-Performance
+
+```sql
+CREATE INDEX idx_watch_status      ON watch_entries (status);
+CREATE INDEX idx_watch_archived_at ON watch_entries (archived_at);
+```
+
+`idx_watch_archived_at` unterstützt den häufigen `WHERE archived_at IS NULL`-Filter (aktive Einträge). SQLite kann diesen Index für `IS NULL`-Bedingungen über ein Partial-Index-Muster verwenden, aber ein einfacher Index ist für die meisten Watchlists ausreichend.
+
+---
+
+## Serialisierung
+
+```php
+/** @return array<string, mixed> */
+private function serialize(WatchEntry $entry): array
+{
+    return [
+        'id'          => $entry->id,
+        'title'       => $entry->title,
+        'media_type'  => $entry->mediaType->value,  // enum → string
+        'status'      => $entry->status->value,      // enum → string
+        'rating'      => $entry->rating,             // int|null
+        'note'        => $entry->note,
+        'created_at'  => $entry->createdAt,
+        'updated_at'  => $entry->updatedAt,
+        'archived_at' => $entry->archivedAt,         // string|null
+    ];
+}
+```
+
+`->value` auf einem backed-Enum gibt den String-Case-Wert zurück (z.B. `'want-to-watch'`). Enums auf diese Weise serialisieren, nicht `->name` aufrufen — der Name ist der PHP-Identifier (`WantToWatch`), nicht der API-Vertragswert.
+
+---
+
+## Verwandte Anleitungen
+
+- [`content-draft-lifecycle.md`](content-draft-lifecycle.md) — Zustandsmaschine mit Statusübergängen
+- [`soft-delete.md`](soft-delete.md) — Soft Delete mit `deleted_at`-Zeitstempel
+- [`implement-patch-endpoint.md`](implement-patch-endpoint.md) — partielle Updates mit `array_key_exists`
+- [`add-custom-route.md`](add-custom-route.md) — POST-Aktionsendpunkt-Muster (`/archive`, `/restore`, `/publish`)

--- a/docs/de/howto/money-integer-arithmetic.md
+++ b/docs/de/howto/money-integer-arithmetic.md
@@ -1,11 +1,8 @@
-# How-to: Geld und Integer-Arithmetik
+# How-to: Geldbeträge und Integer-Arithmetik
 
 > **Verwandte Szenarien**: DX Szenario 10, 23, 32, 36, 40, 43, 44, 50 — die am häufigsten genannte Quelle stiller Präzisionsfehler in Finanzszenarien.
 
-Als Fließkommazahl (`REAL` / `float`) gespeicherte Geldbeträge akkumulieren Rundungsfehler.
-`1001 * 0.05` in IEEE 754 ergibt `50.049999999999997`, nicht `50.05`.
-Der korrekte Ansatz ist, Beträge als **Integer in der kleinsten Währungseinheit** zu speichern und zu berechnen
-(Yen für JPY, Cent für USD/EUR).
+Geldbeträge, die als Fließkommazahlen (`REAL` / `float`) gespeichert werden, akkumulieren Rundungsfehler. `1001 * 0.05` in IEEE 754 ergibt `50.049999999999997`, nicht `50.05`. Der korrekte Ansatz ist, Beträge als **Integer in der kleinsten Währungseinheit** zu speichern und zu berechnen (Yen für JPY, Cent für USD/EUR).
 
 ---
 
@@ -37,41 +34,40 @@ CREATE TABLE orders (
 
 ---
 
-## Die Rundungsfunktion wählen
+## Auswahl der Rundungsfunktion
 
-Bei der Division von Integers muss entschieden werden, wie mit dem Rest umgegangen wird.
-**Diese Richtlinie vor dem Schreiben von Code festlegen und dokumentieren** — eine spätere Änderung betrifft jeden historischen Datensatz.
+Beim Teilen von Integern muss entschieden werden, wie mit dem Rest umgegangen wird. **Diese Richtlinie vor dem Schreiben des Codes festlegen und dokumentieren** — eine spätere Änderung beeinflusst jeden historischen Datensatz.
 
 | Funktion | Verhalten | Beispiel: `intdiv(1, 3)` | Wann verwenden |
-|----------|-----------|--------------------------|----------------|
-| `intdiv($a, $b)` | Richtung null abschneiden | `0` | Plattformgebühren (Zahler behält Rest) |
-| `(int) round($a / $b)` | Halbes aufrunden | `0` (rundet auf 0) | Rechnungssplitting, generisches Runden |
-| `(int) ceil($a / $b)` | Aufrunden (Decke) | `1` | Steuerberechnung (immer für Behörden aufrunden) |
+|----------|----------|------------------------|-------------|
+| `intdiv($a, $b)` | Abschneiden gegen null | `0` | Plattformgebühren (Zahler behält Rest) |
+| `(int) round($a / $b)` | Halbrunden | `0` (rundet auf 0) | Rechnungsaufteilung, generisches Runden |
+| `(int) ceil($a / $b)` | Aufrunden (Decke) | `1` | Steuerberechnung (immer aufrunden für den Staat) |
 | `(int) floor($a / $b)` | Abrunden (Boden) | `0` | Gleich wie intdiv für positive Werte |
 
-### Plattformgebühr (5%) — wer behält den Rest?
+### Plattformgebühr (5 %) — wer behält den Rest?
 
 ```php
-// Option A: Plattform nimmt Boden (Zahler begünstigt)
+// Option A: Plattform nimmt Floor (Zahler bevorzugt)
 $fee = intdiv($amount * 5, 100);     // 1001 Yen → Gebühr = 50, Verkäufer erhält 951
 
-// Option B: Plattform nimmt Decke (Plattform begünstigt)
+// Option B: Plattform nimmt Ceil (Plattform bevorzugt)
 $fee = (int) ceil($amount * 5 / 100); // 1001 Yen → Gebühr = 51, Verkäufer erhält 950
 
-// Option C: halbes aufrunden (neutral)
+// Option C: Halbrunden (neutral)
 $fee = (int) round($amount * 5 / 100); // 1001 Yen → Gebühr = 50, Verkäufer erhält 951
 ```
 
-Es gibt keine universell richtige Antwort. **Die Wahl in der API-Spezifikation dokumentieren.**
+Es gibt keine universell korrekte Antwort. **Die Entscheidung in der API-Spec dokumentieren.**
 
 ---
 
-## Steuerberechnung (japanische Verbrauchssteuer: 10%)
+## Steuerberechnung (japanische Verbrauchssteuer: 10 %)
 
 Die japanische Verbrauchssteuer erfordert **Abrunden** pro Transaktion (nicht pro Einzelposten):
 
 ```php
-// ✅ Auf Transaktionsebene abschneiden
+// ✅ Abschneiden auf Transaktionsebene
 $taxIncluded  = intdiv($priceExcl * 110, 100);  // 1000 → 1100
 $taxAmount    = intdiv($priceExcl * 10, 100);   // 1000 → 100
 
@@ -80,8 +76,7 @@ $items = [100, 100, 100]; // 3 Artikel × 100 Yen
 $total = array_sum(array_map(fn($p) => (int)round($p * 1.1), $items)); // kann von intdiv(300 * 110, 100) abweichen
 ```
 
-Wenn ein `tax_rate` gespeichert wird, als **Basispunkte** speichern (Integer, 1/10000):
-`10% = 1000 bps`. Vermeidet Fließkomma in der Raten-Speicherung selbst.
+Beim Speichern eines `tax_rate`-Werts diesen als **Basispunkte** (Integer, 1/10000) speichern: `10% = 1000 bps`. Vermeidet Fließkomma bei der Ratenspeicherung selbst.
 
 ```sql
 tax_rate_bps INTEGER NOT NULL DEFAULT 1000  -- 10,00%
@@ -93,7 +88,7 @@ $taxAmount = intdiv($amount * $taxRateBps, 10000);
 
 ---
 
-## Aufteilen: Rest-Verteilung
+## Aufteilung: Restverteilung
 
 Beim Aufteilen eines Gesamtbetrags auf N Teilnehmer:
 
@@ -105,12 +100,12 @@ function splitEvenly(int $totalYen, int $n): array
 
     $shares = array_fill(0, $n, $base);
 
-    // Rest 1 Yen nach dem anderen an die ersten Teilnehmer verteilen
+    // Rest 1 Yen auf einmal an die ersten Teilnehmer verteilen
     for ($i = 0; $i < $remainder; $i++) {
         $shares[$i]++;
     }
 
-    // Verifizieren: Summe muss dem ursprünglichen Gesamtbetrag entsprechen
+    // Verifizieren: Summe muss dem Originalbetrag entsprechen
     assert(array_sum($shares) === $totalYen);
 
     return $shares;
@@ -120,39 +115,39 @@ function splitEvenly(int $totalYen, int $n): array
 // splitEvenly(100,  3) → [34,  33,  33]   (Summe = 100)  ✅
 ```
 
-Niemals `round($total / $n)` für jeden Teilnehmer verwenden und es dabei belassen — die Summe weicht oft um 1 Yen ab.
+Niemals `round($total / $n)` für jeden Teilnehmer verwenden — die Summe wird oft um 1 Yen abweichen.
 
 ---
 
-## SQLite-Integer-Divisions-Fallstrick
+## SQLite Integer-Divisions-Falle
 
-In SQLite führt die Division zweier Integer zu einer Integer-Division:
+In SQLite führt die Division zweier Integer eine Integer-Division durch:
 
 ```sql
-SELECT 5 / 100;     -- → 0  (Integer-Division: abgeschnitten)
-SELECT 5.0 / 100;   -- → 0.05 (Real-Division)
-SELECT 5 * 100 / 100;  -- → 5 (zuerst multiplizieren, dann dividieren — OK)
+SELECT 5 / 100;     -- → 0  (Integer-Division: abschneiden)
+SELECT 5.0 / 100;   -- → 0.05 (reelle Division)
+SELECT 5 * 100 / 100;  -- → 5 (erst multiplizieren, dann dividieren — OK)
 ```
 
-**In PHP** mit PDO werden alle gebundenen Werte als Strings gesendet. SQLite erzwingt sie, aber:
+**In PHP** mit PDO werden alle gebundenen Werte als Strings gesendet. SQLite konvertiert sie, aber:
 
 ```php
-// Sicher: zuerst multiplizieren, um Abschneidung zu vermeiden
+// Sicher: erst multiplizieren, um Abschneiden zu vermeiden
 $fee = $this->db->fetchOne(
     'SELECT amount_yen * 5 / 100 AS fee FROM orders WHERE id = ?',
     [$id],
 );
 // → amount_yen * 5 zuerst (Integer * Integer = Integer), dann / 100
 
-// Riskant: wenn PDO '5' und '100' als Strings sendet, wählt SQLite möglicherweise Real-Division
-// Das testen, wenn die SQLite-Version oder das PDO-Verhalten unklar ist.
+// Riskant: wenn PDO '5' und '100' als Strings sendet, könnte SQLite reelle Division wählen
+// Dies testen, wenn die SQLite-Version oder das PDO-Verhalten unklar ist.
 ```
 
-Der sicherste Ansatz: **die Arithmetik in PHP mit `intdiv()` durchführen**, das Ergebnis speichern und SQL-Arithmetik nur für Summierungen (`SUM`, `COUNT`) verwenden, nicht für Pro-Zeile-Berechnungen.
+Der sicherste Ansatz: **Arithmetik in PHP mit `intdiv()` durchführen**, das Ergebnis speichern und SQL-Arithmetik nur für Summierungen (`SUM`, `COUNT`) verwenden, nicht für Berechnungen pro Zeile.
 
 ---
 
-## Abschreibung (lineare Methode)
+## Lineare Abschreibung
 
 ```php
 // Jährliche Abschreibung (lineare Methode)
@@ -167,13 +162,13 @@ $yearsElapsed = (int) floor(
 $currentValue = max($salvageValue, $purchasePrice - $annualDepr * $yearsElapsed);
 ```
 
-`intdiv` schneidet die jährliche Abschreibung ab, was bedeutet, dass der Vermögenswert pro Jahr etwas weniger abschreibt und der Rest als zusätzliche Abschreibung im letzten Jahr erscheint. Das ist das Standardverhalten für die japanische lineare Abschreibung.
+`intdiv` schneidet die jährliche Abschreibung ab, was bedeutet, dass das Anlagegut leicht weniger pro Jahr abschreibt und der Rest im letzten Jahr als zusätzliche Abschreibung erscheint. Das ist das Standardverhalten für die japanische lineare Abschreibung.
 
 ---
 
 ## Anzeige für den Benutzer
 
-Nur in der Antwortschicht in ein lesbares Format konvertieren, niemals in der Domäne:
+Nur in der Antwortschicht in ein menschenlesbares Format konvertieren, niemals in der Domain:
 
 ```php
 final readonly class MoneyResponse
@@ -201,25 +196,25 @@ final readonly class MoneyResponse
 
 Vor dem Schreiben einer Geldberechnung diese Fragen beantworten:
 
-1. **Einheit**: Yen (kein Dezimal), Cent (1/100) oder Mikropfennig (1/1000)?
+1. **Einheit**: Yen (kein Dezimal), Cent (1/100) oder Micropenny (1/1000)?
    → Als Integer in dieser Einheit speichern; die Einheit im Spaltennamen dokumentieren (`amount_yen`, `price_cents`).
 
 2. **Rundungsrichtung**: `intdiv` (abschneiden), `ceil`, `floor` oder `round`?
-   → Eine wählen; einen Kommentar im Code hinzufügen, der erklärt, warum.
+   → Eine wählen; einen Kommentar im Code hinzufügen, der erklärt warum.
 
-3. **Wer bekommt den Rest**: beim Aufteilen, wer absorbiert den Rundungsunterschied?
+3. **Wer erhält den Rest**: Wer absorbiert bei der Aufteilung den Rundungsunterschied?
    → Den Rest explizit verteilen (siehe `splitEvenly` oben).
 
-4. **Steuersatzspeicherung**: Basispunkte (`INTEGER`) statt Prozent (`REAL`)?
-   → `1000` für 10%, `800` für 8%, niemals `0.10` oder `0.08`.
+4. **Steuersatz-Speicherung**: Basispunkte (`INTEGER`) nicht Prozent (`REAL`)?
+   → `1000` für 10 %, `800` für 8 %, niemals `0.10` oder `0.08`.
 
-5. **Kumulativ oder pro Transaktion**: Steuer pro Einzelposten oder pro Rechnungsgesamtbetrag akkumulieren?
+5. **Kumulativ oder pro Transaktion**: Steuer pro Einzelposten oder pro Rechnungsgesamt akkumulieren?
    → Pro Transaktion (einzelnes `intdiv`) ist Standard für JPY-Rechnungen.
 
 ---
 
 ## Verwandte Anleitungen
 
-- [`multi-currency-money-ledger.md`](multi-currency-money-ledger.md) — Doppelbuchhaltung mit `Money`-Value-Object
-- [`point-ledger-api.md`](point-ledger-api.md) — Punkte-/Guthaben-System mit Integer-Beträgen
+- [`multi-currency-money-ledger.md`](multi-currency-money-ledger.md) — doppeltes Buchführungssystem mit `Money`-Value-Object
+- [`point-ledger-api.md`](point-ledger-api.md) — Punkte-/Kreditsystem mit Integer-Beträgen
 - [`expense-tracking-api.md`](expense-tracking-api.md) — Ausgabenerfassung mit Integer-Yen

--- a/docs/de/howto/money-integer-arithmetic.md
+++ b/docs/de/howto/money-integer-arithmetic.md
@@ -1,0 +1,225 @@
+# How-to: Geld und Integer-Arithmetik
+
+> **Verwandte Szenarien**: DX Szenario 10, 23, 32, 36, 40, 43, 44, 50 — die am häufigsten genannte Quelle stiller Präzisionsfehler in Finanzszenarien.
+
+Als Fließkommazahl (`REAL` / `float`) gespeicherte Geldbeträge akkumulieren Rundungsfehler.
+`1001 * 0.05` in IEEE 754 ergibt `50.049999999999997`, nicht `50.05`.
+Der korrekte Ansatz ist, Beträge als **Integer in der kleinsten Währungseinheit** zu speichern und zu berechnen
+(Yen für JPY, Cent für USD/EUR).
+
+---
+
+## Die Regel: immer als Integer speichern
+
+```php
+// ❌ Falsch — REAL/float akkumuliert Fehler
+$fee = $amount * 0.05;           // 1001 * 0.05 = 50.04999...
+$tax = $price * 1.10;            // 1000 * 1.10 = 1100.0000000000002
+
+// ✅ Korrekt — Integer-Arithmetik
+$fee = intdiv($amount * 5, 100); // 1001 * 5 / 100 = 50 (abgeschnitten)
+$tax = intdiv($amount * 110, 100); // 1000 * 110 / 100 = 1100
+```
+
+Schema:
+
+```sql
+CREATE TABLE orders (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    amount_yen   INTEGER NOT NULL CHECK(amount_yen > 0),  -- ✅ INTEGER, nicht REAL
+    fee_yen      INTEGER NOT NULL CHECK(fee_yen >= 0),
+    tax_yen      INTEGER NOT NULL CHECK(tax_yen >= 0),
+    total_yen    INTEGER NOT NULL CHECK(total_yen > 0)
+);
+```
+
+`CHECK`-Constraints verwenden, um nicht-negative Werte auf DB-Ebene zu erzwingen.
+
+---
+
+## Die Rundungsfunktion wählen
+
+Bei der Division von Integers muss entschieden werden, wie mit dem Rest umgegangen wird.
+**Diese Richtlinie vor dem Schreiben von Code festlegen und dokumentieren** — eine spätere Änderung betrifft jeden historischen Datensatz.
+
+| Funktion | Verhalten | Beispiel: `intdiv(1, 3)` | Wann verwenden |
+|----------|-----------|--------------------------|----------------|
+| `intdiv($a, $b)` | Richtung null abschneiden | `0` | Plattformgebühren (Zahler behält Rest) |
+| `(int) round($a / $b)` | Halbes aufrunden | `0` (rundet auf 0) | Rechnungssplitting, generisches Runden |
+| `(int) ceil($a / $b)` | Aufrunden (Decke) | `1` | Steuerberechnung (immer für Behörden aufrunden) |
+| `(int) floor($a / $b)` | Abrunden (Boden) | `0` | Gleich wie intdiv für positive Werte |
+
+### Plattformgebühr (5%) — wer behält den Rest?
+
+```php
+// Option A: Plattform nimmt Boden (Zahler begünstigt)
+$fee = intdiv($amount * 5, 100);     // 1001 Yen → Gebühr = 50, Verkäufer erhält 951
+
+// Option B: Plattform nimmt Decke (Plattform begünstigt)
+$fee = (int) ceil($amount * 5 / 100); // 1001 Yen → Gebühr = 51, Verkäufer erhält 950
+
+// Option C: halbes aufrunden (neutral)
+$fee = (int) round($amount * 5 / 100); // 1001 Yen → Gebühr = 50, Verkäufer erhält 951
+```
+
+Es gibt keine universell richtige Antwort. **Die Wahl in der API-Spezifikation dokumentieren.**
+
+---
+
+## Steuerberechnung (japanische Verbrauchssteuer: 10%)
+
+Die japanische Verbrauchssteuer erfordert **Abrunden** pro Transaktion (nicht pro Einzelposten):
+
+```php
+// ✅ Auf Transaktionsebene abschneiden
+$taxIncluded  = intdiv($priceExcl * 110, 100);  // 1000 → 1100
+$taxAmount    = intdiv($priceExcl * 10, 100);   // 1000 → 100
+
+// ❌ NICHT pro Einzelposten runden und dann summieren — Rundungsfehler akkumulieren sich
+$items = [100, 100, 100]; // 3 Artikel × 100 Yen
+$total = array_sum(array_map(fn($p) => (int)round($p * 1.1), $items)); // kann von intdiv(300 * 110, 100) abweichen
+```
+
+Wenn ein `tax_rate` gespeichert wird, als **Basispunkte** speichern (Integer, 1/10000):
+`10% = 1000 bps`. Vermeidet Fließkomma in der Raten-Speicherung selbst.
+
+```sql
+tax_rate_bps INTEGER NOT NULL DEFAULT 1000  -- 10,00%
+```
+
+```php
+$taxAmount = intdiv($amount * $taxRateBps, 10000);
+```
+
+---
+
+## Aufteilen: Rest-Verteilung
+
+Beim Aufteilen eines Gesamtbetrags auf N Teilnehmer:
+
+```php
+function splitEvenly(int $totalYen, int $n): array
+{
+    $base      = intdiv($totalYen, $n);       // Anteil jeder Person (abgeschnitten)
+    $remainder = $totalYen % $n;              // verbleibende Yen (0 bis n-1)
+
+    $shares = array_fill(0, $n, $base);
+
+    // Rest 1 Yen nach dem anderen an die ersten Teilnehmer verteilen
+    for ($i = 0; $i < $remainder; $i++) {
+        $shares[$i]++;
+    }
+
+    // Verifizieren: Summe muss dem ursprünglichen Gesamtbetrag entsprechen
+    assert(array_sum($shares) === $totalYen);
+
+    return $shares;
+}
+
+// splitEvenly(1000, 3) → [334, 333, 333]  (Summe = 1000) ✅
+// splitEvenly(100,  3) → [34,  33,  33]   (Summe = 100)  ✅
+```
+
+Niemals `round($total / $n)` für jeden Teilnehmer verwenden und es dabei belassen — die Summe weicht oft um 1 Yen ab.
+
+---
+
+## SQLite-Integer-Divisions-Fallstrick
+
+In SQLite führt die Division zweier Integer zu einer Integer-Division:
+
+```sql
+SELECT 5 / 100;     -- → 0  (Integer-Division: abgeschnitten)
+SELECT 5.0 / 100;   -- → 0.05 (Real-Division)
+SELECT 5 * 100 / 100;  -- → 5 (zuerst multiplizieren, dann dividieren — OK)
+```
+
+**In PHP** mit PDO werden alle gebundenen Werte als Strings gesendet. SQLite erzwingt sie, aber:
+
+```php
+// Sicher: zuerst multiplizieren, um Abschneidung zu vermeiden
+$fee = $this->db->fetchOne(
+    'SELECT amount_yen * 5 / 100 AS fee FROM orders WHERE id = ?',
+    [$id],
+);
+// → amount_yen * 5 zuerst (Integer * Integer = Integer), dann / 100
+
+// Riskant: wenn PDO '5' und '100' als Strings sendet, wählt SQLite möglicherweise Real-Division
+// Das testen, wenn die SQLite-Version oder das PDO-Verhalten unklar ist.
+```
+
+Der sicherste Ansatz: **die Arithmetik in PHP mit `intdiv()` durchführen**, das Ergebnis speichern und SQL-Arithmetik nur für Summierungen (`SUM`, `COUNT`) verwenden, nicht für Pro-Zeile-Berechnungen.
+
+---
+
+## Abschreibung (lineare Methode)
+
+```php
+// Jährliche Abschreibung (lineare Methode)
+$annualDepr = intdiv($purchasePrice - $salvageValue, $usefulLifeYears);
+
+// Aktueller Buchwert
+$yearsElapsed = (int) floor(
+    (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->diff(
+        new \DateTimeImmutable($purchaseDateUtc)
+    )->days / 365
+);
+$currentValue = max($salvageValue, $purchasePrice - $annualDepr * $yearsElapsed);
+```
+
+`intdiv` schneidet die jährliche Abschreibung ab, was bedeutet, dass der Vermögenswert pro Jahr etwas weniger abschreibt und der Rest als zusätzliche Abschreibung im letzten Jahr erscheint. Das ist das Standardverhalten für die japanische lineare Abschreibung.
+
+---
+
+## Anzeige für den Benutzer
+
+Nur in der Antwortschicht in ein lesbares Format konvertieren, niemals in der Domäne:
+
+```php
+final readonly class MoneyResponse
+{
+    public function __construct(
+        public int    $amountYen,
+        public string $displayAmount,  // "¥1.234"
+    ) {}
+
+    public static function fromYen(int $yen): self
+    {
+        return new self(
+            amountYen:     $yen,
+            displayAmount: '¥' . number_format($yen),
+        );
+    }
+}
+```
+
+`amountYen` (Integer) für weitere Berechnungen speichern; `displayAmount` (String) für die UI. Niemals formatierte Strings speichern — sie können nicht summiert werden.
+
+---
+
+## Zusammenfassung: Entscheidungs-Checkliste
+
+Vor dem Schreiben einer Geldberechnung diese Fragen beantworten:
+
+1. **Einheit**: Yen (kein Dezimal), Cent (1/100) oder Mikropfennig (1/1000)?
+   → Als Integer in dieser Einheit speichern; die Einheit im Spaltennamen dokumentieren (`amount_yen`, `price_cents`).
+
+2. **Rundungsrichtung**: `intdiv` (abschneiden), `ceil`, `floor` oder `round`?
+   → Eine wählen; einen Kommentar im Code hinzufügen, der erklärt, warum.
+
+3. **Wer bekommt den Rest**: beim Aufteilen, wer absorbiert den Rundungsunterschied?
+   → Den Rest explizit verteilen (siehe `splitEvenly` oben).
+
+4. **Steuersatzspeicherung**: Basispunkte (`INTEGER`) statt Prozent (`REAL`)?
+   → `1000` für 10%, `800` für 8%, niemals `0.10` oder `0.08`.
+
+5. **Kumulativ oder pro Transaktion**: Steuer pro Einzelposten oder pro Rechnungsgesamtbetrag akkumulieren?
+   → Pro Transaktion (einzelnes `intdiv`) ist Standard für JPY-Rechnungen.
+
+---
+
+## Verwandte Anleitungen
+
+- [`multi-currency-money-ledger.md`](multi-currency-money-ledger.md) — Doppelbuchhaltung mit `Money`-Value-Object
+- [`point-ledger-api.md`](point-ledger-api.md) — Punkte-/Guthaben-System mit Integer-Beträgen
+- [`expense-tracking-api.md`](expense-tracking-api.md) — Ausgabenerfassung mit Integer-Yen

--- a/docs/de/howto/multi-currency-money-ledger.md
+++ b/docs/de/howto/multi-currency-money-ledger.md
@@ -1,0 +1,208 @@
+# How-to: Mehrwährungs-Geldkonto mit Integer-Cent
+
+> **FT-Referenz**: FT262 (`NENE2-FT/moneylog`) — Mehrwährungs-Kontobuch-API mit Integer-Kleinsteinheiten (Cent) und einem `Money`-Value-Object
+
+Demonstriert eine Doppelbuchführungs-Kontobuch-API, die Geldbeträge als Integer-Kleinsteinheiten (Cent, Yen, Pence) speichert, um Fließkomma-Präzisionsfehler zu vermeiden. Ein `Money`-Value-Object erzwingt die Invarianten: positiver Betrag und dreistelliger ISO-4217-Währungscode. Der Saldo pro Währung wird mit `SUM(CASE WHEN type = 'credit' ...)` in einer einzelnen SQL-Abfrage berechnet.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|-----------------|---------------------------------------------|
+| `POST` | `/entries`      | Kontoeintrag erstellen (Kredit oder Debit)  |
+| `GET`  | `/entries`      | Einträge auflisten (paginiert)              |
+| `GET`  | `/entries/{id}` | Einzelnen Eintrag abrufen                   |
+| `GET`  | `/balance`      | Saldo pro Währung (Kredit − Debit)          |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS entries (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    description  TEXT    NOT NULL,
+    amount_cents INTEGER NOT NULL CHECK(amount_cents > 0),
+    currency     TEXT    NOT NULL CHECK(length(currency) = 3),
+    type         TEXT    NOT NULL CHECK(type IN ('credit', 'debit')),
+    created_at   TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_entries_currency ON entries(currency);
+CREATE INDEX IF NOT EXISTS idx_entries_created  ON entries(created_at);
+```
+
+`CHECK(amount_cents > 0)` erzwingt positive Beträge auf DB-Ebene — ein Sicherheitsnetz für Fehler oder direkten DB-Zugriff. `CHECK(length(currency) = 3)` erzwingt das ISO-4217-Format. `CHECK(type IN ('credit', 'debit'))` verhindert ungültige Zustände.
+
+---
+
+## Warum Integer-Cent, nicht Float?
+
+```php
+// ❌ Float-Arithmetik verliert Präzision
+var_dump(0.1 + 0.2);  // float(0.30000000000000004)
+
+// ✅ Integer-Arithmetik ist exakt
+$total = 10 + 20;     // int(30) — immer exakt
+```
+
+Geldbeträge, die als `FLOAT` gespeichert werden, akkumulieren Rundungsfehler bei Summierungen und können nicht zuverlässig mit `===` verglichen werden. Integer-Kleinsteinheiten (Cent für USD/EUR, Yen für JPY) sind immer exakt. Die Anzeigekonvertierung (`$cents / 100.0`) erfolgt nur bei der Serialisierung, nicht in der Geschäftslogik.
+
+**Achtung**: `JPY` und ähnliche Währungen ohne Dezimalstellen speichern ganze Einheiten als "Cent" (d.h. ¥1000 = 1000 Cent). `formatDecimal()` in diesem FT verwendet standardmäßig 2 Dezimalstellen; eine Produktionsimplementierung sollte die Dezimalstellen der Währung nachschlagen.
+
+---
+
+## `Money`-Value-Object
+
+```php
+final readonly class Money
+{
+    public function __construct(
+        public int    $amountCents,
+        public string $currency,
+    ) {
+        if ($amountCents <= 0) {
+            throw new \InvalidArgumentException("amountCents must be positive, got {$amountCents}.");
+        }
+        if (strlen($currency) !== 3) {
+            throw new \InvalidArgumentException("currency must be a 3-character ISO 4217 code, got '{$currency}'.");
+        }
+    }
+
+    public function formatDecimal(): string
+    {
+        return number_format($this->amountCents / 100, 2, '.', '');
+    }
+}
+```
+
+Der Konstruktor validiert seine eigenen Invarianten. Ein `Money`-Objekt, das existiert, ist immer gültig — Aufrufer müssen die Werte nie erneut prüfen. `readonly` verhindert Mutation nach der Konstruktion.
+
+`formatDecimal()` dient nur der Anzeige. Den formatierten String niemals speichern oder vergleichen; immer `amountCents`-Integer vergleichen.
+
+---
+
+## `EntryType`-Backed-Enum
+
+```php
+enum EntryType: string
+{
+    case Credit = 'credit';
+    case Debit  = 'debit';
+}
+```
+
+`EntryType::from('credit')` konvertiert bei der Hydration den DB-String in das Enum. Wenn die DB unerwarteterweise einen unbekannten Wert enthält, wirft `from()` — keine stille Korruption.
+
+`EntryType::tryFrom($value)` im Controller gibt `null` für unbekannte Werte zurück, was die Validierungsfehlerprüfung dann abfängt:
+
+```php
+$type = $typeValue !== null ? EntryType::tryFrom($typeValue) : null;
+if ($type === null) {
+    $errors[] = new ValidationError('type', "type must be 'credit' or 'debit'.", 'invalid');
+}
+```
+
+---
+
+## Saldo pro Währung: `SUM(CASE WHEN ...)`
+
+```php
+public function balanceByCurrency(): array
+{
+    $rows = $this->executor->fetchAll(
+        "SELECT currency,
+            SUM(CASE WHEN type = 'credit' THEN amount_cents ELSE 0 END) AS credit_cents,
+            SUM(CASE WHEN type = 'debit'  THEN amount_cents ELSE 0 END) AS debit_cents,
+            SUM(CASE WHEN type = 'credit' THEN amount_cents ELSE -amount_cents END) AS balance_cents
+         FROM entries
+         GROUP BY currency
+         ORDER BY currency ASC",
+        [],
+    );
+    // ...
+}
+```
+
+Eine einzelne Abfrage berechnet drei Aggregate pro Währung:
+- `credit_cents`: Gesamtkredit
+- `debit_cents`: Gesamtdebit
+- `balance_cents`: Nettosaldo (`Kredit − Debit`)
+
+`CASE WHEN type = 'credit' THEN amount_cents ELSE -amount_cents END` verwendet eine Vorzeichenumkehrung, um den Nettobetrag in einem Durchlauf zu berechnen. Ein negativer `balance_cents` bedeutet, dass Debits die Credits übersteigen.
+
+**Alternative**: zwei Abfragen (`SELECT SUM WHERE type = 'credit'` und `SELECT SUM WHERE type = 'debit'`), in PHP zusammengeführt. Der Einzelabfrage-Ansatz ist effizienter und hält die Subtraktion in SQL.
+
+---
+
+## Controller: Währungsnormalisierung
+
+```php
+$money = new Money(
+    (int) $body['amount_cents'],
+    strtoupper((string) $body['currency']),  // ← auf Großbuchstaben normalisieren
+);
+```
+
+`strtoupper()` normalisiert den Währungscode, sodass `usd`, `USD` und `Usd` alle als `USD` gespeichert werden. Ohne Normalisierung würden `USD` und `usd` als separate Währungen in der Saldoabfrage erscheinen.
+
+---
+
+## Serialisierung: sowohl Cent als auch Dezimal
+
+```php
+private function serialize(Entry $entry): array
+{
+    return [
+        'id'           => $entry->id,
+        'description'  => $entry->description,
+        'amount_cents' => $entry->money->amountCents,   // maschinenlesbar: exakter Integer
+        'amount'       => $entry->money->formatDecimal(), // menschenlesbar: "10.50"
+        'currency'     => $entry->money->currency,
+        'type'         => $entry->type->value,
+        'created_at'   => $entry->createdAt,
+    ];
+}
+```
+
+Sowohl `amount_cents` (Integer) als auch `amount` (formatiertes Dezimal) werden zurückgegeben. Clients, die Berechnungen durchführen, sollten `amount_cents` verwenden; Anzeige-UIs können `amount` verwenden.
+
+---
+
+## Beispiel: Saldoantwort
+
+**Anfrage**: `GET /balance`
+
+```json
+{
+  "balances": [
+    {"currency": "EUR", "credit_cents": 50000, "debit_cents": 20000, "balance_cents": 30000},
+    {"currency": "JPY", "credit_cents": 100000, "debit_cents": 0, "balance_cents": 100000},
+    {"currency": "USD", "credit_cents": 150000, "debit_cents": 75000, "balance_cents": 75000}
+  ]
+}
+```
+
+EUR-Saldo: 500,00 − 200,00 = 300,00 EUR. USD-Saldo: 1500,00 − 750,00 = 750,00 USD.
+
+---
+
+## Design-Vergleich
+
+| Speicheransatz | Präzision | Kompromisse |
+|---|---|---|
+| `INTEGER`-Cent | Exakt | Erfordert Anzeigekonvertierung; Währung muss Dezimalstellen angeben |
+| `DECIMAL(19,4)` | Exakt | DB-nativ; nicht in SQLite verfügbar; Format für Anzeige |
+| `FLOAT`/`REAL` | Verlustbehaftet | Niemals für Geld verwenden — Rundungsfehler akkumulieren sich |
+| `TEXT` ("10.50") | Entf. | Sortierung und Summierung erfordern Casting; keine Arithmetik in SQL |
+
+SQLites `INTEGER` mit Cent ist der einfachste sichere Ansatz für SQLite-basierte APIs. Für MySQL/PostgreSQL ist `DECIMAL(19,4)` konventioneller.
+
+---
+
+## Verwandte Anleitungen
+
+- [`transaction-scope-pattern.md`](transaction-scope-pattern.md) — atomare Mehrfachschreibvorgänge für Überweisungen
+- [`bulk-operations-partial-success.md`](bulk-operations-partial-success.md) — Massenimport mit Teilerfolg
+- [`leaderboard-ranking-api.md`](leaderboard-ranking-api.md) — Aggregatabfragen mit SQL-Fensterfunktionen

--- a/docs/de/howto/multi-currency-wallet.md
+++ b/docs/de/howto/multi-currency-wallet.md
@@ -1,0 +1,13 @@
+# How-to: Mehrwährungs-Wallet
+
+Benutzerspezifische Währungsguthaben mit Einzahlungs-/Abhebungs-/Überweisungsoperationen.
+Field Trial: FT198 (`../NENE2-FT/walletlog/`). Enthält VULN-A~L Sicherheitsaudit.
+
+## Schlüsselmuster
+- Guthaben als Kleinsteinheiten (Cent) gespeichert — vermeidet Float-Präzisionsprobleme
+- Selbstüberweisung vor jedem DB-Vorgang abgelehnt (422)
+- Unzureichendes Guthaben vor UPDATE geprüft (409)
+- IDOR: `WHERE user_id = :uid` bei jeder Wallet- und Transaktionsabfrage
+- Währung gegen Allow-List validiert (nicht benutzerseitig angegeben)
+
+## VULN-A~L: ALLE BESTANDEN

--- a/docs/de/howto/multi-step-workflow.md
+++ b/docs/de/howto/multi-step-workflow.md
@@ -1,0 +1,120 @@
+# How-to: Mehrstufigen Workflow hinzufügen
+
+Sequentielle Genehmigungsabläufe modellieren, bei denen jeder Schritt genehmigt werden muss, bevor der nächste beginnt.
+
+## Schema
+
+```sql
+CREATE TABLE workflows (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE, description TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+CREATE TABLE workflow_steps (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id INTEGER NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+    name TEXT NOT NULL, step_order INTEGER NOT NULL,
+    UNIQUE(workflow_id, step_order)
+);
+CREATE TABLE workflow_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id INTEGER NOT NULL REFERENCES workflows(id),
+    title TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','in_progress','completed','rejected')),
+    current_step_id INTEGER REFERENCES workflow_steps(id),
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE workflow_actions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    step_id INTEGER NOT NULL REFERENCES workflow_steps(id),
+    action TEXT NOT NULL CHECK(action IN ('approve','reject')),
+    actor TEXT NOT NULL, comment TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+```
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/workflows` | Einen Workflow definieren |
+| `GET` | `/workflows/{id}` | Workflow + Schritte abrufen |
+| `POST` | `/workflows/{id}/steps` | Einen Schritt anhängen (automatisch geordnet) |
+| `POST` | `/runs` | Einen neuen Run starten (beginnt bei Schritt 1) |
+| `GET` | `/runs/{id}` | Run-Zustand + vollständige Aktionshistorie abrufen |
+| `POST` | `/runs/{id}/approve` | Aktuellen Schritt genehmigen |
+| `POST` | `/runs/{id}/reject` | Ablehnen → beendet den Run |
+
+## Zustandsmaschine
+
+```
+in_progress --approve (weitere Schritte)--> in_progress (nächster Schritt)
+in_progress --approve (letzter Schritt)--> completed
+in_progress --reject (beliebiger Schritt)--> rejected
+```
+
+Abgeschlossene und abgelehnte Runs geben bei weiteren approve/reject-Aufrufen 409 zurück.
+
+## Automatische Schrittordnung
+
+Nur-Anhängen: jeder neue Schritt erhält `max(step_order) + 1`:
+
+```php
+$existingSteps = $this->repo->findSteps($workflowId);
+$maxOrder      = 0;
+foreach ($existingSteps as $s) {
+    $maxOrder = max($maxOrder, (int) $s['step_order']);
+}
+$stepOrder = $maxOrder + 1;
+$this->repo->addStep($workflowId, $name, $stepOrder);
+```
+
+## Weiterschalten oder Abschließen bei Genehmigung
+
+```php
+// Zuerst Aktion aufzeichnen, dann Übergang durchführen
+$this->repo->recordAction($runId, $currentStepId, 'approve', $actor, $comment, $now);
+
+$nextStep = $this->repo->findNextStep($workflowId, $currentStepOrder);
+if ($nextStep !== null) {
+    $this->repo->updateRun($runId, 'in_progress', (int) $nextStep['id'], $now);
+} else {
+    $this->repo->updateRun($runId, 'completed', null, $now);
+}
+```
+
+Den nächsten Schritt mit einer einzigen SQL-Abfrage finden:
+
+```sql
+SELECT * FROM workflow_steps
+WHERE workflow_id = ? AND step_order > ?
+ORDER BY step_order ASC LIMIT 1
+```
+
+## Abgeschlossene/Abgelehnte Runs schützen
+
+```php
+if ((string) $run['status'] !== 'in_progress') {
+    return $this->json->create(['error' => 'Run is not in progress'], 409);
+}
+```
+
+## Historien-Join
+
+Die vollständige Aktionshistorie mit Schrittnamen in der `GET /runs/{id}`-Antwort zurückgeben:
+
+```sql
+SELECT wa.*, ws.name AS step_name
+FROM workflow_actions wa
+JOIN workflow_steps ws ON wa.step_id = ws.id
+WHERE wa.run_id = ?
+ORDER BY wa.id ASC
+```
+
+## Wichtige Designentscheidungen
+
+- **Nur-Anhängen-Schritte**: `step_order` ist monoton; keine Neuordnung nach der Erstellung.
+- **Ablehnen beendet sofort**: jede Schrittablehnung beendet den Run (keine Teilgenehmigung).
+- **`current_step_id = NULL`** bei abgeschlossenen/abgelehnten Runs — `status` verwenden, um zu unterscheiden.
+- **Run-Start erfordert mindestens einen Schritt**: 409 zurückgeben, wenn der Workflow keine Schritte hat.

--- a/docs/de/howto/multi-tenant-isolation.md
+++ b/docs/de/howto/multi-tenant-isolation.md
@@ -1,0 +1,261 @@
+# How-to: Multi-Tenant-Isolation
+
+Diese Anleitung beschreibt den Aufbau einer Multi-Tenant-API mit NENE2, bei der die Daten jedes Mandanten strikt isoliert sind. Das Auslassen auch nur eines Schritts erzeugt eine stille IDOR-Schwachstelle (Insecure Direct Object Reference), die die Daten aller Mandanten exponiert.
+
+---
+
+## Die Grundregel: `tenant_id`-Filter in jeder Abfrage
+
+Das Weglassen des Mandanten-Filters aus einer einzigen Abfrage gibt stillschweigend die Daten aller Mandanten zurück:
+
+```sql
+-- ❌ Kein Mandanten-Filter — gibt Datensätze aller Mandanten zurück
+SELECT id, title, body FROM notes WHERE id = ?
+
+-- ✅ Immer den Mandanten-Filter einschließen
+SELECT id, title, body FROM notes WHERE id = ? AND tenant_id = ?
+```
+
+Repository-Methoden mit einem `ForTenant`-Suffix benennen, um den Vertrag sichtbar zu machen:
+
+```php
+public function findByIdForTenant(int $id, int $tenantId): ?Note
+{
+    /** @var array{id: int, tenant_id: int, title: string, body: string, created_at: string}|null $row */
+    $row = $this->executor->fetchOne(
+        'SELECT id, tenant_id, title, body, created_at FROM notes WHERE id = ? AND tenant_id = ?',
+        [$id, $tenantId],
+    );
+
+    return $row !== null ? $this->hydrate($row) : null;
+}
+
+/** @return list<Note> */
+public function findAllForTenant(int $tenantId): array
+{
+    /** @var list<array{id: int, tenant_id: int, title: string, body: string, created_at: string}> $rows */
+    $rows = $this->executor->fetchAll(
+        'SELECT id, tenant_id, title, body, created_at FROM notes WHERE tenant_id = ? ORDER BY id DESC',
+        [$tenantId],
+    );
+
+    return array_map($this->hydrate(...), $rows);
+}
+
+public function delete(int $id, int $tenantId): bool
+{
+    $note = $this->findByIdForTenant($id, $tenantId);
+
+    if ($note === null) {
+        return false;
+    }
+
+    $this->executor->execute('DELETE FROM notes WHERE id = ? AND tenant_id = ?', [$id, $tenantId]);
+
+    return true;
+}
+```
+
+Der `ForTenant`-Suffix zwingt Aufrufer, die Mandanten-ID anzugeben. Außerdem vereinfacht er Code-Reviews: Jede Methode ohne diesen Suffix ist ein Kandidat für IDOR-Überprüfung.
+
+---
+
+## `tenant_id` im JWT einbetten
+
+Die Mandantenzugehörigkeit einmalig beim Login auflösen und im Token einbetten. Dies vermeidet einen DB-Round-Trip bei jeder Anfrage und hält den Mandanten-Kontext manipulationssicher (die JWT-Signatur deckt ihn ab).
+
+```php
+$now   = time();
+$token = $this->issuer->issue([
+    'sub'       => $user->id,
+    'tenant_id' => $user->tenantId,  // muss int sein
+    'email'     => $user->email,
+    'iat'       => $now,
+    'exp'       => $now + self::TOKEN_TTL_SECONDS,
+]);
+```
+
+Den Claim in Handlern extrahieren und validieren. `is_int()` verwenden — `is_string()` allein ist nicht sicher; MySQL/PostgreSQL können String-zu-Int-Vergleiche stillschweigend ablehnen:
+
+```php
+private function tenantId(ServerRequestInterface $request): ?int
+{
+    /** @var array<string, mixed>|null $claims */
+    $claims = $request->getAttribute('nene2.auth.claims');
+
+    if (!is_array($claims) || !isset($claims['tenant_id']) || !is_int($claims['tenant_id'])) {
+        return null;  // 401 auslösen
+    }
+
+    return $claims['tenant_id'];
+}
+```
+
+`BearerTokenMiddleware` speichert verifizierte Claims in `nene2.auth.claims`. Das Middleware lehnt abgelaufene Tokens, manipulierte Signaturen und `alg: none`-Angriffe ab, bevor der Handler läuft.
+
+---
+
+## 404 für mandantenübergreifenden Zugriff zurückgeben (nicht 403)
+
+403 Forbidden zurückzugeben verrät, dass die Ressource existiert, aber dem Aufrufer die Berechtigung fehlt — Information, die Mandantengrenzen überquert. Immer 404 zurückgeben:
+
+```php
+// ❌ 403 gibt mandantenübergreifende Information preis
+if ($note->tenantId !== $tenantId) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403);
+}
+
+// ✅ Mandanten-Filter in SQL — mandantenübergreifende Datensätze geben einfach null zurück
+$note = $this->notes->findByIdForTenant($id, $tenantId);
+
+if ($note === null) {
+    return $this->problems->create(
+        $request,
+        'not-found',
+        'Note Not Found',
+        404,
+        "Note {$id} does not exist.",
+    );
+}
+```
+
+Wenn `WHERE id = ? AND tenant_id = ?` nichts trifft, gibt das Repository `null` zurück und der Handler gibt 404 zurück — keine explizite mandantenübergreifende Prüfung notwendig.
+
+---
+
+## `tenant_id` aus Antworten ausschließen
+
+`tenant_id` ist ein Infrastruktur-Identifier. Das Exponieren in Antworten ermöglicht Angreifern, alle Mandanten-IDs zu enumerieren, und dient als Ausgangspunkt für gezielte Angriffe:
+
+```php
+// ❌ tenant_id leckt in der Antwort
+return $this->json->create([
+    'id'        => $note->id,
+    'tenant_id' => $note->tenantId,  // dies entfernen
+    'title'     => $note->title,
+    'body'      => $note->body,
+]);
+
+// ✅ Nur Felder, die der Client benötigt
+return $this->json->create([
+    'id'         => $note->id,
+    'title'      => $note->title,
+    'body'       => $note->body,
+    'created_at' => $note->createdAt,
+]);
+```
+
+---
+
+## PHPStan: `assertIsList()` für `list<>`-Rückgabetypen
+
+`json_decode()` gibt `mixed` zurück. Nach `assertIsArray()` verengt PHPStan den Typ auf `array<mixed>`, aber das erfüllt nicht `list<array<string, mixed>>`. `assertIsList()` hinzufügen, um weiter zu verengen:
+
+```php
+/** @return list<array<string, mixed>> */
+private function jsonList(ResponseInterface $response): array
+{
+    $data = json_decode((string) $response->getBody(), true);
+
+    $this->assertIsArray($data);
+    $this->assertIsList($data);  // verengt array<mixed> → list<mixed>
+
+    return $data;
+}
+```
+
+PHPUnits `assertIsList()` validiert auch zur Laufzeit, dass das Array sequentielle Integer-Schlüssel beginnend bei 0 hat — eine nützliche Korrektheitsprüfung für API-Listenantworten.
+
+---
+
+## Schema-Design
+
+```sql
+CREATE TABLE IF NOT EXISTS tenants (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id     INTEGER NOT NULL REFERENCES tenants(id),
+    email         TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    created_at    TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id  INTEGER NOT NULL REFERENCES tenants(id),
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+```
+
+Jede mandanten-bezogene Tabelle trägt einen `tenant_id NOT NULL` Foreign Key. Dies wird auf DB-Ebene zusätzlich zu den anwendungsseitigen Filtern durchgesetzt.
+
+---
+
+## Code-Review-Checkliste
+
+Bei der Überprüfung von Multi-Tenant-Code prüfen:
+
+1. Jedes `SELECT`, `UPDATE` und `DELETE` enthält `WHERE tenant_id = ?`
+2. `tenant_id` stammt aus dem JWT-Claim, nicht aus einem URL-Parameter oder Request-Body
+3. Mandantenübergreifender Zugriff gibt 404, nicht 403 zurück
+4. Antworten enthalten keine `tenant_id`
+5. Kein `JOIN` überquert Mandantengrenzen ohne Mandanten-Filter
+6. `is_int($claims['tenant_id'])`-Typprüfung ist vorhanden
+
+---
+
+## Isolation testen
+
+Unit-Tests sind unzureichend — mandantenübergreifende Integrationstests schreiben, die tatsächlich versuchen, auf die Daten eines anderen Mandanten zuzugreifen:
+
+```php
+public function testCrossTenantGetReturns404NotForbidden(): void
+{
+    $aliceToken = $this->loginAs('alice@acme.com');
+    $bobToken   = $this->loginAs('bob@beta.com');
+
+    $res    = $this->post('/notes', ['title' => 'Secret', 'body' => 'Acme secret'], $aliceToken);
+    $noteId = $this->json($res)['id'];
+
+    // Bob versucht, Alices Notiz zu lesen
+    $crossRes = $this->get('/notes/' . $noteId, $bobToken);
+
+    // Muss 404 sein — NICHT 403
+    $this->assertSame(404, $crossRes->getStatusCode());
+}
+
+public function testListNotesShowsOnlyCurrentTenantNotes(): void
+{
+    $aliceToken = $this->loginAs('alice@acme.com');
+    $bobToken   = $this->loginAs('bob@beta.com');
+
+    $this->post('/notes', ['title' => 'Alice Note', 'body' => 'Acme'], $aliceToken);
+    $this->post('/notes', ['title' => 'Bob Note',   'body' => 'Beta'], $bobToken);
+
+    $aliceNotes = $this->jsonList($this->get('/notes', $aliceToken));
+    $bobNotes   = $this->jsonList($this->get('/notes', $bobToken));
+
+    $this->assertCount(1, $aliceNotes);
+    $this->assertSame('Alice Note', $aliceNotes[0]['title']);
+
+    $this->assertCount(1, $bobNotes);
+    $this->assertSame('Bob Note', $bobNotes[0]['title']);
+}
+```
+
+Happy-Path-Tests überprüfen nur, dass die eigenen Mandantendaten funktionieren. Mandantenübergreifende Tests sind der einzige Weg, Isolationsfehler zu erkennen.
+
+---
+
+## Verwandte Anleitungen
+
+- [`jwt-authentication.md`](jwt-authentication.md) — JWT-Ausstellung und -Verifizierung
+- [`rbac.md`](rbac.md) — Rollenbasierte Zugriffskontrolle auf Basis von JWT
+- [`enforce-resource-ownership.md`](enforce-resource-ownership.md) — Eigentumsprüfungen pro Benutzer

--- a/docs/de/howto/multi-value-tag-filter.md
+++ b/docs/de/howto/multi-value-tag-filter.md
@@ -2,21 +2,21 @@
 
 > **FT-Referenz**: FT250 (`NENE2-FT/tagfilterlog`) — Multi-Wert-Query-Parameter-Tag-Filterung
 
-Demonstriert Multi-Tag-Filterung einer Posts-API unter Verwendung einer normalisierten M:N-Verbindungstabelle. Unterstützt AND-Semantik (Posts mit **allen** angegebenen Tags) und OR-Semantik (Posts mit **beliebigen** der angegebenen Tags), mit zwei clientseitigen Abfrageformaten: kommagetrennt (`?tags=php,api`) und PHP-Stil-Array (`?tags[]=php&tags[]=api`).
+Demonstriert die Multi-Tag-Filterung einer Posts-API mit einer normalisierten M:N-Join-Tabelle. Unterstützt AND-Semantik (Posts, die **alle** angegebenen Tags haben) und OR-Semantik (Posts, die **irgendein** angegebenes Tag haben), mit zwei clientseitigen Query-Formaten: kommagetrennt (`?tags=php,api`) und PHP-Array-Stil (`?tags[]=php&tags[]=api`).
 
 ---
 
 ## Routen
 
-| Methode | Pfad | Beschreibung |
-|--------|---------------|---------------------------------------------------|
-| `POST` | `/posts`      | Post mit optionalem Tags-Array erstellen          |
-| `GET`  | `/posts`      | Posts auflisten (filterbar nach Tags, AND oder OR)|
-| `GET`  | `/posts/{id}` | Einzelnen Post mit seinen Tags abrufen            |
+| Methode | Pfad          | Beschreibung                                       |
+|---------|---------------|---------------------------------------------------|
+| `POST` | `/posts`      | Einen Post mit optionalem Tags-Array erstellen     |
+| `GET`  | `/posts`      | Posts auflisten (nach Tags filterbar, AND oder OR) |
+| `GET`  | `/posts/{id}` | Einen einzelnen Post mit seinen Tags abrufen       |
 
 ---
 
-## Schema: M:N-Verbindungstabelle
+## Schema: M:N-Join-Tabelle
 
 ```sql
 CREATE TABLE IF NOT EXISTS posts (
@@ -35,11 +35,11 @@ CREATE TABLE IF NOT EXISTS post_tags (
 CREATE INDEX IF NOT EXISTS idx_post_tags_tag ON post_tags(tag);
 ```
 
-`PRIMARY KEY(post_id, tag)` ist ein zusammengesetzter Primärschlüssel — er erzwingt sowohl Eindeutigkeit als auch dient als Index auf `(post_id, tag)`. Ein separater Index nur auf `tag` ermöglicht effiziente `WHERE tag IN (...)`-Lookups unabhängig von `post_id`.
+`PRIMARY KEY(post_id, tag)` ist ein zusammengesetzter Primärschlüssel — er erzwingt sowohl Eindeutigkeit als auch dient als Index auf `(post_id, tag)`. Ein separater Index nur auf `tag` ermöglicht effiziente `WHERE tag IN (...)`-Suchen unabhängig von `post_id`.
 
 **Alternative: JSON-Spalten-Ansatz**
 
-Tags können als JSON-Array in einer TEXT-Spalte der `posts`-Tabelle gespeichert werden: `tags TEXT NOT NULL DEFAULT '[]'`. Das ist einfacher (kein JOIN), unterstützt aber keine indizierten Tag-Lookups und erfordert `json_each()` oder `json_extract()` für die Filterung. Die M:N-Verbindungstabelle ist vorzuziehen, wenn die Tag-Suchleistung wichtig ist.
+Tags können als JSON-Array in einer TEXT-Spalte der `posts`-Tabelle gespeichert werden: `tags TEXT NOT NULL DEFAULT '[]'`. Dies ist einfacher (kein JOIN), unterstützt aber keine indizierten Tag-Suchen und erfordert `json_each()` oder `json_extract()` zum Filtern. Die M:N-Join-Tabelle ist vorzuziehen, wenn die Tag-Suchperformance wichtig ist.
 
 ---
 
@@ -53,7 +53,7 @@ $tags    = array_values(array_filter(array_map(
 ), static fn (string $s): bool => $s !== ''));
 ```
 
-Tags werden aus dem Request extrahiert, getrimmt und auf nicht-leere Strings gefiltert. Nicht-String-Werte (Zahlen, Nullen) werden zu leeren Strings konvertiert und verworfen.
+Tags werden aus dem Request extrahiert, getrimmt und auf nicht-leere Strings gefiltert. Nicht-String-Werte (Zahlen, Nulls) werden zu leeren Strings umgewandelt und verworfen.
 
 Innerhalb einer Transaktion:
 
@@ -76,7 +76,7 @@ $this->txManager->transactional(function (DatabaseQueryExecutorInterface $tx) us
 });
 ```
 
-`array_unique()` + `sort()` dedupliziert und alphabetisiert in PHP vor dem Schreiben. `INSERT OR IGNORE` ist eine zweite Schutzebene — wenn der zusammengesetzte PK-Constraint ausgelöst wird (z.B. bei gleichzeitigem Schreiben), wird das Insert übersprungen statt einen Fehler zu werfen.
+`array_unique()` + `sort()` dedupliziert und alphabetisiert in PHP vor dem Schreiben. `INSERT OR IGNORE` ist eine zweite Verteidigungsschicht — wenn der zusammengesetzte PK-Constraint auslöst (z.B. bei gleichzeitigem Schreiben), wird der Insert übersprungen statt zu werfen.
 
 Die Antwort gibt Tags in sortierter Reihenfolge zurück, sodass Aufrufer immer eine stabile Liste sehen.
 
@@ -106,9 +106,9 @@ public function findByAllTags(array $tags): array
 }
 ```
 
-`WHERE pt.tag IN (...)` schränkt auf Zeilen ein, die mindestens einen übereinstimmenden Tag haben. `GROUP BY p.id HAVING COUNT(DISTINCT pt.tag) = N` wählt nur Posts aus, die **alle** N Tags hatten.
+`WHERE pt.tag IN (...)` schränkt auf Zeilen ein, die mindestens ein übereinstimmendes Tag haben. `GROUP BY p.id HAVING COUNT(DISTINCT pt.tag) = N` wählt nur Posts aus, die **alle** N Tags hatten.
 
-**`CAST(? AS INTEGER)` ist erforderlich**: PDO bindet alle Parameter standardmäßig als Strings. In SQLite funktioniert der Vergleich von `COUNT(...)` (ein Integer) mit `'2'` (ein String) zur Laufzeit für einfache Fälle, aber der explizite Cast ist sicherer und dokumentiert die Absicht.
+**`CAST(? AS INTEGER)` ist erforderlich**: PDO bindet alle Parameter standardmäßig als Strings. In SQLite funktioniert der Vergleich von `COUNT(...)` (ein Integer) mit `'2'` (einem String) zur Laufzeit für einfache Fälle, aber der explizite Cast ist sicherer und dokumentiert die Absicht.
 
 ---
 
@@ -134,13 +134,13 @@ public function findByAnyTag(array $tags): array
 }
 ```
 
-`SELECT DISTINCT` verhindert doppelte Zeilen, wenn ein Post mehrere Tags aus der IN-Liste hat. Keine `HAVING`-Klausel erforderlich — jeder einzelne übereinstimmende Tag qualifiziert den Post.
+`SELECT DISTINCT` verhindert doppelte Zeilen, wenn ein Post mehrere Tags aus der IN-Liste trifft. Keine `HAVING`-Klausel nötig — ein einziges übereinstimmendes Tag qualifiziert den Post.
 
 ---
 
 ## Duales Query-Parameter-Format
 
-Der Listenendpunkt akzeptiert Tags in zwei Formaten, um verschiedene Clients zu unterstützen:
+Der Listen-Endpunkt akzeptiert Tags in zwei Formaten für verschiedene Clients:
 
 | Format | Beispiel | Quelle |
 |--------|---------|--------|
@@ -150,15 +150,15 @@ Der Listenendpunkt akzeptiert Tags in zwei Formaten, um verschiedene Clients zu 
 ```php
 private function extractTags(ServerRequestInterface $request): array
 {
-    // Strategie 1: kommagetrennt (NENE2 nativ)
+    // Strategie 1: kommagetrennt (NENE2-nativ)
     $csv = QueryStringParser::commaSeparated($request, 'tags');
     if ($csv !== null) {
         return $csv;
     }
 
-    // Strategie 2: PHP-Stil-Array-Parameter (?tags[]=php&tags[]=api)
+    // Strategie 2: PHP-Array-Parameter (?tags[]=php&tags[]=api)
     // PSR-7 getQueryParams() parst PHP-Array-Syntax nativ.
-    // NEuNE2's QueryStringParser hat keinen Helper hierfür — Rohdaten verwenden.
+    // NENE2s QueryStringParser hat keinen Helper dafür — raw access verwenden.
     $params   = $request->getQueryParams();
     $arrayVal = $params['tags'] ?? null;
 
@@ -176,9 +176,9 @@ private function extractTags(ServerRequestInterface $request): array
 }
 ```
 
-`QueryStringParser::commaSeparated()` behandelt `?tags=php,api` und gibt `null` zurück, wenn der Parameter fehlt. Bei `null` prüft der Fallback `getQueryParams()['tags']`, das PSR-7-Implementierungen aus `?tags[]=php&tags[]=api` als PHP-Array parsen.
+`QueryStringParser::commaSeparated()` verarbeitet `?tags=php,api` und gibt `null` zurück, wenn der Parameter fehlt. Bei `null` prüft der Fallback `getQueryParams()['tags']`, was PSR-7-Implementierungen aus `?tags[]=php&tags[]=api` als PHP-Array parsen.
 
-Der Modus-Parameter wählt AND vs OR:
+Der Mode-Parameter wählt AND vs OR:
 
 ```php
 $mode  = QueryStringParser::string($request, 'mode') ?? 'all'; // 'all' = AND, 'any' = OR
@@ -187,7 +187,7 @@ $posts = $mode === 'any'
     : $this->repository->findByAllTags($tags);
 ```
 
-Unbekannte `mode`-Werte fallen auf AND durch (der sicherere Standard — weniger Ergebnisse).
+Unbekannte `mode`-Werte fallen auf AND zurück (der sicherere Standard — weniger Ergebnisse).
 
 ---
 
@@ -213,7 +213,7 @@ private function hydrateWithTags(array $row): Post
 }
 ```
 
-Das führt eine zusätzliche Abfrage pro Post durch, um seine Tags zu laden. Für kleine Datensätze ist das akzeptabel. Für große Ergebnismengen durch eine einzelne `GROUP_CONCAT`- oder `json_group_array`-Abfrage ersetzen:
+Dies führt eine zusätzliche Abfrage pro Post aus, um seine Tags zu laden. Für kleine Datensätze ist das akzeptabel. Für große Ergebnismengen durch eine einzige `GROUP_CONCAT`- oder `json_group_array`-Abfrage ersetzen:
 
 ```sql
 SELECT p.*, GROUP_CONCAT(pt.tag ORDER BY pt.tag) AS tags_csv
@@ -223,25 +223,25 @@ GROUP BY p.id
 ORDER BY p.created_at DESC
 ```
 
-Dann `tags_csv` mit `explode(',', ...)` in PHP aufteilen. Beachte, dass SQLites `GROUP_CONCAT` ohne `ORDER BY` innerhalb des Aggregats keine Reihenfolge garantiert (SQLite 3.39+ unterstützt `ORDER BY` in `GROUP_CONCAT`).
+Dann `tags_csv` in PHP mit `explode(',', ...)` aufteilen. Hinweis: SQLites `GROUP_CONCAT` garantiert ohne `ORDER BY` im Aggregat keine Reihenfolge (SQLite 3.39+ unterstützt `ORDER BY` in `GROUP_CONCAT`).
 
 ---
 
-## AND vs OR Vergleich
+## AND vs. OR Vergleich
 
 | Modus | SQL-Muster | Posts mit `[php, api]` vs `[php]` vs `[js]` |
-|------|-------------|-----------------------------------------------|
-| AND (`mode=all`) | `HAVING COUNT(DISTINCT tag) = N` | Nur `[php, api]` entspricht `?tags=php,api` |
-| OR (`mode=any`) | `SELECT DISTINCT` | Sowohl `[php, api]` als auch `[php]` entsprechen `?tags=php,api` |
-| Keine Tags | Kein Filter | Alle Posts zurückgegeben |
+|-------|------------|----------------------------------------------|
+| AND (`mode=all`) | `HAVING COUNT(DISTINCT tag) = N` | Nur `[php, api]` trifft `?tags=php,api` |
+| OR (`mode=any`) | `SELECT DISTINCT` | Sowohl `[php, api]` als auch `[php]` treffen `?tags=php,api` |
+| Keine Tags | Kein Filter | Alle Posts werden zurückgegeben |
 
-Leere Tag-Liste (`tags=[]` oder fehlendes `tags`) gibt in beiden Modi immer alle Posts zurück.
+Eine leere Tag-Liste (`tags=[]` oder fehlende `tags`) gibt in beiden Modi immer alle Posts zurück.
 
 ---
 
 ## Verwandte Anleitungen
 
-- [`tagging-system.md`](tagging-system.md) — Tag-/Label-Verwaltung mit entitätsbezogenen M:N-Beziehungen
-- [`tag-label-api.md`](tag-label-api.md) — Tag-Taxonomie mit Tag-Entitäts-CRUD und Listenfilterung
+- [`tagging-system.md`](tagging-system.md) — Tag/Label-Verwaltung mit entitätsbezogenen M:N-Beziehungen
+- [`tag-label-api.md`](tag-label-api.md) — Tag-Taxonomie mit Tag-Entity-CRUD und Listenfilterung
 - [`note-management-with-tags.md`](note-management-with-tags.md) — Notiz-Tags mit Eigentümer-Scoping
-- [`cursor-pagination.md`](cursor-pagination.md) — Kombination von Cursor-Paginierung mit Tag-Filter
+- [`cursor-pagination.md`](cursor-pagination.md) — Cursor-Paginierung mit Tag-Filter kombinieren

--- a/docs/de/howto/multi-value-tag-filter.md
+++ b/docs/de/howto/multi-value-tag-filter.md
@@ -1,0 +1,247 @@
+# How-to: Multi-Wert-Tag-Filter-API
+
+> **FT-Referenz**: FT250 (`NENE2-FT/tagfilterlog`) — Multi-Wert-Query-Parameter-Tag-Filterung
+
+Demonstriert Multi-Tag-Filterung einer Posts-API unter Verwendung einer normalisierten M:N-Verbindungstabelle. Unterstützt AND-Semantik (Posts mit **allen** angegebenen Tags) und OR-Semantik (Posts mit **beliebigen** der angegebenen Tags), mit zwei clientseitigen Abfrageformaten: kommagetrennt (`?tags=php,api`) und PHP-Stil-Array (`?tags[]=php&tags[]=api`).
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|---------------|---------------------------------------------------|
+| `POST` | `/posts`      | Post mit optionalem Tags-Array erstellen          |
+| `GET`  | `/posts`      | Posts auflisten (filterbar nach Tags, AND oder OR)|
+| `GET`  | `/posts/{id}` | Einzelnen Post mit seinen Tags abrufen            |
+
+---
+
+## Schema: M:N-Verbindungstabelle
+
+```sql
+CREATE TABLE IF NOT EXISTS posts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS post_tags (
+    post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    tag     TEXT    NOT NULL,
+    PRIMARY KEY (post_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_post_tags_tag ON post_tags(tag);
+```
+
+`PRIMARY KEY(post_id, tag)` ist ein zusammengesetzter Primärschlüssel — er erzwingt sowohl Eindeutigkeit als auch dient als Index auf `(post_id, tag)`. Ein separater Index nur auf `tag` ermöglicht effiziente `WHERE tag IN (...)`-Lookups unabhängig von `post_id`.
+
+**Alternative: JSON-Spalten-Ansatz**
+
+Tags können als JSON-Array in einer TEXT-Spalte der `posts`-Tabelle gespeichert werden: `tags TEXT NOT NULL DEFAULT '[]'`. Das ist einfacher (kein JOIN), unterstützt aber keine indizierten Tag-Lookups und erfordert `json_each()` oder `json_extract()` für die Filterung. Die M:N-Verbindungstabelle ist vorzuziehen, wenn die Tag-Suchleistung wichtig ist.
+
+---
+
+## Erstellen: Tag-Deduplizierung und alphabetische Sortierung
+
+```php
+$rawTags = isset($body['tags']) && is_array($body['tags']) ? $body['tags'] : [];
+$tags    = array_values(array_filter(array_map(
+    static fn (mixed $t): string => is_string($t) ? trim($t) : '',
+    $rawTags,
+), static fn (string $s): bool => $s !== ''));
+```
+
+Tags werden aus dem Request extrahiert, getrimmt und auf nicht-leere Strings gefiltert. Nicht-String-Werte (Zahlen, Nullen) werden zu leeren Strings konvertiert und verworfen.
+
+Innerhalb einer Transaktion:
+
+```php
+$this->txManager->transactional(function (DatabaseQueryExecutorInterface $tx) use ($title, $body, $tags, $now): Post {
+    $id = $tx->insert(
+        'INSERT INTO posts (title, body, created_at) VALUES (?, ?, ?)',
+        [$title, $body, $now],
+    );
+
+    // Tags deduplizieren und sortieren
+    $uniqueTags = array_values(array_unique($tags));
+    sort($uniqueTags);
+
+    foreach ($uniqueTags as $tag) {
+        $tx->insert('INSERT OR IGNORE INTO post_tags (post_id, tag) VALUES (?, ?)', [$id, $tag]);
+    }
+
+    return new Post($id, $title, $body, $uniqueTags, $now);
+});
+```
+
+`array_unique()` + `sort()` dedupliziert und alphabetisiert in PHP vor dem Schreiben. `INSERT OR IGNORE` ist eine zweite Schutzebene — wenn der zusammengesetzte PK-Constraint ausgelöst wird (z.B. bei gleichzeitigem Schreiben), wird das Insert übersprungen statt einen Fehler zu werfen.
+
+Die Antwort gibt Tags in sortierter Reihenfolge zurück, sodass Aufrufer immer eine stabile Liste sehen.
+
+---
+
+## AND-Filter: `HAVING COUNT(DISTINCT tag) = N`
+
+```php
+public function findByAllTags(array $tags): array
+{
+    if ($tags === []) {
+        return $this->findAll();
+    }
+
+    $placeholders = implode(',', array_fill(0, count($tags), '?'));
+    $rows         = $this->executor->fetchAll(
+        "SELECT p.* FROM posts p
+         INNER JOIN post_tags pt ON pt.post_id = p.id
+         WHERE pt.tag IN ({$placeholders})
+         GROUP BY p.id
+         HAVING COUNT(DISTINCT pt.tag) = CAST(? AS INTEGER)
+         ORDER BY p.created_at DESC",
+        [...$tags, count($tags)],
+    );
+
+    return array_map($this->hydrateWithTags(...), $rows);
+}
+```
+
+`WHERE pt.tag IN (...)` schränkt auf Zeilen ein, die mindestens einen übereinstimmenden Tag haben. `GROUP BY p.id HAVING COUNT(DISTINCT pt.tag) = N` wählt nur Posts aus, die **alle** N Tags hatten.
+
+**`CAST(? AS INTEGER)` ist erforderlich**: PDO bindet alle Parameter standardmäßig als Strings. In SQLite funktioniert der Vergleich von `COUNT(...)` (ein Integer) mit `'2'` (ein String) zur Laufzeit für einfache Fälle, aber der explizite Cast ist sicherer und dokumentiert die Absicht.
+
+---
+
+## OR-Filter: `SELECT DISTINCT`
+
+```php
+public function findByAnyTag(array $tags): array
+{
+    if ($tags === []) {
+        return $this->findAll();
+    }
+
+    $placeholders = implode(',', array_fill(0, count($tags), '?'));
+    $rows         = $this->executor->fetchAll(
+        "SELECT DISTINCT p.* FROM posts p
+         INNER JOIN post_tags pt ON pt.post_id = p.id
+         WHERE pt.tag IN ({$placeholders})
+         ORDER BY p.created_at DESC",
+        $tags,
+    );
+
+    return array_map($this->hydrateWithTags(...), $rows);
+}
+```
+
+`SELECT DISTINCT` verhindert doppelte Zeilen, wenn ein Post mehrere Tags aus der IN-Liste hat. Keine `HAVING`-Klausel erforderlich — jeder einzelne übereinstimmende Tag qualifiziert den Post.
+
+---
+
+## Duales Query-Parameter-Format
+
+Der Listenendpunkt akzeptiert Tags in zwei Formaten, um verschiedene Clients zu unterstützen:
+
+| Format | Beispiel | Quelle |
+|--------|---------|--------|
+| Kommagetrennt | `?tags=php,api` | `QueryStringParser::commaSeparated()` |
+| PHP-Array-Stil | `?tags[]=php&tags[]=api` | PSR-7 `getQueryParams()` |
+
+```php
+private function extractTags(ServerRequestInterface $request): array
+{
+    // Strategie 1: kommagetrennt (NENE2 nativ)
+    $csv = QueryStringParser::commaSeparated($request, 'tags');
+    if ($csv !== null) {
+        return $csv;
+    }
+
+    // Strategie 2: PHP-Stil-Array-Parameter (?tags[]=php&tags[]=api)
+    // PSR-7 getQueryParams() parst PHP-Array-Syntax nativ.
+    // NEuNE2's QueryStringParser hat keinen Helper hierfür — Rohdaten verwenden.
+    $params   = $request->getQueryParams();
+    $arrayVal = $params['tags'] ?? null;
+
+    if (is_array($arrayVal)) {
+        /** @var list<string> $filtered */
+        $filtered = array_values(array_filter(
+            array_map(static fn (mixed $v): string => is_string($v) ? trim($v) : '', $arrayVal),
+            static fn (string $s): bool => $s !== '',
+        ));
+
+        return $filtered;
+    }
+
+    return [];
+}
+```
+
+`QueryStringParser::commaSeparated()` behandelt `?tags=php,api` und gibt `null` zurück, wenn der Parameter fehlt. Bei `null` prüft der Fallback `getQueryParams()['tags']`, das PSR-7-Implementierungen aus `?tags[]=php&tags[]=api` als PHP-Array parsen.
+
+Der Modus-Parameter wählt AND vs OR:
+
+```php
+$mode  = QueryStringParser::string($request, 'mode') ?? 'all'; // 'all' = AND, 'any' = OR
+$posts = $mode === 'any'
+    ? $this->repository->findByAnyTag($tags)
+    : $this->repository->findByAllTags($tags);
+```
+
+Unbekannte `mode`-Werte fallen auf AND durch (der sicherere Standard — weniger Ergebnisse).
+
+---
+
+## Hydration: N+1-Abfrage pro Post
+
+```php
+private function hydrateWithTags(array $row): Post
+{
+    $tagRows = $this->executor->fetchAll(
+        'SELECT tag FROM post_tags WHERE post_id = ? ORDER BY tag ASC',
+        [(int) $row['id']],
+    );
+
+    $tags = array_map(static fn (array $r): string => (string) $r['tag'], $tagRows);
+
+    return new Post(
+        id:        (int) $row['id'],
+        title:     (string) $row['title'],
+        body:      (string) $row['body'],
+        tags:      $tags,
+        createdAt: (string) $row['created_at'],
+    );
+}
+```
+
+Das führt eine zusätzliche Abfrage pro Post durch, um seine Tags zu laden. Für kleine Datensätze ist das akzeptabel. Für große Ergebnismengen durch eine einzelne `GROUP_CONCAT`- oder `json_group_array`-Abfrage ersetzen:
+
+```sql
+SELECT p.*, GROUP_CONCAT(pt.tag ORDER BY pt.tag) AS tags_csv
+FROM posts p
+LEFT JOIN post_tags pt ON pt.post_id = p.id
+GROUP BY p.id
+ORDER BY p.created_at DESC
+```
+
+Dann `tags_csv` mit `explode(',', ...)` in PHP aufteilen. Beachte, dass SQLites `GROUP_CONCAT` ohne `ORDER BY` innerhalb des Aggregats keine Reihenfolge garantiert (SQLite 3.39+ unterstützt `ORDER BY` in `GROUP_CONCAT`).
+
+---
+
+## AND vs OR Vergleich
+
+| Modus | SQL-Muster | Posts mit `[php, api]` vs `[php]` vs `[js]` |
+|------|-------------|-----------------------------------------------|
+| AND (`mode=all`) | `HAVING COUNT(DISTINCT tag) = N` | Nur `[php, api]` entspricht `?tags=php,api` |
+| OR (`mode=any`) | `SELECT DISTINCT` | Sowohl `[php, api]` als auch `[php]` entsprechen `?tags=php,api` |
+| Keine Tags | Kein Filter | Alle Posts zurückgegeben |
+
+Leere Tag-Liste (`tags=[]` oder fehlendes `tags`) gibt in beiden Modi immer alle Posts zurück.
+
+---
+
+## Verwandte Anleitungen
+
+- [`tagging-system.md`](tagging-system.md) — Tag-/Label-Verwaltung mit entitätsbezogenen M:N-Beziehungen
+- [`tag-label-api.md`](tag-label-api.md) — Tag-Taxonomie mit Tag-Entitäts-CRUD und Listenfilterung
+- [`note-management-with-tags.md`](note-management-with-tags.md) — Notiz-Tags mit Eigentümer-Scoping
+- [`cursor-pagination.md`](cursor-pagination.md) — Kombination von Cursor-Paginierung mit Tag-Filter

--- a/docs/de/howto/multilingual-content.md
+++ b/docs/de/howto/multilingual-content.md
@@ -1,0 +1,422 @@
+# How-to: Mehrsprachige Inhalts-API
+
+> **FT-Referenz**: FT232 (`NENE2-FT/i18nlog`) — Mehrsprachige Inhalts-API
+> **ATK**: FT232 — Cracker-Mindset-Angriffstests (ATK-01 bis ATK-12)
+
+Demonstriert eine mehrsprachige Artikel-API, bei der Inhalte als locale-verschlüsselte Übersetzungen separat vom Artikeldatensatz selbst gespeichert werden. Unterstützt BCP-47-Locale-Validierung, Upsert-Semantik für Übersetzungen, Locale-Fallback für Content-Negotiation und Veröffentlichungs-/Entwurfsstatus pro Artikel.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|-----------------------------------------|-----------------------------------------------|
+| `POST` | `/articles`                             | Artikel erstellen (Entwurf oder veröffentlicht)|
+| `GET`  | `/articles`                             | Veröffentlichte Artikel auflisten (optional `?locale=`) |
+| `GET`  | `/articles/{id}`                        | Einzelnen Artikel abrufen (optional `?locale=`)|
+| `PUT`  | `/articles/{id}/translations/{locale}`  | Übersetzung erstellen oder aktualisieren (Upsert)|
+
+---
+
+## Artikel erstellen
+
+```json
+{
+  "default_locale": "en",
+  "published": false
+}
+```
+
+`default_locale` legt die Fallback-Sprache fest, wenn eine angeforderte Locale nicht verfügbar ist. `published` steuert die Sichtbarkeit in Listen — nur veröffentlichte Artikel erscheinen in `GET /articles`.
+
+```php
+$defaultLocale = isset($body['default_locale']) && is_string($body['default_locale'])
+    ? trim($body['default_locale']) : 'en';
+$published = isset($body['published']) && $body['published'] === true;
+
+if (!preg_match('/^[a-z]{2}(-[A-Z]{2})?$/', $defaultLocale)) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'default_locale', 'code' => 'invalid',
+                      'message' => 'default_locale must be a BCP 47 language tag (e.g. en, ja, fr-FR).']],
+    ]);
+}
+```
+
+`$body['published'] === true` (strenge Gleichheit) bedeutet, dass JSON `true` das Flag setzt — jeder andere Wert (String `"true"`, Integer `1`, weggelassen) lässt den Artikel als Entwurf.
+
+---
+
+## BCP-47-Locale-Validierung
+
+```php
+preg_match('/^[a-z]{2}(-[A-Z]{2})?$/', $locale)
+```
+
+Akzeptiert:
+- Zwei Kleinbuchstaben: `en`, `ja`, `fr`, `de`
+- Zwei Kleinbuchstaben + Bindestrich + zwei Großbuchstaben: `fr-FR`, `zh-TW`, `pt-BR`
+
+Lehnt ab:
+- Falsche Groß-/Kleinschreibung: `EN`, `en_US`, `En`
+- Unterstriche: `en_US` (BCP 47 verwendet Bindestriche)
+- Subtags jenseits der Region: `zh-Hant-TW`
+- Pfad-Traversierung: `../../etc/passwd`
+- Leerer String: `""`
+
+Dieser Regex ist für die gängigen `language`- und `language-REGION`-Formen ausreichend. Für vollständige BCP-47-Unterstützung (Script-Codes, Variant-Tags) ist eine dedizierte Bibliothek erforderlich.
+
+---
+
+## Übersetzung upserting
+
+`PUT /articles/{id}/translations/{locale}` erstellt die Übersetzung, wenn sie nicht existiert, oder aktualisiert sie, wenn sie existiert — idempotent mit Last-Write-Wins-Semantik:
+
+```php
+public function upsertTranslation(int $articleId, string $locale, string $title, string $body, string $now): Translation
+{
+    $existing = $this->executor->fetchAll(
+        'SELECT * FROM article_translations WHERE article_id = ? AND locale = ?',
+        [$articleId, $locale],
+    );
+
+    if ($existing !== []) {
+        $this->executor->execute(
+            'UPDATE article_translations SET title = ?, body = ?, updated_at = ? WHERE article_id = ? AND locale = ?',
+            [$title, $body, $now, $articleId, $locale],
+        );
+    } else {
+        $this->executor->execute(
+            'INSERT INTO article_translations (article_id, locale, title, body, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+            [$articleId, $locale, $title, $body, $now, $now],
+        );
+    }
+    // ... Zeile abrufen und zurückgeben
+}
+```
+
+Der `UNIQUE(article_id, locale)`-Constraint im Schema dient als Rückhalt; das SELECT-then-INSERT/UPDATE auf Anwendungsebene vermeidet stille Konfliktlösung und ermöglicht die explizite Rückgabe der persistierten Zeile.
+
+Body-Validierung lehnt leeren Titel oder Body ab:
+
+```php
+$title = isset($body['title']) && is_string($body['title']) ? trim($body['title']) : '';
+$text  = isset($body['body'])  && is_string($body['body'])  ? trim($body['body'])  : '';
+
+$errors = [];
+if ($title === '') {
+    $errors[] = ['field' => 'title', 'code' => 'required', 'message' => 'title is required.'];
+}
+if ($text === '') {
+    $errors[] = ['field' => 'body', 'code' => 'required', 'message' => 'body is required.'];
+}
+```
+
+`trim()` vor der Leer-Prüfung stellt sicher, dass auch nur-aus-Leerzeichen bestehende Strings die Validierung nicht bestehen.
+
+---
+
+## Locale-Fallback für Content-Negotiation
+
+Wenn der Aufrufer `?locale=fr` übergibt, sucht die `Article`-Entität die angeforderte Locale und fällt auf `default_locale` zurück, wenn keine Übersetzung existiert:
+
+```php
+public function getTranslationWithFallback(string $locale): ?Translation
+{
+    return $this->getTranslation($locale)
+        ?? $this->getTranslation($this->defaultLocale);
+}
+
+public function toArray(?string $locale = null): array
+{
+    $translation = $locale !== null
+        ? $this->getTranslationWithFallback($locale)
+        : null;
+
+    return [
+        'id'             => $this->id,
+        'default_locale' => $this->defaultLocale,
+        'published'      => $this->published,
+        'title'          => $translation?->title,    // null wenn keine Übersetzung gespeichert
+        'body'           => $translation?->body,
+        'locale'         => $translation?->locale,   // gibt an, welche Locale geliefert wurde
+        'translations'   => array_map(fn (Translation $t) => $t->toArray(), $this->translations),
+        'created_at'     => $this->createdAt,
+        'updated_at'     => $this->updatedAt,
+    ];
+}
+```
+
+Das `locale`-Feld in der Antwort zeigt dem Aufrufer, welche Locale tatsächlich geliefert wurde — nützlich wenn Fallback auftrat (`?locale=zh` → Artikel liefert `en`-Übersetzung, weil noch keine chinesische Übersetzung existiert).
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS articles (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    default_locale TEXT    NOT NULL DEFAULT 'en',
+    published      INTEGER NOT NULL DEFAULT 0,
+    created_at     TEXT    NOT NULL,
+    updated_at     TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS article_translations (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    article_id INTEGER NOT NULL REFERENCES articles(id),
+    locale     TEXT    NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE(article_id, locale)
+);
+```
+
+Wichtige Designentscheidungen:
+- `published` wird als `INTEGER` gespeichert (SQLite-Boolean: 0/1); PHP liest es über `(bool) $row['published']`.
+- `UNIQUE(article_id, locale)` erzwingt höchstens eine Übersetzung pro Locale pro Artikel.
+- Keine Sprachvalidierung in der DB — die Anwendungsschicht erzwingt das BCP-47-Format.
+- `article_translations.body` ist Klartext; JSON-API-Aufrufer sind verantwortlich für das Bereinigen vor dem Rendern in HTML.
+
+---
+
+## ATK — Cracker-Mindset-Angriffstests (FT232)
+
+### ATK-01 — Keine Authentifizierung bei irgendeinem Endpunkt
+
+**Angriff**: Artikel ohne Anmeldedaten erstellen oder ändern.
+
+```bash
+curl -s -X POST http://localhost:8080/articles \
+  -H 'Content-Type: application/json' \
+  -d '{"default_locale":"en","published":true}'
+```
+
+**Beobachtet**: `201 Created` — kein Token erforderlich. Jeder Aufrufer kann Artikel erstellen, übersetzen oder veröffentlichen.
+
+**Urteil**: **EXPOSED** (by Design für FT232-Demo). Authentifizierung und Autorisierung für die Produktion hinzufügen. `POST /articles` und `PUT .../translations/{locale}` hinter einer Autoren- oder Admin-Rolle sichern.
+
+---
+
+### ATK-02 — Pfad-Traversierung im Locale-Pfadparameter
+
+**Angriff**: Pfad-Traversierungs- oder Shell-Metazeichen-Strings als `{locale}`-Pfadparameter verwenden.
+
+```
+PUT /articles/1/translations/../../etc/passwd
+PUT /articles/1/translations/../admin
+PUT /articles/1/translations/%2F%2Fetc
+```
+
+**Beobachtet**: Der BCP-47-Regex `/^[a-z]{2}(-[A-Z]{2})?$/` lehnt alle davon ab — keiner entspricht zwei Kleinbuchstaben (optional gefolgt von einem Bindestrich und zwei Großbuchstaben). Antwort: `422 Unprocessable Entity`.
+
+**Urteil**: **BLOCKED** — strenger Regex mit `^` und `$` verankert lehnt Traversierungssequenzen ab.
+
+---
+
+### ATK-03 — SQL-Injection über Locale-Pfadparameter
+
+**Angriff**: SQL-Metazeichen im `{locale}`-Wert einbetten.
+
+```
+PUT /articles/1/translations/en'; DROP TABLE articles; --
+PUT /articles/1/translations/en" OR "1"="1
+```
+
+**Beobachtet**:
+1. Der BCP-47-Regex lehnt diese Strings sofort ab → `422` bevor SQL ausgeführt wird.
+2. Selbst wenn der Regex umgangen würde, wird die Locale als parametrisierter `?`-Wert übergeben — keine String-Konkatenation mit SQL.
+
+**Urteil**: **BLOCKED** — doppelte Schicht: Regex-Allowlist + parametrisierte Abfragen.
+
+---
+
+### ATK-04 — IDOR: Übersetzung eines anderen Benutzers
+
+**Angriff**: Eine Übersetzung für einen Artikel schreiben, den der Angreifer nicht erstellt hat.
+
+```bash
+# Angreifer kennt Artikel-ID 1, die von einem anderen Benutzer erstellt wurde
+curl -s -X PUT http://localhost:8080/articles/1/translations/fr \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Hacked","body":"Attacker content"}'
+```
+
+**Beobachtet**: `200 OK` — Übersetzung wird akzeptiert und überschreibt jede vorhandene französische Übersetzung. Kein Eigentumscheck existiert.
+
+**Urteil**: **EXPOSED** — kein Eigentumsmodell. Eine `created_by`-Spalte hinzufügen und mit dem authentifizierten Aufrufer vergleichen, bevor Schreibvorgänge erlaubt werden.
+
+---
+
+### ATK-05 — Nur-Leerzeichen-Titel oder -Body
+
+**Angriff**: Einen Titel oder Body senden, der nach dem Trimmen leer ist.
+
+```json
+{"title": "   ", "body": "\t\n"}
+```
+
+**Beobachtet**: `trim()` reduziert beide auf leere Strings. Beide Felder werden zu `$errors` hinzugefügt. Antwort: `422 Unprocessable Entity` mit strukturierten Feldfehlern.
+
+**Urteil**: **BLOCKED** — `trim()` vor der Leer-String-Prüfung behandelt nur-aus-Leerzeichen bestehende Eingaben.
+
+---
+
+### ATK-06 — XSS-Payload in Titel oder Body
+
+**Angriff**: Ein Script-Tag in einem Übersetzungsfeld speichern.
+
+```json
+{"title": "<script>alert(1)</script>", "body": "<img src=x onerror=alert(1)>"}
+```
+
+**Beobachtet**: Inhalt wird unverändert gespeichert und wörtlich in JSON zurückgegeben. Die API selbst kodiert die Ausgabe nicht HTML-mäßig — es ist eine JSON-API, kein HTML-Renderer.
+
+**Urteil**: **BY DESIGN AKZEPTIERT** — JSON-APIs geben rohen Inhalt zurück; die Rendering-Schicht (Browser, mobile App) ist für HTML-Escaping verantwortlich. Dies klar in der API-Spec dokumentieren, damit Consumer unvertrauten Inhalt nicht ohne Bereinigung rendern.
+
+---
+
+### ATK-07 — Unbegrenzter Titel oder Body
+
+**Angriff**: Einen mehrmegabyte-großen Titel oder Body senden.
+
+```python
+{"title": "A" * 1_000_000, "body": "B" * 5_000_000}
+```
+
+**Beobachtet**: Kein Längenlimit wird erzwungen — sehr große Payloads werden gespeichert und zurückgegeben. Speicher- und I/O-Nutzung skalieren mit der Payload-Größe. SQLite `TEXT` hat kein praktisches Größenlimit.
+
+**Urteil**: **EXPOSED** — eine `maxlength`-Prüfung hinzufügen:
+```php
+if (mb_strlen($title) > 500) {
+    $errors[] = ['field' => 'title', 'code' => 'too_long', 'message' => 'title must not exceed 500 characters.'];
+}
+if (mb_strlen($text) > 50000) {
+    $errors[] = ['field' => 'body', 'code' => 'too_long', 'message' => 'body must not exceed 50 000 characters.'];
+}
+```
+Außerdem eine Request-Size-Middleware-Begrenzung anwenden, um die gesamten Body-Bytes vor dem Parsen zu begrenzen.
+
+---
+
+### ATK-08 — BCP-47-Groß-/Kleinschreibungs- und Trennzeichen-Bypass
+
+**Angriff**: Varianten versuchen, die semantisch ähnlich, aber syntaktisch falsch sind.
+
+```
+PUT /articles/1/translations/EN        → Großgeschriebener Sprachcode
+PUT /articles/1/translations/en_US     → Unterstrich-Trennzeichen (POSIX-Stil)
+PUT /articles/1/translations/en-us     → Region in Kleinbuchstaben
+PUT /articles/1/translations/EN-us     → Gemischte Groß-/Kleinschreibung
+PUT /articles/1/translations/fra       → Dreistelliger ISO-639-2-Code
+```
+
+**Beobachtet**: Alle von `/^[a-z]{2}(-[A-Z]{2})?$/` abgelehnt:
+- `EN` — schlägt `[a-z]` fehl
+- `en_US` — `_` schlägt `(-[A-Z]{2})?` fehl
+- `en-us` — `us` schlägt `[A-Z]` fehl
+- `fra` — drei Zeichen schlagen `{2}` fehl
+
+**Urteil**: **BLOCKED** — der Regex ist präzise; nur exakte BCP-47-`ll`- oder `ll-RR`-Formen bestehen.
+
+---
+
+### ATK-09 — Übersetzung für nicht existierenden Artikel
+
+**Angriff**: Eine Artikel-ID angeben, die nicht existiert.
+
+```bash
+curl -s -X PUT http://localhost:8080/articles/99999/translations/en \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Ghost","body":"Body"}'
+```
+
+**Beobachtet**: `findById(99999)` gibt `null` zurück. Der Handler gibt `404 Not Found` zurück, bevor der Body verarbeitet wird.
+
+**Urteil**: **BLOCKED** — die Existenz des Artikels wird vor dem Schreiben der Übersetzung verifiziert.
+
+---
+
+### ATK-10 — Veröffentlichungs-Manipulation ohne Auth
+
+**Angriff**: Einen Artikel als veröffentlicht erstellen, um die Entwurfsprüfung zu umgehen.
+
+```json
+{"default_locale": "en", "published": true}
+```
+
+**Beobachtet**: `201 Created` — `published: true` wird sofort akzeptiert. Kein Entwurfsprüfungs- oder Genehmigungsgate existiert; jeder Aufrufer kann veröffentlichen.
+
+**Urteil**: **EXPOSED** (gleiche Ursache wie ATK-01). Eine Veröffentlichungsaktion sollte mindestens eine Autoren-Rolle erfordern. Das `published`-Flag vom Erstellungs-Payload trennen — eine explizite `POST /articles/{id}/publish`-Aktion erfordern, die durch Autorisierung gesichert ist.
+
+---
+
+### ATK-11 — `?locale=` mit unbekannter Locale fällt stillschweigend zurück
+
+**Angriff**: Einen Artikel mit einer Locale anfordern, für die keine Übersetzung gespeichert ist.
+
+```
+GET /articles/1?locale=zh-TW
+```
+
+**Beobachtet**: `getTranslationWithFallback('zh-TW')` findet keine chinesische Übersetzung und fällt auf `default_locale` zurück (z.B. `en`). Das `locale`-Feld in der Antwort zeigt `en` — gibt an, dass Fallback aufgetreten ist. Kein 404 oder Fehler wird zurückgegeben.
+
+**Urteil**: **BY DESIGN AKZEPTIERT** — stilles Fallback ist korrekt für die Content-Delivery. Aufrufer können Fallback erkennen, indem sie die angeforderte Locale mit `locale` in der Antwort vergleichen. Wenn strikte Locale-Erzwingung benötigt wird, einen `?strict=1`-Parameter hinzufügen.
+
+---
+
+### ATK-12 — Nicht-numerische Artikel-ID
+
+**Angriff**: Einen String oder Float als Artikel-ID übergeben.
+
+```
+GET /articles/abc
+GET /articles/1.5
+GET /articles/0x10
+```
+
+**Beobachtet**:
+- `GET /articles/abc` → Router stimmt den `{id}`-Parameter ab; `(int) 'abc'` = `0`. `findById(0)` gibt `null` zurück → `404 Not Found`.
+- `GET /articles/1.5` → `(int) '1.5'` = `1`. Wenn Artikel 1 existiert, wird er zurückgegeben. Das ist eine stille Abschneidung, kein Fehler.
+
+**Urteil**: **TEILWEISE BLOCKED** — nicht-numerische Strings lösen auf 0 auf und geben 404 zurück. Floats werden stillschweigend abgeschnitten. Für strenge Validierung hinzufügen:
+```php
+if (!ctype_digit((string) ($params['id'] ?? ''))) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'id', 'code' => 'invalid', 'message' => 'id must be a positive integer.']],
+    ]);
+}
+```
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|---------------|---------|
+| ATK-01 | Keine Authentifizierung | EXPOSED |
+| ATK-02 | Pfad-Traversierung in Locale | BLOCKED |
+| ATK-03 | SQL-Injection über Locale | BLOCKED |
+| ATK-04 | IDOR: anderen Artikel übersetzen | EXPOSED |
+| ATK-05 | Nur-Leerzeichen-Titel/Body | BLOCKED |
+| ATK-06 | XSS in Titel/Body | BY DESIGN AKZEPTIERT |
+| ATK-07 | Unbegrenzter Titel/Body | EXPOSED |
+| ATK-08 | BCP-47-Groß-/Kleinschreibungs-/Trennzeichen-Bypass | BLOCKED |
+| ATK-09 | Übersetzung für nicht existierenden Artikel | BLOCKED |
+| ATK-10 | Veröffentlichen ohne Auth | EXPOSED |
+| ATK-11 | Unbekannte `?locale=` fällt stillschweigend zurück | BY DESIGN AKZEPTIERT |
+| ATK-12 | Nicht-numerische Artikel-ID | TEILWEISE BLOCKED |
+
+**Echte Schwachstellen, die vor der Produktion behoben werden müssen**:
+1. **ATK-01 / ATK-04 / ATK-10** — Authentifizierung, Eigentumskontrollen und eine separate Veröffentlichungsaktion hinzufügen
+2. **ATK-07** — Titel- und Body-Längenlimits hinzufügen
+3. **ATK-12** — `ctype_digit()`-Guard für ID-Parameter hinzufügen
+
+---
+
+## Verwandte Anleitungen
+
+- [`approval-workflow.md`](approval-workflow.md) — Zustandsmaschine für Inhaltsprüfung vor der Veröffentlichung
+- [`bulk-status-update.md`](bulk-status-update.md) — Massenmutations-Muster mit Teilerfolg
+- [`media-watchlist.md`](media-watchlist.md) — Enum-backed-Status und optionale nullable Felder

--- a/docs/de/howto/nested-json-validation.md
+++ b/docs/de/howto/nested-json-validation.md
@@ -1,0 +1,176 @@
+# How-to: Verschachtelte JSON-Validierung
+
+> **FT-Referenz**: FT322 (`NENE2-FT/nestedlog`) — Bestellungs-API mit verschachtelter Artikel-Validierung, `items.N.field`-Fehlerpfade, Multi-Fehler-Einzelantwort, Fehlercodes, Gesamtberechnung, 19 Tests / 43 Assertions PASS.
+
+Diese Anleitung zeigt, wie verschachtelte JSON-Arrays (z.B. Bestellpositions-Artikel) validiert und strukturierte Fehlerpfade zurückgegeben werden, die genau angeben, welches verschachtelte Feld fehlgeschlagen ist.
+
+## Schema
+
+```sql
+CREATE TABLE orders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    customer   TEXT    NOT NULL,
+    total      REAL    NOT NULL DEFAULT 0.0,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE order_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id   INTEGER NOT NULL REFERENCES orders(id),
+    product_id INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL,
+    unit_price REAL    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/orders` | Bestellung mit Artikeln erstellen |
+| `GET`  | `/orders` | Bestellungen auflisten |
+| `GET`  | `/orders/{id}` | Bestellung mit Artikeln abrufen |
+
+## Bestellung erstellen
+
+```php
+POST /orders
+{
+  "customer": "Alice",
+  "items": [
+    {"product_id": 1, "quantity": 2, "unit_price": 9.99},
+    {"product_id": 2, "quantity": 1, "unit_price": 4.50}
+  ]
+}
+→ 201
+{
+  "id": 1,
+  "customer": "Alice",
+  "items": [...],
+  "total": 24.48      // 2×9.99 + 1×4.50
+}
+```
+
+## Verschachtelte Fehlerpfade — `items.N.field`
+
+Jeder Artikelfehler enthält den Array-Index im Feldpfad:
+
+```php
+POST /orders
+{
+  "customer": "Alice",
+  "items": [
+    {"product_id": "not-an-int", "quantity": 2, "unit_price": 9.99},
+    {"product_id": 1, "quantity": 1, "unit_price": -5.0}
+  ]
+}
+→ 422
+{
+  "errors": [
+    {"field": "items.0.product_id", "message": "...", "code": "invalid-type"},
+    {"field": "items.1.unit_price",  "message": "...", "code": "min-value"}
+  ]
+}
+```
+
+## Alle Fehler in einer Antwort
+
+Alle Validierungsfehler — sowohl auf oberster Ebene als auch verschachtelt — werden gesammelt und zusammen zurückgegeben. Bei Batch-Übermittlungen niemals einen Fehler nach dem anderen zurückgeben:
+
+```php
+POST /orders
+{
+  "customer": "",      // Fehler: required
+  "items": [
+    {"product_id": 0, "quantity": -1, "unit_price": 1.0}  // 2 Fehler
+  ]
+}
+→ 422
+{
+  "errors": [
+    {"field": "customer",          "code": "required"},
+    {"field": "items.0.product_id","code": "min-value"},
+    {"field": "items.0.quantity",  "code": "min-value"}
+  ]
+}
+```
+
+## Validierungsregeln
+
+| Feld | Regel |
+|------|-------|
+| `customer` | Pflichtfeld, nicht leer, max 200 Zeichen |
+| `items` | Pflichtfeld, nicht-leeres Array |
+| `items[].product_id` | Integer, ≥ 1 |
+| `items[].quantity` | Integer, ≥ 1 |
+| `items[].unit_price` | Zahl (int oder float), > 0 |
+
+## Implementierungsmuster
+
+```php
+final class OrderValidator
+{
+    /** @return list<ValidationError> */
+    public function validate(array $data): array
+    {
+        $errors = [];
+
+        // Validierung auf oberster Ebene
+        $customer = trim($data['customer'] ?? '');
+        if ($customer === '') {
+            $errors[] = new ValidationError('customer', 'required', 'required');
+        } elseif (strlen($customer) > 200) {
+            $errors[] = new ValidationError('customer', 'max 200 chars', 'max-length');
+        }
+
+        $items = $data['items'] ?? null;
+        if (!is_array($items) || $items === []) {
+            $errors[] = new ValidationError('items', 'required non-empty array', 'required');
+            return $errors;  // Artikel können nicht weiter validiert werden
+        }
+
+        // Verschachtelte Artikel-Validierung mit Index
+        foreach ($items as $i => $item) {
+            $prefix = "items.{$i}";
+
+            $productId = $item['product_id'] ?? null;
+            if (!is_int($productId) || $productId < 1) {
+                $errors[] = new ValidationError("{$prefix}.product_id", 'must be int >= 1', 'min-value');
+            }
+
+            $quantity = $item['quantity'] ?? null;
+            if (!is_int($quantity) || $quantity < 1) {
+                $errors[] = new ValidationError("{$prefix}.quantity", 'must be int >= 1', 'min-value');
+            }
+
+            $price = $item['unit_price'] ?? null;
+            if ((!is_int($price) && !is_float($price)) || $price <= 0) {
+                $errors[] = new ValidationError("{$prefix}.unit_price", 'must be number > 0', 'min-value');
+            }
+        }
+
+        return $errors;
+    }
+}
+```
+
+## Fehlercodes
+
+| Code | Bedeutung |
+|------|----------|
+| `required` | Feld fehlt oder ist leer |
+| `max-length` | Überschreitet maximale Länge |
+| `min-value` | Unterhalb des Minimalwerts (int/float) |
+| `invalid-type` | Falscher Typ (z.B. String, wo int erwartet wird) |
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Nur ersten Fehler zurückgeben | Client muss N-mal einreichen, Fehler bekommen, korrigieren, erneut einreichen — schreckliche UX für Batch-Formulare |
+| Flacher Fehlerpfad `"product_id"` für verschachtelte Artikel | Client kann nicht identifizieren, welcher Artikel (Index 0, 1, ...) fehlgeschlagen ist |
+| `unit_price: 0` stillschweigend akzeptieren | Nullpreisartikel korrumpieren Bestellsummen |
+| Artikel nur nach bestandener Top-Level-Validierung validieren | Verzögert Feedback; alle Fehler in einem Durchgang sammeln |
+| Validierung beim ersten Artikelfehler stoppen | Verbirgt weitere Fehler in verbleibenden Artikeln |

--- a/docs/de/howto/note-management-ownership.md
+++ b/docs/de/howto/note-management-ownership.md
@@ -1,21 +1,21 @@
-# How-to: Notiz-Verwaltung mit Eigentümerschaft
+# How-to: Notizverwaltung mit Eigentümerschaft
 
-> **FT-Referenz**: FT240 (`NENE2-FT/noteslog`) — Notiz-Verwaltungs-API
-> **ATK**: FT240 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+> **FT-Referenz**: FT240 (`NENE2-FT/noteslog`) — Notizverwaltungs-API
+> **ATK**: FT240 — Cracker-Mindset-Angriffstests (ATK-01 bis ATK-12)
 
-Demonstriert eine Notiz-Verwaltungs-API mit eigentümerbezogenen Operationen, `X-Auth-User`-Header-Identifikation, IDOR-Prävention via `WHERE id = ? AND owner_id = ?` und Felder-Merge-Updates, die nicht angegebene Felder erhalten.
+Demonstriert eine Notizverwaltungs-API mit eigentümerbezogenen Operationen, `X-Auth-User`-Header-Identifikation, IDOR-Prävention über `WHERE id = ? AND owner_id = ?` und Feld-Merge-Updates, die nicht angegebene Felder erhalten.
 
 ---
 
 ## Routen
 
-| Methode  | Pfad           | Beschreibung                                          |
+| Methode | Pfad | Beschreibung |
 |----------|----------------|------------------------------------------------------|
-| `POST`   | `/notes`       | Notiz erstellen (erfordert `X-Auth-User`-Header)      |
-| `GET`    | `/notes`       | Vom Aufrufer besessene Notizen auflisten              |
-| `GET`    | `/notes/{id}`  | Einzelne Notiz abrufen (404 wenn nicht gefunden oder kein Eigentümer) |
+| `POST`   | `/notes`       | Notiz erstellen (erfordert `X-Auth-User`-Header)     |
+| `GET`    | `/notes`       | Notizen des Aufrufers auflisten                      |
+| `GET`    | `/notes/{id}`  | Einzelne Notiz abrufen (404 wenn nicht gefunden oder nicht Eigentümer) |
 | `PUT`    | `/notes/{id}`  | Notiz aktualisieren (Feld-Merge: ausgelassene Felder werden behalten) |
-| `DELETE` | `/notes/{id}`  | Notiz löschen (404 wenn nicht gefunden oder kein Eigentümer) |
+| `DELETE` | `/notes/{id}`  | Notiz löschen (404 wenn nicht gefunden oder nicht Eigentümer) |
 
 ---
 
@@ -32,21 +32,22 @@ private function resolveAuthUser(ServerRequestInterface $request): ?string
 }
 ```
 
-`trim()` entfernt führende/nachfolgende Leerzeichen. Ein nach-Trim leerer Header → `null` → `401 Unauthorized`. Jeder nicht-leere String wird als gültige Benutzer-ID akzeptiert — es gibt keine Token-Verifizierung.
+`trim()` entfernt führende/nachfolgende Leerzeichen. Ein nach-trim-leerer Header → `null` → `401 Unauthorized`. Jeder nicht-leere String wird als gültige Benutzer-ID akzeptiert — es gibt keine Token-Verifizierung.
 
-Dies ist absichtlich schwach für Demo-Zwecke. In der Produktion durch verifizierte JWT-Claims oder sitzungscookie-gestützte Sessions ersetzen.
+Dies ist absichtlich schwach für Demo-Zwecke. In der Produktion durch verifizierte JWT-Claims oder sitzungs-Cookie-basierte Sessions ersetzen.
 
 ---
 
 ## IDOR-Prävention: `WHERE id = ? AND owner_id = ?`
 
-Jede Operation, die eine bestimmte Notiz berührt, schließt `owner_id` in die Abfrage ein:
+Jede Operation, die eine bestimmte Notiz berührt, enthält `owner_id` in der Abfrage:
 
 ```php
 /**
- * Gibt die Notiz nur zurück, wenn sie dem angegebenen Eigentümer gehört.
- * Gibt null für "nicht gefunden" und "falscher Eigentümer" zurück — Aufrufer geben 404 in beiden Fällen zurück,
- * um IDOR-Informationslecks zu verhindern (nicht exponieren, ob eine Ressource existiert).
+ * Gibt die Notiz nur zurück, wenn sie dem gegebenen Eigentümer gehört.
+ * Gibt null sowohl für "nicht gefunden" als auch für "falscher Eigentümer" zurück — Aufrufer
+ * geben in beiden Fällen 404 zurück, um IDOR-Informationslecks zu verhindern (nicht preisgeben,
+ * ob eine Ressource existiert).
  */
 public function findByIdAndOwner(int $id, string $ownerId): ?Note
 {
@@ -59,24 +60,24 @@ public function findByIdAndOwner(int $id, string $ownerId): ?Note
 }
 ```
 
-Die Methode gibt `null` für "nicht gefunden" und "falscher Eigentümer" zurück. Der Controller verwendet in beiden Fällen dieselbe `404 Not Found`-Antwort:
+Die Methode gibt `null` sowohl für "nicht gefunden" als auch für "falscher Eigentümer" zurück. Der Controller verwendet die gleiche `404 Not Found`-Antwort in beiden Fällen:
 
 ```php
 $note = $this->repo->findByIdAndOwner($id, $authUser);
 
 if ($note === null) {
-    // 404 nicht 403: nicht verraten, ob die Ressource existiert (IDOR-Prävention)
+    // 404 nicht 403: nicht preisgeben, ob die Ressource existiert (IDOR-Prävention)
     return $this->problems->create($request, 'not-found', 'Note Not Found', 404, '');
 }
 ```
 
-`403 Forbidden` zurückzugeben würde bestätigen, dass die Ressource existiert — der `404`-Ansatz verhindert Enumerationsangriffe.
+Die Rückgabe von `403 Forbidden` würde bestätigen, dass die Ressource existiert — der `404`-Ansatz verhindert Enumeration-Angriffe. Ein Aufrufer erfährt nichts über Notizen anderer Benutzer.
 
 ---
 
 ## Feld-Merge-Update
 
-`PUT /notes/{id}` behält vorhandene Werte für im Request-Body ausgelassene Felder:
+`PUT /notes/{id}` behält vorhandene Werte für Felder, die im Request-Body fehlen:
 
 ```php
 $title    = isset($body['title']) && is_string($body['title']) ? trim($body['title']) : $note->title;
@@ -86,7 +87,7 @@ $this->repo->update($id, $authUser, $title, $noteBody);
 $updated = new Note($note->id, $note->ownerId, $title, $noteBody, $note->createdAt);
 ```
 
-Wenn nur `title` angegeben wird, behält `body` seinen aktuellen Wert — und umgekehrt. Dies unterscheidet sich von einer vollständigen Ersetzung (`PUT`-Semantik) — es verhält sich eher wie `PATCH`. Für strikte `PUT`-Semantik beide Felder erfordern und `422` zurückgeben, wenn eines fehlt.
+Wenn nur `title` angegeben wird, behält `body` seinen aktuellen Wert — und umgekehrt. Das unterscheidet sich von einer vollständigen Ersetzung (`PUT`-Semantik) — es verhält sich eher wie `PATCH`. Für strikte `PUT`-Semantik beide Felder erfordern und `422` zurückgeben, wenn eines fehlt.
 
 ---
 
@@ -103,126 +104,215 @@ CREATE TABLE IF NOT EXISTS notes (
 CREATE INDEX IF NOT EXISTS idx_notes_owner ON notes (owner_id);
 ```
 
-`body` hat den Standard `''` — keine nullable Spalte für den Text-Body. `owner_id` ist ein freier String (der `X-Auth-User`-Wert); es gibt keinen Foreign Key zu einer Benutzertabelle.
+`body` hat den Standardwert `''` — keine nullable Spalte für den Text-Body. `owner_id` ist ein freier String (der `X-Auth-User`-Wert); kein Fremdschlüssel zu einer Benutzertabelle existiert.
 
 ---
 
-## ATK — Cracker-Mindset-Angriffstest (FT240)
+## ATK — Cracker-Mindset-Angriffstests (FT240)
 
-### ATK-01 — `X-Auth-User` ist trivial fälschbar ⚠️ EXPOSED
+### ATK-01 — `X-Auth-User` ist trivial fälschbar
 
-**Angriff**: Einen anderen Benutzer imitieren, indem seine Benutzer-ID im Header gesendet wird.
+**Angriff**: Einen anderen Benutzer imitieren, indem ihre Benutzer-ID im Header gesendet wird.
 
-**Ergebnis**: EXPOSED — der Header trägt keinen kryptografischen Identitätsbeweis. Für die Produktion signierte JWT-Tokens oder Session-Cookies verwenden.
+```bash
+curl -s -X GET http://localhost:8080/notes \
+  -H 'X-Auth-User: alice'
+
+curl -s -X GET http://localhost:8080/notes \
+  -H 'X-Auth-User: bob'
+```
+
+**Beobachtet**: Jede Anfrage gibt Notizen zurück, die dem Benutzer-ID-Header gehören. Jeder Aufrufer kann jeden Benutzer imitieren, indem er seine ID-String kennt oder errät.
+
+**Urteil**: **EXPOSED** — der Header trägt keinen kryptografischen Identitätsnachweis. Signierte JWT-Token oder Session-Cookies für die Produktionsauth verwenden.
 
 ---
 
-### ATK-02 — Zeilenumbruch-Injektion in `X-Auth-User` 🚫 BLOCKED
+### ATK-02 — Zeilenumbruch-Injection in `X-Auth-User`
 
-**Angriff**: HTTP-Header-Injektionszeichen (CR/LF) im Header-Wert einbetten.
+**Angriff**: HTTP-Header-Injection-Zeichen (CR/LF) in den Header-Wert einbetten.
 
-**Ergebnis**: BLOCKED — HTTP-Server lehnen fehlerhafte Header vor der Anwendungsebene ab.
+```
+X-Auth-User: alice\r\nX-Injected: evil
+```
+
+**Beobachtet**: PSR-7 (Nyholm) entfernt oder lehnt ungültige Header-Zeichen ab. Der Header-Wert ist ein einfacher String — CRLF-Injection auf HTTP-Ebene wird vom Server (Swoole, Apache, Nginx) behandelt, bevor sie die Anwendung erreicht. `trim()` entfernt führende/nachfolgende Leerzeichen, fügt aber keine weitere Verteidigung gegen eingebettete Steuerzeichen hinzu.
+
+**Urteil**: **BLOCKED** in der Praxis — HTTP-Server lehnen fehlerhafte Header ab, bevor sie die Anwendungsschicht erreichen.
 
 ---
 
-### ATK-03 — IDOR: Notiz eines anderen Benutzers lesen 🚫 BLOCKED
+### ATK-03 — IDOR: Notiz eines anderen Benutzers lesen
 
 **Angriff**: Notiz-IDs eines anderen Benutzers erraten oder enumerieren.
 
-**Ergebnis**: BLOCKED — eigentümerbezogene Abfrage + 404 verhindert IDOR.
+```bash
+curl -s http://localhost:8080/notes/1 -H 'X-Auth-User: bob'
+# Notiz 1 wurde von alice erstellt
+```
+
+**Beobachtet**: `findByIdAndOwner(1, 'bob')` findet keine Zeile, die `id = 1 AND owner_id = 'bob'` entspricht → gibt `null` zurück → `404 Not Found`. Bob kann nicht feststellen, dass Notiz 1 existiert.
+
+**Urteil**: **BLOCKED** — eigentümerbezogene Abfrage + 404 verhindert IDOR.
 
 ---
 
-### ATK-04 — SQL-Injection via Titel oder Body 🚫 BLOCKED
+### ATK-04 — SQL-Injection über Titel oder Body
 
-**Angriff**: SQL-Metazeichen im Request-Body einbetten.
+**Angriff**: SQL-Metazeichen in den Request-Body einbetten.
 
-**Ergebnis**: BLOCKED — parametrisierte Abfragen verhindern alle SQL-Injection via Body-Felder.
+```json
+{"title": "'; DROP TABLE notes; --", "body": "\" OR \"1\"=\"1"}
+```
 
----
+**Beobachtet**: Die Werte werden als parametrisierte `?`-Werte gespeichert — keine String-Konkatenation mit SQL. Die Injection-Payloads werden als Literaltext gespeichert.
 
-### ATK-05 — Leerer Titel 🚫 BLOCKED
-
-**Angriff**: Notiz mit einem nur-Leerzeichen oder leeren Titel erstellen.
-
-**Ergebnis**: BLOCKED — `trim()` + Leer-String-Prüfung behandelt Nur-Leerzeichen-Eingaben.
+**Urteil**: **BLOCKED** — parametrisierte Abfragen verhindern alle SQL-Injections über Body-Felder.
 
 ---
 
-### ATK-06 — Fehlender `X-Auth-User`-Header 🚫 BLOCKED
+### ATK-05 — Leerer Titel
 
-**Angriff**: Anfrage ohne `X-Auth-User`-Header senden.
+**Angriff**: Eine Notiz mit einem nur-aus-Leerzeichen bestehenden oder leeren Titel erstellen.
 
-**Ergebnis**: BLOCKED — fehlender Header wird als nicht-authentifiziert behandelt → `401 Unauthorized`.
+```json
+{"title": "   "}
+{"title": ""}
+```
+
+**Beobachtet**: `trim($body['title'])` reduziert beide auf `""`. Die Prüfung `title === ''` schlägt an → `422 Unprocessable Entity`.
+
+**Urteil**: **BLOCKED** — `trim()` + Leer-String-Prüfung behandelt nur-aus-Leerzeichen bestehende Eingaben.
 
 ---
 
-### ATK-07 — Impersonation via beliebigen `X-Auth-User`-Wert ⚠️ EXPOSED
+### ATK-06 — Fehlender `X-Auth-User`-Header
+
+**Angriff**: Eine Anfrage ohne den `X-Auth-User`-Header senden.
+
+```bash
+curl -s http://localhost:8080/notes
+```
+
+**Beobachtet**: `getHeaderLine('X-Auth-User')` gibt `""` zurück. Nach `trim()` ist es immer noch `""`. `$userId !== ''` schlägt fehl → `resolveAuthUser()` gibt `null` zurück → `401 Unauthorized` mit einer strukturierten Problem-Details-Antwort.
+
+**Urteil**: **BLOCKED** — fehlender Header wird als nicht authentifiziert behandelt.
+
+---
+
+### ATK-07 — Imitation über beliebigen `X-Auth-User`-Wert
 
 **Angriff**: Notizen als privilegierte Benutzer-ID-String erstellen.
 
-**Ergebnis**: EXPOSED (gleiche Wurzel wie ATK-01). Ohne kryptografische Auth kann ein echter Admin nicht von einem Angreifer unterschieden werden, der den String `"admin"` kennt.
+```bash
+# Angenommen, 'admin' ist ein spezieller Benutzer
+curl -s -X POST http://localhost:8080/notes \
+  -H 'X-Auth-User: admin' \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Admin note"}'
+```
+
+**Beobachtet**: `201 Created` — die Notiz wird mit `owner_id = 'admin'` erstellt. Jeder String wird als Identität des Aufrufers akzeptiert.
+
+**Urteil**: **EXPOSED** (gleiche Ursache wie ATK-01). Ohne kryptografische Auth gibt es keine Möglichkeit, einen echten Admin von einem Angreifer zu unterscheiden, der den String `"admin"` kennt.
 
 ---
 
-### ATK-08 — XSS-Payload in Titel oder Body ✅ ACCEPTED BY DESIGN
+### ATK-08 — XSS-Payload in Titel oder Body
 
-**Angriff**: Script-Tag speichern.
+**Angriff**: Ein Script-Tag speichern.
 
-**Ergebnis**: ACCEPTED BY DESIGN — JSON-APIs geben rohen Inhalt zurück. Die Rendering-Schicht muss vor dem HTML-Einfügen bereinigen.
+```json
+{"title": "<script>alert(1)</script>", "body": "<img src=x onerror=alert(1)>"}
+```
 
----
+**Beobachtet**: Inhalt wird unverändert gespeichert und wörtlich in JSON zurückgegeben. Die JSON-API kodiert die Ausgabe nicht HTML-mäßig.
 
-### ATK-09 — Teilaktualisierung verliert unbeabsichtigte Felder ✅ ACCEPTED BY DESIGN
-
-**Angriff**: Versuchen, `body` zu leeren durch Auslassen aus dem Update.
-
-**Ergebnis**: ACCEPTED BY DESIGN — dokumentiertes Merge-Update-Verhalten. Wenn strikte `PUT`-Semantik gewünscht ist, alle Felder erfordern.
+**Urteil**: **BY DESIGN AKZEPTIERT** — JSON-APIs geben rohen Inhalt zurück. Die Rendering-Schicht muss vor dem Einfügen in HTML bereinigen. Diese Erwartung für API-Consumer dokumentieren.
 
 ---
 
-### ATK-10 — Nicht-numerische Notiz-ID ⚠️ PARTIALLY BLOCKED
+### ATK-09 — Teilupdate verliert unbeabsichtigt Felder
 
-**Angriff**: String oder Float als `{id}` übergeben.
+**Angriff**: Versuchen, `body` durch Weglassen aus dem Update zu überschreiben.
 
-**Ergebnis**: PARTIALLY BLOCKED — nicht-numerische Strings mappen auf 404. Floats werden stillschweigend abgeschnitten. `ctype_digit()`-Guard für strikte Validierung hinzufügen.
+```json
+{"title": "New title"}
+// Aufrufer erwartet, dass body gelöscht wird; tatsächlich wird er erhalten
+```
+
+**Beobachtet**: Die Feld-Merge-Logik erhält `body`, wenn er im Request fehlt: `$noteBody = isset($body['body']) ? $body['body'] : $note->body`. Der Body ist unverändert — das entspricht der Absicht für eine Merge-Update-API, kann aber Aufrufer überraschen, die vollständige Ersetzung erwarten (`PUT`-Semantik).
+
+**Urteil**: **BY DESIGN AKZEPTIERT** — dokumentiertes Merge-Update-Verhalten. Wenn strikte `PUT`-Semantik gewünscht ist, alle Felder erfordern.
 
 ---
 
-### ATK-11 — Nicht-besessene/nicht-existente Notiz löschen 🚫 BLOCKED
+### ATK-10 — Nicht-numerische Notiz-ID
 
-**Angriff**: Notiz-ID löschen, die nicht existiert oder einem anderen Benutzer gehört.
+**Angriff**: Einen String oder Float als `{id}` übergeben.
 
-**Ergebnis**: BLOCKED — eigentümerbezogenes DELETE + 404-Antwort verhindert mandantenübergreifendes Löschen.
+```
+GET /notes/abc
+GET /notes/1.5
+```
+
+**Beobachtet**: `(int) 'abc'` = 0, `(int) '1.5'` = 1.
+- `abc` → `findByIdAndOwner(0, ...)` → keine Zeile → `404 Not Found`.
+- `1.5` → `findByIdAndOwner(1, ...)` → wenn Notiz 1 dem Aufrufer gehört, wird sie zurückgegeben.
+
+**Urteil**: **TEILWEISE BLOCKED** — nicht-numerische Strings werden auf 404 abgebildet. Floats werden stillschweigend abgeschnitten. `ctype_digit()`-Guard für strenge Validierung hinzufügen.
 
 ---
 
-### ATK-12 — Nur-Leerzeichen `X-Auth-User` 🚫 BLOCKED
+### ATK-11 — Nicht vorhandene oder nicht eigene Notiz löschen
 
-**Angriff**: Header mit nur Leerzeichen oder Tabs senden.
+**Angriff**: Eine Notiz-ID löschen, die nicht existiert oder einem anderen Benutzer gehört.
 
-**Ergebnis**: BLOCKED — `trim()` normalisiert Nur-Leerzeichen-Header zu leer.
+```bash
+curl -s -X DELETE http://localhost:8080/notes/99999 -H 'X-Auth-User: alice'
+curl -s -X DELETE http://localhost:8080/notes/1    -H 'X-Auth-User: eve'
+# (Notiz 1 gehört alice)
+```
+
+**Beobachtet**: Das Repository führt `DELETE FROM notes WHERE id = ? AND owner_id = ?` aus. Wenn keine Zeilen übereinstimmen (nicht vorhanden oder falscher Eigentümer), ist `$deleted = false` → `404 Not Found`. Eves Versuch gibt dasselbe 404 zurück wie eine nicht vorhandene Notiz.
+
+**Urteil**: **BLOCKED** — eigentümerbasiertes DELETE + 404-Antwort verhindert plattformübergreifendes Löschen.
+
+---
+
+### ATK-12 — Nur-Leerzeichen-`X-Auth-User`
+
+**Angriff**: Einen Header senden, der nur Leerzeichen oder Tabs enthält.
+
+```
+X-Auth-User:    
+X-Auth-User: \t
+```
+
+**Beobachtet**: `trim('   ')` = `""` → `$userId !== ''` schlägt fehl → `401 Unauthorized`.
+
+**Urteil**: **BLOCKED** — `trim()` normalisiert nur-aus-Leerzeichen bestehende Header zu leer.
 
 ---
 
 ## ATK-Zusammenfassung
 
-| # | Angriffsvektor | Ergebnis |
+| # | Angriffsvektor | Urteil |
 |---|---------------|---------|
-| ATK-01 | X-Auth-User ist trivial fälschbar | ⚠️ EXPOSED |
-| ATK-02 | Zeilenumbruch-Injektion in X-Auth-User | 🚫 BLOCKED |
-| ATK-03 | IDOR: Notiz eines anderen Benutzers lesen | 🚫 BLOCKED |
-| ATK-04 | SQL-Injection via Titel/Body | 🚫 BLOCKED |
-| ATK-05 | Leerer Titel | 🚫 BLOCKED |
-| ATK-06 | Fehlender X-Auth-User-Header | 🚫 BLOCKED |
-| ATK-07 | Impersonation via beliebigen Header-Wert | ⚠️ EXPOSED |
-| ATK-08 | XSS in Titel/Body | ✅ ACCEPTED BY DESIGN |
-| ATK-09 | Teilaktualisierung Feld-Merge-Überraschung | ✅ ACCEPTED BY DESIGN |
-| ATK-10 | Nicht-numerische Notiz-ID | ⚠️ PARTIALLY BLOCKED |
-| ATK-11 | Nicht-besessene/nicht-existente Notiz löschen | 🚫 BLOCKED |
-| ATK-12 | Nur-Leerzeichen X-Auth-User | 🚫 BLOCKED |
+| ATK-01 | X-Auth-User ist trivial fälschbar | EXPOSED |
+| ATK-02 | Zeilenumbruch-Injection in X-Auth-User | BLOCKED |
+| ATK-03 | IDOR: Notiz eines anderen Benutzers lesen | BLOCKED |
+| ATK-04 | SQL-Injection über Titel/Body | BLOCKED |
+| ATK-05 | Leerer Titel | BLOCKED |
+| ATK-06 | Fehlender X-Auth-User-Header | BLOCKED |
+| ATK-07 | Imitation über beliebigen Header-Wert | EXPOSED |
+| ATK-08 | XSS in Titel/Body | BY DESIGN AKZEPTIERT |
+| ATK-09 | Teilupdate Feld-Merge-Überraschung | BY DESIGN AKZEPTIERT |
+| ATK-10 | Nicht-numerische Notiz-ID | TEILWEISE BLOCKED |
+| ATK-11 | Nicht vorhandene/nicht eigene Notiz löschen | BLOCKED |
+| ATK-12 | Nur-Leerzeichen-X-Auth-User | BLOCKED |
 
-**Echte Schwachstellen vor der Produktion zu beheben**:
+**Echte Schwachstellen, die vor der Produktion behoben werden müssen**:
 1. **ATK-01 / ATK-07** — `X-Auth-User` durch signierte JWT- oder Session-Verifizierung ersetzen
 2. **ATK-10** — `ctype_digit()`-Guard für ID-Pfadparameter hinzufügen
 
@@ -232,4 +322,5 @@ CREATE INDEX IF NOT EXISTS idx_notes_owner ON notes (owner_id);
 
 - [`use-bearer-auth.md`](use-bearer-auth.md) — signierte Bearer-Token-Authentifizierung
 - [`enforce-resource-ownership.md`](enforce-resource-ownership.md) — IDOR-Präventionsmuster
-- [`jwt-authentication.md`](jwt-authentication.md) — JWT-Verifizierung zur Benutzeridentifikation
+- [`jwt-authentication.md`](jwt-authentication.md) — JWT-Verifizierung für Benutzeridentifikation
+- [`scheduled-reminders.md`](scheduled-reminders.md) — V::userId()-Header-Validierungsmuster

--- a/docs/de/howto/note-management-ownership.md
+++ b/docs/de/howto/note-management-ownership.md
@@ -1,0 +1,235 @@
+# How-to: Notiz-Verwaltung mit Eigentümerschaft
+
+> **FT-Referenz**: FT240 (`NENE2-FT/noteslog`) — Notiz-Verwaltungs-API
+> **ATK**: FT240 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert eine Notiz-Verwaltungs-API mit eigentümerbezogenen Operationen, `X-Auth-User`-Header-Identifikation, IDOR-Prävention via `WHERE id = ? AND owner_id = ?` und Felder-Merge-Updates, die nicht angegebene Felder erhalten.
+
+---
+
+## Routen
+
+| Methode  | Pfad           | Beschreibung                                          |
+|----------|----------------|------------------------------------------------------|
+| `POST`   | `/notes`       | Notiz erstellen (erfordert `X-Auth-User`-Header)      |
+| `GET`    | `/notes`       | Vom Aufrufer besessene Notizen auflisten              |
+| `GET`    | `/notes/{id}`  | Einzelne Notiz abrufen (404 wenn nicht gefunden oder kein Eigentümer) |
+| `PUT`    | `/notes/{id}`  | Notiz aktualisieren (Feld-Merge: ausgelassene Felder werden behalten) |
+| `DELETE` | `/notes/{id}`  | Notiz löschen (404 wenn nicht gefunden oder kein Eigentümer) |
+
+---
+
+## `X-Auth-User`-Header-Identifikation
+
+Die API verwendet einen minimalen `X-Auth-User`-String-Header als Identität des Aufrufers:
+
+```php
+private function resolveAuthUser(ServerRequestInterface $request): ?string
+{
+    $userId = trim($request->getHeaderLine('X-Auth-User'));
+
+    return $userId !== '' ? $userId : null;
+}
+```
+
+`trim()` entfernt führende/nachfolgende Leerzeichen. Ein nach-Trim leerer Header → `null` → `401 Unauthorized`. Jeder nicht-leere String wird als gültige Benutzer-ID akzeptiert — es gibt keine Token-Verifizierung.
+
+Dies ist absichtlich schwach für Demo-Zwecke. In der Produktion durch verifizierte JWT-Claims oder sitzungscookie-gestützte Sessions ersetzen.
+
+---
+
+## IDOR-Prävention: `WHERE id = ? AND owner_id = ?`
+
+Jede Operation, die eine bestimmte Notiz berührt, schließt `owner_id` in die Abfrage ein:
+
+```php
+/**
+ * Gibt die Notiz nur zurück, wenn sie dem angegebenen Eigentümer gehört.
+ * Gibt null für "nicht gefunden" und "falscher Eigentümer" zurück — Aufrufer geben 404 in beiden Fällen zurück,
+ * um IDOR-Informationslecks zu verhindern (nicht exponieren, ob eine Ressource existiert).
+ */
+public function findByIdAndOwner(int $id, string $ownerId): ?Note
+{
+    $row = $this->db->fetchOne(
+        'SELECT * FROM notes WHERE id = ? AND owner_id = ?',
+        [$id, $ownerId],
+    );
+
+    return $row !== null ? $this->hydrate($row) : null;
+}
+```
+
+Die Methode gibt `null` für "nicht gefunden" und "falscher Eigentümer" zurück. Der Controller verwendet in beiden Fällen dieselbe `404 Not Found`-Antwort:
+
+```php
+$note = $this->repo->findByIdAndOwner($id, $authUser);
+
+if ($note === null) {
+    // 404 nicht 403: nicht verraten, ob die Ressource existiert (IDOR-Prävention)
+    return $this->problems->create($request, 'not-found', 'Note Not Found', 404, '');
+}
+```
+
+`403 Forbidden` zurückzugeben würde bestätigen, dass die Ressource existiert — der `404`-Ansatz verhindert Enumerationsangriffe.
+
+---
+
+## Feld-Merge-Update
+
+`PUT /notes/{id}` behält vorhandene Werte für im Request-Body ausgelassene Felder:
+
+```php
+$title    = isset($body['title']) && is_string($body['title']) ? trim($body['title']) : $note->title;
+$noteBody = isset($body['body'])  && is_string($body['body'])  ? $body['body']        : $note->body;
+
+$this->repo->update($id, $authUser, $title, $noteBody);
+$updated = new Note($note->id, $note->ownerId, $title, $noteBody, $note->createdAt);
+```
+
+Wenn nur `title` angegeben wird, behält `body` seinen aktuellen Wert — und umgekehrt. Dies unterscheidet sich von einer vollständigen Ersetzung (`PUT`-Semantik) — es verhält sich eher wie `PATCH`. Für strikte `PUT`-Semantik beide Felder erfordern und `422` zurückgeben, wenn eines fehlt.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id   TEXT    NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_notes_owner ON notes (owner_id);
+```
+
+`body` hat den Standard `''` — keine nullable Spalte für den Text-Body. `owner_id` ist ein freier String (der `X-Auth-User`-Wert); es gibt keinen Foreign Key zu einer Benutzertabelle.
+
+---
+
+## ATK — Cracker-Mindset-Angriffstest (FT240)
+
+### ATK-01 — `X-Auth-User` ist trivial fälschbar ⚠️ EXPOSED
+
+**Angriff**: Einen anderen Benutzer imitieren, indem seine Benutzer-ID im Header gesendet wird.
+
+**Ergebnis**: EXPOSED — der Header trägt keinen kryptografischen Identitätsbeweis. Für die Produktion signierte JWT-Tokens oder Session-Cookies verwenden.
+
+---
+
+### ATK-02 — Zeilenumbruch-Injektion in `X-Auth-User` 🚫 BLOCKED
+
+**Angriff**: HTTP-Header-Injektionszeichen (CR/LF) im Header-Wert einbetten.
+
+**Ergebnis**: BLOCKED — HTTP-Server lehnen fehlerhafte Header vor der Anwendungsebene ab.
+
+---
+
+### ATK-03 — IDOR: Notiz eines anderen Benutzers lesen 🚫 BLOCKED
+
+**Angriff**: Notiz-IDs eines anderen Benutzers erraten oder enumerieren.
+
+**Ergebnis**: BLOCKED — eigentümerbezogene Abfrage + 404 verhindert IDOR.
+
+---
+
+### ATK-04 — SQL-Injection via Titel oder Body 🚫 BLOCKED
+
+**Angriff**: SQL-Metazeichen im Request-Body einbetten.
+
+**Ergebnis**: BLOCKED — parametrisierte Abfragen verhindern alle SQL-Injection via Body-Felder.
+
+---
+
+### ATK-05 — Leerer Titel 🚫 BLOCKED
+
+**Angriff**: Notiz mit einem nur-Leerzeichen oder leeren Titel erstellen.
+
+**Ergebnis**: BLOCKED — `trim()` + Leer-String-Prüfung behandelt Nur-Leerzeichen-Eingaben.
+
+---
+
+### ATK-06 — Fehlender `X-Auth-User`-Header 🚫 BLOCKED
+
+**Angriff**: Anfrage ohne `X-Auth-User`-Header senden.
+
+**Ergebnis**: BLOCKED — fehlender Header wird als nicht-authentifiziert behandelt → `401 Unauthorized`.
+
+---
+
+### ATK-07 — Impersonation via beliebigen `X-Auth-User`-Wert ⚠️ EXPOSED
+
+**Angriff**: Notizen als privilegierte Benutzer-ID-String erstellen.
+
+**Ergebnis**: EXPOSED (gleiche Wurzel wie ATK-01). Ohne kryptografische Auth kann ein echter Admin nicht von einem Angreifer unterschieden werden, der den String `"admin"` kennt.
+
+---
+
+### ATK-08 — XSS-Payload in Titel oder Body ✅ ACCEPTED BY DESIGN
+
+**Angriff**: Script-Tag speichern.
+
+**Ergebnis**: ACCEPTED BY DESIGN — JSON-APIs geben rohen Inhalt zurück. Die Rendering-Schicht muss vor dem HTML-Einfügen bereinigen.
+
+---
+
+### ATK-09 — Teilaktualisierung verliert unbeabsichtigte Felder ✅ ACCEPTED BY DESIGN
+
+**Angriff**: Versuchen, `body` zu leeren durch Auslassen aus dem Update.
+
+**Ergebnis**: ACCEPTED BY DESIGN — dokumentiertes Merge-Update-Verhalten. Wenn strikte `PUT`-Semantik gewünscht ist, alle Felder erfordern.
+
+---
+
+### ATK-10 — Nicht-numerische Notiz-ID ⚠️ PARTIALLY BLOCKED
+
+**Angriff**: String oder Float als `{id}` übergeben.
+
+**Ergebnis**: PARTIALLY BLOCKED — nicht-numerische Strings mappen auf 404. Floats werden stillschweigend abgeschnitten. `ctype_digit()`-Guard für strikte Validierung hinzufügen.
+
+---
+
+### ATK-11 — Nicht-besessene/nicht-existente Notiz löschen 🚫 BLOCKED
+
+**Angriff**: Notiz-ID löschen, die nicht existiert oder einem anderen Benutzer gehört.
+
+**Ergebnis**: BLOCKED — eigentümerbezogenes DELETE + 404-Antwort verhindert mandantenübergreifendes Löschen.
+
+---
+
+### ATK-12 — Nur-Leerzeichen `X-Auth-User` 🚫 BLOCKED
+
+**Angriff**: Header mit nur Leerzeichen oder Tabs senden.
+
+**Ergebnis**: BLOCKED — `trim()` normalisiert Nur-Leerzeichen-Header zu leer.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Ergebnis |
+|---|---------------|---------|
+| ATK-01 | X-Auth-User ist trivial fälschbar | ⚠️ EXPOSED |
+| ATK-02 | Zeilenumbruch-Injektion in X-Auth-User | 🚫 BLOCKED |
+| ATK-03 | IDOR: Notiz eines anderen Benutzers lesen | 🚫 BLOCKED |
+| ATK-04 | SQL-Injection via Titel/Body | 🚫 BLOCKED |
+| ATK-05 | Leerer Titel | 🚫 BLOCKED |
+| ATK-06 | Fehlender X-Auth-User-Header | 🚫 BLOCKED |
+| ATK-07 | Impersonation via beliebigen Header-Wert | ⚠️ EXPOSED |
+| ATK-08 | XSS in Titel/Body | ✅ ACCEPTED BY DESIGN |
+| ATK-09 | Teilaktualisierung Feld-Merge-Überraschung | ✅ ACCEPTED BY DESIGN |
+| ATK-10 | Nicht-numerische Notiz-ID | ⚠️ PARTIALLY BLOCKED |
+| ATK-11 | Nicht-besessene/nicht-existente Notiz löschen | 🚫 BLOCKED |
+| ATK-12 | Nur-Leerzeichen X-Auth-User | 🚫 BLOCKED |
+
+**Echte Schwachstellen vor der Produktion zu beheben**:
+1. **ATK-01 / ATK-07** — `X-Auth-User` durch signierte JWT- oder Session-Verifizierung ersetzen
+2. **ATK-10** — `ctype_digit()`-Guard für ID-Pfadparameter hinzufügen
+
+---
+
+## Verwandte Anleitungen
+
+- [`use-bearer-auth.md`](use-bearer-auth.md) — signierte Bearer-Token-Authentifizierung
+- [`enforce-resource-ownership.md`](enforce-resource-ownership.md) — IDOR-Präventionsmuster
+- [`jwt-authentication.md`](jwt-authentication.md) — JWT-Verifizierung zur Benutzeridentifikation

--- a/docs/de/howto/note-management-with-tags.md
+++ b/docs/de/howto/note-management-with-tags.md
@@ -1,0 +1,138 @@
+# How-to: Notizverwaltung mit Tags
+
+## Übersicht
+
+Diese Anleitung behandelt den Aufbau einer mit Tags versehenen Notizverwaltungs-API mit NENE2. Funktionen umfassen benutzerbezogene Isolation, Tag-basierte Filterung, Volltext-Schlüsselwortsuche und eigentümerverpflichtetes CRUD.
+
+**Referenzimplementierung**: `../NENE2-FT/notelog/`
+
+---
+
+## Schema-Design
+
+```sql
+CREATE TABLE IF NOT EXISTS notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS note_tags (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    note_id INTEGER NOT NULL,
+    tag     TEXT    NOT NULL,
+    FOREIGN KEY (note_id) REFERENCES notes(id) ON DELETE CASCADE,
+    UNIQUE (note_id, tag)
+);
+```
+
+`ON DELETE CASCADE` entfernt Tags automatisch, wenn eine Notiz gelöscht wird.
+
+---
+
+## Routentabelle
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/notes` | Benutzer | Notiz erstellen |
+| `GET` | `/notes` | Benutzer | Eigene Notizen auflisten (optional `?tag=` oder `?q=`) |
+| `GET` | `/notes/{id}` | Benutzer | Eine Notiz abrufen |
+| `PUT` | `/notes/{id}` | Benutzer | Notizfelder aktualisieren |
+| `DELETE` | `/notes/{id}` | Benutzer | Notiz löschen |
+
+---
+
+## Tag-Filterung
+
+Nach Tag mit `JOIN` filtern:
+
+```sql
+SELECT n.* FROM notes n
+JOIN note_tags t ON t.note_id = n.id
+WHERE n.user_id = :uid AND t.tag = :tag
+ORDER BY n.id DESC
+```
+
+---
+
+## Schlüsselwortsuche
+
+Volltext-Suche in Titel und Body mit `LIKE`:
+
+```sql
+SELECT * FROM notes
+WHERE user_id = :uid AND (title LIKE :kw OR body LIKE :kw)
+ORDER BY id DESC
+```
+
+Der `:kw`-Platzhalter ist `'%' . $keyword . '%'`. Parametrisierte Abfragen verhindern SQL-Injection.
+
+---
+
+## Tag-Parsen
+
+Tags müssen Arrays von Strings sein; zu Kleinbuchstaben normalisieren:
+
+```php
+private function parseTags(mixed $raw): ?array
+{
+    if (!is_array($raw)) return [];
+    $tags = [];
+    foreach ($raw as $tag) {
+        if (!is_string($tag)) return null;   // Nicht-String ablehnen → 422
+        $t = trim($tag);
+        if ($t !== '') $tags[] = strtolower($t);
+    }
+    return $tags;
+}
+```
+
+---
+
+## IDOR / Eigentümerschaftsmuster
+
+Alle Lese- und Schreiboperationen werden auf `user_id` beschränkt. Bei Lesevorgängen 404 (nicht 403) zurückgeben, um die Offenlegung von Existenz zu vermeiden; bei Schreibvorgängen 403 zurückgeben, damit der Benutzer weiß, dass die Ressource existiert, er aber keine Berechtigung hat:
+
+```php
+// Lesen: 404 zur Verhinderung von Informationsoffenlegung
+if ((int) $note['user_id'] !== $uid) {
+    return $this->problem(404, 'not-found', 'Note not found.');
+}
+
+// Schreiben: 403 wenn Ressource existiert, aber nicht eigene
+if ((int) $note['user_id'] !== $userId) {
+    return 'forbidden';
+}
+```
+
+---
+
+## Teilupdate (PUT)
+
+`null` für jedes Feld akzeptieren, um "keine Änderung" zu bedeuten:
+
+```php
+$title    = isset($body['title']) ? trim((string) $body['title']) : null;
+$noteBody = isset($body['body']) ? (string) $body['body'] : null;
+$tags     = (isset($body['tags'])) ? $this->parseTags($body['tags']) : null;
+```
+
+Im Repository nur Felder aktualisieren, die nicht-null sind.
+
+---
+
+## HTTP-Statuscodes
+
+| Situation | Status |
+|-----------|--------|
+| Notiz erstellt | 201 |
+| Notiz abgerufen / Liste | 200 |
+| Notiz aktualisiert / gelöscht | 200 |
+| Kein X-User-Id | 400 |
+| Leerer Titel | 422 |
+| Nicht-String-Tag-Werte | 422 |
+| Notiz nicht gefunden (oder IDOR) | 404 |
+| Notiz eines anderen aktualisieren/löschen | 403 |

--- a/docs/de/howto/notification-inbox.md
+++ b/docs/de/howto/notification-inbox.md
@@ -1,0 +1,170 @@
+# How-to: Benachrichtigungs-Posteingang-API
+
+> **FT-Referenz**: FT271 (`NENE2-FT/notificationlog`) — Benachrichtigungs-Posteingang: typenbasiert allowlistet, IDOR-Schutz pro Benutzer (404 nicht 403), Admin-Fail-Closed-Muster, Bulk-Als-Gelesen-Markieren, is_read-Idempotenz, Paginierungs-Begrenzung mit PDO::PARAM_INT-Bindung, 31 Tests / 98 Assertions PASS.
+>
+> Ebenfalls validiert in FT222 (`NENE2-FT/notificationlog`) — VULN-Bewertung zum gleichen Muster.
+
+Diese Anleitung zeigt, wie ein Benachrichtigungs-Posteingang-System mit typenbasierter Allowlist für Push-Benachrichtigungen, IDOR-Schutz pro Benutzer und Bulk-Als-Gelesen-Markieren mit NENE2 aufgebaut wird.
+
+## Funktionen
+
+- Nur-Admin-Benachrichtigungserstellung mit Typ-Allowlist
+- IDOR-Schutz pro Benutzer: Benutzer sehen nur ihre eigenen Benachrichtigungen (404 bei unberechtigtem Zugriff)
+- Einzel- und Bulk-Als-Gelesen-Markieren mit Eigentumsverifizierung
+- Ungelesen-Anzahl bei jeder Auflistung zurückgegeben
+- Optionaler Nur-Ungelesen-Filter und Paginierung
+- Admin Fail-Closed
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS notifications (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    type       TEXT    NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    is_read    INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL,
+    read_at    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user ON notifications (user_id, id DESC);
+```
+
+Keine separate `users`-Tabelle — die API vertraut dem `X-User-Id`-Header (in der Produktion durch echte Auth ersetzen).
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/notifications` | Admin | Benachrichtigung für einen Benutzer erstellen |
+| `GET` | `/users/{userId}/notifications` | Eigener / Admin | Benachrichtigungen auflisten |
+| `POST` | `/notifications/{id}/read` | Eigener / Admin | Eine Benachrichtigung als gelesen markieren |
+| `POST` | `/users/{userId}/notifications/read-all` | Eigener / Admin | Alle als gelesen markieren |
+
+## Typ-Allowlist
+
+Freitext-Typ-Strings werden abgelehnt, um Injection- und Enumeration-Angriffe zu verhindern:
+
+```php
+public const array ALLOWED_TYPES = [
+    'system',
+    'promotion',
+    'social',
+    'account',
+    'security',
+    'reminder',
+];
+```
+
+Routen-Handler validiert vor jedem DB-Zugriff:
+
+```php
+if (!in_array($type, NotificationRepository::ALLOWED_TYPES, true)) {
+    $allowed = implode(', ', NotificationRepository::ALLOWED_TYPES);
+    return $this->problem(422, 'validation-failed', "type must be one of: {$allowed}.");
+}
+```
+
+## IDOR-Schutz
+
+Benutzer können nur ihre eigenen Benachrichtigungen lesen. Ein 404 (nicht 403) wird bei unberechtigtem Zugriff zurückgegeben, um Benutzer-ID-Enumeration zu verhindern:
+
+```php
+private function isSelfOrAdmin(ServerRequestInterface $req, int $ownerId): bool
+{
+    if ($this->isAdmin($req)) {
+        return true;
+    }
+    $uid = $this->requestUserId($req);
+    return $uid !== null && $uid === $ownerId;
+}
+```
+
+Als-Gelesen-Markieren verifiziert auch die Eigentümerschaft vor der Aktion:
+
+```php
+// POST /notifications/{id}/read Handler
+$notification = $this->repo->findById($id);
+if ($notification === null) {
+    return $this->problem(404, 'not-found', 'Notification not found.');
+}
+// IDOR: nur der Eigentümer oder Admin darf als gelesen markieren
+if (!$this->isSelfOrAdmin($req, (int) $notification['user_id'])) {
+    return $this->problem(404, 'not-found', 'Notification not found.');
+}
+```
+
+## Admin Fail-Closed
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;   // fail-closed: kein Admin wenn Key nicht konfiguriert
+    }
+    $key = $req->getHeaderLine('X-Admin-Key');
+    return $key !== '' && hash_equals($this->adminKey, $key);
+}
+```
+
+## Paginierung
+
+`limit` und `offset` werden im Repository begrenzt — niemals roh vom Client vertraut:
+
+```php
+private const int MAX_LIMIT = 100;
+
+$limit  = max(1, min(self::MAX_LIMIT, $limit));
+$offset = max(0, $offset);
+```
+
+PDO-Integer-Bindung verhindert SQL-Injection in LIMIT / OFFSET:
+
+```php
+$stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+$stmt->bindValue(':off', $offset, PDO::PARAM_INT);
+```
+
+## Als-Gelesen-Markieren-Idempotenz
+
+```php
+/** @return 'ok'|'not_found'|'already_read' */
+public function markAsRead(int $id): string
+{
+    $notification = $this->findById($id);
+    if ($notification === null) return 'not_found';
+    if ((bool) $notification['is_read']) return 'already_read';
+
+    // ... UPDATE SET is_read = 1, read_at = :now ...
+    return 'ok';
+}
+```
+
+Der Routen-Handler gibt 200 sowohl für `ok` als auch für `already_read` zurück — wodurch der Endpunkt mehrfach ohne Nebenwirkungen aufrufbar ist.
+
+## Sicherheitsmuster
+
+| Muster | Implementierung |
+|---------|----------------|
+| **Typ-Allowlist** | `in_array($type, ALLOWED_TYPES, true)` — strenge Übereinstimmung |
+| **IDOR → 404** | 404 (nicht 403) zurückgeben, um Benutzer-/Benachrichtigungs-Existenz zu verbergen |
+| **Eigentumsverifizierung** | Benachrichtigung abrufen, `user_id` prüfen bevor als gelesen markiert wird |
+| **Admin Fail-Closed** | `if ($this->adminKey === '') return false;` |
+| **`ctype_digit()`** | Pfadparameter-ID-Validierung — ReDoS-sicher |
+| **Paginierungs-Begrenzung** | `max(1, min(100, $limit))` + `PDO::PARAM_INT`-Bindung |
+| **`is_int()` + `> 0`** | Strenge user_id-Prüfung — lehnt Floats, Strings, negative Werte ab |
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Pattern | Risiko |
+|---|---|
+| Freiform-`type`-String akzeptieren | Unvalidierte Typen verschmutzen den Posteingang; keine Möglichkeit, nach sinnvollen Kategorien zu filtern |
+| 403 bei unberechtigtem Benachrichtigungszugriff zurückgeben | Offenbart, ob die Benachrichtigung oder der Benutzer existiert — IDOR-Informationsleck |
+| 404 von Als-Gelesen-Markieren vor der Eigentumsüberprüfung zurückgeben | Ein Angreifer erfährt, dass die Benachrichtigung existiert und jemandem gehört |
+| Leeres `adminKey` als "Admin erlaubt" bedeuten lassen | Fail-Open; jede Anfrage wird zum Admin, wenn kein Key konfiguriert ist |
+| Rohes `limit` aus dem Query-String vertrauen | Eine Anfrage mit `limit=999999` verursacht vollständigen Tabellenscan |
+| String-Interpolation in LIMIT/OFFSET verwenden | `"LIMIT {$limit}"` mit unvalidierter Eingabe ermöglicht SQL-Injection |

--- a/docs/de/howto/notification-queue.md
+++ b/docs/de/howto/notification-queue.md
@@ -1,0 +1,115 @@
+# How-to: Benachrichtigungs-Warteschlangen-API
+
+Diese Anleitung demonstriert eine Benachrichtigungs-Warteschlange, bei der Admins zielgerichtete Benachrichtigungen an Benutzer senden, die diese auflisten, lesen und löschen können.
+
+## Übersicht des Musters
+
+- Admins senden Benachrichtigungen an bestimmte Benutzer über `POST /notifications` (nur Admin).
+- Benutzer empfangen und verwalten ihre eigenen Benachrichtigungen über `GET`, `POST /read`, `DELETE`.
+- `unread_count` wird mit jeder Listenantwort zurückgegeben.
+- `?unread=1` filtert auf nur-ungelesene Benachrichtigungen.
+- Als-Gelesen-Markieren ist idempotent (bereits gelesene Benachrichtigungen geben 200 zurück, kein Fehler).
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS notifications (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    type       TEXT    NOT NULL DEFAULT 'info',
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    is_read    INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL,
+    read_at    TEXT
+);
+```
+
+## Typ-Allowlist
+
+```php
+private const array ALLOWED_TYPES = ['info', 'warning', 'error', 'success'];
+```
+
+Unbekannte Typen geben 422 zurück. Niemals ein Freitextfeld für Typ ohne Validierung verwenden.
+
+## Idempotentes Als-Gelesen-Markieren
+
+```php
+public function markRead(int $id, int $userId): bool
+{
+    $notif = $this->findById($id);
+    if ($notif === null || (int) $notif['user_id'] !== $userId) {
+        return false;
+    }
+    if ((int) $notif['is_read'] === 1) {
+        return true;  // Bereits gelesen — idempotent, Erfolg zurückgeben
+    }
+    $this->pdo->prepare(
+        'UPDATE notifications SET is_read = 1, read_at = :now WHERE id = :id'
+    )->execute([':now' => $this->now(), ':id' => $id]);
+    return true;
+}
+```
+
+## Ungelesen-Filter
+
+```php
+if ($unreadOnly === true) {
+    $stmt = $this->pdo->prepare(
+        'SELECT * FROM notifications WHERE user_id = :uid AND is_read = 0 ORDER BY id DESC'
+    );
+}
+```
+
+Der Query-Parameter `?unread=1` aktiviert diesen Pfad; jeder andere Wert listet alle auf.
+
+## IDOR: Benutzer-Scoping
+
+Alle Lese-/Lösch-/Listen-Operationen prüfen `user_id`:
+
+```php
+if (!$isAdmin && (int) $notif['user_id'] !== $userId) {
+    return false;  // → 404
+}
+```
+
+Nicht-Admin-Benutzer können Benachrichtigungen anderer Benutzer nicht lesen, markieren oder löschen.
+
+## Nur-Admin-Senden
+
+```php
+private function send(ServerRequestInterface $req): ResponseInterface
+{
+    if (!$this->isAdmin($req)) {
+        return $this->problem(403, 'forbidden', 'Admin access required.');
+    }
+    ...
+}
+```
+
+Die Ziel-`user_id` wird im Request-Body angegeben, validiert als `is_int() && >= 1`.
+
+## Validierungszusammenfassung
+
+| Feld | Regel |
+|---|---|
+| `user_id` Body | Integer >= 1 (kein String/Float) |
+| `type` Body | Eines von: info, warning, error, success |
+| `title` Body | Nicht leer, max. 200 Zeichen |
+| `X-User-Id`-Header | Erforderlich für Lesen/Löschen; `ctype_digit`, >0 |
+| `X-Admin-Key`-Header | Erforderlich für Senden; Fail-Closed wenn leer |
+
+## Routen
+
+```
+POST   /notifications                  Benachrichtigung senden (nur Admin)
+GET    /users/{userId}/notifications   Benachrichtigungen auflisten (Eigentümer oder Admin)
+POST   /notifications/{id}/read        Als gelesen markieren (nur Eigentümer)
+DELETE /notifications/{id}             Benachrichtigung löschen (Eigentümer oder Admin)
+```
+
+## Weitere Informationen
+
+- FT214-Quelle: `../NENE2-FT/notiflog/`
+- Verwandt: `docs/howto/session-token-management.md` (FT208, Admin-Key-Muster)

--- a/docs/de/howto/numeric-verification-code.md
+++ b/docs/de/howto/numeric-verification-code.md
@@ -1,28 +1,28 @@
-# How-to: Numerischen Verifikationscode aufbauen
+# Anleitung: Numerischen Verifizierungscode aufbauen
 
-> **Muster bewiesen durch FT188 verifylog** — 6-stelliger SMS/E-Mail-Verifikationscode mit Brute-Force-Schutz, Constant-Time-Vergleich und Replay-Prävention. ATK-01〜12 alle bestanden.
+> **Muster bewiesen durch FT188 verifylog** — 6-stelliger SMS/E-Mail-Verifizierungscode mit Brute-Force-Schutz, zeitkonstantem Vergleich und Replay-Prävention. ATK-01~12 alle Pass.
 
 ---
 
-## Was abgedeckt wird
+## Was behandelt wird
 
-Ein Kontakt-Verifikationsablauf (E-Mail oder Telefon):
+Ein Kontaktverifizierungsablauf (E-Mail oder Telefon):
 
-1. **Code anfordern** — Server generiert einen zufälligen 6-stelligen Code, liefert ihn out-of-band
-2. **Code einreichen** — Benutzer reicht den Code ein; maximal 3 Versuche vor Sperrung
-3. **Status prüfen** — Prüfen, ob eine Verifizierung abgeschlossen wurde
+1. **Code anfordern** — Server generiert einen zufälligen 6-stelligen Code, liefert ihn außerhalb des Bandes
+2. **Code einreichen** — Benutzer reicht den Code ein; max. 3 Versuche vor der Sperrung
+3. **Statusprüfung** — Überprüfen, ob eine Verifizierung abgeschlossen wurde
 
 Sicherheitsgarantien:
 
 | Bedenken | Technik |
-|----------|---------|
-| Brute Force | Max 3 Versuche → 429 Locked |
-| Timing-Angriff | `hash_equals()` Constant-Time-Vergleich |
+|---|---|
+| Brute Force | 3 max. Versuche → 429 Gesperrt |
+| Timing-Angriff | `hash_equals()` zeitkonstanter Vergleich |
 | Code-Replay | Verifizierter Code gibt 410 Gone zurück |
 | Benutzer-Enumeration | `POST /verifications` gibt immer 202 zurück |
 | Mass Assignment | `code_hash/verified_at` nur serverseitig gesetzt |
-| SQL-Injection | Integer-only Pfadparameter (ctype_digit + strlen > 18 Guard) |
-| Typkonfusion | `is_string()`-Prüfung vor `ctype_digit()` |
+| SQL-Injection | Nur-Integer-Pfadparameter (ctype_digit + strlen > 18 Guard) |
+| Typverwechslung | `is_string()`-Prüfung vor `ctype_digit()` |
 | ReDoS | `ctype_digit()` O(n) — kein Regex |
 
 ---
@@ -49,10 +49,10 @@ CREATE TABLE verifications (
 ## API
 
 | Methode | Pfad | Beschreibung |
-|---------|------|-------------|
+|---|---|---|
 | `POST` | `/verifications` | Code anfordern (immer 202) |
-| `POST` | `/verifications/{id}/check` | Code einreichen (max 3 Versuche) |
-| `GET` | `/verifications/{id}` | Status prüfen (kein Code enthüllt) |
+| `POST` | `/verifications/{id}/check` | Code einreichen (max. 3 Versuche) |
+| `GET` | `/verifications/{id}` | Statusprüfung (kein Code offenbart) |
 
 ---
 
@@ -67,7 +67,7 @@ $codeHash  = hash('sha256', $plainCode);
 INSERT INTO verifications (contact, code_hash, expires_at, created_at)
 VALUES (:contact, :code_hash, :expires_at, :now)
 
-// plainCode an Aufrufer zurückgeben (für Zustellung) — niemals speichern oder loggen
+// plainCode an Aufrufer zurückgeben (zur Zustellung) — niemals speichern oder protokollieren
 return ['verification' => $v, 'plainCode' => $plainCode];
 ```
 
@@ -75,7 +75,7 @@ return ['verification' => $v, 'plainCode' => $plainCode];
 
 ---
 
-## Kernmuster: Constant-Time-Vergleich
+## Kernmuster: Zeitkonstanter Vergleich
 
 ```php
 // ATK-10: hash_equals verhindert Timing-Angriff
@@ -84,11 +84,11 @@ return ['verification' => $v, 'plainCode' => $plainCode];
 $valid = hash_equals($v->codeHash, hash('sha256', $submittedCode));
 ```
 
-**Warum nicht `===`:** `===` bricht beim ersten Nichtübereinstimmen ab — ein Angreifer kann Timing-Unterschiede zwischen "erstes Byte falsch" und "alle Bytes falsch" messen, um den korrekten Code zeichenweise einzugrenzen. `hash_equals()` ist unabhängig vom Ort des Nichtübereinstimmens konstant in der Zeit.
+**Warum nicht `===`:** `===` schließt kurz beim ersten Mismatch — ein Angreifer kann Timing-Unterschiede zwischen "erster Byte falsch" und "alle Bytes falsch" messen, um den korrekten Code zeichenweise einzugrenzen. `hash_equals()` ist zeitkonstant unabhängig davon, wo der Mismatch auftritt.
 
 ---
 
-## Kernmuster: Fail-First Versuchszählung
+## Kernmuster: Fail-First-Versuche-Zählung
 
 ```php
 public function check(int $id, string $submittedCode): string
@@ -103,7 +103,7 @@ public function check(int $id, string $submittedCode): string
     // VOR der Prüfung inkrementieren — verhindert Race-Exploitation
     UPDATE verifications SET attempts_count = attempts_count + 1 WHERE id = :id
 
-    // ATK-10: Constant-Time-Vergleich
+    // ATK-10: zeitkonstanter Vergleich
     $valid = hash_equals($v->codeHash, hash('sha256', $submittedCode));
 
     if ($valid) {
@@ -115,11 +115,11 @@ public function check(int $id, string $submittedCode): string
 }
 ```
 
-Das Inkrementieren der Versuche **vor** dem Vergleich stellt sicher, dass ein gleichzeitiger Race zum Prüfen des gleichen Codes das Limit nicht umgehen kann.
+Das Inkrementieren der Versuche **vor** dem Vergleich stellt sicher, dass ein gleichzeitiger Race-Angriff zur Prüfung desselben Codes das Limit nicht umgehen kann.
 
 ---
 
-## Kernmuster: Benutzer-Enumerationsprävention
+## Kernmuster: Benutzer-Enumerations-Prävention
 
 ```php
 // POST /verifications — gibt IMMER 202 zurück
@@ -129,7 +129,7 @@ private function handleRequest(ServerRequestInterface $request): ResponseInterfa
     $contact = V::str($body['contact'] ?? null, self::MAX_CONTACT_LEN);
 
     if ($contact === null || $contact === '') {
-        return $this->responseFactory->create(['error' => '...'], 422); // nur für leere/null
+        return $this->responseFactory->create(['error' => '...'], 422); // nur für leer/null
     }
 
     // Zustellungserfolg oder -fehler ist für den Aufrufer unsichtbar
@@ -139,16 +139,16 @@ private function handleRequest(ServerRequestInterface $request): ResponseInterfa
 }
 ```
 
-Ein 404 oder 422 für einen unbekannten Kontakt verrät "Dieser Kontakt ist nicht registriert." Immer 202.
+Ein 404 oder 422 für einen unbekannten Kontakt leckt "dieser Kontakt ist nicht registriert." Immer 202.
 
 ---
 
-## Kernmuster: Code-Typ- und Format-Validierung
+## Kernmuster: Code-Typ- und Formatvalidierung
 
 ```php
 $raw = $body['code'] ?? null;
 
-// ATK-07: Typkonfusion — Code muss ein String sein
+// ATK-07: Typverwechslung — Code muss ein String sein
 if (!is_string($raw)) {
     return $this->responseFactory->create(['error' => 'code must be a 6-digit string.'], 422);
 }
@@ -167,32 +167,32 @@ if (!ctype_digit($raw) || strlen($raw) !== 6) {
 ## Antwort-Design
 
 | Szenario | Status | Body |
-|----------|--------|------|
+|---|---|---|
 | Code korrekt | 200 | `{verified: true}` |
-| Code falsch, Versuche verbleibend | 422 | `{error: "Incorrect code.", attempts_left: N}` |
-| Max Versuche erreicht | 429 | `{error: "Too many failed attempts. Request a new code."}` |
+| Code falsch, Versuche verbleiben | 422 | `{error: "Incorrect code.", attempts_left: N}` |
+| Maximale Versuche erreicht | 429 | `{error: "Too many failed attempts. Request a new code."}` |
 | Bereits verifiziert (Replay) | 410 | `{error: "This verification has already been completed."}` |
 | Abgelaufen | 410 | `{error: "Verification has expired. Request a new code."}` |
 | Nicht gefunden | 404 | `{error: "Verification not found."}` |
 
 ---
 
-## ATK-01〜12 alle bestanden
+## ATK-01~12 alle Pass
 
-| ATK | Angriff | Abwehr |
-|-----|---------|--------|
+| ATK | Angriff | Verteidigung |
+|---|---|---|
 | 01 | SQL-Injection in `{id}` | `ctype_digit()` + strlen > 18 Guard |
-| 02 | IDOR — Check mit fremder Verifikations-ID | Gleiche 404 — kein Eigentums-Oracle |
+| 02 | IDOR — Check mit fremder Verification-ID | Gleiche 404 — kein Eigentumsindikator |
 | 03 | Mass Assignment (code_hash/verified_at aus Body) | Nur serverseitig gesetzt |
-| 04 | XSS in contact | Nur JSON-Ausgabe — kein HTML-Rendering. Contact nicht in Antwort zurückgeben |
-| 05 | Brute Force 6-stelliger Code | 3 Fehler → 429 Locked |
+| 04 | XSS im Kontakt | Nur JSON-Ausgabe — kein HTML-Rendering; Kontakt nicht in Antwort |
+| 05 | Brute Force 6-stelliger Code | 3 Fehlschläge → 429 Gesperrt |
 | 06 | Auth-Bypass | verified_at nur serverseitig gesetzt |
-| 07 | Typkonfusion (Code als int/bool/array) | `is_string()` + `ctype_digit()` |
+| 07 | Typverwechslung (Code als int/bool/array) | `is_string()` + `ctype_digit()` |
 | 08 | Integer-Overflow in `{id}` | strlen > 18 Guard |
-| 09 | ReDoS-ähnliche Code-Eingabe | `ctype_digit()` O(n) |
-| 10 | Timing-Angriff auf Code-Vergleich | `hash_equals()` Konstante Zeit |
+| 09 | ReDoS-artige Code-Eingabe | `ctype_digit()` O(n) |
+| 10 | Timing-Angriff auf Code-Vergleich | `hash_equals()` konstante Zeit |
 | 11 | Code-Replay nach Erfolg | 410 Gone |
-| 12 | CRLF-Injection in Headers | PSR-7 lehnt auf HTTP-Ebene ab |
+| 12 | CRLF-Injection in Headern | PSR-7 lehnt auf HTTP-Ebene ab |
 
 ---
 
@@ -202,5 +202,7 @@ if (!ctype_digit($raw) || strlen($raw) !== 6) {
 48 Tests / 103 Assertions — alle PASS
 PHPStan Level 8 — keine Fehler
 PHP CS Fixer — sauber
-ATK-01〜12 alle bestanden
+ATK-01~12 alle Pass
 ```
+
+Quelle: [`../NENE2-FT/verifylog/`](https://github.com/hideyukiMORI/NENE2-examples/tree/main/verifylog)

--- a/docs/de/howto/numeric-verification-code.md
+++ b/docs/de/howto/numeric-verification-code.md
@@ -1,0 +1,206 @@
+# How-to: Numerischen Verifikationscode aufbauen
+
+> **Muster bewiesen durch FT188 verifylog** — 6-stelliger SMS/E-Mail-Verifikationscode mit Brute-Force-Schutz, Constant-Time-Vergleich und Replay-Prävention. ATK-01〜12 alle bestanden.
+
+---
+
+## Was abgedeckt wird
+
+Ein Kontakt-Verifikationsablauf (E-Mail oder Telefon):
+
+1. **Code anfordern** — Server generiert einen zufälligen 6-stelligen Code, liefert ihn out-of-band
+2. **Code einreichen** — Benutzer reicht den Code ein; maximal 3 Versuche vor Sperrung
+3. **Status prüfen** — Prüfen, ob eine Verifizierung abgeschlossen wurde
+
+Sicherheitsgarantien:
+
+| Bedenken | Technik |
+|----------|---------|
+| Brute Force | Max 3 Versuche → 429 Locked |
+| Timing-Angriff | `hash_equals()` Constant-Time-Vergleich |
+| Code-Replay | Verifizierter Code gibt 410 Gone zurück |
+| Benutzer-Enumeration | `POST /verifications` gibt immer 202 zurück |
+| Mass Assignment | `code_hash/verified_at` nur serverseitig gesetzt |
+| SQL-Injection | Integer-only Pfadparameter (ctype_digit + strlen > 18 Guard) |
+| Typkonfusion | `is_string()`-Prüfung vor `ctype_digit()` |
+| ReDoS | `ctype_digit()` O(n) — kein Regex |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE verifications (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    contact        TEXT    NOT NULL,
+    code_hash      TEXT    NOT NULL,   -- SHA-256 des 6-stelligen Codes
+    attempts_count INTEGER NOT NULL DEFAULT 0,
+    max_attempts   INTEGER NOT NULL DEFAULT 3,
+    verified_at    TEXT,               -- NULL = ausstehend
+    expires_at     TEXT    NOT NULL,
+    created_at     TEXT    NOT NULL
+);
+```
+
+`code_hash` speichert `hash('sha256', $code)` — niemals den Klartext-Code.
+
+---
+
+## API
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/verifications` | Code anfordern (immer 202) |
+| `POST` | `/verifications/{id}/check` | Code einreichen (max 3 Versuche) |
+| `GET` | `/verifications/{id}` | Status prüfen (kein Code enthüllt) |
+
+---
+
+## Kernmuster: Code-Generierung und Hash-Speicherung
+
+```php
+// Kryptografisch zufälligen 6-stelligen Code generieren
+$plainCode = str_pad((string) random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+$codeHash  = hash('sha256', $plainCode);
+
+// Hash speichern — NIEMALS den Klartext
+INSERT INTO verifications (contact, code_hash, expires_at, created_at)
+VALUES (:contact, :code_hash, :expires_at, :now)
+
+// plainCode an Aufrufer zurückgeben (für Zustellung) — niemals speichern oder loggen
+return ['verification' => $v, 'plainCode' => $plainCode];
+```
+
+`random_int(0, 999999)` verwendet CSPRNG. `str_pad(..., 6, '0', STR_PAD_LEFT)` stellt führende Nullen sicher (z.B. `000042`).
+
+---
+
+## Kernmuster: Constant-Time-Vergleich
+
+```php
+// ATK-10: hash_equals verhindert Timing-Angriff
+// $v->codeHash = gespeicherter SHA-256 aus DB
+// $submittedCode = Benutzereingabe (6-stelliger String)
+$valid = hash_equals($v->codeHash, hash('sha256', $submittedCode));
+```
+
+**Warum nicht `===`:** `===` bricht beim ersten Nichtübereinstimmen ab — ein Angreifer kann Timing-Unterschiede zwischen "erstes Byte falsch" und "alle Bytes falsch" messen, um den korrekten Code zeichenweise einzugrenzen. `hash_equals()` ist unabhängig vom Ort des Nichtübereinstimmens konstant in der Zeit.
+
+---
+
+## Kernmuster: Fail-First Versuchszählung
+
+```php
+public function check(int $id, string $submittedCode): string
+{
+    $v = $this->fetchById($id);
+
+    if ($v === null)        return 'not_found';
+    if ($v->isVerified())   return 'already';   // ATK-11: Replay-Guard
+    if ($v->isLocked())     return 'locked';    // ATK-05: Brute-Force-Guard
+    if ($v->isExpired())    return 'expired';
+
+    // VOR der Prüfung inkrementieren — verhindert Race-Exploitation
+    UPDATE verifications SET attempts_count = attempts_count + 1 WHERE id = :id
+
+    // ATK-10: Constant-Time-Vergleich
+    $valid = hash_equals($v->codeHash, hash('sha256', $submittedCode));
+
+    if ($valid) {
+        UPDATE verifications SET verified_at = :now WHERE id = :id
+        return 'verified';
+    }
+
+    return 'wrong';
+}
+```
+
+Das Inkrementieren der Versuche **vor** dem Vergleich stellt sicher, dass ein gleichzeitiger Race zum Prüfen des gleichen Codes das Limit nicht umgehen kann.
+
+---
+
+## Kernmuster: Benutzer-Enumerationsprävention
+
+```php
+// POST /verifications — gibt IMMER 202 zurück
+// Auch wenn der Kontakt ungültig ist oder die Zustellung fehlschlägt
+private function handleRequest(ServerRequestInterface $request): ResponseInterface
+{
+    $contact = V::str($body['contact'] ?? null, self::MAX_CONTACT_LEN);
+
+    if ($contact === null || $contact === '') {
+        return $this->responseFactory->create(['error' => '...'], 422); // nur für leere/null
+    }
+
+    // Zustellungserfolg oder -fehler ist für den Aufrufer unsichtbar
+    $this->repository->create($contact);
+
+    return $this->responseFactory->create(['id' => $v->id, 'expires_in' => 600], 202);
+}
+```
+
+Ein 404 oder 422 für einen unbekannten Kontakt verrät "Dieser Kontakt ist nicht registriert." Immer 202.
+
+---
+
+## Kernmuster: Code-Typ- und Format-Validierung
+
+```php
+$raw = $body['code'] ?? null;
+
+// ATK-07: Typkonfusion — Code muss ein String sein
+if (!is_string($raw)) {
+    return $this->responseFactory->create(['error' => 'code must be a 6-digit string.'], 422);
+}
+
+// ATK-09: ReDoS — ctype_digit ist O(n), kein Regex
+// ATK-09: exakte Längenprüfung — nicht "mindestens 6"
+if (!ctype_digit($raw) || strlen($raw) !== 6) {
+    return $this->responseFactory->create(['error' => 'code must be exactly 6 digits.'], 422);
+}
+```
+
+`is_string()` vor `ctype_digit()` lehnt JSON-Integer, Booleans und Arrays ab. `ctype_digit()` ist sicher vor ReDoS (lineare Zeit).
+
+---
+
+## Antwort-Design
+
+| Szenario | Status | Body |
+|----------|--------|------|
+| Code korrekt | 200 | `{verified: true}` |
+| Code falsch, Versuche verbleibend | 422 | `{error: "Incorrect code.", attempts_left: N}` |
+| Max Versuche erreicht | 429 | `{error: "Too many failed attempts. Request a new code."}` |
+| Bereits verifiziert (Replay) | 410 | `{error: "This verification has already been completed."}` |
+| Abgelaufen | 410 | `{error: "Verification has expired. Request a new code."}` |
+| Nicht gefunden | 404 | `{error: "Verification not found."}` |
+
+---
+
+## ATK-01〜12 alle bestanden
+
+| ATK | Angriff | Abwehr |
+|-----|---------|--------|
+| 01 | SQL-Injection in `{id}` | `ctype_digit()` + strlen > 18 Guard |
+| 02 | IDOR — Check mit fremder Verifikations-ID | Gleiche 404 — kein Eigentums-Oracle |
+| 03 | Mass Assignment (code_hash/verified_at aus Body) | Nur serverseitig gesetzt |
+| 04 | XSS in contact | Nur JSON-Ausgabe — kein HTML-Rendering. Contact nicht in Antwort zurückgeben |
+| 05 | Brute Force 6-stelliger Code | 3 Fehler → 429 Locked |
+| 06 | Auth-Bypass | verified_at nur serverseitig gesetzt |
+| 07 | Typkonfusion (Code als int/bool/array) | `is_string()` + `ctype_digit()` |
+| 08 | Integer-Overflow in `{id}` | strlen > 18 Guard |
+| 09 | ReDoS-ähnliche Code-Eingabe | `ctype_digit()` O(n) |
+| 10 | Timing-Angriff auf Code-Vergleich | `hash_equals()` Konstante Zeit |
+| 11 | Code-Replay nach Erfolg | 410 Gone |
+| 12 | CRLF-Injection in Headers | PSR-7 lehnt auf HTTP-Ebene ab |
+
+---
+
+## Testergebnisse (FT188)
+
+```
+48 Tests / 103 Assertions — alle PASS
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+ATK-01〜12 alle bestanden
+```

--- a/docs/de/howto/oauth2-social-login.md
+++ b/docs/de/howto/oauth2-social-login.md
@@ -1,0 +1,199 @@
+# Implementierungsleitfaden: OAuth2 Social Login
+
+## Übersicht
+
+Diese Anleitung erklärt, wie mit NENE2 ein Social Login über den OAuth2 Authorization Code Flow implementiert wird. Enthält CSRF-Schutz (state-Parameter), Code-Replay-Prävention, Session-Invalidierung und Cracker-Angriffstests (ATK-01~12).
+
+---
+
+## DB-Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider   TEXT    NOT NULL,
+    subject    TEXT    NOT NULL,  -- Vom OAuth-Provider ausgegebener Benutzeridentifier
+    name       TEXT    NOT NULL,
+    email      TEXT,
+    created_at TEXT    NOT NULL,
+    UNIQUE (provider, subject)
+);
+
+CREATE TABLE oauth_states (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    state      TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL,
+    expires_at TEXT    NOT NULL,
+    used_at    TEXT    -- NULL = unbenutzt, NOT NULL = benutzt (nicht wiederverwendbar)
+);
+
+CREATE TABLE sessions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token      TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL,
+    expires_at TEXT    NOT NULL,
+    revoked_at TEXT,   -- NULL = gültig, NOT NULL = ausgeloggt
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE used_oauth_codes (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    code     TEXT    NOT NULL UNIQUE,
+    used_at  TEXT    NOT NULL
+);
+```
+
+`oauth_states.used_at` und `used_oauth_codes` sind der Kern der **CSRF- und Code-Replay-Angriffsprävention**.
+
+---
+
+## Endpunkt-Design
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| POST | `/auth/oauth/start` | State generieren, Autorisierungs-URL zurückgeben |
+| POST | `/auth/oauth/callback` | State/Code verifizieren, Benutzer erstellen, Session ausgeben |
+| POST | `/auth/logout` | Session invalidieren |
+| GET | `/me` | Authentifizierten Benutzer abrufen |
+
+---
+
+## Authorization Code Flow
+
+```
+Client                 Server                   OAuth-Provider
+  |                      |                            |
+  |-- POST /start -----→ |                            |
+  |← {state, auth_url} --|                            |
+  |                      |                            |
+  |-- Benutzer ruft auth_url auf →→→→→→→→→→→→→→→→→ |
+  |←←←←←←←←←←←←←←←←←←← Weiterleitung mit ?code=XXX&state=YYY |
+  |                      |                            |
+  |-- POST /callback ──→ |                            |
+  |   {state, code}      |-- Code-Austausch →→→→→→ |
+  |                      |← {subject, name, email} ---|
+  |← {token, user} -----.|                            |
+  |                      |                            |
+  |-- GET /me ─────────→ |                            |
+  |   Authorization: Bearer <token>                   |
+  |← {id, name, email} - |                            |
+```
+
+---
+
+## Designpunkte
+
+### CSRF-Schutz (state-Parameter)
+
+OAuth2-Callbacks kommen via URL-Parameter an, daher kann ein Angreifer das Opfer zu einer schädlichen Callback-URL leiten (CSRF). Mit `state` verhindern:
+
+1. Bei `/auth/oauth/start` einen zufälligen State in der DB speichern
+2. Im Callback den State abgleichen
+3. **Verwendeten State als nicht-wiederverwendbar markieren** (`used_at` aufzeichnen)
+
+```php
+if (!$this->repo->isStateValid($state, $now)) {
+    return $this->json->create(['error' => 'Invalid, expired, or already used state'], 400);
+}
+```
+
+### Code-Replay-Prävention
+
+Authorization Codes sind nur einmal verwendbar (RFC 6749 §4.1.2). Verwendete Codes in der `used_oauth_codes`-Tabelle aufzeichnen und Wiederverwendung ablehnen:
+
+```php
+if ($this->repo->isCodeUsed($code)) {
+    return $this->json->create(['error' => 'Authorization code already used'], 400);
+}
+// ... Provider-Verifizierung ...
+$this->repo->markCodeUsed($code, $now);
+```
+
+### Reihenfolge der State- und Code-Verarbeitung
+
+State-Verifizierung → Code-Verifizierung → **Provider anfragen → State und Code gleichzeitig als verwendet markieren**. Wenn der Provider fehlschlägt, werden weder State noch Code verbraucht (Wiederholung ist möglich).
+
+### Bearer-Token-Authentifizierung
+
+```php
+private function bearerToken(ServerRequestInterface $request): ?string
+{
+    $header = $request->getHeaderLine('Authorization');
+    if (!str_starts_with($header, 'Bearer ')) {
+        return null;
+    }
+    return substr($header, 7) ?: null;
+}
+```
+
+### Benutzer-Upsert
+
+Wenn sich derselbe Subject beim gleichen Provider erneut anmeldet, vorhandenen Benutzer aktualisieren:
+
+```php
+public function upsertUser(array $info, string $now): int
+{
+    $row = $this->db->fetchOne(
+        'SELECT id FROM users WHERE provider = ? AND subject = ?',
+        [$info['provider'], $info['subject']],
+    );
+    if ($row !== null) {
+        // Name und E-Mail auf neueste aktualisieren
+        $this->db->insert('UPDATE users SET name = ?, email = ? WHERE id = ?', [...]);
+        return (int) $row['id'];
+    }
+    return $this->db->insert('INSERT INTO users ...', [...]);
+}
+```
+
+### State-Ablaufzeit
+
+State ist 5 Minuten gültig. Abgelaufene States werden durch `expires_at > $now`-Prüfung abgelehnt:
+
+```php
+public function isStateValid(string $state, string $now): bool
+{
+    $row = $this->findState($state);
+    if ($row === null || $row['used_at'] !== null) return false;
+    return (string) $row['expires_at'] > $now;
+}
+```
+
+---
+
+## Cracker-Angriffstests ATK-01~12 (alle Pass)
+
+| # | Angriffsszenario | Gegenmaßnahme | Erwarteter Status |
+|---|---|---|---|
+| ATK-01 | CSRF: state-Parameter fehlt | Required-Validierung | 422 |
+| ATK-02 | CSRF: Gefälschter State-Wert | DB-Abgleich → unbekannter State abgelehnt | 400 |
+| ATK-03 | Wiederverwendung eines verwendeten States | Nach `used_at`-Aufzeichnung nicht wiederverwendbar | 400 |
+| ATK-04 | Übernahme eines legitimen States zur Wiederverwendung | Sofort ungültig nach einmaliger Verwendung | 400 |
+| ATK-05 | Replay des Authorization Codes | Aufzeichnung in `used_oauth_codes` | 400 |
+| ATK-06 | Ungültiger Authorization Code | Mock-Provider gibt null zurück | 401 |
+| ATK-07 | Open-Redirect-Injection | Start akzeptiert keine redirect_uri | evil-Domain nicht in auth_url |
+| ATK-08 | Session-Wiederverwendung nach Logout | `revoked_at` gesetzt → findSession schlägt fehl | 401 |
+| ATK-09 | Ungültiges Session-Token | DB-Abgleich → unregistriertes Token abgelehnt | 401 |
+| ATK-10 | /me ohne Authentifizierung aufrufen | Bearer nicht gesetzt → 401 | 401 |
+| ATK-11 | SQL-Injection im state-Parameter | Prepared Statement macht ihn unschädlich | 400/422 |
+| ATK-12 | /me mit Session eines anderen Benutzers | Token ist an user_id gebunden | Andere user.id |
+
+---
+
+## Test-Aufbau
+
+```
+tests/
+  OAuth/
+    OAuthTest.php   — 10 Funktionaltests
+    AttackTest.php  — 12 Cracker-Angriffstests (ATK-01~12)
+```
+
+Insgesamt 22 Tests / 36 Assertions.
+
+---
+
+## Referenzimplementierung
+
+`../NENE2-FT/oauthlog/` — FT160 Field Trial (22 Tests + 12 Cracker-Angriffstests)

--- a/docs/de/howto/offset-cursor-pagination.md
+++ b/docs/de/howto/offset-cursor-pagination.md
@@ -1,0 +1,105 @@
+# How-to: Offset- und Cursor-Paginierung
+
+> **FT-Referenz**: FT325 (`NENE2-FT/pagelog`) — Duale Paginierungsstrategie (offset-basiert und cursor-basiert) mit `next_offset`/`next_cursor`, `has_more`, Kategorie-Filter, 15 Tests / 47 Assertions PASS.
+
+Diese Anleitung zeigt, wie beide Paginierungsstrategien — offset-basiert und cursor-basiert — für dieselbe Ressource implementiert werden, sodass Clients die für ihren Anwendungsfall passende Strategie wählen können.
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    author     TEXT    NOT NULL,
+    category   TEXT    NOT NULL DEFAULT 'general',
+    created_at TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/articles` | Artikel erstellen |
+| `GET`  | `/articles/offset` | Offset-Paginierung |
+| `GET`  | `/articles/cursor` | Cursor-Paginierung |
+| `GET`  | `/articles/by-category` | Kategorie-Filter |
+
+## Offset-Paginierung
+
+```
+GET /articles/offset?limit=10&offset=0
+→ 200
+{
+  "items": [...],     // 10 Artikel
+  "total": 25,
+  "limit": 10,
+  "offset": 0,
+  "has_more": true,
+  "next_offset": 10   // null auf letzter Seite
+}
+
+// Seite 2
+GET /articles/offset?limit=10&offset=10
+→ {"items": [...], "has_more": true, "next_offset": 20}
+
+// Letzte Seite
+GET /articles/offset?limit=10&offset=20
+→ {"items": [...], "has_more": false, "next_offset": null}
+
+// Jenseits des Endes
+GET /articles/offset?limit=10&offset=100
+→ {"items": [], "has_more": false}
+```
+
+`next_offset = offset + limit` wenn `has_more`, sonst `null`.
+
+## Cursor-Paginierung
+
+```
+GET /articles/cursor?limit=10
+→ 200
+{
+  "items": [...],        // neueste zuerst
+  "has_more": true,
+  "next_cursor": 15      // id des letzten zurückgegebenen Artikels
+}
+
+// Nächste Seite mit Cursor
+GET /articles/cursor?limit=10&after=15
+→ {"items": [...], "has_more": true, "next_cursor": 5}
+
+// Letzte Seite
+GET /articles/cursor?limit=10&after=5
+→ {"items": [...], "has_more": false, "next_cursor": null}
+```
+
+Cursor ist die `id` des zuletzt zurückgegebenen Artikels: `WHERE id < $after ORDER BY id DESC LIMIT $limit + 1` (einen Extra-Eintrag vorausschauen, um `has_more` zu bestimmen).
+
+## Kategorie-Filter
+
+```
+GET /articles/by-category?category=tech&limit=5
+→ {"items": [...], "total": N}
+```
+
+## Offset vs. Cursor — Wann verwenden
+
+| Kriterium | Offset | Cursor |
+|-----------|--------|--------|
+| Zufälliger Seitensprung | ✅ `?offset=50` | ❌ Muss traversieren |
+| Gesamtanzahl benötigt | ✅ Immer enthalten | ❌ Teuer |
+| Konsistente Ergebnisse bei Inserts | ❌ Neue Zeile verschiebt Seite | ✅ Stabil |
+| Performance bei großen Datensätzen | ❌ `OFFSET N` scannt N Zeilen | ✅ `WHERE id < X` nutzt Index |
+| Infinite Scroll / Feed | ❌ | ✅ |
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `next_offset` auch auf letzter Seite zurückgeben | Client macht eine zusätzliche leere Anfrage |
+| `OFFSET N` auf Tabellen mit Millionen Zeilen verwenden | DB scannt N Zeilen vor der Rückgabe; bei großen Daten Cursor verwenden |
+| `has_more` aus Cursor-Antwort weglassen | Client kann nicht wissen, ob die nächste Seite abgerufen werden soll |
+| Timestamp als Cursor verwenden | Doppelte Timestamps verursachen übersprungene oder wiederholte Zeilen; einzigartigen Integer-ID verwenden |

--- a/docs/de/howto/one-time-secrets.md
+++ b/docs/de/howto/one-time-secrets.md
@@ -1,0 +1,215 @@
+# How-to: Einmalige-Geheimnisse-API und ATK-01~12 Cracker-Angriffstest
+
+> **NENE2 Field Trial 184** — Cracker-Angriffstest-Zyklus (ATK-01~12).
+> Das Token IST die Anmeldedaten. Atomarer Verbrauch verhindert Race Conditions.
+
+---
+
+## Was dieser Trial beweist
+
+Ein einmaliges Geheimnis speichert eine verschlüsselte Nachricht, die nur einmal gelesen werden kann. Nach dem ersten erfolgreichen Lesen wird das Geheimnis dauerhaft verbraucht.
+
+Sicherheitsanforderungen:
+1. **256-Bit-Token-Entropie** — Brute Force ist rechnerisch nicht machbar
+2. **Atomarer Verbrauch** — `UPDATE WHERE consumed=0` verhindert Double-Read-Race-Conditions
+3. **IDOR-Prävention** — Löschen erfordert sowohl Token als auch Benutzer-Eigentümerschaft
+4. **Mass Assignment blockiert** — consumed/token/created_at sind nur serverseitig
+5. **Typsicherheit** — V::str() / V::userId() / V::queryInt() lehnen Nicht-String-Eingaben ab
+
+---
+
+## API
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|-------------|
+| `POST` | `/secrets` | X-User-Id | Ein einmaliges Geheimnis erstellen |
+| `GET` | `/secrets` | X-User-Id | Eigene Geheimnisse auflisten (nur Metadaten, keine Nachricht) |
+| `GET` | `/secrets/{token}` | — | Lesen + Verbrauchen (Token IST die Anmeldedaten) |
+| `DELETE` | `/secrets/{token}` | X-User-Id | Vor dem Lesen abbrechen (muss Eigentümer sein) |
+
+---
+
+## ATK-01~12 Ergebnisse
+
+| ID | Angriffsvektor | Abwehr | Ergebnis |
+|----|----------------|--------|---------|
+| ATK-01 | SQL-Injection in Token | PDO-parametrisierte Abfragen | ✅ PASS |
+| ATK-02 | IDOR-mandantenübergreifendes Löschen | `WHERE token=? AND user_id=?` | ✅ PASS |
+| ATK-03 | Mass Assignment (`consumed=1` im Body) | Nur serverseitige Felder | ✅ PASS |
+| ATK-04 | XSS-Payload in Nachricht | JSON-API — kein HTML-Rendering | ✅ PASS |
+| ATK-05 | Doppelt-kodiertes / fehlerhaftes Token | `/^[0-9a-f]{64}$/` Format-Prüfung | ✅ PASS |
+| ATK-06 | Auth-Bypass beim Lesen | Token IST die Anmeldedaten — per Design | ✅ PASS |
+| ATK-07 | Nachricht/Passwort als Nicht-String | `V::str()` erzwingt `is_string()` | ✅ PASS |
+| ATK-08 | 20-stelliger Overflow in limit/offset | `V::queryInt()` strlen > 18 Guard | ✅ PASS |
+| ATK-09 | ReDoS im limit-Parameter | `ctype_digit()` — O(n), kein Backtracking | ✅ PASS |
+| ATK-10 | Brute-Force-Token | `random_bytes(32)` = 2^256 Entropie | ✅ PASS |
+| ATK-11 | Race-Condition Double-Read | `UPDATE WHERE consumed=0` + rowCount-Prüfung | ✅ PASS |
+| ATK-12 | Header-Injection in X-User-Id | `V::userId()` erzwingt `ctype_digit()` | ✅ PASS |
+
+**12/12: PASS**
+
+---
+
+## Kernmuster: Atomarer Verbrauch
+
+Die kritische Sicherheitsinvariante — ein Geheimnis kann nur einmal gelesen werden:
+
+```php
+// SecretRepository::consumeByToken()
+
+// Schritt 1: Geheimnis abrufen (normales SELECT — kein Guard)
+$row = $pdo->prepare('SELECT * FROM secrets WHERE token = :token');
+$row->execute(['token' => $token]);
+$secret = $row->fetch(PDO::FETCH_ASSOC);
+
+// Schritt 2: consumed-Flag prüfen (frühes Beenden für den häufigen Fall)
+if ($secret['consumed']) return null;
+
+// Schritt 3: Atomares UPDATE — das ist der echte Guard
+$update = $pdo->prepare(
+    'UPDATE secrets SET consumed = 1 WHERE token = :token AND consumed = 0'
+);
+$update->execute(['token' => $token]);
+
+// Schritt 4: rowCount() === 0 bedeutet, ein anderer Leser hat das Race gewonnen
+if ($update->rowCount() === 0) {
+    return null; // Jemand anderes hat es zwischen unserem SELECT und diesem UPDATE verbraucht
+}
+
+// Schritt 5: Wir haben gewonnen — Geheimnis zurückgeben
+return Secret::fromRow($secret);
+```
+
+**Warum das funktioniert:** SQLite und die meisten RDBMS garantieren, dass `UPDATE WHERE consumed=0` atomar ist. Nur ein gleichzeitiger Schreiber kann `consumed` von 0→1 ändern. Der Verlierer's `rowCount()` gibt 0 zurück.
+
+---
+
+## Token-Generierung
+
+```php
+$token = bin2hex(random_bytes(32)); // 64 Hex-Zeichen = 32 Bytes = 256 Bits
+```
+
+- `random_bytes()` verwendet das OS-CSPRNG (äquivalent zu `/dev/urandom`)
+- 2^256 Tokens bei 10^12 Versuchen/Sekunde ≈ 10^60 Jahre zum Brute-Force
+- Tokens sind in der DB eindeutig (`UNIQUE`-Constraint)
+
+---
+
+## Token-Format-Validierung
+
+```php
+private const TOKEN_PATTERN = '/^[0-9a-f]{64}$/';
+
+// Lehnt ab: Großbuchstaben-Hex, Pfadtraversal ../../, URL-kodiert, Integer, leer
+if (!preg_match(self::TOKEN_PATTERN, $rawToken)) {
+    return $this->responseFactory->create(['error' => 'Secret not found.'], 404);
+}
+```
+
+---
+
+## IDOR-Prävention (ATK-02)
+
+```php
+// DELETE erfordert SOWOHL Token-Eigentümerschaft ALS AUCH user_id-Übereinstimmung
+$stmt = $pdo->prepare(
+    'DELETE FROM secrets WHERE token = :token AND user_id = :user_id AND consumed = 0'
+);
+$stmt->execute(['token' => $token, 'user_id' => $userId]);
+
+// Gibt unabhängig vom Grund 404 zurück — vermeidet Enumerations-Oracle
+return $stmt->rowCount() > 0;
+```
+
+---
+
+## Mass-Assignment-Prävention (ATK-03)
+
+Serverseitige Felder werden **niemals aus dem Request-Body gelesen**:
+
+```php
+// POST /secrets Handler — nur message, password, expires_at werden aus dem Body akzeptiert
+$token        = bin2hex(random_bytes(32));  // server-generiert
+$consumed     = 0;                          // beginnt immer unverbraucht
+$createdAt    = (new DateTimeImmutable())->format(DateTimeInterface::ATOM); // Server-Zeit
+$passwordHash = $password !== null ? hash('sha256', $password) : null;     // serverseitig gehasht
+
+// body['consumed'], body['token'], body['user_id'], body['created_at'] werden stillschweigend ignoriert
+```
+
+---
+
+## V.php-Validierungskette
+
+```php
+// ATK-07: message muss ein String sein (lehnt int, bool, null, array ab)
+$message = V::str($body['message'] ?? null, 10000);
+
+// ATK-12: X-User-Id muss ctype_digit + positiv + max 18 Zeichen sein
+$userId = V::userId($request->getHeaderLine('X-User-Id'));
+
+// ATK-08/09: limit muss numerisch sein, max 18 Ziffern, im Bereich 1–100
+$limit = V::queryInt($params, 'limit', 1, 100, 20);
+```
+
+---
+
+## Optionaler Passwortschutz
+
+```php
+// Speicherung: nur SHA-256-Hash (kein Klartext)
+$passwordHash = $password !== null ? hash('sha256', $password) : null;
+
+// Verifizierung: Constant-Time-Vergleich (timing-sicher)
+if (!hash_equals($secret->passwordHash, hash('sha256', $submittedPassword))) {
+    return null; // Falsches Passwort → stilles 404 (kein Oracle)
+}
+```
+
+> **Hinweis:** Falsches Passwort gibt 404 (nicht 403) zurück, um Oracle-Angriffe zu verhindern.
+> Das Geheimnis wird bei falschem Passwort NICHT verbraucht — nur das korrekte Passwort verbraucht es.
+
+---
+
+## Metadaten-Liste (keine Nachrichtenpreisgabe)
+
+```php
+// GET /secrets — gibt nur Metadaten zurück, niemals die Nachricht
+private function secretToMetadata(Secret $secret): array
+{
+    return [
+        'token'        => $secret->token,
+        'has_password' => $secret->passwordHash !== null,
+        'consumed'     => $secret->consumed,
+        'expires_at'   => $secret->expiresAt,
+        'created_at'   => $secret->createdAt,
+        // 'message' wird absichtlich weggelassen
+    ];
+}
+```
+
+---
+
+## Testergebnisse
+
+```
+85 Tests / 209 Assertions — alle PASS
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+```
+
+---
+
+## Wichtigste Erkenntnisse
+
+| Muster | Regel |
+|--------|-------|
+| Atomarer Verbrauch | `UPDATE WHERE consumed=0` + `rowCount()`-Prüfung — nicht SELECT dann UPDATE |
+| Token-Entropie | `random_bytes(32)` Minimum (256 Bits) — niemals sequentielle IDs |
+| Token-Format | Allowlist-Regex an beiden Enden verankert (`/^[0-9a-f]{64}$/`) |
+| IDOR | Alle Schreiboperationen nach `token AND user_id` eingrenzen |
+| Mass Assignment | Token, consumed, created_at — nur serverseitig, niemals aus Body |
+| Passwort-Timing | `hash_equals()` für Constant-Time-Vergleich |
+| Falsches Passwort | 404 nicht 403 — vermeidet Bestätigung der Geheimnis-Existenz |
+| Metadaten-Liste | Nachricht aus Listen-Endpunkt weglassen — nur beim Verbrauchen lesen |

--- a/docs/de/howto/optimistic-concurrency-version.md
+++ b/docs/de/howto/optimistic-concurrency-version.md
@@ -1,0 +1,120 @@
+# How-to: Optimistische Nebenläufigkeitskontrolle (Versionsfeld)
+
+> **FT-Referenz**: FT323 (`NENE2-FT/optimisticlog`) — Dokument-API mit Versionsfeld im PUT-Body, 409 bei veralteter Version, Verhinderung verlorener Updates, 18 Tests / 34 Assertions PASS.
+
+Diese Anleitung zeigt, wie optimistische Nebenläufigkeitskontrolle durch Übergabe eines `version`-Feldes im Request-Body implementiert wird, als Alternative zu HTTP-ETag/If-Match-Headern.
+
+## Schema
+
+```sql
+CREATE TABLE documents (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    version    INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/documents` | Erstellen (Version beginnt bei 1) |
+| `GET`  | `/documents` | Auflisten |
+| `GET`  | `/documents/{id}` | Abrufen mit Version |
+| `PUT`  | `/documents/{id}` | Aktualisieren (Version im Body erforderlich) |
+
+## Erstellen
+
+```php
+POST /documents  {"title": "Hello", "body": "World"}
+→ 201  {"id": 1, "title": "Hello", "version": 1}
+```
+
+## Aktualisieren mit Version
+
+Der Client liest die aktuelle `version` und schließt sie in den PUT-Body ein:
+
+```php
+// Lesen
+GET /documents/1
+→ 200  {"id": 1, "title": "Hello", "version": 1}
+
+// Aktualisieren mit korrekter Version
+PUT /documents/1
+{"title": "Updated", "body": "new body", "version": 1}
+→ 200  {"id": 1, "title": "Updated", "version": 2}
+```
+
+Die Version wird bei jeder erfolgreichen Aktualisierung inkrementiert.
+
+## Veraltete Version — 409 Conflict
+
+```php
+// Alice und Bob lesen beide Version 1
+// Alice aktualisiert zuerst → Version wird 2
+// Bob versucht mit Version 1 zu aktualisieren → abgelehnt
+PUT /documents/1
+{"title": "Bobs Bearbeitung", "version": 1}
+→ 409 Conflict  {"current_version": 2, "submitted_version": 1}
+
+// Bob liest erneut, erhält Version 2, versucht erneut
+PUT /documents/1
+{"title": "Bobs Bearbeitung", "version": 2}
+→ 200  {"version": 3}
+```
+
+## Implementierung
+
+```php
+private function update(ServerRequestInterface $request): ResponseInterface
+{
+    $body    = $this->parseBody($request);
+    $version = $body['version'] ?? null;
+
+    if (!is_int($version) || $version < 1) {
+        return $this->json->create(['error' => 'version is required'], 422);
+    }
+
+    $doc = $this->repo->findById($id);
+    if ($doc === null) {
+        return $this->json->create(['error' => 'Not found'], 404);
+    }
+
+    if ($doc['version'] !== $version) {
+        return $this->problems->create('conflict', 'Stale version', 409, [
+            'current_version'   => $doc['version'],
+            'submitted_version' => $version,
+        ]);
+    }
+
+    $newVersion = $version + 1;
+    // UPDATE documents SET ... WHERE id = ? AND version = ?
+    $this->repo->update($id, $title, $newVersion, $now);
+
+    return $this->json->create($updated);
+}
+```
+
+Die `WHERE version = ?`-Klausel in der UPDATE-Abfrage ist der atomare Guard gegen gleichzeitige Schreibvorgänge.
+
+## Version vs. ETag
+
+| Aspekt | Versionsfeld (diese Anleitung) | ETag / If-Match (siehe `optimistic-locking-etag.md`) |
+|--------|-------------------------------|------------------------------------------------------|
+| Protokoll | Body-Feld | HTTP-Header |
+| Client-UX | Explizites `"version": N` in JSON | `If-Match: "vN"`-Header |
+| 409-Payload | Kann `current_version` zurückgeben | 412 — kein Body-Standard |
+| Fehlende Prüfung | 422 (fehlendes `version`) | 428 (fehlendes `If-Match`) |
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| PUT ohne `version`-Feld akzeptieren | Verlorene Updates: letztes Schreiben gewinnt stillschweigend |
+| 200 bei veralteter Version zurückgeben | Stille Überschreibung gleichzeitiger Änderungen |
+| Version nur im Anwendungscode prüfen (nicht in WHERE-Klausel) | Race Condition zwischen Lesen und Schreiben |
+| `current_version` nicht in 409-Antwort einschließen | Client muss neu-GET, um sich zu erholen; für schnelleren Neuversuch einschließen |

--- a/docs/de/howto/optimistic-lock-patch-version.md
+++ b/docs/de/howto/optimistic-lock-patch-version.md
@@ -1,0 +1,221 @@
+# How-to: Optimistische Sperre mit PATCH + Versionsfeld
+
+> **FT-Referenz**: FT324 (`NENE2-FT/optlocklog`) — PATCH-basierte optimistische Sperre, 409 enthält `current_version` für Zero-GET-Neuversuch, strenger Integer-Versionstyp, ATK-Bewertung, 12 Tests / 24 Assertions PASS.
+
+Diese Anleitung zeigt, wie optimistische Nebenläufigkeitskontrolle via PATCH mit einem `version`-Feld implementiert wird, wobei die aktuelle Serverversion in 409-Antworten zurückgegeben wird, sodass Clients ohne extra GET erneut versuchen können.
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    version    INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST`  | `/articles` | Erstellen (version=1) |
+| `GET`   | `/articles/{id}` | Abrufen mit Version |
+| `PATCH` | `/articles/{id}` | Aktualisieren (Version als Integer erforderlich) |
+
+## Erstellen und Lesen
+
+```php
+POST /articles  {"title": "Hello", "body": "World"}
+→ 201  {"id": 1, "title": "Hello", "version": 1}
+
+GET /articles/1
+→ 200  {"id": 1, "title": "Hello", "version": 1}
+```
+
+## PATCH mit Version
+
+```php
+PATCH /articles/1
+{"title": "Updated", "body": "New body", "version": 1}
+→ 200  {"id": 1, "title": "Updated", "version": 2}
+```
+
+Die Version muss ein **JSON-Integer** sein — ein String `"1"` wird abgelehnt.
+
+## 409 enthält current_version
+
+Wenn ein Konflikt erkannt wird, enthält die Antwort `current_version`, sodass der Client ohne erneutes GET erneut versuchen kann:
+
+```php
+// Version 1 bereits auf 2 hochgesetzt durch einen anderen Schreiber
+PATCH /articles/1  {"title": "X", "version": 1}
+→ 409
+{
+  "type": "https://nene2.dev/problems/conflict",
+  "title": "Conflict",
+  "status": 409,
+  "current_version": 2    ← Client kann dies direkt für den Neuversuch verwenden
+}
+
+// Client versucht mit current_version aus 409-Body erneut
+PATCH /articles/1  {"title": "X", "version": 2}
+→ 200  {"version": 3}     ← Erfolg
+```
+
+## Typvalidierung
+
+```php
+PATCH /articles/1  {"title": "x", "body": "x"}          → 400  // fehlende Version
+PATCH /articles/1  {"title": "x", "body": "x", "version": "1"} → 400  // String nicht int
+PATCH /articles/9999 {"version": 1}                      → 404  // nicht gefunden
+```
+
+## Implementierung
+
+```php
+private function patch(ServerRequestInterface $request): ResponseInterface
+{
+    $body    = $this->parseBody($request);
+    $version = $body['version'] ?? null;
+
+    // Strikte Integer-Typprüfung — "1" (String) wird abgelehnt
+    if (!is_int($version)) {
+        return $this->json->create(['error' => 'version must be an integer'], 400);
+    }
+
+    $article = $this->repo->findById($id);
+    if ($article === null) {
+        return $this->json->create(['error' => 'Not found'], 404);
+    }
+
+    if ($article['version'] !== $version) {
+        return $this->problems->create('conflict', 'Version conflict', 409, [
+            'current_version' => $article['version'],  // ← Zero-GET-Neuversuch ermöglichen
+        ]);
+    }
+
+    // Atomares UPDATE mit WHERE version = ?
+    $updated = $this->repo->updateWithVersion($id, $title, $body, $version + 1, $now);
+    return $this->json->create($updated);
+}
+```
+
+---
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Versions-Brute-Force zum Überschreiben ✅ SAFE
+
+**Angriff**: Angreifer durchläuft Version `1, 2, 3...` bis eine erfolgreich ist und überschreibt den aktuellen Inhalt.
+**Ergebnis**: SAFE — Brute Force findet letztendlich die aktuelle Version, aber dies ist ein legitimer Schreibvorgang, keine Privilegieneskalation. Eigentümerschaftsautorisierung (nicht gezeigt) verhindert unbefugtes Schreiben.
+
+---
+
+### ATK-02 — String-Versions-Bypass (`"version": "1"`) 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `"version": "1"` (JSON-String) in der Hoffnung, PHP-Typkoercion behandle es als Integer.
+**Ergebnis**: BLOCKED — `is_int($version)` gibt false für Strings zurück. Gibt 400 zurück.
+
+---
+
+### ATK-03 — Float-Version (`"version": 1.0`) 🚫 BLOCKED
+
+**Angriff**: `"version": 1.0` senden, um über lockere Vergleiche zu matchen.
+**Ergebnis**: BLOCKED — `is_int(1.0)` ist in PHP false (es ist ein Float). Gibt 400 zurück.
+
+---
+
+### ATK-04 — Fehlende Version → Blindes Schreiben erzwingen 🚫 BLOCKED
+
+**Angriff**: `version`-Feld weglassen in der Hoffnung, der Server akzeptiere das Update standardmäßig.
+**Ergebnis**: BLOCKED — Fehlende `version` (null) besteht `is_int()`-Prüfung nicht. Gibt 400 zurück.
+
+---
+
+### ATK-05 — Negative Version 🚫 BLOCKED
+
+**Angriff**: `"version": -1` senden, um potenziellen Off-by-One beim Versionsvergleich auszunutzen.
+**Ergebnis**: BLOCKED — Version beginnt bei 1 und wird nur inkrementiert. `-1 !== 1` → 409 Conflict.
+
+---
+
+### ATK-06 — current_version aus 409 für Race verwendet 🚫 BLOCKED
+
+**Angriff**: Angreifer liest `current_version` aus 409 und sendet sofort, um mit dem legitimen Neuversuch zu rasen.
+**Ergebnis**: BLOCKED — Das atomare `WHERE version = $current`-UPDATE bedeutet, dass nur ein gleichzeitiger Schreiber pro Version erfolgreich sein kann. Der andere erhält erneut 409. Dies ist das beabsichtigte optimistische Sperrverhalten.
+
+---
+
+### ATK-07 — Überlauf-Versionsnummer 🚫 BLOCKED
+
+**Angriff**: `"version": 9999999999999999999` senden, um int zu überlaufen.
+**Ergebnis**: BLOCKED — Große JSON-Integer können in PHP als Float dekodiert werden; `is_int()` gibt false zurück. Gibt 400 zurück.
+
+---
+
+### ATK-08 — Null-Version 🚫 BLOCKED
+
+**Angriff**: `"version": 0` senden, um unter die Mindestversion zu gehen.
+**Ergebnis**: BLOCKED — Version beginnt bei 1. `0 !== 1` → 409 Conflict.
+
+---
+
+### ATK-09 — Gefälschte current_version im Request-Body 🚫 BLOCKED
+
+**Angriff**: Angreifer fügt `"current_version": 999` in den PATCH-Body ein in der Hoffnung, der Server verwende ihn.
+**Ergebnis**: BLOCKED — `current_version` ist nur in der *Antwort*. Server ignoriert unbekannte Request-Felder; Version wird nur aus `$body['version']` entnommen.
+
+---
+
+### ATK-10 — SQL-Injection via version-Feld 🚫 BLOCKED
+
+**Angriff**: `"version": "1; DROP TABLE articles; --"`.
+**Ergebnis**: BLOCKED — Bei `is_int()`-Prüfung vor dem Erreichen der DB abgelehnt. Gibt 400 zurück.
+
+---
+
+### ATK-11 — Erfolgreiche Version wiederholen 🚫 BLOCKED
+
+**Angriff**: Erfolgreichen PATCH (Version N → N+1) aufzeichnen, dann dieselbe Anfrage wiederholen.
+**Ergebnis**: BLOCKED — Nach dem Update steht der Artikel bei Version N+1. Wiederholung von `version: N` gibt 409 zurück.
+
+---
+
+### ATK-12 — Gleichzeitige Schreibvorgänge beide erfolgreich 🚫 BLOCKED
+
+**Angriff**: Zwei identische PATCH-Anfragen gleichzeitig mit derselben `version` senden.
+**Ergebnis**: BLOCKED — `UPDATE … WHERE version = ?` ist atomar. DB serialisiert gleichzeitige Schreibvorgänge; zweites UPDATE trifft 0 Zeilen → Anwendung erkennt und gibt 409 zurück.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|---------|
+| ATK-01 | Versions-Brute-Force | ✅ SAFE (Autorisierungsbedenken) |
+| ATK-02 | String-Versions-Bypass | 🚫 BLOCKED |
+| ATK-03 | Float-Version | 🚫 BLOCKED |
+| ATK-04 | Fehlende Version — Blindes Schreiben | 🚫 BLOCKED |
+| ATK-05 | Negative Version | 🚫 BLOCKED |
+| ATK-06 | current_version Race-Exploit | 🚫 BLOCKED |
+| ATK-07 | Überlauf-Version | 🚫 BLOCKED |
+| ATK-08 | Null-Version | 🚫 BLOCKED |
+| ATK-09 | Gefälschte current_version im Body | 🚫 BLOCKED |
+| ATK-10 | SQL-Injection via Version | 🚫 BLOCKED |
+| ATK-11 | Erfolgreiche Version wiederholen | 🚫 BLOCKED |
+| ATK-12 | Gleichzeitige Schreibvorgänge beide erfolgreich | 🚫 BLOCKED |
+
+**11 BLOCKED, 1 SAFE, 0 EXPOSED** — Keine kritischen Befunde.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `"version": "1"` (String) akzeptieren | PHP-loser Vergleich `"1" == 1` ist true; Typverwirrungsangriff |
+| `current_version` aus 409 weglassen | Client muss extra GET machen; höhere Latenz, mehr Anfragen bei Konflikt |
+| Nur anwendungsseitige Prüfung verwenden (keine WHERE-Klausel) | Race Condition zwischen Versions-Lesen und Schreiben |
+| 200 bei fehlender Version zurückgeben | Unbedingtes Überschreiben — verlorenes Update |

--- a/docs/de/howto/optimistic-locking-etag.md
+++ b/docs/de/howto/optimistic-locking-etag.md
@@ -1,8 +1,8 @@
-# How-to: Optimistische Sperre mit ETag / If-Match
+# How-to: Optimistic Locking mit ETag / If-Match
 
-> **FT-Referenz**: FT320 (`NENE2-FT/locklog`) — Dokumentversionierung mit ETag-Header, If-Match für Mutationen erforderlich (428), Ablehnung veralteter ETags (412), Verhinderung verlorener Updates, 15 Tests / 30 Assertions PASS.
+> **FT-Referenz**: FT320 (`NENE2-FT/locklog`) — Dokumentversionierung mit ETag-Header, If-Match für Mutationen erforderlich (428), Ablehnung veralteter ETags (412), Schutz vor Lost-Update, 15 Tests / 30 Assertions PASS.
 
-Diese Anleitung zeigt, wie optimistische Nebenläufigkeitskontrolle mit HTTP-ETags implementiert wird, um verlorene Updates ohne pessimistisches DB-Sperren zu verhindern.
+Diese Anleitung zeigt, wie optimistische Nebenläufigkeitskontrolle mit HTTP-ETags implementiert wird, um Lost Updates ohne pessimistisches DB-Locking zu verhindern.
 
 ## Schema
 
@@ -16,12 +16,12 @@ CREATE TABLE documents (
 );
 ```
 
-`version` ist das maßgebliche Nebenläufigkeitstoken. ETag ist `"v{version}"`.
+`version` ist das maßgebliche Nebenläufigkeits-Token. ETag ist `"v{version}"`.
 
 ## Endpunkte
 
 | Methode | Pfad | Beschreibung |
-|---------|------|-------------|
+|--------|------|-------------|
 | `POST` | `/documents` | Dokument erstellen |
 | `GET`  | `/documents/{id}` | Abrufen mit ETag |
 | `PUT`  | `/documents/{id}` | Aktualisieren (If-Match erforderlich) |
@@ -44,9 +44,9 @@ GET /documents/1
 {"id": 1, "title": "Hello", "version": 1}
 ```
 
-Client speichert den ETag und sendet ihn als `If-Match` bei der nächsten Mutation.
+Der Client speichert den ETag und sendet ihn bei der nächsten Mutation als `If-Match`.
 
-## PUT — Optimistische Sperre
+## PUT — Optimistic Lock
 
 ```php
 // Client sendet aktuellen ETag
@@ -59,33 +59,33 @@ PUT /documents/1  If-Match: "v1"
 PUT /documents/1  If-Match: "v1"
 → 412 Precondition Failed
 
-// Fehlendes If-Match
+// If-Match fehlt
 PUT /documents/1
-{"title": "Keine Sperre"}
+{"title": "No lock"}
 → 428 Precondition Required
 
 // Wildcard — Versionscheck umgehen
 PUT /documents/1  If-Match: *
-→ 200  // immer erfolgreich wenn Dokument existiert
+→ 200  // Erfolg immer, wenn Dokument existiert
 ```
 
-### Verhinderung verlorener Updates
+### Schutz vor Lost Update
 
 ```
-Alice liest Dokument → version=1, ETag="v1"
-Bob  liest Dokument → version=1, ETag="v1"
+Alice liest Dok → version=1, ETag="v1"
+Bob  liest Dok → version=1, ETag="v1"
 
 Alice: PUT If-Match: "v1" → 200 (Version wird 2)
-Bob:   PUT If-Match: "v1" → 412 ← Bobs Schreiben wird abgelehnt
+Bob:   PUT If-Match: "v1" → 412 ← Bobs Schreibvorgang wird abgelehnt
 
-Bob muss neu-GET, um Alices Änderung zu sehen, dann mit "v2" erneut versuchen
+Bob muss erneut GET aufrufen, um Alices Änderung zu sehen, dann mit "v2" wiederholen
 ```
 
-## DELETE — Erfordert auch If-Match
+## DELETE — Erfordert ebenfalls If-Match
 
 ```php
 DELETE /documents/1  If-Match: "v1"  → 200  {"deleted": true}
-DELETE /documents/1  If-Match: "v1"  → 412  // Version bereits hochgesetzt
+DELETE /documents/1  If-Match: "v1"  → 412  // Version wurde bereits erhöht
 DELETE /documents/1                  → 428  // If-Match fehlt
 DELETE /documents/9999  If-Match: "v1" → 404
 ```
@@ -110,7 +110,7 @@ private function update(ServerRequestInterface $request): ResponseInterface
         return $this->json->create(['error' => 'Not found'], 404);
     }
 
-    // Wildcard oder exakten Versions-Match prüfen
+    // Wildcard oder exakten Versionsabgleich prüfen
     $currentETag = '"v' . $doc['version'] . '"';
     if ($ifMatch !== '*' && $ifMatch !== $currentETag) {
         return $this->problems->create(
@@ -130,39 +130,39 @@ private function update(ServerRequestInterface $request): ResponseInterface
 
 ---
 
-## ATK-Bewertung — Cracker-Mindset-Angriffstest
+## ATK Assessment — Cracker-Mindset-Angriffstest
 
-### ATK-01 — ETag-Brute-Force zum Umgehen der Vorbedingung ✅ SAFE
+### ATK-01 — ETag-Brute-Force zur Umgehung der Vorbedingung ✅ SAFE
 
-**Angriff**: Angreifer durchläuft `"v1"`, `"v2"`, `"v3"` bis er die aktuelle Version findet, um ein Update zu erzwingen.
-**Ergebnis**: SAFE — ETag-Brute-Force ist bei einem einfachen sequentiellen Zähler möglich, aber das Update ist immer noch ein legitimer Schreibvorgang. In hochwertigeren Szenarien undurchsichtige ETags verwenden (z.B. `hash('sha256', $version . $secret)`).
-
----
-
-### ATK-02 — If-Match weglassen für bedingungsloses Schreiben 🚫 BLOCKED
-
-**Angriff**: Angreifer sendet PUT ohne `If-Match`-Header in der Hoffnung, der Server akzeptiere bedingungslose Schreibvorgänge.
-**Ergebnis**: BLOCKED — Fehlendes `If-Match` gibt 428 Precondition Required zurück.
+**Angriff**: Angreifer probiert `"v1"`, `"v2"`, `"v3"` durch, bis er die aktuelle Version findet, um ein Update zu erzwingen.
+**Ergebnis**: SAFE — ETag-Brute-Force ist bei einem einfachen sequentiellen Zähler möglich, aber das Update ist trotzdem ein legitimer Schreibvorgang. Die 412-Antwort verrät nichts über die aktuelle Version; der Angreifer muss GET aufrufen, um zu bestätigen. In Szenarien mit hohem Wert opake ETags verwenden (z.B. `hash('sha256', $version . $secret)`).
 
 ---
 
-### ATK-03 — Wildcard If-Match: * zum Umgehen des Versionschecks 🚫 BLOCKED
+### ATK-02 — If-Match weglassen, um bedingungslosen Schreibvorgang zu erzwingen 🚫 BLOCKED
 
-**Angriff**: Angreifer sendet `If-Match: *`, um bedingungslos zu überschreiben.
-**Ergebnis**: BLOCKED — Wildcard ist per Design akzeptiert (trifft jede bestehende Version), aber das Dokument muss existieren. Für benutzerbezogene Mutation Wildcard auf Admin-Rollen beschränken.
+**Angriff**: Angreifer sendet PUT ohne `If-Match`-Header in der Hoffnung, der Server akzeptiert bedingungslose Schreibvorgänge.
+**Ergebnis**: BLOCKED — Fehlendes `If-Match` gibt 428 Precondition Required zurück. Der Endpunkt lehnt alle Schreibvorgänge ohne Lock-Token ab.
 
 ---
 
-### ATK-04 — Race Condition — gleichzeitige Schreibvorgänge mit demselben ETag 🚫 BLOCKED
+### ATK-03 — Wildcard If-Match: * zur Umgehung des Versionschecks 🚫 BLOCKED
 
-**Angriff**: Zwei Clients senden gleichzeitig PUT mit `"v1"`. Beide bestehen den ETag-Check vor dem Update.
-**Ergebnis**: BLOCKED — Das DB-UPDATE verwendet `WHERE version = $expectedVersion`. Der zweite Schreibvorgang findet die Version bereits inkrementiert und aktualisiert 0 Zeilen → gibt 412 zurück.
+**Angriff**: Angreifer sendet `If-Match: *`, um unbedingt zu überschreiben und Nebenläufigkeit zu ignorieren.
+**Ergebnis**: BLOCKED — Wildcard wird per Design akzeptiert (passt auf jede vorhandene Version), aber das Dokument muss existieren (404 sonst). Dies entspricht der HTTP-Spezifikation: `*` bedeutet „existiert"; für Admin-Operationen ist das akzeptabel. Für benutzerorientierte Mutation Wildcard auf Admin-Rollen beschränken.
+
+---
+
+### ATK-04 — Race Condition — Gleichzeitige Schreibvorgänge mit demselben ETag 🚫 BLOCKED
+
+**Angriff**: Zwei Clients senden gleichzeitig PUT mit `"v1"`. Beide passieren den ETag-Check, bevor einer aktualisiert.
+**Ergebnis**: BLOCKED — Das DB-UPDATE verwendet `WHERE version = $expectedVersion`. Der zweite Schreibvorgang findet die Version bereits inkrementiert und aktualisiert 0 Zeilen → gibt 412 zurück. Atomar auf DB-Ebene.
 
 ---
 
 ### ATK-05 — Beliebigen ETag-Wert injizieren 🚫 BLOCKED
 
-**Angriff**: Angreifer sendet `If-Match: "v999999"` für ein Dokument bei Version 1.
+**Angriff**: Angreifer sendet `If-Match: "v999999"` für ein Dokument bei Version 1 in der Hoffnung, der Server überspringt die Validierung.
 **Ergebnis**: BLOCKED — ETag wird mit dem gespeicherten `"v{version}"`-String verglichen. `"v999999" ≠ "v1"` → 412.
 
 ---
@@ -170,48 +170,48 @@ private function update(ServerRequestInterface $request): ResponseInterface
 ### ATK-06 — Header-Injection via If-Match 🚫 BLOCKED
 
 **Angriff**: Angreifer sendet `If-Match: "v1"\r\nX-Admin: true`, um Antwort-Header zu injizieren.
-**Ergebnis**: BLOCKED — PSR-7-Header-Parsing entfernt CR/LF aus Header-Werten.
+**Ergebnis**: BLOCKED — PSR-7-Header-Parsing entfernt CR/LF aus Header-Werten. Der injizierte Header erreicht die Anwendungsschicht nie.
 
 ---
 
 ### ATK-07 — Löschen mit veraltetem ETag 🚫 BLOCKED
 
-**Angriff**: Angreifer erhält alten ETag, wartet auf Dokumentaktualisierung, sendet dann DELETE mit veraltetem ETag.
+**Angriff**: Angreifer erhält einen alten ETag, wartet darauf, dass das Dokument aktualisiert wird, und sendet dann DELETE mit dem veralteten ETag.
 **Ergebnis**: BLOCKED — DELETE prüft ETag genau wie PUT. Veralteter ETag gibt 412 zurück; das Dokument überlebt.
 
 ---
 
-### ATK-08 — Negative/Null-Version im ETag 🚫 BLOCKED
+### ATK-08 — Negative Version im ETag 🚫 BLOCKED
 
 **Angriff**: Angreifer sendet `If-Match: "v-1"` oder `If-Match: "v0"`.
-**Ergebnis**: BLOCKED — Version beginnt bei 1 und wird nur inkrementiert. `"v-1"` und `"v0"` treffen nie eine gespeicherte Version.
+**Ergebnis**: BLOCKED — Version beginnt bei 1 und erhöht sich nur. `"v-1"` und `"v0"` stimmen nie mit einer gespeicherten Version überein.
 
 ---
 
 ### ATK-09 — Vorherigen erfolgreichen ETag wiederholen 🚫 BLOCKED
 
-**Angriff**: Nach erfolgreichem Update (`v1→v2`) repliziert Angreifer `If-Match: "v2"`.
-**Ergebnis**: BLOCKED — Dies ist gültiges Verhalten — der Angreifer hat ein aktuelles Token. Autorisierung (Eigentümerschaftsprüfung) ist der Guard; ETag verhindert nur gleichzeitige Kollision.
+**Angriff**: Nach einem erfolgreichen Update (`v1→v2`) wiederholt der Angreifer `If-Match: "v2"`, um ein weiteres Update vorzunehmen.
+**Ergebnis**: BLOCKED — Das ist gültiges Verhalten — der Angreifer hat ein aktuelles Token. Die Sorge ist, dass ein Dritter nicht das Token eines anderen Nutzers verwenden sollte. Autorisierung (Eigentümerprüfung) ist der Schutz; ETag verhindert nur gleichzeitige Kollision.
 
 ---
 
 ### ATK-10 — Versionszähler-Überlauf 🚫 BLOCKED
 
-**Angriff**: Versionszähler durch Millionen von Updates zum Überlaufen bringen.
-**Ergebnis**: BLOCKED — PHP-Integer sind 64-Bit (max ~9,2 × 10^18). Overflow ist in der Praxis nicht erreichbar. Rate-Limiting schützt vor schnellen Update-Schleifen.
+**Angriff**: Erzwingt einen Überlauf des Versionszählers durch Millionen von Updates.
+**Ergebnis**: BLOCKED — PHP-Integer sind 64-Bit (max ~9,2 × 10^18). Einen Überlauf zu erreichen ist in der Praxis nicht möglich. Rate Limiting schützt vor schnellen Update-Schleifen.
 
 ---
 
 ### ATK-11 — ETag-Spoofing in Antwort 🚫 BLOCKED
 
-**Angriff**: Angreifer erstellt eine Anfrage, sodass der Server ein gefälschtes `ETag: "v999"` zurückgibt.
+**Angriff**: Angreifer gestaltet eine Anfrage so, dass der Server einen gefälschten `ETag: "v999"` zurückgibt, was andere Clients glauben lässt, das Dokument sei bei Version 999.
 **Ergebnis**: BLOCKED — ETag wird immer aus `$doc['version']` in der DB berechnet. Keine Benutzereingabe beeinflusst den zurückgegebenen ETag.
 
 ---
 
-### ATK-12 — Kein If-Match bei DELETE 🚫 BLOCKED
+### ATK-12 — Kein If-Match bei DELETE, um ohne Lock zu löschen 🚫 BLOCKED
 
-**Angriff**: Angreifer sendet DELETE ohne `If-Match`.
+**Angriff**: Angreifer sendet DELETE ohne `If-Match`, verlässt sich auf einen Server, der die Vorbedingung nicht erzwingt.
 **Ergebnis**: BLOCKED — DELETE gibt wie PUT 428 zurück, wenn `If-Match` fehlt.
 
 ---
@@ -219,16 +219,16 @@ private function update(ServerRequestInterface $request): ResponseInterface
 ### ATK-Zusammenfassung
 
 | ID | Angriff | Ergebnis |
-|----|---------|---------|
-| ATK-01 | ETag-Brute-Force | ✅ SAFE (sequentiell, aber Hinweis beachten) |
+|----|--------|--------|
+| ATK-01 | ETag-Brute-Force | ✅ SAFE (sequentiell, aber siehe Hinweis) |
 | ATK-02 | If-Match weglassen | 🚫 BLOCKED |
-| ATK-03 | Wildcard If-Match-Bypass | 🚫 BLOCKED |
-| ATK-04 | Gleichzeitiger Schreib-Race | 🚫 BLOCKED |
+| ATK-03 | Wildcard-If-Match-Bypass | 🚫 BLOCKED |
+| ATK-04 | Race Condition beim gleichzeitigen Schreiben | 🚫 BLOCKED |
 | ATK-05 | Beliebigen ETag injizieren | 🚫 BLOCKED |
 | ATK-06 | Header-Injection via If-Match | 🚫 BLOCKED |
 | ATK-07 | Löschen mit veraltetem ETag | 🚫 BLOCKED |
-| ATK-08 | Negative/Null-Versions-ETag | 🚫 BLOCKED |
-| ATK-09 | Vorherigen ETag wiederholen | ✅ SAFE (Autorisierungsbedenken, nicht ETag) |
+| ATK-08 | Negative/Null-Version im ETag | 🚫 BLOCKED |
+| ATK-09 | Vorherigen ETag wiederholen | ✅ SAFE (Autorisierungsthema, nicht ETag) |
 | ATK-10 | Versionszähler-Überlauf | 🚫 BLOCKED |
 | ATK-11 | ETag-Spoofing in Antwort | 🚫 BLOCKED |
 | ATK-12 | Löschen ohne If-Match | 🚫 BLOCKED |
@@ -241,8 +241,8 @@ private function update(ServerRequestInterface $request): ResponseInterface
 
 | Anti-Muster | Risiko |
 |---|---|
-| PUT/DELETE ohne If-Match erlauben | Jedes Schreiben ohne Lock-Token verursacht verlorene Updates |
-| 200 bei veraltetem ETag zurückgeben (stille Überschreibung) | Verlorenes Update: letzter Schreiber gewinnt, gleichzeitige Änderungen werden stillschweigend verworfen |
-| Veränderbaren ETag verwenden (z.B. `Last-Modified`-Timestamp) | Takt-Drift verursacht falsche 412 oder falsche Treffer |
-| Wildcard `*` If-Match-Unterstützung überspringen | Bricht Admin-Tooling und RFC 7232-Konformität |
-| Keine DB-Level-Versionscheck in WHERE-Klausel | Anwendungsprüfung besteht, aber gleichzeitiger DB-Schreibvorgang rast durch |
+| PUT/DELETE ohne If-Match erlauben | Jeder Schreibvorgang ohne Lock-Token verursacht Lost Updates |
+| 200 bei veraltetem ETag zurückgeben (stilles Überschreiben) | Lost Update: Letzter Schreiber gewinnt, gleichzeitige Bearbeitungen werden still verworfen |
+| Veränderbaren ETag verwenden (z.B. `Last-Modified`-Zeitstempel) | Uhrendrift verursacht unberechtigte 412- oder falsche Übereinstimmungen |
+| Wildcard-`*`-If-Match-Support weglassen | Bricht Admin-Tooling und RFC-7232-Konformität |
+| Keinen DB-seitigen Versionscheck in der WHERE-Klausel | Anwendungscheck gelingt, aber gleichzeitiger DB-Schreibvorgang läuft durch |

--- a/docs/de/howto/optimistic-locking-etag.md
+++ b/docs/de/howto/optimistic-locking-etag.md
@@ -1,0 +1,248 @@
+# How-to: Optimistische Sperre mit ETag / If-Match
+
+> **FT-Referenz**: FT320 (`NENE2-FT/locklog`) — Dokumentversionierung mit ETag-Header, If-Match für Mutationen erforderlich (428), Ablehnung veralteter ETags (412), Verhinderung verlorener Updates, 15 Tests / 30 Assertions PASS.
+
+Diese Anleitung zeigt, wie optimistische Nebenläufigkeitskontrolle mit HTTP-ETags implementiert wird, um verlorene Updates ohne pessimistisches DB-Sperren zu verhindern.
+
+## Schema
+
+```sql
+CREATE TABLE documents (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    version    INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT    NOT NULL
+);
+```
+
+`version` ist das maßgebliche Nebenläufigkeitstoken. ETag ist `"v{version}"`.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/documents` | Dokument erstellen |
+| `GET`  | `/documents/{id}` | Abrufen mit ETag |
+| `PUT`  | `/documents/{id}` | Aktualisieren (If-Match erforderlich) |
+| `DELETE` | `/documents/{id}` | Löschen (If-Match erforderlich) |
+
+## Erstellen
+
+```php
+POST /documents
+{"title": "Hello", "body": "World"}
+→ 201  ETag: "v1"
+{"id": 1, "title": "Hello", "version": 1, ...}
+```
+
+## GET — Gibt ETag zurück
+
+```php
+GET /documents/1
+→ 200  ETag: "v1"
+{"id": 1, "title": "Hello", "version": 1}
+```
+
+Client speichert den ETag und sendet ihn als `If-Match` bei der nächsten Mutation.
+
+## PUT — Optimistische Sperre
+
+```php
+// Client sendet aktuellen ETag
+PUT /documents/1  If-Match: "v1"
+{"title": "Updated"}
+→ 200  ETag: "v2"
+{"id": 1, "title": "Updated", "version": 2}
+
+// Veralteter ETag (ein anderer Client hat zuerst aktualisiert)
+PUT /documents/1  If-Match: "v1"
+→ 412 Precondition Failed
+
+// Fehlendes If-Match
+PUT /documents/1
+{"title": "Keine Sperre"}
+→ 428 Precondition Required
+
+// Wildcard — Versionscheck umgehen
+PUT /documents/1  If-Match: *
+→ 200  // immer erfolgreich wenn Dokument existiert
+```
+
+### Verhinderung verlorener Updates
+
+```
+Alice liest Dokument → version=1, ETag="v1"
+Bob  liest Dokument → version=1, ETag="v1"
+
+Alice: PUT If-Match: "v1" → 200 (Version wird 2)
+Bob:   PUT If-Match: "v1" → 412 ← Bobs Schreiben wird abgelehnt
+
+Bob muss neu-GET, um Alices Änderung zu sehen, dann mit "v2" erneut versuchen
+```
+
+## DELETE — Erfordert auch If-Match
+
+```php
+DELETE /documents/1  If-Match: "v1"  → 200  {"deleted": true}
+DELETE /documents/1  If-Match: "v1"  → 412  // Version bereits hochgesetzt
+DELETE /documents/1                  → 428  // If-Match fehlt
+DELETE /documents/9999  If-Match: "v1" → 404
+```
+
+## Implementierung
+
+```php
+private function update(ServerRequestInterface $request): ResponseInterface
+{
+    $ifMatch = $request->getHeaderLine('If-Match');
+
+    if ($ifMatch === '') {
+        return $this->problems->create(
+            'precondition-required',
+            'If-Match header is required',
+            428,
+        );
+    }
+
+    $doc = $this->repo->findById($id);
+    if ($doc === null) {
+        return $this->json->create(['error' => 'Not found'], 404);
+    }
+
+    // Wildcard oder exakten Versions-Match prüfen
+    $currentETag = '"v' . $doc['version'] . '"';
+    if ($ifMatch !== '*' && $ifMatch !== $currentETag) {
+        return $this->problems->create(
+            'precondition-failed',
+            'Document was modified by another request',
+            412,
+        );
+    }
+
+    $newVersion = $doc['version'] + 1;
+    $this->repo->update($id, $title, $newVersion, $now);
+
+    return $this->json->create($updated, 200)
+        ->withHeader('ETag', '"v' . $newVersion . '"');
+}
+```
+
+---
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — ETag-Brute-Force zum Umgehen der Vorbedingung ✅ SAFE
+
+**Angriff**: Angreifer durchläuft `"v1"`, `"v2"`, `"v3"` bis er die aktuelle Version findet, um ein Update zu erzwingen.
+**Ergebnis**: SAFE — ETag-Brute-Force ist bei einem einfachen sequentiellen Zähler möglich, aber das Update ist immer noch ein legitimer Schreibvorgang. In hochwertigeren Szenarien undurchsichtige ETags verwenden (z.B. `hash('sha256', $version . $secret)`).
+
+---
+
+### ATK-02 — If-Match weglassen für bedingungsloses Schreiben 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet PUT ohne `If-Match`-Header in der Hoffnung, der Server akzeptiere bedingungslose Schreibvorgänge.
+**Ergebnis**: BLOCKED — Fehlendes `If-Match` gibt 428 Precondition Required zurück.
+
+---
+
+### ATK-03 — Wildcard If-Match: * zum Umgehen des Versionschecks 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `If-Match: *`, um bedingungslos zu überschreiben.
+**Ergebnis**: BLOCKED — Wildcard ist per Design akzeptiert (trifft jede bestehende Version), aber das Dokument muss existieren. Für benutzerbezogene Mutation Wildcard auf Admin-Rollen beschränken.
+
+---
+
+### ATK-04 — Race Condition — gleichzeitige Schreibvorgänge mit demselben ETag 🚫 BLOCKED
+
+**Angriff**: Zwei Clients senden gleichzeitig PUT mit `"v1"`. Beide bestehen den ETag-Check vor dem Update.
+**Ergebnis**: BLOCKED — Das DB-UPDATE verwendet `WHERE version = $expectedVersion`. Der zweite Schreibvorgang findet die Version bereits inkrementiert und aktualisiert 0 Zeilen → gibt 412 zurück.
+
+---
+
+### ATK-05 — Beliebigen ETag-Wert injizieren 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `If-Match: "v999999"` für ein Dokument bei Version 1.
+**Ergebnis**: BLOCKED — ETag wird mit dem gespeicherten `"v{version}"`-String verglichen. `"v999999" ≠ "v1"` → 412.
+
+---
+
+### ATK-06 — Header-Injection via If-Match 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `If-Match: "v1"\r\nX-Admin: true`, um Antwort-Header zu injizieren.
+**Ergebnis**: BLOCKED — PSR-7-Header-Parsing entfernt CR/LF aus Header-Werten.
+
+---
+
+### ATK-07 — Löschen mit veraltetem ETag 🚫 BLOCKED
+
+**Angriff**: Angreifer erhält alten ETag, wartet auf Dokumentaktualisierung, sendet dann DELETE mit veraltetem ETag.
+**Ergebnis**: BLOCKED — DELETE prüft ETag genau wie PUT. Veralteter ETag gibt 412 zurück; das Dokument überlebt.
+
+---
+
+### ATK-08 — Negative/Null-Version im ETag 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `If-Match: "v-1"` oder `If-Match: "v0"`.
+**Ergebnis**: BLOCKED — Version beginnt bei 1 und wird nur inkrementiert. `"v-1"` und `"v0"` treffen nie eine gespeicherte Version.
+
+---
+
+### ATK-09 — Vorherigen erfolgreichen ETag wiederholen 🚫 BLOCKED
+
+**Angriff**: Nach erfolgreichem Update (`v1→v2`) repliziert Angreifer `If-Match: "v2"`.
+**Ergebnis**: BLOCKED — Dies ist gültiges Verhalten — der Angreifer hat ein aktuelles Token. Autorisierung (Eigentümerschaftsprüfung) ist der Guard; ETag verhindert nur gleichzeitige Kollision.
+
+---
+
+### ATK-10 — Versionszähler-Überlauf 🚫 BLOCKED
+
+**Angriff**: Versionszähler durch Millionen von Updates zum Überlaufen bringen.
+**Ergebnis**: BLOCKED — PHP-Integer sind 64-Bit (max ~9,2 × 10^18). Overflow ist in der Praxis nicht erreichbar. Rate-Limiting schützt vor schnellen Update-Schleifen.
+
+---
+
+### ATK-11 — ETag-Spoofing in Antwort 🚫 BLOCKED
+
+**Angriff**: Angreifer erstellt eine Anfrage, sodass der Server ein gefälschtes `ETag: "v999"` zurückgibt.
+**Ergebnis**: BLOCKED — ETag wird immer aus `$doc['version']` in der DB berechnet. Keine Benutzereingabe beeinflusst den zurückgegebenen ETag.
+
+---
+
+### ATK-12 — Kein If-Match bei DELETE 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet DELETE ohne `If-Match`.
+**Ergebnis**: BLOCKED — DELETE gibt wie PUT 428 zurück, wenn `If-Match` fehlt.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|---------|
+| ATK-01 | ETag-Brute-Force | ✅ SAFE (sequentiell, aber Hinweis beachten) |
+| ATK-02 | If-Match weglassen | 🚫 BLOCKED |
+| ATK-03 | Wildcard If-Match-Bypass | 🚫 BLOCKED |
+| ATK-04 | Gleichzeitiger Schreib-Race | 🚫 BLOCKED |
+| ATK-05 | Beliebigen ETag injizieren | 🚫 BLOCKED |
+| ATK-06 | Header-Injection via If-Match | 🚫 BLOCKED |
+| ATK-07 | Löschen mit veraltetem ETag | 🚫 BLOCKED |
+| ATK-08 | Negative/Null-Versions-ETag | 🚫 BLOCKED |
+| ATK-09 | Vorherigen ETag wiederholen | ✅ SAFE (Autorisierungsbedenken, nicht ETag) |
+| ATK-10 | Versionszähler-Überlauf | 🚫 BLOCKED |
+| ATK-11 | ETag-Spoofing in Antwort | 🚫 BLOCKED |
+| ATK-12 | Löschen ohne If-Match | 🚫 BLOCKED |
+
+**10 BLOCKED, 2 SAFE, 0 EXPOSED** — Keine kritischen Befunde.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| PUT/DELETE ohne If-Match erlauben | Jedes Schreiben ohne Lock-Token verursacht verlorene Updates |
+| 200 bei veraltetem ETag zurückgeben (stille Überschreibung) | Verlorenes Update: letzter Schreiber gewinnt, gleichzeitige Änderungen werden stillschweigend verworfen |
+| Veränderbaren ETag verwenden (z.B. `Last-Modified`-Timestamp) | Takt-Drift verursacht falsche 412 oder falsche Treffer |
+| Wildcard `*` If-Match-Unterstützung überspringen | Bricht Admin-Tooling und RFC 7232-Konformität |
+| Keine DB-Level-Versionscheck in WHERE-Klausel | Anwendungsprüfung besteht, aber gleichzeitiger DB-Schreibvorgang rast durch |

--- a/docs/de/howto/optimistic-locking.md
+++ b/docs/de/howto/optimistic-locking.md
@@ -1,0 +1,177 @@
+# Optimistische Sperre
+
+Optimistische Sperre verhindert das **Problem verlorener Updates** — wenn zwei gleichzeitige Schreiber denselben Datensatz lesen, unabhängige Änderungen vornehmen und der zweite Schreiber die Änderungen des ersten stillschweigend überschreibt.
+
+Optimistische Sperre verwenden, wenn:
+- Konflikte selten sind (die meisten Updates erfolgreich)
+- Nicht-blockierende Lesevorgänge benötigt werden (kein SELECT FOR UPDATE)
+- Der Datensatz ein `version`- oder `updated_at`-Feld zum Verfolgen seines Zustands hat
+
+## Das Problem verlorener Updates
+
+Ohne Sperre:
+
+```
+Zeit | Schreiber A           | Schreiber B
+-----|----------------------|-------------------
+  1  | GET /articles/1      | GET /articles/1
+     | ← version: 1         | ← version: 1
+  2  | [bearbeitet Titel]   | [bearbeitet Body]
+  3  | PATCH /articles/1    |
+     | title = "A's Titel"  |
+     | ← version: 1, 200 OK |
+  4  |                      | PATCH /articles/1
+     |                      | body = "B's Body"
+     |                      | ← version: 1, 200 OK  ← A's Titel VERLOREN
+```
+
+Schreiber B überschreibt Schreiber A's Titeländerung, weil keiner auf gleichzeitige Modifikation geprüft hat.
+
+## Schema
+
+Eine `version`-Spalte hinzufügen, die bei jedem Update inkrementiert wird:
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    version    INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT NOT NULL
+);
+```
+
+## Repository-Implementierung
+
+```php
+/**
+ * @throws ConflictException wenn ein anderer Schreiber den Datensatz zuerst aktualisiert hat
+ * @throws \RuntimeException wenn der Artikel nicht existiert
+ */
+public function update(int $id, string $title, string $body, int $expectedVersion): Article
+{
+    $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+    // WHERE version = $expectedVersion ist die optimistische Sperr-Prüfung.
+    // Wenn ein anderer Schreiber die Version bereits inkrementiert hat, trifft dieses UPDATE 0 Zeilen.
+    $affected = $this->executor->execute(
+        'UPDATE articles SET title = ?, body = ?, version = version + 1, updated_at = ? WHERE id = ? AND version = ?',
+        [$title, $body, $now, $id, $expectedVersion],
+    );
+
+    if ($affected === 0) {
+        // 0 aktualisierte Zeilen: entweder nicht gefunden ODER Versionskonflikt — unterscheiden
+        $current = $this->findById($id);
+        if ($current === null) {
+            throw new \RuntimeException("Article {$id} does not exist.");
+        }
+        throw new ConflictException($id, $expectedVersion);
+    }
+
+    return new Article(id: $id, title: $title, body: $body, version: $expectedVersion + 1, updatedAt: $now);
+}
+```
+
+### Warum `version = version + 1` in SQL (nicht in PHP)
+
+```php
+// ❌ Race Condition: zwei Schreiber lesen beide version=1, berechnen beide version=2
+$newVersion = $article->version + 1;
+$this->executor->execute('UPDATE ... SET version = ? ...', [$newVersion, $id, $expectedVersion]);
+
+// ✅ Atomar: die Datenbank inkrementiert — version ist immer korrekt
+$this->executor->execute('UPDATE ... SET version = version + 1 ...', [$id, $expectedVersion]);
+```
+
+Die `WHERE version = $expectedVersion`-Prüfung ist der Guard; `version = version + 1` stellt sicher, dass der neue Wert genau eines mehr ist als was den Guard passiert hat.
+
+## Controller-Integration
+
+Der Client muss die aktuelle `version` lesen und sie mit jedem Update zurückschicken:
+
+```php
+private function update(ServerRequestInterface $request): ResponseInterface
+{
+    $id   = (int) Router::param($request, 'id');
+    $body = json_decode((string) $request->getBody(), true);
+
+    if (!is_array($body) || !is_int($body['version'] ?? null)) {
+        return $this->problems->create($request, 'invalid-body', 'version (int) is required.', 400);
+    }
+
+    try {
+        $article = $this->repo->update($id, $body['title'], $body['body'], $body['version']);
+        return $this->json->create($this->serialize($article));
+    } catch (ConflictException $e) {
+        $current = $this->repo->findById($id);
+        return $this->problems->create(
+            $request,
+            'conflict',
+            'Optimistic lock conflict.',
+            409,
+            $e->getMessage(),
+            $current !== null ? ['current_version' => $current->version] : [],
+        );
+    } catch (\RuntimeException) {
+        return $this->problems->create($request, 'not-found', 'Article not found.', 404);
+    }
+}
+```
+
+## Client-Ablauf
+
+```
+POST /articles            → 201 { id: 1, version: 1, ... }
+GET /articles/1           → 200 { id: 1, version: 1, ... }
+
+PATCH /articles/1         → 200 { id: 1, version: 2, ... }
+  { title: "...", version: 1 }
+
+PATCH /articles/1         → 409 { type: "conflict", current_version: 2 }
+  { title: "...", version: 1 }   (veraltete Version — Konflikt!)
+
+PATCH /articles/1         → 200 { id: 1, version: 3, ... }
+  { title: "...", version: 2 }   (neu abrufen oder current_version aus 409 verwenden)
+```
+
+`current_version` in der 409-Antwort zu inkludieren lässt den Client ohne extra GET erneut versuchen.
+
+## Antwort-Payload
+
+`version` immer in jeder Antwort einschließen, damit Clients immer den aktuellen Wert haben:
+
+```php
+/** @return array<string, mixed> */
+private function serialize(Article $article): array
+{
+    return [
+        'id'         => $article->id,
+        'title'      => $article->title,
+        'body'       => $article->body,
+        'version'    => $article->version,  // ← Client braucht dies zum Zurücksenden
+        'updated_at' => $article->updatedAt,
+    ];
+}
+```
+
+## Optimistische vs. Pessimistische Sperre
+
+| | Optimistisch | Pessimistisch |
+|---|---|---|
+| Mechanismus | `WHERE version = ?` + 0-Zeilen-Prüfung | `SELECT ... FOR UPDATE` |
+| Lese-Blockierung | Keine | Blockiert andere Leser |
+| Konfliktrate | Niedrig (die meisten Updates erfolgreich) | Hohe Konkurrenz OK |
+| Neuversuchskosten | Client versucht bei 409 erneut | Wartet auf Lock-Freigabe |
+| SQLite-Unterstützung | ✅ | ❌ (nicht unterstützt) |
+| Am besten für | Seltene Konflikte, UX-gesteuerte Neuversuche | Hohe Konkurrenz, Muss-gelingen-Operationen |
+
+## Code-Review-Checkliste
+
+- [ ] UPDATE enthält `AND version = ?` in der WHERE-Klausel
+- [ ] `execute()`-Rückgabewert (betroffene Zeilen) wird geprüft — 0 bedeutet Konflikt oder nicht gefunden
+- [ ] 0-Zeilen-Fall unterscheidet "nicht gefunden" von "Versionskonflikt" (extra `findById` auf Konfliktpfad)
+- [ ] `version = version + 1` wird in SQL berechnet, nicht im PHP-Anwendungscode
+- [ ] Jeder Antwort-Payload enthält `version`, damit der Client immer den aktuellen hat
+- [ ] 409-Antwort enthält `current_version` für Client-Neuversuch ohne extra GET
+- [ ] `version` im Request-Body wird als `int`, nicht als `string` validiert (`is_int()`-Prüfung)
+- [ ] Tests decken ab: erfolgreiche Aktualisierung, sukzessive Aktualisierungen, gleichzeitiger Konflikt, Neuversuch nach Konflikt, 404, fehlende Version

--- a/docs/de/howto/optimistic-locking.md
+++ b/docs/de/howto/optimistic-locking.md
@@ -1,35 +1,35 @@
-# Optimistische Sperre
+# Optimistic Locking
 
-Optimistische Sperre verhindert das **Problem verlorener Updates** — wenn zwei gleichzeitige Schreiber denselben Datensatz lesen, unabhängige Änderungen vornehmen und der zweite Schreiber die Änderungen des ersten stillschweigend überschreibt.
+Optimistic Locking verhindert das **Lost-Update-Problem** — wenn zwei gleichzeitige Schreiber denselben Datensatz lesen, unabhängige Änderungen vornehmen und der zweite Schreiber die Änderungen des ersten still überschreibt.
 
-Optimistische Sperre verwenden, wenn:
-- Konflikte selten sind (die meisten Updates erfolgreich)
+Optimistic Locking einsetzen, wenn:
+- Konflikte selten sind (die meisten Updates gelingen)
 - Nicht-blockierende Lesevorgänge benötigt werden (kein SELECT FOR UPDATE)
-- Der Datensatz ein `version`- oder `updated_at`-Feld zum Verfolgen seines Zustands hat
+- Der Datensatz ein `version`- oder `updated_at`-Feld zur Zustandsverfolgung hat
 
-## Das Problem verlorener Updates
+## Das Lost-Update-Problem
 
-Ohne Sperre:
+Ohne Locking:
 
 ```
-Zeit | Schreiber A           | Schreiber B
------|----------------------|-------------------
-  1  | GET /articles/1      | GET /articles/1
-     | ← version: 1         | ← version: 1
-  2  | [bearbeitet Titel]   | [bearbeitet Body]
-  3  | PATCH /articles/1    |
-     | title = "A's Titel"  |
-     | ← version: 1, 200 OK |
-  4  |                      | PATCH /articles/1
-     |                      | body = "B's Body"
-     |                      | ← version: 1, 200 OK  ← A's Titel VERLOREN
+Zeit | Schreiber A             | Schreiber B
+-----|------------------------|-------------------
+  1  | GET /articles/1        | GET /articles/1
+     | ← version: 1           | ← version: 1
+  2  | [bearbeitet title]     | [bearbeitet body]
+  3  | PATCH /articles/1      |
+     | title = "A's title"    |
+     | ← version: 1, 200 OK   |
+  4  |                        | PATCH /articles/1
+     |                        | body = "B's body"
+     |                        | ← version: 1, 200 OK  ← A's title VERLOREN
 ```
 
-Schreiber B überschreibt Schreiber A's Titeländerung, weil keiner auf gleichzeitige Modifikation geprüft hat.
+Schreiber B überschreibt Schreiber As Titeländerung, weil keiner auf gleichzeitige Änderungen geprüft hat.
 
 ## Schema
 
-Eine `version`-Spalte hinzufügen, die bei jedem Update inkrementiert wird:
+Eine `version`-Spalte hinzufügen, die bei jedem Update inkrementiert:
 
 ```sql
 CREATE TABLE articles (
@@ -52,7 +52,7 @@ public function update(int $id, string $title, string $body, int $expectedVersio
 {
     $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
 
-    // WHERE version = $expectedVersion ist die optimistische Sperr-Prüfung.
+    // WHERE version = $expectedVersion ist die Optimistic-Lock-Prüfung.
     // Wenn ein anderer Schreiber die Version bereits inkrementiert hat, trifft dieses UPDATE 0 Zeilen.
     $affected = $this->executor->execute(
         'UPDATE articles SET title = ?, body = ?, version = version + 1, updated_at = ? WHERE id = ? AND version = ?',
@@ -75,19 +75,19 @@ public function update(int $id, string $title, string $body, int $expectedVersio
 ### Warum `version = version + 1` in SQL (nicht in PHP)
 
 ```php
-// ❌ Race Condition: zwei Schreiber lesen beide version=1, berechnen beide version=2
+// ❌ Race Condition: zwei Schreiber lesen version=1, berechnen beide version=2
 $newVersion = $article->version + 1;
 $this->executor->execute('UPDATE ... SET version = ? ...', [$newVersion, $id, $expectedVersion]);
 
-// ✅ Atomar: die Datenbank inkrementiert — version ist immer korrekt
+// ✅ Atomar: Die Datenbank inkrementiert — version ist immer korrekt
 $this->executor->execute('UPDATE ... SET version = version + 1 ...', [$id, $expectedVersion]);
 ```
 
-Die `WHERE version = $expectedVersion`-Prüfung ist der Guard; `version = version + 1` stellt sicher, dass der neue Wert genau eines mehr ist als was den Guard passiert hat.
+Die `WHERE version = $expectedVersion`-Prüfung ist der Schutz; `version = version + 1` stellt sicher, dass der neue Wert genau eins mehr als der durch den Schutz bestätigte Wert ist.
 
 ## Controller-Integration
 
-Der Client muss die aktuelle `version` lesen und sie mit jedem Update zurückschicken:
+Der Client muss die aktuelle `version` lesen und sie bei jedem Update zurücksenden:
 
 ```php
 private function update(ServerRequestInterface $request): ResponseInterface
@@ -134,11 +134,11 @@ PATCH /articles/1         → 200 { id: 1, version: 3, ... }
   { title: "...", version: 2 }   (neu abrufen oder current_version aus 409 verwenden)
 ```
 
-`current_version` in der 409-Antwort zu inkludieren lässt den Client ohne extra GET erneut versuchen.
+`current_version` in die 409-Antwort aufzunehmen erlaubt dem Client, ohne extra GET zu wiederholen.
 
 ## Antwort-Payload
 
-`version` immer in jeder Antwort einschließen, damit Clients immer den aktuellen Wert haben:
+`version` immer in jede Antwort einschließen, damit Clients stets den aktuellen Wert haben:
 
 ```php
 /** @return array<string, mixed> */
@@ -148,30 +148,30 @@ private function serialize(Article $article): array
         'id'         => $article->id,
         'title'      => $article->title,
         'body'       => $article->body,
-        'version'    => $article->version,  // ← Client braucht dies zum Zurücksenden
+        'version'    => $article->version,  // ← Client benötigt dies zum Zurücksenden
         'updated_at' => $article->updatedAt,
     ];
 }
 ```
 
-## Optimistische vs. Pessimistische Sperre
+## Optimistic vs. Pessimistic Locking
 
-| | Optimistisch | Pessimistisch |
+| | Optimistic | Pessimistic |
 |---|---|---|
-| Mechanismus | `WHERE version = ?` + 0-Zeilen-Prüfung | `SELECT ... FOR UPDATE` |
-| Lese-Blockierung | Keine | Blockiert andere Leser |
-| Konfliktrate | Niedrig (die meisten Updates erfolgreich) | Hohe Konkurrenz OK |
-| Neuversuchskosten | Client versucht bei 409 erneut | Wartet auf Lock-Freigabe |
+| Mechanismus | `WHERE version = ?` + 0-Zeilen-Check | `SELECT ... FOR UPDATE` |
+| Lese-Blocking | Keines | Blockiert andere Leser |
+| Konfliktrate | Niedrig (die meisten Updates gelingen) | Hoher Contention OK |
+| Wiederholungskosten | Client wiederholt bei 409 | Wartet auf Lock-Freigabe |
 | SQLite-Unterstützung | ✅ | ❌ (nicht unterstützt) |
-| Am besten für | Seltene Konflikte, UX-gesteuerte Neuversuche | Hohe Konkurrenz, Muss-gelingen-Operationen |
+| Am besten für | Seltene Konflikte, UI-gesteuerte Wiederholungen | Hoher Contention, Must-Succeed-Operationen |
 
 ## Code-Review-Checkliste
 
 - [ ] UPDATE enthält `AND version = ?` in der WHERE-Klausel
-- [ ] `execute()`-Rückgabewert (betroffene Zeilen) wird geprüft — 0 bedeutet Konflikt oder nicht gefunden
-- [ ] 0-Zeilen-Fall unterscheidet "nicht gefunden" von "Versionskonflikt" (extra `findById` auf Konfliktpfad)
+- [ ] Rückgabewert von `execute()` (betroffene Zeilen) wird geprüft — 0 bedeutet Konflikt oder nicht gefunden
+- [ ] 0-Zeilen-Fall unterscheidet „nicht gefunden" von „Versionskonflikt" (extra `findById` im Konfliktpfad)
 - [ ] `version = version + 1` wird in SQL berechnet, nicht im PHP-Anwendungscode
-- [ ] Jeder Antwort-Payload enthält `version`, damit der Client immer den aktuellen hat
-- [ ] 409-Antwort enthält `current_version` für Client-Neuversuch ohne extra GET
-- [ ] `version` im Request-Body wird als `int`, nicht als `string` validiert (`is_int()`-Prüfung)
-- [ ] Tests decken ab: erfolgreiche Aktualisierung, sukzessive Aktualisierungen, gleichzeitiger Konflikt, Neuversuch nach Konflikt, 404, fehlende Version
+- [ ] Jeder Antwort-Payload enthält `version`, damit der Client immer den aktuellen Wert hat
+- [ ] 409-Antwort enthält `current_version` für Client-Wiederholung ohne extra GET
+- [ ] `version` im Request-Body wird als `int` validiert, nicht als `string` (`is_int()`-Prüfung)
+- [ ] Tests decken ab: erfolgreiche Aktualisierung, aufeinanderfolgende Updates, gleichzeitiger Konflikt, Wiederholung nach Konflikt, 404, fehlende Version

--- a/docs/de/howto/order-management.md
+++ b/docs/de/howto/order-management.md
@@ -1,0 +1,134 @@
+# How-to: Bestellverwaltungs-API
+
+> **FT-Referenz**: FT274 (`NENE2-FT/orderlog`) — Bestellverwaltung: SKU-validierte Positionen, automatische Berechnung von total_cents, Status-Lebenszyklus (pending→confirmed→shipped→delivered→cancelled), IDOR → 404, Admin-Override, Stornierungskonflikt-Erkennung, 36 Tests PASS.
+>
+> Ebenfalls validiert in FT215 (`NENE2-FT/orderlog`-Vorläufer) — gleiches Muster, frühere Implementierung.
+
+Diese Anleitung zeigt, wie eine Multi-Artikel-Bestellverwaltungs-API mit NENE2 erstellt wird.
+
+## Funktionen
+
+- Bestellungen mit Positionen erstellen (SKU + Menge + Stückpreis)
+- Automatische Gesamtberechnung aus Positionen
+- Status-Lebenszyklus: `pending → confirmed → shipped → delivered → cancelled`
+- Benutzerbezogener IDOR-Schutz (gibt 404 zurück, nicht 403, um Existenz zu verbergen)
+- Admin-Override für benutzerübergreifende Operationen
+- Atomare Stornierung mit Konflikt-Erkennung (kann `cancelled` oder `delivered` nicht stornieren)
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS orders (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'pending',
+    total_cents INTEGER NOT NULL,
+    note        TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+CREATE TABLE IF NOT EXISTS order_items (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id    INTEGER NOT NULL,
+    sku         TEXT    NOT NULL,
+    quantity    INTEGER NOT NULL,
+    unit_cents  INTEGER NOT NULL,
+    FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_orders_user ON orders (user_id, id DESC);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/orders` | Bestellung mit Positionen erstellen |
+| `GET` | `/orders/{id}` | Bestellung mit Positionen abrufen (Eigentümer oder Admin) |
+| `POST` | `/orders/{id}/cancel` | Bestellung stornieren (Eigentümer oder Admin) |
+| `GET` | `/users/{userId}/orders` | Bestellungen für einen Benutzer auflisten (selbst oder Admin) |
+
+## Positionsvalidierung
+
+```php
+/** SKU: Großbuchstaben, alphanumerisch und Bindestriche, 1–32 Zeichen */
+private const string SKU_PATTERN = '/\A[A-Z0-9\-]{1,32}\z/';
+
+// Pro Position:
+// - sku: muss SKU_PATTERN entsprechen
+// - quantity: Integer 1–9999
+// - unit_cents: nicht-negativer Integer
+// Maximal 50 Positionen pro Bestellung
+```
+
+## Repository-Muster
+
+```php
+/**
+ * @param list<array{sku: string, quantity: int, unit_cents: int}> $items
+ * @return array<string, mixed>
+ */
+public function create(int $userId, string $note, array $items): array
+{
+    $totalCents = 0;
+    foreach ($items as $item) {
+        $totalCents += $item['quantity'] * $item['unit_cents'];
+    }
+    // Bestellung INSERT, dann Positionen INSERT, findById() zurückgeben
+}
+
+/** @return 'not_found'|'not_cancellable'|'ok' */
+public function cancel(int $id, int $userId, bool $isAdmin): string
+{
+    // Gibt 'not_found' für falschen Benutzer zurück (IDOR-Schutz)
+    // Gibt 'not_cancellable' für stornierte/gelieferte Bestellungen zurück
+}
+```
+
+## IDOR-Schutz
+
+Benutzerbezogene Endpunkte geben `404` zurück (nicht `403`), wenn ein Benutzer auf die Ressource eines anderen Benutzers zugreift:
+
+```php
+// GET /orders/{id}
+if (!$isAdmin && (int) $order['user_id'] !== $uid) {
+    return $this->problem(404, 'not-found', 'Order not found.');
+}
+
+// GET /users/{userId}/orders
+if (!$isAdmin && $callerUid !== $targetUid) {
+    return $this->problem(404, 'not-found', 'User not found.');
+}
+```
+
+## Stornierung mit Match-Ausdruck
+
+```php
+$result = $this->repo->cancel($id, $uid ?? 0, $isAdmin);
+
+return match ($result) {
+    'not_found'       => $this->problem(404, 'not-found', 'Order not found.'),
+    'not_cancellable' => $this->problem(409, 'conflict', 'Order cannot be cancelled.'),
+    default           => $this->json(['message' => 'Order cancelled.']),
+};
+```
+
+## Sicherheitsmuster
+
+- **Admin fail-closed**: `if ($this->adminKey === '') return false;` vor `hash_equals()`
+- **`ctype_digit()`**: ReDoS-sichere Integer-Validierung für Pfad- und Header-IDs
+- **`is_int()`**: Strenge Typprüfung — lehnt Floats ab (z.B. `1.5` als JSON)
+- **Max-Positionen-Schutz**: Begrenzt auf 50 Positionen, um überdimensionierte Payloads zu verhindern
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Preis als FLOAT speichern | Gleitkomma-Rundungsfehler in Gesamtbeträgen (Integer-Cent verwenden) |
+| Freiform-SKU-Strings akzeptieren | Injection-Angriffsfläche; mit Regex in der Allowlist (z.B. `[A-Z0-9\-]{1,32}`) |
+| Kein Max-Positionen-Limit | Angreifer sendet 10.000-Positions-Array, das eine langsame INSERT-Schleife verursacht |
+| Gesamtbetrag Client-seitig berechnen | Client kann beliebigen Gesamtbetrag senden; immer aus `quantity × unit_cents` ableiten |
+| 403 beim Zugriff auf die Bestellung eines anderen Benutzers zurückgeben | Offenbart, dass die Bestellung existiert; 404 verwenden, um Eigentümerschaft zu verbergen |
+| Stornierung gelieferter Bestellungen erlauben | Erfüllte Bestellungen sollten unveränderlich sein; Zustandsautomat verwenden |
+| `ON DELETE CASCADE` bei order_items weglassen | Beim Löschen einer Bestellung bleiben verwaiste Positionen zurück |

--- a/docs/de/howto/otp-authentication.md
+++ b/docs/de/howto/otp-authentication.md
@@ -1,0 +1,333 @@
+# How-to: OTP-Authentifizierungssystem
+
+> **FT-Referenz**: FT290 (`NENE2-FT/otplog`) — OTP-Authentifizierung: 6-stelliger numerischer Code mit SHA-256-Hash-Speicherung, Brute-Force-Sperrung (3 Versuche → 10 Min), OTP-TTL (5 Min), Replay-Angriffs-Prävention via `used_at`, Session-Token mit SHA-256 + Widerruf, Benutzer-Enumerationsprävention via always-202-Anfrage-Endpunkt, ATK-01~12 PASS, 35 Tests / 44 Assertions PASS.
+
+Diese Anleitung zeigt, wie ein passwortloses OTP-Authentifizierungssystem aufgebaut wird, bei dem Benutzer einen 6-stelligen Code erhalten und ihn gegen ein Session-Token eintauschen.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE otp_codes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    code_hash TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    used_at TEXT,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    locked_until TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE otp_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    session_token_hash TEXT NOT NULL UNIQUE,
+    expires_at TEXT NOT NULL,
+    revoked_at TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+Wichtige Design-Punkte:
+- `code_hash` speichert SHA-256 des OTP, niemals den Rohcode.
+- `attempt_count` + `locked_until` implementieren Brute-Force-Sperrung pro OTP-Zeile.
+- `used_at` verhindert Replay-Angriffe (OTP kann nur einmal verwendet werden).
+- `session_token_hash` speichert SHA-256 des Session-Tokens; `UNIQUE` verhindert Kollisionen.
+- `revoked_at` ermöglicht explizites Ausloggen ohne Löschen der Zeile.
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|-------------|
+| `POST` | `/otp/request` | keine | OTP anfordern (erstellt Benutzer falls nötig) |
+| `POST` | `/otp/verify` | keine | OTP verifizieren, Session-Token erhalten |
+| `GET` | `/otp/session` | `Bearer <token>` | Session-Informationen abrufen |
+| `DELETE` | `/otp/session` | `Bearer <token>` | Ausloggen (Session widerrufen) |
+
+## OTP-Generierung — Rohen Code niemals speichern
+
+```php
+private const int MAX_ATTEMPTS = 3;
+private const int OTP_TTL_MINUTES = 5;
+private const int LOCK_MINUTES = 10;
+private const int SESSION_TTL_HOURS = 24;
+
+$rawCode = str_pad((string) random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+$codeHash = hash('sha256', $rawCode);
+$this->repository->createOtp($userId, $codeHash, $now);
+```
+
+`str_pad` stellt führende Nullen sicher (z.B. `random_int(0, 999999)` gibt `42` zurück → `'000042'`). Der Rohcode wird an die E-Mail des Benutzers gesendet; nur der Hash wird gespeichert. `random_int()` ist kryptografisch sicher.
+
+## Benutzer-Enumerationsprävention — Immer 202
+
+```php
+// Immer 202 — verhindert Benutzer-Enumeration
+// In der Produktion: E-Mail senden. In diesem FT geben wir den Code zum Testen zurück.
+return $this->responseFactory->create([
+    'message' => 'OTP code sent',
+    'code' => $rawCode,  // In der Produktion entfernen
+], 202);
+```
+
+Ob die E-Mail existiert oder nicht, die Antwort ist immer `202 Accepted`. Ein Angreifer kann "Konto existiert" von "Konto existiert nicht" nicht unterscheiden.
+
+## Benutzer bei erster Anfrage automatisch erstellen
+
+```php
+public function findOrCreateUser(string $email, string $now): int
+{
+    $user = $this->findUserByEmail($email);
+    if ($user !== null) {
+        return (int) $user['id'];
+    }
+    return $this->executor->insert(
+        'INSERT INTO users (email, created_at) VALUES (?, ?)',
+        [$email, $now]
+    );
+}
+```
+
+Benutzer werden implizit bei der ersten OTP-Anfrage erstellt — kein separater Registrierungsschritt erforderlich. Der `UNIQUE(email)`-Constraint verhindert Duplikate bei gleichzeitigen Inserts.
+
+## OTP-Verifizierung — Geordnete Prüfungen
+
+```php
+// 1. Sperrungsprüfung (zuerst — vor jedem Code-Vergleich)
+if ($otp['locked_until'] !== null && $now < (string) $otp['locked_until']) {
+    return $this->responseFactory->create(['error' => 'too many attempts, try again later'], 429);
+}
+
+// 2. Ablaufprüfung
+if ($now > (string) $otp['expires_at']) {
+    return $this->responseFactory->create(['error' => 'code expired'], 401);
+}
+
+// 3. Bereits-verwendet-Prüfung
+if ($otp['used_at'] !== null) {
+    return $this->responseFactory->create(['error' => 'code already used'], 401);
+}
+
+// 4. Code-Prüfung mit hash_equals (timing-sicher)
+$codeHash = hash('sha256', $code);
+if (!hash_equals((string) $otp['code_hash'], $codeHash)) {
+    $this->repository->incrementAttempt((int) $otp['id'], $now);
+    return $this->responseFactory->create(['error' => 'invalid code'], 401);
+}
+```
+
+Prüfreihenfolge ist wichtig: Sperrung → Ablauf → verwendet → Code. `attempt_count` nur bei falschem Code inkrementieren — nicht bei Sperrung oder Ablauf.
+
+## Brute-Force-Sperrung
+
+```php
+public function incrementAttempt(int $otpId, string $now): void
+{
+    $otp = $this->executor->fetchOne('SELECT * FROM otp_codes WHERE id = ?', [$otpId]);
+    if ($otp === null) {
+        return;
+    }
+    $newCount = (int) $otp['attempt_count'] + 1;
+    $lockedUntil = null;
+    if ($newCount >= self::MAX_ATTEMPTS) {
+        $lockedUntil = date('c', strtotime($now) + self::LOCK_MINUTES * 60);
+    }
+    $this->executor->execute(
+        'UPDATE otp_codes SET attempt_count = ?, locked_until = ? WHERE id = ?',
+        [$newCount, $lockedUntil, $otpId]
+    );
+}
+```
+
+Nach `MAX_ATTEMPTS` (3) falschen Codes wird `locked_until` 10 Minuten in die Zukunft gesetzt. Die Sperrungsprüfung geschieht vor jedem Code-Vergleich, sodass Versuche während der Sperrung den Timer nicht zurücksetzen.
+
+## Nur neuestes OTP — Neue Anfrage macht altes ungültig
+
+```php
+public function findLatestOtpForUser(int $userId): ?array
+{
+    return $this->executor->fetchOne(
+        'SELECT * FROM otp_codes WHERE user_id = ? ORDER BY id DESC LIMIT 1',
+        [$userId]
+    );
+}
+```
+
+Mehrere OTP-Anfragen erstellen mehrere Zeilen, aber nur das neueste wird zur Verifizierung verwendet. Alte OTPs werden effektiv ungültig — ihr Einreichen gibt 401 zurück.
+
+## Session-Token — SHA-256 + Widerruf
+
+```php
+// Session-Token ausstellen
+$rawToken = bin2hex(random_bytes(32));   // 256-Bit-Entropie, 64 Hex-Zeichen
+$tokenHash = hash('sha256', $rawToken);
+$this->repository->createSession((int) $user['id'], $tokenHash, $now);
+
+return $this->responseFactory->create([
+    'session_token' => $rawToken,
+    'user_id' => (int) $user['id'],
+], 200);
+```
+
+Nur der SHA-256-Hash wird gespeichert. Falls die DB kompromittiert wird, werden Roh-Tokens niemals exponiert.
+
+## Bearer-Token-Extraktion
+
+```php
+private function extractBearerToken(ServerRequestInterface $request): string
+{
+    $header = $request->getHeaderLine('Authorization');
+    if (!str_starts_with($header, 'Bearer ')) {
+        return '';
+    }
+    return trim(substr($header, 7));
+}
+```
+
+Ein leerer String nach `Bearer ` (z.B. `Authorization: Bearer `) wird als fehlend behandelt — gibt 401 zurück.
+
+## Logout — Stilles Erfolgsmeldung
+
+```php
+$session = $this->repository->findSessionByTokenHash($tokenHash);
+if ($session !== null && $session['revoked_at'] === null) {
+    $this->repository->revokeSession($tokenHash, date('c'));
+}
+
+return $this->responseFactory->create(['message' => 'logged out'], 200);
+```
+
+Logout gibt immer 200 zurück — es verrät nicht, ob das Token gültig war. Dies verhindert, dass Angreifer Token-Gültigkeit via Logout-Endpunkt sondieren.
+
+---
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — OTP Brute-Force 🚫 BLOCKED
+
+**Angriff**: Alle `000000`–`999999`-Kombinationen sequentiell ausprobieren.
+**Ergebnis**: BLOCKED — nach `MAX_ATTEMPTS` (3) falschen Codes wird `locked_until` 10 Minuten in die Zukunft gesetzt.
+
+---
+
+### ATK-02 — Replay-Angriff (verwendetes OTP erneut benutzen) 🚫 BLOCKED
+
+**Angriff**: Gültiges OTP erfassen und ein zweites Mal einreichen.
+**Ergebnis**: BLOCKED — `used_at` wird bei erster erfolgreicher Verifizierung gesetzt. Zweiter Versuch findet `used_at !== null` → 401.
+
+---
+
+### ATK-03 — Benutzer-Enumeration via /otp/request 🚫 BLOCKED
+
+**Angriff**: `/otp/request` mit bekannten und unbekannten E-Mails sondieren.
+**Ergebnis**: BLOCKED — sowohl bestehende als auch nicht-existente E-Mails geben immer `202 Accepted` mit identischen Antwort-Bodies zurück.
+
+---
+
+### ATK-04 — Verifizieren für nicht-existenten Benutzer 🚫 BLOCKED
+
+**Angriff**: `/otp/verify` mit einer E-Mail aufrufen, die kein Konto hat.
+**Ergebnis**: BLOCKED — gibt 401 (`invalid code`), nicht 404 oder 500 zurück.
+
+---
+
+### ATK-05 — SQL-Injection im E-Mail-Feld 🚫 BLOCKED
+
+**Angriff**: `'; DROP TABLE users; --` als E-Mail einreichen.
+**Ergebnis**: BLOCKED — `filter_var($email, FILTER_VALIDATE_EMAIL)` lehnt Injektions-Strings als ungültiges E-Mail-Format ab, bevor irgendeine DB-Abfrage ausgeführt wird.
+
+---
+
+### ATK-06 — 5-stelliger Code (zu kurz) 🚫 BLOCKED
+
+**Angriff**: Einen 5-Zeichen-Code einreichen.
+**Ergebnis**: BLOCKED — `/^\d{6}$/` erfordert genau 6 Ziffern. Gibt 422 zurück.
+
+---
+
+### ATK-07 — 7-stelliger Code (zu lang) 🚫 BLOCKED
+
+**Angriff**: Einen 7-stelligen Code einreichen.
+**Ergebnis**: BLOCKED — dasselbe Regex lehnt Codes ab, die nicht genau 6 Ziffern sind. Gibt 422 zurück.
+
+---
+
+### ATK-08 — Session-Token-Wiederverwendung nach Logout 🚫 BLOCKED
+
+**Angriff**: Token nach dem Ausloggen verwenden.
+**Ergebnis**: BLOCKED — `revokeSession()` setzt `revoked_at`. GET-Handler prüft `$session['revoked_at'] !== null` → 401.
+
+---
+
+### ATK-09 — Zufälliges Token-Erraten 🚫 BLOCKED
+
+**Angriff**: Einen zufälligen 64-Hex-String als Bearer-Token einreichen.
+**Ergebnis**: BLOCKED — SHA-256-Hash des zufälligen Tokens entspricht keinem `session_token_hash`. Gibt 401 zurück. Token-Raum ist 2^256.
+
+---
+
+### ATK-10 — Leeres Bearer-Token 🚫 BLOCKED
+
+**Angriff**: `Authorization: Bearer ` senden (leer nach Bearer-Präfix).
+**Ergebnis**: BLOCKED — `trim(substr($header, 7))` gibt leeren String zurück → 401.
+
+---
+
+### ATK-11 — Alphabetischer Code (nicht-numerisch) 🚫 BLOCKED
+
+**Angriff**: `abcdef` als OTP-Code einreichen.
+**Ergebnis**: BLOCKED — `/^\d{6}$/` erfordert nur Dezimalziffern. Gibt 422 zurück.
+
+---
+
+### ATK-12 — Neue OTP-Anfrage macht alten Code ungültig 🚫 BLOCKED (by design)
+
+**Angriff**: Gültiges OTP holen, Opfer lässt neues anfordern, dann ursprünglichen Code einreichen.
+**Ergebnis**: BLOCKED — `findLatestOtpForUser()` ruft nur `ORDER BY id DESC LIMIT 1` ab.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|---------|
+| ATK-01 | OTP Brute-Force | 🚫 BLOCKED |
+| ATK-02 | Replay-Angriff (verwendetes OTP) | 🚫 BLOCKED |
+| ATK-03 | Benutzer-Enumeration via /otp/request | 🚫 BLOCKED |
+| ATK-04 | Nicht-existenten Benutzer verifizieren | 🚫 BLOCKED |
+| ATK-05 | SQL-Injection in E-Mail | 🚫 BLOCKED |
+| ATK-06 | 5-stelliger Code (zu kurz) | 🚫 BLOCKED |
+| ATK-07 | 7-stelliger Code (zu lang) | 🚫 BLOCKED |
+| ATK-08 | Session-Wiederverwendung nach Logout | 🚫 BLOCKED |
+| ATK-09 | Zufälliges Token-Erraten | 🚫 BLOCKED |
+| ATK-10 | Leeres Bearer-Token | 🚫 BLOCKED |
+| ATK-11 | Alphabetischer Code | 🚫 BLOCKED |
+| ATK-12 | Alter OTP durch neue Anfrage ungültig | 🚫 BLOCKED |
+
+**12 BLOCKED, 0 EXPOSED**
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Roh-OTP-Code in DB speichern | DB-Kompromittierung exponiert alle aktiven OTPs; immer SHA-256-Hash |
+| Keine Brute-Force-Sperrung | 6-stelliges OTP hat 10^6 Kombinationen — ohne Sperrung in Sekunden brutforcebar |
+| 404 für unbekannte E-Mail bei verify zurückgeben | Verrät, welche E-Mails Konten haben (Benutzer-Enumeration) |
+| Unterschiedlichen Status für bekannte vs. unbekannte E-Mail bei /request | Dasselbe Enumerationsrisiko; immer 202 zurückgeben |
+| Kein `used_at`-Flag | OTP kann bis zum Ablauf beliebig oft wiederholt werden |
+| Alphabetische oder nicht-6-stellige Codes akzeptieren | Umgeht Format-Vertrag; `/^\d{6}$/`-Prüfung hinzufügen |
+| Roh-Session-Token in DB speichern | DB-Verletzung exponiert alle Sessions; nur SHA-256-Hash speichern |
+| Session-Zeile bei Logout löschen | Widerrufene Tokens können nicht erkannt werden; `revoked_at` für weiches Widerrufen verwenden |
+| Logout-Erfolg/-Fehler basierend auf Token-Gültigkeit verraten | Angreifer sondieren Token-Gültigkeit via Logout; immer 200 zurückgeben |
+| `findAllOtpsForUser()` verwenden und gültiges auswählen | Mehrere aktive OTPs verwirren Zustand; `ORDER BY id DESC LIMIT 1` verwenden |
+| Kein E-Mail-Längenlimit | RFC 5321 Max ist 254 Zeichen; überdimensionierte Eingabe verursacht DB/E-Mail-Probleme |

--- a/docs/de/howto/otp-authentication.md
+++ b/docs/de/howto/otp-authentication.md
@@ -1,8 +1,8 @@
 # How-to: OTP-Authentifizierungssystem
 
-> **FT-Referenz**: FT290 (`NENE2-FT/otplog`) — OTP-Authentifizierung: 6-stelliger numerischer Code mit SHA-256-Hash-Speicherung, Brute-Force-Sperrung (3 Versuche → 10 Min), OTP-TTL (5 Min), Replay-Angriffs-Prävention via `used_at`, Session-Token mit SHA-256 + Widerruf, Benutzer-Enumerationsprävention via always-202-Anfrage-Endpunkt, ATK-01~12 PASS, 35 Tests / 44 Assertions PASS.
+> **FT-Referenz**: FT290 (`NENE2-FT/otplog`) — OTP-Authentifizierung: 6-stelliger numerischer Code mit SHA-256-Hash-Speicherung, Brute-Force-Sperrung (3 Versuche → 10 Min), OTP-TTL (5 Min), Replay-Angriffs-Prävention via `used_at`, Session-Token mit SHA-256 + Widerruf, Benutzer-Enumerations-Prävention via Always-202-Anfrage-Endpunkt, ATK-01~12 PASS, 35 Tests / 44 Assertions PASS.
 
-Diese Anleitung zeigt, wie ein passwortloses OTP-Authentifizierungssystem aufgebaut wird, bei dem Benutzer einen 6-stelligen Code erhalten und ihn gegen ein Session-Token eintauschen.
+Diese Anleitung zeigt, wie ein passwortloses OTP-Authentifizierungssystem (Einmalpasswort) erstellt wird, bei dem Benutzer einen 6-stelligen Code erhalten und ihn gegen ein Session-Token eintauschen.
 
 ## Schema
 
@@ -36,23 +36,23 @@ CREATE TABLE otp_sessions (
 );
 ```
 
-Wichtige Design-Punkte:
+Wichtige Designpunkte:
 - `code_hash` speichert SHA-256 des OTP, niemals den Rohcode.
 - `attempt_count` + `locked_until` implementieren Brute-Force-Sperrung pro OTP-Zeile.
 - `used_at` verhindert Replay-Angriffe (OTP kann nur einmal verwendet werden).
 - `session_token_hash` speichert SHA-256 des Session-Tokens; `UNIQUE` verhindert Kollisionen.
-- `revoked_at` ermöglicht explizites Ausloggen ohne Löschen der Zeile.
+- `revoked_at` ermöglicht expliziten Logout ohne Löschen der Zeile.
 
 ## Endpunkte
 
 | Methode | Pfad | Auth | Beschreibung |
-|---------|------|------|-------------|
-| `POST` | `/otp/request` | keine | OTP anfordern (erstellt Benutzer falls nötig) |
+|--------|------|------|-------------|
+| `POST` | `/otp/request` | keine | OTP anfordern (erstellt Benutzer bei Bedarf) |
 | `POST` | `/otp/verify` | keine | OTP verifizieren, Session-Token erhalten |
 | `GET` | `/otp/session` | `Bearer <token>` | Session-Informationen abrufen |
-| `DELETE` | `/otp/session` | `Bearer <token>` | Ausloggen (Session widerrufen) |
+| `DELETE` | `/otp/session` | `Bearer <token>` | Logout (Session widerrufen) |
 
-## OTP-Generierung — Rohen Code niemals speichern
+## OTP-Generierung — Rohcode niemals speichern
 
 ```php
 private const int MAX_ATTEMPTS = 3;
@@ -65,20 +65,20 @@ $codeHash = hash('sha256', $rawCode);
 $this->repository->createOtp($userId, $codeHash, $now);
 ```
 
-`str_pad` stellt führende Nullen sicher (z.B. `random_int(0, 999999)` gibt `42` zurück → `'000042'`). Der Rohcode wird an die E-Mail des Benutzers gesendet; nur der Hash wird gespeichert. `random_int()` ist kryptografisch sicher.
+`str_pad` stellt führende Nullen sicher (z.B. gibt `random_int(0, 999999)` `42` zurück → `'000042'`). Der Rohcode wird an die E-Mail des Benutzers gesendet; nur der Hash wird gespeichert. `random_int()` ist kryptografisch sicher.
 
-## Benutzer-Enumerationsprävention — Immer 202
+## Benutzer-Enumerations-Prävention — Immer 202
 
 ```php
 // Immer 202 — verhindert Benutzer-Enumeration
-// In der Produktion: E-Mail senden. In diesem FT geben wir den Code zum Testen zurück.
+// In Produktion: E-Mail senden. In diesem FT geben wir den Code zum Testen zurück.
 return $this->responseFactory->create([
     'message' => 'OTP code sent',
-    'code' => $rawCode,  // In der Produktion entfernen
+    'code' => $rawCode,  // in Produktion entfernen
 ], 202);
 ```
 
-Ob die E-Mail existiert oder nicht, die Antwort ist immer `202 Accepted`. Ein Angreifer kann "Konto existiert" von "Konto existiert nicht" nicht unterscheiden.
+Unabhängig davon, ob die E-Mail existiert oder nicht, ist die Antwort immer `202 Accepted`. Ein Angreifer kann „Konto existiert" nicht von „Konto existiert nicht" unterscheiden.
 
 ## Benutzer bei erster Anfrage automatisch erstellen
 
@@ -98,10 +98,10 @@ public function findOrCreateUser(string $email, string $now): int
 
 Benutzer werden implizit bei der ersten OTP-Anfrage erstellt — kein separater Registrierungsschritt erforderlich. Der `UNIQUE(email)`-Constraint verhindert Duplikate bei gleichzeitigen Inserts.
 
-## OTP-Verifizierung — Geordnete Prüfungen
+## OTP-Verifizierung — Reihenfolge der Prüfungen
 
 ```php
-// 1. Sperrungsprüfung (zuerst — vor jedem Code-Vergleich)
+// 1. Sperrprüfung (zuerst — vor jedem Code-Vergleich)
 if ($otp['locked_until'] !== null && $now < (string) $otp['locked_until']) {
     return $this->responseFactory->create(['error' => 'too many attempts, try again later'], 429);
 }
@@ -124,7 +124,7 @@ if (!hash_equals((string) $otp['code_hash'], $codeHash)) {
 }
 ```
 
-Prüfreihenfolge ist wichtig: Sperrung → Ablauf → verwendet → Code. `attempt_count` nur bei falschem Code inkrementieren — nicht bei Sperrung oder Ablauf.
+Die Reihenfolge der Prüfungen ist wichtig: Sperre → Ablauf → verwendet → Code. `attempt_count` nur bei einem falschen Code inkrementieren — nicht bei Sperre oder Ablauf.
 
 ## Brute-Force-Sperrung
 
@@ -147,9 +147,9 @@ public function incrementAttempt(int $otpId, string $now): void
 }
 ```
 
-Nach `MAX_ATTEMPTS` (3) falschen Codes wird `locked_until` 10 Minuten in die Zukunft gesetzt. Die Sperrungsprüfung geschieht vor jedem Code-Vergleich, sodass Versuche während der Sperrung den Timer nicht zurücksetzen.
+Nach `MAX_ATTEMPTS` (3) falschen Codes wird `locked_until` 10 Minuten in die Zukunft gesetzt. Die Sperrprüfung erfolgt vor jedem Code-Vergleich, daher setzen Versuche während der Sperre den Timer nicht zurück.
 
-## Nur neuestes OTP — Neue Anfrage macht altes ungültig
+## Nur neuestes OTP — Neue Anfrage ersetzt alte
 
 ```php
 public function findLatestOtpForUser(int $userId): ?array
@@ -161,7 +161,7 @@ public function findLatestOtpForUser(int $userId): ?array
 }
 ```
 
-Mehrere OTP-Anfragen erstellen mehrere Zeilen, aber nur das neueste wird zur Verifizierung verwendet. Alte OTPs werden effektiv ungültig — ihr Einreichen gibt 401 zurück.
+Mehrere OTP-Anfragen erstellen mehrere Zeilen, aber nur die neueste wird zur Verifizierung verwendet. Alte OTPs sind effektiv ungültig — deren Einreichung gibt 401 zurück.
 
 ## Session-Token — SHA-256 + Widerruf
 
@@ -177,7 +177,7 @@ return $this->responseFactory->create([
 ], 200);
 ```
 
-Nur der SHA-256-Hash wird gespeichert. Falls die DB kompromittiert wird, werden Roh-Tokens niemals exponiert.
+Nur der SHA-256-Hash wird gespeichert. Bei einem DB-Kompromiss werden Rohtoken niemals exponiert.
 
 ## Bearer-Token-Extraktion
 
@@ -194,7 +194,7 @@ private function extractBearerToken(ServerRequestInterface $request): string
 
 Ein leerer String nach `Bearer ` (z.B. `Authorization: Bearer `) wird als fehlend behandelt — gibt 401 zurück.
 
-## Logout — Stilles Erfolgsmeldung
+## Logout — Stiller Erfolg
 
 ```php
 $session = $this->repository->findSessionByTokenHash($tokenHash);
@@ -205,114 +205,115 @@ if ($session !== null && $session['revoked_at'] === null) {
 return $this->responseFactory->create(['message' => 'logged out'], 200);
 ```
 
-Logout gibt immer 200 zurück — es verrät nicht, ob das Token gültig war. Dies verhindert, dass Angreifer Token-Gültigkeit via Logout-Endpunkt sondieren.
+Logout gibt immer 200 zurück — verrät nicht, ob das Token gültig war. Dies verhindert, dass Angreifer Token-Gültigkeit über den Logout-Endpunkt sondieren.
 
 ---
 
-## ATK-Bewertung — Cracker-Mindset-Angriffstest
+## ATK Assessment — Cracker-Mindset-Angriffstest
 
-### ATK-01 — OTP Brute-Force 🚫 BLOCKED
+### ATK-01 — OTP-Brute-Force 🚫 BLOCKED
 
-**Angriff**: Alle `000000`–`999999`-Kombinationen sequentiell ausprobieren.
-**Ergebnis**: BLOCKED — nach `MAX_ATTEMPTS` (3) falschen Codes wird `locked_until` 10 Minuten in die Zukunft gesetzt.
+**Angriff**: Alle `000000`–`999999` Kombinationen sequentiell ausprobieren.
+**Ergebnis**: BLOCKED — nach `MAX_ATTEMPTS` (3) falschen Codes wird `locked_until` 10 Minuten in die Zukunft gesetzt. Nachfolgende Versuche geben 429 zurück, bis die Sperre abläuft.
 
 ---
 
-### ATK-02 — Replay-Angriff (verwendetes OTP erneut benutzen) 🚫 BLOCKED
+### ATK-02 — Replay-Angriff (verwendetes OTP wiederverwenden) 🚫 BLOCKED
 
-**Angriff**: Gültiges OTP erfassen und ein zweites Mal einreichen.
-**Ergebnis**: BLOCKED — `used_at` wird bei erster erfolgreicher Verifizierung gesetzt. Zweiter Versuch findet `used_at !== null` → 401.
+**Angriff**: Ein gültiges OTP aufzeichnen und es ein zweites Mal einreichen, nachdem es bereits verwendet wurde.
+**Ergebnis**: BLOCKED — `used_at` wird bei der ersten erfolgreichen Verifizierung gesetzt. Ein zweiter Versuch findet `used_at !== null` → 401.
 
 ---
 
 ### ATK-03 — Benutzer-Enumeration via /otp/request 🚫 BLOCKED
 
-**Angriff**: `/otp/request` mit bekannten und unbekannten E-Mails sondieren.
-**Ergebnis**: BLOCKED — sowohl bestehende als auch nicht-existente E-Mails geben immer `202 Accepted` mit identischen Antwort-Bodies zurück.
+**Angriff**: `/otp/request` mit bekannten und unbekannten E-Mails sondieren, um herauszufinden, welche Konten existieren.
+**Ergebnis**: BLOCKED — Sowohl vorhandene als auch nicht vorhandene E-Mails geben immer `202 Accepted` mit identischen Response-Bodies zurück.
 
 ---
 
-### ATK-04 — Verifizieren für nicht-existenten Benutzer 🚫 BLOCKED
+### ATK-04 — Verifizierung für nicht existierenden Benutzer 🚫 BLOCKED
 
 **Angriff**: `/otp/verify` mit einer E-Mail aufrufen, die kein Konto hat.
-**Ergebnis**: BLOCKED — gibt 401 (`invalid code`), nicht 404 oder 500 zurück.
+**Ergebnis**: BLOCKED — gibt 401 (`invalid code`) zurück, nicht 404 oder 500. Kein Stack-Trace oder Konto-Existenz-Signal in der Antwort.
 
 ---
 
 ### ATK-05 — SQL-Injection im E-Mail-Feld 🚫 BLOCKED
 
 **Angriff**: `'; DROP TABLE users; --` als E-Mail einreichen.
-**Ergebnis**: BLOCKED — `filter_var($email, FILTER_VALIDATE_EMAIL)` lehnt Injektions-Strings als ungültiges E-Mail-Format ab, bevor irgendeine DB-Abfrage ausgeführt wird.
+**Ergebnis**: BLOCKED — `filter_var($email, FILTER_VALIDATE_EMAIL)` lehnt Injection-Strings als ungültiges E-Mail-Format ab, bevor eine DB-Abfrage erfolgt. Alle Abfragen verwenden parametrisierte Statements.
 
 ---
 
 ### ATK-06 — 5-stelliger Code (zu kurz) 🚫 BLOCKED
 
-**Angriff**: Einen 5-Zeichen-Code einreichen.
+**Angriff**: Einen 5-Zeichen-Code einreichen, um die OTP-Formatprüfung zu umgehen.
 **Ergebnis**: BLOCKED — `/^\d{6}$/` erfordert genau 6 Ziffern. Gibt 422 zurück.
 
 ---
 
 ### ATK-07 — 7-stelliger Code (zu lang) 🚫 BLOCKED
 
-**Angriff**: Einen 7-stelligen Code einreichen.
-**Ergebnis**: BLOCKED — dasselbe Regex lehnt Codes ab, die nicht genau 6 Ziffern sind. Gibt 422 zurück.
+**Angriff**: Einen 7-stelligen Code einreichen, um die Formatvalidierung zu umgehen.
+**Ergebnis**: BLOCKED — Dieselbe Regex lehnt Codes ab, die nicht genau 6 Ziffern sind. Gibt 422 zurück.
 
 ---
 
 ### ATK-08 — Session-Token-Wiederverwendung nach Logout 🚫 BLOCKED
 
-**Angriff**: Token nach dem Ausloggen verwenden.
-**Ergebnis**: BLOCKED — `revokeSession()` setzt `revoked_at`. GET-Handler prüft `$session['revoked_at'] !== null` → 401.
+**Angriff**: Ein Token nach dem Logout verwenden, um den Zugriff aufrechtzuerhalten.
+**Ergebnis**: BLOCKED — `revokeSession()` setzt `revoked_at`. Der GET-Handler prüft `$session['revoked_at'] !== null` → 401.
 
 ---
 
-### ATK-09 — Zufälliges Token-Erraten 🚫 BLOCKED
+### ATK-09 — Zufälliges Token-Raten 🚫 BLOCKED
 
 **Angriff**: Einen zufälligen 64-Hex-String als Bearer-Token einreichen.
-**Ergebnis**: BLOCKED — SHA-256-Hash des zufälligen Tokens entspricht keinem `session_token_hash`. Gibt 401 zurück. Token-Raum ist 2^256.
+**Ergebnis**: BLOCKED — SHA-256-Hash des zufälligen Tokens stimmt mit keinem `session_token_hash` überein. Gibt 401 zurück. Token-Raum ist 2^256.
 
 ---
 
 ### ATK-10 — Leeres Bearer-Token 🚫 BLOCKED
 
 **Angriff**: `Authorization: Bearer ` senden (leer nach Bearer-Präfix).
-**Ergebnis**: BLOCKED — `trim(substr($header, 7))` gibt leeren String zurück → 401.
+**Ergebnis**: BLOCKED — `trim(substr($header, 7))` gibt leeren String zurück → `if ($token === '') return 401`.
 
 ---
 
 ### ATK-11 — Alphabetischer Code (nicht-numerisch) 🚫 BLOCKED
 
 **Angriff**: `abcdef` als OTP-Code einreichen.
-**Ergebnis**: BLOCKED — `/^\d{6}$/` erfordert nur Dezimalziffern. Gibt 422 zurück.
+**Ergebnis**: BLOCKED — `/^\d{6}$/` erfordert nur Dezimalziffern. Gibt 422 zurück, bevor DB-Interaktion.
 
 ---
 
 ### ATK-12 — Neue OTP-Anfrage macht alten Code ungültig 🚫 BLOCKED (by design)
 
-**Angriff**: Gültiges OTP holen, Opfer lässt neues anfordern, dann ursprünglichen Code einreichen.
-**Ergebnis**: BLOCKED — `findLatestOtpForUser()` ruft nur `ORDER BY id DESC LIMIT 1` ab.
+**Angriff**: Gültiges OTP erhalten, Opfer lässt neues OTP anfordern, dann ursprünglichen Code einreichen.
+**Ergebnis**: BLOCKED — `findLatestOtpForUser()` ruft nur `ORDER BY id DESC LIMIT 1` ab. Das alte OTP ist überholt; seine Einreichung gibt 401 zurück (falscher Code-Hash für das neueste OTP).
 
 ---
 
 ### ATK-Zusammenfassung
 
 | ID | Angriff | Ergebnis |
-|----|---------|---------|
-| ATK-01 | OTP Brute-Force | 🚫 BLOCKED |
+|----|--------|--------|
+| ATK-01 | OTP-Brute-Force | 🚫 BLOCKED |
 | ATK-02 | Replay-Angriff (verwendetes OTP) | 🚫 BLOCKED |
 | ATK-03 | Benutzer-Enumeration via /otp/request | 🚫 BLOCKED |
-| ATK-04 | Nicht-existenten Benutzer verifizieren | 🚫 BLOCKED |
+| ATK-04 | Verifizierung nicht existierender Benutzer | 🚫 BLOCKED |
 | ATK-05 | SQL-Injection in E-Mail | 🚫 BLOCKED |
 | ATK-06 | 5-stelliger Code (zu kurz) | 🚫 BLOCKED |
 | ATK-07 | 7-stelliger Code (zu lang) | 🚫 BLOCKED |
 | ATK-08 | Session-Wiederverwendung nach Logout | 🚫 BLOCKED |
-| ATK-09 | Zufälliges Token-Erraten | 🚫 BLOCKED |
+| ATK-09 | Zufälliges Token-Raten | 🚫 BLOCKED |
 | ATK-10 | Leeres Bearer-Token | 🚫 BLOCKED |
 | ATK-11 | Alphabetischer Code | 🚫 BLOCKED |
-| ATK-12 | Alter OTP durch neue Anfrage ungültig | 🚫 BLOCKED |
+| ATK-12 | Altes OTP durch neue Anfrage ungültig | 🚫 BLOCKED |
 
 **12 BLOCKED, 0 EXPOSED**
+Hash-basierte Speicherung, Brute-Force-Sperrung, `used_at`-Replay-Schutz, Formatvalidierung und Always-202-Enumerationsprävention decken alle kritischen OTP-Angriffsvektoren ab.
 
 ---
 
@@ -320,14 +321,14 @@ Logout gibt immer 200 zurück — es verrät nicht, ob das Token gültig war. Di
 
 | Anti-Muster | Risiko |
 |---|---|
-| Roh-OTP-Code in DB speichern | DB-Kompromittierung exponiert alle aktiven OTPs; immer SHA-256-Hash |
-| Keine Brute-Force-Sperrung | 6-stelliges OTP hat 10^6 Kombinationen — ohne Sperrung in Sekunden brutforcebar |
-| 404 für unbekannte E-Mail bei verify zurückgeben | Verrät, welche E-Mails Konten haben (Benutzer-Enumeration) |
-| Unterschiedlichen Status für bekannte vs. unbekannte E-Mail bei /request | Dasselbe Enumerationsrisiko; immer 202 zurückgeben |
-| Kein `used_at`-Flag | OTP kann bis zum Ablauf beliebig oft wiederholt werden |
-| Alphabetische oder nicht-6-stellige Codes akzeptieren | Umgeht Format-Vertrag; `/^\d{6}$/`-Prüfung hinzufügen |
-| Roh-Session-Token in DB speichern | DB-Verletzung exponiert alle Sessions; nur SHA-256-Hash speichern |
-| Session-Zeile bei Logout löschen | Widerrufene Tokens können nicht erkannt werden; `revoked_at` für weiches Widerrufen verwenden |
-| Logout-Erfolg/-Fehler basierend auf Token-Gültigkeit verraten | Angreifer sondieren Token-Gültigkeit via Logout; immer 200 zurückgeben |
-| `findAllOtpsForUser()` verwenden und gültiges auswählen | Mehrere aktive OTPs verwirren Zustand; `ORDER BY id DESC LIMIT 1` verwenden |
-| Kein E-Mail-Längenlimit | RFC 5321 Max ist 254 Zeichen; überdimensionierte Eingabe verursacht DB/E-Mail-Probleme |
+| Rohcode des OTP in DB speichern | DB-Kompromiss exponiert alle aktiven OTPs; immer SHA-256 hashen |
+| Keine Brute-Force-Sperrung | 6-stelliges OTP hat 10^6 Kombinationen — ohne Sperrung in Sekunden knackbar |
+| 404 für unbekannte E-Mail bei Verifizierung zurückgeben | Verrät, welche E-Mails Konten haben (Benutzer-Enumeration) |
+| Unterschiedlichen Status für bekannte vs. unbekannte E-Mail bei /request zurückgeben | Gleiches Enumerationsrisiko; immer 202 zurückgeben |
+| Kein `used_at`-Flag | OTP kann unbegrenzt bis zum Ablauf wiederholt werden |
+| Alphabetische oder nicht-6-stellige Codes akzeptieren | Umgeht Formatvertrag; `/^\d{6}$/`-Prüfung hinzufügen |
+| Rohes Session-Token in DB speichern | DB-Verletzung exponiert alle Sessions; nur SHA-256-Hash speichern |
+| Session-Zeile beim Logout löschen | Widerrufene Tokens können nicht erkannt werden; `revoked_at` für Soft-Widerruf verwenden |
+| Logout-Erfolg/Fehler basierend auf Token-Gültigkeit verraten | Angreifer sondieren Token-Gültigkeit via Logout; immer 200 zurückgeben |
+| `findAllOtpsForUser()` verwenden und gültiges auswählen | Mehrere aktive OTPs verwirren den Zustand; `ORDER BY id DESC LIMIT 1` verwenden |
+| Keine E-Mail-Längenbegrenzung | RFC 5321 Maximum ist 254 Zeichen; überdimensionierter Input verursacht DB/E-Mail-Probleme |

--- a/docs/de/howto/pagination-boundary-attack.md
+++ b/docs/de/howto/pagination-boundary-attack.md
@@ -1,25 +1,27 @@
-# How-to: Paginierungsgrenze und Limit-Injection
+# How-to: Paginierungsgrenze & Limit-Injection
 
 **FT177 — limitlog**
 
-Kugelsichere Integer-Parameter-Validierung für offset- und cursor-basierte Paginierung — verhindert DB-Dumps, Überläufe, Typverwirrung und ReDoS.
+Kugelsichere Integer-Parametervalidierung für Offset- und Cursor-basierte Paginierung —
+verhindert DB-Dumps, Überläufe, Typverwechslung und ReDoS.
 
 ---
 
 ## Die Angriffsfläche
 
-Jeder Paginierungs-Endpunkt exponiert mindestens zwei Integer-Parameter (`limit`, `page` / `after`). Angreifer sondieren diese routinemäßig mit:
+Jeder Paginierungsendpunkt exponiert mindestens zwei Integer-Parameter (`limit`, `page` / `after`).
+Angreifer sondieren diese routinemäßig mit:
 
 | Angriff | Beispiel | Risiko |
-|---------|---------|--------|
-| Überdimensioniertes Limit | `limit=999999` | Full-Table-Dump |
-| Null/negativ | `limit=0`, `limit=-1` | Negatives OFFSET → DB-Fehler oder Umbruch |
+|--------|---------|------|
+| Überdimensionierter Limit | `limit=999999` | Vollständiger Tabellen-Dump |
+| Null/Negativ | `limit=0`, `limit=-1` | Negativer OFFSET → DB-Fehler oder Überlauf |
 | Float-Injection | `limit=10.5`, `limit=1e2` | Stiller Cast: `(int)"10.5" === 10` |
-| Gefüllt / vorzeichenbehaftet | `limit=+10`, `limit= 10` | Stilles Trim: `(int)" 10" === 10` |
-| Integer-Overflow | `limit=99999999999999999999` | 64-Bit-Umbruch zu Negativ |
+| Gepolstert / vorzeichenbehaftet | `limit=+10`, `limit= 10` | Stilles Trimmen: `(int)" 10" === 10` |
+| Integer-Überlauf | `limit=99999999999999999999` | 64-Bit-Überlauf zu negativem Wert |
 | Nicht-numerisch | `limit=abc`, `limit=1;DROP TABLE` | Typfehler oder Injection |
 | Hex / Oktal | `limit=0x10`, `limit=010` | `0x` → schlägt ctype fehl; `010` besteht! |
-| Duplikat-Parameter | `?limit=5&limit=1000` | Letzter Wert überschattet validierten |
+| Doppelter Parameter | `?limit=5&limit=1000` | Letzter Wert überschattet validierten |
 | ReDoS-Payload | `limit=111...1x` | Exponentielles Regex-Backtracking |
 
 ---
@@ -44,7 +46,7 @@ private function clampInt(array $params, string $key, ?int $default, int $min, i
         return null;  // Signal: Aufrufer muss 422 zurückgeben
     }
 
-    // PHP-stillen Overflow verhindern: (int)"99999999999999999999" umbricht
+    // PHP-stillen Überlauf verhindern: (int)"99999999999999999999" läuft über
     if (strlen($raw) > 18) {
         return null;
     }
@@ -62,7 +64,7 @@ private function clampInt(array $params, string $key, ?int $default, int $min, i
 ### Warum `ctype_digit`, nicht Regex
 
 | Validator | ReDoS-sicher? | Lehnt `010` ab? | Lehnt `+10` ab? |
-|-----------|--------------|----------------|----------------|
+|-----------|------------|----------------|----------------|
 | `/^\d+$/` | ❌ exponentiell bei `111...1x` | ✅ | ❌ |
 | `ctype_digit()` | ✅ O(n) | ✅ (`0`-Präfix: besteht — aber durch Bereich begrenzt) | ✅ |
 | `is_numeric()` | ✅ | ❌ | ❌ |
@@ -72,14 +74,16 @@ private function clampInt(array $params, string $key, ?int $default, int $min, i
 
 ### Die `010`-Tücke
 
-`ctype_digit('010')` → `true` (besteht Zifferprüfung), `(int)'010'` → `10` (dezimal, nicht oktal). Dies ist sicher, weil PHP bei String-Cast-Integern keine Oktal-Interpretation durchführt (im Gegensatz zu `010` als PHP-Literal). In Tests bestätigen, wenn das Team unsicher ist.
+`ctype_digit('010')` → `true` (besteht Ziffernprüfung), `(int)'010'` → `10` (dezimal, nicht oktal).
+Das ist sicher, weil PHP bei String-gecasteten Integern keine Oktal-Interpretation durchführt
+(anders als `010` als PHP-Literal). In Tests bestätigen, wenn das Team unsicher ist.
 
 ---
 
 ## Cursor-basierte Paginierung
 
 ```php
-// Eine extra Zeile abrufen, um has_more zu bestimmen — keine COUNT-Abfrage nötig
+// Eine zusätzliche Zeile abrufen, um has_more zu bestimmen — keine COUNT-Abfrage nötig
 $rows = $this->db->fetchAll(
     'SELECT * FROM articles WHERE id < ? ORDER BY id DESC LIMIT ?',
     [$afterId, $limit + 1],
@@ -87,26 +91,27 @@ $rows = $this->db->fetchAll(
 
 $hasMore = count($rows) > $limit;
 if ($hasMore) {
-    array_pop($rows);  // Sentinel-Zeile verwerfen
+    array_pop($rows);  // Sentinel verwerfen
 }
 
 $nextCursor = $hasMore && count($rows) > 0 ? end($rows)->id : null;
 ```
 
-### Cursor-Sentinel für "erste Seite"
+### Cursor-Sentinel für „erste Seite"
 
 ```php
 private const int NO_CURSOR = PHP_INT_MAX;
 
-// GET /articles/cursor (kein ?after-Parameter) → afterId standardmäßig PHP_INT_MAX
+// GET /articles/cursor (kein ?after-Parameter) → afterId auf PHP_INT_MAX voreingestellt
 // WHERE id < PHP_INT_MAX  ==>  effektiv alle Zeilen
 ```
 
 ---
 
-## Offset-Paginierung — Seite-Null-Guard
+## Offset-Paginierung — Seite-Null-Schutz
 
-`page=0` erzeugt `OFFSET = (0-1) * limit = -limit` — negatives OFFSET ist ein SQL-Fehler in einigen Datenbanken (MySQL lehnt es ab) oder umbricht in anderen stillschweigend.
+`page=0` erzeugt `OFFSET = (0-1) * limit = -limit` — negativer OFFSET ist ein SQL-Fehler
+in einigen Datenbanken (MySQL lehnt ihn ab) oder läuft in anderen still über.
 
 ```php
 $page  = $this->clampInt($params, 'page', 1, 1, PHP_INT_MAX);
@@ -115,42 +120,44 @@ $page  = $this->clampInt($params, 'page', 1, 1, PHP_INT_MAX);
 
 ---
 
-## Integer-Overflow-Guard
+## Integer-Überlauf-Schutz
 
-PHPs `(int)`-Cast auf einem 20-stelligen String umbricht stillschweigend:
+PHPs `(int)`-Cast auf einem 20-stelligen String läuft still über:
 
 ```php
-(int)'99999999999999999999'  // === -1 auf 64-Bit PHP
+(int)'99999999999999999999'  // === -1 auf 64-Bit-PHP
 ```
 
-Der `strlen($raw) > 18`-Guard verhindert dies vor dem Cast. 18 Ziffern decken `PHP_INT_MAX` (19 Ziffern) sicher mit einer Marge ab, sodass der Cast immer sicher ist.
+Der `strlen($raw) > 18`-Schutz verhindert dies vor dem Cast. 18 Stellen decken sicher
+`PHP_INT_MAX` (19 Stellen) mit einem Puffer ab, damit der Cast immer sicher ist.
 
 ---
 
 ## VULN-A bis VULN-L Checkliste
 
 | # | Test | Erwartung |
-|---|------|----------|
-| VULN-A | `limit` über MAX (100) | 422 — explizite Ablehnung, kein stilles Abschneiden |
+|---|------|-------------|
+| VULN-A | `limit` über MAX (100) | 422 — explizite Ablehnung, keine stille Abschneidung |
 | VULN-B | `limit=0`, `limit=-1` | 422 — `0` schlägt min=1 fehl; `-` schlägt ctype_digit fehl |
 | VULN-C | Float-String `10.5`, `1e2`, `1.0` | 422 — `.` und `e` schlagen ctype_digit fehl |
-| VULN-D | Gefüllt `%2010`, `10%20`, `%2B10` | 422 — Leerzeichen/`+` schlagen ctype_digit fehl |
-| VULN-E | Overflow `9999...` (20 Ziffern) | 422 — strlen > 18 Guard |
-| VULN-F | Nicht-numerisch, Hex `0x10`, SQL-Injection | 422 — ctype_digit lehnt alles ab |
-| VULN-G | `page=0` (Offset-Paginierung) | 422 — min=1 Guard |
-| VULN-H | Cursor-Grenze: `after=0` gültig, Overflow-Cursor 422 | Gemischt |
+| VULN-D | Gepolstert `%2010`, `10%20`, `%2B10` | 422 — Leerzeichen/`+` schlagen ctype_digit fehl |
+| VULN-E | Überlauf `9999...` (20 Stellen) | 422 — strlen > 18 Schutz |
+| VULN-F | Nicht-numerisch, hex `0x10`, SQL-Injection | 422 — ctype_digit lehnt alle ab |
+| VULN-G | `page=0` (Offset-Paginierung) | 422 — min=1 Schutz |
+| VULN-H | Cursor-Grenze: `after=0` gültig, Überlauf-Cursor 422 | Gemischt |
 | VULN-I | `author_id=0`, `-1`, `abc`, `1.5` | 422 |
-| VULN-J | Sehr große Seite (page=999999) | 200 leer — darf nicht abstürzen |
-| VULN-K | Duplikat-Parameter `?limit=5&limit=1000` | 200 (sicher) oder 422 — niemals > MAX |
-| VULN-L | ReDoS-Payload `111...1x` (50 Ziffern + x) | 422 in < 100ms |
+| VULN-J | Sehr große Seitennummer (page=999999) | 200 leer — darf nicht abstürzen |
+| VULN-K | Doppelter Parameter `?limit=5&limit=1000` | 200 (sicher) oder 422 — niemals > MAX |
+| VULN-L | ReDoS-Payload `111...1x` (50 Stellen + x) | 422 in < 100ms |
 
 ---
 
-## Testhinweis: VULN-J vs VULN-A
+## Test-Hinweis: VULN-J vs. VULN-A
 
-Diese scheinen widersprüchlich, dienen aber unterschiedlichen Zielen:
+Diese sehen widersprüchlich aus, dienen aber unterschiedlichen Zielen:
 
-- **VULN-A**: `limit=999999` → **422** — unangemessen große Zeilenzahl ablehnen
+- **VULN-A**: `limit=999999` → **422** — unangemessen große Zeilenanzahl ablehnen
 - **VULN-J**: `page=999999&limit=10` → **200 leer** — eine gültige Seite, die zufällig keine Daten hat
 
-Der Server darf bei einer semantisch gültigen, aber praktisch leeren Seite nicht abstürzen oder fehler machen. `OFFSET = (999999-1) * 10 = 9999980` ist ein legales SQL-OFFSET; das Ergebnis ist einfach leer.
+Der Server darf bei einer semantisch gültigen, aber praktisch leeren Seite nicht abstürzen oder Fehler zurückgeben.
+`OFFSET = (999999-1) * 10 = 9999980` ist ein legaler SQL-OFFSET; das Ergebnis ist einfach leer.

--- a/docs/de/howto/pagination-boundary-attack.md
+++ b/docs/de/howto/pagination-boundary-attack.md
@@ -1,0 +1,156 @@
+# How-to: Paginierungsgrenze und Limit-Injection
+
+**FT177 — limitlog**
+
+Kugelsichere Integer-Parameter-Validierung für offset- und cursor-basierte Paginierung — verhindert DB-Dumps, Überläufe, Typverwirrung und ReDoS.
+
+---
+
+## Die Angriffsfläche
+
+Jeder Paginierungs-Endpunkt exponiert mindestens zwei Integer-Parameter (`limit`, `page` / `after`). Angreifer sondieren diese routinemäßig mit:
+
+| Angriff | Beispiel | Risiko |
+|---------|---------|--------|
+| Überdimensioniertes Limit | `limit=999999` | Full-Table-Dump |
+| Null/negativ | `limit=0`, `limit=-1` | Negatives OFFSET → DB-Fehler oder Umbruch |
+| Float-Injection | `limit=10.5`, `limit=1e2` | Stiller Cast: `(int)"10.5" === 10` |
+| Gefüllt / vorzeichenbehaftet | `limit=+10`, `limit= 10` | Stilles Trim: `(int)" 10" === 10` |
+| Integer-Overflow | `limit=99999999999999999999` | 64-Bit-Umbruch zu Negativ |
+| Nicht-numerisch | `limit=abc`, `limit=1;DROP TABLE` | Typfehler oder Injection |
+| Hex / Oktal | `limit=0x10`, `limit=010` | `0x` → schlägt ctype fehl; `010` besteht! |
+| Duplikat-Parameter | `?limit=5&limit=1000` | Letzter Wert überschattet validierten |
+| ReDoS-Payload | `limit=111...1x` | Exponentielles Regex-Backtracking |
+
+---
+
+## Das `clampInt()`-Muster
+
+```php
+/**
+ * @param array<string, mixed> $params
+ */
+private function clampInt(array $params, string $key, ?int $default, int $min, int $max): ?int
+{
+    if (!array_key_exists($key, $params)) {
+        return $default;  // abwesend → Standard verwenden (nicht null = ungültig)
+    }
+
+    $raw = $params[$key];
+
+    // ctype_digit: O(n), ReDoS-immun, lehnt '' / '-' / '.' / '+' / ' ' / 'e' ab
+    // ctype_digit('') === false  →  leerer String bereits abgelehnt
+    if (!is_string($raw) || !ctype_digit($raw)) {
+        return null;  // Signal: Aufrufer muss 422 zurückgeben
+    }
+
+    // PHP-stillen Overflow verhindern: (int)"99999999999999999999" umbricht
+    if (strlen($raw) > 18) {
+        return null;
+    }
+
+    $value = (int) $raw;
+
+    if ($value < $min || $value > $max) {
+        return null;
+    }
+
+    return $value;
+}
+```
+
+### Warum `ctype_digit`, nicht Regex
+
+| Validator | ReDoS-sicher? | Lehnt `010` ab? | Lehnt `+10` ab? |
+|-----------|--------------|----------------|----------------|
+| `/^\d+$/` | ❌ exponentiell bei `111...1x` | ✅ | ❌ |
+| `ctype_digit()` | ✅ O(n) | ✅ (`0`-Präfix: besteht — aber durch Bereich begrenzt) | ✅ |
+| `is_numeric()` | ✅ | ❌ | ❌ |
+| `filter_var(FILTER_VALIDATE_INT)` | ✅ | ✅ | ❌ (`+10` besteht!) |
+
+**`ctype_digit()` verwenden** — es ist das strengste und schnellste.
+
+### Die `010`-Tücke
+
+`ctype_digit('010')` → `true` (besteht Zifferprüfung), `(int)'010'` → `10` (dezimal, nicht oktal). Dies ist sicher, weil PHP bei String-Cast-Integern keine Oktal-Interpretation durchführt (im Gegensatz zu `010` als PHP-Literal). In Tests bestätigen, wenn das Team unsicher ist.
+
+---
+
+## Cursor-basierte Paginierung
+
+```php
+// Eine extra Zeile abrufen, um has_more zu bestimmen — keine COUNT-Abfrage nötig
+$rows = $this->db->fetchAll(
+    'SELECT * FROM articles WHERE id < ? ORDER BY id DESC LIMIT ?',
+    [$afterId, $limit + 1],
+);
+
+$hasMore = count($rows) > $limit;
+if ($hasMore) {
+    array_pop($rows);  // Sentinel-Zeile verwerfen
+}
+
+$nextCursor = $hasMore && count($rows) > 0 ? end($rows)->id : null;
+```
+
+### Cursor-Sentinel für "erste Seite"
+
+```php
+private const int NO_CURSOR = PHP_INT_MAX;
+
+// GET /articles/cursor (kein ?after-Parameter) → afterId standardmäßig PHP_INT_MAX
+// WHERE id < PHP_INT_MAX  ==>  effektiv alle Zeilen
+```
+
+---
+
+## Offset-Paginierung — Seite-Null-Guard
+
+`page=0` erzeugt `OFFSET = (0-1) * limit = -limit` — negatives OFFSET ist ein SQL-Fehler in einigen Datenbanken (MySQL lehnt es ab) oder umbricht in anderen stillschweigend.
+
+```php
+$page  = $this->clampInt($params, 'page', 1, 1, PHP_INT_MAX);
+// min=1 → page=0 gibt null zurück → 422
+```
+
+---
+
+## Integer-Overflow-Guard
+
+PHPs `(int)`-Cast auf einem 20-stelligen String umbricht stillschweigend:
+
+```php
+(int)'99999999999999999999'  // === -1 auf 64-Bit PHP
+```
+
+Der `strlen($raw) > 18`-Guard verhindert dies vor dem Cast. 18 Ziffern decken `PHP_INT_MAX` (19 Ziffern) sicher mit einer Marge ab, sodass der Cast immer sicher ist.
+
+---
+
+## VULN-A bis VULN-L Checkliste
+
+| # | Test | Erwartung |
+|---|------|----------|
+| VULN-A | `limit` über MAX (100) | 422 — explizite Ablehnung, kein stilles Abschneiden |
+| VULN-B | `limit=0`, `limit=-1` | 422 — `0` schlägt min=1 fehl; `-` schlägt ctype_digit fehl |
+| VULN-C | Float-String `10.5`, `1e2`, `1.0` | 422 — `.` und `e` schlagen ctype_digit fehl |
+| VULN-D | Gefüllt `%2010`, `10%20`, `%2B10` | 422 — Leerzeichen/`+` schlagen ctype_digit fehl |
+| VULN-E | Overflow `9999...` (20 Ziffern) | 422 — strlen > 18 Guard |
+| VULN-F | Nicht-numerisch, Hex `0x10`, SQL-Injection | 422 — ctype_digit lehnt alles ab |
+| VULN-G | `page=0` (Offset-Paginierung) | 422 — min=1 Guard |
+| VULN-H | Cursor-Grenze: `after=0` gültig, Overflow-Cursor 422 | Gemischt |
+| VULN-I | `author_id=0`, `-1`, `abc`, `1.5` | 422 |
+| VULN-J | Sehr große Seite (page=999999) | 200 leer — darf nicht abstürzen |
+| VULN-K | Duplikat-Parameter `?limit=5&limit=1000` | 200 (sicher) oder 422 — niemals > MAX |
+| VULN-L | ReDoS-Payload `111...1x` (50 Ziffern + x) | 422 in < 100ms |
+
+---
+
+## Testhinweis: VULN-J vs VULN-A
+
+Diese scheinen widersprüchlich, dienen aber unterschiedlichen Zielen:
+
+- **VULN-A**: `limit=999999` → **422** — unangemessen große Zeilenzahl ablehnen
+- **VULN-J**: `page=999999&limit=10` → **200 leer** — eine gültige Seite, die zufällig keine Daten hat
+
+Der Server darf bei einer semantisch gültigen, aber praktisch leeren Seite nicht abstürzen oder fehler machen. `OFFSET = (999999-1) * 10 = 9999980` ist ein legales SQL-OFFSET; das Ergebnis ist einfach leer.

--- a/docs/de/howto/pagination-limit-injection.md
+++ b/docs/de/howto/pagination-limit-injection.md
@@ -1,0 +1,144 @@
+# How-to: Paginierungsgrenze und Limit-Injection-Prävention
+
+> **FT-Referenz**: FT319 (`NENE2-FT/limitlog`) — Offset- und Cursor-Paginierung mit strikter Limit/Seite-Validierung, MAX_LIMIT-Cap-Durchsetzung, ReDoS-sichere ctype_digit-Validierung, 20 Tests / 384 Assertions PASS.
+
+Diese Anleitung zeigt, wie sichere Paginierung mit Offset- und Cursor-Strategien implementiert wird, während Integer-Grenzangriffe und Limit-Injection verhindert werden.
+
+## Konstanten
+
+```php
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT     = 100;
+```
+
+## Offset-Paginierung
+
+```php
+GET /articles?page=1&limit=10
+→ 200
+{
+  "data": [...],      // 10 Artikel
+  "total": 25,
+  "limit": 10,
+  "page": 1,
+  "has_more": true
+}
+```
+
+```php
+// Seite 3 von 25 Artikeln bei limit=10 → letzte Seite
+GET /articles?page=3&limit=10
+→ 200  {"data": [...], "has_more": false}  // 5 Artikel
+```
+
+**OFFSET-Berechnung**: `(page - 1) * limit` — Seite muss ≥ 1 sein, um negatives OFFSET zu verhindern.
+
+## Cursor-Paginierung
+
+```php
+GET /articles/cursor?limit=5
+→ 200  {"data": [...], "next_cursor": 42, "has_more": true}
+
+GET /articles/cursor?after=42&limit=5
+→ 200  {"data": [...], "next_cursor": 37, "has_more": true}
+
+GET /articles/cursor?after=37&limit=5
+→ 200  {"data": [...], "next_cursor": null, "has_more": false}
+```
+
+Cursor ist die `id` des letzten Artikels: `WHERE id < $after ORDER BY id DESC LIMIT $limit`.
+
+## Autoren-Filter
+
+```php
+GET /articles/by-author?author_id=2&limit=10
+→ 200  {"data": [...]}  // nur author_id = 2 Artikel
+```
+
+`author_id` muss ein positiver Integer sein (gleiche Validierung wie `limit`).
+
+## Limit-Validierung — `ctype_digit`-Muster
+
+`ctype_digit()` für O(n)-Validierung verwenden — immun gegen ReDoS im Gegensatz zu Regex `^\d+$`:
+
+```php
+/**
+ * Einen Query-String-Integer-Parameter parsen.
+ * Lehnt ab: null, negativ, float, Overflow, nicht-numerisch, Leerzeichen.
+ */
+function parseQueryInt(string $raw, int $min, int $max): int
+{
+    // Leer, Floats, Vorzeichen, Leerzeichen, Nicht-Ziffer-Zeichen ablehnen
+    if ($raw === '' || !ctype_digit($raw)) {
+        throw new ValidationException(/* 422 */);
+    }
+    // Guard gegen 64-Bit-Overflow vor Cast
+    if (strlen($raw) > 18) {
+        throw new ValidationException(/* 422 */);
+    }
+    $val = (int) $raw;
+    if ($val < $min || $val > $max) {
+        throw new ValidationException(/* 422 */);
+    }
+    return $val;
+}
+```
+
+### Was `ctype_digit` blockiert
+
+| Eingabe | `ctype_digit` | Warum |
+|---------|--------------|-------|
+| `"10"` | ✅ Bestanden | Gültige Ziffern |
+| `"0"` | ✅ Bestanden (ctype) | Von min=1-Prüfung abgelehnt |
+| `"-1"` | ❌ Abgelehnt | `-` ist keine Ziffer |
+| `"10.5"` | ❌ Abgelehnt | `.` ist keine Ziffer |
+| `"1e2"` | ❌ Abgelehnt | `e` ist keine Ziffer |
+| `"+10"` | ❌ Abgelehnt | `+` ist keine Ziffer |
+| `" 10"` | ❌ Abgelehnt | Leerzeichen ist keine Ziffer |
+| `"0x10"` | ❌ Abgelehnt | `x` ist keine Ziffer |
+| `"10\x00"` | ❌ Abgelehnt | Null-Byte ist keine Ziffer |
+| 20-stelliger String | ❌ Abgelehnt | strlen > 18 Guard |
+| ReDoS-Payload `"1...1x"` | ❌ Abgelehnt (schnell) | O(n)-Scan, kein Backtracking |
+
+### Fehlerfälle
+
+```php
+GET /articles?limit=999999  → 422  // überschreitet MAX_LIMIT
+GET /articles?limit=0       → 422  // min=1
+GET /articles?limit=-1      → 422  // nicht ctype_digit
+GET /articles?limit=10.5    → 422  // Float
+GET /articles?limit=abc     → 422  // nicht-numerisch
+GET /articles?page=0        → 422  // negatives OFFSET
+GET /articles/cursor?after=99999999999999999999  → 422  // Overflow
+```
+
+## Duplikat-Parameter-Angriff
+
+```php
+GET /articles?limit=5&limit=1000
+// PHP nimmt letzten Wert: 1000 → überschreitet MAX_LIMIT → 422
+```
+
+Die meisten PSR-7-Implementierungen nehmen das letzte Vorkommen. Entweder 422 (letzter Wert über MAX) oder 200 mit dem gültigen Wert ist akzeptabel — niemals stillschweigend 1000 verwenden.
+
+## Große Seitenzahl
+
+```php
+GET /articles?page=999999&limit=10
+→ 200  {"data": [], "has_more": false}  // leer, kein Absturz
+```
+
+Eine riesige Seite, die die Gesamtzahl überschreitet, ist gültig — sie gibt leere Daten zurück, keinen Fehler.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `(int) $raw` ohne `ctype_digit` | `-1`, `1.5`, `" 10"` werden alle stillschweigend zu Integern gecastet |
+| Regex `/^\d+$/` für Integer-Validierung | Katastrophales Backtracking (ReDoS) bei langen gemischten Eingaben |
+| Kein MAX_LIMIT-Cap | `limit=999999` dumpt die gesamte Tabelle in einer Anfrage |
+| `page=0` erlauben | `OFFSET = (0-1)*limit = -limit` korrumpiert oder verursacht SQL-Fehler |
+| Nur strlen-Overflow-Guard | `"1.5"` ist 3 Zeichen — kurz genug um zu bestehen, aber kein gültiger Integer |
+| Keine Mindestprüfung für `author_id` | `author_id=0` gibt stillschweigend leeres Ergebnis zurück; semantisch ungültig |

--- a/docs/de/howto/pagination-limit-injection.md
+++ b/docs/de/howto/pagination-limit-injection.md
@@ -1,8 +1,8 @@
-# How-to: Paginierungsgrenze und Limit-Injection-Prävention
+# How-to: Paginierungsgrenze & Limit-Injection-Prävention
 
-> **FT-Referenz**: FT319 (`NENE2-FT/limitlog`) — Offset- und Cursor-Paginierung mit strikter Limit/Seite-Validierung, MAX_LIMIT-Cap-Durchsetzung, ReDoS-sichere ctype_digit-Validierung, 20 Tests / 384 Assertions PASS.
+> **FT-Referenz**: FT319 (`NENE2-FT/limitlog`) — Offset- und Cursor-Paginierung mit strikter Limit/Seite-Validierung, MAX_LIMIT-Begrenzung, ReDoS-sichere ctype_digit-Validierung, 20 Tests / 384 Assertions PASS.
 
-Diese Anleitung zeigt, wie sichere Paginierung mit Offset- und Cursor-Strategien implementiert wird, während Integer-Grenzangriffe und Limit-Injection verhindert werden.
+Diese Anleitung zeigt, wie sichere Paginierung mit Offset- und Cursor-Strategien implementiert wird und dabei Integer-Grenzangriffe und Limit-Injection verhindert werden.
 
 ## Konstanten
 
@@ -17,7 +17,7 @@ const MAX_LIMIT     = 100;
 GET /articles?page=1&limit=10
 → 200
 {
-  "data": [...],      // 10 Artikel
+  "data": [...],      // 10 Einträge
   "total": 25,
   "limit": 10,
   "page": 1,
@@ -26,12 +26,12 @@ GET /articles?page=1&limit=10
 ```
 
 ```php
-// Seite 3 von 25 Artikeln bei limit=10 → letzte Seite
+// Seite 3 von 25 Einträgen bei limit=10 → letzte Seite
 GET /articles?page=3&limit=10
-→ 200  {"data": [...], "has_more": false}  // 5 Artikel
+→ 200  {"data": [...], "has_more": false}  // 5 Einträge
 ```
 
-**OFFSET-Berechnung**: `(page - 1) * limit` — Seite muss ≥ 1 sein, um negatives OFFSET zu verhindern.
+**OFFSET-Berechnung**: `(page - 1) * limit` — page muss ≥ 1 sein, um negativen OFFSET zu verhindern.
 
 ## Cursor-Paginierung
 
@@ -46,33 +46,33 @@ GET /articles/cursor?after=37&limit=5
 → 200  {"data": [...], "next_cursor": null, "has_more": false}
 ```
 
-Cursor ist die `id` des letzten Artikels: `WHERE id < $after ORDER BY id DESC LIMIT $limit`.
+Cursor ist die `id` des letzten Elements: `WHERE id < $after ORDER BY id DESC LIMIT $limit`.
 
-## Autoren-Filter
+## Autorenfilter
 
 ```php
 GET /articles/by-author?author_id=2&limit=10
-→ 200  {"data": [...]}  // nur author_id = 2 Artikel
+→ 200  {"data": [...]}  // nur author_id = 2 Einträge
 ```
 
 `author_id` muss ein positiver Integer sein (gleiche Validierung wie `limit`).
 
 ## Limit-Validierung — `ctype_digit`-Muster
 
-`ctype_digit()` für O(n)-Validierung verwenden — immun gegen ReDoS im Gegensatz zu Regex `^\d+$`:
+`ctype_digit()` für O(n)-Validierung verwenden — immun gegen ReDoS, anders als Regex `^\d+$`:
 
 ```php
 /**
  * Einen Query-String-Integer-Parameter parsen.
- * Lehnt ab: null, negativ, float, Overflow, nicht-numerisch, Leerzeichen.
+ * Lehnt ab: null, negativ, float, Überlauf, nicht-numerisch, Leerzeichen.
  */
 function parseQueryInt(string $raw, int $min, int $max): int
 {
-    // Leer, Floats, Vorzeichen, Leerzeichen, Nicht-Ziffer-Zeichen ablehnen
+    // Leere, Floats, Vorzeichen, Leerzeichen, Nicht-Ziffern-Zeichen ablehnen
     if ($raw === '' || !ctype_digit($raw)) {
         throw new ValidationException(/* 422 */);
     }
-    // Guard gegen 64-Bit-Overflow vor Cast
+    // Schutz gegen 64-Bit-Überlauf vor Cast
     if (strlen($raw) > 18) {
         throw new ValidationException(/* 422 */);
     }
@@ -87,9 +87,9 @@ function parseQueryInt(string $raw, int $min, int $max): int
 ### Was `ctype_digit` blockiert
 
 | Eingabe | `ctype_digit` | Warum |
-|---------|--------------|-------|
-| `"10"` | ✅ Bestanden | Gültige Ziffern |
-| `"0"` | ✅ Bestanden (ctype) | Von min=1-Prüfung abgelehnt |
+|-------|--------------|-----|
+| `"10"` | ✅ Besteht | Gültige Ziffern |
+| `"0"` | ✅ Besteht (ctype) | Durch min=1-Prüfung abgelehnt |
 | `"-1"` | ❌ Abgelehnt | `-` ist keine Ziffer |
 | `"10.5"` | ❌ Abgelehnt | `.` ist keine Ziffer |
 | `"1e2"` | ❌ Abgelehnt | `e` ist keine Ziffer |
@@ -97,7 +97,7 @@ function parseQueryInt(string $raw, int $min, int $max): int
 | `" 10"` | ❌ Abgelehnt | Leerzeichen ist keine Ziffer |
 | `"0x10"` | ❌ Abgelehnt | `x` ist keine Ziffer |
 | `"10\x00"` | ❌ Abgelehnt | Null-Byte ist keine Ziffer |
-| 20-stelliger String | ❌ Abgelehnt | strlen > 18 Guard |
+| 20-stelliger String | ❌ Abgelehnt | strlen > 18 Schutz |
 | ReDoS-Payload `"1...1x"` | ❌ Abgelehnt (schnell) | O(n)-Scan, kein Backtracking |
 
 ### Fehlerfälle
@@ -106,29 +106,29 @@ function parseQueryInt(string $raw, int $min, int $max): int
 GET /articles?limit=999999  → 422  // überschreitet MAX_LIMIT
 GET /articles?limit=0       → 422  // min=1
 GET /articles?limit=-1      → 422  // nicht ctype_digit
-GET /articles?limit=10.5    → 422  // Float
+GET /articles?limit=10.5    → 422  // float
 GET /articles?limit=abc     → 422  // nicht-numerisch
-GET /articles?page=0        → 422  // negatives OFFSET
-GET /articles/cursor?after=99999999999999999999  → 422  // Overflow
+GET /articles?page=0        → 422  // negativer OFFSET
+GET /articles/cursor?after=99999999999999999999  → 422  // Überlauf
 ```
 
-## Duplikat-Parameter-Angriff
+## Doppelter-Parameter-Angriff
 
 ```php
 GET /articles?limit=5&limit=1000
 // PHP nimmt letzten Wert: 1000 → überschreitet MAX_LIMIT → 422
 ```
 
-Die meisten PSR-7-Implementierungen nehmen das letzte Vorkommen. Entweder 422 (letzter Wert über MAX) oder 200 mit dem gültigen Wert ist akzeptabel — niemals stillschweigend 1000 verwenden.
+Die meisten PSR-7-Implementierungen nehmen das letzte Vorkommen. Entweder 422 (letzter Wert über MAX) oder 200 mit dem gültigen Wert ist akzeptabel — niemals 1000 still verwenden.
 
-## Große Seitenzahl
+## Große Seitennummer
 
 ```php
 GET /articles?page=999999&limit=10
 → 200  {"data": [], "has_more": false}  // leer, kein Absturz
 ```
 
-Eine riesige Seite, die die Gesamtzahl überschreitet, ist gültig — sie gibt leere Daten zurück, keinen Fehler.
+Eine enorme Seite, die die Gesamtanzahl überschreitet, ist gültig — gibt leere Daten zurück, keinen Fehler.
 
 ---
 
@@ -136,9 +136,9 @@ Eine riesige Seite, die die Gesamtzahl überschreitet, ist gültig — sie gibt 
 
 | Anti-Muster | Risiko |
 |---|---|
-| `(int) $raw` ohne `ctype_digit` | `-1`, `1.5`, `" 10"` werden alle stillschweigend zu Integern gecastet |
+| `(int) $raw` ohne `ctype_digit` | `-1`, `1.5`, `" 10"` werden alle still zu Integern gecastet |
 | Regex `/^\d+$/` für Integer-Validierung | Katastrophales Backtracking (ReDoS) bei langen gemischten Eingaben |
-| Kein MAX_LIMIT-Cap | `limit=999999` dumpt die gesamte Tabelle in einer Anfrage |
-| `page=0` erlauben | `OFFSET = (0-1)*limit = -limit` korrumpiert oder verursacht SQL-Fehler |
-| Nur strlen-Overflow-Guard | `"1.5"` ist 3 Zeichen — kurz genug um zu bestehen, aber kein gültiger Integer |
-| Keine Mindestprüfung für `author_id` | `author_id=0` gibt stillschweigend leeres Ergebnis zurück; semantisch ungültig |
+| Kein MAX_LIMIT-Limit | `limit=999999` dumpt die gesamte Tabelle in einer Anfrage |
+| `page=0` erlauben | `OFFSET = (0-1)*limit = -limit` korrumpiert oder macht die SQL-Abfrage fehlerhaft |
+| Nur strlen-Überlauf-Schutz | `"1.5"` ist 3 Zeichen — kurz genug zum Bestehen, aber kein gültiger Integer |
+| Keine Mindestprüfung für `author_id` | `author_id=0` gibt leere Ergebnisse still zurück; semantisch ungültig |

--- a/docs/de/howto/pagination.md
+++ b/docs/de/howto/pagination.md
@@ -1,0 +1,159 @@
+# Paginierung
+
+Für die Paginierung von Listen-Endpunkten stehen zwei Muster zur Verfügung: **OFFSET** und **Cursor** (Keyset). Die Wahl hängt von Datenmenge und UI-Anforderungen ab.
+
+## Kurzvergleich
+
+| | OFFSET | Cursor |
+|---|---|---|
+| Implementierung | Einfach | Moderat (fetch+1-Muster) |
+| Gesamtanzahl | Erfordert `COUNT(*)` | Nicht benötigt |
+| Tiefe-Seiten-Geschwindigkeit | Sinkt linear | Konstant (Index-Seek) |
+| Seitennummer-UI | Einfach | Schwierig |
+| Infinite Scroll / Feed | Fragil (Zeilen-Drift) | Stabil |
+| Datenänderungen beim Durchsuchen | Kann Zeilen-Drift verursachen | Stabil |
+
+**Faustregel:** OFFSET für Admin-Tabellen mit Seitenzahlen und kleinen Datensätzen verwenden. Cursor für Feeds, Infinite Scroll und jede Tabelle mit mehr als ~10.000 Zeilen.
+
+## OFFSET-Paginierung
+
+```php
+private function listByOffset(ServerRequestInterface $request): ResponseInterface
+{
+    $limit  = max(1, min(100, QueryStringParser::int($request, 'limit', 20) ?? 20));
+    $offset = max(0, QueryStringParser::int($request, 'offset', 0) ?? 0);
+
+    $items = $repo->fetchAll(
+        'SELECT * FROM articles ORDER BY id DESC LIMIT ? OFFSET ?',
+        [$limit, $offset],
+    );
+    $total = $repo->fetchOne('SELECT COUNT(*) AS cnt FROM articles', [])['cnt'] ?? 0;
+
+    return $json->create([
+        'items'       => $items,
+        'limit'       => $limit,
+        'offset'      => $offset,
+        'total'       => (int) $total,
+        'has_more'    => ($offset + $limit) < (int) $total,
+        'next_offset' => ($offset + $limit) < (int) $total ? $offset + $limit : null,
+    ]);
+}
+```
+
+**Warum OFFSET langsamer wird**: Die Datenbank muss alle Zeilen vor dem Offset scannen und verwerfen. Bei `OFFSET 5000` liest die Engine 5001 Zeilen und verwirft die ersten 5000. Mit SQLite überprüfen:
+
+```sql
+EXPLAIN QUERY PLAN
+SELECT * FROM articles ORDER BY id DESC LIMIT 20 OFFSET 5000;
+-- SCAN articles USING INDEX idx_articles_id_desc
+-- Der Scan berührt immer noch 5020 Zeilen.
+```
+
+## Cursor-Paginierung
+
+Der Cursor ist die `id` der zuletzt gesehenen Zeile. Jede Seite holt Zeilen "vor" dem Cursor (für absteigende Reihenfolge) mit `WHERE id < cursor`, was der Index mit einem Seek bedient — keine Zeilen vor dem Cursor werden berührt.
+
+```php
+private function listByCursor(ServerRequestInterface $request): ResponseInterface
+{
+    $limit   = max(1, min(100, QueryStringParser::int($request, 'limit', 20) ?? 20));
+    $afterId = QueryStringParser::int($request, 'after'); // null = erste Seite
+
+    // fetch+1-Muster: has_more erkennen ohne COUNT-Abfrage
+    $fetch = $limit + 1;
+
+    if ($afterId === null) {
+        $rows = $repo->fetchAll(
+            'SELECT * FROM articles ORDER BY id DESC LIMIT ?',
+            [$fetch],
+        );
+    } else {
+        $rows = $repo->fetchAll(
+            'SELECT * FROM articles WHERE id < ? ORDER BY id DESC LIMIT ?',
+            [$afterId, $fetch],
+        );
+    }
+
+    $hasMore = count($rows) > $limit;
+    if ($hasMore) {
+        array_pop($rows); // die extra Sentinel-Zeile verwerfen
+    }
+
+    $nextCursor = $hasMore && $rows !== [] ? (int) end($rows)['id'] : null;
+
+    return $json->create([
+        'items'       => $rows,
+        'limit'       => $limit,
+        'has_more'    => $hasMore,
+        'next_cursor' => $nextCursor,
+    ]);
+}
+```
+
+### Das fetch+1-Muster
+
+Um zu wissen, ob es eine nächste Seite gibt, ohne `COUNT(*)` auszugeben:
+
+1. `limit + 1` Zeilen anfordern.
+2. Wenn das Ergebnis mehr als `limit` Zeilen hat, gibt es eine nächste Seite.
+3. Die letzte Zeile verwerfen (`array_pop`) vor der Rückgabe.
+4. Die `id` der letzten verbleibenden Zeile als `next_cursor` verwenden.
+
+Dies vermeidet eine extra Abfrage auf Kosten des Abrufens einer extra Zeile.
+
+### Client-Verwendung
+
+```
+GET /articles/cursor?limit=20
+→ { items: [...20 Artikel], has_more: true, next_cursor: 42 }
+
+GET /articles/cursor?limit=20&after=42
+→ { items: [...20 Artikel], has_more: true, next_cursor: 22 }
+
+GET /articles/cursor?limit=20&after=22
+→ { items: [...2 Artikel], has_more: false, next_cursor: null }
+```
+
+## Limit-Klemmung
+
+Das Limit immer auf einen vernünftigen Bereich klemmen, um unbegrenzte Abfragen zu verhindern:
+
+```php
+$limit = max(1, min(100, QueryStringParser::int($request, 'limit', 20) ?? 20));
+```
+
+Dies akzeptiert `1–100` und setzt Standard auf `20`, wenn der Parameter fehlt.
+
+## Wann von OFFSET zu Cursor wechseln
+
+Eine grobe Richtlinie basierend auf Tabellengröße und typischer Seitenbenutzte:
+
+| Zeilen | Typische Tiefe | Empfehlung |
+|--------|----------------|-----------|
+| < 10.000 | Beliebig | Beide funktionieren; OFFSET ist einfacher |
+| 10.000–100.000 | Flach (Seite 1–5) | Beide; Index auf Sortierspalte hinzufügen |
+| 10.000–100.000 | Tief (Seite 10+) | Cursor bevorzugt |
+| > 100.000 | Beliebig | Cursor stark empfohlen |
+
+Unabhängig vom verwendeten Ansatz einen Index auf die Sortierspalte hinzufügen:
+
+```sql
+CREATE INDEX idx_articles_id_desc ON articles (id DESC);
+```
+
+## Ergebnisse an derselben Position vergleichen
+
+Bei der Migration von OFFSET zu Cursor die Korrektheit durch Abrufen desselben "Fensters" von Zeilen auf beiden Wegen überprüfen:
+
+```php
+// OFFSET: Zeilen 11–20 (0-indizierter offset=10)
+$offsetPage = $get('/articles/offset?limit=10&offset=10');
+
+// Cursor: die id an Position 10 abrufen (offset=9), als Anker verwenden
+$anchor     = $get('/articles/offset?limit=1&offset=9');
+$anchorId   = $anchor['items'][0]['id'];
+$cursorPage = $get("/articles/cursor?limit=10&after={$anchorId}");
+
+// Diese sollten identisch sein
+assert(array_column($offsetPage['items'], 'id') === array_column($cursorPage['items'], 'id'));
+```

--- a/docs/de/howto/password-auth-argon2id.md
+++ b/docs/de/howto/password-auth-argon2id.md
@@ -1,0 +1,157 @@
+# How-to: Passwort-Authentifizierung mit Argon2id
+
+> **FT-Referenz**: FT331 (`NENE2-FT/pwdlog`) — Benutzerregistrierung und Login mit Argon2id-Passwort-Hashing, Passwort/Hash niemals in Antworten exponiert, Benutzer-Enumerations-Prävention (gleiche 401 für falsches Passwort und unbekannte E-Mail), algorithmische Migrations-Rehash, 14 Tests / 40 Assertions PASS.
+
+Diese Anleitung zeigt, wie sichere passwortbasierte Authentifizierung aufgebaut wird: Passwörter sicher mit Argon2id speichern, Anmeldedaten niemals in Antworten preisgeben und verhindern, dass Angreifer registrierte E-Mail-Adressen aufzählen.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    email         TEXT    NOT NULL UNIQUE,
+    password_hash TEXT    NOT NULL,
+    created_at    TEXT    NOT NULL
+);
+```
+
+`password_hash` speichert den vollständigen Argon2id-Ausgabe-String (z.B. `$argon2id$v=19$m=65536,...`). **Niemals Klartext oder MD5/SHA-1 speichern.**
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/register` | Neuen Benutzer registrieren |
+| `POST` | `/login` | Authentifizieren und Benutzerdaten zurückgeben |
+
+## Registrierung
+
+```php
+POST /register
+{"email": "alice@example.com", "password": "correct-horse"}
+
+→ 201
+{"id": 1, "email": "alice@example.com", "created_at": "2026-05-27T09:00:00Z"}
+```
+
+**`password` und `password_hash` werden NIEMALS** in der Antwort zurückgegeben — nicht einmal maskiert oder abgeschnitten.
+
+### Validierung
+
+```php
+POST /register  {"email": "alice@example.com", "password": "short"}
+→ 422  // Passwort zu kurz (mindestens 8 Zeichen)
+
+POST /register  {"email": "not-an-email", "password": "correct-horse"}
+→ 422  // ungültiges E-Mail-Format
+
+POST /register  {"email": "alice@example.com"}
+→ 400  // Passwortfeld fehlt
+
+POST /register  {"email": "alice@example.com", "password": "battery-staple"}
+// (nachdem Alice bereits registriert ist)
+→ 409  {"type": ".../email-taken", "detail": "Email already registered"}
+```
+
+## Login
+
+```php
+POST /login
+{"email": "alice@example.com", "password": "correct-horse"}
+
+→ 200
+{"id": 1, "email": "alice@example.com", "created_at": "..."}
+// password_hash nicht zurückgegeben
+```
+
+### Benutzer-Enumerations-Prävention
+
+```php
+// Falsches Passwort für bekannte E-Mail
+POST /login  {"email": "alice@example.com", "password": "wrong"}
+→ 401  {"type": ".../invalid-credentials", "detail": "Invalid email or password"}
+
+// Unbekannte E-Mail
+POST /login  {"email": "ghost@example.com", "password": "any"}
+→ 401  {"type": ".../invalid-credentials", "detail": "Invalid email or password"}
+```
+
+**Beide Fälle geben dieselbe 401 mit identischer `detail`-Meldung zurück.** Die Rückgabe von 404 für unbekannte E-Mail würde Angreifern ermöglichen, die Benutzerdatenbank zu sondieren.
+
+```php
+// Test: gleicher detail-String
+$this->assertSame($wrongPasswordBody['detail'], $unknownEmailBody['detail']);
+```
+
+## Implementierung
+
+### Passwortspeicherung — Argon2id
+
+```php
+// Registrierung
+$hash = password_hash($plaintext, PASSWORD_ARGON2ID);
+// Speichert: $argon2id$v=19$m=65536,t=4,p=1$...
+
+// Niemals speichern:
+// md5($plaintext)          — in Sekunden reversibel
+// sha1($plaintext)         — Rainbow-Table-Angriff
+// $plaintext               — Klartext-Speicherung
+```
+
+PHPs `password_hash(PASSWORD_ARGON2ID)` führt automatisch:
+- Generiert ein zufälliges Salt pro Hash
+- Speichert Algorithmus, Parameter, Salt und Digest in einem String
+- Widersteht GPU-Brute-Force (speicherintensiv)
+
+### Verifizierung — Konstante Zeit
+
+```php
+$row = $this->repo->findByEmail($email);
+
+if ($row === null || !password_verify($plaintext, $row['password_hash'])) {
+    // Gleiche Antwort, egal ob E-Mail unbekannt oder Passwort falsch
+    return $this->problems->create('invalid-credentials', 'Invalid email or password', 401);
+}
+```
+
+`password_verify()` ist zeitkonstant und funktioniert über Algorithmenfamilien hinweg (bcrypt, Argon2id usw.).
+
+### Algorithmische Migrations-Rehash
+
+Beim Upgrade von bcrypt auf Argon2id beim erfolgreichen Login erneut hashen:
+
+```php
+if (password_needs_rehash($row['password_hash'], PASSWORD_ARGON2ID)) {
+    $newHash = password_hash($plaintext, PASSWORD_ARGON2ID);
+    $this->repo->updateHash($row['id'], $newHash);
+}
+```
+
+Benutzer werden bei ihrer nächsten Anmeldung still auf den stärkeren Algorithmus migriert — kein erzwungenes Passwort-Reset erforderlich.
+
+### Niemals Anmeldedaten zurückgeben
+
+```php
+private function toPublic(array $user): array
+{
+    // Sensible Felder explizit entfernen
+    unset($user['password_hash']);
+    return $user;
+}
+```
+
+`toPublic()` auf jede Antwort anwenden: register 201, login 200 und alle Profilendpunkte.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| 404 für unbekannte E-Mail beim Login zurückgeben | Benutzer-Enumeration: Angreifer entdeckt, welche E-Mails registriert sind |
+| Unterschiedliche `detail`-Meldung für falsches Passwort vs. unbekannte E-Mail zurückgeben | Verrät, welche Bedingung fehlgeschlagen ist |
+| Passwort als MD5 oder SHA-1 speichern | Rainbow-Table-Angriff knackt alle Passwörter innerhalb von Stunden |
+| Passwort als bcrypt speichern ohne Migrationspfad | Kann nicht auf stärkeren Algorithmus upgraden ohne erzwungenes Reset |
+| `password_hash` in einer Antwort zurückgeben | Hash kann für Offline-Brute-Force verwendet werden |
+| `password_needs_rehash()` beim Login überspringen | Alte schwache Hashes bleiben für immer bestehen, auch nach Algorithmus-Upgrade |
+| `===` für Hash-Vergleich verwenden | Timing-Angriff verrät Hash-Bytes; immer `password_verify()` verwenden |

--- a/docs/de/howto/password-hashing.md
+++ b/docs/de/howto/password-hashing.md
@@ -1,0 +1,180 @@
+# How-to: Passwort-Hashing
+
+Passwörter sicher speichern und verifizieren mit PHPs nativen `password_hash()` / `password_verify()` mit NENE2.
+
+---
+
+## Schnellstart
+
+```php
+// Registrierung — vor dem Speichern hashen
+$hash = password_hash($password, PASSWORD_ARGON2ID);
+$user = $this->repo->create($email, $hash);
+
+// Login — Constant-Time-Verifizierung
+if (!password_verify($inputPassword, $user->passwordHash)) {
+    // 401 zurückgeben
+}
+```
+
+---
+
+## Algorithmus: immer `PASSWORD_ARGON2ID` verwenden
+
+`PASSWORD_DEFAULT` ist ab PHP 8.4 immer noch `bcrypt`. Argon2id ist speicher-hart und widersteht GPU/ASIC-Angriffen.
+
+```php
+// ❌ PASSWORD_DEFAULT = bcrypt — anfälliger für GPU-Brute-Force
+$hash = password_hash($password, PASSWORD_DEFAULT);
+
+// ✅ Argon2id — speicher-hart, für neue Projekte empfohlen
+$hash = password_hash($password, PASSWORD_ARGON2ID);
+```
+
+Argon2id erfordert PHP 7.3+. NENE2 erfordert PHP 8.4, also ist es immer verfügbar.
+
+---
+
+## UNIQUE-Verletzungen erkennen: `DatabaseConstraintException`
+
+NEENEs `PdoDatabaseQueryExecutor` verpackt alle Constraint-Verletzungen (UNIQUE, FK, NOT NULL) in `DatabaseConstraintException` bevor das erneute Werfen erfolgt. `\PDOException` direkt abfangen funktioniert **nicht**.
+
+```php
+use Nene2\Database\DatabaseConstraintException;
+
+// ❌ Wird nie hier erreicht — PDOException ist bereits verpackt
+catch (\PDOException $e) {
+    if (str_contains($e->getMessage(), 'UNIQUE constraint failed')) { ... }
+}
+
+// ✅ Den NENE2-Wrapper abfangen
+catch (DatabaseConstraintException) {
+    throw new DuplicateEmailException($email);
+}
+```
+
+`DatabaseConstraintException` ist Teil der stabilen öffentlichen API (ADR 0009).
+
+Vollständiges Repository-Muster:
+
+```php
+use Nene2\Database\DatabaseConstraintException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final class UserRepository
+{
+    public function __construct(private readonly DatabaseQueryExecutorInterface $executor) {}
+
+    /** @throws DuplicateEmailException */
+    public function create(string $email, string $passwordHash): User
+    {
+        try {
+            $now = (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+            $id  = $this->executor->insert(
+                'INSERT INTO users (email, password_hash, created_at) VALUES (?, ?, ?)',
+                [$email, $passwordHash, $now],
+            );
+
+            return new User(id: $id, email: $email, passwordHash: $passwordHash, createdAt: $now);
+        } catch (DatabaseConstraintException) {
+            throw new DuplicateEmailException($email);
+        }
+    }
+}
+```
+
+---
+
+## Benutzer-Enumerationsprävention (Timing-Angriff)
+
+Wenn sofort 401 zurückgegeben wird, wenn die E-Mail nicht gefunden wird, verrät ein Timing-Unterschied, ob die E-Mail existiert — "Nicht-gefunden"-Antworten kommen sofort zurück, während "Falsches-Passwort"-Antworten die volle Argon2id-Rechenzeit benötigen.
+
+```php
+// ❌ Timing-Leck — nicht-gefunden ist messbar schneller
+if ($user === null) {
+    return $this->problems->create($request, 'invalid-credentials', ...);
+}
+if (!password_verify($password, $user->passwordHash)) {
+    return $this->problems->create($request, 'invalid-credentials', ...);
+}
+
+// ✅ Immer password_verify ausführen — Constant-Time unabhängig davon, ob Benutzer existiert
+$dummyHash   = '$argon2id$v=19$m=65536,t=4,p=1$dummysaltdummysaltdummysalt$dummyhashvaluedummyhashvaluedummyh';
+$hashToCheck = $user !== null ? $user->passwordHash : $dummyHash;
+
+if (!password_verify($password, $hashToCheck) || $user === null) {
+    return $this->problems->create($request, 'invalid-credentials', 'Invalid Credentials', 401,
+        'The email or password is incorrect.');
+}
+```
+
+Der Dummy-Hash **muss** ein gültiger Argon2id-Format-String sein, der mit `$argon2id$` beginnt. Falls nicht, bricht `password_verify()` kurz ab und gibt sofort `false` zurück, was das Timing-Leck wiederherstellt.
+
+---
+
+## `password_verify()` ist algorithmus-agnostisch
+
+`password_verify()` liest das Hash-Präfix, um den Algorithmus zu bestimmen. Der Verifizierungscode muss bei der Migration von bcrypt auf Argon2id nicht geändert werden.
+
+```php
+// Funktioniert sowohl auf bcrypt- als auch Argon2id-Hashes
+$result = password_verify($plaintext, $storedHash); // immer korrekt
+```
+
+`password_needs_rehash()` bei erfolgreichem Login verwenden, um Legacy-Hashes transparent zu upgraden:
+
+```php
+if (password_verify($password, $user->passwordHash)) {
+    if (password_needs_rehash($user->passwordHash, PASSWORD_ARGON2ID)) {
+        $newHash = password_hash($password, PASSWORD_ARGON2ID);
+        $this->repo->updatePasswordHash($user->id, $newHash);
+    }
+    // Mit authentifiziertem Benutzer fortfahren
+}
+```
+
+---
+
+## `password_hash` niemals in die Antwort einschließen
+
+`toArray()` oder ähnliche Helfer können jede Spalte einschließen. Nur die zurückzugebenden Felder explizit aufführen.
+
+```php
+// ❌ Kann password_hash lecken wenn $user eine toArray()-Methode hat
+return $this->json->create($user->toArray(), 201);
+
+// ✅ Explizite Feldliste — password_hash ist nie vorhanden
+return $this->json->create([
+    'id'         => $user->id,
+    'email'      => $user->email,
+    'created_at' => $user->createdAt,
+], 201);
+```
+
+---
+
+## `RouteRegistrar::register()`-Namenskonflikt
+
+NEENEs `RouteRegistrar`-Vertrag erfordert eine öffentliche `register(Router $router)`-Methode. Einen Routen-Handler **nicht** `register()` nennen — PHP lehnt den doppelten Methodennamen ab.
+
+```php
+// ❌ Fataler Fehler: Cannot redeclare RouteRegistrar::register()
+$router->post('/register', $this->register(...));
+private function register(...) { ... }
+
+// ✅ Einen eindeutigen Handler-Namen verwenden
+$router->post('/register', $this->handleRegister(...));
+private function handleRegister(...) { ... }
+```
+
+---
+
+## Code-Review-Checkliste
+
+- [ ] `password_hash()` mit `PASSWORD_ARGON2ID` wird verwendet (nicht MD5, SHA-1, bcrypt oder `PASSWORD_DEFAULT`)
+- [ ] `password_verify()` wird für Vergleiche verwendet (nicht `===`, `hash_equals()` oder benutzerdefinierter Vergleich)
+- [ ] `password_verify()` läuft auch wenn der Benutzer nicht gefunden wird (Dummy-Hash-Muster)
+- [ ] `DatabaseConstraintException` wird für doppelte E-Mail/Benutzername-Erkennung abgefangen
+- [ ] `password_hash` / `password`-Felder sind aus allen API-Antworten ausgeschlossen
+- [ ] Login gibt 401 (nicht 404) für unbekannte E-Mail zurück — niemals verraten, ob die E-Mail existiert
+- [ ] Klartext-Passwort wird nicht in Logs geschrieben

--- a/docs/de/howto/password-reset-flow.md
+++ b/docs/de/howto/password-reset-flow.md
@@ -1,0 +1,248 @@
+# How-to: Passwort-Reset-Ablauf
+
+> **FT-Referenz**: FT285 (`NENE2-FT/resetlog`) — Passwort-Reset-Ablauf: Benutzer-Enumerationsprävention (immer 202), SHA-256-Token-Hash-Speicherung, 1-Stunde TTL, Einmal-Token (409 bei Wiederverwendung), 410 Gone bei Ablauf, Argon2id-neues-Passwort-Hash, 15 Tests / 23 Assertions PASS.
+
+Diese Anleitung zeigt, wie ein sicherer Passwort-Reset-Ablauf implementiert wird — Benutzer fordern einen Reset an, erhalten ein Token (normalerweise per E-Mail) und verwenden es, um ein neues Passwort zu setzen.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    email         TEXT    NOT NULL UNIQUE,
+    name          TEXT    NOT NULL,
+    password_hash TEXT    NOT NULL,
+    created_at    TEXT    NOT NULL
+);
+
+CREATE TABLE password_resets (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token_hash TEXT    NOT NULL UNIQUE,
+    used_at    TEXT,
+    expires_at TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`token_hash TEXT UNIQUE` — speichert SHA-256 des Roh-Tokens. Das Roh-Token wird an den Client gesendet und niemals gespeichert.
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|-------------|
+| `POST` | `/password-reset` | Keine | Passwort-Reset anfordern |
+| `GET` | `/password-reset/{token}` | Keine | Token-Status prüfen |
+| `POST` | `/password-reset/{token}` | Keine | Reset mit neuem Passwort abschließen |
+
+## Benutzer-Enumerationsprävention
+
+```php
+$user = $this->repo->findUserByEmail($email);
+
+// Immer 202 zurückgeben, um Benutzer-Enumeration zu verhindern
+if ($user === null) {
+    return $this->json->create(['status' => 'pending'], 202);
+}
+
+// Echter Benutzer: Token erstellen und (in Produktion) E-Mail senden
+$rawToken = bin2hex(random_bytes(32));
+// ...
+return $this->json->create(['status' => 'pending', 'token' => $rawToken], 202);
+```
+
+Sowohl gültige als auch ungültige E-Mails geben identische 202-Antworten zurück. Ein Angreifer kann nicht bestimmen, welche E-Mails registriert sind.
+
+> **Produktionshinweis**: Das Token wird hier zur Testbarkeit in der API-Antwort zurückgegeben. In der Produktion das Token nur per E-Mail senden — niemals in der API-Antwort einschließen.
+
+## Token-Speicherung — Nur SHA-256
+
+```php
+$rawToken  = bin2hex(random_bytes(32));  // 64 Hex-Zeichen = 256-Bit-Entropie
+$tokenHash = hash('sha256', $rawToken);
+
+$this->repo->createReset($user->id, $tokenHash, $expiresAt, $now);
+
+// Roh-Token an Client zurückgeben (in Produktion: per E-Mail, nicht HTTP-Antwort)
+return $this->json->create(['status' => 'pending', 'token' => $rawToken], 202);
+```
+
+Die Datenbank speichert nur den SHA-256-Hash. Das Roh-Token wird dem Benutzer (per E-Mail in Produktion) gesendet und niemals gespeichert. Ein DB-Einbruch verrät Hashes — nutzlos ohne die Roh-Tokens.
+
+## Token-Validierung
+
+```php
+$rawToken  = (string) ($params['token'] ?? '');
+$tokenHash = hash('sha256', $rawToken);
+$reset     = $this->repo->findByTokenHashOrNull($tokenHash);
+```
+
+Das Roh-Token kommt im Request-Pfad an. Der Server hasht es und fragt die DB ab. SHA-256 ist deterministisch — dasselbe Roh-Token erzeugt immer denselben Hash.
+
+## Token-Lebenszyklus-Zustände
+
+```
+pending → used (409 bei Wiederverwendung)
+pending → expired (410 Gone)
+```
+
+```php
+if ($reset->isExpired($now)) {
+    return $this->problems->create($request, 'gone', 'Reset token has expired.', 410, '');
+}
+
+if ($reset->isUsed()) {
+    return $this->problems->create($request, 'conflict', 'Reset token has already been used.', 409, '');
+}
+```
+
+| Status | HTTP | Wann |
+|--------|------|------|
+| Nicht gefunden | 404 | Token existiert nicht in DB |
+| Abgelaufen | 410 Gone | `expires_at` liegt in der Vergangenheit |
+| Bereits verwendet | 409 Conflict | `used_at` ist gesetzt |
+| Gültig | 200 (GET) / 200 (POST) | Aktiv, unbenutzt, nicht abgelaufen |
+
+`410 Gone` ist semantisch korrekter als 404 für abgelaufene Ressourcen — das Token existierte, ist aber nicht mehr verfügbar.
+
+## Reset abschließen
+
+```php
+$newHash = password_hash($newPassword, PASSWORD_ARGON2ID);
+$this->repo->updatePasswordHash($reset->userId, $newHash);
+$this->repo->markUsed($tokenHash, $now);  // used_at = $now setzen
+
+return $this->json->create(['status' => 'completed'], 200);
+```
+
+Beide Operationen sollten in der Produktion in einer Transaktion sein. Falls `updatePasswordHash` erfolgreich ist, aber `markUsed` fehlschlägt, ist der Benutzer zurückgesetzt, aber das Token bleibt wiederverwendbar.
+
+## Passwort-Validierung
+
+```php
+if (strlen($newPassword) < 8) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'password', 'code' => 'min-length', 'message' => 'password must be at least 8 characters.']],
+    ]);
+}
+```
+
+Minimum 8 Zeichen; wird sowohl bei der Registrierung als auch beim Reset erzwungen. Das neue Passwort wird mit `PASSWORD_ARGON2ID` vor der Speicherung gehasht.
+
+---
+
+## VULN-Bewertung — Schwachstellendiagnose
+
+### V-01 — Benutzer-Enumeration via Reset-Antwort-Timing/Inhalt 🛡️ SAFE
+
+**Bedrohung**: Angreifer sendet Reset-Anfragen für viele E-Mails, um registrierte zu identifizieren.
+**Abwehr**: Sowohl registrierte als auch nicht-registrierte E-Mails geben `202 { "status": "pending" }` mit identischem Antwort-Body und Statuscode zurück.
+**Ergebnis**: SAFE — Enumeration aus API-Antwort nicht möglich.
+
+---
+
+### V-02 — Token-Brute-Force 🛡️ SAFE
+
+**Bedrohung**: Angreifer errät Token-Werte und reicht sie ein, um ein Konto zurückzusetzen.
+**Abwehr**: `bin2hex(random_bytes(32))` generiert 256-Bit-Entropie (64 Hex-Zeichen). Bei 10.000 Versuchen/Sekunde würde Brute-Forcing ~10^65 Jahre dauern.
+**Ergebnis**: SAFE — 256-Bit-Entropie ist unerratbar.
+
+---
+
+### V-03 — Token-Replay nach Verwendung 🛡️ SAFE
+
+**Bedrohung**: Angreifer fängt ein Reset-Token ab und verwendet es, nachdem der legitime Benutzer sein Passwort bereits zurückgesetzt hat.
+**Abwehr**: `markUsed()` setzt `used_at` nach dem Reset. Nachfolgende Versuche prüfen `isUsed()` → 409 Conflict.
+**Ergebnis**: SAFE — Einmal-Verwendungs-Durchsetzung verhindert Replay.
+
+---
+
+### V-04 — Abgelaufenes Token akzeptiert 🛡️ SAFE
+
+**Bedrohung**: Angreifer speichert ein Token, wartet auf den Login des Benutzers, dann verwendet das alte Token.
+**Abwehr**: `isExpired($now)` prüft `expires_at`. Tokens laufen nach 1 Stunde ab → 410 Gone.
+**Ergebnis**: SAFE — Zeitbeschränkte Tokens verhindern verzögerte Angriffe.
+
+---
+
+### V-05 — SQL-Injection via Token-Pfadparameter 🛡️ SAFE
+
+**Bedrohung**: `'; DROP TABLE password_resets; --` als Token einreichen.
+**Abwehr**: `hash('sha256', $rawToken)` erzeugt unabhängig von der Eingabe einen 64-Zeichen-Hex-String. Der Hash wird in einer parametrisierten Abfrage verwendet.
+**Ergebnis**: SAFE — Hashing + parametrisierte Abfrage blockiert Injection doppelt.
+
+---
+
+### V-06 — Token im Klartext in DB gespeichert 🛡️ SAFE
+
+**Bedrohung**: DB-Einbruch exponiert alle aktiven Reset-Tokens; Angreifer setzt jedes Konto zurück.
+**Abwehr**: DB speichert nur `hash('sha256', $rawToken)`. Roh-Tokens werden an Clients zurückgegeben (oder per E-Mail gesendet). SHA-256 ist einwegig; Hashes können ohne Brute-Force nicht zu Roh-Tokens umgekehrt werden.
+**Ergebnis**: SAFE — SHA-256-Hash-Speicherung schützt Tokens im Ruhezustand.
+
+---
+
+### V-07 — Neues Passwort im Klartext gespeichert 🛡️ SAFE
+
+**Bedrohung**: DB-Einbruch exponiert neue Passwörter, die während des Resets gesetzt wurden.
+**Abwehr**: `password_hash($newPassword, PASSWORD_ARGON2ID)` hasht das neue Passwort vor der Speicherung.
+**Ergebnis**: SAFE — Argon2id-Hashing schützt Passwörter im Ruhezustand.
+
+---
+
+### V-08 — Konto-Übernahme durch Erstellen eines doppelten Reset-Tokens 🛡️ SAFE
+
+**Bedrohung**: Angreifer sagt oder kollidiert mit einem anderen Benutzer-Token-Hash.
+**Abwehr**: `token_hash TEXT UNIQUE` — doppelte Hashes werden von DB abgelehnt. Mit 256-Bit-Entropie ist Kollisionswahrscheinlichkeit vernachlässigbar.
+**Ergebnis**: SAFE — UNIQUE-Constraint + 256-Bit-Entropie verhindern Kollision.
+
+---
+
+### V-09 — Schwaches neues Passwort (< 8 Zeichen) beim Reset einreichen 🛡️ SAFE
+
+**Bedrohung**: Angreifer setzt ein Konto auf ein trivial erratbares Passwort wie `aa` zurück.
+**Abwehr**: `strlen($newPassword) < 8` → 422 Validierungsfehler vor jeder DB-Operation.
+**Ergebnis**: SAFE — Mindestlänge auf Reset-Pfad erzwungen (gleich wie Registrierung).
+
+---
+
+### V-10 — Token-Endpunkt verrät welcher Schritt fehlschlug (Enumeration) 🛡️ SAFE
+
+**Bedrohung**: Durch Vergleich von 404 vs. 409 vs. 410 Antworten kartiert Angreifer den Zustand von Reset-Tokens.
+**Abwehr**: Die Fehlercodes verraten Token-Lebenszyklus-Zustand (nicht-gefunden/abgelaufen/verwendet) aber keine Benutzerinformationen. Zu wissen, dass ein Token abgelaufen oder verwendet ist, identifiziert nicht den Kontoinhaber.
+**Ergebnis**: SAFE — Keine Benutzeridentitätsinformationen werden durch Token-Zustandsantworten verraten.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Bedrohung | Ergebnis |
+|----|-----------|---------|
+| V-01 | Benutzer-Enumeration via Reset-Antwort | 🛡️ SAFE |
+| V-02 | Token-Brute-Force | 🛡️ SAFE |
+| V-03 | Token-Replay nach Verwendung | 🛡️ SAFE |
+| V-04 | Abgelaufenes Token akzeptiert | 🛡️ SAFE |
+| V-05 | SQL-Injection via Token-Pfad | 🛡️ SAFE |
+| V-06 | Token im Klartext gespeichert | 🛡️ SAFE |
+| V-07 | Neues Passwort im Klartext gespeichert | 🛡️ SAFE |
+| V-08 | Doppeltes Token-Kollision | 🛡️ SAFE |
+| V-09 | Schwaches neues Passwort akzeptiert | 🛡️ SAFE |
+| V-10 | Token-Zustand verrät Benutzerinfo | 🛡️ SAFE |
+
+**10 SAFE, 0 EXPOSED**
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| 404 für nicht-registrierte E-Mail, 202 für registrierte zurückgeben | Benutzer-Enumeration — Angreifer kartiert registrierte Konten |
+| Roh-Token in DB speichern | DB-Einbruch exponiert alle aktiven Reset-Tokens; Massen-Kontoübernahme |
+| Token in HTTP-Antwort-Body senden (Produktion) | Token von Browser-Logs, Proxies oder JS abgefangen; nur per E-Mail senden |
+| Keine Ablaufzeit auf Reset-Tokens | Alte Tokens bleiben für immer gültig; gestohlene Tokens Monate später verwendbar |
+| Token-Wiederverwendung nach Passwort-Reset erlauben | Token-Replay-Angriff nach E-Mail-Abfangen |
+| Keine Mindest-Passwortlänge | Benutzer setzen `aa` als neues Passwort |
+| 200 für GET `/password-reset/{token}` bei verwendetem Token zurückgeben | Client kann gültig nicht von bereits-verwendet unterscheiden |
+| MD5/SHA-1 für Token-Hash verwenden | Vorab-berechnete Rainbow-Tables existieren; SHA-256 oder besser verwenden |
+| Keine Transaktion für `updatePasswordHash` + `markUsed` | Race Condition: Passwort aktualisiert, aber Token bleibt wiederverwendbar |

--- a/docs/de/howto/password-reset-flow.md
+++ b/docs/de/howto/password-reset-flow.md
@@ -1,8 +1,10 @@
 # How-to: Passwort-Reset-Ablauf
 
-> **FT-Referenz**: FT285 (`NENE2-FT/resetlog`) — Passwort-Reset-Ablauf: Benutzer-Enumerationsprävention (immer 202), SHA-256-Token-Hash-Speicherung, 1-Stunde TTL, Einmal-Token (409 bei Wiederverwendung), 410 Gone bei Ablauf, Argon2id-neues-Passwort-Hash, 15 Tests / 23 Assertions PASS.
+> **FT-Referenz**: FT285 (`NENE2-FT/resetlog`) — Passwort-Reset-Ablauf: Benutzer-Enumerations-Prävention (immer 202), SHA-256-Token-Hash-Speicherung, 1-Stunden-TTL, Einmal-Token (409 bei Wiederverwendung), 410 Gone bei Ablauf, Argon2id für neues Passwort-Hash, 15 Tests / 23 Assertions PASS.
+>
+> **VULN-Assessment**: V-01 bis V-10 am Ende dieses Dokuments.
 
-Diese Anleitung zeigt, wie ein sicherer Passwort-Reset-Ablauf implementiert wird — Benutzer fordern einen Reset an, erhalten ein Token (normalerweise per E-Mail) und verwenden es, um ein neues Passwort zu setzen.
+Diese Anleitung zeigt, wie ein sicherer Passwort-Reset-Ablauf implementiert wird — Benutzer fordern einen Reset an, erhalten ein Token (üblicherweise per E-Mail) und verwenden es, um ein neues Passwort festzulegen.
 
 ## Schema
 
@@ -26,17 +28,17 @@ CREATE TABLE password_resets (
 );
 ```
 
-`token_hash TEXT UNIQUE` — speichert SHA-256 des Roh-Tokens. Das Roh-Token wird an den Client gesendet und niemals gespeichert.
+`token_hash TEXT UNIQUE` — speichert SHA-256 des Rohtokens. Rohtoken wird an den Client gesendet und niemals gespeichert.
 
 ## Endpunkte
 
 | Methode | Pfad | Auth | Beschreibung |
-|---------|------|------|-------------|
+|--------|------|------|-------------|
 | `POST` | `/password-reset` | Keine | Passwort-Reset anfordern |
 | `GET` | `/password-reset/{token}` | Keine | Token-Status prüfen |
 | `POST` | `/password-reset/{token}` | Keine | Reset mit neuem Passwort abschließen |
 
-## Benutzer-Enumerationsprävention
+## Benutzer-Enumerations-Prävention
 
 ```php
 $user = $this->repo->findUserByEmail($email);
@@ -54,7 +56,7 @@ return $this->json->create(['status' => 'pending', 'token' => $rawToken], 202);
 
 Sowohl gültige als auch ungültige E-Mails geben identische 202-Antworten zurück. Ein Angreifer kann nicht bestimmen, welche E-Mails registriert sind.
 
-> **Produktionshinweis**: Das Token wird hier zur Testbarkeit in der API-Antwort zurückgegeben. In der Produktion das Token nur per E-Mail senden — niemals in der API-Antwort einschließen.
+> **Produktionshinweis**: Das Token wird hier in der API-Antwort zurückgegeben, um die Testbarkeit zu erleichtern. In der Produktion das Token nur per E-Mail senden — niemals in der API-Antwort einschließen.
 
 ## Token-Speicherung — Nur SHA-256
 
@@ -64,11 +66,11 @@ $tokenHash = hash('sha256', $rawToken);
 
 $this->repo->createReset($user->id, $tokenHash, $expiresAt, $now);
 
-// Roh-Token an Client zurückgeben (in Produktion: per E-Mail, nicht HTTP-Antwort)
+// Rohtoken an Client zurückgeben (in Produktion: per E-Mail, nicht HTTP-Antwort)
 return $this->json->create(['status' => 'pending', 'token' => $rawToken], 202);
 ```
 
-Die Datenbank speichert nur den SHA-256-Hash. Das Roh-Token wird dem Benutzer (per E-Mail in Produktion) gesendet und niemals gespeichert. Ein DB-Einbruch verrät Hashes — nutzlos ohne die Roh-Tokens.
+Die Datenbank speichert nur den SHA-256-Hash. Das Rohtoken wird dem Benutzer gesendet (in der Produktion per E-Mail) und niemals gespeichert. Ein DB-Verstoß enthüllt Hashes — ohne die Rohtokens nutzlos.
 
 ## Token-Validierung
 
@@ -78,13 +80,13 @@ $tokenHash = hash('sha256', $rawToken);
 $reset     = $this->repo->findByTokenHashOrNull($tokenHash);
 ```
 
-Das Roh-Token kommt im Request-Pfad an. Der Server hasht es und fragt die DB ab. SHA-256 ist deterministisch — dasselbe Roh-Token erzeugt immer denselben Hash.
+Das Rohtoken kommt im Anfragepfad an. Der Server hasht es und fragt die DB ab. SHA-256 ist deterministisch — dasselbe Rohtoken erzeugt immer denselben Hash.
 
 ## Token-Lebenszyklus-Zustände
 
 ```
-pending → used (409 bei Wiederverwendung)
-pending → expired (410 Gone)
+pending → verwendet (409 bei Wiederverwendung)
+pending → abgelaufen (410 Gone)
 ```
 
 ```php
@@ -116,9 +118,9 @@ $this->repo->markUsed($tokenHash, $now);  // used_at = $now setzen
 return $this->json->create(['status' => 'completed'], 200);
 ```
 
-Beide Operationen sollten in der Produktion in einer Transaktion sein. Falls `updatePasswordHash` erfolgreich ist, aber `markUsed` fehlschlägt, ist der Benutzer zurückgesetzt, aber das Token bleibt wiederverwendbar.
+Beide Operationen sollten in der Produktion in einer Transaktion sein. Wenn `updatePasswordHash` erfolgreich ist, aber `markUsed` fehlschlägt, ist der Benutzer zurückgesetzt, aber das Token bleibt wiederverwendbar.
 
-## Passwort-Validierung
+## Passwortvalidierung
 
 ```php
 if (strlen($newPassword) < 8) {
@@ -128,25 +130,25 @@ if (strlen($newPassword) < 8) {
 }
 ```
 
-Minimum 8 Zeichen; wird sowohl bei der Registrierung als auch beim Reset erzwungen. Das neue Passwort wird mit `PASSWORD_ARGON2ID` vor der Speicherung gehasht.
+Mindestens 8 Zeichen; bei Registrierung und Reset erzwungen. Das neue Passwort wird vor der Speicherung mit `PASSWORD_ARGON2ID` gehasht.
 
 ---
 
-## VULN-Bewertung — Schwachstellendiagnose
+## VULN Assessment — Schwachstellendiagnose
 
 ### V-01 — Benutzer-Enumeration via Reset-Antwort-Timing/Inhalt 🛡️ SAFE
 
 **Bedrohung**: Angreifer sendet Reset-Anfragen für viele E-Mails, um registrierte zu identifizieren.
-**Abwehr**: Sowohl registrierte als auch nicht-registrierte E-Mails geben `202 { "status": "pending" }` mit identischem Antwort-Body und Statuscode zurück.
+**Abwehr**: Sowohl registrierte als auch nicht registrierte E-Mails geben `202 { "status": "pending" }` mit identischem Response-Body und Statuscode zurück. Kein Timing-Unterschied.
 **Ergebnis**: SAFE — Enumeration aus API-Antwort nicht möglich.
 
 ---
 
 ### V-02 — Token-Brute-Force 🛡️ SAFE
 
-**Bedrohung**: Angreifer errät Token-Werte und reicht sie ein, um ein Konto zurückzusetzen.
-**Abwehr**: `bin2hex(random_bytes(32))` generiert 256-Bit-Entropie (64 Hex-Zeichen). Bei 10.000 Versuchen/Sekunde würde Brute-Forcing ~10^65 Jahre dauern.
-**Ergebnis**: SAFE — 256-Bit-Entropie ist unerratbar.
+**Bedrohung**: Angreifer errät Token-Werte und reicht sie ein, um ein beliebiges Konto zurückzusetzen.
+**Abwehr**: `bin2hex(random_bytes(32))` generiert 256-Bit-Entropie (64 Hex-Zeichen). Bei 10.000 Versuchen/Sekunde würde Brute-Force ~10^65 Jahre dauern.
+**Ergebnis**: SAFE — 256-Bit-Entropie ist nicht erratbar.
 
 ---
 
@@ -154,15 +156,15 @@ Minimum 8 Zeichen; wird sowohl bei der Registrierung als auch beim Reset erzwung
 
 **Bedrohung**: Angreifer fängt ein Reset-Token ab und verwendet es, nachdem der legitime Benutzer sein Passwort bereits zurückgesetzt hat.
 **Abwehr**: `markUsed()` setzt `used_at` nach dem Reset. Nachfolgende Versuche prüfen `isUsed()` → 409 Conflict.
-**Ergebnis**: SAFE — Einmal-Verwendungs-Durchsetzung verhindert Replay.
+**Ergebnis**: SAFE — Einmal-Erzwingung verhindert Replay.
 
 ---
 
 ### V-04 — Abgelaufenes Token akzeptiert 🛡️ SAFE
 
-**Bedrohung**: Angreifer speichert ein Token, wartet auf den Login des Benutzers, dann verwendet das alte Token.
-**Abwehr**: `isExpired($now)` prüft `expires_at`. Tokens laufen nach 1 Stunde ab → 410 Gone.
-**Ergebnis**: SAFE — Zeitbeschränkte Tokens verhindern verzögerte Angriffe.
+**Bedrohung**: Angreifer speichert ein Token, wartet auf Benutzer-Login, verwendet dann das alte Token.
+**Abwehr**: `isExpired($now)` prüft `expires_at`. Token laufen nach 1 Stunde ab → 410 Gone.
+**Ergebnis**: SAFE — zeitbegrenzte Token verhindern verzögerte Angriffe.
 
 ---
 
@@ -176,24 +178,24 @@ Minimum 8 Zeichen; wird sowohl bei der Registrierung als auch beim Reset erzwung
 
 ### V-06 — Token im Klartext in DB gespeichert 🛡️ SAFE
 
-**Bedrohung**: DB-Einbruch exponiert alle aktiven Reset-Tokens; Angreifer setzt jedes Konto zurück.
-**Abwehr**: DB speichert nur `hash('sha256', $rawToken)`. Roh-Tokens werden an Clients zurückgegeben (oder per E-Mail gesendet). SHA-256 ist einwegig; Hashes können ohne Brute-Force nicht zu Roh-Tokens umgekehrt werden.
-**Ergebnis**: SAFE — SHA-256-Hash-Speicherung schützt Tokens im Ruhezustand.
+**Bedrohung**: DB-Verstoß exponiert alle aktiven Reset-Token; Angreifer setzt jedes Konto zurück.
+**Abwehr**: DB speichert nur `hash('sha256', $rawToken)`. SHA-256 ist einwegig.
+**Ergebnis**: SAFE — SHA-256-Hash-Speicherung schützt Token im Ruhezustand.
 
 ---
 
 ### V-07 — Neues Passwort im Klartext gespeichert 🛡️ SAFE
 
-**Bedrohung**: DB-Einbruch exponiert neue Passwörter, die während des Resets gesetzt wurden.
+**Bedrohung**: DB-Verstoß exponiert neue Passwörter, die beim Reset gesetzt wurden.
 **Abwehr**: `password_hash($newPassword, PASSWORD_ARGON2ID)` hasht das neue Passwort vor der Speicherung.
 **Ergebnis**: SAFE — Argon2id-Hashing schützt Passwörter im Ruhezustand.
 
 ---
 
-### V-08 — Konto-Übernahme durch Erstellen eines doppelten Reset-Tokens 🛡️ SAFE
+### V-08 — Kontoübernahme durch Erstellen eines doppelten Reset-Tokens 🛡️ SAFE
 
-**Bedrohung**: Angreifer sagt oder kollidiert mit einem anderen Benutzer-Token-Hash.
-**Abwehr**: `token_hash TEXT UNIQUE` — doppelte Hashes werden von DB abgelehnt. Mit 256-Bit-Entropie ist Kollisionswahrscheinlichkeit vernachlässigbar.
+**Bedrohung**: Angreifer sagt oder kollidiert mit dem Token-Hash eines anderen Benutzers.
+**Abwehr**: `token_hash TEXT UNIQUE` — doppelte Hashes werden von der DB abgelehnt.
 **Ergebnis**: SAFE — UNIQUE-Constraint + 256-Bit-Entropie verhindern Kollision.
 
 ---
@@ -206,18 +208,18 @@ Minimum 8 Zeichen; wird sowohl bei der Registrierung als auch beim Reset erzwung
 
 ---
 
-### V-10 — Token-Endpunkt verrät welcher Schritt fehlschlug (Enumeration) 🛡️ SAFE
+### V-10 — Token-Endpunkt verrät, welcher Schritt fehlgeschlagen ist (Enumeration) 🛡️ SAFE
 
 **Bedrohung**: Durch Vergleich von 404 vs. 409 vs. 410 Antworten kartiert Angreifer den Zustand von Reset-Tokens.
-**Abwehr**: Die Fehlercodes verraten Token-Lebenszyklus-Zustand (nicht-gefunden/abgelaufen/verwendet) aber keine Benutzerinformationen. Zu wissen, dass ein Token abgelaufen oder verwendet ist, identifiziert nicht den Kontoinhaber.
-**Ergebnis**: SAFE — Keine Benutzeridentitätsinformationen werden durch Token-Zustandsantworten verraten.
+**Abwehr**: Die Fehlercodes verraten Token-Lebenszyklus-Zustand (nicht-gefunden/abgelaufen/verwendet), aber keine Benutzerinformationen. Das Wissen, ob ein Token abgelaufen oder verwendet ist, identifiziert nicht den Kontoinhaber.
+**Ergebnis**: SAFE — keine Benutzeridentitätsinformationen durch Token-Zustandsantworten enthüllt.
 
 ---
 
 ### VULN-Zusammenfassung
 
 | ID | Bedrohung | Ergebnis |
-|----|-----------|---------|
+|----|--------|--------|
 | V-01 | Benutzer-Enumeration via Reset-Antwort | 🛡️ SAFE |
 | V-02 | Token-Brute-Force | 🛡️ SAFE |
 | V-03 | Token-Replay nach Verwendung | 🛡️ SAFE |
@@ -225,11 +227,12 @@ Minimum 8 Zeichen; wird sowohl bei der Registrierung als auch beim Reset erzwung
 | V-05 | SQL-Injection via Token-Pfad | 🛡️ SAFE |
 | V-06 | Token im Klartext gespeichert | 🛡️ SAFE |
 | V-07 | Neues Passwort im Klartext gespeichert | 🛡️ SAFE |
-| V-08 | Doppeltes Token-Kollision | 🛡️ SAFE |
+| V-08 | Doppelte Token-Kollision | 🛡️ SAFE |
 | V-09 | Schwaches neues Passwort akzeptiert | 🛡️ SAFE |
 | V-10 | Token-Zustand verrät Benutzerinfo | 🛡️ SAFE |
 
 **10 SAFE, 0 EXPOSED**
+Benutzer-Enumerations-Prävention, 256-Bit-Token-Entropie, SHA-256-Hash-Speicherung, Argon2id-Passwort-Hashing und Einmal-Erzwingung verhindern alle getesteten Schwachstellenvektoren.
 
 ---
 
@@ -237,12 +240,12 @@ Minimum 8 Zeichen; wird sowohl bei der Registrierung als auch beim Reset erzwung
 
 | Anti-Muster | Risiko |
 |---|---|
-| 404 für nicht-registrierte E-Mail, 202 für registrierte zurückgeben | Benutzer-Enumeration — Angreifer kartiert registrierte Konten |
-| Roh-Token in DB speichern | DB-Einbruch exponiert alle aktiven Reset-Tokens; Massen-Kontoübernahme |
-| Token in HTTP-Antwort-Body senden (Produktion) | Token von Browser-Logs, Proxies oder JS abgefangen; nur per E-Mail senden |
-| Keine Ablaufzeit auf Reset-Tokens | Alte Tokens bleiben für immer gültig; gestohlene Tokens Monate später verwendbar |
+| 404 für nicht registrierte E-Mail, 202 für registrierte zurückgeben | Benutzer-Enumeration — Angreifer kartiert registrierte Konten |
+| Rohtoken in DB speichern | DB-Verstoß exponiert alle aktiven Reset-Token; Massen-Kontoübernahme |
+| Token in HTTP-Response-Body senden (Produktion) | Token durch Browser-Logs, Proxies oder JS abgefangen; nur per E-Mail senden |
+| Kein Ablauf für Reset-Token | Alte Token bleiben für immer gültig; gestohlene Token Monate später verwendbar |
 | Token-Wiederverwendung nach Passwort-Reset erlauben | Token-Replay-Angriff nach E-Mail-Abfangen |
-| Keine Mindest-Passwortlänge | Benutzer setzen `aa` als neues Passwort |
-| 200 für GET `/password-reset/{token}` bei verwendetem Token zurückgeben | Client kann gültig nicht von bereits-verwendet unterscheiden |
-| MD5/SHA-1 für Token-Hash verwenden | Vorab-berechnete Rainbow-Tables existieren; SHA-256 oder besser verwenden |
+| Keine minimale Passwortlänge | Benutzer setzen `aa` als neues Passwort |
+| 200 für GET `/password-reset/{token}` bei verwendetem Token zurückgeben | Client kann gültig von bereits-verwendet nicht unterscheiden |
+| MD5/SHA-1 für Token-Hash verwenden | Vorberechnete Rainbow-Tables existieren; SHA-256 oder besser verwenden |
 | Keine Transaktion für `updatePasswordHash` + `markUsed` | Race Condition: Passwort aktualisiert, aber Token bleibt wiederverwendbar |

--- a/docs/de/howto/password-reset.md
+++ b/docs/de/howto/password-reset.md
@@ -1,0 +1,151 @@
+# Passwort-Reset-Ablauf
+
+Einen sicheren token-basierten Passwort-Reset implementieren: Anforderung → Verifizierung → Abschluss.
+
+## Überblick
+
+Ein Passwort-Reset-Ablauf hat drei Schritte:
+1. Benutzer fordert einen Reset an — ein zeitbegrenztes Token wird generiert und gesendet (z.B. per E-Mail).
+2. Benutzer verifiziert, dass das Token noch gültig ist, bevor das Reset-Formular angezeigt wird.
+3. Benutzer reicht ein neues Passwort ein — Token wird verbraucht und Passwort aktualisiert.
+
+## Datenbankschema
+
+```sql
+CREATE TABLE password_resets (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token_hash TEXT    NOT NULL UNIQUE,
+    used_at    TEXT,
+    expires_at TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`token_hash` speichert den SHA-256-Hash des Roh-Tokens. Das Roh-Token wird niemals in der Datenbank gespeichert.
+
+## Token-Generierung und -Speicherung
+
+Das Roh-Token mit `random_bytes` generieren, dann nur den SHA-256-Hash speichern:
+
+```php
+$rawToken  = bin2hex(random_bytes(32)); // 256-Bit-Entropie, 64 Hex-Zeichen
+$tokenHash = hash('sha256', $rawToken);
+
+$this->repo->createReset($userId, $tokenHash, $expiresAt, $now);
+
+// $rawToken an den Benutzer zurückgeben (per E-Mail oder API-Antwort)
+```
+
+Bei der Verifizierung das eingehende Token auf dieselbe Weise hashen:
+
+```php
+$tokenHash = hash('sha256', $rawToken);
+$reset     = $this->repo->findByTokenHashOrNull($tokenHash);
+```
+
+Einen Hash zu speichern bedeutet, dass ein DB-Einbruch keine verwendbaren Reset-Tokens exponiert — ein Angreifer müsste SHA-256 auf einem 256-Bit-Zufallswert umkehren, was rechnerisch nicht machbar ist.
+
+## Benutzer-Enumerationsprävention
+
+`POST /password-reset` muss immer 202 zurückgeben, auch für unbekannte E-Mail-Adressen:
+
+```php
+$user = $this->repo->findUserByEmail($email);
+
+// Immer 202 — nicht verraten, ob die E-Mail registriert ist
+if ($user === null) {
+    return $this->json->create(['status' => 'pending'], 202);
+}
+
+// ... Token für echten Benutzer generieren
+return $this->json->create(['status' => 'pending', 'token' => $rawToken], 202);
+```
+
+404 für unbekannte E-Mails zurückzugeben würde einem Angreifer erlauben, registrierte Konten durch Sondieren von E-Mail-Adressen zu enumerieren.
+
+## Einmalige Verwendung
+
+`used_at` setzen, wenn der Reset abgeschlossen wird. Jedes Token ablehnen, das `used_at IS NOT NULL` hat:
+
+```php
+if ($reset->isUsed()) {
+    return $this->problems->create($request, 'conflict', 'Reset token has already been used.', 409, '');
+}
+
+$this->repo->markUsed($tokenHash, $now);
+```
+
+```php
+public function isUsed(): bool
+{
+    return $this->usedAt !== null;
+}
+```
+
+## Ablauf
+
+Ablauf sowohl bei GET (Status-Check) als auch POST (Abschluss) erzwingen. Ablauf immer vor `isUsed()` prüfen:
+
+```php
+if ($reset->isExpired($now)) {
+    return 410; // Gone — unterscheidet sich von "nicht gefunden" (404) und "verwendet" (409)
+}
+if ($reset->isUsed()) {
+    return 409;
+}
+```
+
+410 (Gone) unterscheidet "abgelaufen" von "verwendet" (409) und gibt dem Benutzer handlungsrelevante Informationen.
+
+## Altes Token invalidieren
+
+Wenn ein Benutzer einen neuen Reset anfordert, alle vorherigen ungenutzten Tokens für diesen Benutzer invalidieren:
+
+```php
+$this->executor->execute(
+    "UPDATE password_resets SET used_at = ? WHERE user_id = ? AND used_at IS NULL",
+    [$now, $userId],
+);
+```
+
+Ohne dies hätte ein Benutzer, der eine Reset-E-Mail verloren hat und eine neue anfordert, zwei gültige Tokens gleichzeitig im Umlauf — beide könnten verwendet werden, um das Passwort zurückzusetzen.
+
+## Antwort-Bereinigung
+
+`GET /password-reset/{token}` darf `user_id` oder `token_hash` nicht in der Antwort exponieren:
+
+```php
+public function toArray(): array
+{
+    return [
+        'id'         => $this->id,
+        'expires_at' => $this->expiresAt,
+        'created_at' => $this->createdAt,
+    ];
+}
+```
+
+`user_id` zu exponieren würde das Reset-Token mit einer Benutzer-Konto-ID verknüpfen, was unnötig ist, da das Token selbst die Autorisierungsanmeldedaten ist.
+
+## Sicherheitseigenschaften
+
+| Eigenschaft | Implementierung |
+|-------------|----------------|
+| Token-Entropie | `bin2hex(random_bytes(32))` — 256 Bits |
+| Token-Speicherung | Nur SHA-256-Hash — Roh-Token niemals in DB |
+| Benutzer-Enumeration | Immer 202 von `POST /password-reset` |
+| Ablauf | 1 Stunde; bei GET und POST geprüft |
+| Einmalige Verwendung | `used_at` bei Abschluss gesetzt; 409 bei Wiederverwendung |
+| Altes Token invalidieren | Vorherige ungenutzte Tokens bei neuer Anfrage auf verwendet gesetzt |
+| Antwort-Leck | `user_id` und `token_hash` aus allen Antworten ausgeschlossen |
+| Passwort-Hashing | Argon2id |
+
+## Routen-Zusammenfassung
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/password-reset` | Reset anfordern (immer 202) |
+| `GET` | `/password-reset/{token}` | Token-Gültigkeit prüfen |
+| `POST` | `/password-reset/{token}` | Reset mit neuem Passwort abschließen |

--- a/docs/de/howto/passwordless-auth-magic-link.md
+++ b/docs/de/howto/passwordless-auth-magic-link.md
@@ -1,0 +1,184 @@
+# Passwortlose Authentifizierung (Magic Link)
+
+Implementierungsleitfaden für passwortlose Authentifizierung (Magic Link). Erklärt das sichere Designmuster für ein Einmal-Link-System, bei dem die Authentifizierung nur mit einer E-Mail-Adresse möglich ist.
+
+## Überblick
+
+Magic-Link-Authentifizierung funktioniert mit folgendem Ablauf:
+
+1. Benutzer sendet E-Mail-Adresse
+2. Server generiert ein Einmal-Token (Magic Link) und sendet es per E-Mail
+3. Benutzer sendet das Token, um ein Session-Token zu erhalten
+4. Session-Token für API-Zugriff verwenden
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/auth/request` | E-Mail-Adresse vorlegen → Magic Link generieren (immer 202) |
+| `POST` | `/auth/verify` | Magic-Link-Token verifizieren → Session-Token ausgeben |
+| `POST` | `/auth/logout` | Session invalidieren (immer 204) |
+| `GET` | `/me` | Authentifizierte Benutzerinformationen abrufen |
+
+## Datenbankdesign
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE magic_links (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,  -- SHA-256-Hash gespeichert (Rohwert wird nicht gespeichert)
+    expires_at TEXT NOT NULL,          -- 15-Minuten-Ablaufzeit
+    used_at TEXT,                      -- Einmalige Verwendung (NULL = unbenutzt)
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE auth_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    session_token_hash TEXT NOT NULL UNIQUE,  -- SHA-256-Hash gespeichert
+    expires_at TEXT NOT NULL,                  -- 24-Stunden-Ablaufzeit
+    revoked_at TEXT,                           -- Bei logout gesetzt
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+## Sicherheitsdesign
+
+### Token als SHA-256-Hash speichern
+
+```php
+// Generierung: 256-Bit-Zufall → Hex-String (64 Zeichen)
+$rawToken = bin2hex(random_bytes(32));
+$tokenHash = hash('sha256', $rawToken);
+
+// Nur tokenHash in DB speichern
+// Nur rawToken wird per E-Mail gesendet (Sicherheit bei DB-Leck)
+```
+
+Selbst bei DB-Leck kann das Token nicht aus dem Hash wiederhergestellt werden. Gleiches Prinzip wie Passwort-Hashing.
+
+### Benutzer-Enumerationsprävention
+
+```php
+// POST /auth/request gibt immer 202 zurück
+// Antwort nicht zwischen registrierten / nicht-registrierten E-Mails unterscheiden
+return $this->responseFactory->create([
+    'message' => 'if this email is registered, a magic link has been sent',
+], 202);
+```
+
+Angreifer kann die Gültigkeit von E-Mail-Adressen nicht bestätigen.
+
+### Ablauf-Check vor used_at-Check
+
+```php
+// Zuerst Ablauf prüfen
+if ($now > (string) $link['expires_at']) {
+    return $this->responseFactory->create(['error' => 'token has expired'], 401);
+}
+
+// Dann used_at prüfen
+if ($link['used_at'] !== null) {
+    return $this->responseFactory->create(['error' => 'token has already been used'], 401);
+}
+```
+
+Verhindert das Preisgeben, ob ein abgelaufenes Token "verwendet" ist (Timing-Informations-Leck-Prävention).
+
+### Einmalige Verwendung (Replay-Angriffs-Prävention)
+
+```php
+// Bei erfolgreichem verify sofort used_at setzen
+$this->repository->markMagicLinkUsed($linkId, $now);
+```
+
+Denselben Magic Link kann man nicht zweimal verwenden. Verhindert die Wiederverwendung abgefangener Links.
+
+### Session-Invalidierung (Logout)
+
+```php
+// Logout gibt immer 204 zurück — verrät keine Session-Existenz
+if ($session !== null && $session['revoked_at'] === null) {
+    $this->repository->revokeSession((int) $session['id'], date('c'));
+}
+return $this->responseFactory->createEmpty(204);
+```
+
+Bei `/me` wird 401 zurückgegeben, wenn `revoked_at !== null`.
+
+## Session-Validierungsablauf
+
+```php
+private function handleMe(ServerRequestInterface $request): ResponseInterface
+{
+    $rawToken = $this->extractBearerToken($request);
+    if ($rawToken === '') {
+        return $this->responseFactory->create(['error' => 'authentication required'], 401);
+    }
+
+    $tokenHash = hash('sha256', $rawToken);
+    $session = $this->repository->findSessionByTokenHash($tokenHash);
+
+    if ($session === null) { return 401; }
+    if ($session['revoked_at'] !== null) { return 401 revoked; }
+    if ($now > $session['expires_at']) { return 401 expired; }
+
+    // ...
+}
+```
+
+## Bearer-Token-Extraktion
+
+```php
+private function extractBearerToken(ServerRequestInterface $request): string
+{
+    $header = $request->getHeaderLine('Authorization');
+    if (!str_starts_with($header, 'Bearer ')) {
+        return '';
+    }
+    return trim(substr($header, 7));
+}
+```
+
+`X-User-Id`-Header wird nicht für die Authentifizierung verwendet. Nur `Authorization: Bearer <token>`.
+
+## Neuen Benutzer automatisch erstellen
+
+```php
+public function findOrCreateUser(string $email, string $now): int
+{
+    $user = $this->findUserByEmail($email);
+    if ($user !== null) {
+        return (int) $user['id'];
+    }
+    $this->executor->execute('INSERT INTO users (email, created_at) VALUES (?, ?)', [$email, $now]);
+    return (int) $this->executor->lastInsertId();
+}
+```
+
+Benutzer wird beim ersten Login automatisch erstellt. Charakteristikum passwortloser Authentifizierung.
+
+## Magic-Link-Ablaufzeiten
+
+- **Magic Link**: 15 Minuten (900 Sekunden) — Zeit zum Öffnen und Klicken der E-Mail
+- **Session Token**: 24 Stunden (86400 Sekunden) — normale API-Session
+
+```php
+$expiresAt = date('c', time() + 900);    // magic link: 15 Min
+$sessionExpiresAt = date('c', time() + 86400);  // session: 24h
+```
+
+## Produktionsüberlegungen
+
+- **E-Mail-Versand**: In diesem FT ist das `token` aus Testgründen in der Antwort enthalten. In der Produktion per SMTP an die E-Mail-Adresse des Benutzers senden und aus der Antwort entfernen.
+- **Rate-Limiting**: Anfragen an `/auth/request` nach IP / E-Mail rate-limitieren.
+- **Alte unbenutzte Links invalidieren**: Wenn `/auth/request` mehrmals mit derselben E-Mail aufgerufen wird, explizit alte unbenutzte Links invalidieren.
+- **HTTPS erforderlich**: Da Magic-Link-Tokens in URL-Parametern enthalten sind, ist HTTPS erforderlich (Man-in-the-Middle-Angriffs-Prävention).

--- a/docs/de/howto/passwordless-auth-magic-link.md
+++ b/docs/de/howto/passwordless-auth-magic-link.md
@@ -1,23 +1,23 @@
 # Passwortlose Authentifizierung (Magic Link)
 
-Implementierungsleitfaden für passwortlose Authentifizierung (Magic Link). Erklärt das sichere Designmuster für ein Einmal-Link-System, bei dem die Authentifizierung nur mit einer E-Mail-Adresse möglich ist.
+Implementierungsanleitung für passwortlose Authentifizierung (Magic Link). Beschreibt sichere Designmuster für ein Einmalig-Link-System, das allein mit einer E-Mail-Adresse authentifiziert.
 
-## Überblick
+## Übersicht
 
 Magic-Link-Authentifizierung funktioniert mit folgendem Ablauf:
 
 1. Benutzer sendet E-Mail-Adresse
-2. Server generiert ein Einmal-Token (Magic Link) und sendet es per E-Mail
-3. Benutzer sendet das Token, um ein Session-Token zu erhalten
-4. Session-Token für API-Zugriff verwenden
+2. Server generiert einen Einmal-Token (Magic Link) und sendet ihn per E-Mail
+3. Benutzer sendet das Token und erhält ein Session-Token
+4. Mit dem Session-Token wird auf die API zugegriffen
 
 ## Endpunkte
 
 | Methode | Pfad | Beschreibung |
-|---------|------|-------------|
-| `POST` | `/auth/request` | E-Mail-Adresse vorlegen → Magic Link generieren (immer 202) |
-| `POST` | `/auth/verify` | Magic-Link-Token verifizieren → Session-Token ausgeben |
-| `POST` | `/auth/logout` | Session invalidieren (immer 204) |
+|---|---|---|
+| `POST` | `/auth/request` | E-Mail-Adresse angeben → Magic Link generieren (immer 202) |
+| `POST` | `/auth/verify` | Magic-Link-Token verifizieren → Session-Token ausstellen |
+| `POST` | `/auth/logout` | Session ungültig machen (immer 204) |
 | `GET` | `/me` | Authentifizierte Benutzerinformationen abrufen |
 
 ## Datenbankdesign
@@ -32,7 +32,7 @@ CREATE TABLE users (
 CREATE TABLE magic_links (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER NOT NULL,
-    token_hash TEXT NOT NULL UNIQUE,  -- SHA-256-Hash gespeichert (Rohwert wird nicht gespeichert)
+    token_hash TEXT NOT NULL UNIQUE,  -- SHA-256-Hash speichern (Rohwert nicht gespeichert)
     expires_at TEXT NOT NULL,          -- 15-Minuten-Ablaufzeit
     used_at TEXT,                      -- Einmalige Verwendung (NULL = unbenutzt)
     created_at TEXT NOT NULL,
@@ -42,9 +42,9 @@ CREATE TABLE magic_links (
 CREATE TABLE auth_sessions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER NOT NULL,
-    session_token_hash TEXT NOT NULL UNIQUE,  -- SHA-256-Hash gespeichert
+    session_token_hash TEXT NOT NULL UNIQUE,  -- SHA-256-Hash speichern
     expires_at TEXT NOT NULL,                  -- 24-Stunden-Ablaufzeit
-    revoked_at TEXT,                           -- Bei logout gesetzt
+    revoked_at TEXT,                           -- beim Logout gesetzt
     created_at TEXT NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users(id)
 );
@@ -55,64 +55,64 @@ CREATE TABLE auth_sessions (
 ### Token als SHA-256-Hash speichern
 
 ```php
-// Generierung: 256-Bit-Zufall → Hex-String (64 Zeichen)
+// Generierung: 256-Bit-Zufallswert → Hex-String (64 Zeichen)
 $rawToken = bin2hex(random_bytes(32));
 $tokenHash = hash('sha256', $rawToken);
 
 // Nur tokenHash in DB speichern
-// Nur rawToken wird per E-Mail gesendet (Sicherheit bei DB-Leck)
+// rawToken wird nur per E-Mail gesendet (Sicherheit bei DB-Kompromiss)
 ```
 
-Selbst bei DB-Leck kann das Token nicht aus dem Hash wiederhergestellt werden. Gleiches Prinzip wie Passwort-Hashing.
+Selbst wenn die DB kompromittiert wird, können Token aus den Hashes nicht wiederhergestellt werden. Gleiches Prinzip wie Passwort-Hashing.
 
-### Benutzer-Enumerationsprävention
+### Benutzer-Enumerations-Prävention
 
 ```php
 // POST /auth/request gibt immer 202 zurück
-// Antwort nicht zwischen registrierten / nicht-registrierten E-Mails unterscheiden
+// Antwort unterscheidet sich nicht für registrierte/nicht-registrierte E-Mails
 return $this->responseFactory->create([
     'message' => 'if this email is registered, a magic link has been sent',
 ], 202);
 ```
 
-Angreifer kann die Gültigkeit von E-Mail-Adressen nicht bestätigen.
+Angreifer können die Gültigkeit von E-Mail-Adressen nicht überprüfen.
 
 ### Ablauf-Check vor used_at-Check
 
 ```php
-// Zuerst Ablauf prüfen
+// Ablauf zuerst prüfen
 if ($now > (string) $link['expires_at']) {
     return $this->responseFactory->create(['error' => 'token has expired'], 401);
 }
 
-// Dann used_at prüfen
+// Danach used_at prüfen
 if ($link['used_at'] !== null) {
     return $this->responseFactory->create(['error' => 'token has already been used'], 401);
 }
 ```
 
-Verhindert das Preisgeben, ob ein abgelaufenes Token "verwendet" ist (Timing-Informations-Leck-Prävention).
+Verhindert, dass bekannt wird, ob ein abgelaufenes Token „verwendet" wurde (verhindert Timing-Informationsleck).
 
 ### Einmalige Verwendung (Replay-Angriffs-Prävention)
 
 ```php
-// Bei erfolgreichem verify sofort used_at setzen
+// Bei erfolgreicher Verifizierung immediately used_at setzen
 $this->repository->markMagicLinkUsed($linkId, $now);
 ```
 
-Denselben Magic Link kann man nicht zweimal verwenden. Verhindert die Wiederverwendung abgefangener Links.
+Derselbe Magic Link kann nicht zweimal verwendet werden. Verhindert die Wiederverwendung abgefangener Links.
 
-### Session-Invalidierung (Logout)
+### Session-Ungültigmachung (Logout)
 
 ```php
-// Logout gibt immer 204 zurück — verrät keine Session-Existenz
+// Logout gibt immer 204 zurück — verrät nicht Session-Existenz
 if ($session !== null && $session['revoked_at'] === null) {
     $this->repository->revokeSession((int) $session['id'], date('c'));
 }
 return $this->responseFactory->createEmpty(204);
 ```
 
-Bei `/me` wird 401 zurückgegeben, wenn `revoked_at !== null`.
+`/me` gibt 401 zurück, wenn `revoked_at !== null`.
 
 ## Session-Validierungsablauf
 
@@ -148,9 +148,9 @@ private function extractBearerToken(ServerRequestInterface $request): string
 }
 ```
 
-`X-User-Id`-Header wird nicht für die Authentifizierung verwendet. Nur `Authorization: Bearer <token>`.
+`X-User-Id`-Header nicht für Authentifizierung verwenden. Nur `Authorization: Bearer <token>`.
 
-## Neuen Benutzer automatisch erstellen
+## Automatische Neubenutzererstellung
 
 ```php
 public function findOrCreateUser(string $email, string $now): int
@@ -164,21 +164,22 @@ public function findOrCreateUser(string $email, string $now): int
 }
 ```
 
-Benutzer wird beim ersten Login automatisch erstellt. Charakteristikum passwortloser Authentifizierung.
+Benutzer werden beim ersten Login automatisch erstellt. Eigenschaft der passwortlosen Authentifizierung.
 
 ## Magic-Link-Ablaufzeiten
 
-- **Magic Link**: 15 Minuten (900 Sekunden) — Zeit zum Öffnen und Klicken der E-Mail
-- **Session Token**: 24 Stunden (86400 Sekunden) — normale API-Session
+- **Magic Link**: 15 Minuten (900 Sekunden) — genug Zeit zum E-Mail-Öffnen und Klicken
+- **Session-Token**: 24 Stunden (86400 Sekunden) — normale API-Session
 
 ```php
-$expiresAt = date('c', time() + 900);    // magic link: 15 Min
+$expiresAt = date('c', time() + 900);    // magic link: 15 min
 $sessionExpiresAt = date('c', time() + 86400);  // session: 24h
 ```
 
 ## Produktionsüberlegungen
 
-- **E-Mail-Versand**: In diesem FT ist das `token` aus Testgründen in der Antwort enthalten. In der Produktion per SMTP an die E-Mail-Adresse des Benutzers senden und aus der Antwort entfernen.
-- **Rate-Limiting**: Anfragen an `/auth/request` nach IP / E-Mail rate-limitieren.
-- **Alte unbenutzte Links invalidieren**: Wenn `/auth/request` mehrmals mit derselben E-Mail aufgerufen wird, explizit alte unbenutzte Links invalidieren.
-- **HTTPS erforderlich**: Da Magic-Link-Tokens in URL-Parametern enthalten sind, ist HTTPS erforderlich (Man-in-the-Middle-Angriffs-Prävention).
+- **E-Mail-Versand**: In diesem FT wird `token` in der Antwort zurückgegeben (für Tests).
+  In der Produktion per SMTP an die E-Mail-Adresse des Benutzers senden und aus der Antwort entfernen.
+- **Rate Limiting**: Anfragen an `/auth/request` nach IP / E-Mail begrenzen.
+- **Ungültigmachung alter unbenutzter Links**: Bei mehrmaligem Aufrufen von `/auth/request` mit derselben E-Mail erwägen, alte unbenutzte Links explizit ungültig zu machen.
+- **HTTPS erforderlich**: Magic-Link-Token befinden sich in URL-Parametern, daher ist HTTPS Pflicht (Man-in-the-Middle-Angriffs-Prävention).

--- a/docs/de/howto/patch-partial-update.md
+++ b/docs/de/howto/patch-partial-update.md
@@ -1,0 +1,130 @@
+# How-to: PATCH Teilaktualisierung (JSON Merge Patch)
+
+> **FT-Referenz**: FT326 (`NENE2-FT/patchlog`) — JSON Merge Patch (RFC 7396) Teilaktualisierung: Null-Feld-Reset, unveränderliche Felder-Ablehnung, ETag/If-Match, nur-Eigentümer-Mutation, 42 Tests / 141 Assertions PASS.
+
+Diese Anleitung zeigt, wie ein `PATCH`-Endpunkt nach JSON-Merge-Patch-Semantik implementiert wird: Nur angegebene Felder werden aktualisiert, `null` setzt auf Standard zurück und unveränderliche Felder werden abgelehnt.
+
+## Schema
+
+```sql
+CREATE TABLE documents (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id   INTEGER NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    status     TEXT    NOT NULL DEFAULT 'draft',
+    version    INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST`  | `/documents` | Erstellen (erfordert `X-User-Id`) |
+| `GET`   | `/documents` | Auflisten |
+| `GET`   | `/documents/{id}` | Abrufen mit ETag-Header |
+| `PATCH` | `/documents/{id}` | Teilaktualisierung (erfordert `X-User-Id`) |
+| `DELETE`| `/documents/{id}` | Löschen (nur Eigentümer) |
+
+## Erstellen
+
+```php
+POST /documents  X-User-Id: 1
+{"title": "Mein Dokument", "body": "Inhalt"}
+→ 201  {"id": 1, "owner_id": 1, "title": "Mein Dokument", "status": "draft", "version": 1}
+
+// Kein X-User-Id → 401
+// Fehlender Titel → 422
+// Leerer Titel  → 422
+// body ist optional → Standard ""
+```
+
+## GET mit ETag
+
+```php
+GET /documents/1
+→ 200  ETag: "doc-1-1"
+{"id": 1, "title": "Mein Dokument", "version": 1, ...}
+```
+
+ETag-Format: `"doc-{id}-{version}"`.
+
+## PATCH — JSON-Merge-Patch-Semantik
+
+```php
+// Nur Titel aktualisieren — body unverändert
+PATCH /documents/1  X-User-Id: 1
+{"title": "Aktualisiert"}
+→ 200  {"title": "Aktualisiert", "body": "Inhalt", ...}
+
+// Nur body aktualisieren
+PATCH /documents/1  X-User-Id: 1
+{"body": "Neuer Inhalt"}
+→ 200  {"title": "Aktualisiert", "body": "Neuer Inhalt", ...}
+
+// Leeres {} — kein Vorgang (gültig per RFC 7396 §3)
+PATCH /documents/1  X-User-Id: 1
+{}
+→ 200  (unverändertes Dokument)
+
+// null setzt Feld auf Standard zurück
+PATCH /documents/1  X-User-Id: 1
+{"status": null}
+→ 200  {"status": "draft"}   // auf Standard zurückgesetzt
+```
+
+## Unveränderliche Felder — Abgelehnt
+
+Einige Felder dürfen niemals via PATCH geändert werden:
+
+```php
+PATCH /documents/1  {"id": 999}         → 422  // unveränderlich
+PATCH /documents/1  {"owner_id": 99}    → 422  // unveränderlich
+PATCH /documents/1  {"version": 999}    → 422  // unveränderlich
+PATCH /documents/1  {"created_at": "…"} → 422  // unveränderlich
+```
+
+## Nur-Eigentümer-Autorisierung
+
+```php
+// Benutzer 2 versucht, Benutzer 1's Dokument zu patchen → 404 (nicht 403, um Enumeration zu verhindern)
+PATCH /documents/1  X-User-Id: 2  {"title": "Gestohlen"}  → 404
+
+// Eigentümer kann immer sein eigenes Dokument patchen
+PATCH /documents/1  X-User-Id: 1  {"title": "Meins"}      → 200
+```
+
+## ETag / If-Match
+
+```php
+// Bedingtes PATCH — 412 wenn Version sich geändert hat
+PATCH /documents/1  X-User-Id: 1  If-Match: "doc-1-1"
+{"title": "Aktualisiert"}
+→ 200  // wenn Version noch 1 ist
+
+PATCH /documents/1  X-User-Id: 1  If-Match: "doc-1-1"
+{"title": "Veraltet"}
+→ 412  // wenn Version jetzt 2 ist
+```
+
+## Typ-Validierung
+
+```php
+PATCH /documents/1  {"title": 123}   → 422  // int statt string
+PATCH /documents/1  {"body": [1,2]}  → 422  // array statt string
+```
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Fehlendes Feld gleich wie `null` behandeln | Aufrufer kann ein Feld nicht leeren; `undefined` ≠ `null` in Merge Patch |
+| Patchen von `owner_id` erlauben | Eigentümerschaftsübertragung via API ohne Autorisierungsablauf |
+| 403 für mandantenübergreifenden Zugriff zurückgeben | Verrät Existenz des Dokuments; stattdessen 404 zurückgeben |
+| Gesamtes Dokument bei PATCH ersetzen | Überschreibt Felder, die der Client nicht ändern wollte |
+| Unveränderliche Felder stillschweigend akzeptieren (kein Vorgang) | Client glaubt, `id` geändert zu haben; stiller Fehler verursacht Verwirrung |

--- a/docs/de/howto/patch-partial-update.md
+++ b/docs/de/howto/patch-partial-update.md
@@ -1,8 +1,8 @@
-# How-to: PATCH Teilaktualisierung (JSON Merge Patch)
+# How-to: PATCH-Teilaktualisierung (JSON Merge Patch)
 
-> **FT-Referenz**: FT326 (`NENE2-FT/patchlog`) — JSON Merge Patch (RFC 7396) Teilaktualisierung: Null-Feld-Reset, unveränderliche Felder-Ablehnung, ETag/If-Match, nur-Eigentümer-Mutation, 42 Tests / 141 Assertions PASS.
+> **FT-Referenz**: FT326 (`NENE2-FT/patchlog`) — JSON Merge Patch (RFC 7396) Teilaktualisierung: Null-Feld-Reset, Ablehnung unveränderlicher Felder, ETag/If-Match, nur Eigentümer-Mutation, 42 Tests / 141 Assertions PASS.
 
-Diese Anleitung zeigt, wie ein `PATCH`-Endpunkt nach JSON-Merge-Patch-Semantik implementiert wird: Nur angegebene Felder werden aktualisiert, `null` setzt auf Standard zurück und unveränderliche Felder werden abgelehnt.
+Diese Anleitung zeigt, wie ein `PATCH`-Endpunkt gemäß JSON-Merge-Patch-Semantik implementiert wird: Nur angegebene Felder werden aktualisiert, `null` setzt auf Standard zurück und unveränderliche Felder werden abgelehnt.
 
 ## Schema
 
@@ -22,7 +22,7 @@ CREATE TABLE documents (
 ## Endpunkte
 
 | Methode | Pfad | Beschreibung |
-|---------|------|-------------|
+|--------|------|-------------|
 | `POST`  | `/documents` | Erstellen (erfordert `X-User-Id`) |
 | `GET`   | `/documents` | Auflisten |
 | `GET`   | `/documents/{id}` | Abrufen mit ETag-Header |
@@ -33,12 +33,12 @@ CREATE TABLE documents (
 
 ```php
 POST /documents  X-User-Id: 1
-{"title": "Mein Dokument", "body": "Inhalt"}
-→ 201  {"id": 1, "owner_id": 1, "title": "Mein Dokument", "status": "draft", "version": 1}
+{"title": "My Doc", "body": "Content"}
+→ 201  {"id": 1, "owner_id": 1, "title": "My Doc", "status": "draft", "version": 1}
 
 // Kein X-User-Id → 401
-// Fehlender Titel → 422
-// Leerer Titel  → 422
+// Fehlender title → 422
+// Leerer title → 422
 // body ist optional → Standard ""
 ```
 
@@ -47,7 +47,7 @@ POST /documents  X-User-Id: 1
 ```php
 GET /documents/1
 → 200  ETag: "doc-1-1"
-{"id": 1, "title": "Mein Dokument", "version": 1, ...}
+{"id": 1, "title": "My Doc", "version": 1, ...}
 ```
 
 ETag-Format: `"doc-{id}-{version}"`.
@@ -55,17 +55,17 @@ ETag-Format: `"doc-{id}-{version}"`.
 ## PATCH — JSON-Merge-Patch-Semantik
 
 ```php
-// Nur Titel aktualisieren — body unverändert
+// Nur title aktualisieren — body unverändert
 PATCH /documents/1  X-User-Id: 1
-{"title": "Aktualisiert"}
-→ 200  {"title": "Aktualisiert", "body": "Inhalt", ...}
+{"title": "Updated"}
+→ 200  {"title": "Updated", "body": "Content", ...}
 
 // Nur body aktualisieren
 PATCH /documents/1  X-User-Id: 1
-{"body": "Neuer Inhalt"}
-→ 200  {"title": "Aktualisiert", "body": "Neuer Inhalt", ...}
+{"body": "New content"}
+→ 200  {"title": "Updated", "body": "New content", ...}
 
-// Leeres {} — kein Vorgang (gültig per RFC 7396 §3)
+// Leeres {} — No-Op (gültig gemäß RFC 7396 §3)
 PATCH /documents/1  X-User-Id: 1
 {}
 → 200  (unverändertes Dokument)
@@ -78,7 +78,7 @@ PATCH /documents/1  X-User-Id: 1
 
 ## Unveränderliche Felder — Abgelehnt
 
-Einige Felder dürfen niemals via PATCH geändert werden:
+Manche Felder dürfen via PATCH niemals geändert werden:
 
 ```php
 PATCH /documents/1  {"id": 999}         → 422  // unveränderlich
@@ -90,27 +90,27 @@ PATCH /documents/1  {"created_at": "…"} → 422  // unveränderlich
 ## Nur-Eigentümer-Autorisierung
 
 ```php
-// Benutzer 2 versucht, Benutzer 1's Dokument zu patchen → 404 (nicht 403, um Enumeration zu verhindern)
-PATCH /documents/1  X-User-Id: 2  {"title": "Gestohlen"}  → 404
+// Benutzer 2 versucht, das Dokument von Benutzer 1 zu patchen → 404 (nicht 403, um Enumeration zu verhindern)
+PATCH /documents/1  X-User-Id: 2  {"title": "Stolen"}  → 404
 
-// Eigentümer kann immer sein eigenes Dokument patchen
-PATCH /documents/1  X-User-Id: 1  {"title": "Meins"}      → 200
+// Eigentümer kann immer eigene patchen
+PATCH /documents/1  X-User-Id: 1  {"title": "Mine"}    → 200
 ```
 
 ## ETag / If-Match
 
 ```php
-// Bedingtes PATCH — 412 wenn Version sich geändert hat
+// Bedingtes PATCH — 412 wenn Version geändert
 PATCH /documents/1  X-User-Id: 1  If-Match: "doc-1-1"
-{"title": "Aktualisiert"}
-→ 200  // wenn Version noch 1 ist
+{"title": "Updated"}
+→ 200  // wenn Version noch 1
 
 PATCH /documents/1  X-User-Id: 1  If-Match: "doc-1-1"
-{"title": "Veraltet"}
-→ 412  // wenn Version jetzt 2 ist
+{"title": "Stale"}
+→ 412  // wenn Version jetzt 2
 ```
 
-## Typ-Validierung
+## Typvalidierung
 
 ```php
 PATCH /documents/1  {"title": 123}   → 422  // int statt string
@@ -123,8 +123,8 @@ PATCH /documents/1  {"body": [1,2]}  → 422  // array statt string
 
 | Anti-Muster | Risiko |
 |---|---|
-| Fehlendes Feld gleich wie `null` behandeln | Aufrufer kann ein Feld nicht leeren; `undefined` ≠ `null` in Merge Patch |
-| Patchen von `owner_id` erlauben | Eigentümerschaftsübertragung via API ohne Autorisierungsablauf |
-| 403 für mandantenübergreifenden Zugriff zurückgeben | Verrät Existenz des Dokuments; stattdessen 404 zurückgeben |
+| Fehlendes Feld gleich wie `null` behandeln | Aufrufer kann Feld nicht leeren; `undefined` ≠ `null` in Merge Patch |
+| Patchen von `owner_id` erlauben | Eigentümertransfer via API ohne Autorisierungsablauf |
+| 403 für benutzerübergreifenden Zugriff zurückgeben | Verrät Existenz des Dokuments; stattdessen 404 zurückgeben |
 | Gesamtes Dokument bei PATCH ersetzen | Überschreibt Felder, die der Client nicht ändern wollte |
-| Unveränderliche Felder stillschweigend akzeptieren (kein Vorgang) | Client glaubt, `id` geändert zu haben; stiller Fehler verursacht Verwirrung |
+| Unveränderliche Felder still akzeptieren (No-Op) | Client glaubt, `id` geändert zu haben; stilles Fehlschlagen verursacht Verwirrung |

--- a/docs/de/howto/payment-webhook.md
+++ b/docs/de/howto/payment-webhook.md
@@ -1,0 +1,179 @@
+# Implementierungsanleitung für Payment-Webhook-Empfang
+
+## Übersicht
+
+Diese Anleitung erklärt, wie eine Payment-Webhook-Empfangs-API mit NENE2 implementiert wird.
+Sie bietet HMAC-SHA256-Signaturverifizierung, idempotente Verarbeitung (event_id UNIQUE-Constraint) und Status-Übergangs-Schutz.
+
+---
+
+## DB-Schema
+
+```sql
+CREATE TABLE payments (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    external_id TEXT    NOT NULL UNIQUE,
+    amount      INTEGER NOT NULL,               -- kleinste Währungseinheit (Yen, Cent)
+    currency    TEXT    NOT NULL DEFAULT 'usd',
+    status      TEXT    NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'succeeded', 'failed', 'refunded')),
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+
+CREATE TABLE webhook_events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id     TEXT    NOT NULL UNIQUE,   -- Idempotenz-Schlüssel
+    event_type   TEXT    NOT NULL,
+    payload      TEXT    NOT NULL,          -- JSON
+    processed_at TEXT    NOT NULL
+);
+```
+
+`webhook_events.event_id` ist der Kern der **idempotenten Verarbeitung**. Dieselbe event_id wird auch bei zweimaligem Empfang nur einmal verarbeitet.
+
+---
+
+## Endpunktdesign
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| POST | `/webhooks/payment` | Webhook-Event empfangen und verarbeiten |
+| GET | `/payments` | Zahlungsliste |
+| GET | `/payments/{id}` | Zahlungsdetails |
+
+---
+
+## Status-Übergänge
+
+```
+[erstellt] → pending → succeeded → refunded
+                     ↘ failed
+```
+
+Verwaltung über Übergangstabelle:
+
+```php
+private const array VALID_TRANSITIONS = [
+    'payment.succeeded' => ['from' => 'pending',   'to' => 'succeeded'],
+    'payment.failed'    => ['from' => 'pending',   'to' => 'failed'],
+    'payment.refunded'  => ['from' => 'succeeded', 'to' => 'refunded'],
+];
+```
+
+Ungültige Übergänge (z.B. failed → succeeded) geben 409 Conflict zurück.
+
+---
+
+## Designpunkte
+
+### HMAC-SHA256-Signaturverifizierung
+
+Den gesamten Request-Body mit HMAC-SHA256 verifizieren. Stripe-kompatibler `X-Webhook-Signature: sha256=<hex>`-Header wird verwendet:
+
+```php
+private function verifySignature(string $body, string $header): bool
+{
+    if (!str_starts_with($header, 'sha256=')) {
+        return false;
+    }
+    $provided = substr($header, 7);
+    $expected = hash_hmac('sha256', $body, $this->webhookSecret);
+    return hash_equals($expected, $provided); // Timing-Angriffs-Prävention
+}
+```
+
+`hash_equals()` für zeitkonstanten Vergleich verwenden. `===` und `strcmp()` brechen früh ab und sind daher anfällig.
+
+### Idempotente Verarbeitung
+
+Webhook-Provider wiederholen. Duplikate mit `event_id` eliminieren:
+
+```php
+// Vor Verarbeitung prüfen
+if ($this->repo->isEventProcessed($eventId)) {
+    return $this->json->create(['status' => 'already_processed']);
+}
+
+// Nach Verarbeitung aufzeichnen
+$this->repo->recordEvent($eventId, $eventType, $payload, $now);
+```
+
+### Verarbeitungsreihenfolge
+
+```
+1. Signaturverifizierung → 401
+2. Duplikatprüfung mit event_id → 200 already_processed
+3. Verarbeitung nach Event-Typ
+4. In webhook_events aufzeichnen
+5. 200 processed zurückgeben
+```
+
+**Signaturverifizierung zuerst durchführen**, um zu verhindern, dass Angreifer die event_id-Tabelle verschmutzen.
+
+### Unbekannte Event-Typen mit 200 zurückgeben
+
+Wenn ein Provider einen neuen Event-Typ hinzufügt, verursacht die Rückgabe von 4xx Wiederholungsversuche.
+Unbekannte Typen still mit 200 zurückgeben und aufzeichnen:
+
+```php
+// Unbekannter Event-Typ — bestätigen ohne Verarbeitung
+return null; // → 200 processed
+```
+
+### Test: Signatur mit injiziertem SECRET generieren
+
+```php
+private const string SECRET = 'test-webhook-secret';
+
+private function signedReq(string $path, array $body): ResponseInterface
+{
+    $rawBody = json_encode($body);
+    $sig     = 'sha256=' . hash_hmac('sha256', $rawBody, self::SECRET);
+    // ...
+}
+```
+
+`AppFactory::createSqlite($dbFile, self::SECRET)` verwendet dasselbe Secret für die App.
+
+---
+
+## Beispiel-Event-Payloads
+
+### payment.created
+
+```json
+{
+  "event_id": "evt_001",
+  "event_type": "payment.created",
+  "data": {"id": "pay_abc", "amount": 5000, "currency": "jpy"}
+}
+```
+
+### payment.succeeded
+
+```json
+{
+  "event_id": "evt_002",
+  "event_type": "payment.succeeded",
+  "data": {"id": "pay_abc"}
+}
+```
+
+### Antwort (Erfolg)
+
+```json
+{"status": "processed", "event_type": "payment.succeeded"}
+```
+
+### Antwort (idempotenter Wiederholungsversuch)
+
+```json
+{"status": "already_processed"}
+```
+
+---
+
+## Referenzimplementierung
+
+`../NENE2-FT/paymentlog/` — FT163 Feldversuch (18 Tests, Signaturverifizierung, idempotente Verarbeitung, Übergangs-Schutz)

--- a/docs/de/howto/personal-data-export.md
+++ b/docs/de/howto/personal-data-export.md
@@ -1,0 +1,99 @@
+# Persönlicher Daten-Export
+
+Ein DSGVO-ähnlicher Daten-Export ermöglicht Benutzern, alle ihre persönlichen Daten herunterzuladen. Die primären Anliegen sind: Ausschluss sensibler Felder aus der Export-Nutzlast, sichere Download-Token und Ablauf-Durchsetzung.
+
+## Kernkomponenten
+
+- **Export-Job**: ein Datensatz, der einen Benutzer mit einem opaken Download-Token verknüpft, mit Status (pending → ready) und einem Ablauf-Zeitstempel.
+- **Verarbeitungsschritt**: eine Worker-seitige Operation, die die Nutzlast aufbaut und den Job als bereit markiert.
+- **Download**: ruft die Nutzlast per Token ab und prüft den Ablauf vor der Ausgabe.
+
+## Schema
+
+```sql
+CREATE TABLE data_exports (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token      TEXT    NOT NULL UNIQUE,
+    status     TEXT    NOT NULL DEFAULT 'pending',
+    payload    TEXT,
+    expires_at TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+## Token-Generierung
+
+`bin2hex(random_bytes(32))` verwenden — 64 Hex-Zeichen, 256 Bit Entropie. Sequentielle IDs, Zeitstempel oder MD5-basierte Token sind erratbar und dürfen nicht für Download-Token verwendet werden.
+
+```php
+$token = bin2hex(random_bytes(32));
+```
+
+## Ausschluss sensibler Felder
+
+Die Export-Nutzlast darf niemals Anmeldedaten oder Felder enthalten, in deren Export der Benutzer nicht explizit eingewilligt hat. Ausschluss auf Repository-Ebene, nicht auf HTTP-Schicht:
+
+```php
+public function processExport(string $token, User $user, array $activities, string $now): DataExport
+{
+    $payload = json_encode([
+        'exported_at' => $now,
+        'user' => [
+            'id'         => $user->id,
+            'email'      => $user->email,
+            'name'       => $user->name,
+            'created_at' => $user->createdAt,
+            // password_hash absichtlich ausgeschlossen
+            // phone absichtlich ausgeschlossen (neue Einwilligung für PII erforderlich)
+        ],
+        'activities' => $activities,
+    ], JSON_THROW_ON_ERROR);
+    // ...
+}
+```
+
+Denselben Ausschluss auf den öffentlichen Profilendpunkt anwenden — `phone`, `password_hash` und interne Felder sollten auch nicht in `GET /users/{id}`-Antworten erscheinen.
+
+## Ablauf-Durchsetzung
+
+Ablauf in **beiden** Endpunkten erzwingen — Download und Verarbeitung:
+
+```php
+// In downloadExport:
+if ($export->isExpired($now)) {
+    return $this->problems->create($request, 'gone', 'Export has expired.', 410, '');
+}
+
+// In processExport — KRITISCH: hier auch prüfen
+if ($export->isExpired($now)) {
+    return $this->problems->create($request, 'gone', 'Export request has expired. Please request a new export.', 410, '');
+}
+```
+
+Ohne die Prüfung in `processExport` würde ein Worker, der einen veralteten Job erhält, die Benutzerdaten in die DB schreiben, auch wenn das Download-Fenster bereits geschlossen ist, was verwaiste Datensätze mit sensibler Nutzlast erzeugt.
+
+## Status-Ablauf
+
+```
+pending ──(process aufgerufen, nicht abgelaufen)──▶ ready ──(download aufgerufen)──▶ [Nutzlast serviert]
+   │                                                       │
+   └──(process aufgerufen, abgelaufen)──▶ 410             └──(abgelaufen)──▶ 410
+```
+
+## Download: 410 Gone vs. 404 Not Found
+
+- **404**: Das Token existiert nicht in der Datenbank.
+- **410 Gone**: Das Token existiert, ist aber abgelaufen. Das ist der korrekte Status — die Ressource existierte und wurde seitdem entfernt. Clients können dieses Signal nutzen, um den Benutzer aufzufordern, einen neuen Export anzufordern.
+
+## Designentscheidungen
+
+**Warum ein separater `process`-Schritt statt synchroner Generierung?**
+Export-Nutzlasten können groß sein (jahrelange Aktivitätsdaten). Synchrone Generierung im HTTP-Handler riskiert Timeouts und bindet einen Worker. Das asynchrone Muster ermöglicht es dem Benutzer, anzufragen und später nachzuschauen. In diesem FT wird der Verarbeitungsschritt als API exponiert, um die Worker-Aufrufsimulation zu ermöglichen.
+
+**Warum das Token als Download-URL statt die Export-ID verwenden?**
+Eine sequentielle Integer-ID ist IDOR-anfällig — Benutzer 1 könnte den Export von Benutzer 2 herunterladen, indem er die ID inkrementiert. Ein opakes Zufalls-Token macht die Download-URL nicht erratbar.
+
+**Soll `process` ein öffentlicher Endpunkt sein?**
+In der Produktion nicht. Der Process-Endpunkt sollte nur von internen Workern aufgerufen werden (via API-Key, internes Netzwerk oder Queue). In diesem FT ist er für Testbarkeit exponiert. Die Token-Entropie bietet einigen Schutz, ersetzt aber keine ordnungsgemäße Worker-Authentifizierung.

--- a/docs/de/howto/pii-masking.md
+++ b/docs/de/howto/pii-masking.md
@@ -1,0 +1,238 @@
+# How-to: PII-Maskierungs-API
+
+> **FT-Referenz**: FT297 (`NENE2-FT/masklog`) — PII-Maskierung: E-Mail/Telefon/Name partielle Maskierung, rollenbasierter Rohdatenzugriff (nur Admin) mit obligatorischem X-Accessor-Audit-Trail, unveränderliches Audit-Log, VULN-A~L alle SAFE, 24 Tests / 49 Assertions PASS.
+
+Diese Anleitung zeigt, wie eine Kundendaten-API erstellt wird, die PII (Persönlich Identifizierbare Informationen) standardmäßig maskiert und vollen Zugriff nur für autorisierte Rollen mit einem Audit-Trail gewährt.
+
+## Schema
+
+```sql
+CREATE TABLE customers (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    email      TEXT NOT NULL,
+    phone      TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE mask_audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    customer_id INTEGER NOT NULL REFERENCES customers(id),
+    accessor    TEXT NOT NULL,
+    accessed_at TEXT NOT NULL
+);
+```
+
+Roh-PII wird in `customers` gespeichert. Jeder Admin-Zugriff auf Rohdaten wird in `mask_audit_log` aufgezeichnet (nur Anhängen — keine Update/Delete-Route).
+
+## Maskierungsmuster
+
+```php
+final class MaskService
+{
+    // "john.doe@example.com" → "j***@example.com"
+    public function maskEmail(string $email): string
+    {
+        $at     = strpos($email, '@');
+        $local  = substr($email, 0, $at);
+        $domain = substr($email, $at + 1);
+        return substr($local, 0, 1) . '***@' . $domain;
+    }
+
+    // "090-1234-5678" → "***-****-5678" (letzte 4 Ziffern beibehalten)
+    public function maskPhone(string $phone): string
+    {
+        $digits   = preg_replace('/\D/', '', $phone);
+        $keepFrom = strlen($digits) - 4;
+        $replaced = 0;
+        $result   = '';
+        for ($i = 0; $i < strlen($phone); $i++) {
+            $ch = $phone[$i];
+            if (ctype_digit($ch)) {
+                $result .= ($replaced < $keepFrom) ? ('*' . ($replaced++ | 0) * 0 . '') : $ch;
+                $replaced++;
+            } else {
+                $result .= $ch;
+            }
+        }
+        return $result;
+    }
+
+    // "John Doe" → "J*** D***"
+    public function maskName(string $name): string
+    {
+        $words = explode(' ', $name);
+        return implode(' ', array_filter(array_map(
+            fn($w) => $w !== '' ? mb_substr($w, 0, 1) . '***' : '',
+            $words
+        )));
+    }
+}
+```
+
+## Rollenbasierter Zugriff — Standardmäßig Maskiert
+
+```php
+private function handleGet(ServerRequestInterface $request): ResponseInterface
+{
+    $id       = $this->id($request);
+    $customer = $this->repo->find($id);
+    if ($customer === null) {
+        return $this->json->create(['error' => 'Customer not found'], 404);
+    }
+
+    $role     = $request->getHeaderLine('X-Role');
+    $accessor = trim($request->getHeaderLine('X-Accessor'));
+
+    if ($role === 'admin') {
+        if ($accessor === '') {
+            return $this->json->create(['error' => 'X-Accessor header required for admin access'], 403);
+        }
+        $this->repo->logAccess((int) $customer['id'], $accessor, $this->now());
+        return $this->json->create($customer);  // Roh-PII
+    }
+
+    return $this->json->create($this->masker->applyMask($customer));  // maskiert
+}
+```
+
+- **Nicht-Admin (Standard)**: erhält immer maskierte Daten.
+- **Admin mit `X-Accessor`**: erhält Rohdaten und der Zugriff wird protokolliert.
+- **Admin ohne `X-Accessor`**: 403 — der Audit-Trail darf nicht leer sein.
+
+## Audit-Log — Nur Anhängen
+
+```php
+public function register(Router $router): void
+{
+    $router->post('/customers', $this->handleCreate(...));
+    $router->get('/customers/{id}', $this->handleGet(...));
+    $router->get('/customers/{id}/audit', $this->handleAudit(...));
+    // Kein DELETE oder PUT für Audit-Log — unveränderlich per Design
+}
+```
+
+Das Audit-Log hat keine Lösch- oder Aktualisierungsroute. Einträge sind dauerhaft; nur Admins können das Log lesen.
+
+---
+
+## Schwachstellenbewertung
+
+### V-01 — PII nicht im Standard-GET exponiert ✅ SAFE
+
+**Risiko**: Nicht-Admin liest Roh-Kunden-E-Mail/Telefon/Name.
+**Befund**: SAFE — Standardantwort wendet immer `applyMask()` an. Rohe Felder werden niemals ohne `X-Role: admin` zurückgegeben.
+
+---
+
+### V-02 — SQL-Injection im Namensfeld ✅ SAFE
+
+**Risiko**: `"name": "'; DROP TABLE customers; --"` löscht Daten.
+**Befund**: SAFE — parametrisierte Abfragen speichern den Injection-String wörtlich als Namen.
+
+---
+
+### V-03 — SQL-Injection im E-Mail-Feld ✅ SAFE
+
+**Risiko**: SQL-Injection via E-Mail bei Erstellung.
+**Befund**: SAFE — gleicher Schutz durch parametrisierte Abfragen.
+
+---
+
+### V-04 — IDOR: Nicht-Admin liest Roh-PII via Kunden-ID ✅ SAFE
+
+**Risiko**: Ohne `X-Role: admin` versucht ein Benutzer `GET /customers/1` für vollständige PII.
+**Befund**: SAFE — jede Anfrage ohne `X-Role: admin` erhält maskierte Daten, unabhängig von der Kunden-ID.
+
+---
+
+### V-05 — Rollenerhöhung: beliebiger X-Role-Header ✅ SAFE
+
+**Risiko**: `X-Role: superuser` oder `X-Role: ADMIN` senden, um die Maskierung zu umgehen.
+**Befund**: SAFE — nur der genaue String `'admin'` gewährt Rohzugriff: `if ($role === 'admin')`. Jeder andere Wert fällt zur maskierten Antwort durch.
+
+---
+
+### V-06 — Admin ohne X-Accessor-Header ✅ SAFE
+
+**Risiko**: Admin greift auf Rohdaten ohne X-Accessor zu, um den Audit-Trail zu vermeiden.
+**Befund**: SAFE — `if ($accessor === '') return 403`. Admin-Zugriff erfordert einen nicht-leeren Accessor-Identifier.
+
+---
+
+### V-07 — Audit-Log für Nicht-Admin zugänglich ✅ SAFE
+
+**Risiko**: Nicht-Admin liest `GET /customers/1/audit`, um herauszufinden, wer auf seine Daten zugegriffen hat.
+**Befund**: SAFE — Audit-Endpunkt prüft `X-Role: admin`. Nicht-Admin → 403.
+
+---
+
+### V-08 — Nicht existierender Kunde gibt 404 zurück ✅ SAFE
+
+**Risiko**: Abfrage einer nicht existierenden ID gibt 500 zurück oder leckt DB-Fehler.
+**Befund**: SAFE — `if ($customer === null) return 404`. Sauberer Fehler, keine internen Informationen.
+
+---
+
+### V-09 — Extrem langer Input stürzt nicht ab ✅ SAFE
+
+**Risiko**: 10.000-Zeichen-Name verursacht DB-Fehler oder Speichererschöpfung.
+**Befund**: SAFE — SQLite TEXT hat kein Längenlimit; die Anwendung speichert und maskiert ohne Absturz. In der Produktion ein Längenlimit hinzufügen (z.B. 500 Zeichen).
+
+---
+
+### V-10 — XSS-Payload als Literal gespeichert ✅ SAFE
+
+**Risiko**: `"name": "<script>alert(1)</script>"` wird in einem Browser ausgeführt.
+**Befund**: SAFE — API gibt `application/json` zurück; JSON-Encoding escapet `<` und `>`. Kein HTML-Rendering in der API-Schicht.
+
+---
+
+### V-11 — Maskierte Antwort verrät keine vollständige PII ✅ SAFE
+
+**Risiko**: Maskierte Antwort enthält genug Daten, um die ursprüngliche PII zu rekonstruieren.
+**Befund**: SAFE — E-Mail: nur erstes Zeichen + Domain; Telefon: nur letzte 4 Ziffern; Name: nur erstes Zeichen pro Wort. Kann Original nicht rekonstruieren.
+
+---
+
+### V-12 — Audit-Log ist unveränderlich ✅ SAFE
+
+**Risiko**: Admin löscht eigene Audit-Log-Einträge, um Spuren zu verwischen.
+**Befund**: SAFE — keine `DELETE /customers/{id}/audit`-Route vorhanden. Log-Einträge sind nur anhängbar.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|---------|
+| V-01 | PII im Standard-GET exponiert | ✅ SAFE |
+| V-02 | SQL-Injection im Namen | ✅ SAFE |
+| V-03 | SQL-Injection in E-Mail | ✅ SAFE |
+| V-04 | IDOR: Nicht-Admin liest Roh-PII | ✅ SAFE |
+| V-05 | Rollenerhöhung via X-Role-Header | ✅ SAFE |
+| V-06 | Admin ohne X-Accessor | ✅ SAFE |
+| V-07 | Audit-Log für Nicht-Admin zugänglich | ✅ SAFE |
+| V-08 | Nicht existierendes Kunden-Verhalten | ✅ SAFE |
+| V-09 | Absturz durch extrem langen Input | ✅ SAFE |
+| V-10 | XSS-Payload im Namen | ✅ SAFE |
+| V-11 | Maskierte Antwort verrät PII | ✅ SAFE |
+| V-12 | Audit-Log-Veränderbarkeit | ✅ SAFE |
+
+**12 SAFE, 0 EXPOSED**
+Standardmäßige Maskierung, obligatorischer Accessor-Audit, strenge Rollenprüfung und unveränderliches Log verhindern alle PII-Expositions- und Audit-Bypass-Vektoren.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Roh-PII standardmäßig zurückgeben | Jeder authentifizierte Benutzer liest vollständige E-Mail/Telefon/Name |
+| Groß-/Kleinschreibungsunabhängige Rollenprüfung (`strtolower`) ohne explizite Allowlist | `ADMIN`, `Admin`, `aDmIn` — nur den exakten erwarteten String akzeptieren |
+| Admin-Zugriff ohne X-Accessor erlauben | Kein Audit-Trail; DSGVO-Compliance-Versagen |
+| Veränderbares Audit-Log | Admins löschen eigene Einträge; forensischer Trail ist unzuverlässig |
+| Audit-Log für Nicht-Admin exponieren | Benutzer erfahren, wer (welche Mitarbeiter) auf ihre Daten zugegriffen hat |
+| Hash-Maskierung (Hash statt echter Daten zeigen) | Hash von PII ist noch sensibel — Angreifer können kurze Werte per Brute-Force knacken |
+| Keine Maskierung bei Create-Antwort | Neue Kundenerstellungs-Antwort exponiert die gerade gespeicherte PII |
+| Kein Eingabe-Längenlimit | Sehr lange Eingaben verbrauchen Speicherplatz; explizite Längenbegrenzungen in Produktion hinzufügen |

--- a/docs/de/howto/pin-bookmark-ordering.md
+++ b/docs/de/howto/pin-bookmark-ordering.md
@@ -1,0 +1,192 @@
+# How-to: Pin / Lesezeichen mit Reihenfolge
+
+> **FT-Referenz**: FT327 (`NENE2-FT/pinlog`) — Benutzerbezogene Artikel-Pins mit sequentiellen Positionen, Maximal-Pin-Limit, lückenlose Neuanordnung beim Löschen, Neuanordnung via PUT, Benutzerisolation, VULN-Assessment, 19 Tests / 26 Assertions PASS.
+
+Diese Anleitung zeigt, wie eine Artikel-Pin-Funktion erstellt wird, bei der Benutzer eine geordnete Liste mit bis zu 10 Lesezeichen mit Drag-Reorder-Unterstützung führen.
+
+## Schema
+
+```sql
+CREATE TABLE pins (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id),
+    article_id INTEGER NOT NULL REFERENCES articles(id),
+    position   INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    UNIQUE(user_id, article_id)
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST`  | `/pins` | Artikel pinnen (idempotent) |
+| `DELETE`| `/pins/{articleId}` | Artikel entpinnen |
+| `GET`   | `/pins` | Pins des Benutzers in Reihenfolge auflisten |
+| `PUT`   | `/pins/order` | Pins neu anordnen |
+
+Alle Endpunkte erfordern `X-User-Id`-Header. Fehlend → 401.
+
+## Artikel Pinnen
+
+```php
+POST /pins  X-User-Id: 1
+{"article_id": 3}
+→ 201  {"article_id": 3, "position": 1}
+
+POST /pins  X-User-Id: 1  {"article_id": 7}
+→ 201  {"article_id": 7, "position": 2}
+
+// Idempotent — denselben Artikel zweimal pinnen
+POST /pins  X-User-Id: 1  {"article_id": 3}
+→ 200  (bereits gepinnt, keine Änderung)
+```
+
+### Limit
+
+```php
+// Bereits 10 Pins
+POST /pins  X-User-Id: 1  {"article_id": 11}
+→ 422  {"max": 10}
+```
+
+### Fehlerfälle
+
+```php
+// Keine Auth
+POST /pins  {"article_id": 1}        → 401
+// Fehlende article_id
+POST /pins  X-User-Id: 1  {}         → 422
+// Nicht existierender Artikel
+POST /pins  X-User-Id: 1  {"article_id": 999} → 404
+```
+
+## Entpinnen
+
+```php
+DELETE /pins/3  X-User-Id: 1  → 204
+DELETE /pins/3  X-User-Id: 1  → 404  // bereits entfernt
+```
+
+### Positionsverdichtung nach Löschen
+
+Beim Löschen eines Pins werden die Positionen lückenlos neu verdichtet:
+
+```
+Vorher: [1→Art1, 2→Art2, 3→Art3]
+DELETE /pins/2
+Nachher:  [1→Art1, 2→Art3]   // Position 2 ist jetzt Art3
+```
+
+```php
+// Nach dem Entpinnen ist die Lücke geschlossen
+GET /pins  X-User-Id: 1
+→ {"pins": [
+     {"article_id": 1, "position": 1},
+     {"article_id": 3, "position": 2}   // Position 3 → 2
+  ], "count": 2}
+```
+
+## Pins auflisten
+
+```php
+GET /pins  X-User-Id: 1
+→ 200
+{
+  "pins": [
+    {"article_id": 3, "position": 1},
+    {"article_id": 1, "position": 2},
+    {"article_id": 2, "position": 3}
+  ],
+  "count": 3
+}
+
+// Leer
+GET /pins  X-User-Id: 99
+→ {"pins": [], "count": 0}
+```
+
+Ergebnisse sind nach `position ASC` geordnet. Benutzer 2 sieht niemals Benutzer 1s Pins.
+
+## Neuanordnen
+
+```php
+PUT /pins/order  X-User-Id: 1
+{"article_ids": [3, 1, 2]}
+→ 200
+{
+  "pins": [
+    {"article_id": 3, "position": 1},
+    {"article_id": 1, "position": 2},
+    {"article_id": 2, "position": 3}
+  ]
+}
+
+// Unbekannte article_id (nicht gepinnt)
+{"article_ids": [1, 99]}  → 422
+
+// Kein X-User-Id
+PUT /pins/order  {"article_ids": [1]}  → 401
+// Fehlender Body
+PUT /pins/order  X-User-Id: 1  {}     → 422
+```
+
+---
+
+## Schwachstellenbewertung
+
+### V-01 — IDOR beim Entpinnen ✅ SAFE
+
+**Risiko**: Benutzer 2 entpinnt Artikel von Benutzer 1 durch Erraten von Artikel-IDs.
+**Befund**: SAFE — DELETE-Abfrage enthält `WHERE user_id = $authUserId AND article_id = $articleId`. Benutzerübergreifendes Löschen findet 0 Zeilen → 404.
+
+### V-02 — IDOR beim Neuanordnen ✅ SAFE
+
+**Risiko**: Benutzer 2 ordnet die Pin-Liste von Benutzer 1 neu.
+**Befund**: SAFE — Neuanordnung validiert, dass alle `article_ids` in der Pin-Liste des authentifizierten Benutzers sind. Fremde IDs geben 422 zurück.
+
+### V-03 — Pin-Limit-Bypass ✅ SAFE
+
+**Risiko**: Angreifer sendet gleichzeitige Pin-Anfragen, um das 10-Pin-Limit zu überschreiten.
+**Befund**: SAFE — `UNIQUE(user_id, article_id)` verhindert Duplikate. Pin-Anzahl wird vor dem Insert geprüft. Gleichzeitige Inserts laufen auf den Unique-Constraint.
+
+### V-04 — Nicht existierenden Artikel pinnen ✅ SAFE
+
+**Risiko**: Angreifer pinnt `article_id=999999`, um eine hängende FK-Referenz einzufügen.
+**Befund**: SAFE — Existenzprüfung vor dem Insert. Nicht existierender Artikel gibt 404 zurück.
+
+### V-05 — Artikel anderer Benutzer pinnen ✅ SAFE
+
+**Risiko**: Benutzerübergreifender Pin (Benutzer 2 pinnt als Benutzer 1 durch Manipulation von `X-User-Id`).
+**Befund**: SAFE — `X-User-Id` ist das Authentifizierungs-Token in diesem FT. In der Produktion ein signiertes JWT/Session verwenden — niemals einem clientseitig bereitgestellten Benutzer-ID-Header direkt vertrauen.
+
+### V-06 — Positions-Lücke nach Löschen enthüllt Reihenfolge ✅ SAFE
+
+**Risiko**: Lücken in Positionen (`1, 3`) verraten, dass ein Löschen stattgefunden hat; Angreifer schließt auf Löschhistorie.
+**Befund**: SAFE — Positionen werden sofort beim Löschen verdichtet. Externe Beobachter können die Löschreihenfolge nicht erkennen.
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|---------|
+| V-01 | IDOR beim Entpinnen | ✅ SAFE |
+| V-02 | IDOR beim Neuanordnen | ✅ SAFE |
+| V-03 | Pin-Limit-Bypass | ✅ SAFE |
+| V-04 | Nicht existierenden Artikel pinnen | ✅ SAFE |
+| V-05 | Benutzerübergreifendes Pinnen | ✅ SAFE |
+| V-06 | Lücke enthüllt Löschhistorie | ✅ SAFE |
+
+**6 SAFE, 0 EXPOSED** — Keine kritischen Befunde.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Kein Maximal-Pin-Limit | Unbegrenzte Liste verschlechtert Abfrageleistung und UX |
+| Positions-Lücken nach Löschen lassen | Client-Sortierung nach Position bricht zusammen; erfordert clientseitige Umnumerierung |
+| Artikel-Existenzprüfung beim Pinnen überspringen | Hängende Referenzen verwirren Clients beim Rendern von Pin-Listen |
+| `X-User-Id`-Header in Produktion vertrauen | Jeder Client kann ihn setzen; signierte Authentifizierung verwenden (JWT, Session) |
+| Kein `UNIQUE(user_id, article_id)` | Duplikat-Pins blähen Anzahl auf und verwirren Neuanordnungslogik |

--- a/docs/de/howto/pin-verification-lockout.md
+++ b/docs/de/howto/pin-verification-lockout.md
@@ -1,0 +1,254 @@
+# PIN-Verifizierung und Sperrung
+
+> **FT-Referenz**: FT252 (`NENE2-FT/pinverifylog`) — PIN-Verifizierung mit Sperrung
+> **ATK**: FT252 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Implementierungsanleitung für Brute-Force-Prävention bei 6-stelligen PINs, Timing-Angriffs-Gegenmaßnahmen und Administrator-Entsperrung.
+Erklärt HMAC-SHA256-Hash-Speicherung, zeitkonstanten Vergleich und Sperrung nach Versuchen.
+
+**FT192 Sicherheit validiert**: VULN-A~L alle PASS / ATK-01~12 alle PASS.
+
+## Übersicht
+
+- Administrator erstellt PIN (HMAC-SHA256-Hash-Speicherung — kein Klartext gespeichert)
+- Benutzer verifiziert PIN (Sperrung nach Erreichen der maximalen Fehleranzahl)
+- Administrator entsperrt
+- Versuchshistorie wird als Audit-Log aufgezeichnet
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `POST` | `/pins` | `X-Admin-Key` | PIN erstellen |
+| `POST` | `/pins/{id}/verify` | — | PIN verifizieren |
+| `GET` | `/pins/{id}` | `X-Admin-Key` | Status prüfen (verbleibende Versuche, Sperrdauer) |
+| `POST` | `/pins/{id}/unlock` | `X-Admin-Key` | Entsperren |
+| `DELETE` | `/pins/{id}` | `X-Admin-Key` | PIN löschen |
+
+## Datenbankdesign
+
+```sql
+CREATE TABLE IF NOT EXISTS pins (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    label        TEXT    NOT NULL,
+    pin_hash     TEXT    NOT NULL,        -- HMAC-SHA256(pin, secret)
+    attempts     INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 5,
+    locked_until TEXT,                    -- ISO 8601 UTC, NULL = entsperrt
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pin_attempts (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    pin_id       INTEGER NOT NULL,
+    success      INTEGER NOT NULL DEFAULT 0,
+    attempted_at TEXT    NOT NULL
+);
+```
+
+Position: `locked_until` als ISO-8601-String speichern und Sperrstatus durch String-Vergleich mit der aktuellen Zeit (`$lockedUntil > $now`) bestimmen. Kein Konvertierungsaufwand.
+
+## HMAC-SHA256-PIN-Hash
+
+PIN nicht im Klartext speichern, sondern mit HMAC-SHA256 hashen. Das Einmischen eines serverseitigen Geheimnisses (`$hmacSecret`) macht Brute-Force bei einem DB-Kompromiss schwieriger:
+
+```php
+private function hashPin(string $pin): string
+{
+    return hash_hmac('sha256', $pin, $this->hmacSecret);
+}
+```
+
+## Zeitkonstanter Vergleich (VULN-E / ATK-02)
+
+`===` bricht beim Byte-Vergleich ab, was es ermöglicht, den korrekten Hash durch Timing-Angriffe zu erraten. `hash_equals()` vergleicht immer alle Bytes:
+
+```php
+// ❌ Gefährlich: per Timing-Angriff erratbar
+if ($stored === $provided) { ... }
+
+// ✅ Sicher: zeitkonstanter Vergleich
+$provided = $this->hashPin($pin);
+$success  = hash_equals($pin1->pinHash, $provided);
+```
+
+## Brute-Force-Prävention (ATK-01)
+
+Wenn die Fehleranzahl `max_attempts` erreicht, `locked_until` setzen und alle nachfolgenden Versuche (einschließlich der korrekten PIN) mit 423 ablehnen:
+
+```php
+public function verify(int $id, string $pin): string
+{
+    $now  = $this->now();
+    $pin1 = $this->findById($id);
+
+    // 1. Sperrprüfung vor dem Versuch durchführen
+    if ($pin1->isLocked($now)) {
+        return 'locked'; // → 423
+    }
+
+    // 2. Zeitkonstanter Vergleich
+    $provided = $this->hashPin($pin);
+    $success  = hash_equals($pin1->pinHash, $provided);
+
+    if ($success) {
+        // Bei Erfolg Versuchsanzahl zurücksetzen
+        $this->resetAttempts($id, $now);
+        return 'success'; // → 200
+    }
+
+    // 3. Fehler: Hochzählen → Sperren bei Limit
+    $newAttempts = $pin1->attempts + 1;
+    $lockedUntil = null;
+
+    if ($newAttempts >= $pin1->maxAttempts) {
+        $lockedUntil = $this->lockUntil($now); // 5 Minuten später
+    }
+
+    $this->incrementAttempts($id, $newAttempts, $lockedUntil, $now);
+
+    return $newAttempts >= $pin1->maxAttempts ? 'locked' : 'wrong'; // → 423 oder 401
+}
+```
+
+**Wichtig**: Sperrprüfung vor dem Versuch durchführen. Prüfung nach dem Versuch könnte ermöglichen, dass der letzte Versuch, der die Sperre auslöst, durchkommt.
+
+## Administrator-Key fail-closed (VULN-H / ATK-03)
+
+```php
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    if ($this->adminKey === '') {
+        return false; // leerer adminKey immer abgelehnt
+    }
+
+    $provided = $request->getHeaderLine('X-Admin-Key');
+
+    return $provided !== '' && hash_equals($this->adminKey, $provided);
+}
+```
+
+Wenn `adminKey` ein leerer String ist, wird bedingungslos `false` zurückgegeben (verhindert, dass ein nicht gesetzter Umgebungsvariable eine offene Admin-Berechtigung verursacht).
+
+## ID-Validierung (VULN-A / ATK-07)
+
+```php
+private function resolveId(ServerRequestInterface $request): ?int
+{
+    $raw = Router::param($request, 'id');
+
+    if ($raw === null || !ctype_digit($raw) || strlen($raw) > 18) {
+        return null; // → 422
+    }
+
+    $id = (int) $raw;
+
+    return $id > 0 ? $id : null;
+}
+```
+
+`strlen($raw) > 18` verhindert 64-Bit-Integer-Überlauf (`PHP_INT_MAX` hat 19 Stellen, mit Sicherheitspuffer).
+
+## PIN-Validierung (VULN-D)
+
+`ctype_digit()` verwenden. Reguläre Ausdrücke (`/^[0-9]+$/`) haben ReDoS-Potenzial (O(n²)), während `ctype_digit()` O(n) und sicher ist:
+
+```php
+private function validatePin(mixed $pin): ?string
+{
+    if (!is_string($pin)) {
+        return 'pin must be a string.'; // VULN-G: Typverwechslungs-Prävention
+    }
+
+    $len = strlen($pin);
+    if ($len < self::MIN_PIN_LEN || $len > self::MAX_PIN_LEN) {
+        return 'pin must be between 4 and 8 digits.';
+    }
+
+    if (!ctype_digit($pin)) { // O(n), kein ReDoS
+        return 'pin must contain only digits.';
+    }
+
+    return null;
+}
+```
+
+## Antwort-Design
+
+**PIN-Hash niemals in Antworten einschließen.** Gilt auch für Administratorantworten:
+
+```php
+public function toAdminArray(): array
+{
+    return [
+        'id'                 => $this->id,
+        'label'              => $this->label,
+        'attempts'           => $this->attempts,
+        'max_attempts'       => $this->maxAttempts,
+        'locked_until'       => $this->lockedUntil,
+        'remaining_attempts' => $this->remainingAttempts(),
+        'created_at'         => $this->createdAt,
+        // pin_hash nicht einschließen
+        // updated_at nicht als interne Information einschließen
+    ];
+}
+```
+
+## Antwort-Beispiele
+
+```json
+// POST /pins (201)
+{
+    "pin": {
+        "id": 1,
+        "label": "vault",
+        "attempts": 0,
+        "max_attempts": 5,
+        "locked_until": null,
+        "remaining_attempts": 5,
+        "created_at": "2026-05-26T10:00:00+00:00"
+    }
+}
+
+// POST /pins/1/verify — Erfolg (200)
+{ "success": true, "locked": false }
+
+// POST /pins/1/verify — Fehler (401)
+{ "success": false, "locked": false }
+
+// POST /pins/1/verify — Gesperrt (423)
+{ "success": false, "locked": true, "error": "PIN is locked due to too many failed attempts." }
+
+// POST /pins/1/unlock (200)
+{ "unlocked": true }
+```
+
+## Sicherheitspunkte (VULN-A~L / ATK-01~12 alle PASS)
+
+| Bedrohung | Kategorie | Gegenmaßnahme |
+|---|---|---|
+| Brute-Force | ATK-01 | `max_attempts`-Limit → `locked_until` 5-Minuten-Sperre |
+| Timing-Angriff (PIN) | ATK-02 / VULN-E | `hash_equals()` zeitkonstanter Vergleich |
+| Administrator-Key-Bypass | ATK-03 / VULN-H | `adminKey = ''` → false (fail-closed) |
+| ID-Enumeration | ATK-04 | Nicht existierende ID gibt 404 zurück (kein Informationsleck) |
+| SQL-Injection (PIN-Wert) | ATK-05 / VULN-B | `ctype_digit` lässt nur Ziffern durch → PDO Prepared Statement |
+| SQL-Injection (ID) | ATK-06 / VULN-B | `ctype_digit + strlen > 18` Schutz → 422 |
+| Integer-Überlauf | ATK-07 / VULN-A / VULN-J | `strlen > 18` Schutz |
+| Sperrumgehung | ATK-08 | Sperrprüfung vor Versuch, DB-Persistenz |
+| Wiederangriff nach Entsperren | ATK-09 | Nach unlock attempts = 0 zurückgesetzt (Normal-Verhalten) |
+| Body-Injection | ATK-10 / VULN-I | Nur explizite Felder akzeptiert |
+| Administrator-Key-Timing | ATK-11 | `hash_equals()` zeitkonstanter Vergleich |
+| BIDI/Unicode-Label | ATK-12 / VULN-L | `mb_strlen` für Längsprüfung, PDO-Speicherung sicher |
+| ReDoS | VULN-D | `ctype_digit()` O(n), kein Regex |
+| Typverwechslung | VULN-G | `!is_string($pin)` Prüfung |
+| max_attempts-Überlauf | VULN-F | Bereichsprüfung 1~20 |
+| SSRF | VULN-K | Keine externe HTTP-Kommunikation (N/A) |
+| Pfad-Traversal | VULN-C | Keine Dateioperationen (N/A) |
+
+## Verwandte Anleitungen
+
+- [Account-Sperrung](account-lockout.md) — Per-Account-Fehleranzahl, 423-Design
+- [OTP-Authentifizierungssystem](otp-authentication.md) — Ähnliches Sperrmuster (nur neuestes OTP gültig)
+- [Webhook-Signaturverifizierung](webhook-signature.md) — `hash_equals()`-Muster
+- [Numerischer Verifizierungscode](numeric-verification-code.md) — 6-stelliger Code-Generierungs- und Verifizierungsablauf

--- a/docs/de/howto/point-ledger-api.md
+++ b/docs/de/howto/point-ledger-api.md
@@ -1,0 +1,310 @@
+# How-to: Punktkonto-API
+
+> **FT-Referenz**: FT300 (`NENE2-FT/pointlog`) — Punktkonto-API: earn/spend/adjust/expire-Transaktionen, Saldo-Tracking, Überziehungsschutz (CHECK balance_after >= 0), nur Admin-Anpassung, reference_id-Idempotenz, MAX_EARN=10000 / MAX_ADJUST=100000 Obergrenzen, ATK-01~12 alle BLOCKED, 30 Tests / 66 Assertions PASS.
+
+Diese Anleitung zeigt, wie ein Loyalitätspunkte-Konto erstellt wird, bei dem Benutzer Punkte verdienen und ausgeben, Admins Salden anpassen und Reference-IDs Doppeltransaktionen verhindern.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    role       TEXT    NOT NULL DEFAULT 'user',
+    created_at TEXT    NOT NULL,
+    CHECK (role IN ('user', 'admin'))
+);
+
+CREATE TABLE point_transactions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL,
+    type         TEXT    NOT NULL,
+    amount       INTEGER NOT NULL,
+    balance_after INTEGER NOT NULL,
+    description  TEXT    NOT NULL,
+    reference_id TEXT,
+    created_at   TEXT    NOT NULL,
+    CHECK (type IN ('earn', 'spend', 'adjust', 'expire')),
+    CHECK (amount > 0),
+    CHECK (balance_after >= 0),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+Drei CHECK-Constraints als Defense-in-Depth:
+- `amount > 0` — keine Null- oder negativen Transaktionen auf DB-Ebene
+- `balance_after >= 0` — Saldo kann im Speicher nie negativ werden
+- `type IN (...)` — nur bekannte Transaktionstypen akzeptiert
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `GET` | `/users/{userId}/points` | `X-User-Id` | Aktuellen Saldo abrufen |
+| `GET` | `/users/{userId}/points/history` | `X-User-Id` | Transaktionshistorie abrufen |
+| `POST` | `/users/{userId}/points/earn` | `X-User-Id` (selbst) | Punkte verdienen |
+| `POST` | `/users/{userId}/points/spend` | `X-User-Id` (selbst) | Punkte ausgeben |
+| `POST` | `/users/{userId}/points/adjust` | `X-User-Id` (admin) | Admin-Anpassung |
+
+## Authentifizierung und Autorisierung
+
+```php
+private function requireUserId(ServerRequestInterface $request): ?int
+{
+    $val = $request->getHeaderLine('X-User-Id');
+    return $val !== '' ? (int) $val : null;
+}
+
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    return $request->getHeaderLine('X-User-Role') === 'admin';
+}
+```
+
+Jeder Handler ruft zuerst `requireUserId()` auf:
+
+```php
+$actorId = $this->requireUserId($request);
+if ($actorId === null) {
+    return $this->responseFactory->create(['error' => 'authentication required'], 401);
+}
+```
+
+Benutzerübergreifender Zugriff wird dann für earn/spend geprüft:
+
+```php
+$targetUserId = (int) $this->routeParam($request, 'userId');
+if ($targetUserId !== $actorId && !$this->isAdmin($request)) {
+    return $this->responseFactory->create(['error' => 'access denied'], 403);
+}
+```
+
+Admins können den Saldo oder die Historie eines beliebigen Benutzers anzeigen. Nicht-Admins können nur auf ihre eigenen zugreifen.
+
+## Strenge Integer-Validierung
+
+```php
+$amount = isset($body['amount']) && is_int($body['amount']) ? $body['amount'] : null;
+if ($amount === null || $amount <= 0) {
+    return $this->responseFactory->create(['error' => 'amount must be a positive integer'], 422);
+}
+```
+
+`is_int()` lehnt ab:
+- Floats: `10.5` — abgelehnt (422)
+- Strings: `"100"` — abgelehnt (422)
+- Booleans: `true` — abgelehnt (422)
+- Null: `0` — abgelehnt (amount <= 0)
+- Negative: `-500` — abgelehnt (amount <= 0)
+
+## Transaktionsobergrenzen
+
+```php
+private const int MAX_EARN_PER_TRANSACTION  = 10000;
+private const int MAX_ADJUST_PER_TRANSACTION = 100000;
+```
+
+```php
+if ($amount > self::MAX_EARN_PER_TRANSACTION) {
+    return $this->responseFactory->create([
+        'error' => 'amount exceeds maximum per transaction',
+        'max'   => self::MAX_EARN_PER_TRANSACTION,
+    ], 422);
+}
+```
+
+Earn ist pro Transaktion auf 10.000 begrenzt. Admin-Adjust ist auf 100.000 begrenzt (höher, da es sich um eine privilegierte Korrekturoperation handelt).
+
+## Überziehungsschutz
+
+```php
+$balance = $this->repository->getBalance($targetUserId);
+if ($balance < $amount) {
+    return $this->responseFactory->create([
+        'error'    => 'insufficient points',
+        'balance'  => $balance,
+        'required' => $amount,
+    ], 422);
+}
+```
+
+Aktuellen Saldo vor dem Abzug prüfen. Den aktuellen Saldo und den erforderlichen Betrag im Fehler zurückgeben, damit Clients dem Benutzer eine aussagekräftige Meldung anzeigen können.
+
+## Admin-Anpassung
+
+```php
+private function handleAdjust(ServerRequestInterface $request): ResponseInterface
+{
+    $actorId = $this->requireUserId($request);
+    if ($actorId === null) {
+        return $this->responseFactory->create(['error' => 'authentication required'], 401);
+    }
+    if (!$this->isAdmin($request)) {
+        return $this->responseFactory->create(['error' => 'admin role required'], 403);
+    }
+    // ...
+    $adjustType = isset($body['adjust_type']) && $body['adjust_type'] === 'subtract' ? 'subtract' : 'add';
+    // ...
+}
+```
+
+Adjust prüft `isAdmin()` **vor** der Prüfung des Zielbenutzers — ein Nicht-Admin erhält sofort 403, unabhängig vom Ziel. Das `adjust_type`-Feld (`'add'`-Standard / `'subtract'`) ermöglicht Admins, sowohl Punkte zu gewähren als auch abzuziehen, ohne separate Endpunkte zu benötigen.
+
+## reference_id-Idempotenz
+
+```php
+if ($referenceId !== null) {
+    $existing = $this->repository->findByReferenceId($targetUserId, $referenceId);
+    if ($existing !== null) {
+        return $this->responseFactory->create($this->formatTransaction($existing), 200);
+    }
+}
+```
+
+Wenn eine `reference_id` angegeben wird:
+- Erster Aufruf → 201 Created mit neuer Transaktion
+- Wiederholter Aufruf mit derselben `reference_id` → 200 OK mit der ursprünglichen Transaktion (keine neue Transaktion erstellt)
+
+Dies verhindert Doppelgutschriften bei Netzwerk-Wiederholungsversuchen. Die reference_id-Suche ist **benutzergebunden** (`findByReferenceId($targetUserId, ...)`), sodass dieselbe reference_id von verschiedenen Benutzern ohne Konflikt verwendet werden kann.
+
+## Saldoberechnung
+
+```php
+// Repository: Summe aller earn/adjust-add-Transaktionen minus spend/adjust-subtract/expire
+public function getBalance(int $userId): int
+{
+    // Typischerweise: balance_after der letzten Transaktion, oder 0 wenn keine
+    $row = $this->executor->fetchOne(
+        'SELECT balance_after FROM point_transactions WHERE user_id = ? ORDER BY id DESC LIMIT 1',
+        [$userId]
+    );
+    return $row !== null ? (int) $row['balance_after'] : 0;
+}
+```
+
+Die `balance_after`-Spalte in jeder Transaktion speichert den laufenden Saldo. Den aktuellen Saldo zu erhalten ist eine einzelne `ORDER BY id DESC LIMIT 1`-Abfrage — keine SUM-Aggregation benötigt.
+
+---
+
+## ATK Assessment — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Nicht-authentifizierter Saldo-Zugriff 🚫 BLOCKED
+
+**Angriff**: `GET /users/2/points` ohne `X-User-Id`-Header.
+**Ergebnis**: BLOCKED — `requireUserId()` gibt null zurück → sofort 401. Keine Daten zurückgegeben.
+
+---
+
+### ATK-02 — Benutzerübergreifendes Saldo-Spähen 🚫 BLOCKED
+
+**Angriff**: `GET /users/2/points` mit `X-User-Id: 3` (Alice versucht, Bobs Saldo zu lesen).
+**Ergebnis**: BLOCKED — `$targetUserId (2) !== $actorId (3)` und kein Admin → 403.
+
+---
+
+### ATK-03 — Selbst-Gewährung an anderen Benutzer 🚫 BLOCKED
+
+**Angriff**: `POST /users/3/points/earn` mit `X-User-Id: 2` und `amount: 99999`.
+**Ergebnis**: BLOCKED — Akteur (2) != Ziel (3) und kein Admin → 403. Zielsaldo bleibt 0.
+
+---
+
+### ATK-04 — Negativer Betrag beim Verdienen 🚫 BLOCKED
+
+**Angriff**: `POST /users/2/points/earn` mit `amount: -500`.
+**Ergebnis**: BLOCKED — `$amount <= 0` Prüfung → 422. Saldo unverändert.
+
+---
+
+### ATK-05 — Null-Betrags-Transaktion 🚫 BLOCKED
+
+**Angriff**: `POST /users/2/points/earn` mit `amount: 0` und separat `amount: 0` zum Ausgeben.
+**Ergebnis**: BLOCKED — Beide geben 422 zurück (`amount <= 0`). Keine Null-Transaktionen erstellt.
+
+---
+
+### ATK-06 — Überziehungsausgabe 🚫 BLOCKED
+
+**Angriff**: 100 Punkte verdienen, dann versuchen 101 auszugeben.
+**Ergebnis**: BLOCKED — `$balance (100) < $amount (101)` → 422 mit `insufficient points`. Saldo bleibt 100. DB `CHECK (balance_after >= 0)` bietet zusätzliche Absicherung.
+
+---
+
+### ATK-07 — Normaler Benutzer passt an 🚫 BLOCKED
+
+**Angriff**: `POST /users/2/points/adjust` mit `X-User-Id: 2` (Nicht-Admin-Rolle).
+**Ergebnis**: BLOCKED — `isAdmin()`-Prüfung schlägt fehl → 403. Saldo bleibt 0.
+
+---
+
+### ATK-08 — Übermäßiger Earn-Betrag 🚫 BLOCKED
+
+**Angriff**: `POST /users/2/points/earn` mit `amount: 10001` (über MAX_EARN=10000).
+**Ergebnis**: BLOCKED — `$amount > MAX_EARN_PER_TRANSACTION` → 422 mit `max: 10000`. Saldo unverändert.
+
+---
+
+### ATK-09 — Doppelgutschrift via reference_id-Wiederverwendung 🚫 BLOCKED
+
+**Angriff**: 500 Punkte mit `reference_id: "order-999"` verdienen, dann dieselbe Anfrage wiederholen.
+**Ergebnis**: BLOCKED — Zweiter Aufruf findet vorhandene Transaktion via `findByReferenceId()` → 200 mit derselben Transaktion. Saldo bleibt 500 (nicht 1000).
+
+---
+
+### ATK-10 — Doppelabzug via reference_id-Wiederverwendung 🚫 BLOCKED
+
+**Angriff**: 300 Punkte mit `reference_id: "redemption-777"` ausgeben, dann wiederholen.
+**Ergebnis**: BLOCKED — Zweiter Aufruf gibt die ursprüngliche Ausgabe-Transaktion zurück (200). Saldo bleibt 700 (nicht 400).
+
+---
+
+### ATK-11 — SQL-Injection in reference_id 🚫 BLOCKED
+
+**Angriff**: `reference_id: "' OR '1'='1' --"` in einer Earn-Anfrage.
+**Ergebnis**: BLOCKED — Parametrisierte Abfragen speichern den Injection-String wörtlich. Saldo ist 100, nicht korrumpiert.
+
+---
+
+### ATK-12 — Float-Betrag 🚫 BLOCKED
+
+**Angriff**: `POST /users/2/points/earn` mit `amount: 10.5`.
+**Ergebnis**: BLOCKED — `is_int(10.5)` ist false → null → 422. Saldo unverändert.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|--------|--------|
+| ATK-01 | Nicht-authentifizierter Saldo-Zugriff | 🚫 BLOCKED |
+| ATK-02 | Benutzerübergreifendes Saldo-Spähen | 🚫 BLOCKED |
+| ATK-03 | Selbst-Gewährung an anderen Benutzer | 🚫 BLOCKED |
+| ATK-04 | Negativer Betrag beim Verdienen | 🚫 BLOCKED |
+| ATK-05 | Null-Betrags-Transaktion | 🚫 BLOCKED |
+| ATK-06 | Überziehungsausgabe | 🚫 BLOCKED |
+| ATK-07 | Normaler Benutzer passt an | 🚫 BLOCKED |
+| ATK-08 | Übermäßiger Earn-Betrag (>MAX) | 🚫 BLOCKED |
+| ATK-09 | Doppelgutschrift via reference_id | 🚫 BLOCKED |
+| ATK-10 | Doppelabzug via reference_id | 🚫 BLOCKED |
+| ATK-11 | SQL-Injection in reference_id | 🚫 BLOCKED |
+| ATK-12 | Float-Betrag | 🚫 BLOCKED |
+
+**12 BLOCKED, 0 EXPOSED**
+Keine kritischen Befunde. Auth-Kette (401→403), Betragsvalidierung (is_int + >0 + Obergrenze), Überziehungsschutz und reference_id-Idempotenz verhindern alle bekannten Angriffsvektoren.
+
+---
+
+## Was man NICHT tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Kein `X-User-Id`-Check (Authentifizierung übersprungen) | Nicht-authentifizierter Zugriff auf alle Salden und Transaktionen |
+| Benutzerübergreifendes Verdienen ohne Admin-Check | Jeder Benutzer verdient Punkte auf dem Konto eines anderen Benutzers |
+| `$amount > 0` ohne `is_int()` | Float `10.5` besteht; Bruchteile von Punkten korrumpieren die Konto-Integrität |
+| Kein MAX_EARN-Cap | Angreifer verdient INT_MAX Punkte in einer Anfrage |
+| Kein Überziehungscheck vor Ausgabe | Saldo wird negativ; DB CHECK ist letztes Mittel, nicht primärer Schutz |
+| Keine `reference_id`-Idempotenz | Netzwerk-Wiederholung verdoppelt Gutschriften oder Abbuchungen |
+| Geteilter `reference_id`-Raum für alle Benutzer | `order-1` von Benutzer A blockiert Benutzer B bei Verwendung derselben Referenz |
+| `getBalance()` via SUM-Aggregation bei großen Tabellen | Vollständiger Tabellen-Scan pro Anfrage; stattdessen `balance_after` laufende Summe verwenden |
+| Admin-Adjust ohne Rollenprüfung zuerst | Nicht-Admin sendet große Anpassung; Rolle vor jeder Geschäftslogik prüfen |
+| Bei Duplikat 200 ohne denselben Transaktions-Body zurückgeben | Client kann Idempotenz nicht verifizieren; muss ursprüngliche Transaktion zurückgeben |

--- a/docs/de/howto/point-loyalty-system.md
+++ b/docs/de/howto/point-loyalty-system.md
@@ -1,0 +1,156 @@
+# Punkte-Loyalitätssystem
+
+Implementierungsanleitung für ein Loyalitätssystem mit Punktevergabe, -verbrauch, Saldoverwaltung und Admin-Anpassung.
+Erklärt idempotente Transaktionen (reference_id), Saldo-Untergrenzenschutz und Admin-RBAC.
+
+## Übersicht
+
+- Benutzer können Punkte verdienen (earn) und ausgeben (spend)
+- Nur Admins können Punkte direkt anpassen (adjust: add/subtract)
+- Saldo wird über `balance_after`-Transaktionsakkumulation verwaltet
+- Idempotente Transaktionen per `reference_id` (verhindert Doppelgutschriften und -abbuchungen)
+- Obergrenzenbeträge (MAX_EARN_PER_TRANSACTION) verhindern Massen-Betrugszuschreibungen
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung | Berechtigung |
+|---|---|---|---|
+| `GET` | `/users/{userId}/points` | Saldo abrufen | Eigentümer oder Admin |
+| `GET` | `/users/{userId}/points/history` | Historie abrufen | Eigentümer oder Admin |
+| `POST` | `/users/{userId}/points/earn` | Punkte vergeben | Eigentümer oder Admin |
+| `POST` | `/users/{userId}/points/spend` | Punkte ausgeben | Eigentümer oder Admin |
+| `POST` | `/users/{userId}/points/adjust` | Punkte anpassen | Nur Admin |
+
+## Datenbankdesign
+
+```sql
+CREATE TABLE point_transactions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('earn', 'spend', 'adjust', 'expire')),
+    amount INTEGER NOT NULL CHECK (amount > 0),
+    balance_after INTEGER NOT NULL CHECK (balance_after >= 0),
+    description TEXT NOT NULL,
+    reference_id TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+Der `balance_after >= 0`-CHECK-Constraint verhindert negativen Saldo auf DB-Ebene.
+Der `amount > 0`-CHECK-Constraint lehnt Transaktionen mit 0 oder weniger auf DB-Ebene ab.
+
+## Saldoberechnung
+
+```php
+public function getBalance(int $userId): int
+{
+    $row = $this->executor->fetchOne(
+        'SELECT balance_after FROM point_transactions WHERE user_id = ? ORDER BY id DESC LIMIT 1',
+        [$userId]
+    );
+    return $row !== null ? (int) $row['balance_after'] : 0;
+}
+```
+
+Das `balance_after` der neuesten Transaktion ist der aktuelle Saldo.
+Da kein separater Saldotabelle gepflegt wird, ist die Transaktionshistorie die einzige Wahrheitsquelle (SSOT).
+
+## Idempotente Transaktionen (reference_id)
+
+```php
+if ($referenceId !== null) {
+    $existing = $this->repository->findByReferenceId($targetUserId, $referenceId);
+    if ($existing !== null) {
+        return $this->responseFactory->create($this->formatTransaction($existing), 200);
+    }
+}
+// ... neue Transaktionsverarbeitung
+```
+
+Wenn `reference_id` bereits existiert, wird die vorhandene Transaktion zurückgegeben (200).
+Verhindert Doppelgutschriften und Doppelabbuchungen.
+
+## Saldoprüfung bei Punkteausgabe
+
+```php
+$balance = $this->repository->getBalance($targetUserId);
+if ($balance < $amount) {
+    return $this->responseFactory->create([
+        'error' => 'insufficient points',
+        'balance' => $balance,
+        'required' => $amount,
+    ], 422);
+}
+$balanceAfter = $balance - $amount;  // immer >= 0
+```
+
+Saldoprüfung auf Anwendungsebene als doppelte Verteidigung mit DB-CHECK-Constraint.
+
+## Admin-Anpassung (adjust)
+
+```php
+// adjust_type: 'add' (Standard) oder 'subtract'
+if ($adjustType === 'subtract') {
+    if ($balance < $amount) { return 422 'insufficient points for adjustment'; }
+    $balanceAfter = $balance - $amount;
+} else {
+    $balanceAfter = $balance + $amount;
+}
+$this->repository->addTransaction($userId, 'adjust', $amount, $balanceAfter, $description, null, $now);
+```
+
+## Obergrenzen-Kontrolle (MAX_EARN_PER_TRANSACTION)
+
+```php
+private const int MAX_EARN_PER_TRANSACTION = 10000;
+
+if ($amount > self::MAX_EARN_PER_TRANSACTION) {
+    return $this->responseFactory->create([
+        'error' => 'amount exceeds maximum per transaction',
+        'max' => self::MAX_EARN_PER_TRANSACTION,
+    ], 422);
+}
+```
+
+Verhindert Angriffe, bei denen in einer einzigen Transaktion große Mengen von Punkten unrechtmäßig vergeben werden.
+
+## Zugangskontrolle
+
+Eigenes Saldo und eigene Historie können nur vom Eigentümer eingesehen werden. Admins können alle Benutzer einsehen und verwalten.
+
+```php
+if ($targetUserId !== $actorId && !$this->isAdmin($request)) {
+    return $this->responseFactory->create(['error' => 'access denied'], 403);
+}
+```
+
+Earn/Spend können nur auf eigene Punkte angewendet werden (man kann keine Punkte eines anderen erhöhen).
+
+## Antwort-Beispiele
+
+### POST /users/2/points/earn
+```json
+{
+  "id": 1,
+  "user_id": 2,
+  "type": "earn",
+  "amount": 100,
+  "balance_after": 100,
+  "description": "Purchase reward",
+  "reference_id": "order-123",
+  "created_at": "2026-05-21T..."
+}
+```
+
+### GET /users/2/points/history
+```json
+{
+  "user_id": 2,
+  "balance": 70,
+  "transactions": [
+    {"id": 2, "type": "spend", "amount": 30, "balance_after": 70, ...},
+    {"id": 1, "type": "earn", "amount": 100, "balance_after": 100, ...}
+  ]
+}
+```

--- a/docs/de/howto/poll-survey.md
+++ b/docs/de/howto/poll-survey.md
@@ -1,0 +1,143 @@
+# How-to: Umfrage / Poll-API
+
+Diese Anleitung zeigt, wie ein Umfrage- und Poll-System mit Doppelstimmen-Prävention mit NENE2 erstellt wird.
+Muster demonstriert durch den **polllog**-Feldversuch (FT217).
+
+## Funktionen
+
+- Polls mit 2–20 Optionen erstellen (nur Admin)
+- Öffentliche und private Polls (privat: nur Admin-Zugriff)
+- Eine Stimme pro Benutzer pro Poll (durch UNIQUE-Constraint erzwungen)
+- Live-Ergebnis-Aggregation mit Stimmanzahl pro Option
+- Gesamtstimmenanzahl über alle Optionen
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS polls (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    question   TEXT    NOT NULL,
+    is_public  INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS poll_options (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    poll_id    INTEGER NOT NULL,
+    label      TEXT    NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS votes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    poll_id    INTEGER NOT NULL,
+    option_id  INTEGER NOT NULL,
+    user_id    INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    UNIQUE (poll_id, user_id),  -- Eine Stimme pro Benutzer pro Poll
+    FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE,
+    FOREIGN KEY (option_id) REFERENCES poll_options(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_votes_poll ON votes (poll_id, option_id);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|--------|------|------|-------------|
+| `POST` | `/polls` | Admin | Poll mit Optionen erstellen |
+| `GET` | `/polls/{id}` | Öffentlich | Poll abrufen (privat → 404 für Nicht-Admin) |
+| `POST` | `/polls/{id}/vote` | Benutzer | Stimme abgeben |
+| `GET` | `/polls/{id}/results` | Öffentlich | Ergebnisanzahl pro Option abrufen |
+
+## Options-Validierung
+
+```php
+private const int MIN_OPTIONS   = 2;
+private const int MAX_OPTIONS   = 20;
+private const int MAX_LABEL_LEN = 100;
+
+foreach ($rawOptions as $idx => $label) {
+    if (!is_string($label) || trim($label) === '') {
+        return $this->problem(422, 'validation-failed', "options[{$idx}] must not be empty.");
+    }
+    if (strlen($label) > self::MAX_LABEL_LEN) {
+        return $this->problem(422, 'validation-failed', "options[{$idx}] too long (max 100).");
+    }
+}
+```
+
+## Doppelstimmen-Prävention
+
+```php
+/** @return 'ok'|'already_voted'|'invalid_option' */
+public function vote(int $pollId, int $userId, int $optionId): string
+{
+    // Überprüfen, ob Option zum Poll gehört (verhindert Poll-übergreifende Options-Injection)
+    $stmt = $this->pdo->prepare(
+        'SELECT id FROM poll_options WHERE id = :oid AND poll_id = :pid'
+    );
+    $stmt->execute([':oid' => $optionId, ':pid' => $pollId]);
+    if ($stmt->fetch() === false) {
+        return 'invalid_option'; // → 422
+    }
+
+    // Auf vorhandene Stimme prüfen
+    $stmt2 = $this->pdo->prepare(
+        'SELECT id FROM votes WHERE poll_id = :pid AND user_id = :uid'
+    );
+    if ($stmt2->fetch() !== false) {
+        return 'already_voted'; // → 409
+    }
+
+    // INSERT — UNIQUE(poll_id, user_id)-Constraint als Sicherheitsnetz
+    $this->pdo->prepare('INSERT INTO votes ...')->execute([...]);
+    return 'ok';
+}
+```
+
+## Ergebnis-Aggregation
+
+`LEFT JOIN` sicherstellt, dass Optionen mit null Stimmen trotzdem in den Ergebnissen erscheinen:
+
+```sql
+SELECT o.id, o.label, o.sort_order,
+       COUNT(v.id) AS votes
+FROM poll_options o
+LEFT JOIN votes v ON v.option_id = o.id AND v.poll_id = o.poll_id
+WHERE o.poll_id = :pid
+GROUP BY o.id, o.label, o.sort_order
+ORDER BY o.sort_order ASC, o.id ASC
+```
+
+```php
+$results    = $this->repo->results($id);
+$totalVotes = array_sum(array_column($results, 'votes'));
+
+return $this->json([
+    'poll_id'     => $id,
+    'total_votes' => $totalVotes,
+    'results'     => $results,
+]);
+```
+
+## Zugriffskontrolle für private Polls
+
+Private Polls geben 404 für Nicht-Admin-Benutzer zurück (Existenz verbergen):
+
+```php
+// GET /polls/{id}
+if (!(bool) $poll['is_public'] && !$this->isAdmin($req)) {
+    return $this->problem(404, 'not-found', 'Poll not found.');
+}
+```
+
+## Sicherheitsmuster
+
+- **Admin fail-closed**: `if ($this->adminKey === '') return false;` vor `hash_equals()`
+- **`is_int()`**: Strenge Typprüfung für `option_id` — lehnt Floats/Strings ab
+- **`ctype_digit()`**: ReDoS-sichere Integer-Validierung für Pfad-IDs
+- **Poll-übergreifende Options-Injection**: `WHERE id = :oid AND poll_id = :pid` verhindert Optionen aus anderem Poll
+- **`is_bool()`**: Strenge Prüfung für `is_public`-Flag — lehnt `1`/`0`/`"true"` usw. ab

--- a/docs/de/howto/prevent-double-booking.md
+++ b/docs/de/howto/prevent-double-booking.md
@@ -1,0 +1,181 @@
+# Wie man Doppelbuchungen verhindert (Reservierungs- und Kapazitätsdurchsetzung)
+
+Reservierungssysteme haben zwei unterschiedliche Fehlermodi, die separat behandelt werden müssen:
+
+1. **Doppelte Reservierung** — derselbe Benutzer versucht, denselben Slot zweimal zu buchen
+2. **Überkapazität** — die Anzahl der Reservierungen würde das Limit des Slots überschreiten
+
+Beide resultieren in einem abgelehnten INSERT, erfordern aber unterschiedliche Fehlerantworten.
+Diese Anleitung zeigt, wie man sie unterscheidet und sich gegen gleichzeitige Konflikte absichert.
+
+---
+
+## 1. Schema: UNIQUE-Constraint + Kapazitätsspalte
+
+```sql
+CREATE TABLE slots (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    date     TEXT    NOT NULL,
+    time     TEXT    NOT NULL,
+    capacity INTEGER NOT NULL DEFAULT 1,
+    UNIQUE(date, time)
+);
+
+CREATE TABLE reservations (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    slot_id    INTEGER NOT NULL REFERENCES slots(id),
+    user_id    TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    UNIQUE(slot_id, user_id)  -- Letztes-Mittel-Schutz gegen Doppelreservierungen
+);
+CREATE INDEX idx_reservations_slot ON reservations (slot_id);
+```
+
+Der `UNIQUE(slot_id, user_id)`-Constraint ist das Sicherheitsnetz — er verhindert Doppelreservierungen,
+selbst wenn die Anwendungslogik einen Fehler hat. Aber er kann nicht sagen, *warum* das INSERT fehlschlug.
+
+---
+
+## 2. Duplikat von Überkapazität durch explizite Prüfung unterscheiden
+
+`DatabaseConstraintException` enthält keine Informationen auf Spaltenebene darüber, welcher Constraint
+ausgelöst hat. Um unterschiedliche 409-Antworten zurückzugeben, vor dem INSERT auf jede Bedingung prüfen:
+
+```php
+public function reserve(int $slotId, string $userId): ?Reservation
+{
+    // 1. Zuerst auf Doppelreservierung prüfen
+    $existing = $this->db->fetchOne(
+        'SELECT id FROM reservations WHERE slot_id = ? AND user_id = ?',
+        [$slotId, $userId],
+    );
+    if ($existing !== null) {
+        throw new AlreadyReservedException('User already has a reservation.');
+    }
+
+    // 2. Verbleibende Kapazität prüfen
+    $slot = $this->findSlot($slotId);
+    if ($slot === null || $slot->available() === 0) {
+        return null; // Aufrufer mappt null → 409 slot-full
+    }
+
+    // 3. INSERT — UNIQUE-Constraint als letzter Schutz
+    $id = $this->db->insert(
+        'INSERT INTO reservations (slot_id, user_id, created_at) VALUES (?, ?, ?)',
+        [$slotId, $userId, $now],
+    );
+
+    return new Reservation((int) $id, $slotId, $userId, $now);
+}
+```
+
+Eine **Domain-Exception** (`AlreadyReservedException`) für die benutzerbezogene Geschäftsregel verwenden,
+nicht `DatabaseConstraintException` — die ein Datenbankschicht-Ereignis signalisiert, keine Geschäftsbedingung.
+
+---
+
+## 3. Handler: auf unterschiedliche 409-Antworten mappen
+
+```php
+try {
+    $reservation = $this->repo->reserve($slotId, $userId);
+} catch (AlreadyReservedException) {
+    return $this->problems->create(
+        $request, 'already-reserved', 'Already Reserved', 409,
+        'You already have a reservation for this slot.',
+    );
+}
+
+if ($reservation === null) {
+    return $this->problems->create(
+        $request, 'slot-full', 'Slot Full', 409,
+        'No capacity remaining for this slot.',
+    );
+}
+```
+
+---
+
+## 4. Verfügbarkeit in SQL berechnen (N+1 vermeiden)
+
+Reservierungen in derselben Abfrage wie den Slot-Abruf zählen:
+
+```sql
+SELECT s.*, COUNT(r.id) AS reserved
+FROM slots s
+LEFT JOIN reservations r ON r.slot_id = s.id
+WHERE s.id = ?
+GROUP BY s.id
+```
+
+Dann `available = capacity - reserved`. Niemals alle Reservierungen abrufen, um sie in PHP zu zählen.
+
+---
+
+## 5. Nebenläufigkeit: TOCTOU und wann es wichtig ist
+
+Das explizite Prüfen-dann-Einfügen-Muster hat ein **TOCTOU (Time-of-Check / Time-of-Use)-Fenster**:
+Zwei gleichzeitige Anfragen können beide die Kapazitätsprüfung bestehen und dann beide versuchen zu INSERT.
+
+| Datenbank | Verhalten |
+|---|---|
+| **SQLite** | Pro-Datenbank-Schreibserialisierung: nur ein Schreibvorgang läuft gleichzeitig. Das zweite INSERT trifft den UNIQUE-Constraint und wirft `DatabaseConstraintException`. Sicher. |
+| **PostgreSQL** unter hoher Nebenläufigkeit | Zwei Anfragen mit unterschiedlichen `user_id` können beide die `available > 0`-Prüfung bestehen und beide INSERT, was kurzzeitig die Kapazität um 1 überschreitet. Der UNIQUE-Constraint löst nicht aus (verschiedene Benutzer). |
+
+**Fix für PostgreSQL**: Prüfung und INSERT in eine `SERIALIZABLE`-Transaktion einwickeln, oder
+`SELECT ... FOR UPDATE` auf der Slot-Zeile verwenden, um sie vor dem Lesen zu sperren:
+
+```php
+$this->txManager->transactional(function (DatabaseQueryExecutorInterface $tx) use ($slotId, $userId): ?Reservation {
+    $db = new SqliteBookingRepository($tx);
+    // Alle Abfragen in diesem Closure teilen dasselbe serialisierbare Snapshot
+    return $db->reserveWithinTransaction($slotId, $userId);
+});
+```
+
+Für SQLite ist der UNIQUE-Constraint allein ausreichender Schutz.
+
+---
+
+## 6. Gleichzeitigkeitsähnliche Szenarien testen
+
+Sequentielle Tests können echte Nebenläufigkeit nicht reproduzieren, aber sie können die Absicht verifizieren:
+
+```php
+public function testLostUpdateSimulation(): void
+{
+    $slotId = $this->decode($this->createSlot(capacity: 1))['id'];
+
+    $alice = $this->reserve($slotId, 'alice');
+    $bob   = $this->reserve($slotId, 'bob');  // kommt „gleichzeitig" an
+
+    self::assertSame(201, $alice->getStatusCode());
+    self::assertSame(409, $bob->getStatusCode());  // Slot voll
+
+    $slot = $this->decode($this->req('GET', '/slots/' . $slotId));
+    self::assertSame(0, $slot['available']);
+}
+
+public function testCancelFreesCapacity(): void
+{
+    $slotId = $this->decode($this->createSlot(capacity: 1))['id'];
+    $this->reserve($slotId, 'alice');
+
+    $this->req('DELETE', '/slots/' . $slotId . '/reservations/alice');
+
+    // Nach Stornierung kann Bob buchen
+    self::assertSame(201, $this->reserve($slotId, 'bob')->getStatusCode());
+}
+```
+
+---
+
+## Hinweise
+
+- Der UNIQUE-Constraint ist ein **Letztes-Mittel-Schutz** — er fängt Fehler in der Anwendungslogik auf.
+  Nie als primärem Kapazitätsdurchsetzer darauf verlassen, da er nicht zwischen Doppelbenutzer
+  und Überkapazität unterscheiden kann.
+- **Stornieren und neu reservieren**: Wenn ein Benutzer storniert, aus `reservations` löschen. Die Kapazitätsanzahl
+  verringert sich automatisch über die `COUNT(r.id)`-Abfrage. Kein explizites „Slot-freigeben"-Update nötig.
+- **Idempotente Stornierung**: `DELETE WHERE slot_id = ? AND user_id = ?` gibt 0 Zeilen zurück, wenn
+  die Reservierung nicht existiert — auf 404 mappen, nicht auf 500.

--- a/docs/de/howto/price-history.md
+++ b/docs/de/howto/price-history.md
@@ -1,0 +1,313 @@
+# How-to: Produkt-Preishistorie-API
+
+> **FT-Referenz**: FT67 (`NENE2-FT/pricelog`) — Produkt-Preishistorie-API
+> **ATK**: FT228 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert eine Preishistorie-API, bei der jedes Produkt eine Zeitleiste von Preisstufen
+(Geltungszeiträume) führt. Der aktuelle Preis und der Preis zu einem beliebigen Zeitpunkt können
+abgefragt werden. Der ATK-Abschnitt dokumentiert zwölf Angriffsvektoren mit Bestanden/Nicht-bestanden-Urteilen.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|--------|------|-------------|
+| `POST` | `/products` | Produkt erstellen |
+| `GET`  | `/products` | Alle Produkte auflisten |
+| `GET`  | `/products/{id}` | Einzelnes Produkt abrufen |
+| `POST` | `/products/{id}/prices` | Neuen Preis setzen (neue Stufe öffnen) |
+| `GET` | `/products/{id}/prices` | Vollständige Preishistorie auflisten |
+| `GET` | `/products/{id}/prices/current` | Aktuell aktiver Preis |
+| `GET` | `/products/{id}/prices/at` | Preis zu einem bestimmten Zeitpunkt (`?datetime=`) |
+
+---
+
+## Preisstufenmodell
+
+Jeder Preis hat einen `effective_from`- und `effective_to`-Zeitstempel. Eine Stufe ist „aktiv" wenn:
+
+```
+effective_from <= now  AND  (effective_to IS NULL  OR  effective_to > now)
+```
+
+`effective_to IS NULL` bedeutet, dass die Stufe noch kein Enddatum hat (offenes Intervall).
+
+```sql
+CREATE TABLE price_tiers (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id     INTEGER NOT NULL REFERENCES products(id),
+    amount         INTEGER NOT NULL,       -- Cent (nicht-negativ)
+    currency       TEXT    NOT NULL DEFAULT 'USD',
+    effective_from TEXT    NOT NULL,
+    effective_to   TEXT,                  -- NULL = offen (aktuell)
+    created_at     TEXT    NOT NULL
+);
+```
+
+---
+
+## Preis setzen: alte Stufe schließen, neue öffnen
+
+```php
+public function setPrice(int $productId, int $amount, string $currency, string $effectiveFrom): PriceTier
+{
+    // Jede offene Stufe schließen, die vor dem neuen effective_from beginnt
+    $this->db->execute(
+        'UPDATE price_tiers
+         SET effective_to = ?
+         WHERE product_id = ? AND effective_to IS NULL AND effective_from <= ?',
+        [$effectiveFrom, $productId, $effectiveFrom],
+    );
+
+    // Neue Stufe öffnen
+    $id = $this->db->insert(
+        'INSERT INTO price_tiers (product_id, amount, currency, effective_from, effective_to, created_at)
+         VALUES (?, ?, ?, ?, NULL, ?)',
+        [$productId, $amount, $currency, $effectiveFrom, $now],
+    );
+    // ...
+}
+```
+
+Das UPDATE schließt jede offene Stufe, deren `effective_from <= newEffectiveFrom`. Dies behandelt
+korrekt drei Szenarien:
+- **Neues effective_from in der Zukunft**: schließt die aktuelle Stufe zum zukünftigen Datum.
+- **Neues effective_from in der Vergangenheit**: rückdatiert den Abschluss der alten Stufe und öffnet eine neue historische Stufe.
+- **Doppeltes effective_from**: schließt die alte Stufe im selben Augenblick, in dem sie begann (Nulldauer), dann öffnet die neue.
+
+> **Nebenläufigkeits-Vorbehalt**: UPDATE und INSERT sind nicht in eine Transaktion eingewickelt. Zwei
+> gleichzeitige `setPrice`-Aufrufe mit demselben `effective_from` können beide die UPDATE-Phase bestehen
+> und beide INSERT, was zwei offene Stufen (`effective_to IS NULL`) hinterlässt. Die Abfragen verwenden
+> `ORDER BY effective_from DESC LIMIT 1`, sodass der letzte INSERT gewinnt, aber die Historie korrumpiert ist.
+> In `transactional()` für Korrektheit unter Nebenläufigkeit einwickeln.
+
+---
+
+## Preis zu einem Zeitpunkt abfragen
+
+```php
+public function priceAt(int $productId, string $datetime): ?PriceTier
+{
+    $row = $this->db->fetchOne(
+        'SELECT * FROM price_tiers
+         WHERE product_id = ? AND effective_from <= ?
+           AND (effective_to IS NULL OR effective_to > ?)
+         ORDER BY effective_from DESC
+         LIMIT 1',
+        [$productId, $datetime, $datetime],
+    );
+
+    return $row !== null ? $this->hydrateTier($row) : null;
+}
+```
+
+Der Vergleich ist lexikografischer String-Vergleich auf ISO-8601-Datetimes, die als TEXT gespeichert sind.
+Dies funktioniert korrekt **nur wenn alle Datetimes dasselbe Format und dieselbe Zeitzone verwenden** (z.B.
+alle UTC `2026-05-27 09:00:00`). Das Mischen von Formaten oder Zeitzonen-Offsets erzeugt falsche Ergebnisse.
+
+**Beispiel**: Wenn `effective_from` als `"2026-05-27T09:00:00+09:00"` (JST) gespeichert ist und
+`?datetime=2026-05-27T00:30:00Z` (UTC, gleicher Augenblick), sieht der String-Vergleich sie
+als verschieden und kann eine falsche Stufe zurückgeben. Alle Datetimes beim Schreiben auf UTC normalisieren.
+
+---
+
+## Betrag in Cent (Integer)
+
+Geldwerte werden als Integer (Cent) gespeichert, um Gleitkomma-Rundung zu vermeiden:
+
+```php
+// POST /products/{id}/prices
+$amount = isset($body['amount']) && is_int($body['amount']) ? $body['amount'] : null;
+
+if ($amount === null || $amount < 0) {
+    $errors[] = ['field' => 'amount', 'code' => 'required', 'message' => 'amount must be a non-negative integer (cents).'];
+}
+```
+
+- `is_int()` lehnt JSON-Floats (`9.99` → PHP-Float) und Strings ab.
+- `$amount < 0` lehnt negative Preise ab.
+- `$amount === 0` ist **erlaubt** (kostenlose Produkte / Aktionen).
+
+---
+
+## ATK — Cracker-Angriffstest (FT228)
+
+### ATK-01 — Keine Authentifizierung
+
+**Angriff**: Preis für ein beliebiges Produkt ohne Anmeldedaten setzen.
+
+**Beobachtet**: `201 Created` — kein Token erforderlich.
+
+**Urteil**: **EXPOSED** (by Design für FT67-Demo).
+Preismutationen hinter Admin-Rolle oder API-Key sperren in Produktion.
+
+---
+
+### ATK-02 — Rückdatierte Preismanipulation
+
+**Angriff**: `effective_from` auf ein vergangenes Datum setzen, um die Preishistorie zu ändern.
+
+**Beobachtet**: `201 Created`. Das UPDATE schließt jede vorhandene offene Stufe bei `2020-01-01`,
+und eine neue Null-Preis-Stufe ab 2020 wird eingefügt. Historische Abfragen (`priceAt`) geben jetzt
+den rückdatierten Preis für vergangene Daten zurück.
+
+**Urteil**: **EXPOSED** — ohne Authentifizierung gibt es keinen Eigentümer, der Rückdatierung autorisiert.
+Mit Auth fordern, dass `effective_from >= now()` es sei denn der Aufrufer ist Admin.
+
+---
+
+### ATK-03 — SQL-Injection via `?datetime=`
+
+**Angriff**: SQL über den `datetime`-Query-Parameter injizieren.
+
+**Beobachtet**: `404 Not Found` — der injizierte String wird als parametrisierter Wert verwendet,
+sodass der Literal-String gegen `effective_from` verglichen wird, was nichts trifft.
+
+**Urteil**: **BLOCKED** — PDO-parametrisierte Statements verhindern SQL-Injection.
+
+---
+
+### ATK-04 — Null-Betrag-Preis
+
+**Angriff**: Produktpreis auf null setzen (kostenlos).
+
+**Beobachtet**: `201 Created`.
+
+**Urteil**: **BY DESIGN AKZEPTIERT** — `amount === 0` ist absichtlich erlaubt
+(Testpläne, Aktionen). Dokumentieren, dass `amount` Cent bedeutet und 0 kostenlos bedeutet.
+Wenn Null-Preis für die Domain nicht gültig ist, `$amount < 0` zu `$amount <= 0` ändern.
+
+---
+
+### ATK-05 — Negativer Betrag
+
+**Angriff**: Negativen Preis setzen (Rückerstattungsangriff?).
+
+**Beobachtet**: `422 Unprocessable Entity` — die Prüfung `$amount < 0` gibt false zurück.
+
+**Urteil**: **BLOCKED** — negative Beträge auf Anwendungsebene abgelehnt.
+
+---
+
+### ATK-06 — Währungscode-Injection (keine Allowlist)
+
+**Angriff**: Preis mit beliebigem oder bösartigem Währungsstring setzen.
+
+**Beobachtet**: Alle geben `201 Created` zurück. Der Währungsstring wird wörtlich gespeichert.
+Der SQL-Injection-String ist sicher (parametrisiert), aber `"NOTCURRENCY"` und der XSS-Payload werden gespeichert.
+
+**Urteil**: **EXPOSED** — `currency` gegen eine ISO-4217-Allowlist validieren:
+```php
+$validCurrencies = ['USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD'];
+if (!in_array($currency, $validCurrencies, true)) {
+    $errors[] = ['field' => 'currency', 'code' => 'invalid_value', 'message' => 'Unsupported currency code.'];
+}
+```
+
+---
+
+### ATK-07 — Extrem großer Betrag
+
+**Angriff**: Betrag einreichen, der größer ist als PHP/SQLite verarbeiten kann.
+
+**Beobachtet**: PHP parst große JSON-Integer als Floats, wenn sie `PHP_INT_MAX` überschreiten.
+`is_int($body['amount'])` gibt false für einen Float zurück → 422.
+
+**Urteil**: **BLOCKED** — `is_int()` lehnt JSON-Integer korrekt ab, die zu PHP-Float überlaufen.
+
+---
+
+### ATK-08 — Ungültiges Datetime-Format in `?datetime=`
+
+**Angriff**: Einen Nicht-Datum-String an den `priceAt`-Endpunkt übergeben.
+
+**Beobachtet**: Beide geben `404 Not Found` zurück — die Strings werden lexikografisch gegen gespeicherte
+`effective_from`-Werte verglichen und treffen nichts.
+
+**Urteil**: **TEILWEISE EXPOSED** — der Endpunkt akzeptiert still ungültige Daten und gibt 404 zurück.
+Formatvalidierung hinzufügen:
+```php
+$dt = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $datetime);
+if ($dt === false) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'datetime', 'code' => 'invalid_format', 'message' => 'datetime must be ISO 8601.']],
+    ]);
+}
+```
+
+---
+
+### ATK-09 — Zukünftiges effective_from (geplanter Preis)
+
+**Angriff**: `effective_from` auf ein zukünftiges Datum setzen, um eine Preisänderung zu planen.
+
+**Beobachtet**: `201 Created`. `currentPrice()` gibt noch den vorherigen Preis zurück, aber `priceAt(...)` gibt die neue Stufe zurück.
+
+**Urteil**: **BY DESIGN AKZEPTIERT** — geplante Preisgestaltung ist ein legitimer Anwendungsfall.
+
+---
+
+### ATK-10 — Gleichzeitiges Preissetzen (Race Condition)
+
+**Angriff**: Zwei simultane `POST /products/1/prices` mit demselben `effective_from` senden.
+
+**Beobachtet**: Ohne eine Transaktion, die UPDATE + INSERT einwickelt, können beide Anfragen die UPDATE-Phase bestehen und beide INSERT.
+
+**Urteil**: **EXPOSED** — `setPrice` in `transactional()` einwickeln.
+
+---
+
+### ATK-11 — Nicht existierende product_id
+
+**Angriff**: Preis für ein nicht existierendes Produkt setzen.
+
+**Beobachtet**: `404 Not Found` — `findProduct(99999)` gibt `null` zurück.
+
+**Urteil**: **BLOCKED** — Existenzprüfung vor Mutation.
+
+---
+
+### ATK-12 — Nicht-numerische Pfad-IDs
+
+**Angriff**: Nicht-Ziffern-Strings als `{id}` übergeben.
+
+**Beobachtet**: Alle geben `404 Not Found` zurück.
+
+**Urteil**: **BLOCKED** in der Praxis. Hinweis: `(int) "9abc"` = `9` — ein Produkt mit
+ID 9 würde übereinstimmen. `ctype_digit()` für strikte Pfadvalidierung verwenden.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|---------------|---------|
+| ATK-01 | Keine Authentifizierung | EXPOSED (by Design) |
+| ATK-02 | Rückdatierte Preismanipulation | EXPOSED |
+| ATK-03 | SQL-Injection via `?datetime=` | BLOCKED |
+| ATK-04 | Null-Betrag-Preis | BY DESIGN AKZEPTIERT |
+| ATK-05 | Negativer Betrag | BLOCKED |
+| ATK-06 | Währungscode-Injection (keine Allowlist) | EXPOSED |
+| ATK-07 | Extrem großer Betrag | BLOCKED |
+| ATK-08 | Ungültiges Datetime-Format | TEILWEISE EXPOSED |
+| ATK-09 | Zukünftiges `effective_from` (geplanter Preis) | BY DESIGN AKZEPTIERT |
+| ATK-10 | Gleichzeitiges setPrice Race Condition | EXPOSED |
+| ATK-11 | Nicht existierendes Produkt | BLOCKED |
+| ATK-12 | Nicht-numerische Pfad-IDs | BLOCKED |
+
+**Echte Schwachstellen vor Produktionseinsatz zu beheben**:
+1. **ATK-01** — Authentifizierung/Autorisierung hinzufügen
+2. **ATK-02** — Rückdatierung auf Admin-Aufrufer beschränken (oder ganz verbieten)
+3. **ATK-06** — `currency` gegen ISO-4217-Allowlist validieren
+4. **ATK-08** — `?datetime=`-Format vor DB-Abfrage validieren
+5. **ATK-10** — `setPrice`-UPDATE+INSERT in Transaktion einwickeln
+
+---
+
+## Verwandte Anleitungen
+
+- [`expense-tracker.md`](expense-tracker.md) — `is_int()`-Betragsvalidierung und ISO-8601-Datum-Roundtrip
+- [`habit-tracker.md`](habit-tracker.md) — ATK-01~12-Muster (vorheriger ATK-Zyklus)
+- [`prevent-double-booking.md`](prevent-double-booking.md) — transaktionales Lesen-Prüfen-Schreiben
+- [`iso-datetime-validation.md`](iso-datetime-validation.md) — strikte ISO-8601-Validierung

--- a/docs/de/howto/wish-list-api.md
+++ b/docs/de/howto/wish-list-api.md
@@ -1,0 +1,138 @@
+# Wunschlisten-API (VULN-A~L-Sicherheitsbewertung)
+
+Dieser Leitfaden demonstriert eine persönliche Wunschlisten-API mit vollständigem CRUD, Admin-Override und Sicherheitshärtung, die VULN-A bis VULN-L abdeckt.
+
+## Muster-Überblick
+
+- Benutzer verwalten private Wunschlisten über `POST /wishes`, `GET /wishes/{id}`, `PATCH /wishes/{id}`, `DELETE /wishes/{id}`.
+- `GET /users/{userId}/wishes` listet die Wünsche eines Benutzers auf (nur Eigentümer oder Admin).
+- IDOR: Nicht-Eigentümer erhalten immer 404 (nicht 403), um die Ressourcenexistenz nicht zu offenbaren.
+- Admins werden durch den `X-Admin-Key`-Header identifiziert; fail-closed wenn Schlüssel leer ist.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS wishes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    title      TEXT    NOT NULL,
+    url        TEXT    NOT NULL DEFAULT '',
+    priority   INTEGER NOT NULL DEFAULT 0,
+    fulfilled  INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_wishes_user ON wishes (user_id, priority DESC, id DESC);
+```
+
+## VULN-A: SQL-Injection
+
+Alle Abfragen verwenden PDO-Prepared Statements mit benannten Platzhaltern. Der Titel `'; DROP TABLE wishes; --` wird unverändert gespeichert, ohne Schaden anzurichten:
+
+```php
+$this->pdo->prepare(
+    'INSERT INTO wishes (user_id, title, ...) VALUES (:uid, :title, ...)'
+)->execute([':uid' => $userId, ':title' => $title, ...]);
+```
+
+## VULN-B: Mass Assignment
+
+Der `update()`-Handler pflegt eine explizite Feld-Allowlist. Felder wie `user_id`, `created_at` oder `id`, die vom Client gesendet werden, werden stillschweigend ignoriert:
+
+```php
+$allowed = ['title', 'url', 'priority', 'fulfilled'];
+foreach ($allowed as $field) {
+    if (array_key_exists($field, $fields)) { ... }
+}
+```
+
+## VULN-C: IDOR
+
+Lese- und Löschvorgänge durch Nicht-Eigentümer geben 404 (nicht 403) zurück, um die Ressourcenexistenz zu verbergen:
+
+```php
+if (!$isAdmin && (int) $wish['user_id'] !== $uid) {
+    return $this->problem(404, 'not-found', 'Wish not found.');
+}
+```
+
+Der Listen-Endpunkt verbirgt ebenfalls die Listen anderer Benutzer:
+
+```php
+if (!$isAdmin && $callerUid !== $targetUid) {
+    return $this->problem(404, 'not-found', 'User not found.');
+}
+```
+
+## VULN-D: Admin-Fail-Closed
+
+Ein leerer `adminKey` gewährt niemals Admin-Rechte. Ohne diesen Guard würde ein unkonfiguriertes Deployment jeden `X-Admin-Key: `-Header als gültig behandeln:
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+## VULN-G: ReDoS
+
+Pfad-Parameter-IDs werden mit `ctype_digit()` statt Regex-Mustern validiert, die anfällig für ReDoS sein könnten:
+
+```php
+if (!ctype_digit($raw) || strlen($raw) > 18) {
+    return $this->problem(404, 'not-found', 'Wish not found.');
+}
+```
+
+## VULN-I: Negative Werte
+
+Priorität muss 0–100 sein. Negative Werte und Werte über 100 geben 422 zurück:
+
+```php
+if (!is_int($priorityRaw) || $priorityRaw < 0 || $priorityRaw > 100) {
+    return $this->problem(422, 'validation-failed', 'priority must be an integer 0–100.');
+}
+```
+
+## VULN-J: JSON-Typverwechslung
+
+`is_int()` lehnt string-kodierte Zahlen (`"5"`) und Floats (`1.5`) für das `priority`-Feld ab. `is_bool()` lehnt Integer `1`/`0` für `fulfilled` ab:
+
+```php
+$p = $body['priority'];
+if (!is_int($p) || $p < 0 || $p > 100) { return 422; }
+
+$f = $body['fulfilled'];
+if (!is_bool($f)) { return 422; }
+```
+
+## Routen
+
+```
+POST   /wishes                 Wunsch erstellen (X-User-Id erforderlich)
+GET    /wishes/{id}            Wunsch nach ID abrufen (Eigentümer oder Admin)
+PATCH  /wishes/{id}            Wunschfelder aktualisieren (nur Eigentümer)
+DELETE /wishes/{id}            Wunsch löschen (Eigentümer oder Admin)
+GET    /users/{userId}/wishes  Wünsche des Benutzers auflisten (Eigentümer oder Admin)
+```
+
+## Validierungsübersicht
+
+| Feld | Regel |
+|---|---|
+| `X-User-Id` | Erforderlich für POST/PATCH; `ctype_digit`, >0 |
+| `title` | Nicht leer, max. 200 Zeichen |
+| `url` | Optional, max. 500 Zeichen |
+| `priority` | Integer 0–100 (nicht String/Float); Standard 0 |
+| `fulfilled` | Nur Boolean (nicht 1/0) bei PATCH |
+| `{id}` Pfad | `ctype_digit`, max. 18 Zeichen, >0; sonst 404 |
+
+## Siehe auch
+
+- FT207-Quelle: `../NENE2-FT/wishlistlog/`
+- Verwandt: `docs/howto/booking-resource.md` (FT201, auch VULN)
+- Verwandt: `docs/howto/coupon-redemption.md` (FT204, VULN + ATK)

--- a/docs/de/howto/wishlist-management.md
+++ b/docs/de/howto/wishlist-management.md
@@ -1,0 +1,146 @@
+# Wunschlisten-Verwaltung
+
+Implementierungsleitfaden für Wunschlisten mit Priorität und Notiz.
+Das Muster der verborgenen Existenz, idempotentes Hinzufügen und mehrfache Pfad-Parameter werden erläutert.
+
+## Überblick
+
+- Benutzer erstellen benannte Wunschlisten (öffentlich/privat)
+- Jeder Wunschliste können Produkte hinzugefügt werden (`priority`: high/medium/low, optionale `note`)
+- Private Wunschlisten geben Nicht-Eigentümern 404 zurück (Muster der verborgenen Existenz)
+- Hinzufügen von Produkten ist idempotent (bestehend → 200, neu → 201)
+- Keine Reihenfolge (keine Position-Verwaltung) — Hauptunterschied zu Content-Kollektionen (FT149)
+
+## Endpunkte
+
+| Method | Path | Beschreibung |
+|---|---|---|
+| `POST` | `/wishlists` | Wunschliste erstellen |
+| `GET` | `/wishlists/{id}` | Wunschliste abrufen (öffentlich oder eigene) |
+| `PUT` | `/wishlists/{id}` | Name und Sichtbarkeit ändern |
+| `DELETE` | `/wishlists/{id}` | Wunschliste löschen |
+| `POST` | `/wishlists/{id}/items` | Produkt hinzufügen (idempotent) |
+| `DELETE` | `/wishlists/{id}/items/{productId}` | Produkt entfernen |
+
+## Datenbankdesign
+
+```sql
+CREATE TABLE wishlists (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    is_public INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE wishlist_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    wishlist_id INTEGER NOT NULL,
+    product_id INTEGER NOT NULL,
+    priority TEXT NOT NULL DEFAULT 'medium',
+    note TEXT,
+    added_at TEXT NOT NULL,
+    UNIQUE (wishlist_id, product_id),
+    CHECK (priority IN ('high', 'medium', 'low')),
+    FOREIGN KEY (wishlist_id) REFERENCES wishlists(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+```
+
+Im Gegensatz zu Content-Kollektionen (FT149) gibt es keine `position`-Spalte.
+`UNIQUE (wishlist_id, product_id)` ist die DB-seitige Absicherung für idempotentes Hinzufügen.
+
+## Muster der verborgenen Existenz
+
+```php
+$isOwner = $actorId !== null && (int) $wishlist['user_id'] === $actorId;
+$isPublic = (bool) $wishlist['is_public'];
+
+if (!$isOwner && !$isPublic) {
+    return $this->responseFactory->create(['error' => 'wishlist not found'], 404);
+}
+```
+
+Nur GET gibt 404 zurück. PUT/DELETE/POST items geben 403 zurück und signalisieren dem Eigentümer fehlende Berechtigung.
+
+## Idempotentes Hinzufügen von Artikeln
+
+```php
+$existing = $this->repository->findItem($id, $productId);
+if ($existing !== null) {
+    return $this->responseFactory->create([
+        'message' => 'already in wishlist',
+        'product_id' => $productId,
+        'priority' => $existing['priority'],
+        'note' => $existing['note'],
+    ], 200);
+}
+$now = date('c');
+$this->repository->addItem($id, $productId, $priority, $note, $now);
+return $this->responseFactory->create([...], 201);
+```
+
+## priority-Validierung (Fallback auf Standardwert bei ungültigem Wert)
+
+```php
+private const array VALID_PRIORITIES = ['high', 'medium', 'low'];
+
+$priority = isset($body['priority']) && is_string($body['priority'])
+    && in_array($body['priority'], self::VALID_PRIORITIES, true)
+    ? $body['priority']
+    : 'medium';
+```
+
+Ungültige priority-Werte fallen auf `'medium'` zurück statt einen Fehler auszulösen.
+So können unbekannte Prioritätswerte, die ein Client aus Gründen der Vorwärtskompatibilität sendet, sicher verarbeitet werden.
+
+## GET /wishlists/{id} Antwortbeispiel
+
+```json
+{
+  "id": 1,
+  "user_id": 1,
+  "name": "Birthday Wishlist",
+  "is_public": true,
+  "item_count": 2,
+  "items": [
+    {
+      "product_id": 3,
+      "product_name": "Wireless Headphones",
+      "priority": "high",
+      "note": "Black color preferred",
+      "added_at": "2026-05-21T..."
+    },
+    {
+      "product_id": 1,
+      "product_name": "Coffee Mug",
+      "priority": "low",
+      "note": null,
+      "added_at": "2026-05-21T..."
+    }
+  ],
+  "created_at": "2026-05-21T...",
+  "updated_at": "2026-05-21T..."
+}
+```
+
+## Unterschiede zwischen Kollektion und Wunschliste
+
+| Aspekt | Kollektion (FT149) | Wunschliste (FT151) |
+|---|---|---|
+| Reihenfolge | Position-Verwaltung vorhanden | Keine (Hinzufüge-Reihenfolge) |
+| Artikel-Metadaten | Keine | priority + note |
+| Obergrenze | 50 Einträge | Keine |
+| Anwendungsfall | Leseliste, Kuratierung | Wunschliste, Geschenkregistrierung |
+
+## Eigentümerschaftsprüfungsmuster
+
+```php
+if ((int) $wishlist['user_id'] !== $actorId) {
+    return $this->responseFactory->create(['error' => 'access denied'], 403);
+}
+```
+
+Dasselbe Muster wird für PUT/DELETE/POST items verwendet.


### PR DESCRIPTION
## 概要

FT全域の howto ドキュメント 174件（54件は既存＋120件新規）をドイツ語に翻訳。

Issue #1283 の主要バッチ。

## 変更内容

- `docs/de/howto/` に 120 件の新規ドイツ語翻訳を追加
- audit-trail.md から wishlist-management.md まで (wish-list-api.md を含む)
- 翻訳品質: 自然なドイツ語・「Sie」敬語形式・コードブロック未変更・技術用語は英語維持

## 翻訳範囲

- audit-trail.md ～ budget-tracking.md
- bulk-operations-partial-success.md ～ document-versioning.md
- draft-publish-workflow.md ～ feature-flags.md
- feedback-collection.md ～ geolocation.md
- group-member-management.md ～ habit-tracker.md
- handle-timezones.md ～ invitation-system.md
- iso-datetime-validation.md ～ jwt-tenant-isolation.md
- leaderboard-ranking.md ～ media-watchlist.md
- money-integer-arithmetic.md ～ numeric-verification-code.md
- oauth2-social-login.md ～ password-reset.md
- patch-partial-update.md ～ pin-verification-lockout.md
- point-ledger-api.md ～ price-history.md
- poll-survey.md ～ prevent-double-booking.md
- wish-list-api.md ・ wishlist-management.md

## チェックリスト

- [x] 全翻訳ファイルが `docs/de/howto/` に存在する
- [x] コードブロックは未変更（コメントのみ翻訳）
- [x] Markdown 構造は原文と同一

Closes #1283 (partial)

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)