### PR TITLE
docs(de): ドイツ語 howto 翻訳 バッチ-b 7件 (slug〜sql-injection-defence) (#1283)

### DIFF
--- a/docs/de/howto/slug-management.md
+++ b/docs/de/howto/slug-management.md
@@ -1,0 +1,193 @@
+# Slug-Verwaltung — Eindeutige URL-Slugs mit Kollisionsauflösung und Verlauf
+
+URL-sichere Slugs aus Titeln generieren, Kollisionen automatisch auflösen und eine
+**Slug-Verlaufstabelle** führen, sodass alte Slugs auf die kanonische URL weiterleiten,
+ohne eingehende Links zu unterbrechen.
+
+**Referenzimplementierung:** `FT174 sluglog` in
+[hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    slug       TEXT    NOT NULL UNIQUE,   -- aktueller kanonischer Slug
+    body       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+-- Alte Slugs für Weiterleitungsunterstützung aufbewahren
+CREATE TABLE slug_history (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    article_id  INTEGER NOT NULL,
+    old_slug    TEXT    NOT NULL UNIQUE,  -- Weiterleitungsquelle; UNIQUE verhindert Duplikate
+    replaced_at TEXT    NOT NULL,
+    FOREIGN KEY (article_id) REFERENCES articles(id)
+);
+```
+
+---
+
+## Slug-Generierung
+
+```php
+final class SlugHelper
+{
+    public static function fromTitle(string $title): string
+    {
+        $slug = mb_strtolower($title);
+        $slug = (string) preg_replace('/[^a-z0-9]+/', '-', $slug);
+        $slug = trim($slug, '-');
+        return $slug !== '' ? $slug : 'untitled';
+    }
+
+    /**
+     * @param callable(string): bool $exists  Gibt true zurück, wenn Slug bereits vergeben.
+     */
+    public static function makeUnique(string $base, callable $exists): string
+    {
+        if (!$exists($base)) {
+            return $base;
+        }
+        $counter = 2;
+        while ($exists("{$base}-{$counter}")) {
+            $counter++;
+        }
+        return "{$base}-{$counter}";
+    }
+}
+```
+
+### Eindeutigkeitsprüfung — Beide Tabellen einbeziehen
+
+Bei der Prüfung, ob ein Slug „vergeben" ist, **beide** Tabellen prüfen: `articles.slug` und
+`slug_history.old_slug`. Andernfalls könnte ein neuer Artikel einen Slug beanspruchen, der noch
+aktiv als Weiterleitungsquelle verwendet wird:
+
+```php
+private function slugExists(string $slug): bool
+{
+    return $this->db->fetchOne('SELECT id FROM articles WHERE slug = ?', [$slug]) !== null
+        || $this->db->fetchOne('SELECT id FROM slug_history WHERE old_slug = ?', [$slug]) !== null;
+}
+```
+
+---
+
+## Slug-Suche mit Weiterleitungshinweis
+
+```php
+public function findBySlugWithRedirect(string $slug): ?array
+{
+    // 1. Aktuellen Slug prüfen (200 OK)
+    $article = $this->findBySlug($slug);
+    if ($article !== null) {
+        return ['found' => $article, 'redirect' => false];
+    }
+
+    // 2. Slug-Verlauf prüfen (301 Weiterleitungshinweis)
+    $row = $this->db->fetchOne(
+        'SELECT article_id FROM slug_history WHERE old_slug = ?', [$slug],
+    );
+    if ($row === null) {
+        return null;  // 404
+    }
+
+    $article = $this->findById((int) $row['article_id']);
+    return $article !== null ? ['found' => $article, 'redirect' => true] : null;
+}
+```
+
+Der Handler gibt dann HTTP 301 mit `canonical_slug` und `data` zurück:
+
+```json
+// GET /articles/by-slug/old-title  →  301
+{
+  "redirect": true,
+  "canonical_slug": "new-title",
+  "data": { "id": 1, "slug": "new-title", ... }
+}
+```
+
+---
+
+## Slug-Aktualisierung — Verlauf protokollieren
+
+Wenn ein Artikel umbenannt wird, den alten Slug nach `slug_history` verschieben:
+
+```php
+if ($newSlug !== $article->slug) {
+    // Nur einfügen, wenn noch nicht im Verlauf (idempotent)
+    $alreadyIn = $this->db->fetchOne(
+        'SELECT id FROM slug_history WHERE old_slug = ?', [$article->slug],
+    );
+    if ($alreadyIn === null) {
+        $this->db->insert(
+            'INSERT INTO slug_history (article_id, old_slug, replaced_at) VALUES (?, ?, ?)',
+            [$id, $article->slug, $now],
+        );
+    }
+}
+```
+
+### Kollisionsbehandlung bei Aktualisierung
+
+Bei der Berechnung des neuen Slugs für einen aktualisierten Artikel den aktuellen Slug des Artikels
+aus der „exists"-Prüfung ausschließen — andernfalls würde er unnötigerweise auf `-2` hochzählen:
+
+```php
+$newSlug = SlugHelper::makeUnique(
+    $newSlugBase,
+    fn (string $s): bool => $s !== $article->slug && $this->slugExists($s),
+);
+```
+
+---
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `POST`  | `/articles` | Artikel erstellen — Slug wird automatisch aus Titel abgeleitet |
+| `GET`   | `/articles/{id}` | Per numerischer ID abrufen |
+| `GET`   | `/articles/by-slug/{slug}` | Per Slug abrufen (200 aktuell / 301 historisch / 404) |
+| `PUT`   | `/articles/{id}` | Titel/Body/Slug aktualisieren; alter Slug → Verlauf |
+| `GET`   | `/articles/{id}/slug-history` | Historische Slugs auflisten |
+
+---
+
+## Kollisionsszenarien
+
+| Szenario | Ergebnis |
+|---|---|
+| Erstes „Hallo Welt" | `hallo-welt` |
+| Zweites „Hallo Welt" | `hallo-welt-2` |
+| Drittes „Hallo Welt" | `hallo-welt-3` |
+| Artikel umbenannt auf einen bereits vergebenen Slug | `vergeben-slug-2` |
+| Gleicher Titel, keine Slug-Änderung | Kein Verlaufseintrag, Slug unverändert |
+| Alter Slug passt zu einem Verlaufseintrag | 301 Weiterleitungsantwort |
+
+---
+
+## Domain-Schicht-Struktur
+
+```
+src/Article/
+├── Article.php
+├── ArticleRepository.php   # create / findBySlug / findBySlugWithRedirect / update / slugHistory
+├── SlugHelper.php          # fromTitle() + makeUnique()
+└── ArticleNotFoundException.php
+```
+
+---
+
+## Siehe auch
+
+- [Soft Delete](./soft-delete.md) — Slug-Verlauf mit soft-gelöschten Datensätzen kombinieren
+- [Inhalts-Versionierung](./content-versioning.md) — Versionshistorie neben Slug-Verlauf
+- [Inhalts-Entwurfs-Lebenszyklus](./content-draft-lifecycle.md) — Slug-Verhalten über Entwurfszustände hinweg

--- a/docs/de/howto/slug-url-history.md
+++ b/docs/de/howto/slug-url-history.md
@@ -1,0 +1,285 @@
+# How-to: Slug-URL-Verwaltung mit Verlauf
+
+> **FT-Referenz**: FT339 (`NENE2-FT/sluglog`) — Automatisch generierte Slugs aus Titeln, Kollisionszähler,
+> Slug-Verlauf für 301-Weiterleitungen bei alten Slugs, explizite Slug-Überschreibung,
+> Schwachstellenbewertung; 17 Tests / 50+ Assertions PASS.
+
+Diese Anleitung zeigt, wie saubere URL-Slugs aus Inhalts-Titeln generiert, Kollisionen mit sequenziellen
+Suffixen behandelt, alte Slugs in einer Verlaufstabelle für dauerhafte Weiterleitungen aufbewahrt und
+häufige Angriffsvektoren verhindert werden.
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    slug       TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+CREATE TABLE slug_history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    article_id INTEGER NOT NULL REFERENCES articles(id),
+    old_slug   TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST`  | `/articles` | Artikel erstellen (automatischer Slug aus Titel) |
+| `PUT`   | `/articles/{id}` | Artikel aktualisieren (Slug wird bei Titeländerung neu generiert) |
+| `GET`   | `/articles/by-slug/{slug}` | Per aktuellem oder altem Slug abrufen |
+| `GET`   | `/articles/{id}/slug-history` | Slug-Verlauf auflisten |
+
+## Slug-Generierung
+
+### `SlugHelper::fromTitle()`
+
+```php
+SlugHelper::fromTitle('Hello World')          // → "hello-world"
+SlugHelper::fromTitle('PHP 8.4: New Features!') // → "php-8-4-new-features"
+SlugHelper::fromTitle('  --Hello--  ')        // → "hello"
+SlugHelper::fromTitle('')                     // → "untitled"
+SlugHelper::fromTitle('---')                  // → "untitled"
+```
+
+Regeln:
+1. Alles in Kleinbuchstaben
+2. Nicht-alphanumerische Zeichen durch `-` ersetzen
+3. Aufeinanderfolgende Bindestriche zusammenfassen
+4. Führende/abschließende Bindestriche entfernen
+5. `"untitled"` zurückgeben wenn Ergebnis leer
+
+```php
+public static function fromTitle(string $title): string
+{
+    $slug = strtolower($title);
+    $slug = preg_replace('/[^a-z0-9]+/', '-', $slug) ?? '';
+    $slug = trim($slug, '-');
+    return $slug !== '' ? $slug : 'untitled';
+}
+```
+
+### Kollisionsauflösung
+
+```php
+POST /articles  {"title": "Hello", "body": "..."}  → 201  {"slug": "hello"}
+POST /articles  {"title": "Hello", "body": "..."}  → 201  {"slug": "hello-2"}
+POST /articles  {"title": "Hello", "body": "..."}  → 201  {"slug": "hello-3"}
+```
+
+```php
+public static function makeUnique(string $base, callable $isTaken): string
+{
+    if (!$isTaken($base)) {
+        return $base;
+    }
+
+    $i = 2;
+    while ($isTaken("{$base}-{$i}")) {
+        $i++;
+    }
+
+    return "{$base}-{$i}";
+}
+```
+
+`$isTaken` ist ein DB-Lookup-Callback: `fn(string $s): bool => (bool) $repo->findBySlug($s)`.
+
+## Artikel erstellen
+
+```php
+POST /articles
+{"title": "My First Post", "body": "Content here."}
+→ 201
+{
+  "id": 1,
+  "title": "My First Post",
+  "slug": "my-first-post",
+  "body": "...",
+  "created_at": "..."
+}
+```
+
+## Artikel aktualisieren
+
+```php
+PUT /articles/1
+{"title": "New Title", "body": "Updated content."}
+→ 200  {"slug": "new-title", ...}
+```
+
+Bei einer Titeländerung wird der neue Slug abgeleitet und der alte Slug in `slug_history` gespeichert.
+
+```php
+// Gleicher Titel — Slug unverändert, kein Verlaufseintrag
+PUT /articles/1  {"title": "New Title", "body": "Different body."}
+→ 200  {"slug": "new-title"}  // gleicher Slug
+
+// Explizite Slug-Überschreibung
+PUT /articles/1  {"title": "New Title", "body": "Body.", "slug": "custom-url-here"}
+→ 200  {"slug": "custom-url-here"}
+
+// Kollision bei Aktualisierung — automatisch aufgelöst
+// (wenn "popular" existiert, Umbenennung auf "popular-2")
+PUT /articles/2  {"title": "Popular", "body": "Body."}
+→ 200  {"slug": "popular-2"}
+
+// Unbekannter Artikel
+PUT /articles/9999  {"title": "X", "body": "Y"}
+→ 404
+```
+
+## Per Slug abrufen
+
+```php
+// Aktueller Slug → 200
+GET /articles/by-slug/new-title
+→ 200  {"id": 1, "slug": "new-title", "title": "New Title", ...}
+
+// Alter Slug → 301 Weiterleitung
+GET /articles/by-slug/my-first-post
+→ 301
+{
+  "redirect": true,
+  "canonical_slug": "new-title"
+}
+
+// Unbekannt → 404
+GET /articles/by-slug/does-not-exist
+→ 404
+```
+
+301-Antworten teilen Crawlern/Clients mit, ihre Links auf den kanonischen Slug zu aktualisieren.
+
+## Slug-Verlauf
+
+```php
+GET /articles/1/slug-history
+→ 200
+{
+  "current_slug": "new-title",
+  "slug_history": [
+    {"old_slug": "my-first-post", "created_at": "..."}
+  ]
+}
+
+// Neuer Artikel — leerer Verlauf
+{"current_slug": "fresh", "slug_history": []}
+
+// Unbekannter Artikel → 404
+GET /articles/9999/slug-history → 404
+```
+
+Verlaufseinträge akkumulieren sich nur, wenn sich der Slug tatsächlich ändert. Das Aktualisieren
+des Body ohne Titeländerung lässt den Verlauf unverändert.
+
+---
+
+## Schwachstellenbewertung
+
+### V-01 — Pfad-Traversal via Slug ✅ SICHER
+
+**Risiko**: Angreifer sendet `GET /articles/by-slug/../../../etc/passwd` um Server-Verzeichnisse zu durchsuchen.
+**Befund**: SICHER — Slug-Lookups sind SQL `WHERE slug = ?` mit einem gebundenen Parameter. Das Pfadsegment wird nie als Dateisystempfad interpretiert. Routing parst den Pfad bevor er den Controller erreicht; `../` in einem URL-Pfad wird durch die HTTP-Schicht kanonisiert.
+
+---
+
+### V-02 — SQL-Injection via Slug in URL ✅ SICHER
+
+**Risiko**: `GET /articles/by-slug/' OR '1'='1` gibt alle Artikel preis.
+**Befund**: SICHER — Slug wird als gebundener Parameter in `WHERE slug = ?` übergeben. SQL-Injection ist unabhängig vom Slug-Wert unmöglich.
+
+---
+
+### V-03 — Slug-Enumeration (Brute-Force-Entdeckung) ⚠️ EXPONIERT
+
+**Risiko**: Angreifer iteriert übliche Slugs (`/articles/by-slug/admin`, `/articles/by-slug/secret-doc`) um private Artikel zu entdecken.
+**Befund**: EXPONIERT — Slugs sind vorhersehbare Ableitungen menschenlesbarer Titel. Auf `GET /articles/by-slug/{slug}` wird weder Ratenbegrenzung noch Authentifizierung erzwungen. Abhilfe: Authentifizierung für private Inhalte erforderlich machen; IP-basierte Ratenbegrenzung hinzufügen; opake IDs für sensible Ressourcen in Betracht ziehen.
+
+---
+
+### V-04 — Slug-Verlauf IDOR ✅ SICHER
+
+**Risiko**: Angreifer ruft `GET /articles/{id}/slug-history` für den Artikel eines anderen Benutzers auf, um vergangene Titel zu entdecken.
+**Befund**: SICHER — Slug-Verlauf ist öffentliche Metadaten. Wenn Artikel öffentlich sind, gilt das auch für ihren Verlauf. Wenn Artikel Autorisierung erfordern, dieselbe Auth-Prüfung konsequent auf den `/slug-history`-Endpunkt anwenden.
+
+---
+
+### V-05 — Unendliche Weiterleitungsschleife via Slug-Verlauf ✅ SICHER
+
+**Risiko**: Artikel A wird auf Slug B umbenannt; Artikel B wird auf Slug A umbenannt — `GET /by-slug/a` → Weiterleitung auf B → Weiterleitung auf A (unendliche Schleife).
+**Befund**: SICHER — Die Implementierung sucht den **aktuellen** Slug in `articles.slug`, prüft dann `slug_history` nur für alte Slugs. Eine 301-Antwort zeigt stets auf den aktuellen kanonischen Slug. Clients, die Weiterleitungen folgen, erreichen den kanonischen Slug in einem Hop.
+
+---
+
+### V-06 — Slug-Kollisionsmissbrauch (Sequenzieller Zählererschöpfungsangriff) ⚠️ EXPONIERT
+
+**Risiko**: Angreifer erstellt tausende Artikel mit dem Titel „popular" um „popular-2" bis „popular-9999" zu reservieren, löscht sie dann — oder erzwingt teure Zählerscans.
+**Befund**: EXPONIERT — Keine Ratenbegrenzung bei der Artikelerstellung. Der `makeUnique`-Zählerscan ist O(n) DB-Abfragen. Abhilfe: POST /articles pro Benutzer ratenbegrenzen; Slug-Zähler bei einem vernünftigen Limit deckeln (z.B. 99); zufälliges Suffix nach Schwellenwert verwenden.
+
+---
+
+### V-07 — Explizite Slug-Injection (Slug eines anderen Artikels überschreiben) ✅ SICHER
+
+**Risiko**: Angreifer verwendet `PUT /articles/2  {"slug": "popular"}` wo „popular" zu Artikel 1 gehört.
+**Befund**: SICHER — `articles.slug` hat einen `UNIQUE`-Constraint. Der Versuch, einen bereits von einem anderen Artikel beanspruchten Slug zu setzen, löst einen DB-Constraint-Verstoß aus, der als 409 Conflict übersetzt wird.
+
+---
+
+### V-08 — Unicode/Homograph-Slug-Angriff ⚠️ EXPONIERT
+
+**Risiko**: Angreifer erstellt einen Artikel mit einem Unicode-Titel, der zu denselben Bytes wie ein vorhandener ASCII-Slug normalisiert (z.B. `café` → `caf-`) um eine visuell verwirrende URL zu erzeugen.
+**Befund**: EXPONIERT — `SlugHelper::fromTitle()` verwendet `preg_replace('/[^a-z0-9]+/', '-', strtolower($title))`. Nicht-ASCII-Zeichen werden durch `-` ersetzt, was unerwartete Kollisionen oder leere Slugs verursachen kann. Abhilfe: Unicode vor der Slug-Generierung auf ASCII-Transliteration normalisieren (z.B. `iconv`); alle Nicht-ASCII nach Normalisierung als `-` behandeln.
+
+---
+
+### V-09 — XSS via im Slug gespeichertem Titel ✅ SICHER
+
+**Risiko**: Titel `<script>alert(1)</script>` erzeugt Slug `script-alert-1-script` — sicherer alphanumerischer Output.
+**Befund**: SICHER — `SlugHelper::fromTitle()` entfernt alle nicht-alphanumerischen Zeichen zu `-`. Der Slug-Output ist stets `[a-z0-9-]`, was HTML-Injection durch den Slug unmöglich macht.
+
+---
+
+### V-10 — Alter Slug gibt umbenannten Inhalt preis ⚠️ EXPONIERT
+
+**Risiko**: Artikel von „secret-plan-v1" auf „public-announcement" umbenannt; Angreifer verwendet alten Slug um den Originaltitel über die `canonical_slug`-Weiterleitungsantwort zu entdecken.
+**Befund**: EXPONIERT — Die 301-Antwort gibt den neuen kanonischen Slug preis, der den umbenannten Inhalt enthüllen kann. Der Slug-Verlaufs-Endpunkt gibt auch alle alten Namen preis. Für sensible Umbenennungen alte Slugs ohne Preisgabe des neuen Speicherorts tombstonen; oder opake Slugs verwenden.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|--------|
+| V-01 | Pfad-Traversal via Slug | ✅ SICHER |
+| V-02 | SQL-Injection via Slug | ✅ SICHER |
+| V-03 | Slug-Enumeration | ⚠️ EXPONIERT |
+| V-04 | Slug-Verlauf IDOR | ✅ SICHER |
+| V-05 | Unendliche Weiterleitungsschleife | ✅ SICHER |
+| V-06 | Kollisionszählererschöpfung | ⚠️ EXPONIERT |
+| V-07 | Explizite Slug-Überschreibung | ✅ SICHER |
+| V-08 | Unicode-Homograph-Angriff | ⚠️ EXPONIERT |
+| V-09 | XSS via Titel | ✅ SICHER |
+| V-10 | Alter Slug gibt umbenannten Inhalt preis | ⚠️ EXPONIERT |
+
+**6 SICHER, 4 EXPONIERT** — Artikelerstellung ratenbegrenzen; Authentifizierung für private Inhalte hinzufügen; Unicode vor Slug-Generierung normalisieren; für sensible Umbenennungen ausschließlich Tombstone-Slug-Verlauf in Betracht ziehen.
+
+---
+
+## Was NOT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Slug direkt in SQL interpolieren | SQL-Injection via Slug-Pfadparameter |
+| Slug-Verlauf bei Artikel-Löschung hard-deleten | Alte URLs geben 404 statt 301 zurück; SEO und Link-Rot |
+| Kein `UNIQUE`-Constraint auf `articles.slug` | Gleichzeitige Inserts erzeugen doppelte Slugs |
+| Alten Slug bei Titeländerung unverändert lassen | Slug-Drift — URL spiegelt Inhalt nicht mehr wider |
+| Kein Zähler-Limit in `makeUnique` | Angreifer erschöpft Zähler durch Massenerstellung |
+| `!==` zum Vergleichen vorhandener Slugs verwenden | Typkoerzionstücken; stets `===` für Slug-Vergleiche verwenden |

--- a/docs/de/howto/soft-delete-restore-permanent.md
+++ b/docs/de/howto/soft-delete-restore-permanent.md
@@ -1,0 +1,169 @@
+# How-to: Soft Delete, Wiederherstellen und dauerhaftes Löschen
+
+> **FT-Referenz**: `NENE2-FT/softdelete` — Soft Delete via `deleted_at`-Zeitstempel, Wiederherstellen
+> (nur soft-gelöschte Notizen können wiederhergestellt werden), dauerhaftes Hard Delete (nur soft-gelöschte
+> Notizen können permanent gelöscht werden); 14 Tests PASS.
+
+Diese Anleitung zeigt, wie drei Löschzustände implementiert werden: aktiv, soft-gelöscht
+(wiederherstellbar) und dauerhaft gelöscht (weg). Vergleiche mit
+`docs/howto/soft-delete-trash-restore.md` (FT340 softdeletelog), das eine dedizierte
+Papierkorb-Ansicht und Massen-Purge hinzufügt.
+
+## Schema
+
+```sql
+CREATE TABLE notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    deleted_at TEXT             -- NULL = aktiv; Zeitstempel = soft-gelöscht
+);
+
+CREATE INDEX idx_notes_deleted ON notes(deleted_at);
+```
+
+`deleted_at IS NULL` → aktiv. `deleted_at IS NOT NULL` → soft-gelöscht.
+
+## Endpunkte
+
+| Methode   | Pfad                     | Beschreibung                          |
+|-----------|--------------------------|---------------------------------------|
+| `POST`    | `/notes`                 | Notiz erstellen                       |
+| `GET`     | `/notes`                 | Nur aktive Notizen auflisten          |
+| `GET`     | `/notes/{id}`            | Notiz abrufen (404 wenn gelöscht)     |
+| `DELETE`  | `/notes/{id}`            | Soft Delete (setzt deleted_at)        |
+| `POST`    | `/notes/{id}/restore`    | Soft-gelöschte Notiz wiederherstellen |
+| `DELETE`  | `/notes/{id}/permanent`  | Soft-gelöschte Notiz dauerhaft löschen |
+
+## Notiz erstellen
+
+```php
+POST /notes  {"title": "My Note", "body": "Some content"}
+
+→ 201
+{
+  "id": 1,
+  "title": "My Note",
+  "body": "Some content",
+  "deleted_at": null,    // ← null = aktiv
+  "created_at": "..."
+}
+```
+
+## Aktive Notizen auflisten
+
+```php
+GET /notes
+→ 200  {"items": [{...aktive Notizen...}], "total": 2}
+```
+
+Gibt nur Notizen mit `deleted_at IS NULL` zurück. Soft-gelöschte Notizen sind hier unsichtbar.
+
+## Soft Delete
+
+```php
+DELETE /notes/1
+→ 200  // setzt deleted_at = jetzt
+
+// Soft-gelöschte Notiz verschwindet aus aktiver Liste
+GET /notes
+→ 200  {"items": [], "total": 0}
+
+// Und aus direktem GET
+GET /notes/1
+→ 404
+```
+
+```sql
+UPDATE notes SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL
+```
+
+## Wiederherstellen
+
+```php
+// Soft-gelöschte Notiz wiederherstellen
+POST /notes/1/restore
+→ 200  {"id": 1, "title": "My Note", "deleted_at": null, ...}  // wieder aktiv
+
+// Wiederhergestellte Notiz erscheint wieder in aktiver Liste
+GET /notes
+→ 200  {"items": [{...}], "total": 1}
+```
+
+### Wiederherstellen einer aktiven Notiz → 404
+
+```php
+// Versuch, eine aktive (nicht soft-gelöschte) Notiz wiederherzustellen → 404
+POST /notes/2/restore   // Notiz 2 wurde nie gelöscht
+→ 404
+```
+
+Nur soft-gelöschte Notizen können wiederhergestellt werden. Aktive Notizen geben 404 bei der
+Wiederherstellung zurück.
+
+```sql
+UPDATE notes SET deleted_at = NULL WHERE id = ? AND deleted_at IS NOT NULL
+-- Wenn 0 Zeilen betroffen → Notiz ist aktiv oder existiert nicht → 404
+```
+
+## Dauerhaftes Löschen
+
+```php
+// Muss zuerst soft-gelöscht sein
+DELETE /notes/1   // soft delete
+POST /notes/1/restore  // wiederherstellen (optional)
+
+// Soft-gelöschte Notiz dauerhaft löschen
+DELETE /notes/1          // zuerst soft-löschen
+DELETE /notes/1/permanent
+→ 200  {"permanent": true}
+
+GET /notes/1
+→ 404  // für immer weg
+```
+
+### Dauerhaftes Löschen einer aktiven Notiz → 404
+
+```php
+// Eine aktive Notiz dauerhaft löschen → 404
+// Muss zuerst soft-löschen, dann dauerhaft löschen
+DELETE /notes/2/permanent   // Notiz 2 ist aktiv
+→ 404
+```
+
+```sql
+DELETE FROM notes WHERE id = ? AND deleted_at IS NOT NULL
+-- Wenn 0 Zeilen betroffen → Notiz ist aktiv oder existiert nicht → 404
+```
+
+## Zustandsdiagramm
+
+```
+Aktiv
+  │
+  │ DELETE /notes/{id}     (soft delete)
+  ▼
+Soft-gelöscht
+  │           │
+  │ POST      │ DELETE
+  │ /restore  │ /permanent
+  ▼           ▼
+Aktiv      Weg (hard deleted)
+```
+
+**Die zentrale Invariante**: dauerhaftes Löschen erfordert einen vorherigen Soft Delete. Dies
+verhindert versehentliche Hard Deletes aus dem aktiven Zustand.
+
+---
+
+## Was NOT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Dauerhaftes Löschen aktiver Notiz erlauben | Übergeht das Soft-Delete-Sicherheitsnetz; Daten weg ohne Wiederherstellungsfenster |
+| 200 bei Wiederherstellen einer aktiven Notiz zurückgeben | Aufrufer kann nicht feststellen ob die Wiederherstellung nötig war; 404 signalisiert „nicht im Papierkorb" |
+| Kein Index auf `deleted_at` | Vollständiger Tabellen-Scan für jede Listenabfrage; `WHERE deleted_at IS NULL` ist ohne Index langsam |
+| Bei `DELETE /notes/{id}` sofort hard-deleten | Keine Wiederherstellung möglich; zuerst Soft Delete verwenden |
+| `deleted_at` in aktiver Liste ausgeben | Clients sehen das Feld; visualisiert Antworten unübersichtlich; herausfiltern oder `null` verwenden |

--- a/docs/de/howto/soft-delete-trash-purge.md
+++ b/docs/de/howto/soft-delete-trash-purge.md
@@ -1,0 +1,278 @@
+# How-to: Soft Delete, Papierkorb und dauerhafter Purge
+
+> **FT-Referenz**: FT257 (`NENE2-FT/softdeletelog`) — Soft Delete / Papierkorb / dauerhaftes Purge-Muster
+> mit `deleted_at`-Spalte
+
+Demonstriert einen dreistufigen Lebenszyklus für Datensätze: aktiv → soft-gelöscht (Papierkorb) →
+dauerhaft gelöscht. Aktive Listen schließen gelöschte Datensätze automatisch aus. Ein dedizierter
+Papierkorb-Endpunkt listet nur gelöschte Datensätze auf. Wiederherstellen bringt einen Datensatz
+vom Papierkorb zurück auf aktiv. Purge entfernt den Datensatz physisch aus der Datenbank
+(nur erlaubt, solange er sich im Papierkorb befindet).
+
+---
+
+## Routen
+
+| Methode   | Pfad                   | Beschreibung                                        |
+|-----------|------------------------|-----------------------------------------------------|
+| `POST`    | `/notes`               | Notiz erstellen                                     |
+| `GET`     | `/notes`               | Aktive Notizen auflisten (ohne soft-gelöschte)      |
+| `GET`     | `/notes/trash`         | Nur Papierkorb-Notizen auflisten                    |
+| `GET`     | `/notes/{id}`          | Eine einzelne aktive Notiz abrufen                  |
+| `DELETE`  | `/notes/{id}`          | Notiz soft-löschen (in Papierkorb verschieben)      |
+| `POST`    | `/notes/{id}/restore`  | Aus Papierkorb auf aktiv wiederherstellen           |
+| `DELETE`  | `/notes/{id}/purge`    | Dauerhaft löschen (nur aus Papierkorb)              |
+
+> **Routenreihenfolge**: `/notes/trash` muss vor `/notes/{id}` registriert werden, damit das
+> literale Segment `trash` nicht als Pfadparameter erfasst wird.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT NULL
+);
+```
+
+`deleted_at TEXT NULL` ist der Soft-Delete-Marker. Wenn `NULL` ist der Datensatz aktiv; wenn auf
+einen ISO-Zeitstempel gesetzt befindet sich der Datensatz im Papierkorb. Kein separates `is_deleted`-
+Boolean ist nötig — der Zeitstempel zeichnet auch auf _wann_ das Löschen stattfand, was für
+Audit-Protokolle und TTL-basierte Purge-Jobs nützlich ist.
+
+---
+
+## Domain-Objekt
+
+```php
+final readonly class Note
+{
+    public function __construct(
+        public int     $id,
+        public string  $title,
+        public string  $body,
+        public string  $createdAt,
+        public string  $updatedAt,
+        public ?string $deletedAt,     // null = aktiv, nicht-null = im Papierkorb
+    ) {}
+
+    public function isDeleted(): bool
+    {
+        return $this->deletedAt !== null;
+    }
+}
+```
+
+`isDeleted()` kapselt die Null-Prüfung, sodass Aufrufer das Implementierungsdetail nicht kennen müssen.
+
+---
+
+## Repository: das `includeTrashed`-Flag
+
+```php
+public function findById(int $id, bool $includeTrashed = false): ?Note
+{
+    $sql = $includeTrashed
+        ? 'SELECT * FROM notes WHERE id = ?'
+        : 'SELECT * FROM notes WHERE id = ? AND deleted_at IS NULL';
+
+    $rows = $this->executor->fetchAll($sql, [$id]);
+    return $rows === [] ? null : $this->hydrate($rows[0]);
+}
+```
+
+Der Standard (`includeTrashed: false`) wendet den `deleted_at IS NULL`-Filter an, sodass Aufrufer
+automatisch sicheres Verhalten erhalten. Nur Wiederherstellen und Purge müssen gelöschte Datensätze
+sehen und übergeben `includeTrashed: true` explizit.
+
+**Warum keine separate `findByIdIncludingTrashed()`-Methode?**
+
+Ein benannter Boolean-Parameter ist an der Aufrufstelle selbst-dokumentierend:
+- `findById($id)` — klar nur-aktiv
+- `findById($id, includeTrashed: true)` — klar papierkorb-bewusst
+
+Eine separate Methode würde die Hydration-Logik duplizieren oder einen internen gemeinsamen Helfer erfordern.
+
+---
+
+## Auflisten: aktiv vs. Papierkorb
+
+```php
+public function listActive(): array
+{
+    return $this->executor->fetchAll(
+        'SELECT * FROM notes WHERE deleted_at IS NULL ORDER BY created_at DESC',
+        [],
+    );
+}
+
+public function listTrashed(): array
+{
+    return $this->executor->fetchAll(
+        'SELECT * FROM notes WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC',
+        [],
+    );
+}
+```
+
+Aktive Notizen werden nach Erstellungszeit sortiert (neueste zuerst). Papierkorb-Notizen werden
+nach Löschzeit sortiert (zuletzt gelöschte zuerst), was für eine „kürzlich gelöscht"-UI natürlich ist.
+
+---
+
+## Soft Delete
+
+```php
+public function softDelete(int $id, string $now): ?Note
+{
+    $note = $this->findById($id);   // nur-aktive Suche
+    if ($note === null) {
+        return null;   // nicht gefunden ODER bereits im Papierkorb → 404
+    }
+
+    $this->executor->execute(
+        'UPDATE notes SET deleted_at = ? WHERE id = ?',
+        [$now, $id],
+    );
+
+    return new Note($note->id, $note->title, $note->body, $note->createdAt, $note->updatedAt, $now);
+}
+```
+
+`findById($id)` ohne `includeTrashed` bedeutet, dass `DELETE /notes/{id}` auf einer bereits im
+Papierkorb befindlichen Notiz `null` → 404 zurückgibt. Dies verhindert Doppel-Lösch-Verwirrung:
+ein Client kann aus einem 404 nicht ableiten, ob die Notiz aktiv und fehlend war oder bereits im Papierkorb.
+
+---
+
+## Wiederherstellen
+
+```php
+public function restore(int $id): ?Note
+{
+    $note = $this->findById($id, includeTrashed: true);
+    if ($note === null || !$note->isDeleted()) {
+        return null;   // nicht gefunden ODER bereits aktiv → 404
+    }
+
+    $this->executor->execute(
+        'UPDATE notes SET deleted_at = NULL WHERE id = ?',
+        [$id],
+    );
+
+    return new Note($note->id, $note->title, $note->body, $note->createdAt, $note->updatedAt, null);
+}
+```
+
+`includeTrashed: true` ist hier erforderlich — die Notiz IST gelöscht, also würde der Standard-Filter
+sie verbergen. Der `!$note->isDeleted()`-Schutz lehnt eine aktive Notiz ab: `restore()` auf einer
+aktiven Notiz aufzurufen gibt `null` → 404 zurück. Dies macht `restore()` idempotent auf dem
+„bereits wiederhergestellt"-Pfad: ein Client, der restore zweimal aufruft, erhält beim ersten
+Aufruf 200 und beim zweiten 404.
+
+---
+
+## Purge (dauerhaftes Löschen)
+
+```php
+public function purge(int $id): bool
+{
+    $note = $this->findById($id, includeTrashed: true);
+    if ($note === null || !$note->isDeleted()) {
+        return false;   // nicht gefunden ODER noch aktiv → 404
+    }
+
+    $this->executor->execute('DELETE FROM notes WHERE id = ?', [$id]);
+    return true;
+}
+```
+
+`purge()` funktioniert nur auf Papierkorb-Datensätzen (`isDeleted()` muss true sein). `DELETE /notes/{id}/purge`
+auf einer aktiven Notiz aufzurufen gibt `false` → 404 zurück. Dies schützt vor versehentlicher
+Datenzerstörung über den falschen Endpunkt — ein Client muss explizit soft-löschen, bevor er purgen kann.
+
+---
+
+## Zustandsautomat
+
+```
+           POST /notes
+               │
+               ▼
+           [aktiv]  ←──────── POST /notes/{id}/restore ────────┐
+               │                                                │
+    DELETE /notes/{id}                                         │
+               │                                                │
+               ▼                                                │
+          [Papierkorb]  ─────────────────────────────────────┘
+               │
+    DELETE /notes/{id}/purge
+               │
+               ▼
+          [weg — physisches DELETE]
+```
+
+`aktiv → Papierkorb` ist umkehrbar. `Papierkorb → weg` ist irreversibel. Es gibt keinen direkten
+Weg von `aktiv → weg`: Purge erfordert einen vorherigen Soft-Delete-Schritt.
+
+---
+
+## Controller: Reihenfolge der Routenregistrierung
+
+```php
+public function register(Router $router): void
+{
+    $router->post('/notes',              $this->create(...));
+    $router->get('/notes',               $this->listActive(...));
+    $router->get('/notes/trash',         $this->listTrashed(...));   // ← muss vor {id} kommen
+    $router->get('/notes/{id}',          $this->get(...));
+    $router->delete('/notes/{id}',       $this->softDelete(...));
+    $router->post('/notes/{id}/restore', $this->restore(...));
+    $router->delete('/notes/{id}/purge', $this->purge(...));
+}
+```
+
+`/notes/trash` muss vor `/notes/{id}` registriert werden. Wäre die Reihenfolge umgekehrt, würde
+eine `GET /notes/trash`-Anfrage `{id}` mit `id = "trash"` matchen, den Integer-Cast fehlschlagen
+lassen und 404 oder 200 mit leerem Body statt der Papierkorbliste zurückgeben.
+
+---
+
+## HTTP-Semantik
+
+| Aktion          | Methode   | Warum                                                              |
+|-----------------|-----------|--------------------------------------------------------------------|
+| Soft Delete     | `DELETE`  | Client möchte die Ressource aus seiner Ansicht entfernen           |
+| Wiederherstellen | `POST`   | Nicht idempotent (zweiter Aufruf gibt 404 zurück); `POST` passend  |
+| Purge           | `DELETE`  | Client möchte dauerhafte Entfernung                                |
+
+`PATCH /notes/{id}` mit `{"deleted_at": null}` ist eine Alternative für die Wiederherstellung,
+aber `POST /restore` ist expliziter und vermeidet das Preisgeben des internen Spaltennamens im
+API-Vertrag.
+
+---
+
+## Design-Vergleich
+
+| Ansatz | Aktiv-Filter | Gelöscht-Marker | Wiederherstellen | Purge |
+|---|---|---|---|---|
+| `deleted_at`-Zeitstempel | `WHERE deleted_at IS NULL` | Zeitstempel + Audit-Spur | `SET deleted_at = NULL` | Physisches `DELETE` |
+| `is_deleted`-Boolean | `WHERE is_deleted = 0` | Nur Boolean | `SET is_deleted = 0` | Physisches `DELETE` |
+| Separate `deleted_notes`-Tabelle | Kein Filter nötig | Zeile in andere Tabelle verschieben | Zeile zurückverschieben | Aus `deleted_notes` löschen |
+
+`deleted_at` ist das häufigste Muster: eine Spalte, minimale Schema-Änderung und ein eingebauter
+Audit-Zeitstempel ohne zusätzliche Kosten.
+
+---
+
+## Verwandte Anleitungen
+
+- [`article-versioning-api.md`](article-versioning-api.md) — Versionshistorie für Inhalte (Audit-Spur-Muster)
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — Explizites DTO-Whitelisting zur Verhinderung von Feld-Injection
+- [`transaction-scope-pattern.md`](transaction-scope-pattern.md) — Atomare Multi-Write-Operationen

--- a/docs/de/howto/soft-delete-trash-restore.md
+++ b/docs/de/howto/soft-delete-trash-restore.md
@@ -1,0 +1,282 @@
+# How-to: Soft Delete, Papierkorb & Wiederherstellungs-API
+
+> **FT-Referenz**: FT340 (`NENE2-FT/softlog`) — Notizen-API mit Soft Delete (`deleted_at`), Papierkorb-Ansicht,
+> Wiederherstellen, dauerhaftes Hard Delete, Massen-Purge, Angepinnt-zuerst-Sortierung und ATK
+> Cracker-Mindset-Angriffstest; 26 Tests / 60+ Assertions PASS.
+
+Diese Anleitung zeigt, wie ein zweistufiger Löschlebenszyklus implementiert wird: Elemente werden
+zuerst soft-gelöscht (in den Papierkorb verschoben) und können wiederhergestellt werden, dann via
+explizitem Hard Delete oder Massen-Purge dauerhaft gelöscht.
+
+## Schema
+
+```sql
+CREATE TABLE notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    is_pinned  INTEGER NOT NULL DEFAULT 0,
+    deleted_at TEXT,               -- NULL = aktiv; ISO 8601 wenn soft-gelöscht
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+`deleted_at IS NULL` = aktiv; `deleted_at IS NOT NULL` = soft-gelöscht (im Papierkorb).
+
+## Endpunkte
+
+| Methode   | Pfad | Beschreibung |
+|-----------|------|-------------|
+| `POST`    | `/notes` | Notiz erstellen |
+| `GET`     | `/notes` | Aktive Notizen auflisten (angepinnte zuerst) |
+| `GET`     | `/notes/{id}` | Aktive Notiz abrufen |
+| `PUT`     | `/notes/{id}` | Aktive Notiz aktualisieren |
+| `DELETE`  | `/notes/{id}` | Soft Delete (→ Papierkorb) |
+| `GET`     | `/notes/trash` | Papierkorb-Notizen auflisten |
+| `POST`    | `/notes/{id}/restore` | Aus Papierkorb wiederherstellen |
+| `DELETE`  | `/notes/{id}/permanent` | Hard Delete (dauerhaft) |
+| `POST`    | `/notes/trash/purge` | Gesamten Papierkorb leeren |
+
+## Notiz erstellen
+
+```php
+POST /notes
+{"title": "My Note", "body": "Content", "is_pinned": false}
+→ 201
+{
+  "id": 1,
+  "title": "My Note",
+  "body": "Content",
+  "is_pinned": false,
+  "deleted_at": null,
+  "created_at": "..."
+}
+
+POST /notes  {"body": "No title"}  → 422  // title erforderlich
+```
+
+## Aktive Notizen auflisten (Angepinnte zuerst)
+
+```php
+GET /notes
+→ 200
+{
+  "total": 3,
+  "items": [
+    {"id": 2, "title": "Pinned", "is_pinned": true, ...},
+    {"id": 1, "title": "Normal A", ...},
+    {"id": 3, "title": "Normal B", ...}
+  ]
+}
+```
+
+```sql
+SELECT * FROM notes WHERE deleted_at IS NULL
+ORDER BY is_pinned DESC, created_at DESC
+```
+
+Soft-gelöschte Notizen werden nie in der aktiven Liste zurückgegeben.
+
+## Notiz abrufen
+
+```php
+GET /notes/1
+→ 200  {"id": 1, "title": "My Note", ...}
+
+// Soft-gelöscht oder unbekannt → gleiches 404
+GET /notes/9999    → 404
+GET /notes/1 (nach DELETE /notes/1)  → 404
+```
+
+## Notiz aktualisieren
+
+```php
+PUT /notes/1
+{"title": "Updated", "body": "New body", "is_pinned": true}
+→ 200  {"title": "Updated", "is_pinned": true, ...}
+
+// Soft-gelöschte Notiz ist nicht aktualisierbar
+PUT /notes/1  (nach DELETE /notes/1)  → 404
+```
+
+## Soft Delete
+
+```php
+DELETE /notes/1
+→ 204  (kein Body)
+
+// Notiz verschwindet aus GET /notes und GET /notes/1
+// Erscheint aber in GET /notes/trash
+
+DELETE /notes/9999  → 404  // nicht gefunden
+```
+
+## Papierkorb-Ansicht
+
+```php
+GET /notes/trash
+→ 200
+{
+  "total": 1,
+  "items": [
+    {"id": 1, "title": "Gone", "deleted_at": "2026-05-27T10:00:00Z", ...}
+  ]
+}
+
+// Aktive Notizen sind NICHT im Papierkorb
+```
+
+`deleted_at` ist für alle Papierkorb-Elemente nicht-null.
+
+## Wiederherstellen
+
+```php
+POST /notes/1/restore
+→ 200  {"id": 1, "title": "Restore Me", "deleted_at": null, ...}
+
+// Wiederhergestellte Notiz erscheint wieder in GET /notes
+// POST /notes/9999/restore  → 404
+```
+
+## Hard Delete (dauerhaft)
+
+```php
+DELETE /notes/1/permanent
+→ 204  (kein Body; Notiz ist aus DB weg)
+
+// Auch aus Papierkorb weg
+// DELETE /notes/9999/permanent  → 404
+```
+
+## Papierkorb leeren
+
+```php
+POST /notes/trash/purge
+→ 200  {"purged": 2}
+
+// Leerer Papierkorb
+POST /notes/trash/purge  → 200  {"purged": 0}
+```
+
+`purge` führt `DELETE FROM notes WHERE deleted_at IS NOT NULL` aus und gibt die Zeilenanzahl zurück.
+
+---
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Hard Delete ohne vorherigen Soft Delete 🚫 BLOCKIERT
+
+**Angriff**: Angreifer ruft `DELETE /notes/1/permanent` auf einer aktiven (noch nicht soft-gelöschten) Notiz auf.
+**Ergebnis**: BLOCKIERT — `DELETE /notes/{id}/permanent` prüft `deleted_at IS NOT NULL` vor dem Fortfahren. Aktive Notizen geben 404 an den permanent-delete-Endpunkt zurück; nur Papierkorb-Elemente können hard-deleted werden.
+
+---
+
+### ATK-02 — Auf soft-gelöschte Notiz via direktem GET zugreifen ✅ SICHER
+
+**Angriff**: Angreifer kennt Notiz-ID 5, die soft-gelöscht wurde, und ruft `GET /notes/5` auf, um geschützten Inhalt zu lesen.
+**Ergebnis**: SICHER — `GET /notes/{id}` fragt `WHERE id = ? AND deleted_at IS NULL` ab. Soft-gelöschte Notizen geben 404 identisch mit unbekannten Notizen zurück — kein Existenzhinweis.
+
+---
+
+### ATK-03 — Papierkorb ohne Auth leeren (Massenzerstörung) ⚠️ EXPONIERT
+
+**Angriff**: Jeder Client ruft `POST /notes/trash/purge` auf, um alle im Papierkorb befindlichen Notizen aller Benutzer dauerhaft zu vernichten.
+**Ergebnis**: EXPONIERT — Es gibt keine Authentifizierungsprüfung auf `POST /notes/trash/purge`. Ohne Pro-Benutzer-Scoping kann ein nicht-authentifizierter Client alle Papierkorb-Daten aller Benutzer irreversibel löschen. Abhilfe: Authentifizierung erforderlich machen; Purge auf den Papierkorb des authentifizierten Benutzers beschränken; Admin-Rolle für globalen Purge erforderlich.
+
+---
+
+### ATK-04 — Doppeltes Soft Delete korrumpiert deleted_at ✅ SICHER
+
+**Angriff**: Angreifer sendet `DELETE /notes/1` zweimal, in der Hoffnung, dass der zweite Aufruf `deleted_at` auf einen späteren Zeitstempel zurücksetzt.
+**Ergebnis**: SICHER — Der erste Delete setzt `deleted_at`. Der zweite Delete findet `deleted_at IS NULL = false`, also gibt die Suche 0 Zeilen zurück → 404. Der Zeitstempel wird nicht geändert.
+
+---
+
+### ATK-05 — Aktive Notiz wiederherstellen (Zustand korrumpieren) 🚫 BLOCKIERT
+
+**Angriff**: Angreifer ruft `POST /notes/1/restore` auf einer aktiven (nicht-gelöschten) Notiz auf, um `deleted_at = null` unbedingt zu erzwingen.
+**Ergebnis**: BLOCKIERT — `restore` fragt `WHERE id = ? AND deleted_at IS NOT NULL` ab. Aktive Notizen passen nicht → 404. Idempotent: eine bereits-aktive Notiz wiederherzustellen ist ein No-Op 404.
+
+---
+
+### ATK-06 — SQL-Injection via Titel beim Erstellen ✅ SICHER
+
+**Angriff**: Angreifer reicht `{"title": "'; DROP TABLE notes; --"}` ein, um die Datenbank zu korrumpieren.
+**Ergebnis**: SICHER — Alle Schreibvorgänge verwenden parametrisierte Statements. Titel wird als Literalzeichenkette gespeichert.
+
+---
+
+### ATK-07 — Notiz-ID überlaufen um Validierung zu umgehen 🚫 BLOCKIERT
+
+**Angriff**: Angreifer sendet `GET /notes/99999999999999999999` (20-stellig) um PHP-Integer zu überlaufen und unbeabsichtigte IDs zu erreichen.
+**Ergebnis**: BLOCKIERT — Notiz-IDs werden mit `ctype_digit` + `strlen <= 18` vor der Konvertierung validiert. Überlauf-Werte → 422.
+
+---
+
+### ATK-08 — Gelöschte Notiz aktualisieren (Ghost schreiben) 🚫 BLOCKIERT
+
+**Angriff**: Angreifer hat eine veraltete Sitzungsreferenz auf eine gelöschte Notiz und reicht PUT ein, um sie zu ändern.
+**Ergebnis**: BLOCKIERT — `PUT /notes/{id}` fragt `WHERE id = ? AND deleted_at IS NULL` ab. Soft-gelöschte Notizen bestehen diese Prüfung nicht → 404. Die Aktualisierung wird abgelehnt.
+
+---
+
+### ATK-09 — Race: Wiederherstellen dann sofort Purge 🚫 BLOCKIERT
+
+**Angriff**: Angreifer wetteifert `POST /notes/1/restore` und `POST /notes/trash/purge`, um eine Notiz mitten im Wiederherstellen zu zerstören.
+**Ergebnis**: BLOCKIERT — Jede Operation ist eine einzelne atomare DB-Transaktion. Das Purge führt `DELETE WHERE deleted_at IS NOT NULL` aus; das Wiederherstellen setzt `deleted_at = NULL`. Eines gewinnt und die Notiz endet in einem konsistenten Zustand.
+
+---
+
+### ATK-10 — Gleichzeitiges Soft Delete hinterlässt Waise ✅ SICHER
+
+**Angriff**: Zwei Anfragen rufen gleichzeitig `DELETE /notes/1` auf. Beide prüfen `deleted_at IS NULL`, sehen null, und versuchen `deleted_at` zu setzen.
+**Ergebnis**: SICHER — Das erste Update gelingt. Das zweite findet `deleted_at IS NOT NULL` (oder 0 aktualisierte Zeilen) → 404. SQLite serialisiert Schreibvorgänge; der zweite Aufruf ist auf DB-Ebene idempotent.
+
+---
+
+### ATK-11 — Titel zu lang (Speichermissbrauch) ⚠️ EXPONIERT
+
+**Angriff**: Angreifer reicht eine 10 MB lange Titelzeichenkette ein, um den Datenbankspeicher zu erschöpfen.
+**Ergebnis**: EXPONIERT — Es wird keine maximale Länge für `title` oder `body` erzwungen. Abhilfe: `MAX_TITLE_LENGTH` (z.B. 500 Zeichen) und `MAX_BODY_LENGTH` (z.B. 100.000 Zeichen) hinzufügen und 422 zurückgeben wenn überschritten. Request-Size-Middleware bietet einen sekundären Schutz.
+
+---
+
+### ATK-12 — Angepinnt-Überschwemmung (Angepinnte Notizen fluten) ⚠️ EXPONIERT
+
+**Angriff**: Angreifer erstellt Tausende angepinnter Notizen, um alle echten Notizen vom Anfang der aktiven Liste zu verdrängen.
+**Ergebnis**: EXPONIERT — Keine Begrenzung der Anzahl angepinnter Notizen. Jede Notiz kann mit `is_pinned: true` erstellt werden. Abhilfe: maximale Anzahl angepinnter Notizen pro Benutzer begrenzen (z.B. 10); 422 zurückgeben wenn überschritten.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|---------|
+| ATK-01 | Hard Delete ohne Soft Delete | 🚫 BLOCKIERT |
+| ATK-02 | Auf soft-gelöschte Notiz per GET zugreifen | ✅ SICHER |
+| ATK-03 | Papierkorb ohne Auth leeren | ⚠️ EXPONIERT |
+| ATK-04 | Doppeltes Soft Delete | ✅ SICHER |
+| ATK-05 | Aktive Notiz wiederherstellen | 🚫 BLOCKIERT |
+| ATK-06 | SQL-Injection via Titel | ✅ SICHER |
+| ATK-07 | Notiz-ID überlaufen | 🚫 BLOCKIERT |
+| ATK-08 | Soft-gelöschte Notiz aktualisieren | 🚫 BLOCKIERT |
+| ATK-09 | Race: Wiederherstellen + Purge | 🚫 BLOCKIERT |
+| ATK-10 | Gleichzeitiges Soft Delete | ✅ SICHER |
+| ATK-11 | Titel zu lang | ⚠️ EXPONIERT |
+| ATK-12 | Angepinnt-Überschwemmung | ⚠️ EXPONIERT |
+
+**7 BLOCKIERT, 2 SICHER, 3 EXPONIERT** — Kritisch: Purge authentifizieren und auf Daten des Akteurs beschränken; Titel/Body-Längenbegrenzungen hinzufügen; Anzahl angepinnter Notizen pro Benutzer begrenzen.
+
+---
+
+## Was NOT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Hard-Delete beim ersten DELETE | Kein Wiederherstellungspfad; versehentliches Löschen ist dauerhaft |
+| Kein `deleted_at IS NULL`-Filter in List/Get-Abfragen | Soft-gelöschte Elemente erscheinen wieder als aktiv |
+| `PUT` auf soft-gelöschten Notizen erlauben | Ghost-Schreibvorgänge — Benutzer bearbeiten Daten, die sie gelöscht glaubten |
+| Keine Auth auf `POST /trash/purge` | Jeder Client vernichtet irreversibel alle Papierkorb-Daten |
+| 403 für soft-gelöschte Notiz bei GET zurückgeben | Gibt Existenz der Notiz preis; 404 verhindert Existenz-Enumeration |
+| Keine Zeilenanzahl-Prüfung nach Soft Delete | Stilles 200 wenn Notiz nicht gefunden; betroffene Zeilen immer prüfen |

--- a/docs/de/howto/soft-delete.md
+++ b/docs/de/howto/soft-delete.md
@@ -1,0 +1,200 @@
+# Soft Delete (Logisches Löschen)
+
+Soft Delete bewahrt einen Datensatz in der Datenbank, markiert ihn aber als gelöscht, indem ein
+`deleted_at`-Zeitstempel gesetzt wird. Dies ermöglicht:
+- Rückgängig machen / Wiederherstellen
+- Audit-Protokolle (wer hat was wann gelöscht)
+- Referentielle Integrität (Datensätze können noch referenziert werden, bis sie endgültig gelöscht werden)
+
+## Schema
+
+Eine `deleted_at`-Spalte hinzufügen, die für aktive Datensätze `NULL` ist und für gelöschte
+Datensätze einen Zeitstempel enthält:
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT NULL          -- NULL = aktiv, Zeitstempel = gelöscht
+);
+```
+
+## Die kritische Regel: deleted_at immer filtern
+
+**Jede Abfrage, die nur aktive Datensätze zurückgeben soll, muss `AND deleted_at IS NULL` enthalten.**
+Diesen Filter wegzulassen ist der häufigste Fehler — der Code funktioniert, aber gelöschte Daten
+fließen in API-Antworten ein.
+
+```php
+// ❌ Fehlender Filter — gibt auch gelöschte Datensätze zurück
+$rows = $this->executor->fetchAll('SELECT * FROM articles WHERE id = ?', [$id]);
+
+// ✅ Gelöschte ausschließen
+$rows = $this->executor->fetchAll(
+    'SELECT * FROM articles WHERE id = ? AND deleted_at IS NULL',
+    [$id],
+);
+```
+
+Dies gilt für jede Abfrage: `findById`, `findAll`, `findByUser`, Paginierungsabfragen und JOIN-Ziele.
+
+## Entität
+
+```php
+final readonly class Article
+{
+    public function __construct(
+        public int $id,
+        public string $title,
+        public string $body,
+        public string $createdAt,
+        public string $updatedAt,
+        public ?string $deletedAt,
+    ) {
+    }
+
+    public function isDeleted(): bool
+    {
+        return $this->deletedAt !== null;
+    }
+}
+```
+
+## Repository-Muster
+
+Ein `$includeTrashed = false`-Flag verwenden. Der Standardwert `false` bedeutet, dass Aufrufer
+explizit gelöschte Datensätze anfordern müssen, was versehentliche Lecks verhindert:
+
+```php
+final class ArticleRepository
+{
+    public function findById(int $id, bool $includeTrashed = false): ?Article
+    {
+        $sql = $includeTrashed
+            ? 'SELECT * FROM articles WHERE id = ?'
+            : 'SELECT * FROM articles WHERE id = ? AND deleted_at IS NULL';
+
+        $row = $this->executor->fetchOne($sql, [$id]);
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    /** @return list<Article> */
+    public function findActive(): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT * FROM articles WHERE deleted_at IS NULL ORDER BY created_at DESC',
+        );
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    /** @return list<Article> */
+    public function findTrashed(): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT * FROM articles WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC',
+        );
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function softDelete(int $id): ?Article
+    {
+        $article = $this->findById($id); // nur aktive
+        if ($article === null) {
+            return null;
+        }
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $this->executor->execute('UPDATE articles SET deleted_at = ? WHERE id = ?', [$now, $id]);
+        return new Article($article->id, $article->title, $article->body, $article->createdAt, $article->updatedAt, $now);
+    }
+
+    public function restore(int $id): ?Article
+    {
+        $article = $this->findById($id, includeTrashed: true);
+        if ($article === null || !$article->isDeleted()) {
+            return null; // nicht gefunden oder nicht im Papierkorb
+        }
+        $this->executor->execute('UPDATE articles SET deleted_at = NULL WHERE id = ?', [$id]);
+        return new Article($article->id, $article->title, $article->body, $article->createdAt, $article->updatedAt, null);
+    }
+
+    /** Dauerhaft löschen — nur aus dem Papierkorb erlaubt. */
+    public function purge(int $id): bool
+    {
+        $article = $this->findById($id, includeTrashed: true);
+        if ($article === null || !$article->isDeleted()) {
+            return false; // Schutz: muss zuerst im Papierkorb sein
+        }
+        $this->executor->execute('DELETE FROM articles WHERE id = ?', [$id]);
+        return true;
+    }
+}
+```
+
+### `insert()` für INSERT verwenden
+
+Beim Erstellen von Datensätzen `insert()` verwenden (nicht `execute()` + `lastInsertId()`):
+
+```php
+// ❌ Zwei Aufrufe
+$this->executor->execute('INSERT INTO articles ...', [...]);
+$id = $this->executor->lastInsertId();
+
+// ✅ Ein Aufruf — gibt die eingefügte Zeilen-ID zurück
+$id = $this->executor->insert('INSERT INTO articles ...', [...]);
+```
+
+## Endpunkte
+
+Eine typische Soft-Delete-API:
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `POST`   | `/articles` | Erstellen |
+| `GET`    | `/articles` | Nur aktive Datensätze |
+| `GET`    | `/articles/trash` | Nur gelöschte Datensätze |
+| `GET`    | `/articles/{id}` | Einzelnen abrufen (404 wenn gelöscht) |
+| `DELETE` | `/articles/{id}` | Soft Delete → 404 wenn bereits gelöscht |
+| `POST`   | `/articles/{id}/restore` | Wiederherstellen → 404 wenn nicht im Papierkorb |
+| `DELETE` | `/articles/{id}/purge` | Hard Delete → 404 wenn nicht im Papierkorb |
+
+**Hinweis zu REST-Semantik:** `DELETE /articles/{id}` verhält sich als Soft Delete, nicht als
+dauerhafte Entfernung. Falls dies Clients überrascht, klar in der OpenAPI-Spezifikation dokumentieren
+oder `POST /articles/{id}/trash` für die Soft-Delete-Aktion verwenden.
+
+## `deleted_at` immer in Antworten einschließen
+
+`deleted_at` in jede Antwort aufnehmen, damit Clients den Ressourcenstatus ohne zusätzliche Anfragen
+bestimmen können:
+
+```php
+return $this->json->create([
+    'id'         => $article->id,
+    'title'      => $article->title,
+    'body'       => $article->body,
+    'created_at' => $article->createdAt,
+    'updated_at' => $article->updatedAt,
+    'deleted_at' => $article->deletedAt, // null = aktiv; Zeitstempel = gelöscht
+]);
+```
+
+## Fremdschlüssel und Soft Delete
+
+Wenn andere Tabellen auf einen soft-gelöschten Datensatz verweisen:
+- Soft Delete verletzt keine Fremdschlüssel-Constraints — die Zeile existiert noch
+- Hard Delete (Purge) kann Constraints verletzen, wenn verweisende Zeilen existieren
+- Vor dem Purge abhängige Datensätze prüfen oder Soft Delete auf abhängige Datensätze kaskadieren
+
+## Code-Review-Checkliste
+
+- [ ] Jede Abfrage für aktive Datensätze enthält `AND deleted_at IS NULL`
+- [ ] Standard von `findById()` ist `$includeTrashed = false` — Aufrufer fordern explizit an
+- [ ] `purge()` schützt gegen Hard-Deleten aktiver Datensätze (Prüfung mit `isDeleted()`)
+- [ ] `restore()` gibt `null` zurück (→ 404) wenn Datensatz nicht im Papierkorb
+- [ ] JOIN-Abfragen auf Soft-Delete-Tabellen filtern auch `deleted_at IS NULL` auf der JOIN-Tabelle
+- [ ] `deleted_at` ist in API-Antworten enthalten, damit Clients den Status bestimmen können
+- [ ] `DELETE /articles/{id}`-Verhalten (soft vs. hard) ist in OpenAPI dokumentiert
+- [ ] Tests decken ab: löschen → 404 bei GET, Liste schließt gelöschte aus, wiederherstellen → wieder sichtbar, purge → überall weg, doppeltes Löschen → 404, aktiven purgen → 404
+- [ ] `insert()` wird für INSERT verwendet (nicht `execute()` + `lastInsertId()`)

--- a/docs/de/howto/sql-injection-defence.md
+++ b/docs/de/howto/sql-injection-defence.md
@@ -1,0 +1,338 @@
+# How-to: SQL-Injection-Abwehr
+
+> **FT-Referenz**: FT264 (`NENE2-FT/injectionlog`) — SQL-Injection-Abwehr: parametrisierte Abfragen,
+> LIKE-Injection, ORDER BY-Allowlist
+> **ATK**: FT264 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert die drei hauptsächlichen SQL-Injection-Vektoren in einer PHP-API — Wert-Injection,
+LIKE-Wildcard-Injection und ORDER BY-Spalten-Injection — sowie die korrekte Abwehr für jeden.
+Enthält eine vollständige Cracker-Mindset-Angriffsbewertung.
+
+---
+
+## Routen
+
+| Methode   | Pfad            | Beschreibung                               |
+|-----------|-----------------|--------------------------------------------|
+| `GET`     | `/products`     | Produkte auflisten/suchen (filterbar, sortierbar) |
+| `POST`    | `/products`     | Produkt erstellen                          |
+| `GET`     | `/products/{id}`| Einzelnes Produkt abrufen                  |
+| `DELETE`  | `/products/{id}`| Produkt löschen                            |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL,
+    category    TEXT    NOT NULL,
+    price       REAL    NOT NULL DEFAULT 0.0,
+    description TEXT    NOT NULL DEFAULT ''
+);
+```
+
+---
+
+## Die drei SQL-Injection-Angriffsflächen
+
+### 1. Wert-Injection: parametrisierte Abfragen
+
+```php
+// ❌ String-Interpolation — injizierbar
+$rows = $db->fetchAll("SELECT * FROM products WHERE id = {$id}");
+
+// ✅ Parametrisiert — der Treiber escaped alle Werte
+$rows = $db->fetchAll('SELECT * FROM products WHERE id = ?', [$id]);
+```
+
+Der `?`-Platzhalter von PDO bindet den Wert als typisierten Parameter. Der Wert wird nie in den
+SQL-String interpoliert. Ein Angreifer, der `id = "1; DROP TABLE products; --"` sendet, bekommt
+seine gesamte Eingabe als wörtliche Zeichenketten-Bindung gespeichert — das SQL wird nicht geändert.
+
+### 2. LIKE-Wildcard-Injection: parametrisierte Wildcards
+
+```php
+// ❌ Interpoliertes LIKE — injizierbar UND wildcard-escapiert
+$rows = $db->fetchAll("SELECT * FROM products WHERE name LIKE '%{$q}%'");
+
+// ✅ Parametrisierte Wildcard — der ?-Wert wird nach der ||-Konkatenation gebunden
+$rows = $db->fetchAll(
+    "SELECT * FROM products WHERE name LIKE '%' || ? || '%' OR description LIKE '%' || ? || '%'",
+    [$q, $q],
+);
+```
+
+`'%' || ? || '%'` ist Standard-SQL-Zeichenketten-Konkatenation (SQLite, PostgreSQL). Der `?`-Wert
+wird als Parameter gebunden — die `%`-Wildcards sind Literale im SQL-String, nicht aus Benutzereingaben.
+
+**LIKE-Metazeichen-Escape**: `%` und `_` in der Benutzereingabe `$q` werden in dieser Implementierung
+NICHT escaped. Eine Suche nach `%` würde alles treffen. Für Produktion LIKE-Metazeichen escapen:
+
+```php
+$escaped = str_replace(['%', '_', '\\'], ['\\%', '\\_', '\\\\'], $q);
+$rows = $db->fetchAll("... WHERE name LIKE '%' || ? || '%' ESCAPE '\\'", [$escaped, $escaped]);
+```
+
+### 3. ORDER BY-Injection: Spalten-Allowlist
+
+```php
+private const array ALLOWED_SORT_FIELDS = ['id', 'name', 'category', 'price'];
+
+public function search(string $query = '', string $sortField = 'id', string $sortDir = 'asc'): array
+{
+    if (!in_array($sortField, self::ALLOWED_SORT_FIELDS, true)) {
+        throw new InvalidSortFieldException("Invalid sort field: {$sortField}");
+    }
+
+    $sortDir    = strtolower($sortDir) === 'desc' ? 'DESC' : 'ASC';
+    $sortClause = $sortField . ' ' . $sortDir;   // sicher: allowlisted Spalte + whitelisted Richtung
+
+    $rows = $db->fetchAll(
+        "SELECT * FROM products ORDER BY {$sortClause}",
+    );
+}
+```
+
+`ORDER BY` kann keine parametrisierten Platzhalter verwenden — der Spaltenname muss interpoliert werden.
+Die korrekte Abwehr ist eine explizite Allowlist: nur Werte in `ALLOWED_SORT_FIELDS` dürfen im SQL-String
+erscheinen. Jeder andere Wert wirft eine Exception (400 im Controller).
+
+`sortDir` wird genau auf `'ASC'` oder `'DESC'` abgebildet — Benutzereingaben werden nie direkt interpoliert.
+
+---
+
+## ATK — Cracker-Mindset-Angriffstest (FT264)
+
+### ATK-01 — Klassische SELECT-Injection via GET-Parameter
+
+**Angriff**: SQL via die Suchabfrage `?q=' OR '1'='1` einschleusen.
+
+```
+GET /products?q=' OR '1'='1
+```
+
+**Beobachtet**: `$q` wird als `?`-Parameter in `LIKE '%' || ? || '%'` gebunden. Die gesamte Zeichenkette
+`' OR '1'='1` wird als wörtlicher Textwert behandelt, nach dem gesucht wird. Es werden keine
+zusätzlichen Zeilen zurückgegeben.
+
+**Urteil**: **BLOCKIERT** — parametrisiertes LIKE verhindert Wert-Injection.
+
+---
+
+### ATK-02 — DROP TABLE-Injection via Suche
+
+**Angriff**: Eine destruktive Anweisung einschleusen.
+
+```
+GET /products?q='; DROP TABLE products; --
+```
+
+**Beobachtet**: Der Payload wird als LIKE-Parameterwert gebunden. `'; DROP TABLE products; --` wird
+als wörtlicher Text gesucht. Die Tabelle wird nicht gedroppt.
+
+**Urteil**: **BLOCKIERT** — parametrisierte Abfragen können keine eingeschleusten Anweisungen ausführen.
+
+---
+
+### ATK-03 — ORDER BY-Spalten-Injection: beliebige Spalte
+
+**Angriff**: Eine nicht erkannte Sortierspalte einschleusen.
+
+```
+GET /products?sort=password
+```
+
+**Beobachtet**: `in_array('password', self::ALLOWED_SORT_FIELDS, true)` gibt `false` zurück.
+`InvalidSortFieldException` wird geworfen. Der Controller fängt sie und gibt 400 zurück.
+
+**Urteil**: **BLOCKIERT** — Spalten-Allowlist lehnt unbekannte Spaltennamen ab.
+
+---
+
+### ATK-04 — ORDER BY-Injection: Unterabfrage-Injection
+
+**Angriff**: Eine Unterabfrage als Sortierspalte einschleusen.
+
+```
+GET /products?sort=(SELECT%20name%20FROM%20users%20LIMIT%201)
+```
+
+**Beobachtet**: Der dekodierte Wert `(SELECT name FROM users LIMIT 1)` ist nicht in `ALLOWED_SORT_FIELDS`.
+`InvalidSortFieldException` wird geworfen. 400 zurückgegeben.
+
+**Urteil**: **BLOCKIERT** — Allowlist lehnt jeden Wert ab, der nicht in der bekannten Spaltenliste steht, einschließlich Unterabfragen.
+
+---
+
+### ATK-05 — ORDER BY-Injection: Richtungsmanipulation
+
+**Angriff**: SQL via den Sortierrichtungsparameter einschleusen.
+
+```
+GET /products?order=DESC;%20DROP%20TABLE%20products;--
+```
+
+**Beobachtet**: `strtolower($sortDir) === 'desc'` ist `false` für den eingeschleusten Wert. Die Richtung
+fällt durch auf `'ASC'`. Das eingeschleuste SQL wird nie interpoliert. 200 zurückgegeben mit Produkten in
+ASC-Reihenfolge sortiert.
+
+**Urteil**: **BLOCKIERT** — Richtung wird genau auf `'ASC'` oder `'DESC'` abgebildet, nie interpoliert.
+
+---
+
+### ATK-06 — UNION-Injection via Suchabfrage
+
+**Angriff**: Ein `UNION SELECT` einschleusen, um Daten zu exfiltrieren.
+
+```
+GET /products?q=' UNION SELECT id,name,email,password,'' FROM users --
+```
+
+**Beobachtet**: Die vollständige Injection-Zeichenkette wird als LIKE-Parameterwert gebunden. Das
+`UNION SELECT` wird als wörtlicher Text in den Spalten `name` und `description` gesucht. Es werden
+keine Benutzerdaten zurückgegeben.
+
+**Urteil**: **BLOCKIERT** — parametrisierte Abfrage verhindert UNION-Injection.
+
+---
+
+### ATK-07 — ID-Injection via Pfadparameter
+
+**Angriff**: SQL via den Pfadparameter einschleusen.
+
+```
+GET /products/1;%20DROP%20TABLE%20products;
+```
+
+**Beobachtet**: Der Pfadparameter `{id}` wird durch `(int) $params['id']` auf int gecastet. Das SQL
+wird zu `WHERE id = 1` — das Injection-Suffix wird durch den Cast abgeschnitten. Die Tabelle wird
+nicht gedroppt.
+
+**Urteil**: **BLOCKIERT** — `(int)`-Cast schneidet beim ersten Nicht-Ziffer-Zeichen ab.
+
+---
+
+### ATK-08 — Boolean-basierte blinde Injection via Suche
+
+**Angriff**: Daten über boolesche Bedingungen herauslecken.
+
+```
+GET /products?q=' AND '1'='1
+GET /products?q=' AND '1'='2
+```
+
+**Beobachtet**: Beide Zeichenketten werden als LIKE-Parameter gebunden. Beide geben Produkte zurück,
+deren Name oder Beschreibung den wörtlichen Text `' AND '1'='1` enthält. Keine der Abfragen ändert
+die SQL-WHERE-Logik. Beide geben dasselbe (leere) Ergebnisset zurück.
+
+**Urteil**: **BLOCKIERT** — parametrisierte Bindung verhindert boolesche Injection.
+
+---
+
+### ATK-09 — Second-Order Injection: gespeicherter Payload wird später abgerufen
+
+**Angriff**: Produkt mit SQL im Namen erstellen, dann alle Produkte abrufen.
+
+```json
+POST /products {"name": "'; DROP TABLE products; --", "category": "test", "price": 1}
+GET /products
+```
+
+**Beobachtet**: Das `INSERT` verwendet parametrisiertes `?` — der Injection-Payload wird als Literaltext
+gespeichert. Die `SELECT *`- und `LIKE`-Abfragen verwenden ebenfalls parametrisierte Abfragen. Der Payload
+wird als Zeichenkettenwert zurückgegeben, nie als SQL ausgeführt.
+
+**Urteil**: **BLOCKIERT** — alle Lese- und Schreibpfade verwenden parametrisierte Abfragen.
+
+---
+
+### ATK-10 — LIKE-Metazeichen-Flut: `%`-Suche
+
+**Angriff**: `?q=%` senden, um alle Produkte zu treffen und eine beabsichtigte Leersuche zu umgehen.
+
+```
+GET /products?q=%25   (URL-dekodiert: %)
+```
+
+**Beobachtet**: `$q = '%'` wird als LIKE-Parameter gebunden. `LIKE '%' || '%' || '%'` = `LIKE '%%%'`
+trifft jede Zeile. Alle Produkte werden zurückgegeben.
+
+**Urteil**: **EXPONIERT** — `%` und `_` in Benutzereingaben werden nicht escaped. Eine Suche nach `%`
+trifft alles; eine Suche nach `_` trifft jedes einzelne Zeichen. LIKE-Metazeichen escapen oder
+das Verhalten als beabsichtigt dokumentieren.
+
+---
+
+### ATK-11 — Null-Byte-Injection
+
+**Angriff**: Ein Null-Byte in die Suchabfrage einbetten.
+
+```
+GET /products?q=widget%00extra
+```
+
+**Beobachtet**: PHPs `?`-Bindung übergibt die rohe Zeichenkette einschließlich des Null-Bytes an
+SQLites parametrisierte Abfrage. SQLite behandelt das Null-Byte als Teil der Zeichenkette. `LIKE '%widget\0extra%'`
+trifft keine normalen Produktnamen. Keine Injection tritt auf.
+
+**Urteil**: **BLOCKIERT** — parametrisierte Abfragen behandeln Null-Bytes als wörtlichen Zeichenketteninhalt.
+
+---
+
+### ATK-12 — Gestapelte Abfragen (Multi-Statement-Injection)
+
+**Angriff**: Eine zweite Anweisung nach einem Semikolon einschleusen.
+
+```
+GET /products?q=test'; INSERT INTO products VALUES (99,'hacked','x',0,''); --
+```
+
+**Beobachtet**: PDO führt nur eine Anweisung pro `query()`/`prepare()`-Aufruf aus — gestapelte Abfragen
+werden standardmäßig nicht unterstützt. Selbst wenn PDO mehrere Anweisungen erlaubte, wird der Wert als
+Parameter gebunden (nicht interpoliert). Das eingeschleuste INSERT wird als wörtlicher LIKE-Suchtext gespeichert.
+
+**Urteil**: **BLOCKIERT** — parametrisierte Bindung + PDO-Single-Statement-Modus verhindern gestapelte Abfragen.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|---|---|
+| ATK-01 | Klassische SELECT-Injection via `?q=` | BLOCKIERT |
+| ATK-02 | DROP TABLE via Suche | BLOCKIERT |
+| ATK-03 | ORDER BY unbekannte Spalte | BLOCKIERT |
+| ATK-04 | ORDER BY Unterabfrage-Injection | BLOCKIERT |
+| ATK-05 | Sortierrichtungs-Injection | BLOCKIERT |
+| ATK-06 | UNION SELECT via Suche | BLOCKIERT |
+| ATK-07 | ID-Injection via Pfadparam | BLOCKIERT |
+| ATK-08 | Boolean-basierte blinde Injection | BLOCKIERT |
+| ATK-09 | Second-Order-Injection | BLOCKIERT |
+| ATK-10 | LIKE-Metazeichen-Flut (`%`) | EXPONIERT |
+| ATK-11 | Null-Byte-Injection | BLOCKIERT |
+| ATK-12 | Gestapelte Abfragen | BLOCKIERT |
+
+**Echte Schwachstellen vor der Produktion beheben**:
+1. **ATK-10** — LIKE-Metazeichen (`%`, `_`, `\`) vor der Bindung escapen, um Wildcard-Flutung zu verhindern.
+
+---
+
+## Abwehr-Zusammenfassung
+
+| Angriffsfläche | Verwundbares Muster | Sicheres Muster |
+|---|---|---|
+| Wert in WHERE | `WHERE id = {$id}` | `WHERE id = ?` mit `[$id]` |
+| LIKE-Suche | `WHERE name LIKE '%{$q}%'` | `WHERE name LIKE '%' \|\| ? \|\| '%'` |
+| ORDER BY-Spalte | `ORDER BY {$sortField}` | `in_array($sortField, ALLOWED, true)` + interpolieren |
+| ORDER BY-Richtung | `ORDER BY col {$dir}` | `$dir === 'desc' ? 'DESC' : 'ASC'` |
+| Pfadparameter-ID | `WHERE id = {$id}` | `(int) $id` + parametrisiert |
+
+---
+
+## Verwandte Anleitungen
+
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — Explizites DTO-Whitelisting als umfassenderes Abwehrmuster
+- [`sqlite-fts5-search.md`](sqlite-fts5-search.md) — FTS5 als Alternative zu LIKE für Volltextsuche
+- [`jwt-authentication.md`](jwt-authentication.md) — VULN-Bewertung einschließlich SQL-Injection (V-08)


### PR DESCRIPTION
## 概要

slug-management.md から sql-injection-defence.md まで 7件のドイツ語翻訳を追加。

Issue #1283 の継続バッチ。

## 変更内容

- slug-management.md
- slug-url-history.md
- soft-delete-restore-permanent.md
- soft-delete-trash-purge.md
- soft-delete-trash-restore.md
- soft-delete.md
- sql-injection-defence.md

Closes #1283 (partial)

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)