### PR TITLE
docs(de): ドイツ語 howto 翻訳 バッチ-c 9件 (sql-injection〜system-announcement) (#1283)

### DIFF
--- a/docs/de/howto/sql-injection.md
+++ b/docs/de/howto/sql-injection.md
@@ -1,0 +1,87 @@
+# SQL-Injection-Abwehr
+
+NEne2-Datenbankm methoden (`execute`, `insert`, `fetchOne`, `fetchAll`) verwenden intern PDO Prepared
+Statements. Jeder Wert, der im `$parameters`-Array übergeben wird, wird als PDO-Parameter gebunden —
+niemals in den SQL-String interpoliert.
+
+## Standardmäßig sicher: Wert-Parameter
+
+```php
+// Alle Werte durchlaufen PDO-Bindung — injection-sicher unabhängig vom Inhalt
+$product = $this->db->fetchOne(
+    'SELECT * FROM products WHERE id = ?',
+    [$userId],
+);
+
+// LIKE-Suche — Wildcard im SQL-Literal, Wert separat gebunden
+$rows = $this->db->fetchAll(
+    "SELECT * FROM products WHERE name LIKE '%' || ? || '%'",
+    [$searchQuery],
+);
+```
+
+Klassische Payloads (`' OR '1'='1`, `'; DROP TABLE products; --`, `UNION SELECT ...`) werden zu
+wörtlichen Suchzeichenketten, weil PDO sie nie in SQL interpoliert.
+
+## Die ORDER BY-Fußangel — Whitelist erforderlich
+
+**PDO kann Spaltennamen oder SQL-Strukturelemente nicht parametrisieren.** `ORDER BY ?` funktioniert
+nicht — es bindet einen wörtlichen Zeichenkettenwert, keine Spaltenreferenz.
+
+Wenn ein Entwickler Benutzereingaben direkt in `ORDER BY` einfügt, wird es zu einem Injection-Vektor:
+
+```php
+// UNSICHER — niemals so machen
+$sort = QueryStringParser::string($request, 'sort') ?? 'id';
+$rows = $this->db->fetchAll("SELECT * FROM products ORDER BY {$sort} ASC");
+// ?sort=id;+DROP+TABLE+products;+-- führt den DROP aus
+```
+
+**Immer gegen eine explizite Whitelist validieren, bevor Spaltennamen interpoliert werden:**
+
+```php
+private const array ALLOWED_SORT_FIELDS = ['id', 'name', 'price', 'created_at'];
+
+public function list(string $sortField, string $sortDir): array
+{
+    if (!in_array($sortField, self::ALLOWED_SORT_FIELDS, true)) {
+        throw new InvalidSortFieldException("Invalid sort field: {$sortField}");
+    }
+
+    // Nur ASC oder DESC — normalisieren, nie rohe Benutzereingaben interpolieren
+    $dir  = strtolower($sortDir) === 'desc' ? 'DESC' : 'ASC';
+    $rows = $this->db->fetchAll(
+        "SELECT * FROM products ORDER BY {$sortField} {$dir}",
+    );
+
+    return $rows;
+}
+```
+
+Dasselbe Prinzip gilt für jedes SQL-Strukturelement: Tabellennamen, Spaltennamen in `GROUP BY`,
+`HAVING`, `INSERT INTO ... (col1, col2)` — keines davon kann als PDO-Parameter gebunden werden.
+Vor der Interpolation Whitelist-validieren.
+
+## IN-Klausel mit variabler Länge
+
+PDO unterstützt nicht das direkte Binden einer Liste variabler Länge. Die Platzhalter-Liste explizit aufbauen:
+
+```php
+$ids          = [1, 2, 3];
+$placeholders = implode(', ', array_fill(0, count($ids), '?'));
+$rows         = $this->db->fetchAll(
+    "SELECT * FROM products WHERE id IN ({$placeholders})",
+    $ids,
+);
+```
+
+## Zusammenfassung
+
+| Eingabetyp | Sichere Methode |
+|---|---|
+| Filterwert (`WHERE col = ?`) | `?`-Platzhalter in `$parameters` |
+| LIKE-Wert | `'%' \|\| ? \|\| '%'` — Wert in `$parameters` |
+| ORDER BY-Spalte | Whitelist `in_array` + nur nach Bestehen interpolieren |
+| ORDER-Richtung | Auf wörtliches `'ASC'` oder `'DESC'` normalisieren |
+| IN-Liste | `?`-Platzhalter aus `count()` aufbauen, Array als Params spreaden |
+| Tabellen-/Spaltenname | Nur Whitelist — niemals aus Benutzereingaben akzeptieren |

--- a/docs/de/howto/sql-orderby-injection.md
+++ b/docs/de/howto/sql-orderby-injection.md
@@ -1,0 +1,177 @@
+# So verhindern Sie SQL ORDER BY-Injection
+
+SQL-`ORDER BY`-Klauseln können nicht mit Standard-Platzhaltern (`?`) parametrisiert werden. Das bedeutet,
+dass vom Benutzer kontrollierte Sortierspalten und -richtungen niemals direkt in SQL interpoliert werden
+dürfen. Diese Anleitung erklärt den einzigen sicheren Ansatz: eine explizite Allowlist.
+
+---
+
+## Das Problem
+
+Prepared-Statement-Platzhalter schützen Spaltenwerte in `WHERE`-Klauseln, funktionieren aber **nicht**
+für Spaltennamen oder Sortierrichtungen in `ORDER BY`:
+
+```php
+// ❌ FALSCH — schützt NICHT gegen Injection
+$stmt = $pdo->prepare("SELECT * FROM articles ORDER BY ? ?");
+$stmt->execute([$column, $direction]);
+// Viele Datenbanktreiber behandeln ORDER BY-Argumente als Literale, nicht als Bezeichner.
+```
+
+Ein Angreifer, der `?sort=SLEEP(5)` oder `?sort=(SELECT password FROM users LIMIT 1)` sendet, kann
+zeitbasierte Angriffe, Informationsleckagen oder Fehler verursachen, die Schema-Details enthüllen.
+
+---
+
+## Die einzige sichere Lösung: Explizite Allowlist
+
+```php
+// ✅ SICHER — Allowlist + in_array strict
+public const array SORT_COLUMNS = ['id', 'title', 'status', 'created_at'];
+public const array SORT_DIRS    = ['asc', 'desc'];
+
+$sql = "SELECT * FROM articles ORDER BY {$sortCol} {$sortDir} LIMIT ?";
+```
+
+Die Allowlist-Werte sind **hardcodierte Zeichenketten**, die Sie kontrollieren. Nur diese Werte erreichen
+jemals SQL.
+
+---
+
+## Vollständiges Route-Handler-Muster
+
+```php
+// ── Sortierspalte — MUSS gegen Allowlist validiert werden ─────────────────────────
+//
+// SICHERHEIT: ORDER BY unterstützt keine ?-Platzhalter in Standard-SQL.
+// Der EINZIGE sichere Ansatz ist eine explizite Allowlist, geprüft mit in_array strict.
+//
+$rawSort = $params['sort'] ?? null;
+
+if ($rawSort !== null) {
+    // Array-Injection: PSR-7 könnte Array für ?sort[]=id liefern
+    if (!is_string($rawSort)) {
+        return $this->responseFactory->create(['error' => 'sort must be a string.'], 422);
+    }
+
+    // Null-Byte-Prüfung — PSR-7 dekodiert %00 zum tatsächlichen Null-Byte
+    if (str_contains($rawSort, "\0")) {
+        return $this->responseFactory->create(['error' => 'sort contains invalid characters.'], 422);
+    }
+
+    // Allowlist-Prüfung — strict, case-sensitiv.
+    // PSR-7 URL-dekodiert Query-Strings bereits einmal (%65 → e), daher werden
+    // einfach kodierte gültige Spaltennamen akzeptiert. Doppelt kodierte Werte
+    // (%2565 → %65 in $rawSort) werden NICHT ein zweites Mal dekodiert, sie scheitern
+    // daher an der Allowlist und werden abgelehnt.
+    if (!in_array($rawSort, MyRepository::SORT_COLUMNS, true)) {
+        return $this->responseFactory->create(
+            ['error' => sprintf('sort must be one of: %s.', implode(', ', MyRepository::SORT_COLUMNS))],
+            422,
+        );
+    }
+
+    $sortCol = $rawSort;
+} else {
+    $sortCol = 'created_at';  // sicherer Standardwert
+}
+
+// ── Sortierrichtung — nur Allowlist ───────────────────────────────────────────
+$rawOrder = $params['order'] ?? null;
+
+if ($rawOrder !== null) {
+    if (!is_string($rawOrder)) {
+        return $this->responseFactory->create(['error' => 'order must be a string.'], 422);
+    }
+
+    $dir = strtolower(trim($rawOrder));
+
+    if (!in_array($dir, MyRepository::SORT_DIRS, true)) {
+        return $this->responseFactory->create(
+            ['error' => sprintf('order must be one of: %s.', implode(', ', MyRepository::SORT_DIRS))],
+            422,
+        );
+    }
+
+    $sortDir = $dir;
+} else {
+    $sortDir = 'desc';  // sicherer Standardwert
+}
+```
+
+---
+
+## Repository-Schicht
+
+Das Repository empfängt bereits validierte Werte und interpoliert sie direkt:
+
+```php
+/**
+ * $sortCol und $sortDir MÜSSEN vom Aufrufer Allowlist-verifiziert sein.
+ * Diese Methode vertraut ihnen und interpoliert sie direkt in SQL.
+ *
+ * @return array{data: list<Article>, total: int, sort: string, order: string, limit: int}
+ */
+public function list(string $sortCol, string $sortDir, ?ArticleStatus $status, int $limit): array
+{
+    $where  = $status !== null ? 'WHERE status = ?' : '';
+    $params = $status !== null ? [$status->value] : [];
+
+    // $sortCol und $sortDir sind vorvalidiert — sicher zum Interpolieren.
+    // Hier niemals rohe Benutzereingaben einfügen.
+    $sql  = "SELECT * FROM articles {$where} ORDER BY {$sortCol} {$sortDir} LIMIT ?";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([...$params, $limit]);
+    ...
+}
+```
+
+---
+
+## Von diesem Ansatz blockierte Angriffsmuster
+
+| Angriff | Eingabe | Ergebnis |
+|---|---|---|
+| DROP TABLE-Injection | `?sort='; DROP TABLE articles--` | 422 — nicht in Allowlist |
+| UNION SELECT-Exfiltration | `?sort=1; SELECT password` | 422 — nicht in Allowlist |
+| Unterabfrage-Extraktion | `?sort=(SELECT name FROM sqlite_master)` | 422 — nicht in Allowlist |
+| Zeitbasierter Blind-Angriff | `?sort=SLEEP(5)` | 422 — nicht in Allowlist |
+| Spaltenindex-Injection | `?sort=1` | 422 — nicht in Allowlist |
+| Unbekannte Spalte | `?sort=password` | 422 — nicht in Allowlist |
+| Case/Kommentar-Umgehung | `?sort=CREATED_AT--` | 422 — case-sensitiv |
+| Null-Byte-Umgehung | `?sort=created_at%00` | 422 — Null-Byte-Prüfung |
+| Array-Injection | `?sort[]=created_at` | 422 — Typprüfung |
+| Doppelte URL-Kodierung | `?sort=cr%2565ated_at` | 422 — PSR-7 dekodiert einmal; `cr%65ated_at` nicht in Allowlist |
+| Einfache URL-Kodierung (gültig) | `?sort=cr%65ated_at` | 200 — PSR-7 dekodiert zu `created_at` ✓ |
+| Richtungs-Injection | `?order=asc; UNION SELECT 1--` | 422 — nicht in Allowlist |
+
+---
+
+## Schlüsselpunkte
+
+1. **Kein `rawurldecode()` nach PSR-7**: `getQueryParams()` von PSR-7 dekodiert den Query-String
+   bereits einmal. Erneutes Aufrufen von `rawurldecode()` würde doppelt kodierte Werte durch die
+   Allowlist-Prüfung schlüpfen lassen.
+
+2. **`in_array($value, $allowlist, true)`**: Das dritte Argument `true` aktiviert strikten
+   (typsicheren) Vergleich. Ohne es gibt `in_array(0, ['id', 'created_at'])` `true` zurück,
+   weil PHP Zeichenketten zu Integers koerziert.
+
+3. **Case-sensitiver Check**: Spaltennamen sollten kleingeschrieben und exakt abgeglichen werden.
+   `strcasecmp` oder `strtolower` niemals vor dem Allowlist-Check verwenden — `CREATED_AT` ist
+   aus Vertrauensperspektive nicht dasselbe Token wie `created_at`.
+
+4. **Richtung: `strtolower(trim())` ist sicher**: Im Gegensatz zu Spaltennamen hat die Richtung
+   (`asc`/`desc`) nur zwei gültige Werte. Case vor dem Allowlist-Check zu normalisieren ist
+   akzeptabel, da die Allowlist selbst erschöpfend und kleingeschrieben ist.
+
+5. **Vertrag dokumentieren**: Die Repository-Methode muss dokumentieren, dass sie ihrer Eingabe
+   vertraut. Aufrufer dürfen niemals rohe Benutzereingaben übergeben.
+
+---
+
+## Verwandt
+
+- FT180 — sortlog: SQL ORDER BY-Injection & Dynamische Sort/Filter-Prävention
+- [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) — URI-Kodierung
+- [PSR-7](https://www.php-fig.org/psr/psr-7/) — `ServerRequestInterface::getQueryParams()`

--- a/docs/de/howto/sqlite-fts5-search.md
+++ b/docs/de/howto/sqlite-fts5-search.md
@@ -1,0 +1,244 @@
+# How-to: SQLite FTS5-Volltextsuche
+
+> **FT-Referenz**: FT254 (`NENE2-FT/ftslog`) — Volltextsuche mit SQLite FTS5
+
+Demonstriert die Volltextsuche (FTS) mit der eingebauten FTS5-Erweiterung von SQLite. Eine virtuelle
+`posts_fts`-Tabelle spiegelt die `posts`-Tabelle und wird über Trigger synchron gehalten.
+Die Suche verwendet `MATCH` mit relevanzgerankten Ergebnissen via `fts.rank`.
+
+---
+
+## Routen
+
+| Methode | Pfad             | Beschreibung                            |
+|---------|------------------|-----------------------------------------|
+| `POST`  | `/posts`         | Beitrag erstellen (automatisch indiziert) |
+| `GET`   | `/posts`         | Alle Beiträge auflisten                 |
+| `GET`   | `/posts/search`  | Volltextsuche (`?q=`)                   |
+
+> **Routenreihenfolge**: `/posts/search` muss **vor** `/posts/{id}` registriert werden,
+> damit das literale Segment `search` nicht als Pfadparameter erfasst wird.
+
+---
+
+## Schema: Virtuelle FTS5-Tabelle + Trigger
+
+```sql
+CREATE TABLE IF NOT EXISTS posts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    tags       TEXT    NOT NULL DEFAULT '',  -- leerzeichen-getrennte Tag-Zeichenkette
+    created_at TEXT    NOT NULL
+);
+
+-- Virtuelle FTS5-Tabelle: spiegelt posts für die Volltextsuche
+CREATE VIRTUAL TABLE IF NOT EXISTS posts_fts USING fts5(
+    title,
+    body,
+    tags,
+    content='posts',      -- externe Content-Tabelle
+    content_rowid='id'    -- rowid-Spalte in der Content-Tabelle
+);
+
+-- FTS-Index mit posts synchron halten
+CREATE TRIGGER IF NOT EXISTS posts_ai AFTER INSERT ON posts BEGIN
+    INSERT INTO posts_fts(rowid, title, body, tags)
+    VALUES (new.id, new.title, new.body, new.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS posts_ad AFTER DELETE ON posts BEGIN
+    INSERT INTO posts_fts(posts_fts, rowid, title, body, tags)
+    VALUES ('delete', old.id, old.title, old.body, old.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS posts_au AFTER UPDATE ON posts BEGIN
+    INSERT INTO posts_fts(posts_fts, rowid, title, body, tags)
+    VALUES ('delete', old.id, old.title, old.body, old.tags);
+    INSERT INTO posts_fts(rowid, title, body, tags)
+    VALUES (new.id, new.title, new.body, new.tags);
+END;
+```
+
+**`content='posts'`** deklariert `posts_fts` als Content-Tabelle — sie speichert FTS-Tokens,
+delegiert aber die eigentliche Textspeicherung an `posts`. Dadurch wird eine Verdoppelung des
+vollen Texts vermieden.
+
+**`content_rowid='id'`** teilt FTS5 mit, welche Spalte in `posts` die rowid für den Join ist.
+
+**Trigger** halten den FTS-Index synchron. Ohne sie würden Inserts und Updates in `posts`
+nicht in `posts_fts` reflektiert. Der Delete-Trigger verwendet die spezielle `'delete'`-Befehlssyntax,
+um eine Zeile aus dem FTS-Index zu entfernen.
+
+---
+
+## Tags als leerzeichen-getrennte Zeichenkette
+
+```php
+$tags = isset($body['tags']) && is_string($body['tags']) ? trim($body['tags']) : '';
+// z.B. "php api backend"
+$post = $this->repo->create($title, $postBody, $tags, $now);
+```
+
+Tags werden als leerzeichen-getrennte Zeichenkette gespeichert (z.B. `"php api backend"`) statt
+als JSON-Array oder M:N-Join-Tabelle. Dadurch sind Tags von FTS5 durchsuchbar ohne einen JOIN —
+eine Suche nach `kubernetes` trifft einen Beitrag mit dem Tag `"docker kubernetes devops"`.
+
+**Kompromiss**:
+
+| Ansatz | FTS durchsuchbar | Exakter Tag-Filter | Kanonische Tag-Entität |
+|---|---|---|---|
+| Leerzeichen-getrennte Zeichenkette | ✅ | ❌ (LIKE nötig) | ❌ |
+| M:N-Join-Tabelle | ❌ (JOIN erforderlich) | ✅ (IN-Klausel) | ✅ |
+| JSON-Array-Spalte | Begrenzt (`json_each`) | Begrenzt | ❌ |
+
+Den M:N-Join-Tabellen-Ansatz verwenden (siehe [`multi-value-tag-filter.md`](multi-value-tag-filter.md)),
+wenn exakter Tag-Filter der primäre Anwendungsfall ist.
+
+---
+
+## Volltextsuche: `MATCH` + `rank`
+
+```php
+public function search(string $query): array
+{
+    if (trim($query) === '') {
+        return [];
+    }
+
+    $rows = $this->executor->fetchAll(
+        'SELECT p.*, fts.rank
+         FROM posts_fts fts
+         JOIN posts p ON p.id = fts.rowid
+         WHERE posts_fts MATCH ?
+         ORDER BY fts.rank',
+        [$query],
+    );
+
+    return array_map(
+        static fn (array $row): SearchResult => new SearchResult(
+            new Post(...),
+            (float) $row['rank'],
+        ),
+        $rows,
+    );
+}
+```
+
+`WHERE posts_fts MATCH ?` sucht über alle indizierten Spalten (`title`, `body`, `tags`).
+Der `?`-Platzhalter ist ein parametrisierter Wert — die Query-Zeichenkette wird nicht in SQL
+interpoliert und kann daher die Abfragestruktur nicht ändern.
+
+`fts.rank` ist ein negativer Float — niedrigere (negativere) Werte bedeuten höhere Relevanz.
+`ORDER BY fts.rank` sortiert beste Treffer zuerst (aufsteigend, also am relevantesten zuerst).
+
+---
+
+## FTS5-Abfragesyntax
+
+FTS5 unterstützt eine umfangreiche Abfragesprache, die als MATCH-Wert übergeben wird:
+
+| Abfrage | Trifft |
+|---------|--------|
+| `php` | Jeden Beitrag, der „php" enthält |
+| `php api` | Beiträge, die „php" ODER „api" enthalten (Standard: implizites OR) |
+| `php AND api` | Beiträge, die sowohl „php" als auch „api" enthalten |
+| `"quick brown"` | Beiträge, die die exakte Phrase „quick brown" enthalten |
+| `php*` | Beiträge, bei denen ein Token mit „php" beginnt (Präfixsuche) |
+| `title:php` | Beiträge, bei denen die Titelspalte „php" enthält |
+| `php NOT python` | Beiträge mit „php" aber ohne „python" |
+
+Phrasensuche (`"..."`) trifft exakte Token-Sequenzen.
+Spalten-beschränkte Suche (`title:php`) begrenzt den Treffer auf eine Spalte.
+
+---
+
+## Behandlung ungültiger Abfragen: try-catch → 400
+
+FTS5 wirft eine `PDOException` (oder kapselt sie), wenn die Abfragesyntax ungültig ist:
+
+```php
+private function searchPosts(ServerRequestInterface $request): ResponseInterface
+{
+    $query = isset($params['q']) && is_string($params['q']) ? trim($params['q']) : '';
+
+    if ($query === '') {
+        return $this->json->create(['error' => 'q query parameter is required'], 422);
+    }
+
+    try {
+        $results = $this->repo->search($query);
+    } catch (\Exception $e) {
+        // FTS5 wirft bei Syntaxfehlern (z.B. nicht geschlossene Anführungszeichen: '"unclosed')
+        return $this->json->create(['error' => 'invalid search query'], 400);
+    }
+
+    return $this->json->create([...]);
+}
+```
+
+Ungültige FTS-Abfragen (nicht geschlossene Anführungszeichen, missgebildete Operatoren) führen zu
+einer DB-Exception. Das Abfangen und Zurückgeben von `400 Bad Request` verhindert, dass ein `500`
+zum Client durchsickert.
+
+---
+
+## Groß-/Kleinschreibungsunempfindlichkeit
+
+FTS5 ist standardmäßig für ASCII-Zeichen groß-/kleinschreibungsunempfindlich. Eine Suche nach `php`
+trifft Beiträge, die `PHP`, `Php` oder `php` enthalten. Nicht-ASCII-Groß-/Kleinschreibungsanpassung
+erfordert einen benutzerdefinierten Tokenizer (`unicode61` oder `ascii`). Der Standard-`porter`-Tokenizer
+wendet Stemming für englische Wörter an.
+
+---
+
+## Suchantwort
+
+```json
+GET /posts/search?q=php
+
+{
+    "query": "php",
+    "total": 2,
+    "items": [
+        {
+            "id": 1,
+            "title": "PHP Framework",
+            "body": "Building APIs with PHP",
+            "tags": "php backend",
+            "created_at": "2026-05-27T10:00:00Z",
+            "rank": -1.234
+        }
+    ]
+}
+```
+
+`rank` ist in jedem Ergebnis zur clientseitigen Anzeige oder Sortierung enthalten.
+Niedrigerer (negativerer) `rank` = höhere Relevanz.
+
+---
+
+## Vergleich: FTS5 vs. LIKE-Suche
+
+| Funktion | FTS5 MATCH | LIKE `%term%` |
+|---|---|---|
+| Indiziert | ✅ | ❌ (vollständiger Scan) |
+| Relevanzranking | ✅ (`rank`) | ❌ |
+| Mehrwort-Suche | ✅ (natürlich) | ❌ (mehrere LIKE erforderlich) |
+| Phrasensuche | ✅ (`"..."`) | Teilweise (`%quick brown%`) |
+| Groß-/Kleinschreibungsunempfindlich | ✅ (ASCII) | ✅ (mit NOCASE) |
+| Präfixsuche | ✅ (`php*`) | ✅ (`php%`) |
+| Spalten-beschränkt | ✅ (`title:php`) | ❌ |
+| Einrichtungsaufwand | Virtuelle FTS-Tabelle + Trigger | Keiner |
+
+FTS5 wird für große Datensätze bevorzugt, bei denen Suche eine primäre Funktion ist. LIKE ist
+ausreichend für kleine Tabellen oder einfache Präfix-Autovervollständigung.
+
+---
+
+## Verwandte Anleitungen
+
+- [`use-fts5-search.md`](use-fts5-search.md) — FTS5 zu einer bestehenden Tabelle hinzufügen
+- [`search-autocomplete.md`](search-autocomplete.md) — LIKE-basierte Präfix-Autovervollständigung (searchlog FT157)
+- [`multi-value-tag-filter.md`](multi-value-tag-filter.md) — M:N-Tag-Filterung mit AND/OR-Semantik
+- [`event-analytics-api.md`](event-analytics-api.md) — `json_extract()` für JSON-Eigenschaftssuche

--- a/docs/de/howto/state-machine-audit-log.md
+++ b/docs/de/howto/state-machine-audit-log.md
@@ -1,0 +1,389 @@
+# How-to: Zustandsautomat mit Audit-Protokoll
+
+> **FT-Referenz**: FT237 (`NENE2-FT/statemachinelog`) — Zustandsautomat mit Audit-Protokoll
+> **VULN**: FT237 — Sicherheits- und Schwachstellenbewertung (V-01 bis V-10)
+
+Demonstriert eine Zustandsautomaten-API, bei der jeder Übergang in einer unveränderlichen
+Audit-Protokoll-Tabelle aufgezeichnet wird. Der aktuelle Status befindet sich auf dem Auftrag;
+die vollständige Historie befindet sich in einer separaten `order_transitions`-Tabelle.
+`InvalidTransitionException` liefert strukturierte 409-Antworten mit `from`- und `to`-Kontext.
+
+---
+
+## Routen
+
+| Methode | Pfad                            | Beschreibung                                     |
+|---------|----------------------------------|-------------------------------------------------|
+| `POST`  | `/orders`                        | Auftrag erstellen (beginnt als `draft`)         |
+| `GET`   | `/orders/{id}`                   | Aktuellen Auftragsstatus abrufen                |
+| `POST`  | `/orders/{id}/transitions`       | Zustandsübergang anwenden                       |
+| `GET`   | `/orders/{id}/transitions`       | Vollständige Überganghistorie auflisten         |
+
+---
+
+## Zustandsautomat: erlaubte Übergänge
+
+```php
+enum OrderStatus: string
+{
+    case Draft     = 'draft';
+    case Submitted = 'submitted';
+    case Approved  = 'approved';
+    case Rejected  = 'rejected';
+    case Cancelled = 'cancelled';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Draft     => [self::Submitted, self::Cancelled],
+            self::Submitted => [self::Approved, self::Rejected, self::Cancelled],
+            self::Approved  => [],
+            self::Rejected  => [],
+            self::Cancelled => [],
+        };
+    }
+
+    public function canTransitionTo(self $target): bool
+    {
+        return in_array($target, $this->allowedTransitions(), true);
+    }
+}
+```
+
+Terminale Zustände (`approved`, `rejected`, `cancelled`) geben eine leere Liste zurück — sie
+können nicht weiter übergehen.
+
+---
+
+## InvalidTransitionException → 409 mit Kontext
+
+Wenn ein Aufrufer einen unerlaubten Übergang anfordert, enthält die Exception die Von- und Bis-Zustände
+als strukturierte Daten für die Fehlerantwort:
+
+```php
+final class InvalidTransitionException extends \RuntimeException
+{
+    public function __construct(OrderStatus $from, OrderStatus $to)
+    {
+        parent::__construct(
+            sprintf('Transition from "%s" to "%s" is not allowed.', $from->value, $to->value)
+        );
+    }
+}
+```
+
+Der Controller schließt `from` und `to` in die Problem-Details-Erweiterung ein:
+
+```php
+try {
+    $updated = $this->repo->transition($id, $targetEnum, $now);
+} catch (InvalidTransitionException $e) {
+    return $this->problems->create(
+        $request,
+        'invalid-transition',
+        'Invalid State Transition',
+        409,
+        $e->getMessage(),
+        ['from' => $order->status->value, 'to' => $targetEnum->value],
+    );
+}
+```
+
+Antwort:
+```json
+{
+  "type": "https://nene2.dev/problems/invalid-transition",
+  "title": "Invalid State Transition",
+  "status": 409,
+  "detail": "Transition from \"approved\" to \"submitted\" is not allowed.",
+  "from": "approved",
+  "to": "submitted"
+}
+```
+
+`from` und `to` ermöglichen dem Aufrufer genau zu verstehen, welcher Übergang abgelehnt wurde,
+ohne die `detail`-Zeichenkette parsen zu müssen.
+
+---
+
+## Übergangs-Audit-Protokoll: Zwei-Schreib-Muster
+
+Jeder erfolgreiche Übergang aktualisiert den Auftragsstatus UND fügt einen Protokolldatensatz atomar ein:
+
+```php
+public function transition(int $orderId, OrderStatus $targetStatus, string $now): Order
+{
+    $order = $this->findById($orderId);
+
+    if (!$order->status->canTransitionTo($targetStatus)) {
+        throw new InvalidTransitionException($order->status, $targetStatus);
+    }
+
+    // Aktuellen Status aktualisieren
+    $this->executor->execute(
+        'UPDATE orders SET status = ?, updated_at = ? WHERE id = ?',
+        [$targetStatus->value, $now, $orderId],
+    );
+
+    // An Audit-Protokoll anhängen
+    $this->executor->execute(
+        'INSERT INTO order_transitions (order_id, from_status, to_status, transitioned_at) VALUES (?, ?, ?, ?)',
+        [$orderId, $order->status->value, $targetStatus->value, $now],
+    );
+
+    return new Order($order->id, $order->title, $targetStatus, $order->createdAt, $now);
+}
+```
+
+> **Atomizitätshinweis**: Ohne eine umschließende Transaktion hinterlässt ein Fehler zwischen dem
+> UPDATE und dem INSERT den Auftrag im neuen Zustand ohne Protokolldatensatz. Beide Anweisungen in
+> einer Transaktion einwickeln für echte Atomizität. Der WAL-Modus von SQLite macht dies unter
+> gleichzeitigem Zugriff sicher.
+
+---
+
+## Schema: Auftragsstatus + Überganghistorie
+
+```sql
+CREATE TABLE IF NOT EXISTS orders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    status     TEXT NOT NULL DEFAULT 'draft',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS order_transitions (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id        INTEGER NOT NULL,
+    from_status     TEXT    NOT NULL,
+    to_status       TEXT    NOT NULL,
+    transitioned_at TEXT    NOT NULL,
+    FOREIGN KEY (order_id) REFERENCES orders (id)
+);
+```
+
+`order_transitions` ist by design nur-anfügend — es existiert kein UPDATE- oder DELETE-Endpunkt
+dafür. Die vollständige Überganghistorie wird für die Buchprüfung aufbewahrt.
+
+---
+
+## Überganghistorie-Antwort
+
+```json
+{
+  "order_id": 1,
+  "transitions": [
+    {"id": 1, "order_id": 1, "from_status": "draft", "to_status": "submitted", "transitioned_at": "2026-05-27 10:00:00"},
+    {"id": 2, "order_id": 1, "from_status": "submitted", "to_status": "approved", "transitioned_at": "2026-05-27 11:00:00"}
+  ]
+}
+```
+
+Die Liste ist nach `id ASC` geordnet, sodass die Historie chronologisch ist.
+
+---
+
+## VULN — Sicherheitsbewertung (FT237)
+
+### V-01 — Keine Authentifizierung auf einem beliebigen Endpunkt
+
+**Angriff**: Aufträge erstellen und Übergänge ohne Anmeldedaten anwenden.
+
+```bash
+curl -s -X POST http://localhost:8080/orders/1/transitions \
+  -H 'Content-Type: application/json' \
+  -d '{"status":"approved"}'
+```
+
+**Beobachtet**: `200 OK` — kein Token erforderlich. Jeder kann jeden Auftrag genehmigen oder abbrechen.
+
+**Urteil**: **EXPONIERT** (by design für FT237 Demo). Authentifizierung und Autorisierung hinzufügen:
+Übergänge hinter einer Rolle absichern (Einreicher vs. Prüfer) und jeden Auftrag auf seinen Eigentümer beschränken.
+
+---
+
+### V-02 — Ungültiger Status-Wert
+
+**Angriff**: Eine unbekannte Status-Zeichenkette senden.
+
+```json
+{"status": "hacked"}
+{"status": ""}
+```
+
+**Beobachtet**: `OrderStatus::tryFrom('hacked')` = `null` → `422` mit einem Fehler, der alle
+gültigen Status auflistet.
+
+**Urteil**: **BLOCKIERT** — backed Enum `tryFrom()` lehnt unbekannte Werte ab.
+
+---
+
+### V-03 — Unerlaubter Übergang (terminaler Zustand → aktiv)
+
+**Angriff**: Übergang von `approved` oder `cancelled` zu einem anderen Status versuchen.
+
+```json
+{"status": "submitted"}   // von approved
+{"status": "draft"}       // von cancelled
+```
+
+**Beobachtet**: `canTransitionTo()` gibt `false` zurück → `InvalidTransitionException` →
+`409 Conflict` mit `from`/`to`-Kontext im Antwort-Body.
+
+**Urteil**: **BLOCKIERT** — Zustandsautomat erzwingt alle Übergangsregeln auf Domänenebene.
+
+---
+
+### V-04 — Nicht-numerische Auftrags-ID
+
+**Angriff**: Zeichenkette oder Float als `{id}` übergeben.
+
+```
+GET /orders/abc
+GET /orders/1.5
+```
+
+**Beobachtet**: `(int) 'abc'` = 0, `(int) '1.5'` = 1. Bei `abc` gibt `findById(0)` `null` zurück
+→ `404 Not Found`. Bei `1.5` wird wenn Auftrag 1 existiert dieser zurückgegeben — stille Kürzung.
+
+**Urteil**: **TEILWEISE BLOCKIERT** — nicht-numerische Zeichenketten resultieren in 404. Floats werden
+still gekürzt. `ctype_digit()`-Schutz für strikte Validierung hinzufügen.
+
+---
+
+### V-05 — Überganghistorie ist nicht auf den Aufrufer beschränkt
+
+**Angriff**: Überganghistorie eines anderen Benutzers lesen.
+
+```
+GET /orders/1/transitions
+```
+
+**Beobachtet**: `200 OK` — vollständige Historie wird ohne Eigentümlichkeits- oder Authentifizierungsprüfung
+zurückgegeben. Die Historie enthüllt wer eingereicht, genehmigt oder abgebrochen hat (via Zeitstempel,
+obwohl kein Akteur aufgezeichnet wird).
+
+**Urteil**: **EXPONIERT** — kein Eigentümermodell. Ein `created_by`-Feld zu Aufträgen hinzufügen und
+Historielesevorgänge auf den Eigentümer oder autorisierte Prüfer beschränken.
+
+---
+
+### V-06 — SQL-Injection via `status`-Body-Feld
+
+**Angriff**: SQL-Metazeichen in den `status`-Wert einbetten.
+
+```json
+{"status": "'; DROP TABLE orders; --"}
+{"status": "approved' OR '1'='1"}
+```
+
+**Beobachtet**:
+1. `OrderStatus::tryFrom("'; DROP TABLE orders; --")` = `null` → `422` vor jedem SQL.
+2. Selbst wenn die Prüfung umgangen würde, wird der Status als parametrisierter `?`-Wert übergeben.
+
+**Urteil**: **BLOCKIERT** — Doppelschicht: Enum-Allowlist + parametrisierte Abfragen.
+
+---
+
+### V-07 — Übergang in denselben Status (Idempotenz)
+
+**Angriff**: Einen Übergang in den aktuellen Status senden.
+
+```json
+// Auftrag ist bereits 'submitted'
+{"status": "submitted"}
+```
+
+**Beobachtet**: `allowedTransitions()` für `submitted` ist `[approved, rejected, cancelled]`
+— `submitted` ist nicht in der Liste. `canTransitionTo(submitted)` gibt `false` zurück → `409 Conflict`.
+
+**Urteil**: **BLOCKIERT** — Selbst-Übergänge werden implizit durch den Zustandsautomaten abgelehnt.
+
+---
+
+### V-08 — Gleichzeitige Übergänge auf demselben Auftrag
+
+**Angriff**: Zwei simultane Übergangsanfragen für denselben Auftrag senden.
+
+```
+POST /orders/1/transitions {"status":"approved"}  // gleichzeitige Anfrage A
+POST /orders/1/transitions {"status":"rejected"}  // gleichzeitige Anfrage B
+```
+
+**Beobachtet**: Beide Anfragen rufen den Auftrag ab (Status = `submitted`) bevor eines der UPDATEs
+läuft. Beide sehen `canTransitionTo()` = true. Beide UPDATE — das zweite UPDATE überschreibt das
+erste. Ein Übergangsprotokolldatensatz pro Anfrage wird eingefügt, aber der Auftrag endet in dem
+Status, der zuletzt ausgeführt wurde. Die Historie zeigt beide Übergänge, was inkonsistent ist
+(z.B. `submitted → approved`, dann `submitted → rejected`).
+
+**Urteil**: **EXPONIERT** — die Sequenz `findById` + `canTransitionTo` + `UPDATE` + `INSERT` in
+eine einzelne Transaktion einwickeln, um Race Conditions zu verhindern.
+
+---
+
+### V-09 — Nur-Leerzeichen-Titel
+
+**Angriff**: Einen Auftrag mit einem leeren Titel erstellen.
+
+```json
+{"title": "   "}
+```
+
+**Beobachtet**: `trim($body['title'])` reduziert auf `""` → `title === ''`-Prüfung greift →
+`422 Unprocessable Entity`.
+
+**Urteil**: **BLOCKIERT** — `trim()` vor der Leerzeichenkettenprüfung behandelt nur-Leerzeichen-Eingaben.
+
+---
+
+### V-10 — Unbegrenzte Titellänge
+
+**Angriff**: Einen Auftrag mit einem sehr langen Titel erstellen.
+
+```json
+{"title": "A".repeat(100_000)}
+```
+
+**Beobachtet**: Es wird keine Längenbegrenzung erzwungen — sehr lange Titel werden ohne
+Einschränkung in der `TEXT`-Spalte gespeichert.
+
+**Urteil**: **EXPONIERT** — einen Längen-Schutz hinzufügen:
+```php
+if (mb_strlen($title) > 500) {
+    $errors[] = ['field' => 'title', 'code' => 'too_long', 'message' => 'title must not exceed 500 characters.'];
+}
+```
+
+---
+
+## VULN-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|----------------|--------|
+| V-01 | Keine Authentifizierung | EXPONIERT |
+| V-02 | Ungültiger Status-Wert | BLOCKIERT |
+| V-03 | Unerlaubter Übergang von terminalem Zustand | BLOCKIERT |
+| V-04 | Nicht-numerische Auftrags-ID | TEILWEISE BLOCKIERT |
+| V-05 | Überganghistorie nicht auf Aufrufer beschränkt | EXPONIERT |
+| V-06 | SQL-Injection via Status-Body | BLOCKIERT |
+| V-07 | Selbst-Übergang (gleicher Status) | BLOCKIERT |
+| V-08 | Gleichzeitige Übergänge Race Condition | EXPONIERT |
+| V-09 | Nur-Leerzeichen-Titel | BLOCKIERT |
+| V-10 | Unbegrenzte Titellänge | EXPONIERT |
+
+**Echte Schwachstellen vor der Produktion beheben**:
+1. **V-01 / V-05** — Authentifizierung und Autorisierung hinzufügen (Eigentümer-Scoping)
+2. **V-08** — Übergang in eine Transaktion einwickeln
+3. **V-10** — Titellängengrenze hinzufügen
+4. **V-04** — `ctype_digit()`-Schutz für ID-Parameter hinzufügen
+
+---
+
+## Verwandte Anleitungen
+
+- [`approval-workflow.md`](approval-workflow.md) — Enum-basierter Zustandsautomat mit separaten Aktions-Endpunkten
+- [`audit-trail.md`](audit-trail.md) — Nur-anfügen-Audit-Protokoll-Muster
+- [`transactions.md`](transactions.md) — Multi-Schreib-Sequenzen in eine Transaktion einwickeln
+- [`enforce-resource-ownership.md`](enforce-resource-ownership.md) — IDOR-Prävention

--- a/docs/de/howto/state-machine-workflow-api.md
+++ b/docs/de/howto/state-machine-workflow-api.md
@@ -1,0 +1,266 @@
+# How-to: Zustandsautomaten-Workflow-API
+
+> **FT-Referenz**: FT349 (`NENE2-FT/workflowlog`) — Zustandsautomaten-Workflow-Instanzen mit
+> fest codierter Übergangs-Map, `allowed_next` in Antworten, Übergangshistorie-Protokoll, Erzwingung
+> terminaler Zustände, Status-Filter bei Liste; 13 Tests PASS.
+
+Diese Anleitung zeigt, wie eine Workflow-Engine mit einem Zustandsautomaten aufgebaut wird: erlaubte
+Zustandsübergänge definieren, Workflow-Instanzen erstellen, sie mit Akteur-Zuordnung durch Zustände
+treiben und die vollständige Überganghistorie protokollieren.
+
+## Schema
+
+```sql
+CREATE TABLE instances (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow      TEXT    NOT NULL,          -- z.B. "order"
+    current_state TEXT    NOT NULL,
+    context       TEXT    NOT NULL DEFAULT '{}',  -- JSON
+    created_at    TEXT    NOT NULL,
+    updated_at    TEXT    NOT NULL
+);
+
+CREATE TABLE transitions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
+    from_state  TEXT    NOT NULL,
+    to_state    TEXT    NOT NULL,
+    actor       TEXT    NOT NULL,
+    note        TEXT    NOT NULL DEFAULT '',
+    occurred_at TEXT    NOT NULL
+);
+```
+
+## Workflow-Definition — „order"
+
+```
+draft ──┬──► submitted ──┬──► approved ──► fulfilled (terminal)
+        │                ├──► rejected   (terminal)
+        └──► cancelled   └──► cancelled  (terminal)
+        (terminal)
+```
+
+| Von Zustand | Erlaubte Nächste Zustände             |
+|-------------|---------------------------------------|
+| `draft`     | `submitted`, `cancelled`              |
+| `submitted` | `approved`, `cancelled`, `rejected`   |
+| `approved`  | `fulfilled`                           |
+| `fulfilled` | _(terminal — keine)_                  |
+| `cancelled` | _(terminal — keine)_                  |
+| `rejected`  | _(terminal — keine)_                  |
+
+## Endpunkte
+
+| Methode | Pfad                                           | Beschreibung                   |
+|---------|------------------------------------------------|-------------------------------|
+| `POST`  | `/workflows/{workflow}/instances`              | Workflow-Instanz erstellen     |
+| `GET`   | `/workflows/{workflow}/instances`              | Instanzen auflisten            |
+| `GET`   | `/workflows/{workflow}/instances/{id}`         | Instanz mit Historie abrufen   |
+| `POST`  | `/workflows/{workflow}/instances/{id}/transition` | Zustandsübergang auslösen  |
+
+## Instanz erstellen
+
+```php
+POST /workflows/order/instances
+{"context": {"order_ref": "ORD-001", "amount": 99.99}}
+
+→ 201
+{
+  "id": 1,
+  "workflow": "order",
+  "current_state": "draft",
+  "context": {"order_ref": "ORD-001", "amount": 99.99},
+  "allowed_next": ["submitted", "cancelled"],  // ← nächste gültige Zustände
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+`allowed_next` wird aus der Übergangs-Map berechnet — reflektiert stets den aktuellen Zustand.
+
+### Unbekannter Workflow → 404
+
+```php
+POST /workflows/unknown/instances  {}
+→ 404  // Workflow nicht definiert
+```
+
+## Instanzen auflisten
+
+```php
+// Alle Instanzen des "order"-Workflows
+GET /workflows/order/instances
+→ 200  {"instances": [{...}, {...}]}
+
+// Nach aktuellem Zustand filtern
+GET /workflows/order/instances?state=draft
+→ 200  {"instances": [{...}]}  // nur draft-Instanzen
+```
+
+## Instanz abrufen (mit Historie)
+
+```php
+GET /workflows/order/instances/1
+
+→ 200
+{
+  "id": 1,
+  "workflow": "order",
+  "current_state": "approved",
+  "context": {...},
+  "allowed_next": ["fulfilled"],
+  "history": [
+    {
+      "from_state": "draft",
+      "to_state": "submitted",
+      "actor": "alice",
+      "occurred_at": "..."
+    },
+    {
+      "from_state": "submitted",
+      "to_state": "approved",
+      "actor": "manager",
+      "occurred_at": "..."
+    }
+  ],
+  ...
+}
+```
+
+`history` ist immer chronologisch geordnet (ASC nach `occurred_at`). Der Listen-Endpunkt lässt `history` für die Performance weg.
+
+## Übergänge auslösen
+
+```php
+// Gültiger Übergang
+POST /workflows/order/instances/1/transition
+{"to_state": "submitted", "actor": "alice"}
+
+→ 200
+{
+  "current_state": "submitted",
+  "allowed_next": ["approved", "cancelled", "rejected"],
+  "history": [
+    {"from_state": "draft", "to_state": "submitted", "actor": "alice", ...}
+  ]
+}
+```
+
+### Vollständiger Happy Path
+
+```php
+POST .../transition  {"to_state": "submitted", "actor": "alice"}    → submitted
+POST .../transition  {"to_state": "approved",  "actor": "manager"}  → approved
+POST .../transition  {"to_state": "fulfilled", "actor": "warehouse"} → fulfilled
+
+// fulfilled ist terminal
+→ {"current_state": "fulfilled", "allowed_next": [], ...}
+```
+
+### Ungültiger Übergang → 409
+
+```php
+// draft → approved (muss zuerst durch submitted)
+POST .../transition  {"to_state": "approved", "actor": "alice"}
+→ 409
+{
+  "type": "https://nene2.dev/problems/invalid-transition",
+  "detail": "Transition from 'draft' to 'approved' is not allowed"
+}
+```
+
+### Terminaler Zustand → 409
+
+```php
+// cancelled ist terminal — keine Übergänge erlaubt
+POST .../transition  {"to_state": "draft", "actor": "alice"}
+→ 409  // "cancelled" hat keine erlaubten Übergänge
+```
+
+## Implementierung
+
+### WorkflowDefinition — Übergangs-Map
+
+```php
+final class WorkflowDefinition
+{
+    /** @var array<string, array<string, list<string>>> */
+    private static array $transitions = [
+        'order' => [
+            'draft'     => ['submitted', 'cancelled'],
+            'submitted' => ['approved', 'cancelled', 'rejected'],
+            'approved'  => ['fulfilled'],
+            'fulfilled' => [],     // terminal
+            'cancelled' => [],     // terminal
+            'rejected'  => [],     // terminal
+        ],
+    ];
+
+    /** @return list<string> */
+    public static function allowedTransitions(string $workflow, string $fromState): array
+    {
+        return self::$transitions[$workflow][$fromState] ?? [];
+    }
+
+    public static function isValidWorkflow(string $workflow): bool
+    {
+        return isset(self::$transitions[$workflow]);
+    }
+
+    public static function initialState(string $workflow): string
+    {
+        return match ($workflow) {
+            'order' => 'draft',
+            default => throw new \InvalidArgumentException("Unknown workflow: {$workflow}"),
+        };
+    }
+}
+```
+
+### Übergangs-Handler
+
+```php
+public function transition(int $id, string $toState, string $actor): ?WorkflowInstance
+{
+    $instance = $this->repo->findByIdOrNull($id);
+    if ($instance === null) {
+        return null;  // → 404
+    }
+
+    $allowed = WorkflowDefinition::allowedTransitions(
+        $instance->workflow,
+        $instance->currentState,
+    );
+
+    if (!in_array($toState, $allowed, true)) {
+        return false;  // → 409 ungültig oder terminal
+    }
+
+    // Atomar: Instanz aktualisieren + Übergangsproto einfügen
+    $this->db->execute(
+        'UPDATE instances SET current_state = ?, updated_at = ? WHERE id = ?',
+        [$toState, $now, $id],
+    );
+    $this->db->execute(
+        'INSERT INTO transitions (instance_id, from_state, to_state, actor, occurred_at) VALUES (?, ?, ?, ?, ?)',
+        [$id, $instance->currentState, $toState, $actor, $now],
+    );
+
+    return $this->hydrateInstanceWithHistory($id);
+}
+```
+
+`allowed_next` wird stets aus der Übergangs-Map berechnet, nie gespeichert — es bleibt konsistent mit `current_state`.
+
+---
+
+## Was NOT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `allowed_next` in DB speichern | Veraltete Daten wenn Übergangs-Map sich ändert; immer aus aktuellem Zustand berechnen |
+| Freie `to_state`-Eingabe ohne Allowlist-Prüfung erlauben | Angreifer kann Zustand auf beliebigen Wert setzen und Workflow-Logik umgehen |
+| Übergangsprotokollierung weglassen | Kein Audit-Protokoll; Workflow-Historie kann nicht rekonstruiert oder feststeckende Instanzen nicht debuggt werden |
+| Terminale Zustände in `allowed_next` zurückgeben | Führt Aufrufer irre; terminale Zustände haben stets leeres `allowed_next` |
+| 404 für ungültigen Übergang zurückgeben | 404 verbirgt den Unterschied zwischen „Instanz nicht gefunden" und „Übergang nicht erlaubt"; 409 für letzteren verwenden |
+| Kein `workflow`-Feld in Instanzen-Tabelle | Instanzen verschiedener Workflow-Typen können nicht unterschieden werden; keine workflow-übergreifende Abfrage möglich |

--- a/docs/de/howto/step-workflow-approval.md
+++ b/docs/de/howto/step-workflow-approval.md
@@ -1,0 +1,246 @@
+# How-to: Schrittbasierter Workflow mit Genehmigung
+
+> **FT-Referenz**: FT247 (`NENE2-FT/stepflowlog`) — Schritt-Workflow-Genehmigungs-API
+
+Demonstriert ein zweistufiges Workflow-System, bei dem eine wiederverwendbare Workflow-Definition
+eine geordnete Liste von Schritten enthält und ein Workflow-Lauf eine Instanz dieser Definition ist,
+die durch Schritte via Genehmigungs-/Ablehnungsaktionen voranschreitet. Jede Aktion wird in einem
+Audit-Historie-Protokoll aufgezeichnet.
+
+---
+
+## Routen
+
+| Methode | Pfad                      | Beschreibung                                                       |
+|---------|---------------------------|-------------------------------------------------------------------|
+| `POST`  | `/workflows`              | Neuen Workflow definieren                                          |
+| `GET`   | `/workflows/{id}`         | Workflow mit seinen Schritten abrufen                              |
+| `POST`  | `/workflows/{id}/steps`   | Schritt zu einem Workflow hinzufügen (automatisch geordnet)        |
+| `POST`  | `/runs`                   | Lauf eines Workflows starten (schlägt fehl wenn Workflow keine Schritte hat) |
+| `GET`   | `/runs/{id}`              | Laufstatus mit Aktionshistorie abrufen                             |
+| `POST`  | `/runs/{id}/approve`      | Aktuellen Schritt genehmigen (rückt zum nächsten Schritt oder schließt ab) |
+| `POST`  | `/runs/{id}/reject`       | Aktuellen Schritt ablehnen (beendet Lauf als abgelehnt)            |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS workflows (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL UNIQUE,
+    description TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workflow_steps (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id INTEGER NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+    name        TEXT    NOT NULL,
+    step_order  INTEGER NOT NULL,
+    UNIQUE(workflow_id, step_order)
+);
+
+CREATE TABLE IF NOT EXISTS workflow_runs (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id     INTEGER NOT NULL REFERENCES workflows(id),
+    title           TEXT    NOT NULL,
+    status          TEXT    NOT NULL DEFAULT 'pending'
+                        CHECK(status IN ('pending', 'in_progress', 'completed', 'rejected')),
+    current_step_id INTEGER REFERENCES workflow_steps(id),
+    created_at      TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workflow_actions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id     INTEGER NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    step_id    INTEGER NOT NULL REFERENCES workflow_steps(id),
+    action     TEXT    NOT NULL CHECK(action IN ('approve', 'reject')),
+    actor      TEXT    NOT NULL,
+    comment    TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL
+);
+```
+
+`UNIQUE(workflow_id, step_order)` verhindert doppelte Reihenfolge innerhalb eines Workflows.
+`current_step_id` ist nullable — `NULL` bedeutet, dass der Lauf `completed` oder `rejected` ist
+(kein aktiver Schritt). `action` hat einen DB-Ebene-`CHECK` für `approve`/`reject`.
+
+---
+
+## Automatische Schritt-Reihenfolge
+
+Beim Hinzufügen eines Schritts berechnet der Controller den nächsten `step_order` automatisch:
+
+```php
+$existingSteps = $this->repo->findSteps($id);
+$maxOrder      = 0;
+foreach ($existingSteps as $s) {
+    if ((int) $s['step_order'] > $maxOrder) {
+        $maxOrder = (int) $s['step_order'];
+    }
+}
+$stepOrder = $maxOrder + 1;
+$stepId    = $this->repo->addStep($id, $name, $stepOrder);
+```
+
+`step_order` beginnt bei `1` und erhöht sich um `1` für jeden neuen Schritt. Der `UNIQUE`-Constraint
+verhindert, dass zwei Schritte dieselbe Reihenfolge teilen. Schritte werden stets in Reihenfolge
+zurückgegeben:
+
+```php
+$this->db->fetchAll(
+    'SELECT * FROM workflow_steps WHERE workflow_id = ? ORDER BY step_order ASC',
+    [$workflowId],
+);
+```
+
+---
+
+## Lauf starten: Initialisierung des ersten Schritts
+
+Ein Lauf wird mit dem ersten Schritt des Workflows als `current_step_id` initialisiert:
+
+```php
+$steps = $this->repo->findSteps($workflowId);
+if ($steps === []) {
+    return $this->json->create(['error' => 'Workflow has no steps'], 409);
+}
+
+$firstStep = $steps[0];
+$runId = $this->repo->createRun($workflowId, $title, (int) $firstStep['id'], $now);
+```
+
+`409 Conflict` wird zurückgegeben, wenn der Workflow keine Schritte hat — ein Lauf kann durch
+einen schrittlosen Workflow nicht voranschreiten. Der erste Schritt (niedrigstes `step_order`)
+wird zum aktiven Schritt.
+
+---
+
+## `approve`: Zum nächsten Schritt vorrücken oder abschließen
+
+`POST /runs/{id}/approve` prüft den aktuellen Status, zeichnet die Aktion auf, dann
+findet den nächsten Schritt nach `step_order`:
+
+```php
+if ((string) $run['status'] !== 'in_progress') {
+    return $this->json->create(['error' => 'Run is not in progress'], 409);
+}
+
+$this->repo->recordAction($id, $currentStepId, 'approve', $actor, $comment, $this->now());
+
+$nextStep = $this->repo->findNextStep($workflowId, $currentStepOrder);
+if ($nextStep !== null) {
+    $this->repo->updateRun($id, 'in_progress', (int) $nextStep['id'], $this->now());
+} else {
+    $this->repo->updateRun($id, 'completed', null, $this->now());
+}
+```
+
+`findNextStep` ruft den Schritt mit dem nächsten `step_order` ab:
+
+```php
+public function findNextStep(int $workflowId, int $currentOrder): ?array
+{
+    return $this->db->fetchOne(
+        'SELECT * FROM workflow_steps WHERE workflow_id = ? AND step_order > ? ORDER BY step_order ASC LIMIT 1',
+        [$workflowId, $currentOrder],
+    );
+}
+```
+
+`step_order > current` + `ORDER BY step_order ASC LIMIT 1` findet den unmittelbar folgenden Schritt.
+Wenn kein nächster Schritt existiert (letzter Schritt), gibt `findNextStep` `null` zurück → der Lauf
+wird als `completed` mit `current_step_id = null` markiert.
+
+---
+
+## `reject`: Lauf beenden
+
+`POST /runs/{id}/reject` zeichnet die Aktion auf und markiert den Lauf als `rejected`:
+
+```php
+$this->repo->recordAction($id, $currentStepId, 'reject', $actor, $comment, $this->now());
+$this->repo->updateRun($id, 'rejected', null, $this->now());
+```
+
+`current_step_id` wird bei Ablehnung auf `null` gesetzt — kein aktiver Schritt verbleibt. Der Lauf
+ist terminal: weitere `approve`/`reject`-Aufrufe geben `409` zurück, da `status !== 'in_progress'`.
+
+---
+
+## Aktionshistorie: JOIN mit Schrittname
+
+Die Laufantwort enthält die vollständige Aktionshistorie:
+
+```php
+$run     = $this->repo->findRun($id);
+$actions = $this->repo->findActions($id);
+return $this->json->create(array_merge($run, ['history' => $actions]));
+```
+
+Aktionen werden mit einem `JOIN` abgerufen, um jede Zeile mit dem Schrittnamen anzureichern:
+
+```php
+$this->db->fetchAll(
+    'SELECT wa.*, ws.name AS step_name FROM workflow_actions wa
+     JOIN workflow_steps ws ON wa.step_id = ws.id
+     WHERE wa.run_id = ? ORDER BY wa.id ASC',
+    [$runId],
+);
+```
+
+`ORDER BY wa.id ASC` bewahrt die chronologische Einfügereihenfolge für das Audit-Protokoll.
+
+---
+
+## Lauf-Zustandsautomat
+
+```
+                 POST /runs
+                     │
+                     ▼
+               in_progress  ──genehmigen (letzter Schritt)──► completed
+                     │
+               genehmigen (nicht letzter Schritt)
+                     │
+                     ▼
+               in_progress (nächster Schritt)
+                     │
+                  ablehnen
+                     │
+                     ▼
+                 rejected
+```
+
+Die Zustände `completed` und `rejected` sind terminal — keine weiteren Zustandsübergänge sind erlaubt.
+Jedes `approve`/`reject` auf einem terminalen Lauf gibt `409 Conflict` zurück.
+
+---
+
+## `findRun` mit `current_step_name` via `LEFT JOIN`
+
+Der Lauf wird mit einem `LEFT JOIN` abgerufen, um den Namen des aktuellen Schritts einzuschließen:
+
+```php
+$this->db->fetchOne(
+    'SELECT wr.*, ws.name AS current_step_name, ws.step_order AS current_step_order
+     FROM workflow_runs wr
+     LEFT JOIN workflow_steps ws ON wr.current_step_id = ws.id
+     WHERE wr.id = ?',
+    [$id],
+);
+```
+
+`LEFT JOIN` (nicht `INNER JOIN`) — wenn `current_step_id` `null` ist (abgeschlossener/abgelehnter
+Lauf), sind `ws.*`-Spalten `null` anstatt die Zeile verschwinden zu lassen.
+
+---
+
+## Verwandte Anleitungen
+
+- [`approval-workflow.md`](approval-workflow.md) — Genehmigungs-Muster mit pending/approved/rejected-Zuständen
+- [`state-machine-audit-log.md`](state-machine-audit-log.md) — Zustandsübergangs-Aufzeichnung und InvalidTransitionException
+- [`multi-step-workflow.md`](multi-step-workflow.md) — Sequenzielles mehrstufiges Formular-/Prozessmuster
+- [`audit-trail.md`](audit-trail.md) — Nur-anfügen-Ereignisaufzeichnungs-Muster

--- a/docs/de/howto/subscription-plan-management.md
+++ b/docs/de/howto/subscription-plan-management.md
@@ -1,0 +1,241 @@
+# How-to: Abonnement-Plan-Verwaltung
+
+> **FT-Referenz**: FT328 (`NENE2-FT/planlog`) — Plan-Katalog, Abonnement-Lebenszyklus pro Benutzer
+> (abonnieren / wechseln / kündigen), nur-Eigentümer-Zugriff, ATK-Bewertung; 20 Tests / 69 Assertions PASS.
+
+Diese Anleitung zeigt, wie eine Abonnement-Verwaltungs-API aufgebaut wird, bei der Benutzer einen von
+mehreren vordefinierten Plänen abonnieren, den Plan wechseln und kündigen können.
+
+## Schema
+
+```sql
+CREATE TABLE plans (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug       TEXT    NOT NULL UNIQUE,
+    name       TEXT    NOT NULL,
+    price_cents INTEGER NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE subscriptions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL UNIQUE,  -- ein aktives Abonnement pro Benutzer
+    plan_slug    TEXT    NOT NULL REFERENCES plans(slug),
+    status       TEXT    NOT NULL DEFAULT 'active',  -- 'active' | 'cancelled'
+    cancelled_at TEXT,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL
+);
+```
+
+Vorinstallierte Pläne: `free` (0), `pro` (980), `enterprise` (9800).
+
+## Authentifizierungsmodell
+
+Alle Abonnement-Endpunkte erfordern `X-Actor-Id: {userId}`. Der Zugriff auf das Abonnement eines
+anderen Benutzers gibt **403** zurück.
+
+## Endpunkte
+
+| Methode   | Pfad | Beschreibung |
+|-----------|------|-------------|
+| `GET`     | `/plans` | Alle Pläne auflisten (öffentlich) |
+| `POST`    | `/users/{id}/subscription` | Abonnieren |
+| `GET`     | `/users/{id}/subscription` | Abonnement abrufen (nur Eigentümer) |
+| `PUT`     | `/users/{id}/subscription` | Plan wechseln (nur Eigentümer) |
+| `DELETE`  | `/users/{id}/subscription` | Kündigen (nur Eigentümer) |
+
+## Pläne auflisten
+
+```php
+GET /plans
+→ 200
+{
+  "count": 3,
+  "items": [
+    {"slug": "free",       "name": "Free",       "price_cents": 0},
+    {"slug": "pro",        "name": "Pro",         "price_cents": 980},
+    {"slug": "enterprise", "name": "Enterprise",  "price_cents": 9800}
+  ]
+}
+// Nach price_cents ASC geordnet
+```
+
+## Abonnieren
+
+```php
+POST /users/1/subscription  X-Actor-Id: 1
+{"plan": "pro"}
+→ 201
+{"plan_slug": "pro", "status": "active", "cancelled_at": null}
+
+// Bereits abonniert
+POST /users/1/subscription  X-Actor-Id: 1  {"plan": "free"}
+→ 409 Conflict
+
+// Unbekannter Plan
+POST /users/1/subscription  X-Actor-Id: 1  {"plan": "platinum"}
+→ 404
+
+// Endpunkt eines anderen Benutzers
+POST /users/1/subscription  X-Actor-Id: 2  {"plan": "free"}
+→ 403 Forbidden
+```
+
+## Abonnement abrufen
+
+```php
+GET /users/1/subscription  X-Actor-Id: 1
+→ 200  {"plan_slug": "pro", "status": "active", ...}
+
+// Kein Abonnement
+GET /users/1/subscription  X-Actor-Id: 1  → 404
+
+// Anderer Benutzer
+GET /users/1/subscription  X-Actor-Id: 2  → 403
+```
+
+## Plan wechseln
+
+```php
+PUT /users/1/subscription  X-Actor-Id: 1  {"plan": "enterprise"}
+→ 200  {"plan_slug": "enterprise", "status": "active"}
+
+// Upgrade und Downgrade beide erlaubt
+PUT /users/1/subscription  X-Actor-Id: 1  {"plan": "free"}
+→ 200
+
+// Kein Abonnement zum Wechseln
+PUT /users/1/subscription  X-Actor-Id: 1  {"plan": "pro"}  → 404
+
+// Versuch, ein gekündigtes Abonnement zu wechseln
+PUT /users/1/subscription  X-Actor-Id: 1  {"plan": "pro"}  → 409
+```
+
+## Kündigen
+
+```php
+DELETE /users/1/subscription  X-Actor-Id: 1  → 204
+
+// Nach Kündigung zeigt GET gekündigten Status
+GET /users/1/subscription  X-Actor-Id: 1
+→ 200  {"status": "cancelled", "cancelled_at": "2026-05-27T..."}
+```
+
+---
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Abonnement für anderen Benutzer erstellen 🚫 BLOCKIERT
+
+**Angriff**: Angreifer sendet `POST /users/1/subscription  X-Actor-Id: 2`, um ein Abonnement auf dem Konto des Opfers zu starten.
+**Ergebnis**: BLOCKIERT — Akteur-ID wird mit Pfad-Benutzer-ID verglichen. Mismatch → 403.
+
+---
+
+### ATK-02 — Abonnement eines anderen Benutzers kündigen 🚫 BLOCKIERT
+
+**Angriff**: Angreifer kündigt das kostenpflichtige Abonnement des Opfers via `DELETE /users/1/subscription  X-Actor-Id: 2`.
+**Ergebnis**: BLOCKIERT — Dieselbe Akteur/Pfad-Prüfung. 403 zurückgegeben.
+
+---
+
+### ATK-03 — Opfer auf Free-Plan herabstufen 🚫 BLOCKIERT
+
+**Angriff**: `PUT /users/1/subscription  X-Actor-Id: 2  {"plan": "free"}`.
+**Ergebnis**: BLOCKIERT — 403 auf benutzerübergreifendem Pfad.
+
+---
+
+### ATK-04 — Doppeltes Abonnement zur Zahlung-Umgehung 🚫 BLOCKIERT
+
+**Angriff**: Zwei schnelle `POST /subscribe`-Anfragen einreichen, in der Hoffnung, dass eine vor dem UNIQUE-Constraint landet.
+**Ergebnis**: BLOCKIERT — `UNIQUE(user_id)` auf der Abonnement-Tabelle verhindert doppelte Zeilen. Zweites Insert löst Constraint aus → 409.
+
+---
+
+### ATK-05 — Abonnieren mit ungültigem Plan-Slug ✅ SICHER
+
+**Angriff**: `{"plan": "'; DROP TABLE plans; --"}` oder unbekannte Slugs.
+**Ergebnis**: SICHER — Plan-Existenz wird via parametrisierten SELECT geprüft. SQL-Injection wird verhindert. Unbekannter Slug → 404.
+
+---
+
+### ATK-06 — Gekündigtes Abonnement via PUT reaktivieren 🚫 BLOCKIERT
+
+**Angriff**: Nach Kündigung sendet Angreifer PUT, um ohne Neuabonnierung (ohne Zahlung) zu reaktivieren.
+**Ergebnis**: BLOCKIERT — PUT auf ein gekündigtes Abonnement gibt 409 zurück. Muss frisch abonnieren (POST), was Zahlungsprüfungen erzwingen kann.
+
+---
+
+### ATK-07 — Für nicht-existierenden Benutzer abonnieren 🚫 BLOCKIERT
+
+**Angriff**: `POST /users/9999/subscription  X-Actor-Id: 9999`.
+**Ergebnis**: BLOCKIERT — Benutzer-Existenz wird vor der Abonnement-Erstellung validiert. 404 zurückgegeben.
+
+---
+
+### ATK-08 — Abonnement ohne Auth lesen 🚫 BLOCKIERT
+
+**Angriff**: `GET /users/1/subscription` ohne `X-Actor-Id`-Header.
+**Ergebnis**: BLOCKIERT — Fehlender Akteur → 401.
+
+---
+
+### ATK-09 — Akteur-ID-Typverwirrung 🚫 BLOCKIERT
+
+**Angriff**: `X-Actor-Id: 1abc` oder `X-Actor-Id: 1.0` um den Integer-Vergleich zu verwirren.
+**Ergebnis**: BLOCKIERT — Akteur-ID wird als positive Integer validiert. Nicht-Ziffern → 401.
+
+---
+
+### ATK-10 — Plan-Slugs via Trial-and-Error enumerieren 🚫 BLOCKIERT
+
+**Angriff**: `{"plan": "internal"}`, `{"plan": "vip"}` usw. ausprobieren, um verborgene Pläne zu entdecken.
+**Ergebnis**: BLOCKIERT — Unbekannter Plan → 404. Kein Nebeneffekt wird erzeugt. Ratenbegrenzung schützt vor Enumeration im großen Maßstab.
+
+---
+
+### ATK-11 — Gleichen Plan abonnieren (No-Op-Angriff) 🚫 BLOCKIERT
+
+**Angriff**: PUT mit demselben aktuellen Plan-Slug, um ein Abrechnungsereignis auszulösen.
+**Ergebnis**: BLOCKIERT — Wechsel zum gleichen Plan gibt 200 zurück (No-Op oder by design erlaubt); kein Abrechnungsereignis wird für identische Pläne ausgelöst.
+
+---
+
+### ATK-12 — IDOR via numerische Benutzer-ID-Inkrementierung ✅ SICHER
+
+**Angriff**: Angreifer erhöht Benutzer-ID (`/users/1`, `/users/2`, ...) um Abonnements zu enumerieren.
+**Ergebnis**: SICHER — Alle Abonnement-Endpunkte erfordern Akteur == Pfad-Benutzer. Anderer Akteur → 403. Enumeration enthüllt keine Daten.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|---------|
+| ATK-01 | Für anderen Benutzer abonnieren | 🚫 BLOCKIERT |
+| ATK-02 | Abonnement eines anderen Benutzers kündigen | 🚫 BLOCKIERT |
+| ATK-03 | Anderen Benutzer herabstufen | 🚫 BLOCKIERT |
+| ATK-04 | Doppeltes Abonnement zur Umgehung | 🚫 BLOCKIERT |
+| ATK-05 | Ungültige Plan-Slug-Injection | ✅ SICHER |
+| ATK-06 | Nach Kündigung via PUT reaktivieren | 🚫 BLOCKIERT |
+| ATK-07 | Nicht-existierenden Benutzer abonnieren | 🚫 BLOCKIERT |
+| ATK-08 | Ohne Auth lesen | 🚫 BLOCKIERT |
+| ATK-09 | Akteur-ID-Typverwirrung | 🚫 BLOCKIERT |
+| ATK-10 | Plan-Slug-Enumeration | 🚫 BLOCKIERT |
+| ATK-11 | Gleicher-Plan-No-Op-Angriff | 🚫 BLOCKIERT |
+| ATK-12 | IDOR via Benutzer-ID-Inkrementierung | ✅ SICHER |
+
+**10 BLOCKIERT, 2 SICHER, 0 EXPONIERT** — Keine kritischen Befunde.
+
+---
+
+## Was NOT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| PUT auf gekündigtem Abonnement erlauben | Angreifer reaktiviert ohne Zahlung |
+| Kein UNIQUE-Constraint auf user_id | Gleichzeitige Abonnements erstellen mehrere Zeilen |
+| 404 statt 403 für benutzerübergreifende Zugriffe zurückgeben | 404 verbirgt Existenz aber auch Autorisierungsfehler; 403 explizit verwenden |
+| Abonnement bei Kündigung hard-deleten | Audit-Spur verlieren; `status: cancelled` + `cancelled_at` verwenden |

--- a/docs/de/howto/subscription-plan.md
+++ b/docs/de/howto/subscription-plan.md
@@ -1,0 +1,117 @@
+# How-to: Abonnement-/Plan-Verwaltungs-API (VULN-A bis L)
+
+Diese Anleitung demonstriert eine Abonnement-Verwaltungs-API, bei der Benutzer Pläne abonnieren,
+mit Duplikat-Prävention, Kündigung und IDOR-Schutz.
+
+## Musterübersicht
+
+- Seed-Pläne werden beim Schema-Erstellen eingefügt (`free`, `starter`, `pro`, `annual`).
+- Benutzer abonnieren via `POST /subscriptions` mit einer `plan_id`.
+- Jedes (Benutzer, Plan)-Paar kann höchstens ein aktives Abonnement haben.
+- Kündigung ändert den Status auf `'cancelled'`; gekündigte Abonnements können nicht erneut gekündigt werden.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS plans (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL UNIQUE,
+    price_cents INTEGER NOT NULL,
+    interval    TEXT    NOT NULL DEFAULT 'monthly'
+);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL,
+    plan_id      INTEGER NOT NULL,
+    status       TEXT    NOT NULL DEFAULT 'active',
+    started_at   TEXT    NOT NULL,
+    cancelled_at TEXT,
+    FOREIGN KEY (plan_id) REFERENCES plans(id),
+    UNIQUE (user_id, plan_id, status)
+);
+```
+
+## VULN-A: SQL-Injection
+
+Alle Abfragen verwenden PDO Prepared Statements. Plan-Namen und Benutzer-IDs werden nie interpoliert.
+
+## VULN-C: IDOR
+
+Nicht-Admin-Benutzer können nur auf ihre eigenen Abonnements zugreifen. Der Zugriff auf das Abonnement
+eines anderen Benutzers gibt 404 zurück (nicht 403):
+
+```php
+if (!$isAdmin && (int) $sub['user_id'] !== $uid) {
+    return $this->problem(404, 'not-found', 'Subscription not found.');
+}
+```
+
+## VULN-D: Admin Fail-Closed
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+## VULN-G: ReDoS
+
+Pfad-IDs verwenden `ctype_digit()` + Längenbegrenzung. Nicht-numerische Pfade (`/subscriptions/abc`)
+geben sofort 404 zurück.
+
+## VULN-J: Typverwirrung
+
+```php
+$planId = $body['plan_id'] ?? null;
+if (!is_int($planId) || $planId < 1) {
+    return $this->problem(422, 'validation-failed', 'plan_id must be a positive integer.');
+}
+```
+
+String `"2"`, Float `2.5` und null geben alle 422 zurück.
+
+## Duplikat-Prävention
+
+```php
+$stmt = $this->pdo->prepare(
+    "SELECT id FROM subscriptions WHERE user_id = :uid AND plan_id = :pid AND status = 'active'"
+);
+```
+
+Der Versuch, einen bereits aktiven Plan zu abonnieren, gibt 409 zurück.
+
+## Kündigungsidempotenz
+
+Die `cancel()`-Methode prüft den Status vor dem Update. Ein zweiter Kündigungsversuch auf einem
+`'cancelled'`-Abonnement gibt `'already_cancelled'` zurück → 409 (nicht 204).
+
+## JOIN für umfangreiche Antwort
+
+Abonnement-Details enthalten Plan-Informationen via JOIN:
+
+```sql
+SELECT s.*, p.name AS plan_name, p.price_cents, p.interval AS plan_interval
+FROM subscriptions s JOIN plans p ON p.id = s.plan_id
+WHERE s.id = :id
+```
+
+## Routen
+
+```
+GET    /plans                           Verfügbare Pläne auflisten (öffentlich)
+POST   /subscriptions                   Einen Plan abonnieren (X-User-Id erforderlich)
+GET    /subscriptions/{id}              Abonnement abrufen (Eigentümer oder Admin)
+POST   /subscriptions/{id}/cancel       Abonnement kündigen (Eigentümer oder Admin)
+GET    /users/{userId}/subscriptions    Abonnements eines Benutzers auflisten (Eigentümer oder Admin)
+```
+
+## Siehe auch
+
+- FT213-Quelle: `../NENE2-FT/subscriptionlog/`
+- Verwandt: `docs/howto/coupon-redemption.md` (FT204, ebenfalls zustandsgebundene Pro-Benutzer-Limits)
+- Verwandt: `docs/howto/wish-list-api.md` (FT207, VULN-Muster)

--- a/docs/de/howto/system-announcement-management.md
+++ b/docs/de/howto/system-announcement-management.md
@@ -1,0 +1,177 @@
+# So bauen Sie ein Systemankündigungs-Management
+
+> **Muster bewiesen durch FT190 announcelog** — Zeitbasierte Systemankündigungen mit
+> Admin-Key-Authentifizierung, Pro-Benutzer-Ausblendung und Prioritätssortierung. 38 Tests / 93 Assertions PASS.
+
+---
+
+## Was diese Anleitung abdeckt
+
+Eine Systemankündigungs-API zum Übertragen von Wartungshinweisen, Feature-Updates und Alarmen:
+
+1. **Erstellen/Aktualisieren/Löschen** — Nur-Admin-Operationen via zeitkonstantem Key-Vergleich
+2. **Aktive auflisten** — UTC-zeitgefilterter nach `starts_at` / `ends_at`
+3. **Ausblenden** — Pro-Benutzer-Opt-out, persistent als idempotentes UPSERT
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE announcements (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    starts_at  TEXT    NOT NULL,   -- ISO 8601 UTC
+    ends_at    TEXT    NOT NULL,   -- ISO 8601 UTC
+    priority   INTEGER NOT NULL DEFAULT 0,  -- höher = wird zuerst angezeigt
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+CREATE TABLE announcement_dismissals (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER NOT NULL,
+    announcement_id INTEGER NOT NULL,
+    dismissed_at    TEXT    NOT NULL,
+    UNIQUE(user_id, announcement_id)
+);
+```
+
+`UNIQUE(user_id, announcement_id)` ermöglicht idempotentes Ausblenden. `starts_at` / `ends_at` sind
+ISO-8601-Zeichenketten — lexikografischer Vergleich funktioniert korrekt für UTC-Datetimes.
+
+---
+
+## API
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `POST`   | `/announcements` | `X-Admin-Key` | Ankündigung erstellen (201) |
+| `PUT`    | `/announcements/{id}` | `X-Admin-Key` | Ankündigung aktualisieren (200) |
+| `DELETE` | `/announcements/{id}` | `X-Admin-Key` | Ankündigung löschen (200) |
+| `GET`    | `/announcements` | optionales `X-User-Id` | Aktuell aktive Ankündigungen auflisten |
+| `POST`   | `/announcements/{id}/dismiss` | `X-User-Id` | Für diesen Benutzer ausblenden (200) |
+
+---
+
+## Kernmuster: Zeitkonstante Admin-Key-Verifizierung
+
+```php
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    // Leere adminKey-Konfiguration bedeutet kein Admin-Zugriff — fail-closed
+    if ($this->adminKey === '') {
+        return false;
+    }
+
+    $provided = $request->getHeaderLine('X-Admin-Key');
+
+    // hash_equals: zeitkonstant — verhindert Timing-Angriffe beim Key-Vergleich
+    return $provided !== '' && hash_equals($this->adminKey, $provided);
+}
+```
+
+**Warum nicht `===`:** Zeichenkettenvergleich schließt beim ersten Mismatch kurz. Ein Angreifer kann
+Timing-Unterschiede messen, um Teil-Präfix-Übereinstimmungen zu finden, dann Zeichen für Zeichen
+brute-forcen. `hash_equals()` benötigt unabhängig davon, wo der Mismatch ist, konstante Zeit.
+
+**Fail-Closed:** Eine leere `adminKey`-Konfiguration gibt immer `false` zurück — es gibt keinen
+versehentlichen „offenen Admin"-Modus.
+
+---
+
+## Kernmuster: UTC-zeitbasierte Filterung
+
+```php
+// Aktuell aktive Ankündigungen auflisten
+$now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DateTimeInterface::ATOM);
+
+SELECT ... FROM announcements
+WHERE starts_at <= :now AND ends_at > :now
+ORDER BY priority DESC, id DESC
+```
+
+ISO-8601-Zeichenketten in UTC sortieren lexikografisch korrekt — `'2025-06-01T...' > '2025-05-01T...'`.
+Stets UTC in der Datenbank verwenden.
+
+Das `ends_at > :now` (strikte Größer-als) bedeutet, dass eine Ankündigung genau bei `ends_at` abläuft,
+nicht eine Sekunde danach.
+
+---
+
+## Kernmuster: Pro-Benutzer-Ausblendung (Idempotent)
+
+```php
+// UNIQUE(user_id, announcement_id) ermöglicht sichere wiederholte Ausblende-Aufrufe
+INSERT INTO announcement_dismissals (user_id, announcement_id, dismissed_at)
+VALUES (:user_id, :announcement_id, :now)
+ON CONFLICT(user_id, announcement_id) DO NOTHING
+```
+
+Ein Benutzer, der `POST /announcements/5/dismiss` zweimal aufruft, ist sicher — der zweite Aufruf
+gelingt stillschweigend. Der Client muss nie zuerst prüfen.
+
+---
+
+## Kernmuster: Optionaler Benutzerkontext bei Liste
+
+```php
+// Ohne X-User-Id: alle aktiven Ankündigungen anzeigen
+// Mit X-User-Id: ausgeblendete für diesen Benutzer ausschließen
+
+// Ohne Benutzer:
+WHERE a.starts_at <= :now AND a.ends_at > :now
+
+// Mit Benutzer (LEFT JOIN + IS NULL-Filter):
+LEFT JOIN announcement_dismissals d
+  ON d.announcement_id = a.id AND d.user_id = :user_id
+WHERE a.starts_at <= :now AND a.ends_at > :now
+  AND d.id IS NULL
+```
+
+Dieser einzelne `GET /announcements`-Endpunkt behandelt sowohl nicht-authentifizierte (Monitoring,
+Admin-Ansicht) als auch authentifizierte (UI zeigt relevante Banner) Anwendungsfälle.
+
+---
+
+## Kernmuster: ends_at muss nach starts_at liegen
+
+```php
+// Serverseitige Validierung — nicht nur Client-Vertrauen
+if ($body['ends_at'] <= $body['starts_at']) {
+    return 'ends_at must be after starts_at.';
+}
+```
+
+Eine Ankündigung mit `ends_at <= starts_at` ist unmittelbar nach der Erstellung unsichtbar —
+validieren und ablehnen anstatt stillschweigend fehlerhafte Daten zu akzeptieren.
+
+---
+
+## Antwort-Design
+
+| Szenario | Status | Body |
+|---|---|---|
+| Erfolgreich erstellt | 201 | `{announcement: {id, title, body, starts_at, ends_at, priority}}` |
+| Erfolgreich aktualisiert | 200 | `{announcement: {...}}` |
+| Erfolgreich gelöscht | 200 | `{deleted: true}` |
+| Aktive auflisten | 200 | `{data: [...], total: N}` |
+| Ausblenden | 200 | `{dismissed: true}` |
+| Admin-Key fehlend/falsch | 401 | `{error: "Admin key required."}` |
+| Nicht gefunden | 404 | `{error: "Announcement not found."}` |
+| Validierung fehlgeschlagen | 422 | `{error: "..."}` |
+
+`created_at` / `updated_at` sind **nicht** in der öffentlichen Antwort — sie sind interne Metadaten.
+
+---
+
+## Testergebnisse (FT190)
+
+```
+38 Tests / 93 Assertions — alle PASS
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+```
+
+Quelle: [`../NENE2-FT/announcelog/`](https://github.com/hideyukiMORI/NENE2-examples/tree/main/announcelog)


### PR DESCRIPTION
## 概要

sql-injection.md から system-announcement-management.md まで 9件のドイツ語翻訳を追加。

## 変更内容

- sql-injection.md / sql-orderby-injection.md
- sqlite-fts5-search.md
- state-machine-audit-log.md / state-machine-workflow-api.md
- step-workflow-approval.md
- subscription-plan-management.md / subscription-plan.md
- system-announcement-management.md

Closes #1283 (partial)

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)