### PR TITLE
docs(de): ドイツ語 howto 翻訳 残り83件 (#1283)

### DIFF
--- a/docs/de/howto/price-history.md
+++ b/docs/de/howto/price-history.md
@@ -1,0 +1,348 @@
+# Anleitung: Produktpreishistorie-API
+
+> **FT-Referenz**: FT67 (`NENE2-FT/pricelog`) — Produktpreishistorie-API
+> **ATK**: FT228 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert eine Preishistorie-API, bei der jedes Produkt eine Zeitachse von Preisstufen
+(Gültigkeitszeiträume) pflegt. Der aktuelle Preis sowie der Preis zu einem beliebigen Zeitpunkt
+können abgefragt werden. Der ATK-Abschnitt dokumentiert zwölf Angriffsvektoren mit Bestanden/Nicht bestanden-Urteilen.
+
+---
+
+## Routen
+
+| Methode | Pfad                              | Beschreibung                                     |
+|---------|-----------------------------------|--------------------------------------------------|
+| `POST`  | `/products`                       | Produkt erstellen                                |
+| `GET`   | `/products`                       | Alle Produkte auflisten                          |
+| `GET`   | `/products/{id}`                  | Einzelnes Produkt abrufen                        |
+| `POST`  | `/products/{id}/prices`           | Neuen Preis setzen (neue Stufe öffnen)           |
+| `GET`   | `/products/{id}/prices`           | Vollständige Preishistorie auflisten             |
+| `GET`   | `/products/{id}/prices/current`   | Aktuell gültiger Preis                           |
+| `GET`   | `/products/{id}/prices/at`        | Preis zu einem bestimmten Zeitpunkt (`?datetime=`) |
+
+---
+
+## Preisstufen-Modell
+
+Jeder Preis hat einen `effective_from`- und einen `effective_to`-Zeitstempel. Eine Stufe ist „aktiv", wenn:
+
+```
+effective_from <= now  AND  (effective_to IS NULL  OR  effective_to > now)
+```
+
+`effective_to IS NULL` bedeutet, dass die Stufe noch kein Enddatum hat (offenes Intervall).
+
+```sql
+CREATE TABLE price_tiers (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id     INTEGER NOT NULL REFERENCES products(id),
+    amount         INTEGER NOT NULL,       -- Cent (nicht negativ)
+    currency       TEXT    NOT NULL DEFAULT 'USD',
+    effective_from TEXT    NOT NULL,
+    effective_to   TEXT,                  -- NULL = offen (aktuell)
+    created_at     TEXT    NOT NULL
+);
+```
+
+---
+
+## Preis setzen: alte Stufe schließen, neue öffnen
+
+```php
+public function setPrice(int $productId, int $amount, string $currency, string $effectiveFrom): PriceTier
+{
+    // Alle offenen Stufen schließen, die vor dem neuen effective_from beginnen
+    $this->db->execute(
+        'UPDATE price_tiers
+         SET effective_to = ?
+         WHERE product_id = ? AND effective_to IS NULL AND effective_from <= ?',
+        [$effectiveFrom, $productId, $effectiveFrom],
+    );
+
+    // Neue Stufe öffnen
+    $id = $this->db->insert(
+        'INSERT INTO price_tiers (product_id, amount, currency, effective_from, effective_to, created_at)
+         VALUES (?, ?, ?, ?, NULL, ?)',
+        [$productId, $amount, $currency, $effectiveFrom, $now],
+    );
+    // ...
+}
+```
+
+Das UPDATE schließt alle offenen Stufen, deren `effective_from <= newEffectiveFrom`. Damit werden drei Szenarien korrekt behandelt:
+- **Neues effective_from in der Zukunft**: Aktuelle Stufe wird am zukünftigen Datum geschlossen.
+- **Neues effective_from in der Vergangenheit**: Altes Enddatum wird rückdatiert und eine neue historische Stufe geöffnet.
+- **Gleiches effective_from**: Alte Stufe wird zum gleichen Zeitpunkt geschlossen (Nulldauer), neue Stufe beginnt.
+
+> **Hinweis zur Nebenläufigkeit**: UPDATE und INSERT sind nicht in einer Transaktion zusammengefasst. Zwei gleichzeitige `setPrice`-Aufrufe mit demselben `effective_from` können beide die UPDATE-Phase passieren und beide ein INSERT ausführen, was zwei offene Stufen (`effective_to IS NULL`) hinterlässt. Die Abfragen verwenden `ORDER BY effective_from DESC LIMIT 1`, sodass der letzte Insert gewinnt, aber die Historie ist beschädigt. Verwenden Sie `transactional()` für Korrektheit unter Nebenläufigkeit.
+
+---
+
+## Preis zu einem Zeitpunkt abfragen
+
+```php
+public function priceAt(int $productId, string $datetime): ?PriceTier
+{
+    $row = $this->db->fetchOne(
+        'SELECT * FROM price_tiers
+         WHERE product_id = ? AND effective_from <= ?
+           AND (effective_to IS NULL OR effective_to > ?)
+         ORDER BY effective_from DESC
+         LIMIT 1',
+        [$productId, $datetime, $datetime],
+    );
+
+    return $row !== null ? $this->hydrateTier($row) : null;
+}
+```
+
+Der Vergleich ist ein lexikografischer Zeichenkettenvergleich von ISO 8601-Datetimes, die als TEXT gespeichert sind. Dies funktioniert **nur dann korrekt, wenn alle Datetimes dasselbe Format und dieselbe Zeitzone verwenden** (z. B. alle UTC `2026-05-27 09:00:00`). Das Mischen von Formaten oder Zeitzonen-Offsets liefert falsche Ergebnisse.
+
+**Beispiel**: Wenn `effective_from` als `"2026-05-27T09:00:00+09:00"` (JST) gespeichert ist und `?datetime=2026-05-27T00:30:00Z` (UTC, derselbe Augenblick), sieht der Zeichenkettenvergleich sie als unterschiedlich an und gibt möglicherweise eine falsche Stufe zurück. Normalisieren Sie alle Datetimes beim Schreiben auf UTC.
+
+---
+
+## Betrag in Cent (Integer)
+
+Geldbeträge werden als Integer (Cent) gespeichert, um Rundungsfehler durch Fließkommazahlen zu vermeiden:
+
+```php
+// POST /products/{id}/prices
+$amount = isset($body['amount']) && is_int($body['amount']) ? $body['amount'] : null;
+
+if ($amount === null || $amount < 0) {
+    $errors[] = ['field' => 'amount', 'code' => 'required', 'message' => 'amount must be a non-negative integer (cents).'];
+}
+```
+
+- `is_int()` lehnt JSON-Floats (`9.99` → PHP float) und Strings ab.
+- `$amount < 0` lehnt negative Preise ab.
+- `$amount === 0` ist **erlaubt** (kostenlose Produkte / Aktionen).
+
+---
+
+## ATK — Cracker-Angriffstest (FT228)
+
+### ATK-01 — Keine Authentifizierung
+
+**Angriff**: Preis für ein beliebiges Produkt ohne Anmeldedaten setzen.
+
+```http
+POST /products/1/prices
+{"amount": 1, "currency": "USD", "effective_from": "2026-01-01T00:00:00Z"}
+```
+
+**Beobachtet**: `201 Created` — kein Token erforderlich.
+
+**Urteil**: **EXPONIERT** (absichtlich für FT67-Demo). Preis-Mutationen in der Produktion hinter einer Admin-Rolle oder einem API-Key absichern.
+
+---
+
+### ATK-02 — Rückdatierte Preismanipulation
+
+**Angriff**: `effective_from` auf ein vergangenes Datum setzen, um die Preishistorie zu ändern.
+
+```json
+{"amount": 0, "currency": "USD", "effective_from": "2020-01-01T00:00:00Z"}
+```
+
+**Beobachtet**: `201 Created`. Das UPDATE schließt alle vorhandenen offenen Stufen bei `2020-01-01`, und eine neue Nullpreis-Stufe ab 2020 wird eingefügt. Historische Abfragen (`priceAt`) geben nun den rückdatierten Preis für vergangene Daten zurück.
+
+**Urteil**: **EXPONIERT** — ohne Authentifizierung gibt es keinen Eigentümer, der die Rückdatierung autorisiert. Mit Auth fordern, dass `effective_from >= now()` gilt, sofern der Aufrufer kein Admin ist.
+
+---
+
+### ATK-03 — SQL-Injection über `?datetime=`
+
+**Angriff**: SQL über den `datetime`-Queryparameter einschleusen.
+
+```http
+GET /products/1/prices/at?datetime=2026-01-01' OR '1'='1
+```
+
+**Beobachtet**: `404 Not Found` — der injizierte String wird als parametrisierter Wert verwendet, sodass der Literalstring mit `effective_from` verglichen wird, was nichts trifft.
+
+**Urteil**: **BLOCKIERT** — PDO-parametrisierte Anweisungen verhindern SQL-Injection.
+
+---
+
+### ATK-04 — Nullbetrag
+
+**Angriff**: Produktpreis auf null setzen (kostenlos).
+
+```json
+{"amount": 0, "currency": "USD", "effective_from": "2026-05-27T00:00:00Z"}
+```
+
+**Beobachtet**: `201 Created`.
+
+**Urteil**: **ABSICHTLICH ERLAUBT** — `amount === 0` ist bewusst zugelassen (Testpläne, Aktionen). Dokumentieren Sie, dass `amount` Cent bedeutet und 0 kostenlos ist. Wenn Nullpreise in Ihrer Domäne ungültig sind, ändern Sie `$amount < 0` zu `$amount <= 0`.
+
+---
+
+### ATK-05 — Negativer Betrag
+
+**Angriff**: Negativen Preis setzen (Rückerstattungsangriff?).
+
+```json
+{"amount": -100, "currency": "USD", "effective_from": "2026-05-27T00:00:00Z"}
+```
+
+**Beobachtet**: `422 Unprocessable Entity` — die Prüfung `$amount < 0` gibt false zurück.
+
+**Urteil**: **BLOCKIERT** — negative Beträge werden auf Anwendungsebene abgelehnt.
+
+---
+
+### ATK-06 — Währungscode-Injection (keine Allowlist)
+
+**Angriff**: Preis mit beliebigem oder schädlichem Währungsstring setzen.
+
+```json
+{"amount": 100, "currency": "NOTCURRENCY", "effective_from": "2026-05-27T00:00:00Z"}
+{"amount": 100, "currency": "<script>alert(1)</script>", "effective_from": "..."}
+{"amount": 100, "currency": "'; DROP TABLE price_tiers; --", "effective_from": "..."}
+```
+
+**Beobachtet**: Alle geben `201 Created` zurück. Der Währungsstring wird unverändert gespeichert. Der SQL-Injection-String ist sicher (parametrisiert), aber `"NOTCURRENCY"` und die XSS-Nutzlast werden gespeichert.
+
+**Urteil**: **EXPONIERT** — `currency` gegen eine ISO 4217-Allowlist validieren:
+```php
+$validCurrencies = ['USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD'];
+if (!in_array($currency, $validCurrencies, true)) {
+    $errors[] = ['field' => 'currency', 'code' => 'invalid_value', 'message' => 'Unsupported currency code.'];
+}
+```
+
+---
+
+### ATK-07 — Extrem großer Betrag
+
+**Angriff**: Betrag einreichen, der größer ist als PHP/SQLite verarbeiten kann.
+
+```json
+{"amount": 9999999999999999999, "currency": "USD", "effective_from": "..."}
+```
+
+**Beobachtet**: PHP parst große JSON-Integer als Floats, wenn sie `PHP_INT_MAX` (2^63 - 1 auf 64-Bit) überschreiten. `is_int($body['amount'])` gibt false für einen Float zurück → 422.
+
+**Urteil**: **BLOCKIERT** — `is_int()` lehnt JSON-Integer, die zu PHP-Float überlaufen, korrekt ab. Werte innerhalb von `PHP_INT_MAX` werden als SQLite-Integer korrekt gespeichert.
+
+---
+
+### ATK-08 — Ungültiges Datetime in `?datetime=`
+
+**Angriff**: Nicht-Datumsstring an den `priceAt`-Endpunkt übergeben.
+
+```http
+GET /products/1/prices/at?datetime=not-a-date
+GET /products/1/prices/at?datetime=2026-02-30T00:00:00Z
+```
+
+**Beobachtet**: Beide geben `404 Not Found` zurück — die Strings werden lexikografisch mit gespeicherten `effective_from`-Werten verglichen und treffen nichts. Es wird keine Ausnahme geworfen.
+
+**Urteil**: **TEILWEISE EXPONIERT** — der Endpunkt akzeptiert ungültige Datumsangaben stillschweigend und gibt 404 zurück, was Aufrufer verwirren kann, die ein 422 erwarten. Formatvalidierung hinzufügen:
+```php
+$dt = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $datetime);
+if ($dt === false) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'datetime', 'code' => 'invalid_format', 'message' => 'datetime must be ISO 8601.']],
+    ]);
+}
+```
+
+---
+
+### ATK-09 — Zukünftiges effective_from (geplante Preisänderung)
+
+**Angriff**: `effective_from` auf ein zukünftiges Datum setzen, um eine Preisänderung zu planen.
+
+```json
+{"amount": 999, "currency": "USD", "effective_from": "2099-12-31T00:00:00Z"}
+```
+
+**Beobachtet**: `201 Created`. `currentPrice()` gibt weiterhin den vorherigen Preis zurück (das `effective_from` der zukünftigen Stufe liegt noch in der Zukunft), aber `priceAt("2099-12-31T01:00:00Z")` gibt die neue Stufe zurück.
+
+**Urteil**: **ABSICHTLICH ERLAUBT** — geplante Preisänderungen sind ein legitimer Anwendungsfall. In der API-Spezifikation dokumentieren. Wenn die Planung auf Admins beschränkt sein soll, Auth erfordern und `effective_from <= now + 30 days` für Nicht-Admin-Aufrufer prüfen.
+
+---
+
+### ATK-10 — Gleichzeitiges Preissetzen (Race Condition)
+
+**Angriff**: Zwei gleichzeitige `POST /products/1/prices` mit demselben `effective_from` senden.
+
+**Beobachtet**: Ohne eine Transaktion, die UPDATE + INSERT umschließt, können beide Anfragen die UPDATE-Phase passieren und beide ein INSERT ausführen, was zwei offene Stufen (`effective_to IS NULL`) erzeugt. Abfragen verwenden `ORDER BY effective_from DESC LIMIT 1`, sodass die Ergebnisse nicht deterministisch sind.
+
+**Urteil**: **EXPONIERT** — `setPrice` in `transactional()` einschließen:
+```php
+return $this->txManager->transactional(function ($tx) use (...) {
+    // UPDATE dann INSERT innerhalb der Transaktion
+});
+```
+
+---
+
+### ATK-11 — Nicht existierende product_id
+
+**Angriff**: Preis für ein nicht existierendes Produkt setzen.
+
+```http
+POST /products/99999/prices
+{"amount": 100, "currency": "USD", "effective_from": "2026-05-27T00:00:00Z"}
+```
+
+**Beobachtet**: `404 Not Found` — `findProduct(99999)` gibt `null` zurück und der Controller gibt eine Not-Found-Problem-Details-Antwort zurück, bevor `setPrice` aufgerufen wird.
+
+**Urteil**: **BLOCKIERT** — Existenzprüfung vor der Mutation.
+
+---
+
+### ATK-12 — Nicht-numerische Pfad-IDs
+
+**Angriff**: Nicht-Ziffer-Strings als `{id}` übergeben.
+
+```http
+GET /products/abc
+GET /products/-1
+POST /products/0/prices
+```
+
+**Beobachtet**: Alle geben `404 Not Found` zurück. `(int) "abc"` = `0`; `findProduct(0)` gibt `null` zurück (kein Produkt mit ID 0); Controller gibt 404 zurück.
+
+**Urteil**: **BLOCKIERT** in der Praxis. Hinweis: `(int) "9abc"` = `9` — ein Produkt mit ID 9 würde übereinstimmen. Verwenden Sie `ctype_digit()` für strikte Pfadvalidierung, wenn nötig.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|----------------|--------|
+| ATK-01 | Keine Authentifizierung | EXPONIERT (absichtlich) |
+| ATK-02 | Rückdatierte Preismanipulation | EXPONIERT |
+| ATK-03 | SQL-Injection über `?datetime=` | BLOCKIERT |
+| ATK-04 | Nullbetrag | ABSICHTLICH ERLAUBT |
+| ATK-05 | Negativer Betrag | BLOCKIERT |
+| ATK-06 | Währungscode-Injection (keine Allowlist) | EXPONIERT |
+| ATK-07 | Extrem großer Betrag | BLOCKIERT |
+| ATK-08 | Ungültiges Datetime-Format | TEILWEISE EXPONIERT |
+| ATK-09 | Zukünftiges `effective_from` (geplanter Preis) | ABSICHTLICH ERLAUBT |
+| ATK-10 | Gleichzeitiges setPrice (Race Condition) | EXPONIERT |
+| ATK-11 | Nicht existierendes Produkt | BLOCKIERT |
+| ATK-12 | Nicht-numerische Pfad-IDs | BLOCKIERT |
+
+**Echte Schwachstellen, die vor dem Produktivbetrieb behoben werden müssen**:
+1. **ATK-01** — Authentifizierung/Autorisierung hinzufügen
+2. **ATK-02** — Rückdatierung auf Admin-Aufrufer beschränken (oder vollständig verbieten)
+3. **ATK-06** — `currency` gegen ISO 4217-Allowlist validieren
+4. **ATK-08** — `?datetime=`-Format vor der DB-Abfrage validieren
+5. **ATK-10** — `setPrice` UPDATE+INSERT in eine Transaktion einschließen
+
+---
+
+## Verwandte Anleitungen
+
+- [`expense-tracker.md`](expense-tracker.md) — `is_int()`-Betragsvalidierung und ISO 8601-Datum-Roundtrip
+- [`habit-tracker.md`](habit-tracker.md) — ATK-01〜12-Muster (vorheriger ATK-Zyklus)
+- [`prevent-double-booking.md`](prevent-double-booking.md) — Transaktionales Read-Check-Write
+- [`iso-datetime-validation.md`](iso-datetime-validation.md) — Strikte ISO 8601-Validierung

--- a/docs/de/howto/privacy-consent-management.md
+++ b/docs/de/howto/privacy-consent-management.md
@@ -1,0 +1,216 @@
+# Datenschutz-Einwilligungsverwaltung implementieren
+
+> **Muster erprobt in FT189 consentlog** — DSGVO-konformes Einwilligungs-Tracking mit unveränderlicher Historie, IDOR-Prävention und Benutzer-Enumerationsschutz. VULN-A〜L alle bestanden.
+
+---
+
+## Was diese Anleitung abdeckt
+
+Ein Datenschutz-Einwilligungsverwaltungsablauf:
+
+1. **Einwilligung erteilen** — Benutzer erteilt Einwilligung für einen benannten Zweck
+2. **Einwilligung widerrufen** — Benutzer widerruft die Einwilligung
+3. **Einwilligungen auflisten** — aktueller Einwilligungsstatus für alle Zwecke
+4. **Historie** — unveränderliches, append-only-Prüfprotokoll pro Zweck
+
+Sicherheitsgarantien:
+
+| Bedrohung | Technik |
+|---|---|
+| IDOR — Einwilligungen anderer Benutzer | Alle Abfragen mit `WHERE user_id = :user_id` |
+| Mass Assignment (granted-Feld) | `granted` wird serverseitig bestimmt; Body kann nicht überschreiben |
+| SQL-Injection im Zweck | `ctype_alnum()` — nur alphanumerisch |
+| ReDoS im Zweck | `ctype_alnum()` O(n) — kein Regex |
+| Typverwechslung | `is_string()` vor `ctype_alnum()` |
+| Benutzer-Enumeration | Unbekannter Benutzer gibt leeres Array zurück, kein 404 |
+| Race Condition bei grant/withdraw | UPSERT-Atomarität auf `UNIQUE(user_id, purpose)` |
+| Einwilligungs-Replay | Historie ist append-only; jede Änderung ist ein neuer Eintrag |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE consents (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    purpose    TEXT    NOT NULL,  -- alphanumerischer Slug: 'marketing', 'analytics', etc.
+    granted    INTEGER NOT NULL DEFAULT 1,  -- 1=erteilt, 0=widerrufen
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE(user_id, purpose)
+);
+
+CREATE TABLE consent_history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    purpose    TEXT    NOT NULL,
+    granted    INTEGER NOT NULL,   -- 1=erteilt, 0=widerrufen
+    created_at TEXT    NOT NULL    -- Zeitpunkt dieser Änderung
+);
+```
+
+`UNIQUE(user_id, purpose)` ermöglicht atomares Upsert. `consent_history` ist append-only — wird nie aktualisiert.
+
+---
+
+## API
+
+| Methode | Pfad | Header | Beschreibung |
+|---|---|---|---|
+| `POST` | `/consents` | `X-User-Id` | Einwilligung erteilen (201) |
+| `DELETE` | `/consents/{purpose}` | `X-User-Id` | Einwilligung widerrufen (200) |
+| `GET` | `/consents` | `X-User-Id` | Aktuelle Einwilligungen auflisten |
+| `GET` | `/consents/{purpose}/history` | `X-User-Id` | Prüfhistorie (append-only) |
+
+---
+
+## Kernmuster: Idempotentes UPSERT
+
+```php
+// Erteilen — idempotent: eine bereits erteilte Einwilligung erneut zu erteilen ist sicher
+INSERT INTO consents (user_id, purpose, granted, created_at, updated_at)
+VALUES (:user_id, :purpose, 1, :now, :now)
+ON CONFLICT(user_id, purpose) DO UPDATE
+SET granted = 1, updated_at = :now
+
+// Widerrufen — gleiches Muster
+INSERT INTO consents (user_id, purpose, granted, created_at, updated_at)
+VALUES (:user_id, :purpose, 0, :now, :now)
+ON CONFLICT(user_id, purpose) DO UPDATE
+SET granted = 0, updated_at = :now
+```
+
+UPSERT auf `UNIQUE(user_id, purpose)` ist atomar — verhindert Race Conditions, bei denen gleichzeitige grant+withdraw-Aufrufe eine doppelte Zeile erstellen könnten.
+
+---
+
+## Kernmuster: Unveränderliche Historie
+
+```php
+// Immer an die Historie anhängen — auch erneutes Erteilen wird aufgezeichnet
+INSERT INTO consent_history (user_id, purpose, granted, created_at)
+VALUES (:user_id, :purpose, 1, :now)
+```
+
+Die Historie wird **nie aktualisiert** — sie ist ein Prüfprotokoll jeder Einwilligungsänderung. Dies ermöglicht Regulierungsbehörden zu überprüfen, wann die Einwilligung erteilt und wann sie widerrufen wurde.
+
+---
+
+## Kernmuster: Zweck-Validierung
+
+```php
+private function resolvePurpose(mixed $raw): ?string
+{
+    // VULN-G: Typverwechslung — muss ein String sein
+    if (!is_string($raw)) {
+        return null;
+    }
+
+    $len = strlen($raw);
+
+    if ($len === 0 || $len > self::MAX_PURPOSE_LEN) {
+        return null;
+    }
+
+    // VULN-I: ctype_alnum ist O(n) — kein Regex, kein ReDoS
+    // VULN-D: nur alphanumerisch — kein HTML, keine SQL-Sonderzeichen
+    if (!ctype_alnum($raw)) {
+        return null;
+    }
+
+    return $raw;
+}
+```
+
+`ctype_alnum()` akzeptiert nur `[a-zA-Z0-9]` — lehnt Leerzeichen, Bindestriche, SQL-Metazeichen und HTML-Tags in einem einzigen O(n)-Durchlauf ab.
+
+---
+
+## Kernmuster: Benutzer-Enumerationsschutz
+
+```php
+// VULN-F: für unbekannte Benutzer leeres Array zurückgeben — kein 404
+public function listForUser(int $userId): array
+{
+    $stmt = $this->pdo->prepare(
+        'SELECT ... FROM consents WHERE user_id = :user_id ORDER BY purpose ASC',
+    );
+    $stmt->execute(['user_id' => $userId]);
+
+    return array_map(fn(array $r) => $this->hydrateConsent($r), $stmt->fetchAll(PDO::FETCH_ASSOC));
+}
+```
+
+Eine 404-Antwort für unbekannte Benutzer gibt preis: „Diese user_id existiert nicht." Geben Sie immer 200 mit leeren Daten zurück.
+
+---
+
+## Kernmuster: IDOR-Prävention
+
+```php
+// VULN-B: alle Lese- und Schreibvorgänge auf den authentifizierten Benutzer beschränken
+// Selbst wenn ein Angreifer X-User-Id: 999 sendet, sieht er nur die Daten von Benutzer 999
+WHERE user_id = :user_id AND purpose = :purpose
+```
+
+Keine benutzerübergreifende Abfrage greift jemals auf den Datensatz eines anderen Benutzers zu.
+
+---
+
+## Kernmuster: Serverseitig gesteuertes granted-Feld
+
+```php
+// VULN-C/E: granted wird vom Endpunkt gesteuert — niemals aus dem Body
+// POST /consents → erteilt immer (granted = 1)
+// DELETE /consents/{purpose} → widerruft immer (granted = 0)
+// Body { "granted": false } bei POST wird stillschweigend ignoriert
+```
+
+Der Endpunkt selbst bestimmt den `granted`-Wert. Ein Body-Feld kann ihn nie überschreiben.
+
+---
+
+## Antwort-Design
+
+| Szenario | Status | Body |
+|---|---|---|
+| Erteilen erfolgreich | 201 | `{consent: {id, purpose, granted: true, updated_at}}` |
+| Widerrufen erfolgreich | 200 | `{consent: {id, purpose, granted: false, updated_at}}` |
+| Einwilligungen auflisten | 200 | `{data: [...], total: N}` |
+| Historie | 200 | `{data: [{id, purpose, granted, created_at}, ...], total: N}` |
+| Unbekannter Benutzer | 200 | `{data: [], total: 0}` — kein 404 |
+
+`user_id` wird **nie** in einer Antwort eingeschlossen — sie ist implizit aus `X-User-Id`.
+
+---
+
+## VULN-A〜L alle bestanden
+
+| VULN | Angriff | Abwehr |
+|---|---|---|
+| A | SQL-Injection in X-User-Id | `ctype_digit()` + strlen > 18 Prüfung |
+| B | IDOR — Einwilligung anderer Benutzer manipulieren | Alle Abfragen mit `WHERE user_id = :user_id` |
+| C | Mass Assignment (granted-Feld manipulieren) | granted wird vom Endpunkt bestimmt — Body nicht verwendet |
+| D | XSS im Zweck | `ctype_alnum()` — nur alphanumerisch |
+| E | Direkte Überschreibung des Einwilligungsstatus | grant/withdraw sind getrennte Endpunkte |
+| F | Benutzer-Enumeration | Unbekannte user_id gibt leeres Array 200 zurück |
+| G | Typverwechslung (purpose als int/array/null) | `is_string()` + `ctype_alnum()` |
+| H | Einwilligungs-Replay | Historie ist append-only, erneutes Erteilen ist neuer Eintrag |
+| I | ReDoS im Zweck | `ctype_alnum()` O(n) |
+| J | Integer-Überlauf in X-User-Id | strlen > 18 Prüfung |
+| K | Gleichzeitige grant+withdraw Race Condition | `UNIQUE(user_id, purpose)` UPSERT-Atomarität |
+| L | CRLF-Injection in Headers | PSR-7 lehnt auf HTTP-Ebene ab |
+
+---
+
+## Testergebnisse (FT189)
+
+```
+51 Tests / 142 Assertions — alle BESTANDEN
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+VULN-A〜L alle bestanden
+```
+
+Quelle: [`../NENE2-FT/consentlog/`](https://github.com/hideyukiMORI/NENE2-examples/tree/main/consentlog)

--- a/docs/de/howto/product-catalog.md
+++ b/docs/de/howto/product-catalog.md
@@ -1,0 +1,133 @@
+# Anleitung: Produktkatalog-API (ATK-01~12)
+
+Diese Anleitung demonstriert eine Produktkatalog-API mit ausschließlich für Admins zugänglichen Schreiboperationen, Stichwortsuche und Soft Delete — und deckt die ATK-01~12-Cracker-Angriffsvektoren ab.
+
+## Muster-Überblick
+
+- Katalog-Lesevorgänge sind öffentlich; Schreibvorgänge (Erstellen, Löschen) erfordern Admin (`X-Admin-Key`).
+- SKUs sind großgeschriebene alphanumerische Zeichen mit Bindestrichen (`/\A[A-Z0-9\-]{1,32}\z/`).
+- Soft Delete (`active = 0`) versteckt Produkte, ohne die Historie zu verlieren.
+- Die Stichwortsuche verwendet `LIKE` mit Längenbegrenzung, um Keyword-Bombs zu verhindern.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    sku         TEXT    NOT NULL UNIQUE,
+    name        TEXT    NOT NULL,
+    description TEXT    NOT NULL DEFAULT '',
+    price_cents INTEGER NOT NULL,
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_at  TEXT    NOT NULL
+);
+```
+
+## ATK-01: SQL-Injection im Suchstichwort
+
+```php
+$kw   = '%' . $keyword . '%';
+$stmt = $this->pdo->prepare(
+    'SELECT * FROM products WHERE active = 1 AND (name LIKE :kw OR ...) LIMIT :lim OFFSET :off'
+);
+$stmt->bindValue(':kw', $kw, PDO::PARAM_STR);
+```
+
+Das `%`-Wildcard ist Teil des Literalwerts, der an eine parametrisierte Abfrage übergeben wird — es findet keine Interpolation statt.
+
+## ATK-02: Admin Fail-Closed
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+Leerer Admin-Key → immer 403. Falscher Key → `hash_equals()` verhindert Timing-Leaks.
+
+## ATK-03: Integer-Überlauf bei der Produkt-ID
+
+```php
+if (!ctype_digit($raw) || strlen($raw) > 18) {
+    return null;  // → 404
+}
+```
+
+Ein 20-stelliger ID-String überschreitet 18 Zeichen und wird vor jedem `(int)`-Cast oder DB-Abfrage abgelehnt.
+
+## ATK-04: Negative ID
+
+`ctype_digit()` schlägt bei `-1` fehl (Nicht-Ziffer-Zeichen) → 404.
+
+## ATK-05: Fließkommazahl als Preis
+
+```php
+if (!is_int($priceCents) || $priceCents < 0) {
+    return $this->problem(422, ...);
+}
+```
+
+`is_int(9.99)` gibt `false` zurück — Fließkommazahl-Preise werden abgelehnt.
+
+## ATK-06: SKU-Injection
+
+Der SKU-Regex `/\A[A-Z0-9\-]{1,32}\z/` lehnt `; DROP TABLE`, Anführungszeichen, Leerzeichen und Kleinbuchstaben ab. Nur das exakte Format wird akzeptiert.
+
+## ATK-07: Wildcard-Suche-Injection
+
+`%` in einem Suchstichwort wird als SQL-LIKE-Wildcard behandelt — es trifft alles. Dies ist absichtlich (Benutzer können alles suchen). Das LIKE ist parametrisiert, sodass `%; DROP TABLE products; --` nicht als SQL ausgeführt wird:
+
+```sql
+WHERE name LIKE '%%; DROP TABLE products; --%'
+```
+
+Das Ergebnis ist nur ein breiterer LIKE-Treffer, keine Injection.
+
+## ATK-08: Doppeltes Löschen
+
+Die `delete()`-Methode des Repositorys prüft zuerst `findById()` (nur active=1). Ein soft-gelöschtes Produkt gibt null zurück → 404 beim zweiten Löschversuch.
+
+## ATK-09: SKU zu lang
+
+Der Regex-Quantor `{1,32}` lehnt SKUs mit mehr als 32 Zeichen ab, bevor die DB erreicht wird.
+
+## ATK-10: Falscher Admin-Key
+
+Der `hash_equals()`-Vergleich benötigt immer dieselbe Zeit, unabhängig davon, wie viele Zeichen übereinstimmen.
+
+## Stichwort-Längenbegrenzung
+
+```php
+if ($keyword !== null && strlen($keyword) > 100) {
+    return $this->problem(422, 'validation-failed', 'q too long (max 100).');
+}
+```
+
+Verhindert das Senden eines 10 MB großen LIKE-Musters an die Datenbank.
+
+## Soft Delete
+
+```php
+$this->pdo->prepare('UPDATE products SET active = 0 WHERE id = :id')->execute([':id' => $id]);
+```
+
+Alle Lesevorgänge enthalten `WHERE active = 1`. Gelöschte Produkte werden unsichtbar, ohne physisch entfernt zu werden.
+
+## Routen
+
+```
+POST   /products      Produkt erstellen (nur Admin)
+GET    /products      Produkte auflisten/suchen (öffentlich)
+GET    /products/{id} Produkt abrufen (öffentlich)
+DELETE /products/{id} Produkt soft-löschen (nur Admin)
+```
+
+## Siehe auch
+
+- FT212-Quellcode: `../NENE2-FT/productlog/`
+- Verwandt: `docs/howto/inventory-management.md` (FT203, SKU-basierter Lagerbestand)
+- Verwandt: `docs/howto/session-token-management.md` (FT208, ebenfalls ATK)

--- a/docs/de/howto/product-review-system.md
+++ b/docs/de/howto/product-review-system.md
@@ -1,0 +1,141 @@
+# Produktbewertungs- und Rezensionssystem
+
+Implementierung eines Produktbewertungs- und Rezensionssystems mit NENE2.
+Enthält die Einschränkung „1 Benutzer, 1 Produkt, 1 Rezension", Bewertungsaggregation (Durchschnitt und Verteilung) sowie CRUD-Operationen.
+
+---
+
+## Endpunktübersicht
+
+| Methode | Pfad | Beschreibung | Authentifizierung |
+|---|---|---|---|
+| `POST` | `/products/{productId}/reviews` | Rezension einreichen | Erforderlich |
+| `GET` | `/products/{productId}/reviews` | Rezensionen auflisten (Cursor) | Erforderlich |
+| `GET` | `/products/{productId}/reviews/summary` | Durchschnittsbewertung und Verteilung | Erforderlich |
+| `PUT` | `/products/{productId}/reviews/{reviewId}` | Rezension aktualisieren | Nur der Eigentümer |
+| `DELETE` | `/products/{productId}/reviews/{reviewId}` | Rezension löschen | Nur der Eigentümer |
+
+---
+
+## DB-Schema
+
+```sql
+CREATE TABLE reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    rating INTEGER NOT NULL CHECK (rating >= 1 AND rating <= 5),
+    body TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (product_id, user_id),
+    FOREIGN KEY (product_id) REFERENCES products(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+---
+
+## Einschränkung „1 Benutzer, 1 Produkt, 1 Rezension"
+
+Die `UNIQUE(product_id, user_id)`-Einschränkung verhindert Doppelrezensionen auf Datenbankebene.
+
+Auf Anwendungsebene wird ebenfalls vorher geprüft und 409 Conflict zurückgegeben:
+
+```php
+if ($this->repository->findByProductAndUser($productId, $userId) !== null) {
+    return $this->json->create(['error' => 'already reviewed'], 409);
+}
+```
+
+Nach dem Löschen ist eine erneute Einreichung möglich (da die UNIQUE-Einschränkung aufgehoben wird).
+
+---
+
+## Bewertungsvalidierung
+
+```php
+// is_int() lehnt Fließkommazahlen ab (JSON 4.5 ist float → 422)
+if (!isset($body['rating']) || !is_int($body['rating'])) {
+    $errors[] = new ValidationError('rating', 'Rating must be an integer.', 'required');
+} elseif ($body['rating'] < 1 || $body['rating'] > 5) {
+    $errors[] = new ValidationError('rating', 'Rating must be between 1 and 5.', 'out_of_range');
+}
+```
+
+| Wert | Ergebnis |
+|---|---|
+| `5` (int) | Bestanden |
+| `4.5` (float) | 422 |
+| `0` | 422 |
+| `6` | 422 |
+| Fehlt | 422 |
+
+---
+
+## Bewertungsaggregation (Zusammenfassung)
+
+```sql
+-- Gesamtanzahl und Durchschnitt
+SELECT COUNT(*) as total, AVG(rating) as avg_rating
+FROM reviews WHERE product_id = ?
+
+-- Verteilung nach Sternenzahl
+SELECT COUNT(*) as cnt FROM reviews WHERE product_id = ? AND rating = ?
+```
+
+Beispielantwort:
+
+```json
+GET /products/1/reviews/summary
+
+{
+    "total": 150,
+    "avg_rating": 4.23,
+    "distribution": {
+        "1": 5,
+        "2": 8,
+        "3": 20,
+        "4": 52,
+        "5": 65
+    }
+}
+```
+
+Bei 0 Rezensionen ist `"avg_rating": null`.
+
+---
+
+## Eigentümerprüfung (Aktualisieren und Löschen)
+
+```php
+$review = $this->repository->findReviewById($reviewId);
+if ($review === null || (int) $review['product_id'] !== $productId) {
+    return $this->json->create(['error' => 'review not found'], 404);
+}
+if ((int) $review['user_id'] !== $userId) {
+    return $this->json->create(['error' => 'forbidden'], 403);
+}
+```
+
+Die Kreuzprüfung der `product_id` gibt auch dann 404 zurück, wenn eine Rezensions-ID für ein anderes Produkt angegeben wird.
+
+---
+
+## Cursor-Paginierung
+
+```
+GET /products/1/reviews?limit=20
+→ { items: [...], next_cursor: 42 }
+
+GET /products/1/reviews?limit=20&before_id=42
+→ { items: [...], next_cursor: null }
+```
+
+`next_cursor: null` zeigt das Ende der Liste an.
+
+---
+
+## Implementierungsbeispiel (FT154)
+
+`/home/xi/docker/NENE2-FT/reviewlog/`

--- a/docs/de/howto/project-task-management.md
+++ b/docs/de/howto/project-task-management.md
@@ -1,0 +1,306 @@
+# Anleitung: Projekt- und Aufgabenverwaltung mit verschachtelten Ressourcen
+
+> **FT-Referenz**: FT241 (`NENE2-FT/projtrack`) — Projekt- und Aufgabenverwaltungs-API
+
+Demonstriert eine zweistufige verschachtelte Ressourcen-API, bei der Aufgaben zu Projekten gehören,
+mit Überprüfung der Eltern-Existenz, selektiven PATCH-Aktualisierungen über `array_key_exists()`,
+Status-Allowlist über CHECK-Einschränkung, Priorität als Integer und `204 No Content`
+für DELETE-Antworten.
+
+---
+
+## Routen
+
+| Methode   | Pfad                                  | Beschreibung                                          |
+|-----------|---------------------------------------|-------------------------------------------------------|
+| `GET`     | `/projects`                           | Projekte auflisten (paginiert)                        |
+| `POST`    | `/projects`                           | Projekt erstellen                                     |
+| `GET`     | `/projects/{id}`                      | Einzelnes Projekt abrufen                             |
+| `DELETE`  | `/projects/{id}`                      | Projekt löschen (kaskadiert auf Aufgaben)             |
+| `GET`     | `/projects/{projectId}/tasks`         | Aufgaben eines Projekts auflisten (paginiert, filterbar) |
+| `POST`    | `/projects/{projectId}/tasks`         | Aufgabe in einem Projekt erstellen                    |
+| `GET`     | `/projects/{projectId}/tasks/{taskId}`| Einzelne Aufgabe abrufen                              |
+| `PATCH`   | `/projects/{projectId}/tasks/{taskId}`| Aufgabe selektiv aktualisieren (fehlende Felder beibehalten) |
+| `DELETE`  | `/projects/{projectId}/tasks/{taskId}`| Aufgabe löschen (`204 No Content`)                    |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS projects (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL,
+    description TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    title       TEXT    NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'open' CHECK(status IN ('open', 'in_progress', 'done')),
+    priority    INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+```
+
+`status` ist auf DB-Ebene durch `CHECK(status IN (...))` eingeschränkt — ein Sicherheitsnetz
+gegen ungültige Werte. `ON DELETE CASCADE` bedeutet, dass das Löschen eines Projekts
+alle zugehörigen Aufgaben automatisch entfernt. `priority` ist standardmäßig `0`; höhere Werte sortieren zuerst.
+
+---
+
+## Verschachtelte Ressourcen: Überprüfung der Eltern-Existenz
+
+Jede Aufgabenoperation validiert, dass das übergeordnete Projekt **vor** der Aufgabenverarbeitung
+existiert. Wenn die Projekt-ID unbekannt ist, wird sofort `ProjectNotFoundException` geworfen:
+
+```php
+private function listTasks(ServerRequestInterface $request): ResponseInterface
+{
+    $params    = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $projectId = (int) ($params['projectId'] ?? 0);
+
+    // Sicherstellen, dass das Projekt existiert (wirft ProjectNotFoundException → 404)
+    $this->projects->findById($projectId);
+
+    $items = $this->tasks->findByProject($projectId, $status, $pagination->limit, $pagination->offset);
+    // ...
+}
+```
+
+`ProjectNotFoundException` ist als Exception-Handler registriert, der auf
+`404 Not Found` abbildet. Das bedeutet: `/projects/99/tasks` gibt `404` zurück, wenn Projekt 99 nicht
+existiert — denselben Status wie eine fehlende Aufgabe. Aufrufer können „Projekt fehlt"
+nicht von „Aufgabe fehlt" unterscheiden, ohne das Problem-Details-`detail`-Feld zu lesen.
+
+Das Aufgaben-Repository erzwingt auch auf SQL-Ebene die Projektzugehörigkeit:
+
+```php
+public function findByProjectAndId(int $projectId, int $taskId): Task
+{
+    $row = $this->executor->fetchOne(
+        'SELECT * FROM tasks WHERE id = ? AND project_id = ?',
+        [$taskId, $projectId],
+    );
+    if ($row === null) {
+        throw new TaskNotFoundException($projectId, $taskId);
+    }
+    return $this->hydrate($row);
+}
+```
+
+`WHERE id = ? AND project_id = ?` verhindert projektübergreifenden Zugriff — Aufgabe 5 unter Projekt
+1 kann nicht über `/projects/2/tasks/5` abgerufen werden, selbst wenn Aufgabe 5 existiert.
+
+---
+
+## PATCH: selektive Feldaktualisierung mit `array_key_exists()`
+
+`PATCH /projects/{projectId}/tasks/{taskId}` akzeptiert jede Teilmenge von `title`, `status`
+und `priority`. Im Request-Body fehlende Felder werden beibehalten.
+
+`isset()` kann nicht zwischen „Schlüssel fehlt" und „Schlüssel vorhanden mit null" unterscheiden. Für
+PATCH-Semantik ist `array_key_exists()` das richtige Werkzeug:
+
+```php
+$title    = null;
+$status   = null;
+$priority = null;
+
+if (array_key_exists('title', $body)) {
+    if (!is_string($body['title']) || trim($body['title']) === '') {
+        $errors[] = new ValidationError('title', 'title must be a non-empty string.', 'invalid_value');
+    } else {
+        $title = trim($body['title']);
+    }
+}
+
+if (array_key_exists('status', $body)) {
+    $validStatuses = ['open', 'in_progress', 'done'];
+    if (!is_string($body['status']) || !in_array($body['status'], $validStatuses, true)) {
+        $errors[] = new ValidationError('status', 'status must be one of: open, in_progress, done.', 'invalid_value');
+    } else {
+        $status = $body['status'];
+    }
+}
+
+if (array_key_exists('priority', $body)) {
+    if (!is_int($body['priority'])) {
+        $errors[] = new ValidationError('priority', 'priority must be an integer.', 'invalid_type');
+    } else {
+        $priority = $body['priority'];
+    }
+}
+```
+
+`$title`, `$status` und `$priority` bleiben `null`, wenn der Schlüssel fehlt. Das
+Repository interpretiert `null` als „nicht ändern":
+
+```php
+public function update(int $projectId, int $taskId, ?string $title, ?string $status, ?int $priority, string $now): Task
+{
+    $existing    = $this->findByProjectAndId($projectId, $taskId);
+    $newTitle    = $title    ?? $existing->title;
+    $newStatus   = $status   ?? $existing->status;
+    $newPriority = $priority ?? $existing->priority;
+
+    $this->executor->execute(
+        'UPDATE tasks SET title = ?, status = ?, priority = ?, updated_at = ? WHERE id = ? AND project_id = ?',
+        [$newTitle, $newStatus, $newPriority, $now, $taskId, $projectId],
+    );
+
+    return $this->findByProjectAndId($projectId, $taskId);
+}
+```
+
+Der Null-Koaleszierende `??` führt bereitgestellte Werte mit dem vorhandenen Datensatz zusammen. Ein einziges
+`UPDATE` wird immer ausgeführt (keine dynamische Spaltenliste nötig) — der vorhandene Wert
+ersetzt sich einfach selbst, wenn ein Feld fehlt.
+
+---
+
+## `is_int()` für priority: Fließkommazahlen und Strings aus JSON ablehnen
+
+JSON `1` dekodiert als PHP `int`, aber `1.0` dekodiert als `float` und `"1"` als `string`.
+`is_int()` akzeptiert nur die Integer-Form:
+
+```php
+if (isset($body['priority'])) {
+    if (!is_int($body['priority'])) {
+        $errors[] = new ValidationError('priority', 'priority must be an integer.', 'invalid_type');
+    } else {
+        $priority = $body['priority'];
+    }
+}
+```
+
+`is_numeric()` würde `"1"` und `1.0` akzeptieren — verwenden Sie `is_int()` für strikte Integer-Validierung.
+Hinweis: `priority` ist bei der Erstellung optional (Standard: `0`); beim PATCH gilt dieselbe Prüfung
+innerhalb des `array_key_exists('priority', $body)`-Blocks.
+
+---
+
+## Status-Allowlist-Validierung
+
+Der Status wird gegen eine explizite Allowlist validiert, bevor er die DB erreicht:
+
+```php
+$validStatuses = ['open', 'in_progress', 'done'];
+if (!is_string($body['status']) || !in_array($body['status'], $validStatuses, true)) {
+    $errors[] = new ValidationError('status', 'status must be one of: open, in_progress, done.', 'invalid_value');
+}
+```
+
+`in_array(..., true)` — strenger Vergleich — stellt sicher, dass der Wert ein String ist, der einem
+der erlaubten Zustände entspricht. Die DB-`CHECK`-Einschränkung bietet eine zweite Verteidigungslinie,
+aber die Prüfung auf Anwendungsebene liefert ein strukturiertes `422` mit einer aussagekräftigen Fehlermeldung
+statt einem rohen DB-Fehler.
+
+---
+
+## Status-Filter für die Aufgabenauflistung
+
+`GET /projects/{projectId}/tasks?status=open` filtert Aufgaben nach Status. Der Querystring
+wird mit `QueryStringParser::string()` gelesen:
+
+```php
+$status = QueryStringParser::string($request, 'status');
+
+$validStatuses = ['open', 'in_progress', 'done'];
+if ($status !== null && !in_array($status, $validStatuses, true)) {
+    throw new ValidationException([
+        new ValidationError('status', 'status must be one of: open, in_progress, done.', 'invalid_value'),
+    ]);
+}
+```
+
+`QueryStringParser::string()` gibt `null` zurück, wenn der Parameter fehlt — kein Filter
+wird angewendet. Ein ungültiger Wert gibt `422 Unprocessable Entity` zurück, anstatt stillschweigend
+eine leere Liste zurückzugeben.
+
+Das Repository baut die WHERE-Klausel dynamisch auf:
+
+```php
+public function findByProject(int $projectId, ?string $status = null, int $limit = 20, int $offset = 0): array
+{
+    $where  = ['project_id = ?'];
+    $params = [$projectId];
+
+    if ($status !== null) {
+        $where[]  = 'status = ?';
+        $params[] = $status;
+    }
+
+    $sql = 'SELECT * FROM tasks WHERE ' . implode(' AND ', $where)
+        . ' ORDER BY priority DESC, created_at ASC LIMIT ? OFFSET ?';
+    $params[] = $limit;
+    $params[] = $offset;
+
+    return array_map($this->hydrate(...), $this->executor->fetchAll($sql, $params));
+}
+```
+
+Aufgaben werden nach `priority DESC` sortiert (höhere Priorität zuerst), dann nach `created_at ASC`
+(ältere Aufgaben zuerst bei gleicher Priorität).
+
+---
+
+## `204 No Content` für DELETE
+
+DELETE-Antworten enthalten keinen Body. `JsonResponseFactory::createEmpty(204)` erzeugt eine
+`204 No Content`-Antwort:
+
+```php
+private function deleteTask(ServerRequestInterface $request): ResponseInterface
+{
+    $params    = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $projectId = (int) ($params['projectId'] ?? 0);
+    $taskId    = (int) ($params['taskId'] ?? 0);
+
+    $this->projects->findById($projectId);
+    $this->tasks->delete($projectId, $taskId);
+
+    return $this->json->createEmpty(204);
+}
+```
+
+Das Aufgaben-Repository prüft die Existenz vor dem Löschen:
+
+```php
+public function delete(int $projectId, int $taskId): void
+{
+    $this->findByProjectAndId($projectId, $taskId);  // wirft TaskNotFoundException, wenn nicht vorhanden
+    $this->executor->execute('DELETE FROM tasks WHERE id = ? AND project_id = ?', [$taskId, $projectId]);
+}
+```
+
+Wenn die Aufgabe nicht existiert (oder zu einem anderen Projekt gehört), wird `TaskNotFoundException`
+geworfen → `404 Not Found`, bevor ein DELETE ausgeführt wird.
+
+---
+
+## Verwendete NENE2-Bausteine
+
+| Baustein | Zweck |
+|---|---|
+| `PaginationQueryParser::parse()` | Liest `?limit=` und `?offset=` mit sicheren Standardwerten |
+| `PaginationResponse` | Erzeugt `{ items, total, limit, offset }` Hüllstruktur |
+| `ValidationException` / `ValidationError` | Strukturiertes `422` mit `errors`-Array |
+| `QueryStringParser::string()` | Liest einen benannten Querystring-Parameter, gibt `null` zurück, wenn nicht vorhanden |
+| `JsonRequestBodyParser::parse()` | Dekodiert JSON-Body |
+| `JsonResponseFactory::create()` | Kodiert JSON-Antwort |
+| `JsonResponseFactory::createEmpty()` | Erzeugt eine körperlose Antwort (z. B. `204`) |
+| `Router::PARAMETERS_ATTRIBUTE` | Ruft Pfadparameter aus dem Request ab |
+
+---
+
+## Verwandte Anleitungen
+
+- [`note-management-ownership.md`](note-management-ownership.md) — IDOR-Prävention mit `WHERE id = ? AND owner_id = ?`
+- [`contact-management.md`](contact-management.md) — Viele-zu-viele-Beziehungen, Suchfilterung
+- [`document-versioning.md`](document-versioning.md) — Append-only-Versionierung mit `is_current`-Flag
+- [`scheduled-reminders.md`](scheduled-reminders.md) — V::userId()-Header-Validierungsmuster

--- a/docs/de/howto/quality-tools.md
+++ b/docs/de/howto/quality-tools.md
@@ -1,0 +1,132 @@
+# Qualitätswerkzeuge
+
+Diese Anleitung behandelt PHPStan, PHP-CS-Fixer und häufige Probleme beim Einsatz in NENE2-basierten Projekten.
+
+---
+
+## PHPStan
+
+NENE2 zielt auf PHPStan-Level 8 ab. Consumer-Projekte, die `hideyukimori/nene2` über Composer installieren, können PHPStan für ihre eigenen Quellen in einer `phpstan.neon`-Datei konfigurieren.
+
+### Minimale Konfiguration
+
+```neon
+# phpstan.neon
+parameters:
+    level: 8
+    paths:
+        - src
+        - tests
+```
+
+### Speicherlimit
+
+PHPStan kann bei der Analyse eines Projekts, das viele Vendor-Pakete importiert, zu wenig Speicher bekommen (nene2 + psr/* + nyholm/psr7 + phpunit-Stubs summieren sich schnell). Das Standard-PHP-Speicherlimit von 128 MB ist oft zu niedrig.
+
+**In PHPStan 2.x ist `memory_limit` eine reine CLI-Option — sie kann nicht in `phpstan.neon` gesetzt werden.**
+
+Übergeben Sie sie stattdessen auf der Kommandozeile:
+
+```bash
+phpstan analyse --level=8 --memory-limit=512M src tests
+```
+
+Oder tragen Sie sie im `scripts`-Abschnitt von `composer.json` ein, damit sie konsistent angewendet wird:
+
+```json
+{
+    "scripts": {
+        "analyse": "phpstan analyse --level=8 --memory-limit=512M src tests",
+        "check": ["@test", "@analyse", "@cs"]
+    }
+}
+```
+
+> **Hinweis**: Das Hinzufügen von `memory_limit: 512M` unter `parameters:` in `phpstan.neon` verursacht
+> `Invalid configuration: Unexpected item 'parameters › memory_limit'.` in PHPStan 2.x.
+> Verwenden Sie stattdessen das CLI-Flag.
+
+### Falsch-Positive unterdrücken
+
+Wenn PHPStan einen falsch-positiven Befund ausgibt, der nicht behoben werden kann (z. B. eine PHPDoc-Nichtübereinstimmung in einer Vendor-Klasse), verwenden Sie eine Inline-Unterdrückung:
+
+```php
+/** @phpstan-ignore-next-line */
+$value = $externalLib->getSomething();
+```
+
+Oder erstellen Sie eine Baseline-Datei:
+
+```bash
+phpstan analyse --generate-baseline
+```
+
+---
+
+## PHP-CS-Fixer
+
+NENE2 verwendet `@PSR12` als Basis-Regelwerk, ergänzt durch `strict_param` und `declare_strict_types`.
+
+### Minimale Konfiguration
+
+Erstellen Sie `.php-cs-fixer.php` im Projektstamm:
+
+```php
+<?php
+
+$finder = PhpCsFixer\Finder::create()->in([__DIR__ . '/src', __DIR__ . '/tests']);
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12'               => true,
+        'strict_param'         => true,
+        'declare_strict_types' => true,
+    ])
+    ->setFinder($finder);
+```
+
+### Häufige Formatierungsprobleme
+
+**Erweiterung des Konstruktorrumpfs**: `@PSR12` erfordert, dass Konstruktorrümpfe mehrere Zeilen umfassen, selbst wenn sie leer sind. CS-Fixer erweitert automatisch:
+
+```php
+// Vorher (handgeschrieben)
+public function __construct(private Foo $foo) {}
+
+// Nachher (CS-Fixer-Korrektur)
+public function __construct(private Foo $foo)
+{
+}
+```
+
+Führen Sie `composer cs:fix` nach dem Schreiben neuer Klassen aus, um manuelle Korrekturen zu vermeiden.
+
+**Platzierung von `declare(strict_types=1)`**: Die `declare_strict_types`-Regel fügt diese Deklaration automatisch hinzu. Wenn Sie sie manuell schreiben, normalisiert CS-Fixer die Leerzeichen darum.
+
+### Dry-run vs. Korrektur
+
+```bash
+composer cs        # Dry-run, zeigt was geändert werden würde
+composer cs:fix    # Korrekturen anwenden
+```
+
+---
+
+## Checks kombinieren
+
+Fügen Sie ein `check`-Composer-Skript hinzu, das alle Werkzeuge nacheinander ausführt:
+
+```json
+{
+    "scripts": {
+        "test":     "phpunit",
+        "analyse":  "phpstan analyse --level=8 --memory-limit=512M src tests",
+        "cs":       "php-cs-fixer fix --dry-run --diff",
+        "cs:fix":   "php-cs-fixer fix",
+        "check":    ["@test", "@analyse", "@cs"]
+    }
+}
+```
+
+Führen Sie `composer check` vor jedem Commit aus, um Probleme frühzeitig zu erkennen. Die CI sollte denselben Befehl ausführen.

--- a/docs/de/howto/quota-management.md
+++ b/docs/de/howto/quota-management.md
@@ -1,0 +1,429 @@
+# Anleitung: Kontingentverwaltungs-API
+
+> **FT-Referenz**: FT236 (`NENE2-FT/quotalog`) — Kontingentverwaltungs-API
+> **ATK**: FT236 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert eine Kontingentverwaltungs-API, bei der jedes Benutzer/Ressource-Paar eine konfigurierbare
+Richtlinie (stündlich oder täglich) hat, der Verbrauch in einer separaten Tabelle nach Fensterbeginn
+verfolgt wird und ein `consume`-Endpunkt das Limit mit `429 Too Many Requests` durchsetzt, wenn es
+überschritten wird. `check` (nur lesen) und `consume` (mutierend) sind getrennte Operationen.
+
+---
+
+## Routen
+
+| Methode | Pfad                                     | Beschreibung                                       |
+|---------|------------------------------------------|----------------------------------------------------|
+| `PUT`   | `/quotas/{userId}/{resource}`            | Kontingent-Richtlinie erstellen oder aktualisieren |
+| `GET`   | `/quotas/{userId}`                       | Alle Kontingent-Richtlinien für einen Benutzer auflisten |
+| `GET`   | `/quotas/{userId}/{resource}`            | Aktuellen Kontingentstatus prüfen (nur lesen)      |
+| `POST`  | `/quotas/{userId}/{resource}/consume`    | Eine Einheit verbrauchen (gibt 429 zurück, wenn überschritten) |
+| `POST`  | `/quotas/{userId}/{resource}/reset`      | Verbrauch für das aktuelle Fenster auf null zurücksetzen |
+
+---
+
+## QuotaWindow: Fensterbeginn berechnen
+
+`QuotaWindow` ist ein backed enum mit einer `windowStart()`-Methode, die den aktuellen
+Zeitstempel auf die Fenstergrenze abrundet:
+
+```php
+enum QuotaWindow: string
+{
+    case Hourly = 'hourly';
+    case Daily  = 'daily';
+
+    public function windowStart(string $now): string
+    {
+        $dt = new \DateTimeImmutable($now, new \DateTimeZone('UTC'));
+
+        return match ($this) {
+            self::Hourly => $dt->setTime((int) $dt->format('H'), 0, 0)->format('Y-m-d H:i:s'),
+            self::Daily  => $dt->setTime(0, 0, 0)->format('Y-m-d H:i:s'),
+        };
+    }
+}
+```
+
+`setTime(H, 0, 0)` rundet auf die aktuelle Stunde; `setTime(0, 0, 0)` rundet auf Mitternacht
+UTC. Das Ergebnis wird als `window_start`-Schlüssel in der Verbrauchstabelle gespeichert — alle Anfragen
+innerhalb desselben Fensters haben denselben `window_start`-Wert.
+
+---
+
+## Zwei-Tabellen-Design: Richtlinien und Verbrauch
+
+```sql
+-- Kontingent-Richtlinie: maximal erlaubte Anfragen pro Fenster
+CREATE TABLE IF NOT EXISTS quota_policies (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     TEXT    NOT NULL,
+    resource    TEXT    NOT NULL,
+    window      TEXT    NOT NULL DEFAULT 'hourly',
+    limit_count INTEGER NOT NULL,
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL,
+    UNIQUE(user_id, resource)
+);
+
+-- Verbrauchsverfolgung: tatsächliche Anzahl pro Fenster
+CREATE TABLE IF NOT EXISTS quota_usage (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      TEXT    NOT NULL,
+    resource     TEXT    NOT NULL,
+    window_start TEXT    NOT NULL,
+    usage        INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL,
+    UNIQUE(user_id, resource, window_start)
+);
+```
+
+Die Trennung von Richtlinien und Verbrauch bedeutet:
+- Richtlinien bleiben über Fenster hinweg bestehen — sie müssen nicht jede Periode neu erstellt werden.
+- Verbrauchszeilen werden automatisch nach `window_start` partitioniert. Alte Fenster akkumulieren
+  sich in der Tabelle; ein Hintergrundjob kann sie bereinigen.
+- `UNIQUE(user_id, resource)` für Richtlinien verhindert doppelte Konfigurationen.
+- `UNIQUE(user_id, resource, window_start)` für den Verbrauch stellt einen Zähler pro Fenster sicher.
+
+---
+
+## check vs. consume
+
+`check` ist nur lesend — es berechnet den verbleibenden Verbrauch ohne Mutation:
+
+```php
+public function check(string $userId, string $resource, string $now): ?QuotaStatus
+{
+    $policy      = $this->findPolicy($userId, $resource);
+    $windowStart = $policy->window->windowStart($now);
+    $usage       = $this->getUsage($userId, $resource, $windowStart);
+    $remaining   = max(0, $policy->limitCount - $usage);
+
+    return new QuotaStatus(..., remaining: $remaining, allowed: $remaining > 0);
+}
+```
+
+`consume` prüft zuerst das Limit und erhöht nur, wenn erlaubt:
+
+```php
+public function consume(string $userId, string $resource, string $now): ?QuotaStatus
+{
+    $policy      = $this->findPolicy($userId, $resource);
+    $windowStart = $policy->window->windowStart($now);
+    $usage       = $this->getUsage($userId, $resource, $windowStart);
+
+    if ($usage >= $policy->limitCount) {
+        // Kontingent überschritten — Status mit allowed=false zurückgeben, NICHT erhöhen
+        return new QuotaStatus(..., remaining: 0, allowed: false);
+    }
+
+    $this->incrementUsage($userId, $resource, $windowStart, $now);
+    $newUsage  = $usage + 1;
+    $remaining = max(0, $policy->limitCount - $newUsage);
+
+    return new QuotaStatus(..., remaining: $remaining, allowed: true);
+}
+```
+
+Der Controller ordnet `allowed=false` auf `429 Too Many Requests` zu:
+
+```php
+$httpStatus = $status->allowed ? 200 : 429;
+return $this->json->create($status->toArray(), $httpStatus);
+```
+
+`429` ist semantisch korrekt für Kontingenterschöpfung. In der Produktion einen `Retry-After`-Header
+hinzufügen, der auf die Fenster-Reset-Zeit verweist.
+
+---
+
+## Verbrauchserhöhung: SELECT-then-INSERT/UPDATE
+
+Die Verbrauchserhöhung ist ein anwendungsseitiges Upsert:
+
+```php
+private function incrementUsage(string $userId, string $resource, string $windowStart, string $now): void
+{
+    $existing = $this->executor->fetchAll(
+        'SELECT id FROM quota_usage WHERE user_id = ? AND resource = ? AND window_start = ?',
+        [$userId, $resource, $windowStart],
+    );
+
+    if ($existing !== []) {
+        $this->executor->execute(
+            'UPDATE quota_usage SET usage = usage + 1, updated_at = ? WHERE user_id = ? AND resource = ? AND window_start = ?',
+            [$now, $userId, $resource, $windowStart],
+        );
+    } else {
+        $this->executor->execute(
+            'INSERT INTO quota_usage (user_id, resource, window_start, usage, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)',
+            [$userId, $resource, $windowStart, $now, $now],
+        );
+    }
+}
+```
+
+`usage = usage + 1` ist eine atomare DB-seitige Erhöhung — kein Read-Modify-Write im
+Anwendungscode. Die `UNIQUE`-Einschränkung auf `(user_id, resource, window_start)`
+verhindert eine Race Condition zwischen zwei gleichzeitigen Erstverwendungs-Inserts.
+
+---
+
+## Richtlinien-Upsert über `PUT`
+
+`PUT /quotas/{userId}/{resource}` ist idempotent — es erstellt oder aktualisiert:
+
+```php
+$window     = QuotaWindow::tryFrom($windowRaw);
+$limitCount = isset($body['limit_count']) && is_int($body['limit_count']) ? $body['limit_count'] : -1;
+
+$errors = [];
+if ($window === null) {
+    $errors[] = ['field' => 'window', 'code' => 'invalid', 'message' => 'window must be one of: hourly, daily.'];
+}
+if ($limitCount < 1) {
+    $errors[] = ['field' => 'limit_count', 'code' => 'invalid', 'message' => 'limit_count must be a positive integer.'];
+}
+```
+
+Die strikte `is_int()`-Prüfung lehnt JSON-Floats und Strings ab. `limitCount < 1` erfordert
+mindestens 1 — Null- und negative Werte werden abgelehnt.
+
+---
+
+## ATK — Cracker-Mindset-Angriffstest (FT236)
+
+### ATK-01 — Keine Authentifizierung
+
+**Angriff**: Eine Kontingent-Richtlinie erstellen oder im Namen eines beliebigen Benutzers verbrauchen, ohne Anmeldedaten.
+
+```bash
+curl -s -X PUT http://localhost:8080/quotas/user-123/api-calls \
+  -H 'Content-Type: application/json' \
+  -d '{"window":"daily","limit_count":10}'
+```
+
+**Beobachtet**: `200 OK` — kein Token erforderlich. Jeder kann das Kontingent eines beliebigen Benutzers setzen oder erschöpfen.
+
+**Urteil**: **EXPONIERT** (absichtlich für FT236-Demo). Authentifizierung hinzufügen; Richtlinienverwaltung hinter eine Admin-Rolle stellen und consume hinter das Token des Eigentümers.
+
+---
+
+### ATK-02 — SQL-Injection über `{resource}`-Pfadparameter
+
+**Angriff**: SQL-Metazeichen in den Ressourcennamen einbetten.
+
+```
+PUT /quotas/user-1/api'; DROP TABLE quota_policies; --
+POST /quotas/user-1/" OR "1"="1/consume
+```
+
+**Beobachtet**: Der Ressource-String wird in allen Abfragen direkt als parametrisierter `?`-Wert übergeben — keine String-Interpolation. Das injizierte SQL wird als Literalstring gespeichert/verglichen, nicht ausgeführt.
+
+**Urteil**: **BLOCKIERT** — parametrisierte Abfragen verhindern Injection über Pfadparameter.
+
+---
+
+### ATK-03 — Negativer oder null `limit_count`
+
+**Angriff**: Ein Limit von 0 oder -1 setzen, um den Zugang eines anderen Benutzers zu deaktivieren.
+
+```json
+{"window": "daily", "limit_count": 0}
+{"window": "daily", "limit_count": -999}
+```
+
+**Beobachtet**: Die Prüfung `$limitCount < 1` wird ausgelöst → `422 Unprocessable Entity` mit einem
+strukturierten Fehler für `limit_count`.
+
+**Urteil**: **BLOCKIERT** — Mindest-`limit_count` von 1 auf Anwendungsebene erzwungen.
+
+---
+
+### ATK-04 — Ungültiger `window`-Wert
+
+**Angriff**: Einen nicht unterstützten Window-String senden.
+
+```json
+{"window": "weekly", "limit_count": 100}
+{"window": "minutely", "limit_count": 100}
+```
+
+**Beobachtet**: `QuotaWindow::tryFrom('weekly')` gibt `null` zurück → `422` mit strukturiertem
+Fehler für `window`.
+
+**Urteil**: **BLOCKIERT** — backed enum `tryFrom()` lehnt unbekannte Window-Werte ab.
+
+---
+
+### ATK-05 — Verbrauchen ohne Richtlinie
+
+**Angriff**: `POST .../consume` für einen Benutzer/eine Ressource ohne konfigurierte Richtlinie aufrufen.
+
+```bash
+curl -s -X POST http://localhost:8080/quotas/user-ghost/api-calls/consume
+```
+
+**Beobachtet**: `findPolicy()` gibt `null` zurück → `404 Not Found` mit einer Problem-Details-Antwort.
+
+**Urteil**: **BLOCKIERT** — keine Richtlinie → kein Verbrauch. Der Aufrufer muss vor dem Verbrauch eine Richtlinie konfigurieren.
+
+---
+
+### ATK-06 — Fließkommazahl als `limit_count`
+
+**Angriff**: Einen Float statt eines Integer senden.
+
+```json
+{"window": "daily", "limit_count": 9.9}
+```
+
+**Beobachtet**: `is_int(9.9)` = `false` in PHP — der von JSON dekodierte Float-Wert
+(`float`-Typ) besteht die Prüfung nicht. `$limitCount` wird auf `-1` gesetzt → die `< 1`-Prüfung
+wird ausgelöst → `422`.
+
+**Urteil**: **BLOCKIERT** — strikte `is_int()`-Typprüfung lehnt JSON-Floats ab.
+
+---
+
+### ATK-07 — Extrem großer `limit_count`
+
+**Angriff**: `limit_count` auf `PHP_INT_MAX` oder `9999999999` setzen.
+
+```json
+{"window": "daily", "limit_count": 9223372036854775807}
+```
+
+**Beobachtet**: `is_int()` besteht (PHP repräsentiert dies als `int`); `< 1`-Prüfung besteht.
+Der Wert wird gespeichert und in Vergleichen ohne Probleme verwendet. Es existiert keine Obergrenze.
+
+**Urteil**: **EXPONIERT** — kein maximaler `limit_count` wird erzwungen. Ein sehr großes Limit ist
+effektiv dasselbe wie „kein Limit". Hinzufügen:
+```php
+if ($limitCount > 1_000_000) {
+    $errors[] = ['field' => 'limit_count', 'code' => 'too_large', 'message' => 'limit_count must not exceed 1 000 000.'];
+}
+```
+
+---
+
+### ATK-08 — Race Condition bei gleichzeitigem Verbrauch am Limit
+
+**Angriff**: Zwei gleichzeitige `POST .../consume`-Anfragen senden, wenn `usage == limit - 1`.
+
+**Beobachtet**: Beide Anfragen lesen `usage = limit - 1`, bevor eine Erhöhung ausgeführt wird. Beide
+sehen `usage < limitCount` → beide rufen `incrementUsage()` auf. Beide gelingen — Verbrauch endet bei
+`limit + 1`, beide Antworten geben `allowed: true` zurück.
+
+**Urteil**: **EXPONIERT** — das Check-then-increment-Muster ist nicht atomar. Mit einer
+Transaktion beheben:
+```sql
+BEGIN;
+SELECT usage FROM quota_usage WHERE ... FOR UPDATE;
+-- Prüfen ob < limit
+UPDATE quota_usage SET usage = usage + 1 WHERE ...;
+COMMIT;
+```
+Oder `UPDATE ... SET usage = CASE WHEN usage < ? THEN usage + 1 ELSE usage END RETURNING usage` auf PostgreSQL verwenden.
+
+---
+
+### ATK-09 — Unbekannter oder beliebiger `{resource}`-Name
+
+**Angriff**: Einen Ressourcennamen verwenden, der nie beabsichtigt war.
+
+```
+PUT /quotas/user-1/../../../../etc/passwd
+PUT /quotas/user-1/system::admin
+POST /quotas/user-1/; DROP TABLE quota_usage;--/consume
+```
+
+**Beobachtet**: Path-Traversal (`../`) wird vor dem Routing URL-dekodiert; der Router sieht sie
+als Mehrsegment-Pfade und trifft die `{resource}`-Route nicht. Sonderzeichen werden als Literalstrings
+über parametrisierte Abfragen gespeichert (siehe ATK-02).
+
+**Urteil**: **BLOCKIERT** — Router lehnt Path-Traversal ab, SQL ist sicher.
+Eine Ressourcennamen-Allowlist oder Formatprüfung hinzufügen, wenn Ressourcennamen auf bekannte Werte
+beschränkt sein sollen.
+
+---
+
+### ATK-10 — Kontingent eines anderen Benutzers zurücksetzen
+
+**Angriff**: Den Kontingentzähler eines anderen Benutzers zurücksetzen, um seine Drosselung zu umgehen.
+
+```bash
+curl -s -X POST http://localhost:8080/quotas/target-user/api-calls/reset
+```
+
+**Beobachtet**: `200 OK` — keine Eigentümerprüfung. Jeder Aufrufer kann den Kontingentverbrauch eines beliebigen Benutzers zurücksetzen und so seinen Zugang sofort wiederherstellen.
+
+**Urteil**: **EXPONIERT** — gleiche Ursache wie ATK-01. `reset` hinter einer Admin-Rolle absichern.
+
+---
+
+### ATK-11 — Unbegrenzte Länge von `{userId}` und `{resource}`
+
+**Angriff**: Extrem lange Pfadsegmentwerte senden.
+
+```
+PUT /quotas/<10000 Zeichen>/<5000 Zeichen>
+```
+
+**Beobachtet**: Lange Strings werden ohne Limit in `TEXT`-Spalten akzeptiert und gespeichert.
+Die Index-Performance bei sehr langen Schlüsseln verschlechtert sich.
+
+**Urteil**: **EXPONIERT** — Längenprüfung hinzufügen:
+```php
+if (strlen($userId) > 255 || strlen($resource) > 255) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, ...);
+}
+```
+
+---
+
+### ATK-12 — `window_start`-Manipulation durch Uhren-Drift
+
+**Angriff**: Wenn der Aufrufer `$now` beeinflussen kann, kann er den Fensterbeginn verschieben, um
+ein Fenster künstlich zu verlängern oder neu zu starten.
+
+**Beobachtet**: `$now` wird innerhalb des Controllers über `new \DateTimeImmutable()` berechnet —
+es wird nicht vom Benutzer geliefert. Der Aufrufer kann die Fensterberechnung nicht beeinflussen.
+
+**Urteil**: **BLOCKIERT** — die Serveruhr ist die einzige Zeitquelle. Für verteilte
+Systeme mit mehreren Knoten sicherstellen, dass alle Knoten UTC verwenden und NTP-synchronisiert sind.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|----------------|--------|
+| ATK-01 | Keine Authentifizierung | EXPONIERT |
+| ATK-02 | SQL-Injection über Ressource-Pfadparameter | BLOCKIERT |
+| ATK-03 | Negativer/null limit_count | BLOCKIERT |
+| ATK-04 | Ungültiger window-Wert | BLOCKIERT |
+| ATK-05 | Verbrauchen ohne Richtlinie | BLOCKIERT |
+| ATK-06 | Fließkommazahl als limit_count | BLOCKIERT |
+| ATK-07 | Extrem großer limit_count | EXPONIERT |
+| ATK-08 | Gleichzeitige Verbrauchs-Race Condition | EXPONIERT |
+| ATK-09 | Beliebiger Ressourcenname | BLOCKIERT |
+| ATK-10 | Kontingent eines anderen Benutzers zurücksetzen | EXPONIERT |
+| ATK-11 | Unbegrenzte userId/resource-Länge | EXPONIERT |
+| ATK-12 | window_start-Manipulation | BLOCKIERT |
+
+**Echte Schwachstellen, die vor dem Produktivbetrieb behoben werden müssen**:
+1. **ATK-01 / ATK-10** — Authentifizierung und Autorisierung hinzufügen
+2. **ATK-08** — Verbrauch in eine Transaktion einschließen (atomares Check-then-increment)
+3. **ATK-07** — Obergrenze für `limit_count` hinzufügen
+4. **ATK-11** — Längenlimits für Pfadparameter hinzufügen
+
+---
+
+## Verwandte Anleitungen
+
+- [`rate-limiting.md`](rate-limiting.md) — Ratenbegrenzung auf Middleware-Ebene
+- [`sliding-window-rate-limiter.md`](sliding-window-rate-limiter.md) — Sliding-Window-Zähler
+- [`api-usage-metering.md`](api-usage-metering.md) — Verbrauchsverfolgung pro API-Key
+- [`credit-ledger.md`](credit-ledger.md) — Guthaben/Abbuchungs-Modell für kontingentähnliche Systeme

--- a/docs/de/howto/rate-limiting.md
+++ b/docs/de/howto/rate-limiting.md
@@ -1,0 +1,308 @@
+# Ratenbegrenzung
+
+> **FT-Referenz**: FT284 (`NENE2-FT/throttlelog`) — ThrottleMiddleware-Ratenbegrenzung: IP-basiertes Fixed-Window, benutzerdefinierter Key-Extraktor (Benutzer/API-Key), X-RateLimit-*-Header, 429 Problem Details mit Retry-After, InMemoryRateLimitStorage für Tests, 9 Tests / 33 Assertions BESTANDEN.
+>
+> **ATK-Bewertung**: ATK-01 bis ATK-12 am Ende dieses Dokuments.
+
+`ThrottleMiddleware` erzwingt eine Fixed-Window-Ratenbegrenzung für alle Anfragen. Es fügt `X-RateLimit-Limit`-, `X-RateLimit-Remaining`- und `X-RateLimit-Reset`-Header zu jeder Antwort hinzu und gibt eine `429 Too Many Requests`-Problem-Details-Antwort zurück, wenn das Limit überschritten wird.
+
+## Grundlegende Einrichtung
+
+Übergeben Sie `ThrottleMiddleware` an `RuntimeApplicationFactory` über den `throttleMiddleware`-Parameter:
+
+```php
+use Nene2\Middleware\InMemoryRateLimitStorage;
+use Nene2\Middleware\ThrottleMiddleware;
+
+$storage  = new InMemoryRateLimitStorage(); // nur lokal/Test — siehe „Produktion" unten
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    limit:         60,   // erlaubte Anfragen pro Fenster
+    windowSeconds: 60,   // Fensterdauer in Sekunden
+);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    throttleMiddleware: $throttle, // ← benannter Parameter, nicht "middlewares"
+    routeRegistrars: [...],
+))->create();
+```
+
+Der benannte Parameter ist `throttleMiddleware`, nicht `middlewares` — `RuntimeApplicationFactory` hat einen dedizierten Slot für diese Middleware, der sie korrekt in der Pipeline positioniert (nach der Authentifizierung, sodass Limits pro Benutzer möglich sind).
+
+## Antwort-Header
+
+Jede Antwort enthält den Ratenbegrenzungsstatus:
+
+```http
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 42
+X-RateLimit-Reset: 1716292860
+```
+
+Wenn das Limit überschritten wird:
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 18
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1716292860
+Content-Type: application/problem+json
+
+{
+  "type": "https://nene2.dev/problems/too-many-requests",
+  "title": "Too Many Requests",
+  "status": 429,
+  "detail": "Rate limit of 60 requests per 60 seconds exceeded. Try again in 18 seconds."
+}
+```
+
+## Ratenbegrenzungs-Keys
+
+### Standard: IP-basiert (REMOTE_ADDR)
+
+Standardmäßig ist der Key `ip:<REMOTE_ADDR>`. Jede Client-IP bekommt ihren eigenen Bucket.
+
+### Benutzerdefiniert: Authentifizierter Benutzer
+
+Nachdem die Authentifizierungs-Middleware ein Benutzerattribut gesetzt hat, nach Benutzer-ID schlüsseln:
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    limit:        100,
+    windowSeconds: 3600,
+    keyExtractor: static fn (ServerRequestInterface $r): string
+        => 'user:' . ($r->getAttribute('user_id') ?? 'anonymous'),
+);
+```
+
+Dies verhindert, dass gemeinsam genutzte IP-Umgebungen (Büro-NAT) unfairerweise einen Bucket teilen, und ermöglicht strengere Limits für nicht authentifizierte Anfragen.
+
+### Benutzerdefiniert: API-Key-Header
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    keyExtractor: static fn (ServerRequestInterface $r): string
+        => 'apikey:' . ($r->getHeaderLine('X-Api-Key') ?: 'anonymous'),
+);
+```
+
+## Reverse-Proxy / Load-Balancer-Warnung
+
+Hinter einem Reverse-Proxy ist `REMOTE_ADDR` die IP des Proxys — alle echten Clients teilen einen einzigen Bucket. Beheben Sie dies, indem Sie einen vertrauenswürdigen Forwarded-IP-Header lesen:
+
+```php
+$throttle = new ThrottleMiddleware(
+    $problemDetails,
+    $storage,
+    keyExtractor: static fn (ServerRequestInterface $r): string
+        => $r->getHeaderLine('X-Forwarded-For') ?: $r->getServerParams()['REMOTE_ADDR'] ?? 'unknown',
+);
+```
+
+**Vertrauen Sie `X-Forwarded-For` nur, wenn Ihr Proxy unter Ihrer Kontrolle steht und ihn zuverlässig setzt.** Ein Angreifer kann diesen Header fälschen, wenn der Traffic die Anwendung direkt ohne den Proxy erreicht.
+
+## Produktion: Gemeinsamen Speicher verwenden
+
+`InMemoryRateLimitStorage` hält Zähler in einem PHP-Array. PHP-FPM betreibt mehrere Worker-Prozesse; **jeder Worker hat sein eigenes Array, sodass Zähler nicht geteilt werden**. In der Produktion bedeuten 10 Worker mit einem Limit von 60 ein tatsächliches Limit von ~600.
+
+Für die Produktion `RateLimitStorageInterface` mit einem gemeinsamen Speicher implementieren:
+
+```php
+use Nene2\Middleware\RateLimitStorageInterface;
+
+final class RedisRateLimitStorage implements RateLimitStorageInterface
+{
+    public function __construct(private \Redis $redis) {}
+
+    public function hit(string $key, int $windowSeconds): array
+    {
+        $count = $this->redis->incr($key);
+        if ($count === 1) {
+            $this->redis->expire($key, $windowSeconds);
+        }
+        $ttl     = max(0, $this->redis->ttl($key));
+        $resetAt = time() + $ttl;
+
+        return ['count' => $count, 'reset_at' => $resetAt];
+    }
+}
+```
+
+Dann einbinden:
+
+```php
+$throttle = new ThrottleMiddleware($problemDetails, new RedisRateLimitStorage($redis), limit: 60);
+```
+
+## Fixed-Window-Burst-Problem
+
+`ThrottleMiddleware` verwendet einen Fixed-Window-Algorithmus. Clients können die effektive Rate verdoppeln, indem sie Anfragen an der Grenze zweier Fenster senden:
+
+```
+Limit: 100 Anfragen/Minute, Fenster: :00–:59
+
+:59 — 100 Anfragen → trifft das Limit
+:00 — 100 Anfragen → neues Fenster, alle passieren
+
+Ergebnis: 200 Anfragen in ~2 Sekunden
+```
+
+Falls dies ein Problem darstellt, einen Sliding-Window- oder Token-Bucket-Algorithmus in Ihrer `RateLimitStorageInterface`-Implementierung implementieren. Die Schnittstelle und Middleware sind algorithmus-agnostisch.
+
+## Limits pro Route
+
+`RuntimeApplicationFactory` unterstützt eine `ThrottleMiddleware`-Instanz, die global angewendet wird. Für Limits pro Route mit unterschiedlichen Einstellungen `ThrottleMiddleware` als routenseitige Middleware manuell anwenden, indem individuelle Handler umschlossen werden.
+
+## Client-Retry-Muster
+
+```typescript
+async function fetchWithRetry(url: string, options: RequestInit): Promise<Response> {
+    const res = await fetch(url, options);
+    if (res.status === 429) {
+        const retryAfter = parseInt(res.headers.get('Retry-After') ?? '5', 10);
+        await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+        return fetch(url, options); // ein Wiederholungsversuch
+    }
+    return res;
+}
+```
+
+## Code-Review-Checkliste
+
+- [ ] `InMemoryRateLimitStorage` wird NICHT im Produktionscode verwendet
+- [ ] Gemeinsamer Speicher (Redis, Memcached oder datenbankgestützt) wird in der Produktion über `RateLimitStorageInterface` eingebunden
+- [ ] `keyExtractor` verwendet die richtige Granularität: IP, Benutzer oder API-Key (nicht immer `REMOTE_ADDR`)
+- [ ] Hinter einem Reverse-Proxy: `X-Forwarded-For` wird nur von einem vertrauenswürdigen Proxy gelesen, nicht aus beliebigen Client-Headern
+- [ ] `limit` und `windowSeconds` sind für den erwarteten Traffic des Endpunkts angemessen (Login-Endpunkte: strenger; schreibgeschützte APIs: großzügiger)
+- [ ] Der `throttleMiddleware`-benannte Parameter (nicht `middlewares`) wird mit `RuntimeApplicationFactory` verwendet
+- [ ] Tests verwenden `InMemoryRateLimitStorage` und ein niedriges `limit` (z. B. 3), um das 429-Verhalten ohne Wartezeit zu überprüfen
+
+---
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Ratenlimit erschöpfen, um legitime Benutzer zu blockieren (DoS) 🚫 BLOCKIERT (absichtlich)
+
+**Angriff**: Angreifer sendet 60 Anfragen pro Minute von seiner IP, um sich selbst zu blockieren (oder Limits zu sondieren).
+**Ergebnis**: BLOCKIERT (absichtlich) — das Limit gilt für die eigene IP/den eigenen Key des Angreifers. Andere Clients sind nicht betroffen (separate Buckets). Die 429-Antwort enthält `Retry-After`, sodass der Angreifer weiß, wann er es erneut versuchen kann. Dies ist das beabsichtigte Verhalten; Ratenbegrenzung soll Missbrauch blockieren, nicht DoS gegen andere verhindern.
+
+---
+
+### ATK-02 — Per-IP-Limit durch Verwendung verschiedener IP-Adressen umgehen 🚫 BLOCKIERT (abgemildert)
+
+**Angriff**: Angreifer verwendet mehrere IPs (Botnet, VPN-Rotation), um Anfragen unter dem Limit von jeder IP zu senden.
+**Ergebnis**: ABGEMILDERT — jede IP hat ihren eigenen Bucket; einzelne IPs werden ratenbegrenzt. Verteilte Angriffe von vielen IPs können durch Single-Node-Ratenbegrenzung nicht gestoppt werden. Produktionsminderung: CAPTCHA, WAF, CDN-seitige Ratenbegrenzung oder authentifizierte Raten-Limits.
+
+---
+
+### ATK-03 — X-Forwarded-For fälschen, um IP-basiertes Limit zu umgehen 🚫 BLOCKIERT (Design-Hinweis)
+
+**Angriff**: Angreifer sendet `X-Forwarded-For: 10.0.0.1`, um bei jeder Anfrage als eine andere IP zu erscheinen.
+**Ergebnis**: BLOCKIERT (bei korrekter Konfiguration) — Standard-Key verwendet `REMOTE_ADDR` (vom Server gesetzt), keine vom Client gelieferten Header. Wenn `X-Forwarded-For` als Key verwendet wird, darf es nur von einem vertrauenswürdigen Proxy gelesen werden. **Nicht vertrauenswürdige Client-Header als Ratenbegrenzungs-Keys zu verwenden ist das Anti-Muster — siehe „Was man nicht tun sollte".**
+
+---
+
+### ATK-04 — Fenstergrenz-Burst 🚫 BLOCKIERT (Design-Einschränkung)
+
+**Angriff**: 60 Anfragen bei :59 und 60 Anfragen bei :00 (neues Fenster) für 120 Anfragen in 2 Sekunden senden.
+**Ergebnis**: BLOCKIERT (innerhalb des Fixed-Window-Designs) — jedes 60-Sekunden-Fenster ist unabhängig. Fixed-Window erlaubt Bursts an Grenzen per Design. Für strengere Kontrolle eine Sliding-Window- oder Token-Bucket-`RateLimitStorageInterface`-Implementierung verwenden.
+
+---
+
+### ATK-05 — Missgebildeten `X-RateLimit-Remaining`-Header senden, um das Limit zu beeinflussen 🚫 BLOCKIERT
+
+**Angriff**: Client sendet `X-RateLimit-Remaining: 999`-Header in der Hoffnung, der Server vertraut ihm.
+**Ergebnis**: BLOCKIERT — `X-RateLimit-*`-Header sind **Antwort**-Header, die vom Server gesetzt werden. Der Server liest `REMOTE_ADDR` (oder einen konfigurierten Key) aus der Anfrage, nicht diese Header. Vom Client gelieferte `X-RateLimit-*`-Werte werden ignoriert.
+
+---
+
+### ATK-06 — Ratenlimit erschöpfen, dann anderen Pfad verwenden, um es zu umgehen 🚫 BLOCKIERT
+
+**Angriff**: Nach dem Erreichen des Limits auf `/notes`, `/notes?q=1` oder `/other-path` versuchen.
+**Ergebnis**: BLOCKIERT — `ThrottleMiddleware` gilt global für alle Pfade. Das Ratenlimit ist auf IP (oder konfigurierten Key) ausgerichtet, nicht auf den Pfad. Verschiedene Pfade teilen denselben Bucket.
+
+---
+
+### ATK-07 — Race Condition, um das Limit zu überschreiten 🚫 BLOCKIERT
+
+**Angriff**: 61 gleichzeitige Anfragen senden, wenn der verbleibende Zähler 1 beträgt, um das Limit zu überschreiten.
+**Ergebnis**: BLOCKIERT — `InMemoryRateLimitStorage` verwendet PHPs sequentielle Anfragebearbeitung innerhalb eines einzelnen Prozesses. Für Multi-Prozess-Produktionseinsätze sind atomare Inkrementoperationen (Redis `INCR`) erforderlich. Das Middleware-Design erfordert, dass Speicher-Implementierungen Nebenläufigkeit behandeln.
+
+---
+
+### ATK-08 — Ratenbegrenzungs-Timing sondieren, um Systemlast zu erschließen 🚫 BLOCKIERT (irrelevant)
+
+**Angriff**: `Retry-After` messen, um Serverlast oder Anfragemuster zu bestimmen.
+**Ergebnis**: IRRELEVANT — `Retry-After` gibt die verbleibende Fensterzeit zurück (fest), nicht die Systemlast. Es zeigt, wann das Fenster zurückgesetzt wird, aber keine internen Metriken.
+
+---
+
+### ATK-09 — Fehlender `Retry-After`-Header bei 429-Antwort 🚫 BLOCKIERT
+
+**Angriff**: Verlässt sich darauf, dass der Client 429 ignoriert, weil `Retry-After` fehlt, was unendliche Wiederholungsschleifen verursacht.
+**Ergebnis**: BLOCKIERT — `ThrottleMiddleware` enthält immer sowohl `Retry-After` als auch `X-RateLimit-Reset` in 429-Antworten. Gut implementierte Clients respektieren diese Header.
+
+---
+
+### ATK-10 — Gefälschten API-Key für unbegrenzten Bucket verwenden 🚫 BLOCKIERT (absichtlich)
+
+**Angriff**: Bei API-Key-basierter Ratenbegrenzung einen erfundenen Key wie `X-Api-Key: unlimited` angeben.
+**Ergebnis**: BLOCKIERT (absichtlich) — jeder API-Key bekommt seinen eigenen Bucket. Der Key `unlimited` hat dasselbe `limit` wie jeder andere. Unbekannte/erfundene Keys sind nicht besonders. Wenn Keys Benutzern zugeordnet sind, sollten ungültige Keys die Authentifizierung fehlschlagen lassen, bevor sie den Ratenbegrenzer erreichen.
+
+---
+
+### ATK-11 — Leeren Ratenbegrenzungs-Key senden, um den gesamten Traffic in einen Bucket zusammenzuführen 🚫 BLOCKIERT
+
+**Angriff**: `REMOTE_ADDR` aus den Server-Params entfernen, um einen leeren Key zu erzwingen, in der Hoffnung, dass der gesamte Traffic einen Bucket teilt.
+**Ergebnis**: BLOCKIERT — wenn `REMOTE_ADDR` fehlt, wird der Key `ip:` (leerer String als IP-Präfix). Dies erstellt einen einzigen gemeinsamen Bucket für alle unbekannten IPs — nicht was man in der Produktion möchte, aber kein Bypass für das Limit selbst.
+
+---
+
+### ATK-12 — InMemoryRateLimitStorage in der Produktion verwenden, um Pro-Prozess-Isolation zu erhalten 🚫 BLOCKIERT (Design-Warnung)
+
+**Angriff**: Betreiber setzt mit `InMemoryRateLimitStorage` in der Produktion ein (z. B. versehentlich). Jeder PHP-FPM-Worker hat sein eigenes Array, sodass 10 Worker das Limit effektiv mit 10 multiplizieren.
+**Ergebnis**: BLOCKIERT (durch Dokumentationswarnung) — dies ist ein bekanntes Anti-Muster, das oben dokumentiert ist. Die Code-Review-Checkliste kennzeichnet es explizit. Produktionseinsätze müssen gemeinsamen Speicher (Redis, DB-gestützt) verwenden.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Limit erschöpfen, um sich selbst zu DoS-en | 🚫 BLOCKIERT (absichtlich) |
+| ATK-02 | Mehrere IPs, um Per-IP-Limit zu umgehen | 🚫 BLOCKIERT (abgemildert) |
+| ATK-03 | X-Forwarded-For fälschen | 🚫 BLOCKIERT (Design-Hinweis) |
+| ATK-04 | Fenstergrenz-Burst | 🚫 BLOCKIERT (Design-Einschränkung) |
+| ATK-05 | X-RateLimit-*-Anfrage-Header manipulieren | 🚫 BLOCKIERT |
+| ATK-06 | Anderen Pfad verwenden, um Limit zu umgehen | 🚫 BLOCKIERT |
+| ATK-07 | Race Condition, um Limit zu überschreiten | 🚫 BLOCKIERT |
+| ATK-08 | Systemlast aus Retry-After erschließen | 🚫 BLOCKIERT (irrelevant) |
+| ATK-09 | Fehlender Retry-After verursacht Wiederholungsschleifen | 🚫 BLOCKIERT |
+| ATK-10 | Gefälschter API-Key für unbegrenzten Bucket | 🚫 BLOCKIERT (absichtlich) |
+| ATK-11 | Leerer Key führt allen Traffic zusammen | 🚫 BLOCKIERT |
+| ATK-12 | InMemoryStorage multipliziert Limit in Produktion | 🚫 BLOCKIERT (dokumentiert) |
+
+**12 BLOCKIERT / ABGEMILDERT, 0 EXPONIERT**
+Separate Per-IP-Buckets, standardmäßiger REMOTE_ADDR-Key und obligatorischer `Retry-After`-Header verhindern alle getesteten Angriffsvektoren.
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `InMemoryRateLimitStorage` in der Produktion verwenden | PHP-FPM-Worker teilen keinen Speicher; effektives Limit = konfiguriertes Limit × Worker-Anzahl |
+| Auf `X-Forwarded-For` von nicht vertrauenswürdigen Clients basieren | Angreifer fälschen beliebige IP; Ratenbegrenzung wird umgangen |
+| Einen globalen Bucket für alle Clients verwenden | Ein Client blockiert durch Ratenbegrenzung alle anderen Clients |
+| 403 statt 429 für Ratenlimit zurückgeben | Client kann nicht zwischen „verboten" und „zu viele Anfragen" unterscheiden; `Retry-After` fehlt |
+| Kein `Retry-After`-Header bei 429 | Clients wiederholen sofort; Thundering Herd beim Fenster-Reset |
+| `limit` zu hoch für sensible Endpunkte setzen | Login-Endpunkt mit limit=10000 ist effektiv ungeschützt |
+| Keine Ratenbegrenzung bei Login/Passwort-Reset-Endpunkten | Brute-Force-Angriffe gelingen ohne Sperrung oder Drosselung |

--- a/docs/de/howto/rating-review-api.md
+++ b/docs/de/howto/rating-review-api.md
@@ -1,0 +1,234 @@
+# Anleitung: Bewertungs- und Rezensions-API
+
+> **FT-Referenz**: FT333 (`NENE2-FT/ratinglog`) — Pro-Artikel-, Pro-Benutzer-Bewertungssystem mit Score-Validierung (1–5), Upsert-Semantik, Zusammenfassung mit Verteilungsaufschlüsselung und Sicherheitsbewertung, 16 Tests / 40+ Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Bewertungssystem erstellt wird, bei dem Benutzer numerische Scores mit optionalen Textrezensionen einreichen, und die API Live-Aggregatzusammenfassungen berechnet.
+
+## Schema
+
+```sql
+CREATE TABLE ratings (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id    TEXT    NOT NULL,
+    rater_id   TEXT    NOT NULL,
+    score      INTEGER NOT NULL CHECK (score BETWEEN 1 AND 5),
+    review     TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE(item_id, rater_id)
+);
+```
+
+`UNIQUE(item_id, rater_id)` erzwingt eine Bewertung pro Bewerter pro Artikel. `item_id` und `rater_id` sind opake String-Identifikatoren — keine Fremdschlüssel-Einschränkung erforderlich.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `PUT`   | `/items/{itemId}/ratings/{raterId}` | Bewertung erstellen oder aktualisieren (Upsert) |
+| `GET`   | `/items/{itemId}/ratings` | Alle Bewertungen für einen Artikel auflisten |
+| `GET`   | `/items/{itemId}/ratings/summary` | Aggregatzusammenfassung mit Verteilung |
+| `GET`   | `/items/{itemId}/ratings/{raterId}` | Bewertung eines bestimmten Bewerters abrufen |
+| `DELETE`| `/items/{itemId}/ratings/{raterId}` | Bewertung löschen |
+
+## Bewertung erstellen / aktualisieren (Upsert)
+
+```php
+PUT /items/product-1/ratings/alice
+{"score": 5, "review": "Excellent!"}
+→ 200  {"rater_id": "alice", "score": 5, "review": "Excellent!", ...}
+
+// Vorhandene Bewertung aktualisieren
+PUT /items/product-1/ratings/alice
+{"score": 3, "review": "Changed my mind."}
+→ 200  {"score": 3}
+```
+
+`PUT` mit `UNIQUE(item_id, rater_id)` wirkt als natürliches Upsert (`INSERT OR REPLACE`). Derselbe Endpunkt verarbeitet Erstellen und Aktualisieren ohne separates `PATCH`.
+
+### Validierung
+
+```php
+// Fehlender Score
+PUT /items/product-1/ratings/alice  {"review": "Nice"}
+→ 422
+
+// Außerhalb des Bereichs
+PUT /items/product-1/ratings/alice  {"score": 6}
+→ 422
+
+PUT /items/product-1/ratings/alice  {"score": 0}
+→ 422
+```
+
+Score muss ein Integer im Bereich [1, 5] sein. `review` ist optional (Standard: `""`).
+
+## Bewertungen auflisten
+
+```php
+GET /items/product-1/ratings
+→ 200
+{
+  "ratings": [
+    {"rater_id": "alice", "score": 5, "review": "Excellent!"},
+    {"rater_id": "bob",   "score": 3, "review": ""}
+  ]
+}
+```
+
+Bewertungen sind auf den Artikel beschränkt — Bewertungen von `product-2` erscheinen nie in der Liste von `product-1`.
+
+## Zusammenfassung mit Verteilung
+
+```php
+GET /items/product-1/ratings/summary
+→ 200
+{
+  "count": 3,
+  "average": 4.0,
+  "distribution": {
+    "1": 0, "2": 0, "3": 1, "4": 1, "5": 1
+  }
+}
+
+// Noch keine Bewertungen
+GET /items/product-2/ratings/summary
+→ 200  {"count": 0, "average": 0.0, "distribution": {"1":0,"2":0,"3":0,"4":0,"5":0}}
+```
+
+`distribution` gibt immer alle fünf Schlüssel zurück, auch wenn die Anzahl null ist — Clients können Sterne-Balken ohne Null-Prüfungen rendern.
+
+## Einzelne Bewertung abrufen
+
+```php
+GET /items/product-1/ratings/alice
+→ 200  {"score": 4, "review": "..."}
+
+GET /items/product-1/ratings/nobody
+→ 404
+```
+
+## Bewertung löschen
+
+```php
+DELETE /items/product-1/ratings/alice
+→ 200  {"deleted": true}
+
+DELETE /items/product-1/ratings/nobody
+→ 404
+```
+
+Nach dem Löschen wird die Zusammenfassung bei der nächsten Anfrage sofort neu berechnet.
+
+```php
+// Vorher: alice(5) + bob(1), average=3.0
+DELETE /items/product-1/ratings/bob
+
+// Nachher: nur alice(5)
+GET /items/product-1/ratings/summary
+→ 200  {"count": 1, "average": 5.0}
+```
+
+---
+
+## Sicherheitsbewertung
+
+### V-01 — Bewertungsverkörperung (IDOR bei raterId) ⚠️ EXPONIERT
+
+**Risiko**: Jeder Client kann eine Bewertung mit einem beliebigen `raterId`-Pfadsegment einreichen oder löschen.
+**Befund**: EXPONIERT — `raterId` in der URL wird nicht gegen einen authentifizierten Akteur validiert. Ein Angreifer kann eine 1-Stern-Bewertung als `raterId: "competitor"` posten oder die Bewertung eines anderen Benutzers löschen. Minderung: Bewerter authentifizieren (Session, JWT oder `X-User-Id`-Header) und Anfragen ablehnen, bei denen die authentifizierte Identität nicht mit dem Pfad-`raterId` übereinstimmt.
+
+---
+
+### V-02 — Score-Bereichs-Bypass 🛡️ SICHER
+
+**Risiko**: Angreifer sendet `score: 0` oder `score: 6`, um ungültige Daten zu erzeugen oder Durchschnittswerte zu verfälschen.
+**Befund**: SICHER — Score wird vor jedem DB-Schreibvorgang auf `[1, 5]` validiert. Außerhalb des Bereichs liegende Werte geben 422 zurück. Der DB-seitige `CHECK (score BETWEEN 1 AND 5)` bietet eine sekundäre Sicherung.
+
+---
+
+### V-03 — Durchschnittsvergiftung durch Massen-Fake-Bewertungen ⚠️ EXPONIERT
+
+**Risiko**: Angreifer registriert Tausende von Benutzer-IDs und gibt 1-Stern-Bewertungen ab, um den Durchschnittswert eines Produkts zu senken.
+**Befund**: EXPONIERT — Keine Ratenbegrenzung oder Kontoüberprüfung wird am Bewertungsendpunkt erzwungen. Minderung: Kontoalter / E-Mail-Verifizierung vor der Bewertung erfordern; Per-IP- und Per-Benutzer-Ratenlimits anwenden; statistische Anomalien erkennen (plötzlicher Ansturm niedriger Scores).
+
+---
+
+### V-04 — XSS über Rezensionstext ✅ SICHER
+
+**Risiko**: Angreifer speichert `<script>alert(1)</script>` in `review`, um JavaScript auf Clients auszuführen, die die Rezension als HTML rendern.
+**Befund**: SICHER — Die API gibt `application/json` zurück. JSON-Kodierung maskiert HTML-Sonderzeichen (`<`, `>`, `&`). Solange Clients den JSON-Wert als Text analysieren und rendern (nicht als `innerHTML`), wird gespeichertes XSS verhindert. Serverseitige HTML-Kodierung als zusätzliche Schicht wird empfohlen.
+
+---
+
+### V-05 — SQL-Injection über itemId / raterId 🛡️ SICHER
+
+**Risiko**: Angreifer sendet `item_id = "x' OR '1'='1"` oder `rater_id = "'; DROP TABLE ratings--"`, um die Abfrage zu manipulieren.
+**Befund**: SICHER — Alle Abfragen verwenden parametrisierte Anweisungen (`?`-Platzhalter). Pfadsegmente werden als Bindewerte übergeben, nie in SQL-Strings interpoliert.
+
+---
+
+### V-06 — Unbegrenzter Rezensionstext (Speichermissbrauch) ⚠️ EXPONIERT
+
+**Risiko**: Angreifer sendet einen 100 MB großen Rezensionsstring, um Datenbank-/Speicherressourcen zu erschöpfen.
+**Befund**: EXPONIERT — Keine `max_length`-Prüfung wird für `review` erzwungen. Minderung: Eine `MAX_REVIEW_LENGTH`-Konstante hinzufügen (z. B. 2000 Zeichen) und 422 zurückgeben, wenn überschritten. Anfragengrößen-Middleware bietet eine sekundäre Sicherung.
+
+---
+
+### V-07 — Durchschnitts-Integer-Abschneidung bei Zusammenfassung 🛡️ SICHER
+
+**Risiko**: Das Durchschnittlich von 3 Bewertungen (5+3+4=12, 12/3=4.0) könnte auf manchen DB-Engines Präzision verlieren.
+**Befund**: SICHER — `AVG()` in SQLite gibt einen Float zurück. PHP wandelt das Ergebnis vor der Kodierung in `float` um. `(int)(5+3)/2`-Stil-Abschneidung wird nicht verwendet.
+
+---
+
+### V-08 — Fehlende Schlüssel in Verteilung (Client-Absturz) 🛡️ SICHER
+
+**Risiko**: Wenn `distribution` Schlüssel für Scores mit null Bewertungen weglässt, stürzen Clients ab, die auf `distribution[1]` zugreifen, mit `undefined`.
+**Befund**: SICHER — Die API gibt immer alle fünf Schlüssel (`1`–`5`) mit `0` initialisiert zurück. Clients benötigen keine defensiven Null-Prüfungen.
+
+---
+
+### V-09 — Artikelübergreifendes Datenleck 🛡️ SICHER
+
+**Risiko**: `GET /items/product-1/ratings` gibt Bewertungen von `product-2` zurück.
+**Befund**: SICHER — Alle Abfragen enthalten `WHERE item_id = ?`. Der Isolationstest verifiziert explizit, dass die Bewertung von `product-2` nicht in der Liste von `product-1` erscheint.
+
+---
+
+### V-10 — Float-Score, um Integer-Validierung zu umgehen 🛡️ SICHER
+
+**Risiko**: Angreifer sendet `score: 4.9` (rundet auf 5) oder `score: 5.1` (rundet auf 5 oder 6), um die Bereichsprüfung zu umgehen.
+**Befund**: SICHER — Score wird als strikter Integer validiert. Ein JSON-Float besteht die Typvalidierung nicht und gibt 422 zurück, bevor eine Bereichsprüfung stattfindet.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|--------|
+| V-01 | Bewertungsverkörperung (IDOR bei raterId) | ⚠️ EXPONIERT |
+| V-02 | Score-Bereichs-Bypass | 🛡️ SICHER |
+| V-03 | Durchschnittsvergiftung durch Massen-Fake-Bewertungen | ⚠️ EXPONIERT |
+| V-04 | XSS über Rezensionstext | ✅ SICHER |
+| V-05 | SQL-Injection über itemId / raterId | 🛡️ SICHER |
+| V-06 | Unbegrenzter Rezensionstext (Speichermissbrauch) | ⚠️ EXPONIERT |
+| V-07 | Durchschnitts-Integer-Abschneidung bei Zusammenfassung | 🛡️ SICHER |
+| V-08 | Fehlende Schlüssel in Verteilung | 🛡️ SICHER |
+| V-09 | Artikelübergreifendes Datenleck | 🛡️ SICHER |
+| V-10 | Float-Score umgeht Integer-Validierung | 🛡️ SICHER |
+
+**7 SICHER, 3 EXPONIERT** — Kritisch: `raterId` authentifizieren; `review`-Längenbegrenzung hinzufügen; Ratenbegrenzung gegen Massen-Fake-Bewertungen anwenden.
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `raterId` aus dem Pfad ohne Authentifizierung vertrauen | Jeder Client kann als beliebiger Benutzer bewerten oder löschen |
+| Keine `max_length` für Rezensionstext | Speicher-Bombe — eine einzelne Anfrage schreibt Gigabytes in die DB |
+| `null` für Verteilungsschlüssel mit null Zähler zurückgeben | Client-Code, der auf `distribution[2]` zugreift, stürzt ab |
+| Durchschnitt in PHP mit `array_sum` neu berechnen | Verlustbehaftete Float-Arithmetik bei großen Datensätzen; DB `AVG()` verwenden |
+| Kein Per-Benutzer-Ratenlimit | Massen-Fake-Konten vergiften Produktdurchschnitte |
+| `SELECT * FROM ratings` ohne `WHERE item_id` verwenden | Artikelübergreifendes Datenleck |

--- a/docs/de/howto/rbac-jwt-auth.md
+++ b/docs/de/howto/rbac-jwt-auth.md
@@ -1,0 +1,262 @@
+# Anleitung: RBAC + JWT-Authentifizierung
+
+> **FT-Referenz**: FT279 (`NENE2-FT/rbaclog`) — Rollenbasierte Zugriffskontrolle mit JWT: Argon2id-Passwort-Hashing mit Timing-Angriffs-Schutz, Rollen-Claim in JWT, Unterscheidung zwischen 401 und 403, BearerTokenMiddleware mit manuellem Fallback, 14 Tests / 48 Assertions BESTANDEN.
+>
+> **VULN-Bewertung**: V-01 bis V-10 am Ende dieses Dokuments.
+
+Diese Anleitung zeigt, wie ein rollenbasiertes Zugriffskontrollsystem (RBAC) mit JWT-Tokens in NENE2 erstellt wird.
+
+## Funktionen
+
+- E-Mail + Passwort-Anmeldung (Argon2id-Hashing)
+- Rollen-Claim im JWT (`user` / `admin`)
+- Öffentliche, authentifizierte und nur-Admin-Endpunkte
+- `BearerTokenMiddleware` mit Per-Handler-Fallback
+- Korrekte Semantik: `401 Unauthorized` vs. `403 Forbidden`
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    email         TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    role          TEXT NOT NULL DEFAULT 'user',
+    created_at    TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    author_id  INTEGER NOT NULL,
+    created_at TEXT NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Authentifizierung | Beschreibung |
+|---------|------|-------------------|-------------|
+| `POST` | `/auth/login` | Keine | Anmelden, JWT erhalten |
+| `GET` | `/posts` | Keine | Alle Posts auflisten (öffentlich) |
+| `POST` | `/posts` | Benutzer oder Admin | Post erstellen |
+| `DELETE` | `/posts/{id}` | Nur Admin | Post löschen |
+
+## Anmeldung mit Timing-Angriffs-Schutz
+
+Der Dummy-Hash-Trick stellt sicher, dass die Anmeldung immer dieselbe Zeit benötigt, unabhängig davon, ob die E-Mail-Adresse existiert:
+
+```php
+$user = $this->users->findByEmail(trim($body['email']));
+
+$dummyHash   = '$argon2id$v=19$m=65536,t=4,p=1$dummysaltdummysaltdummysalt$dummyhashvaluedummyhashvaluedummyh';
+$hashToCheck = $user !== null ? $user->passwordHash : $dummyHash;
+
+if (!password_verify($body['password'], $hashToCheck) || $user === null) {
+    return $this->problems->create($request, 'invalid-credentials', 'Invalid Credentials', 401, '...');
+}
+```
+
+Ohne den Dummy-Hash kann ein Timing-Angriff gültige E-Mail-Adressen erkennen, indem die Antwortzeit gemessen wird — die Hash-Berechnung wird für unbekannte E-Mails übersprungen.
+
+## Rollen-Claim im JWT
+
+Die Rolle wird in der JWT-Payload gespeichert, um pro Anfrage einen DB-Abfrageaufwand zu vermeiden:
+
+```php
+$token = $this->issuer->issue([
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'role'  => $user->role->value,   // Role::User → 'user', Role::Admin → 'admin'
+    'iat'   => $now,
+    'exp'   => $now + self::TOKEN_TTL_SECONDS,
+]);
+```
+
+## Rollenprüfung mit Enum
+
+```php
+private function requireRole(ServerRequestInterface $request, Role $required): array|ResponseInterface
+{
+    $claims = $this->requireAuth($request);
+    if ($claims instanceof ResponseInterface) {
+        return $claims;
+    }
+
+    $actualRole = Role::tryFrom((string) ($claims['role'] ?? ''));
+
+    if ($actualRole !== $required) {
+        return $this->problems->create(
+            $request, 'forbidden', 'Forbidden', 403,
+            "This action requires the '{$required->value}' role."
+        );
+    }
+
+    return $claims;
+}
+```
+
+`Role::tryFrom()` ordnet den String-Claim sicher dem Enum zu — ungültige Rollen-Strings werden zu `null`, was die Prüfung fehlschlagen lässt.
+
+## Unterscheidung zwischen 401 und 403
+
+| Status | Bedeutung | Wann |
+|--------|-----------|------|
+| `401 Unauthorized` | Nicht authentifiziert | Kein Token, ungültiges Token, abgelaufenes Token |
+| `403 Forbidden` | Authentifiziert, aber unzureichende Rolle | Gültiges Token, falsche Rolle |
+
+Diese Unterscheidung ist für Clients wichtig: Ein `401` sollte zu einer erneuten Anmeldung auffordern; ein `403` sollte eine „Zugriff verweigert"-Meldung anzeigen.
+
+## BearerTokenMiddleware mit Fallback
+
+Einige Pfade bedienen sowohl öffentliche als auch geschützte Methoden (z. B. `GET /posts` ist öffentlich, `POST /posts` ist authentifiziert). Die Middleware schließt den Pfad vollständig aus, und Handler, die Auth erfordern, rufen `requireAuth()` manuell auf:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier: $this->verifier,
+    excludedPaths: ['/auth/login', '/posts'],  // /posts benötigt Per-Methoden-Behandlung
+);
+```
+
+```php
+private function requireAuth(ServerRequestInterface $request): array|ResponseInterface
+{
+    // Schneller Pfad: Middleware hat bereits verifiziert
+    $claims = $request->getAttribute('nene2.auth.claims');
+    if (is_array($claims)) {
+        return $claims;
+    }
+
+    // Langsamer Pfad: manuelle Extraktion für ausgeschlossene Pfade
+    $authorization = $request->getHeaderLine('Authorization');
+    if ($authorization === '' || !str_starts_with($authorization, 'Bearer ')) {
+        return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401, '...');
+    }
+
+    try {
+        return $this->verifier->verify(substr($authorization, 7));
+    } catch (TokenVerificationException) {
+        return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401, '...');
+    }
+}
+```
+
+---
+
+## VULN-Bewertung — Sicherheitsdiagnose
+
+### V-01 — Rollenerhöhung durch gefälschten JWT-Claim 🛡️ SICHER
+
+**Bedrohung**: Angreifer erstellt ein JWT mit `"role": "admin"` und signiert es mit einem zufälligen Secret.
+**Abwehr**: `LocalBearerTokenVerifier` validiert die HMAC-HS256-Signatur gegen das Server-Secret. Ein nicht übereinstimmendes Secret verursacht `TokenVerificationException` → 401.
+**Ergebnis**: SICHER — Signaturverifizierung verhindert Claim-Fälschung.
+
+---
+
+### V-02 — Timing-Angriff durch E-Mail-Enumeration bei der Anmeldung 🛡️ SICHER
+
+**Bedrohung**: Angreifer sendet Anmeldeanfragen für unbekannte vs. bekannte E-Mails und misst die Antwortzeit, um gültige Konten zu enumerieren.
+**Abwehr**: Für unbekannte E-Mails wird `password_verify()` gegen einen Dummy-Argon2id-Hash (gleiche Kostenparameter) aufgerufen. Beide Pfade benötigen ~200ms. Die Anmeldemisserfolgs-Meldung ist identisch für falsche E-Mail und falsches Passwort.
+**Ergebnis**: SICHER — Timing ist angeglichen; Fehlermeldung ist generisch.
+
+---
+
+### V-03 — Abgelaufenes Token als gültig akzeptiert 🛡️ SICHER
+
+**Bedrohung**: Angreifer verwendet ein erfasstes JWT erneut, nachdem es abgelaufen ist.
+**Abwehr**: `LocalBearerTokenVerifier` prüft den `exp`-Claim gegen `time()`. Abgelaufene Tokens werfen `TokenVerificationException` → 401.
+**Ergebnis**: SICHER — `exp`-Prüfung wird erzwungen.
+
+---
+
+### V-04 — Rollen-Downgrade durch Änderung der JWT-Payload (ohne erneutes Signieren) 🛡️ SICHER
+
+**Bedrohung**: Angreifer base64-dekodiert die JWT-Payload, ändert `"role": "user"` zu `"role": "admin"`, rekodiert und sendet mit der ursprünglichen Signatur.
+**Abwehr**: Die JWT-Signatur deckt Header + Payload ab. Das Ändern der Payload macht die Signatur ungültig → `TokenVerificationException` → 401.
+**Ergebnis**: SICHER — Payload-Manipulation durch HMAC erkannt.
+
+---
+
+### V-05 — Admin-Endpunkt mit Benutzerrolle erreichbar 🛡️ SICHER
+
+**Bedrohung**: Angreifer meldet sich als `user` an und versucht `DELETE /posts/{id}`.
+**Abwehr**: `requireRole($request, Role::Admin)` prüft den JWT-`role`-Claim. Ein `user`-Token hat `role: 'user'` → `Role::tryFrom('user') !== Role::Admin` → 403.
+**Ergebnis**: SICHER — 403 Forbidden zurückgegeben; Benutzer-Token kann nicht auf Admin erhöht werden.
+
+---
+
+### V-06 — Nicht authentifizierter Zugriff auf geschützten Endpunkt 🛡️ SICHER
+
+**Bedrohung**: Angreifer sendet `POST /posts` oder `DELETE /posts/{id}` ohne Authorization-Header.
+**Abwehr**: `requireAuth()` prüft auf `Bearer `-Präfix; fehlender Header → 401 `unauthorized`.
+**Ergebnis**: SICHER — 401 Unauthorized zurückgegeben.
+
+---
+
+### V-07 — Verwechslung von 401 und 403 (Informationsleck) 🛡️ SICHER
+
+**Bedrohung**: Falsche 401/403-Verwendung gibt preis, ob eine Ressource existiert oder ob der Benutzer authentifiziert ist.
+**Abwehr**: Das System gibt 401 für nicht authentifizierten Zugriff (kein/ungültiges Token) und 403 für authentifizierten Zugriff mit unzureichender Rolle zurück. Die Unterscheidung ist semantisch korrekt und gibt keine Ressourcenexistenz über die Rollenanforderung hinaus preis.
+**Ergebnis**: SICHER — 401/403-Semantik ist korrekt; Tests `test401MeansNotAuthenticated` und `test403MeansAuthenticatedButForbidden` bestehen beide.
+
+---
+
+### V-08 — Unbekannter Rollen-String im JWT-Bypass 🛡️ SICHER
+
+**Bedrohung**: Angreifer erstellt ein JWT (mit gültigem Secret, z. B. kompromittiertes Secret-Szenario) und setzt `role` auf einen unbekannten Wert wie `"superadmin"`.
+**Abwehr**: `Role::tryFrom((string) ($claims['role'] ?? ''))` gibt `null` für unbekannte Strings zurück → `null !== Role::Admin` → 403.
+**Ergebnis**: SICHER — `tryFrom()` ist null-sicher; unbekannte Rollen werden als unzureichend behandelt.
+
+---
+
+### V-09 — SQL-Injection über E-Mail-Feld bei der Anmeldung 🛡️ SICHER
+
+**Bedrohung**: Angreifer sendet `{"email": "' OR '1'='1", "password": "anything"}`.
+**Abwehr**: `findByEmail()` verwendet parametrisierte Abfrage (`WHERE email = ?`). Der injizierte String wird als Literalwert behandelt, nicht als SQL.
+**Ergebnis**: SICHER — parametrisierte Abfragen verhindern SQL-Injection.
+
+---
+
+### V-10 — Passwort im Klartext gespeichert 🛡️ SICHER
+
+**Bedrohung**: Bei einem DB-Einbruch sind Passwörter lesbar.
+**Abwehr**: `password_hash($password, PASSWORD_ARGON2ID)` mit Kostenparametern `m=65536,t=4,p=1`. Nur der Argon2id-Hash wird gespeichert; das Klartext-Passwort wird nie persistiert.
+**Ergebnis**: SICHER — Argon2id ist der aktuell empfohlene Algorithmus (RFC 9106); PBKDF2/bcrypt/scrypt würden ebenfalls bestehen.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Bedrohung | Ergebnis |
+|----|-----------|----------|
+| V-01 | Rollenerhöhung durch gefälschtes JWT | 🛡️ SICHER |
+| V-02 | Timing-Angriff durch E-Mail-Enumeration | 🛡️ SICHER |
+| V-03 | Abgelaufenes Token akzeptiert | 🛡️ SICHER |
+| V-04 | JWT-Payload-Manipulation ohne erneutes Signieren | 🛡️ SICHER |
+| V-05 | Admin-Endpunkt mit Benutzer-Rollen-Token | 🛡️ SICHER |
+| V-06 | Nicht authentifizierter Zugriff auf geschützten Endpunkt | 🛡️ SICHER |
+| V-07 | Verwechslung von 401 und 403 | 🛡️ SICHER |
+| V-08 | Unbekannter Rollen-String-Bypass | 🛡️ SICHER |
+| V-09 | SQL-Injection über E-Mail-Feld | 🛡️ SICHER |
+| V-10 | Passwort im Klartext gespeichert | 🛡️ SICHER |
+
+**10 SICHER, 0 EXPONIERT**
+Argon2id-Hashing, HMAC-signiertes JWT, `Role::tryFrom()`-Schutz und parametrisierte Abfragen verhindern alle getesteten Schwachstellenvektoren.
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Rolle in DB speichern und bei jeder Anfrage nachschlagen | Zusätzliche DB-Abfrage pro Anfrage; Rollenänderungen erfordern Token-Widerrufslogik |
+| `Role::from()` statt `Role::tryFrom()` verwenden | Unbekannte Rollen-Strings werfen `ValueError` — 500 statt 403 |
+| 403 für nicht authentifizierte Anfragen zurückgeben | Irreführt Clients — 403 sollte „authentifiziert, aber verboten" bedeuten, nicht „nicht angemeldet" |
+| 401 für falschen Rollenzugriff zurückgeben | Client könnte erneute Anmeldung versuchen statt „Zugriff verweigert" anzuzeigen |
+| Dummy-Hash bei der Anmeldung überspringen | Timing-Angriff gibt gültige E-Mail-Adressen preis |
+| Passwörter als MD5/SHA1/Klartext speichern | Brute-Force- oder Rainbow-Table-Angriffe gefährden alle Passwörter bei einem DB-Einbruch |
+| Berechtigungen im JWT einbetten (nicht Rollen) | Berechtigungsänderungen erfordern Token-Neuausstellung; Rollen sind stabil, Berechtigungen ändern sich |
+| `alg: none` JWT zulassen | Angreifer kann Tokens fälschen, indem die Signatur vollständig entfernt wird |
+| `str_contains($role, 'admin')` statt Enum-Prüfung verwenden | `"not-admin"` oder `"superadmin"` könnte unerwartet treffen |

--- a/docs/de/howto/rbac.md
+++ b/docs/de/howto/rbac.md
@@ -1,0 +1,233 @@
+# Anleitung: Rollenbasierte Zugriffskontrolle (RBAC)
+
+Implementierung rollenbasierter Zugriffskontrolle mit JWT-Claims und `BearerTokenMiddleware`.
+
+---
+
+## Schnellstart
+
+```php
+// 1. Rolle bei der Anmeldung ins JWT einbinden
+$token = $issuer->issue([
+    'sub'  => $user->id,
+    'role' => $user->role->value,  // 'user' oder 'admin'
+    'exp'  => time() + 3600,
+]);
+
+// 2. Rolle im Handler prüfen
+/** @var array<string, mixed>|null $claims */
+$claims     = $request->getAttribute('nene2.auth.claims');
+$actualRole = Role::tryFrom((string) ($claims['role'] ?? ''));
+
+if ($actualRole !== Role::Admin) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+        "This action requires the 'admin' role.");
+}
+```
+
+---
+
+## Rollen in JWT-Claims einbetten
+
+**Zwei Ansätze:**
+
+| Ansatz | Vorteil | Nachteil |
+|--------|---------|----------|
+| Rolle in JWT-Claims | Keine DB-Abfrage pro Anfrage | Rollenänderungen treten erst nach Ablauf des Tokens in Kraft |
+| DB-Nachschlagen pro Anfrage | Sofortige Rollenänderungen | Zusätzliche Abfrage bei jeder authentifizierten Anfrage |
+
+Für die meisten Anwendungen ist der JWT-Ansatz geeignet. Für hochsicherheitskritische Kontexte (Medizin, Finanzen, Admin-Widerruf) eine DB-Nachschlagenoperation bei sensiblen Operationen hinzufügen.
+
+```php
+// Anmeldung — Rolle in Claims einbetten
+$token = $issuer->issue([
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'role'  => $user->role->value,   // String: 'user' | 'admin'
+    'iat'   => time(),
+    'exp'   => time() + 3600,
+]);
+```
+
+---
+
+## 401 Unauthorized vs. 403 Forbidden
+
+Diese Unterscheidung ist wichtig für die Client-Fehlerbehandlung (401 → zur Anmeldung weiterleiten, 403 → Berechtigungsfehler anzeigen):
+
+| Situation | Status |
+|-----------|--------|
+| Kein Token / abgelaufen / ungültige Signatur | **401** Unauthorized |
+| Gültiges Token, aber unzureichende Rolle | **403** Forbidden |
+| Ressource nicht gefunden | **404** Not Found |
+
+```php
+// Falsch — authentifizierter Benutzer erhält 401 (impliziert "nicht angemeldet")
+if ($role !== Role::Admin) {
+    return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401, '...');
+}
+
+// Richtig — authentifiziert, aber fehlende Berechtigung
+if ($role !== Role::Admin) {
+    return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+        "This action requires the 'admin' role.");
+}
+```
+
+---
+
+## `requireAuth()` / `requireRole()`-Muster
+
+Ein wiederverwendbares Helferpaar im Route-Registrar:
+
+```php
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+
+final class RouteRegistrar
+{
+    public function __construct(
+        private readonly TokenVerifierInterface $verifier,
+        // ... andere Abhängigkeiten
+    ) {}
+
+    /**
+     * Gibt Claims bei Erfolg oder eine 401-ResponseInterface zurück.
+     * Prüft zuerst das Middleware-Attribut; fällt für von BearerTokenMiddleware
+     * ausgeschlossene Pfade auf manuelle Verifizierung zurück.
+     *
+     * @return array<string, mixed>|ResponseInterface
+     */
+    private function requireAuth(ServerRequestInterface $request): array|ResponseInterface
+    {
+        /** @var array<string, mixed>|null $claims */
+        $claims = $request->getAttribute('nene2.auth.claims');
+
+        if (is_array($claims)) {
+            return $claims;
+        }
+
+        $authorization = $request->getHeaderLine('Authorization');
+
+        if ($authorization === '' || !str_starts_with($authorization, 'Bearer ')) {
+            return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401,
+                'Authentication required.');
+        }
+
+        try {
+            return $this->verifier->verify(substr($authorization, 7));
+        } catch (TokenVerificationException) {
+            return $this->problems->create($request, 'unauthorized', 'Unauthorized', 401,
+                'Token is invalid or expired.');
+        }
+    }
+
+    /**
+     * Gibt Claims zurück, wenn der Benutzer die erforderliche Rolle hat, oder eine 401/403-ResponseInterface.
+     *
+     * @return array<string, mixed>|ResponseInterface
+     */
+    private function requireRole(ServerRequestInterface $request, Role $required): array|ResponseInterface
+    {
+        $claims = $this->requireAuth($request);
+
+        if ($claims instanceof ResponseInterface) {
+            return $claims;
+        }
+
+        $actualRole = Role::tryFrom((string) ($claims['role'] ?? ''));
+
+        if ($actualRole !== $required) {
+            return $this->problems->create($request, 'forbidden', 'Forbidden', 403,
+                "This action requires the '{$required->value}' role.");
+        }
+
+        return $claims;
+    }
+}
+```
+
+Verwendung in Handlern:
+
+```php
+private function deletePost(ServerRequestInterface $request): ResponseInterface
+{
+    $claims = $this->requireRole($request, Role::Admin);
+    if ($claims instanceof ResponseInterface) {
+        return $claims;  // 401 oder 403
+    }
+    // $claims ist jetzt die verifizierte JWT-Payload eines Admins
+}
+```
+
+---
+
+## `BearerTokenMiddleware` unterscheidet nicht nach HTTP-Methode
+
+`BearerTokenMiddleware` verwendet den Request-Pfad, nicht die HTTP-Methode, um zu entscheiden, ob Authentifizierung erforderlich ist. Wenn `GET /posts` (öffentlich) und `POST /posts` (auth-erforderlich) denselben Pfad teilen, `/posts` von der Middleware ausschließen und das Token manuell im Handler verifizieren:
+
+```php
+// Middleware: /posts vollständig ausschließen (deckt sowohl GET als auch POST ab)
+$auth = new BearerTokenMiddleware($problems, $verifier, excludedPaths: ['/auth/login', '/posts']);
+
+// Für DELETE /posts/{id} (Pfad /posts/1, /posts/2 etc.) — NICHT in excludedPaths → Middleware schützt es.
+// Für POST /posts (Pfad /posts) — ausgeschlossen → Handler muss requireAuth() manuell aufrufen.
+```
+
+Der obige `requireAuth()`-Helfer behandelt dies transparent: er liest `nene2.auth.claims` aus dem Middleware-Attribut, wenn vorhanden, und fällt auf direktes Parsen des `Authorization`-Headers zurück, wenn nicht.
+
+**Alternative**: Unterschiedliche Pfad-Präfixe verwenden, um die Zweideutigkeit vollständig zu vermeiden:
+- `GET /public/posts` — keine Auth
+- `POST /posts` — Auth erforderlich (Middleware kann `/posts` ohne Konflikt schützen)
+
+---
+
+## `Role`-Enum-Muster
+
+Ein backed enum für typsichere Rollenbehandlung verwenden:
+
+```php
+enum Role: string
+{
+    case User  = 'user';
+    case Admin = 'admin';
+}
+
+// Role::from() wirft bei unbekannten Werten
+$role = Role::from($claims['role']);  // UnhandledMatchError für 'superuser' oder ''
+
+// Role::tryFrom() gibt null für unbekannte Werte zurück
+$role = Role::tryFrom((string) ($claims['role'] ?? ''));
+if ($role === null || $role !== Role::Admin) {
+    return 403;
+}
+```
+
+---
+
+## 204 No Content — `createEmpty()` verwenden
+
+`JsonResponseFactory::create()` erfordert ein `array`-Argument. Für 204-Antworten ohne Body `createEmpty()` verwenden:
+
+```php
+// Typfehler — create() akzeptiert kein null
+return $this->json->create(null, 204);
+
+// Gibt leeres JSON-Objekt {} zurück (Body sollte bei 204 fehlen)
+return $this->json->create([], 204);
+
+// Richtig — kein Body, korrekter Status
+return $this->json->createEmpty(204);
+```
+
+---
+
+## Code-Review-Checkliste
+
+- [ ] `role`-Claim wird mit `Role::tryFrom()` dekodiert (nicht `Role::from()` — wirft bei unbekannten Werten)
+- [ ] 403 wird für unzureichende Berechtigungen zurückgegeben, 401 für nicht authentifiziert (nicht beide als 401)
+- [ ] `requireRole()` ruft auch `requireAuth()` auf — keine doppelten Auth-Prüfungen nötig
+- [ ] `BearerTokenMiddleware`-Ausschluss ist verstanden: ausgeschlossene Pfade umgehen das Claims-Attribut
+- [ ] Handler auf ausgeschlossenen Pfaden rufen `requireAuth()` mit manueller Token-Verifizierung auf
+- [ ] 204-Antworten verwenden `createEmpty(204)` statt `create(null, 204)`
+- [ ] JWT-Rollen-Caching ist verstanden: Rollenänderungen treten erst nach Ablauf des Tokens in Kraft

--- a/docs/de/howto/refresh-token-pattern.md
+++ b/docs/de/howto/refresh-token-pattern.md
@@ -1,0 +1,173 @@
+# Anleitung: Refresh-Token-Muster
+
+> **FT-Referenz**: FT281 (`NENE2-FT/refreshlog`) — Refresh-Token-Muster: kurzlebiges Access-Token (5 Min. JWT) + langlebiges Refresh-Token (7 Tage), SHA-256-Hash-Speicherung, Token-Rotation bei Verwendung, Replay-Angriffserkennung (widerrufenes Token → alle widerrufen), Logout gibt immer 204 zurück, 15 Tests / 63 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie das Refresh-Token-Muster implementiert wird — kurzlebige Access-Tokens für die Sicherheit, Refresh-Tokens für Sitzungskontinuität.
+
+## Warum es wichtig ist
+
+JWTs sind zustandslos. Einmal ausgestellt, können sie bis zu ihrem Ablauf nicht widerrufen werden. Eine 5-Minuten-TTL begrenzt das Risiko, wenn ein Token gestohlen wird. Refresh-Tokens verlängern Sitzungen ohne wiederholte Passwort-Eingabeaufforderungen und können bei jeder Verwendung rotiert (widerrufen und neu ausgestellt) werden, um Diebstahl zu erkennen.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id),
+    token_hash TEXT    NOT NULL UNIQUE,
+    expires_at TEXT    NOT NULL,
+    revoked    INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+```
+
+`token_hash` speichert den SHA-256 des rohen Tokens — nie den Rohwert. `revoked` ist ein Soft-Delete-Flag (im Gegensatz zu Hard-Delete für die Replay-Erkennung).
+
+## Endpunkte
+
+| Methode | Pfad | Authentifizierung | Beschreibung |
+|---------|------|-------------------|-------------|
+| `POST` | `/auth/login` | Keine | E-Mail + Passwort → Access-Token + Refresh-Token |
+| `POST` | `/auth/refresh` | Refresh-Token im Body | Refresh-Token rotieren, neues Paar ausstellen |
+| `POST` | `/auth/logout` | Refresh-Token im Body | Refresh-Token widerrufen |
+| `GET` | `/auth/me` | Bearer-Access-Token | Aktuelle Benutzerinformationen abrufen |
+
+## Token-Laufzeiten
+
+```php
+private const int ACCESS_TOKEN_TTL_SECONDS = 300; // 5 Minuten — kurz für Sicherheit
+// Refresh-Tokens: 7 Tage (RefreshTokenRepository::TTL_DAYS)
+```
+
+Kurze Access-Tokens begrenzen das Risiko bei Diebstahl. Lange Refresh-Tokens ermöglichen es Benutzern, über Sitzungen hinweg angemeldet zu bleiben, ohne Passwörter erneut eingeben zu müssen.
+
+## Token-Paar ausstellen
+
+```php
+private function issueTokenPair(User $user): array
+{
+    $now         = time();
+    $accessToken = $this->issuer->issue([
+        'jti'   => bin2hex(random_bytes(8)),  // eindeutige Token-ID — ermöglicht zukünftiges Revocation-Tracking
+        'sub'   => $user->id,
+        'email' => $user->email,
+        'iat'   => $now,
+        'exp'   => $now + self::ACCESS_TOKEN_TTL_SECONDS,
+    ]);
+
+    $refreshToken = $this->refreshTokens->issue($user->id);
+
+    return [
+        'access_token'  => $accessToken,
+        'token_type'    => 'Bearer',
+        'expires_in'    => self::ACCESS_TOKEN_TTL_SECONDS,
+        'refresh_token' => $refreshToken,
+    ];
+}
+```
+
+## Nur den Hash speichern
+
+```php
+public function issue(int $userId): string
+{
+    $raw       = bin2hex(random_bytes(32));  // 64 Hex-Zeichen = 256 Bit Entropie
+    $hash      = hash('sha256', $raw);
+    // INSERT token_hash = $hash ...
+
+    return $raw;  // ← Rohwert an Client zurückgeben; wird nie gespeichert
+}
+
+public function findByRaw(string $raw): ?RefreshToken
+{
+    $hash = hash('sha256', $raw);
+    // SELECT WHERE token_hash = $hash
+}
+```
+
+Bei einem DB-Einbruch erhalten Angreifer Hashes — nutzlos ohne die Rohwerte, die von den Clients gehalten werden.
+
+## Token-Rotation
+
+```php
+// Bei erfolgreichem /auth/refresh:
+$this->refreshTokens->revoke($stored->id);      // altes widerrufen
+return $this->json->create($this->issueTokenPair($user));  // neues Paar ausstellen
+```
+
+Jede Aktualisierung rotiert das Token. Das alte Token wird sofort ungültig, sodass ein gestohlenes Refresh-Token nur einmal verwendet werden kann, bevor die Rotation es ungültig macht.
+
+## Replay-Angriffserkennung
+
+```php
+$stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+
+if ($stored === null || !$stored->isValid()) {
+    // Ein widerrufenes Token wird erneut verwendet → möglicher Replay-Angriff
+    if ($stored !== null && $stored->revoked) {
+        $this->refreshTokens->revokeAllForUser($stored->userId);
+    }
+    return $this->problems->create($request, 'invalid-refresh-token', '...', 401);
+}
+```
+
+Wenn ein Angreifer ein Refresh-Token stiehlt, es verwendet und der legitime Client es dann (jetzt widerrufen) versucht — erkennt das System dies und widerruft alle Sitzungen des Benutzers, was eine erneute Authentifizierung erzwingt.
+
+## Logout gibt immer 204 zurück
+
+```php
+private function logout(ServerRequestInterface $request): ResponseInterface
+{
+    $stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+
+    if ($stored !== null && !$stored->revoked) {
+        $this->refreshTokens->revoke($stored->id);
+    }
+
+    // Immer 204 — nie preisgeben, ob das Token gültig war
+    return $this->json->createEmpty(204);
+}
+```
+
+Die Rückgabe von 401 für ein bereits widerrufenes Token beim Logout würde einem Angreifer ermöglichen, zu prüfen, ob er ausgeloggt wurde.
+
+## Token-Gültigkeitsprüfung
+
+```php
+public function isValid(): bool
+{
+    if ($this->revoked) {
+        return false;
+    }
+    return $this->expiresAt > (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+}
+```
+
+Sowohl Widerruf als auch Ablauf werden geprüft. Abgelaufene, aber nicht widerrufene Tokens werden ebenfalls abgelehnt.
+
+## Sicherheitseigenschaften-Zusammenfassung
+
+| Eigenschaft | Implementierung |
+|-------------|----------------|
+| Access-Token-TTL | 5 Minuten (Diebstahl-Exposition minimieren) |
+| Refresh-Token-TTL | 7 Tage (Sitzungskontinuität) |
+| Token-Speicherung | Nur SHA-256-Hash; Rohwert wird nie gespeichert |
+| Token-Rotation | Altes Token wird bei jeder erfolgreichen Aktualisierung widerrufen |
+| Replay-Erkennung | Widerrufenes Token erneut verwendet → alle Benutzersitzungen widerrufen |
+| Logout | Immer 204 (Token-Gültigkeit nie preisgeben) |
+| `jti`-Claim | Eindeutig pro Token (zukünftiges Revocation-Tracking) |
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Rohes Refresh-Token in DB speichern | DB-Einbruch gefährdet alle aktiven Sitzungen |
+| Hard Delete bei Widerruf verwenden | Replay-Angriffe können nicht erkannt werden (benötigt `revoked = 1`, um zu wissen, dass das Token existierte) |
+| Lange Access-Token-TTL (Stunden/Tage) | Gestohlenes Token bietet Langzeitzugang; macht Refresh-Tokens sinnlos |
+| 401 beim Logout mit ungültigem Token zurückgeben | Angreifer kann prüfen, ob er noch angemeldet ist |
+| Kein `jti` im Access-Token | Individuelle Tokens können nicht für zukünftige Revocation-Listen verfolgt werden |
+| Einzelnes Token (nur Access, kein Refresh) | Benutzer muss sich alle 5 Minuten neu authentifizieren oder gefährlich lange TTLs verwenden |
+| MD5 oder SHA-1 für Token-Hash | Schwacher Hash; SHA-256 oder besser verwenden |
+| Kein Ablauf bei Refresh-Tokens | Refresh-Tokens leben ewig; ein gestohlenes Token bietet unbegrenzten Zugang |

--- a/docs/de/howto/refresh-token-rotation.md
+++ b/docs/de/howto/refresh-token-rotation.md
@@ -1,0 +1,246 @@
+# Anleitung: JWT-Refresh-Token-Rotation
+
+Diese Anleitung behandelt die Implementierung kurzlebiger Access-Tokens in Kombination mit langlebigen Refresh-Tokens. Die entscheidende Eigenschaft ist die **Rotation**: jede Verwendung eines Refresh-Tokens widerruft es sofort und stellt ein neues aus. Ein wiederverwendetes (bereits widerrufenes) Refresh-Token löst den Widerruf aller Tokens dieses Benutzers aus.
+
+---
+
+## Warum zwei Tokens?
+
+| Token | TTL | Speicherung | Zweck |
+|-------|-----|-------------|-------|
+| Access-Token | 5 Min. | Client-Speicher | Authentifiziert API-Anfragen (zustandslos, kein DB-Lookup) |
+| Refresh-Token | 7 Tage | DB (gehasht) | Stellt neue Access-Tokens aus; verwaltet durch Rotation |
+
+Ein kurzlebiges Access-Token begrenzt den Schaden bei einem Leck — es läuft in Minuten ab. Das Refresh-Token verlängert die Sitzung ohne erneute Anmeldung, ist aber widerrufbar, weil es in der Datenbank gespeichert ist.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE refresh_tokens (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id),
+    token_hash TEXT    NOT NULL UNIQUE,  -- SHA-256-Hash; nie der Rohwert
+    expires_at TEXT    NOT NULL,
+    revoked    INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+```
+
+`token_hash` — immer den Hash speichern, nie das rohe Token. Bei einem DB-Leck können gehashte Tokens nicht direkt verwendet werden.
+
+---
+
+## Tokens ausstellen
+
+### Access-Token: `jti` für Eindeutigkeit hinzufügen
+
+Ohne `jti` sind zwei Tokens, die in derselben Sekunde für denselben Benutzer ausgestellt werden, identisch — ihre Payloads sind byte-für-byte gleich. `jti` (JWT-ID) garantiert die Eindeutigkeit jedes Tokens und ist die Grundlage für zukünftige Access-Token-Blocklisten:
+
+```php
+$accessToken = $this->issuer->issue([
+    'jti'   => bin2hex(random_bytes(8)),  // eindeutig pro Ausstellung
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'iat'   => time(),
+    'exp'   => time() + 300,  // 5 Minuten
+]);
+```
+
+### Refresh-Token: Hash speichern, Rohwert zurückgeben
+
+```php
+public function issue(int $userId): string
+{
+    $raw       = bin2hex(random_bytes(32));  // 256-Bit-Zufalls-Token
+    $hash      = hash('sha256', $raw);       // nur dies speichern
+    $expiresAt = (new \DateTimeImmutable())->modify('+7 days')->format('Y-m-d\TH:i:s\Z');
+    $createdAt = (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+
+    $this->executor->insert(
+        'INSERT INTO refresh_tokens (user_id, token_hash, expires_at, revoked, created_at)
+         VALUES (?, ?, ?, 0, ?)',
+        [$userId, $hash, $expiresAt, $createdAt],
+    );
+
+    return $raw;  // der Client erhält dies; die DB speichert es nie
+}
+```
+
+Um ein Token anhand eines vom Client gelieferten Werts nachzuschlagen:
+
+```php
+public function findByRaw(string $raw): ?RefreshToken
+{
+    $hash = hash('sha256', $raw);
+
+    $row = $this->executor->fetchOne(
+        'SELECT ... FROM refresh_tokens WHERE token_hash = ?',
+        [$hash],
+    );
+    // ...
+}
+```
+
+---
+
+## Token-Rotation
+
+Jede Aktualisierungsanfrage muss das alte Token widerrufen, bevor ein neues ausgestellt wird:
+
+```php
+private function refresh(ServerRequestInterface $request): ResponseInterface
+{
+    // ... Body parsen, gespeichertes Token finden ...
+
+    if ($stored === null || !$stored->isValid()) {
+        // Wiederverwendung eines widerrufenen Tokens ist ein möglicher Replay-Angriff —
+        // alle Tokens des Benutzers widerrufen, um erneute Authentifizierung zu erzwingen.
+        if ($stored !== null && $stored->revoked) {
+            $this->refreshTokens->revokeAllForUser($stored->userId);
+        }
+
+        return $this->problems->create(
+            $request,
+            'invalid-refresh-token',
+            'Invalid or Expired Refresh Token',
+            401,
+            'The refresh token is invalid, expired, or has already been used.',
+        );
+    }
+
+    $user = $this->users->findById($stored->userId);
+
+    // Rotation: altes Token zuerst widerrufen, dann neues Paar ausstellen
+    $this->refreshTokens->revoke($stored->id);
+
+    return $this->json->create($this->issueTokenPair($user));
+}
+```
+
+**Wiederverwendungserkennung**: Wenn ein widerrufenes Refresh-Token am `/auth/refresh`-Endpunkt ankommt, bedeutet dies entweder, dass der Benutzer ein altes Token wiederverwendet (ungewöhnlich) oder ein Angreifer es gestohlen hat. `revokeAllForUser()` zwingt jede Sitzung zur erneuten Authentifizierung und begrenzt den Schaden.
+
+---
+
+## Logout: immer 204 zurückgeben
+
+Niemals unterschiedliche Statuscodes zurückgeben, je nachdem ob das Refresh-Token gültig war. Andernfalls kann ein Angreifer prüfen, ob ein Token noch aktiv ist:
+
+```php
+private function logout(ServerRequestInterface $request): ResponseInterface
+{
+    // ... Body parsen ...
+
+    $stored = $this->refreshTokens->findByRaw($body['refresh_token']);
+
+    if ($stored !== null && !$stored->revoked) {
+        $this->refreshTokens->revoke($stored->id);
+    }
+
+    // Immer 204 — nie preisgeben, ob das Token gültig war oder nicht
+    return $this->json->createEmpty(204);
+}
+```
+
+Das bedeutet auch, dass doppeltes Logout (Logout zweimal mit demselben Token aufrufen) beide Male 204 zurückgibt — der Client kann Logout immer sicher aufrufen, ohne sich um den Status des Tokens sorgen zu müssen.
+
+---
+
+## Gültigkeitsprüfung auf der RefreshToken-Entität
+
+```php
+public function isValid(): bool
+{
+    if ($this->revoked) {
+        return false;
+    }
+
+    return $this->expiresAt > (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z');
+}
+```
+
+Zeichenkettenvergleich funktioniert für lexikografisch sortierte ISO-8601-Datumsangaben. Wenn Sie Zeitstempel als Unix-Integer speichern, mit `time()` vergleichen.
+
+---
+
+## BearerTokenMiddleware: Refresh/Logout-Pfade ausschließen
+
+Die Refresh- und Logout-Endpunkte erhalten ein Refresh-Token im Body, kein Bearer-Access-Token im Authorization-Header. Schließen Sie sie von `BearerTokenMiddleware` aus:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails: $problems,
+    verifier: $verifier,
+    excludedPaths: ['/auth/login', '/auth/refresh', '/auth/logout'],
+);
+```
+
+Der `/auth/me`-Endpunkt (und jeder andere geschützte Pfad) bleibt durch die Middleware geschützt.
+
+---
+
+## Antwortformat
+
+```json
+{
+  "access_token":  "eyJhbGci...",
+  "token_type":    "Bearer",
+  "expires_in":    300,
+  "refresh_token": "a3f92c..."
+}
+```
+
+`expires_in` (Sekunden) lässt den Client eine proaktive Aktualisierung vor dem Ablauf des Access-Tokens planen, sodass keine fehlgeschlagene Anfrage gefolgt von einer Aktualisierung entsteht.
+
+---
+
+## Code-Review-Checkliste
+
+1. `token_hash`-Spalte speichert `hash('sha256', $raw)` — nie den Rohwert
+2. `revoke()` wird vor `issueTokenPair()` im Refresh-Handler aufgerufen
+3. Wiederverwendung widerrufener Tokens löst `revokeAllForUser()` aus (nicht nur ein 401)
+4. Logout gibt immer 204 zurück — kein bedingtes 401/404
+5. Access-Token-TTL ist kurz (≤ 15 Minuten)
+6. `jti`-Claim ist in Access-Tokens vorhanden
+7. Tests decken Token-Rotation (altes Token nach Aktualisierung ungültig) und Wiederverwendungserkennung ab
+
+---
+
+## Rotation und Wiederverwendungserkennung testen
+
+```php
+public function testRefreshTokenRotation_OldTokenIsInvalidAfterRefresh(): void
+{
+    $tokens = $this->login();
+
+    $this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]);
+
+    // Altes Token muss abgelehnt werden
+    $res = $this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]);
+    $this->assertSame(401, $res->getStatusCode());
+}
+
+public function testRefreshTokenReuseRevokesAllUserTokens(): void
+{
+    $tokens = $this->login();
+
+    // Einmal rotieren — altes Token ist jetzt widerrufen
+    $newTokens = $this->json($this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]));
+
+    // Angreifer wiederholt das alte (widerrufene) Refresh-Token — löst revokeAllForUser() aus
+    $this->post('/auth/refresh', ['refresh_token' => $tokens['refresh_token']]);
+
+    // Das neu ausgestellte Refresh-Token ist jetzt ebenfalls widerrufen
+    $res = $this->post('/auth/refresh', ['refresh_token' => (string) $newTokens['refresh_token']]);
+    $this->assertSame(401, $res->getStatusCode());
+}
+```
+
+---
+
+## Siehe auch
+
+- `docs/howto/jwt-authentication.md` — JWT-Ausstellung, BearerTokenMiddleware, `nene2.auth.claims`
+- `docs/howto/password-hashing.md` — Argon2id, Dummy-Hash-Muster zur Benutzer-Enumerationsverhinderung
+- `docs/field-trials/2026-05-field-trial-113.md` — Refresh-Token-Rotation-Feldversuch

--- a/docs/de/howto/request-deduplication.md
+++ b/docs/de/howto/request-deduplication.md
@@ -1,0 +1,90 @@
+# Anfrage-Deduplizierung hinzufügen
+
+Verhindert doppelte Verarbeitung durch Netzwerk-Wiederholungen oder Doppelklicks mithilfe eines `Idempotency-Key`-Headers. Der Server cached Antworten pro Key und gibt sie bei nachfolgenden identischen Anfragen wieder ab.
+
+## Schema
+
+```sql
+CREATE TABLE idempotency_keys (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    method          TEXT NOT NULL,
+    path            TEXT NOT NULL,
+    status_code     INTEGER NOT NULL,
+    response_body   TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    expires_at      TEXT NOT NULL
+);
+```
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/payments` | Zahlung verarbeiten (Idempotency-Key erforderlich) |
+| `POST` | `/orders` | Bestellung erstellen (Idempotency-Key erforderlich) |
+
+## Handler-Muster
+
+Jeder mutierende Endpunkt, der idempotent sein soll, folgt demselben Dreischritt-Muster:
+
+```php
+// 1. Den Idempotency-Key-Header erfordern
+$key = trim($request->getHeaderLine('Idempotency-Key'));
+if ($key === '') {
+    return $this->json->create(['error' => 'Idempotency-Key header is required'], 400);
+}
+
+// 2. Gecachte Antwort zurückgeben, wenn der Key bereits verwendet wurde
+$cached = $this->repo->find($key);
+if ($cached !== null && $cached['expires_at'] >= $this->now()) {
+    $body = json_decode($cached['response_body'], true);
+    return $this->json->create(
+        array_merge($body, ['replayed' => true]),
+        (int) $cached['status_code']
+    );
+}
+
+// 3. Verarbeiten und cachen
+$result = $this->doWork($body);
+$this->repo->store($key, 'POST', '/payments', 201, json_encode($result), $now, $expiresAt);
+return $this->json->create($result, 201);
+```
+
+Das `replayed: true`-Feld signalisiert Clients, dass die Antwort aus dem Cache kam.
+
+## Strikte Betragsvalidierung
+
+Nicht-Integer-Eingaben an der Grenze ablehnen — PHPs `(int)`-Cast kürzt Strings wie `"100; DROP TABLE …"` stillschweigend auf `100`. Eine explizite Typprüfung verwenden:
+
+```php
+$rawAmount = $body['amount'] ?? null;
+if (!is_int($rawAmount) && !(is_string($rawAmount) && ctype_digit($rawAmount))) {
+    $errors[] = new ValidationError('amount', 'amount must be a positive integer', 'invalid');
+} else {
+    $amount = (int) $rawAmount;
+    if ($amount <= 0) {
+        $errors[] = new ValidationError('amount', 'amount must be a positive integer', 'invalid');
+    }
+}
+```
+
+## TTL und Ablauf
+
+Keys laufen nach 24 Stunden (86400 Sekunden) ab. Abgelaufene Einträge werden als frisch behandelt — derselbe Key kann nach dem Ablauf erneut verwendet werden:
+
+```php
+private const int TTL_SECONDS = 86400;
+
+$expiresAt = (new \DateTimeImmutable($now, new \DateTimeZone('UTC')))
+    ->modify('+' . self::TTL_SECONDS . ' seconds')
+    ->format('Y-m-d\TH:i:s\Z');
+```
+
+## Sicherheitseigenschaften
+
+- **SQL-Injection über Key-Header**: Parametrisierte Abfragen speichern schädliche Keys als Literale.
+- **Replay-Flood**: 10 identische Anfragen erstellen genau 1 Datensatz in der Geschäftstabelle.
+- **Nur-Leerzeichen-Key**: `trim()` vor der Leer-Prüfung verhindert `"   "` als gültigen Key.
+- **Typ-Injection in numerischen Feldern**: `ctype_digit()`-Prüfung lehnt partielle Integer-Strings ab.
+- **Keine internen Lecks**: 400/422-Antworten enthalten nur die `error`- oder `errors`-Felder — keine Pfade, Stack-Traces oder Engine-Details.

--- a/docs/de/howto/request-scoped-state.md
+++ b/docs/de/howto/request-scoped-state.md
@@ -1,0 +1,82 @@
+# Anfrage-gebundenen Zustand zwischen Middleware und Handlern weitergeben
+
+Einige Middlewares extrahieren einen Wert aus der eingehenden Anfrage — eine Tenant-ID, einen dekodierter JWT-Claim, einen Trace-Kontext — und Route-Handler benötigen diesen Wert nachgelagert. Diese Anleitung zeigt das empfohlene Muster mit `RequestScopedHolder`.
+
+## Das Holder-Muster
+
+`RequestScopedHolder<T>` ist ein kleiner, veränderbarer Container. Injizieren Sie **eine gemeinsame Instanz** sowohl in die Middleware, die ihn schreibt, als auch in den Handler (oder das Repository), der ihn liest:
+
+```php
+use Nene2\Http\RequestScopedHolder;
+
+// Gemeinsame Instanz — einmalig an der Composition-Root verdrahtet.
+/** @var RequestScopedHolder<int> $teamId */
+$teamId = new RequestScopedHolder();
+
+// Middleware schreibt ihn.
+$tenantMiddleware = new TenantMiddleware($teamId, $problemDetails);
+
+// Route-Handler liest ihn.
+$routeRegistrar = new TaskRouteRegistrar($repository, $teamId, $json);
+```
+
+Innerhalb der Middleware:
+
+```php
+public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+{
+    $raw = $request->getHeaderLine('X-Team-Id');
+    // ... validieren ...
+    $this->teamId->set((int) $raw);   // schreiben
+    return $handler->handle($request);
+}
+```
+
+Innerhalb des Route-Handlers:
+
+```php
+$id = $this->teamId->get();  // lesen — wirft LogicException, wenn Middleware nicht ausgeführt wurde
+```
+
+## Warum nicht PSR-7-Request-Attribute?
+
+PSR-7-Request-Attribute sind unveränderlich — jeder `withAttribute()`-Aufruf gibt eine neue Instanz zurück. Um ein Attribut von der Middleware an einen Handler weiterzugeben, müssen Sie das neue Request-Objekt durch die gesamte Aufrufkette fädeln, was der Dispatcher von NENE2 bereits tut. Die Verwendung von `withAttribute()` ist in Ordnung, wenn der nachgelagerte Code den `$request` direkt erhält.
+
+`RequestScopedHolder` ist das richtige Werkzeug, wenn der nachgelagerte Konsument den `$request` **nicht** erhält — zum Beispiel ein Repository, das nur Ihre Domain-Typen kennt und keinen PSR-7-Request als Abhängigkeit akzeptieren kann.
+
+## Mehrere Middlewares stapeln
+
+Übergeben Sie eine Liste an `RuntimeApplicationFactory::$authMiddleware`, um mehrere Middlewares nacheinander auszuführen:
+
+```php
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    authMiddleware: [
+        new TenantMiddleware($teamId, $probs),        // läuft zuerst
+        new BearerTokenMiddleware($probs, $verifier), // läuft zweites
+    ],
+))->create();
+```
+
+Beide Middlewares teilen dieselbe Pipeline-Position (nach dem Anfragengrößenlimit, vor der Ratenbegrenzung). Das erste Element der Liste verarbeitet die Anfrage vor dem zweiten.
+
+## Sicherheit: PHPs Shared-Nothing-Modell
+
+In PHP-FPM und CLI läuft jede Anfrage in einem frischen Prozess. Der `RequestScopedHolder`-Wert, der während Anfrage A gesetzt wird, ist für Anfrage B nie sichtbar, da jeder Prozess nach der Behandlung einer Anfrage beendet wird. Der Holder ist unter diesem Modell sicher zu verwenden.
+
+### Async-Runtimes (Swoole, ReactPHP, FrankenPHP Worker-Modus)
+
+Wenn mehrere Anfragen denselben PHP-Prozess teilen, behält ein während Anfrage A geschriebener Holder seinen Wert bis in Anfrage B bei, sofern er nicht explizit geleert wird. `reset()` zu Beginn (oder Ende) jedes Anfragezyklus aufrufen:
+
+```php
+// Beispiel Swoole-Request-Handler
+$server->on('request', function ($request, $response) use ($app, $teamId) {
+    $teamId->reset();            // Wert der vorherigen Anfrage löschen
+    $psrRequest = /* konvertieren */;
+    $psrResponse = $app->handle($psrRequest);
+    // $psrResponse ausgeben ...
+});
+```
+
+NENE2 zielt derzeit auf PHP-FPM / CLI und wird nicht mit eingebautem Async-Support ausgeliefert. Wenn Sie eine Async-Runtime verwenden, sind Sie für das Zurücksetzen gemeinsamer Holder zwischen Anfragen verantwortlich.

--- a/docs/de/howto/reservation-availability-api.md
+++ b/docs/de/howto/reservation-availability-api.md
@@ -1,0 +1,271 @@
+# Anleitung: Reservierungs- und Verfügbarkeits-API
+
+> **FT-Referenz**: FT336 (`NENE2-FT/reservelog`) — Ressourcenreservierungssystem mit Halboffenes-Intervall-Überlappungserkennung, statusbasierter Verfügbarkeitsabfrage, Stornierung-und-Wiederholung-Semantik und ATK-Cracker-Mindset-Angriffsbewertung, 16 Tests / 30+ Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie eine zustandslose Reservierungs-API erstellt wird, bei der Buchungen einen Lebenszyklus haben (`active` → `cancelled`) und die Verfügbarkeitsansicht nach Datumsbereich und Status filtert.
+
+## Schema
+
+```sql
+CREATE TABLE resources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE reservations (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL REFERENCES resources(id),
+    booker      TEXT    NOT NULL,  -- opaker Identifikator (Name, E-Mail, Benutzer-ID-String)
+    starts_at   TEXT    NOT NULL,
+    ends_at     TEXT    NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'active',  -- 'active' | 'cancelled'
+    created_at  TEXT    NOT NULL
+);
+```
+
+`status` verfolgt, ob ein Slot aktiv oder storniert ist. Nur `active`-Reservierungen blockieren zukünftige Buchungen.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST`   | `/resources` | Ressource erstellen |
+| `POST`   | `/reservations` | Slot buchen |
+| `GET`    | `/reservations/{id}` | Reservierungsdetails abrufen |
+| `DELETE` | `/reservations/{id}` | Reservierung stornieren |
+| `GET`    | `/resources/{id}/availability` | Aktive Reservierungen im Bereich auflisten |
+
+## Ressource erstellen
+
+```php
+POST /resources
+{"name": "Conference Room"}
+→ 201  {"id": 1, "name": "Conference Room", "created_at": "..."}
+
+POST /resources  {}
+→ 422  // name erforderlich
+```
+
+## Slot buchen
+
+```php
+POST /reservations
+{
+  "resource_id": 1,
+  "booker": "alice",
+  "starts_at": "2026-06-01 09:00:00",
+  "ends_at": "2026-06-01 10:00:00"
+}
+→ 201  {"id": 1, "booker": "alice", "status": "active", ...}
+```
+
+### Validierung
+
+```php
+// ends_at vor starts_at
+→ 422
+
+// starts_at == ends_at (Nulldauer)
+→ 422
+
+// Fehlende Pflichtfelder
+{"resource_id": 1}  → 422
+```
+
+### Überlappungsverhinderung
+
+Die Überlappungsprüfung verwendet **halboffene Intervalle**: `[starts_at, ends_at)`.
+
+```php
+// Vorhanden: 09:00–10:00
+POST /reservations  {"starts_at": "09:30", "ends_at": "10:30"}  → 409  Überlappung
+POST /reservations  {"starts_at": "09:00", "ends_at": "10:00"}  → 409  identisch
+POST /reservations  {"starts_at": "09:15", "ends_at": "09:45"}  → 409  enthalten
+
+// Angrenzend — Ende des ersten == Beginn des zweiten → KEIN Konflikt
+POST /reservations  {"starts_at": "10:00", "ends_at": "11:00"}  → 201  ✅
+
+// Andere Ressource — kein Konflikt, auch bei denselben Zeiten
+POST /reservations  {"resource_id": 2, "starts_at": "09:00", "ends_at": "10:00"}  → 201  ✅
+```
+
+```sql
+-- Konflikt-Abfrage (nur aktive Reservierungen prüfen)
+SELECT COUNT(*) FROM reservations
+WHERE resource_id = ?
+  AND status = 'active'
+  AND starts_at < ?   -- vorhanden.starts_at < neu.ends_at
+  AND ends_at   > ?   -- vorhanden.ends_at > neu.starts_at
+```
+
+## Reservierung abrufen
+
+```php
+GET /reservations/1
+→ 200  {"id": 1, "booker": "alice", "status": "active", ...}
+
+GET /reservations/999
+→ 404
+```
+
+## Reservierung stornieren
+
+```php
+DELETE /reservations/1
+→ 200  {"id": 1, "status": "cancelled"}
+
+// Bereits storniert
+DELETE /reservations/1
+→ 409  // kann nicht zweimal stornieren
+
+// Nicht gefunden
+DELETE /reservations/999
+→ 404
+```
+
+**Stornierung ist weich**: Der Datensatz wird mit `status = 'cancelled'` beibehalten. Stornierte Slots werden für eine Neubuchung freigegeben.
+
+```php
+// Nach Stornierung kann derselbe Slot erneut gebucht werden
+DELETE /reservations/1               → 200
+POST /reservations  {gleicher Slot...}   → 201  ✅ Slot ist frei
+```
+
+## Verfügbarkeitsansicht
+
+```php
+GET /resources/1/availability?from=2026-06-01&to=2026-06-02
+→ 200
+{
+  "reservations": [
+    {"id": 1, "booker": "alice", "starts_at": "2026-06-01 09:00:00", "ends_at": "2026-06-01 10:00:00"},
+    {"id": 2, "booker": "bob",   "starts_at": "2026-06-01 11:00:00", "ends_at": "2026-06-01 12:00:00"}
+  ]
+}
+
+// Stornierte Reservierungen sind NICHT enthalten
+// Fehlende from/to-Parameter
+GET /resources/1/availability
+→ 422
+```
+
+---
+
+## ATK-Bewertung — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Reservierung eines anderen Buchenden stornieren ⚠️ EXPONIERT
+
+**Angriff**: Angreifer errät oder entdeckt eine Reservierungs-ID und sendet `DELETE /reservations/{id}`, um die Buchung von jemand anderem zu stornieren.
+**Ergebnis**: EXPONIERT — Es gibt keine Authentifizierungsprüfung bei DELETE. Jeder Client, der eine Reservierungs-ID kennt, kann sie stornieren. Minderung: Authentifizierungstoken oder ein geheimes Stornierungstoken erfordern, das bei der Buchung ausgestellt wird (ähnlich einem Terminbestätigungscode).
+
+---
+
+### ATK-02 — Doppelbuchung durch schnelles Stornieren + Neubuchungs-Race 🚫 BLOCKIERT
+
+**Angriff**: Angreifer storniert eine Reservierung und bucht sie gleichzeitig erneut, um den Slot exklusiv zu belegen, während andere blockiert sind.
+**Ergebnis**: BLOCKIERT — Stornierung setzt `status = 'cancelled'` und die Überlappungsabfrage filtert nach `status = 'active'`. DB-Zeilensperrung verhindert, dass gleichzeitiges Stornieren+Buchen einen inkonsistenten Zustand sieht. Der Slot wird sauber freigegeben, bevor die nächste Buchung gelingen kann.
+
+---
+
+### ATK-03 — Überlappung einschleusen, um eine andere Buchung ablaufen zu lassen 🚫 BLOCKIERT
+
+**Angriff**: Angreifer sendet eine Buchung mit `starts_at`, das genau mit einer vorhandenen Buchungsgrenze übereinstimmt, in der Hoffnung, angrenzende Slots zu „absorbieren".
+**Ergebnis**: BLOCKIERT — Halboffene-Intervall-Semantik ist streng. `starts_at == vorhandene.ends_at` ist angrenzend, nicht überlappend. Das Einschleusen von Teilüberlappungen wird durch die SQL-Konfliktabfrage erfasst.
+
+---
+
+### ATK-04 — SQL-Injection über `booker`-Feld 🚫 BLOCKIERT
+
+**Angriff**: Angreifer sendet `"booker": "alice'; DROP TABLE reservations--"`, um die DB zu korrumpieren.
+**Ergebnis**: BLOCKIERT — Alle Abfragen verwenden parametrisierte Anweisungen. `booker` wird als gebundener Wert eingefügt, nie interpoliert.
+
+---
+
+### ATK-05 — `resource_id` überlaufen, um auf unerreichbare Ressourcen zuzugreifen 🚫 BLOCKIERT
+
+**Angriff**: Angreifer sendet `resource_id: 9999999999999999999`, um die Validierung zu umgehen.
+**Ergebnis**: BLOCKIERT — `resource_id` wird als positive Integer validiert. Überlaufwerte → 422. Die Ressourcen-Existenzprüfung gibt 404 für unbekannte IDs zurück, bevor irgendeine Buchungslogik ausgeführt wird.
+
+---
+
+### ATK-06 — Bereits stornierte Reservierung stornieren, um Zustandsverwirrung zu verursachen 🚫 BLOCKIERT
+
+**Angriff**: Angreifer sendet zweimal `DELETE /reservations/1` in der Hoffnung, dass der zweite Aufruf die Buchung reaktiviert oder den Status korrumpiert.
+**Ergebnis**: BLOCKIERT — Die zweite Stornierung gibt 409 Conflict zurück. Die Anwendung prüft `status = 'active'` vor der Stornierung; `status = 'cancelled'`-Datensätze werden nicht verändert.
+
+---
+
+### ATK-07 — Verfügbarkeitsabfrage mit massivem Datumsbereich (DoS) ⚠️ EXPONIERT
+
+**Angriff**: Angreifer sendet `GET /resources/1/availability?from=2000-01-01&to=2099-12-31`, um einen Hundertjahres-Dump zurückzugeben.
+**Ergebnis**: EXPONIERT — Keine maximale Bereichsgrenze wird erzwungen. Ein großer Datumsbereich gibt alle Reservierungen in diesem Fenster zurück, was möglicherweise einen langsamen DB-Scan verursacht. Minderung: Das `to - from`-Fenster begrenzen (z. B. 31 Tage) und 422 zurückgeben, wenn überschritten.
+
+---
+
+### ATK-08 — Slot in der Vergangenheit buchen 🚫 BLOCKIERT
+
+**Angriff**: Angreifer sendet `starts_at: "2020-01-01 00:00:00"`, um eine historische Reservierung zu erstellen und möglicherweise die Berichterstattung zu manipulieren.
+**Ergebnis**: BLOCKIERT — Der Server validiert `ends_at > starts_at`, erfordert aber standardmäßig nicht, dass `starts_at` in der Zukunft liegt. Für Produktionssysteme `starts_at >= now()`-Validierung hinzufügen, um vergangene Buchungen abzulehnen.
+
+---
+
+### ATK-09 — Ungültiges Datumsformat einschleusen 🚫 BLOCKIERT
+
+**Angriff**: Angreifer sendet `"starts_at": "not-a-date"`, um die Vergleichslogik zu korrumpieren.
+**Ergebnis**: BLOCKIERT — Datumsangaben werden vor jeder DB-Operation gegen das erwartete Format validiert. Ungültige Formate geben 422 zurück.
+
+---
+
+### ATK-10 — Verfügbarkeit für nicht existierende Ressource 🚫 BLOCKIERT
+
+**Angriff**: Angreifer fragt `GET /resources/9999/availability?from=...&to=...` ab, in der Hoffnung, Daten zu leaken oder Auth zu umgehen.
+**Ergebnis**: BLOCKIERT — Ressourcenexistenz wird geprüft; unbekannte Ressource → 404.
+
+---
+
+### ATK-11 — Zu langes Booker-Feld (Speichermissbrauch) ⚠️ EXPONIERT
+
+**Angriff**: Angreifer sendet einen 1 MB großen `booker`-String, um den Speicher zu erschöpfen.
+**Ergebnis**: EXPONIERT — Keine maximale Länge wird für `booker` erzwungen. Minderung: Eine `MAX_BOOKER_LENGTH`-Konstante hinzufügen (z. B. 255 Zeichen) und 422 zurückgeben, wenn überschritten.
+
+---
+
+### ATK-12 — Mehrfaches Stornieren, um Slots für Flash-Buchungsangriff freizugeben 🚫 BLOCKIERT
+
+**Angriff**: Angreifer storniert viele Reservierungen gleichzeitig und bucht sie schnell erneut, um eine Ressource zu monopolisieren.
+**Ergebnis**: BLOCKIERT — Jedes Stornieren+Neubuchungs-Paar muss die Überlappungsabfrage bestehen. Die DB serialisiert Schreibvorgänge pro Zeile; gleichzeitige Versuche können nicht beide für denselben Slot gelingen.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Reservierung eines anderen Buchenden stornieren | ⚠️ EXPONIERT |
+| ATK-02 | Doppelbuchung durch Stornieren + Neubuchungs-Race | 🚫 BLOCKIERT |
+| ATK-03 | Überlappung einschleusen, um angrenzende Slots zu absorbieren | 🚫 BLOCKIERT |
+| ATK-04 | SQL-Injection über Booker-Feld | 🚫 BLOCKIERT |
+| ATK-05 | resource_id überlaufen | 🚫 BLOCKIERT |
+| ATK-06 | Bereits stornierte stornieren (Zustandsverwirrung) | 🚫 BLOCKIERT |
+| ATK-07 | Verfügbarkeitsabfrage mit riesigem Datumsbereich | ⚠️ EXPONIERT |
+| ATK-08 | Slot in der Vergangenheit buchen | 🚫 BLOCKIERT |
+| ATK-09 | Ungültiges Datumsformat einschleusen | 🚫 BLOCKIERT |
+| ATK-10 | Verfügbarkeit für nicht existierende Ressource | 🚫 BLOCKIERT |
+| ATK-11 | Booker-Feld zu lang | ⚠️ EXPONIERT |
+| ATK-12 | Flash-Buchungsmonopolisierung | 🚫 BLOCKIERT |
+
+**9 BLOCKIERT, 3 EXPONIERT** — Kritisch: Stornierung authentifizieren; Verfügbarkeits-Datumsbereich begrenzen; Booker-Feldlänge begrenzen.
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Keine Auth bei DELETE /reservations/{id} | Jeder Client kann jede Buchung stornieren |
+| Stornierte Reservierungen hart löschen | Slot-Verlauf ist verloren; Verfügbarkeitslücken erscheinen im Prüfprotokoll |
+| Kein Statusfilter in der Überlappungsabfrage | Stornierte Slots blockieren neue Buchungen |
+| Geschlossene Intervalle in der Überlappungsprüfung | Angrenzende Slots (Ende = Beginn) werden fälschlicherweise als Konflikte abgelehnt |
+| Kein maximaler Datumsbereich bei Verfügbarkeit | Großer Bereich verursacht vollständigen Tabellen-Scan |
+| `starts_at >= ends_at` akzeptieren | Null- oder negative Dauer erzeugt Logikfehler |

--- a/docs/de/howto/resource-booking.md
+++ b/docs/de/howto/resource-booking.md
@@ -1,0 +1,155 @@
+# Anleitung: Ressourcenbuchungssystem
+
+## Überblick
+
+Diese Anleitung behandelt den Aufbau einer Ressourcenbuchungs-API mit NENE2. Zu den Funktionen gehören Kapazitätsdurchsetzung, Doppelbuchungsverhinderung, Per-Benutzer-IDOR-Isolation und Admin-Stornierung.
+
+**Referenzimplementierung**: `../NENE2-FT/bookinglog/`
+
+---
+
+## Schema-Design
+
+```sql
+CREATE TABLE IF NOT EXISTS resources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL UNIQUE,
+    capacity   INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bookings (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL,
+    user_id     INTEGER NOT NULL,
+    slot_date   TEXT    NOT NULL,   -- 'YYYY-MM-DD'
+    slot_hour   INTEGER NOT NULL,   -- 0-23
+    created_at  TEXT    NOT NULL,
+    cancelled   INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE CASCADE,
+    UNIQUE (resource_id, user_id, slot_date, slot_hour)
+);
+```
+
+Wichtige Einschränkungen:
+- `UNIQUE (resource_id, user_id, slot_date, slot_hour)` — eine Buchung pro Benutzer pro Slot.
+- `cancelled`-Soft-Delete-Flag — Geschichte beibehalten und gleichzeitig Neubuchungen erlauben.
+- Kapazität wird zur Abfragezeit geprüft (aktive Buchungen zählen vs. resource.capacity).
+
+---
+
+## Routentabelle
+
+| Methode | Pfad | Authentifizierung | Beschreibung |
+|---------|------|-------------------|-------------|
+| `GET` | `/resources` | Keine | Alle Ressourcen auflisten |
+| `POST` | `/resources` | Admin | Ressource erstellen |
+| `POST` | `/bookings` | Benutzer | Slot buchen |
+| `GET` | `/bookings` | Benutzer | Eigene Buchungen auflisten |
+| `GET` | `/bookings/{id}` | Benutzer | Eine Buchung abrufen |
+| `DELETE` | `/bookings/{id}` | Benutzer/Admin | Buchung stornieren |
+
+---
+
+## Doppelbuchungsverhinderung
+
+Zuerst prüfen, ob der Benutzer diesen Slot bereits hat (Anwendungsebene):
+
+```php
+$stmt = $this->pdo->prepare(
+    'SELECT id FROM bookings WHERE resource_id = :rid AND user_id = :uid
+     AND slot_date = :d AND slot_hour = :h AND cancelled = 0'
+);
+$stmt->execute([...]);
+if ($stmt->fetch() !== false) {
+    return 'double_booking';
+}
+```
+
+Dann Kapazität prüfen:
+
+```php
+$count = $this->countSlotBookings($resourceId, $date, $hour);
+if ($count >= (int) $resource['capacity']) {
+    return 'capacity_full';
+}
+```
+
+---
+
+## IDOR-Isolation
+
+Benutzer können nur ihre eigenen Buchungen lesen/stornieren. 404 zurückgeben (nicht 403), um die Existenz nicht preiszugeben:
+
+```php
+if (!$this->isAdmin($req) && (int) $booking['user_id'] !== $uid) {
+    return $this->problem(404, 'not-found', 'Booking not found.');
+}
+```
+
+---
+
+## Admin-Stornierung ohne X-User-Id
+
+Admin kann jede Buchung stornieren, ohne seine eigene Benutzer-ID anzugeben:
+
+```php
+$isAdmin = $this->isAdmin($req);
+$uid     = $this->uid($req);
+if ($uid === null && !$isAdmin) {
+    return $this->problem(400, 'bad-request', 'X-User-Id required.');
+}
+$result = $this->repo->cancel($id, $uid ?? 0, $isAdmin);
+```
+
+---
+
+## Validierungsregeln
+
+| Feld | Regel |
+|------|-------|
+| `resource_id` | `is_int()` + positiv |
+| `slot_date` | Regex `/\A\d{4}-\d{2}-\d{2}\z/` |
+| `slot_hour` | `is_int()` + 0–23 |
+| `capacity` | `is_int()` + positiv |
+| `name` | Nicht-leerer String |
+
+---
+
+## HTTP-Statuscodes
+
+| Situation | Status |
+|-----------|--------|
+| Ressource erstellt | 201 |
+| Buchung bestätigt | 201 |
+| Buchung gefunden / Liste | 200 |
+| Kein X-User-Id | 400 |
+| Ungültiger Feldtyp | 422 |
+| Ungültiges Datumsformat | 422 |
+| slot_hour außerhalb 0–23 | 422 |
+| Ressource nicht gefunden | 404 |
+| Buchung nicht gefunden | 404 |
+| Kein Admin-Key | 403 |
+| Eigene Buchung stornieren | 200 |
+| Fremde Buchung stornieren | 403 |
+| Doppelbuchung | 409 |
+| Kapazität voll | 409 |
+
+---
+
+## Abgedeckte VULN-Muster
+
+| VULN | Muster | Abwehr |
+|------|--------|--------|
+| A | IDOR: Benutzer sieht fremde Buchung | `WHERE user_id = :uid` + 404 |
+| B | Negative resource_id | `is_int() + > 0`-Prüfung |
+| C | Null als slot_hour (Mitternacht) | 0-23-Bereich erlaubt 0 |
+| D | SQL-Injection in slot_date | Regex-Validierung + parametrisierte Abfrage |
+| E | String resource_id Typverwechslung | `is_int()`-strikte Prüfung |
+| F | Doppelbuchung | Existenzprüfung vor INSERT |
+| G | Kapazitätsüberlauf | COUNT vs. Kapazitätsprüfung |
+| H | Kein X-User-Id | 400 mit Meldung |
+| I | Fremde Buchung stornieren | `user_id`-Eigentümerprüfung → 403 |
+| J | Liste gibt fremde Benutzerdaten preis | `WHERE user_id = :uid` |
+| K | Admin storniert jede Buchung | `isAdmin`-Bypass-Eigentümerschaft |
+| L | slot_hour = 24 (außerhalb des Bereichs) | `$hour > 23` → 422 |

--- a/docs/de/howto/resource-reservation-booking.md
+++ b/docs/de/howto/resource-reservation-booking.md
@@ -1,0 +1,231 @@
+# Anleitung: Ressourcenreservierung und Buchungs-API
+
+> **FT-Referenz**: FT335 (`NENE2-FT/reservationlog`) — Ressourcen-Zeitslot-Buchung mit Halboffenes-Intervall-Überlappungsverhinderung, user_id aus öffentlichen Antworten ausgeschlossen, Stornierung-IDOR-Schutz (403), Admin/Benutzer-Dual-Level-Zugriff, 30 Tests / 70+ Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Raum/Ressourcen-Buchungssystem erstellt wird: buchbare Ressourcen erstellen (Admin), Zeitslots buchen (Benutzer), Überlappungen atomar verhindern und die Privatsphäre der Benutzer in öffentlichen Antworten schützen.
+
+## Schema
+
+```sql
+CREATE TABLE resources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE bookings (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL REFERENCES resources(id),
+    user_id     INTEGER NOT NULL,
+    starts_at   TEXT    NOT NULL,   -- ISO 8601 UTC
+    ends_at     TEXT    NOT NULL,
+    note        TEXT,               -- optional
+    created_at  TEXT    NOT NULL
+);
+```
+
+Datumsangaben werden als ISO 8601 UTC-Strings gespeichert (`2026-06-01T09:00:00Z`). Lexikografischer Vergleich ist für UTC ISO-Strings korrekt.
+
+## Endpunkte
+
+| Methode | Pfad | Authentifizierung | Beschreibung |
+|---------|------|-------------------|-------------|
+| `POST` | `/resources` | Admin | Buchbare Ressource erstellen |
+| `POST` | `/resources/{id}/book` | Benutzer | Zeitslot buchen |
+| `DELETE` | `/bookings/{id}` | Benutzer (Eigentümer) | Eigene Buchung stornieren |
+| `GET` | `/bookings` | Benutzer | Eigene Buchungen auflisten |
+| `GET` | `/resources/{id}/bookings` | Admin | Alle Buchungen für Ressource auflisten |
+
+## Ressource erstellen (Admin)
+
+```php
+POST /resources
+X-Admin-Key: admin-secret
+{"name": "Meeting Room 1"}
+→ 201  {"resource": {"id": 1, "name": "Meeting Room 1", "created_at": "..."}}
+
+// Kein Admin-Key
+POST /resources  {"name": "Room"}
+→ 401
+
+POST /resources  X-Admin-Key: admin-secret  {"name": ""}
+→ 422  // name erforderlich
+
+POST /resources  X-Admin-Key: admin-secret  {"name": "x".repeat(201)}
+→ 422  // name zu lang (max 200 Zeichen)
+```
+
+## Zeitslot buchen
+
+```php
+POST /resources/1/book
+X-User-Id: 101
+{"starts_at": "2026-06-01T09:00:00Z", "ends_at": "2026-06-01T10:00:00Z"}
+→ 201
+{
+  "booking": {
+    "id": 1,
+    "resource_id": 1,
+    "starts_at": "2026-06-01T09:00:00Z",
+    "ends_at": "2026-06-01T10:00:00Z",
+    "note": null,
+    "created_at": "..."
+    // user_id wird NICHT zurückgegeben — IDOR-Prävention
+  }
+}
+
+// Optionale Notiz
+POST /resources/1/book  X-User-Id: 101
+{"starts_at": "2026-06-01T09:00:00Z", "ends_at": "2026-06-01T10:00:00Z", "note": "Team meeting"}
+→ 201  {"booking": {..., "note": "Team meeting"}}
+```
+
+### Validierungsfehler
+
+```php
+// ends_at vor starts_at
+{"starts_at": "2026-06-01T10:00:00Z", "ends_at": "2026-06-01T09:00:00Z"}
+→ 422
+
+// starts_at == ends_at (Nulldauer)
+{"starts_at": "2026-06-01T09:00:00Z", "ends_at": "2026-06-01T09:00:00Z"}
+→ 422
+
+// Fehlendes starts_at
+{"ends_at": "2026-06-01T10:00:00Z"}
+→ 422
+
+// Fehlender X-User-Id
+POST /resources/1/book  (kein Header)
+→ 400
+
+// Null oder Überlauf X-User-Id
+X-User-Id: 0    → 400
+X-User-Id: 9999999999999999999  → 400
+
+// Unbekannte Ressource
+POST /resources/9999/book  X-User-Id: 101  {...}
+→ 404
+```
+
+## Überlappungsverhinderung — Halboffene Intervalle
+
+Slots sind **halboffen**: `[starts_at, ends_at)`. Das Ende einer Buchung und der Beginn der nächsten sind gleich, aber nicht überlappend.
+
+```php
+// 09:00–10:00 buchen
+POST /resources/1/book  {"starts_at": "09:00", "ends_at": "10:00"}  → 201
+
+// Überlappend — beginnt innerhalb des vorhandenen Slots
+POST /resources/1/book  {"starts_at": "10:00", "ends_at": "11:00"}  → 201  ✅ angrenzend, erlaubt
+
+// Überlappend — innerhalb
+POST /resources/1/book  {"starts_at": "09:30", "ends_at": "11:00"}  → 409  ❌ Überlappung
+
+// Identischer Slot
+POST /resources/1/book  {"starts_at": "09:00", "ends_at": "10:00"}  → 409  ❌
+
+// Nicht überlappend auf derselben Ressource
+POST /resources/1/book  {"starts_at": "14:00", "ends_at": "15:00"}  → 201  ✅
+
+// Gleicher Slot auf ANDERER Ressource — immer erlaubt
+POST /resources/2/book  {"starts_at": "09:00", "ends_at": "10:00"}  → 201  ✅
+```
+
+### Überlappungs-SQL-Abfrage
+
+```sql
+-- Konflikt erkennen: NOT (neu.ends_at <= vorhanden.starts_at OR neu.starts_at >= vorhanden.ends_at)
+SELECT COUNT(*) FROM bookings
+WHERE resource_id = ?
+  AND starts_at < ?   -- vorhanden.starts_at < neu.ends_at
+  AND ends_at   > ?   -- vorhanden.ends_at > neu.starts_at
+```
+
+Wenn Anzahl > 0, 409 Conflict zurückgeben.
+
+## Buchung stornieren (IDOR-Schutz)
+
+```php
+DELETE /bookings/1
+X-User-Id: 101
+→ 200  {"cancelled": true}
+
+// Falscher Benutzer → 403, NICHT 404
+DELETE /bookings/1
+X-User-Id: 102
+→ 403  // Benutzer 102 besitzt Buchung 1 nicht
+
+// Nicht gefunden → 404
+DELETE /bookings/9999
+X-User-Id: 101
+→ 404
+```
+
+**403 zurückgeben (nicht 404) bei falscher Benutzer-Stornierung** — 404 zurückzugeben würde Benutzern erlauben, Buchungs-IDs anderer Benutzer zu sondieren. Die Buchung existiert; der Anforderer ist nicht der Eigentümer.
+
+```php
+// Nach Stornierung ist der Slot frei
+DELETE /bookings/1  X-User-Id: 101  → 200
+POST /resources/1/book  X-User-Id: 102  {"starts_at": "09:00", "ends_at": "10:00"}  → 201
+```
+
+### ID-Validierung
+
+```php
+DELETE /bookings/0                    → 422  // null ist ungültig
+DELETE /bookings/99999999999999999999 → 422  // Überlauf
+POST /resources/0/book  X-User-Id: 101 {...} → 422  // resource_id null ungültig
+```
+
+## Eigene Buchungen auflisten (Benutzer)
+
+```php
+GET /bookings
+X-User-Id: 101
+→ 200
+{
+  "total": 2,
+  "data": [
+    {"id": 1, "resource_id": 1, "starts_at": "...", "ends_at": "...", "note": null, "created_at": "..."}
+    // user_id ist NICHT enthalten
+  ]
+}
+
+// Buchungen anderer Benutzer werden nicht zurückgegeben
+// Benutzer 101 sieht nur seine eigenen Buchungen, auch wenn Benutzer 102 Buchungen hat
+```
+
+## Ressourcenbuchungen auflisten (Admin)
+
+```php
+GET /resources/1/bookings
+X-Admin-Key: admin-secret
+→ 200
+{
+  "total": 2,
+  "data": [
+    {"id": 1, "user_id": 101, "starts_at": "2026-06-01T09:00:00Z", ...},  // user_id sichtbar
+    {"id": 2, "user_id": 102, "starts_at": "2026-06-01T14:00:00Z", ...}
+  ]
+}
+// Geordnet nach starts_at ASC
+
+GET /resources/1/bookings  (kein Admin-Key)  → 401
+GET /resources/9999/bookings  X-Admin-Key: key  → 404
+```
+
+Admin erhält `user_id` in der Antwort; öffentliche Benutzerendpunkte geben nie `user_id` zurück.
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Überlappungsprüfung: `neu.starts_at < vorhanden.ends_at AND neu.ends_at > vorhanden.starts_at` (geschlossene Intervalle) | Angrenzende Slots (Ende von A = Beginn von B) werden fälschlicherweise als überlappend abgelehnt |
+| `user_id` in öffentlichen Buchungsantworten zurückgeben | Gibt preis, wem jede Buchung gehört, und ermöglicht Benutzer-Enumeration |
+| 404 bei falscher Benutzer-Stornierung zurückgeben | Angreifer bestätigt, dass die Buchung existiert; 403 verwenden, um Eigentümerschafts-Nichtübereinstimmung anzuzeigen |
+| `starts_at >= ends_at` akzeptieren | Buchungen mit Null- oder negativer Dauer korrumpieren Verfügbarkeitsberechnungen |
+| Kein resource_id-Scoping in der Überlappungsabfrage | Buchung von Benutzer A auf Ressource 1 blockiert Ressource 2 (falscher Konflikt) |
+| `user_id` aus dem Request-Body vertrauen | Angreifer erstellt Buchungen im Namen eines beliebigen Benutzers; Identität immer aus `X-User-Id`-Header lesen |

--- a/docs/de/howto/resource-reservation.md
+++ b/docs/de/howto/resource-reservation.md
@@ -1,0 +1,154 @@
+# Anleitung: Ressourcenreservierung / Zeitslot-Buchungs-API
+
+Diese Anleitung zeigt, wie ein Zeitslot-Buchungssystem mit Überlappungsverhinderung unter Verwendung von NENE2 erstellt wird. Muster demonstriert durch das **reservationlog**-Feldversuch (FT216).
+
+## Funktionen
+
+- Benannte Ressourcen erstellen (Besprechungsräume, Geräte usw.) — nur Admin
+- Zeitslots mit automatischer Überlappungserkennung buchen
+- Buchungen pro Ressource (Admin) oder pro Benutzer (selbst) auflisten
+- Buchungen mit Eigentümerschaftsverifizierung stornieren
+- Öffentliche Antworten schließen `user_id` aus (IDOR-Prävention)
+- Admin-Ansicht enthält `user_id` für Prüfzwecke
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS resources (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bookings (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL,
+    user_id     INTEGER NOT NULL,
+    starts_at   TEXT    NOT NULL,   -- ISO 8601 UTC
+    ends_at     TEXT    NOT NULL,   -- ISO 8601 UTC
+    note        TEXT,
+    created_at  TEXT    NOT NULL,
+    FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE CASCADE
+);
+
+-- Index für schnelle Überlappungsabfragen
+CREATE INDEX IF NOT EXISTS idx_bookings_resource_time
+    ON bookings (resource_id, starts_at, ends_at);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Authentifizierung | Beschreibung |
+|---------|------|-------------------|-------------|
+| `POST` | `/resources` | Admin | Ressource erstellen |
+| `GET` | `/resources/{id}/bookings` | Admin | Alle Buchungen für Ressource auflisten |
+| `POST` | `/resources/{id}/book` | Benutzer | Zeitslot buchen |
+| `GET` | `/bookings` | Benutzer | Eigene Buchungen auflisten |
+| `DELETE` | `/bookings/{id}` | Benutzer | Eigene Buchung stornieren |
+
+## Überlappungserkennung
+
+Zwei Zeitbereiche `[A.start, A.end)` und `[B.start, B.end)` überlappen sich, wenn:
+
+```
+A.start < B.end AND A.end > B.start
+```
+
+Dies behandelt alle Überlappungsfälle korrekt (enthält, überlappt, identisch), während angrenzende Slots erlaubt werden (A.end = B.start ist OK — Halboffenes-Intervall-Semantik).
+
+```sql
+SELECT COUNT(*) FROM bookings
+WHERE resource_id = :rid
+  AND starts_at < :ends_at
+  AND ends_at   > :starts_at
+```
+
+```php
+public function book(int $resourceId, int $userId, string $startsAt, string $endsAt, ?string $note): ?Booking
+{
+    $overlap = $this->countOverlaps($resourceId, $startsAt, $endsAt, excludeId: null);
+    if ($overlap > 0) {
+        return null; // → 409 Conflict
+    }
+    // ... INSERT
+}
+```
+
+## Value Objects
+
+Readonly-Value-Objects für Domain-Klarheit verwenden:
+
+```php
+final readonly class Booking
+{
+    public function __construct(
+        public int     $id,
+        public int     $resourceId,
+        public int     $userId,
+        public string  $startsAt,
+        public string  $endsAt,
+        public ?string $note,
+        public string  $createdAt,
+    ) {}
+
+    /** Öffentliche Ansicht: schließt user_id aus (IDOR-Prävention) */
+    public function toPublicArray(): array { ... }
+
+    /** Admin-Ansicht: enthält user_id für Prüfzwecke */
+    public function toAdminArray(): array { ... }
+}
+```
+
+## IDOR-Prävention
+
+Buchungen bieten öffentliche und Admin-Ansichten mit verschiedenen Feldern:
+
+```php
+// Benutzer: GET /bookings — öffentliche Ansicht (kein user_id)
+return $this->responseFactory->create([
+    'data'  => array_map(fn(Booking $b) => $b->toPublicArray(), $bookings),
+    'total' => count($bookings),
+]);
+
+// Admin: GET /resources/{id}/bookings — Admin-Ansicht (enthält user_id)
+return $this->responseFactory->create([
+    'data'  => array_map(fn(Booking $b) => $b->toAdminArray(), $bookings),
+    'total' => count($bookings),
+]);
+```
+
+Stornierung gibt 403 zurück (nicht 404), wenn ein Benutzer versucht, die Buchung von jemand anderem zu stornieren, da die Buchungs-ID bereits sichtbar ist (keine versteckte Existenz):
+
+```php
+/** @return 'cancelled'|'not_found'|'not_owner' */
+public function cancel(int $id, int $userId): string
+{
+    $booking = $this->findBookingById($id);
+    if ($booking === null) return 'not_found';     // → 404
+    if ($booking->userId !== $userId) return 'not_owner'; // → 403
+    // DELETE ...
+    return 'cancelled'; // → 200
+}
+```
+
+## Sicherheitsmuster
+
+- **Admin Fail-Closed**: `if ($this->adminKey === '') return false;` vor `hash_equals()`
+- **`ctype_digit()`**: ReDoS-sichere Integer-Validierung für Pfad-IDs
+- **ISO 8601-Validierung**: Regex-Muster + lexikografischer Vergleich (funktioniert in UTC)
+- **Notiz-Längenbegrenzung**: `mb_strlen($note) > 500` gibt 422 zurück
+- **Kaskadierende Löschung**: `ON DELETE CASCADE` stellt sicher, dass Buchungen mit der Ressource entfernt werden
+
+## VULN + ATK-Bewertung (FT216)
+
+Dieser FT besteht vollständige VULN-A bis VULN-L und ATK-01 bis ATK-12-Bewertungen:
+
+- **VULN-B**: Keine Mass-Assignment — Ressourcen-/Buchungsfelder werden explizit gebunden
+- **VULN-C**: Stornierung gibt 403 für falschen Eigentümer zurück; Ressourcen-/Buchungsnachschlager verwenden typisierte IDs
+- **VULN-D**: Admin Fail-Closed — leerer Admin-Key gibt immer false zurück
+- **VULN-F**: ISO 8601-Regex verhindert Datetime-Injection
+- **VULN-G**: `ctype_digit()` schützt alle Integer-Pfadparameter
+- **ATK-01**: SQL-Injection durch parametrisierte Abfragen blockiert
+- **ATK-02/03**: Integer-Überlauf in IDs durch `strlen > 18`-Prüfung blockiert
+- **ATK-06**: Authentifizierungs-Bypass durch Fail-Closed-Admin-Prüfung blockiert
+- **ATK-09**: Überlappungslogik verhindert Doppelbuchungen korrekt

--- a/docs/de/howto/scheduled-publish-article.md
+++ b/docs/de/howto/scheduled-publish-article.md
@@ -1,0 +1,126 @@
+# Anleitung: Geplante Artikelveröffentlichung
+
+> **FT-Referenz**: FT330 (`NENE2-FT/pubschedulelog`) — Artikel-Entwurf/Planung/Veröffentlichung/Archiv-Lebenszyklus, nur-Eigentümer-Entwurfszugriff, öffentliche veröffentlichte Artikel, geplanter Veröffentlichungs-Trigger, 34 Tests / 95 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Artikelverwaltungssystem mit verzögerter Veröffentlichung erstellt wird: Autoren schreiben Entwürfe, planen sie für einen zukünftigen Zeitpunkt, und ein Hintergrundjob (oder API-Aufruf) überführt sie in den veröffentlichten Zustand.
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    author_id  INTEGER NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    status     TEXT    NOT NULL DEFAULT 'draft',   -- draft | scheduled | published | archived
+    publish_at TEXT,                               -- ISO-8601, NULL, sofern nicht geplant
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+## Statusübergänge
+
+```
+draft ──veröffentlichen──► published ──archivieren──► archived
+  │
+  └──planen──► scheduled ──(Zeit vergeht)──► published
+  │                  │
+  │               Planung aufheben
+  │                  │
+  └──────────────────┘
+```
+
+Nur erlaubte Übergänge — ungültige Übergänge geben 409 zurück.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST`  | `/articles` | Entwurf erstellen (`X-User-Id` erforderlich) |
+| `GET`   | `/articles/{id}` | Abrufen (Entwurf: nur Eigentümer; veröffentlicht: öffentlich) |
+| `PUT`   | `/articles/{id}` | Entwurf aktualisieren (`X-User-Id` erforderlich) |
+| `POST`  | `/articles/{id}/publish` | Sofort veröffentlichen |
+| `POST`  | `/articles/{id}/schedule` | Für zukünftigen Zeitpunkt planen |
+| `POST`  | `/articles/{id}/unschedule` | Zurück zum Entwurf |
+| `POST`  | `/articles/{id}/archive` | Veröffentlichten Artikel archivieren |
+| `GET`   | `/articles` | Auflisten (mit `?status=`-Filter) |
+| `POST`  | `/publish-due` | Geplante Artikel nach publish_at auslösen |
+
+## Entwurf erstellen
+
+```php
+POST /articles  X-User-Id: 1
+{"title": "Hello", "body": "World"}
+→ 201  {"id": 1, "status": "draft", "author_id": 1}
+
+// Keine Auth → 401
+```
+
+## Sichtbarkeitsregeln
+
+```php
+// Entwurf: nur Eigentümer
+GET /articles/1  X-User-Id: 1  → 200   // Autor sieht eigenen Entwurf
+GET /articles/1  X-User-Id: 2  → 404   // anderer Benutzer kann Entwurf nicht sehen
+GET /articles/1               → 404   // keine Auth, Entwurf ausgeblendet
+
+// Veröffentlicht: alle
+GET /articles/1               → 200   // öffentlich
+```
+
+## Veröffentlichen und Archivieren
+
+```php
+POST /articles/1/publish  X-User-Id: 1  → 200  {"status": "published"}
+POST /articles/1/archive  X-User-Id: 1  → 200  {"status": "archived"}
+
+// Entwurf kann nicht archiviert werden
+POST /articles/1/archive  X-User-Id: 1  → 409
+```
+
+## Planen
+
+```php
+// Für 1 Stunde ab jetzt planen
+POST /articles/1/schedule  X-User-Id: 1
+{"publish_at": "2026-05-27T15:00:00+09:00"}
+→ 200  {"status": "scheduled", "publish_at": "2026-05-27T15:00:00+09:00"}
+
+// Vergangener Zeitpunkt → 422
+POST /articles/1/schedule  X-User-Id: 1
+{"publish_at": "2020-01-01T00:00:00Z"}
+→ 422
+
+// Planung aufheben → zurück zum Entwurf
+POST /articles/1/unschedule  X-User-Id: 1
+→ 200  {"status": "draft", "publish_at": null}
+```
+
+## Geplante Artikel auslösen
+
+Ein Cron-Job oder Admin-Endpunkt überführt alle geplanten Artikel mit `publish_at <= now`:
+
+```php
+POST /publish-due
+→ 200  {"published_count": 3}
+```
+
+## Artikel auflisten
+
+```php
+GET /articles?status=published      → 200  // öffentlich, keine Auth nötig
+GET /articles?status=draft  X-User-Id: 1  → 200  // nur eigene Entwürfe
+```
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Entwurf nicht authentifizierten Benutzern zeigen | Unveröffentlichte Inhalte lecken |
+| Planung in der Vergangenheit erlauben | Artikel würde „sofort" über den Trigger-Job veröffentlicht werden, Überprüfung umgehend |
+| Echtzeit-now() im Test für Planungs-Trigger verwenden | Tests werden zeitabhängig; in Tests Force-Insert mit vergangenem `publish_at` verwenden |
+| Hard-Delete beim Archivieren | Prüfpfad verloren gehen; Statusfeld verwenden |
+| Übergang von archived → published erlauben | Entfernte Inhalte werden zurückgebracht; explizite Neuveröffentlichung erfordern |

--- a/docs/de/howto/scheduled-reminders.md
+++ b/docs/de/howto/scheduled-reminders.md
@@ -1,0 +1,285 @@
+# Anleitung: Geplante Erinnerungs-API
+
+> **FT-Referenz**: FT235 (`NENE2-FT/reminderlog`) — Geplante Erinnerungs-API
+
+Demonstriert eine Erinnerungs-Planungs-API mit zeitzonenbewusster zukünftiger Datetime-Validierung,
+leichter Per-Anfrage-Benutzeridentifikation über einen Header, IDOR-Prävention durch
+eigentümerschaftsbeschränkte Abfragen und eine 404/409-Unterscheidung beim Stornieren einer Erinnerung.
+
+---
+
+## Routen
+
+| Methode  | Pfad                        | Beschreibung                                           |
+|----------|-----------------------------|--------------------------------------------------------|
+| `POST`   | `/reminders`                | Erinnerung erstellen (zukünftiges `remind_at` erforderlich) |
+| `GET`    | `/reminders`                | Erinnerungen des Aufrufers auflisten (nach Status filterbar) |
+| `PATCH`  | `/reminders/{id}/cancel`    | Ausstehende Erinnerung stornieren                      |
+
+Alle Routen erfordern den `X-User-Id`-Header.
+
+---
+
+## Leichte Benutzeridentifikation über Header
+
+Statt Bearer-JWT verwendet diese API einen `X-User-Id`-Integer-Header als minimalen
+Authentifizierungs-/Identifikationsmechanismus:
+
+```php
+$userId = V::userId($request->getHeaderLine('X-User-Id'));
+
+if ($userId === null) {
+    return $this->responseFactory->create(
+        ['error' => 'X-User-Id header must be a positive integer.'],
+        401,
+    );
+}
+```
+
+`V::userId()` validiert den Header-Wert:
+
+```php
+public static function userId(string $header): ?int
+{
+    // ctype_digit('') === false — leerer String wird bereits abgelehnt.
+    if (!ctype_digit($header) || strlen($header) > 18) {
+        return null;
+    }
+
+    $id = (int) $header;
+
+    return $id > 0 ? $id : null;
+}
+```
+
+Wichtige Eigenschaften:
+- `ctype_digit()` — ReDoS-immun, lehnt `0`, `-1`, `1.5`, `abc`, leeren String ab.
+- `strlen > 18` — Überlauf-Schutz vor dem `(int)`-Cast (PHP_INT_MAX hat 19 Ziffern).
+- `$id > 0` — lehnt den geparsten Integer null ab.
+
+Für die Produktion durch JWT- oder Session-Validierung ersetzen. Das `X-User-Id`-Muster ist
+für interne Dienste geeignet, wo das vorgelagerte Gateway den Benutzer bereits authentifiziert
+hat und seine ID weiterleitet.
+
+---
+
+## Zukünftige Datetime-Validierung (zeitzonenbewusst)
+
+`remind_at` muss ein gültiges ISO 8601-Datetime mit einem expliziten Zeitzonenoffset sein **und**
+muss relativ zu jetzt strikt in der Zukunft liegen:
+
+```php
+$now      = (new DateTimeImmutable())->format(DATE_ATOM);
+$remindAt = V::futureDatetime($rawRemindAt, $now);
+
+if ($remindAt === null) {
+    return $this->responseFactory->create(
+        ['error' => 'remind_at must be a valid ISO 8601 datetime with timezone offset and must be in the future.'],
+        422,
+    );
+}
+```
+
+`V::futureDatetime()` kombiniert zwei Prüfungen:
+
+```php
+public static function futureDatetime(mixed $raw, string $now): ?string
+{
+    $dt = self::isoDatetime($raw);   // Schritt 1: Format- und Bereichsvalidierung
+
+    if ($dt === null) {
+        return null;
+    }
+
+    // Schritt 2: zeitzonenbewusste Zukunftsprüfung
+    $dtObj  = DateTimeImmutable::createFromFormat(DATE_ATOM, $dt);
+    $nowObj = DateTimeImmutable::createFromFormat(DATE_ATOM, $now);
+
+    if ($dtObj === false || $nowObj === false) {
+        return null;
+    }
+
+    return $dtObj > $nowObj ? $dt : null;  // Objektvergleich normalisiert auf UTC
+}
+```
+
+`V::isoDatetime()` führt zuerst die Formatprüfung durch:
+
+```php
+public static function isoDatetime(mixed $raw): ?string
+{
+    // Striktes Regex: erfordert ±HH:MM-Offset — lehnt 'Z', nur-Datum, fehlenden Offset ab.
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-])(\d{2}):(\d{2})$/', $raw, $m)) {
+        return null;
+    }
+
+    // Zeitzonenoffset-Bereich validieren: gültige UTC-Offsets sind −14:00 … +14:00.
+    $tzHours   = (int) $m[2];
+    $tzMinutes = (int) $m[3];
+
+    if ($tzHours > 14 || $tzMinutes > 59 || ($tzHours === 14 && $tzMinutes > 0)) {
+        return null;
+    }
+    // ... Roundtrip-Validierung für Überlaufdaten (30. Feb. usw.)
+}
+```
+
+Der `DateTimeImmutable`-Objektvergleich (`>`) konvertiert beide Seiten vor dem
+Vergleich auf UTC — sodass `2026-06-01T09:00:00+09:00` (00:00 UTC) korrekt mit
+`2026-06-01T01:00:00+01:00` (00:00 UTC) als gleich verglichen wird.
+
+---
+
+## IDOR-Prävention: eigentümerschaftsbeschränkte Suche
+
+Alle Operationen, die eine bestimmte Erinnerung berühren, verwenden `WHERE id = ? AND user_id = ?`:
+
+```php
+public function findForUser(int $id, int $userId): ?Reminder
+{
+    $stmt = $this->pdo->prepare('SELECT * FROM reminders WHERE id = ? AND user_id = ?');
+    $stmt->execute([$id, $userId]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    return is_array($row) ? $this->hydrate($row) : null;
+}
+```
+
+Wenn die Erinnerung einem anderen Benutzer gehört, gibt `findForUser()` `null` zurück — der Aufrufer
+erhält `404 Not Found`, nicht von „Erinnerung existiert nicht" zu unterscheiden. Die Rückgabe von
+`403 Forbidden` würde bestätigen, dass die ID existiert, und Enumerationsinformationen preisgeben.
+
+---
+
+## 404 vs. 409: Stornierung mit vorherigem Abruf
+
+Der Stornierungshandler ruft die Erinnerung ab, bevor er den Status prüft. Dieser Zwei-Schritte-Ansatz
+ermöglicht die Rückgabe des korrekten HTTP-Status für jeden Fehlerfall:
+
+```php
+// Zuerst abrufen, um 404 (nicht gefunden/falscher Eigentümer) von 409 (falscher Status) zu unterscheiden
+$reminder = $this->repository->findForUser($id, $userId);
+
+if ($reminder === null) {
+    return $this->responseFactory->create(['error' => 'Reminder not found.'], 404);
+}
+
+if ($reminder->status !== ReminderStatus::Pending) {
+    return $this->responseFactory->create(
+        ['error' => sprintf('Cannot cancel a reminder with status "%s".', $reminder->status->value)],
+        409,
+    );
+}
+
+$this->repository->cancel($id, $userId);
+```
+
+Die DB-seitige Stornierung enthält die Statusprüfung als Sicherheits-Backup:
+
+```php
+public function cancel(int $id, int $userId): bool
+{
+    $stmt = $this->pdo->prepare(
+        "UPDATE reminders SET status = 'cancelled' WHERE id = ? AND user_id = ? AND status = 'pending'"
+    );
+    $stmt->execute([$id, $userId]);
+
+    return $stmt->rowCount() > 0;
+}
+```
+
+`WHERE status = 'pending'` im UPDATE stellt sicher, dass eine Race Condition (zwei gleichzeitige
+Stornierungsanfragen) dazu führt, dass nur eine Zeile aktualisiert wird.
+
+---
+
+## Abfrageparameter-Validierung (`?limit=` und `?status=`)
+
+`limit` verwendet `V::queryInt()`, das zwischen fehlendem Schlüssel (Standard verwenden) und ungültigem
+Wert (422 zurückgeben) unterscheidet:
+
+```php
+$limit = V::queryInt(
+    $params,
+    'limit',
+    ReminderRepository::MIN_LIMIT,   // 1
+    ReminderRepository::MAX_LIMIT,   // 100
+    ReminderRepository::DEFAULT_LIMIT, // 20 — zurückgegeben, wenn Schlüssel fehlt
+);
+
+if ($limit === null) {
+    return $this->responseFactory->create(
+        ['error' => sprintf('limit must be between %d and %d.', MIN_LIMIT, MAX_LIMIT)],
+        422,
+    );
+}
+```
+
+`?status=` verwendet `V::enum()`, um gegen das backed enum zu validieren:
+
+```php
+$status = V::enum($rawStatus, ReminderStatus::class);
+
+if ($status === null) {
+    return $this->responseFactory->create(
+        ['error' => 'status must be one of: pending, triggered, cancelled.'],
+        422,
+    );
+}
+```
+
+`V::enum()` ruft intern `BackedEnum::tryFrom()` auf und gibt `null` für unbekannte
+Werte zurück.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE reminders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    message    TEXT    NOT NULL,
+    remind_at  TEXT    NOT NULL,  -- ISO 8601 mit Zeitzonenoffset, unverändert gespeichert
+    status     TEXT    NOT NULL DEFAULT 'pending',
+    created_at TEXT    NOT NULL,
+    CHECK (status IN ('pending', 'triggered', 'cancelled'))
+);
+
+CREATE INDEX idx_reminders_user   ON reminders (user_id, id);
+CREATE INDEX idx_reminders_status ON reminders (status, id);
+```
+
+`remind_at` wird als ursprünglicher ISO 8601-String mit dem Zeitzonenoffset des Einreichers
+gespeichert (z. B. `2026-06-01T09:00:00+09:00`). Die DB normalisiert nicht auf UTC — die
+Anwendung ist für den korrekten Vergleich verantwortlich (siehe `V::futureDatetime()`).
+
+Zwei Indizes:
+- `(user_id, id)` — deckt Per-Benutzer-Liste und Stornierungssuchen ab
+- `(status, id)` — deckt eine Poller-Abfrage ab, die `pending`-Erinnerungen zum Auslösen abruft
+
+---
+
+## Status-Enum
+
+```php
+enum ReminderStatus: string
+{
+    case Pending   = 'pending';
+    case Triggered = 'triggered';
+    case Cancelled = 'cancelled';
+}
+```
+
+Nur `pending`-Erinnerungen können storniert werden (`409` sonst). `triggered` wird von
+einem Hintergrundjob gesetzt, wenn die Erinnerung ausgelöst wird — diese API enthält nicht
+den Trigger-Endpunkt, der auf einer geplanten Aufgabe außerhalb des HTTP-Servers laufen würde.
+
+---
+
+## Verwandte Anleitungen
+
+- [`iso-datetime-validation.md`](iso-datetime-validation.md) — ISO 8601-Datetime-Validierungsmuster
+- [`content-scheduling.md`](content-scheduling.md) — Geplante Veröffentlichung mit zukünftigem `publish_at`
+- [`approval-workflow.md`](approval-workflow.md) — 404/409-Unterscheidung bei Statusübergängen
+- [`enforce-resource-ownership.md`](enforce-resource-ownership.md) — IDOR-Präventionsmuster

--- a/docs/de/howto/search-autocomplete.md
+++ b/docs/de/howto/search-autocomplete.md
@@ -1,0 +1,302 @@
+# Implementierungsanleitung für Volltextsuche und Autovervollständigungs-API
+
+## Überblick
+
+Diese Anleitung erklärt, wie Volltextsuche und Autovervollständigungs-Endpunkte mit NENE2 implementiert werden.
+Sie bietet feldübergreifende Suche mit LIKE-Abfragen, Relevanzbewertung und Präfix-Vervollständigung als REST-API.
+
+---
+
+## DB-Schema
+
+```sql
+CREATE TABLE products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    category TEXT NOT NULL,
+    price_cents INTEGER NOT NULL DEFAULT 0 CHECK (price_cents >= 0),
+    created_at TEXT NOT NULL
+);
+```
+
+---
+
+## Endpunkt-Design
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| GET | `/search` | Volltextsuche |
+| GET | `/autocomplete` | Namens-Präfix-Vervollständigung |
+
+### Query-Parameter
+
+**GET /search**
+
+| Parameter | Erforderlich | Standard | Beschreibung |
+|-----------|--------------|---------|-------------|
+| `q` | ✓ | — | Suchanfrage (2–100 Zeichen) |
+| `category` | — | — | Kategoriefilter |
+| `limit` | — | 10 | Maximal 50 |
+| `offset` | — | 0 | Paginierung |
+
+**GET /autocomplete**
+
+| Parameter | Erforderlich | Standard | Beschreibung |
+|-----------|--------------|---------|-------------|
+| `q` | ✓ | — | Präfix (2–100 Zeichen) |
+| `limit` | — | 5 | Maximal 10 |
+
+---
+
+## Implementierung
+
+### SearchRepository
+
+```php
+class SearchRepository
+{
+    public function __construct(private readonly DatabaseQueryExecutorInterface $db) {}
+
+    /** @return array{items: list<array<string, mixed>>, total: int} */
+    public function search(string $query, ?string $category, int $limit, int $offset): array
+    {
+        $lq = strtolower($query);
+        $escaped = $this->escapeLike($lq);
+        $pattern = '%' . $escaped . '%';
+        $prefix  = $escaped . '%';
+
+        $whereConditions = [
+            "LOWER(name) LIKE ? ESCAPE '!'",
+            "LOWER(description) LIKE ? ESCAPE '!'",
+            "LOWER(category) LIKE ? ESCAPE '!'",
+        ];
+        $whereParams = [$pattern, $pattern, $pattern];
+        $whereClause = 'WHERE (' . implode(' OR ', $whereConditions) . ')';
+
+        if ($category !== null) {
+            $whereClause .= ' AND LOWER(category) = ?';
+            $whereParams[] = strtolower($category);
+        }
+
+        $row = $this->db->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM products ' . $whereClause,
+            $whereParams
+        ) ?? ['cnt' => 0];
+        $total = (int) $row['cnt'];
+
+        // Relevanz: 0 = exakte Namensübereinstimmung, 1 = Name beginnt mit Anfrage, 2 = enthält irgendwo
+        $selectParams = [$lq, $prefix, ...$whereParams, $limit, $offset];
+        $items = $this->db->fetchAll(
+            "SELECT id, name, description, category, price_cents, created_at,
+                    CASE WHEN LOWER(name) = ? THEN 0
+                         WHEN LOWER(name) LIKE ? ESCAPE '!' THEN 1
+                         ELSE 2
+                    END AS relevance
+             FROM products " . $whereClause . "
+             ORDER BY relevance ASC, id ASC
+             LIMIT ? OFFSET ?",
+            $selectParams
+        );
+
+        return ['items' => $items, 'total' => $total];
+    }
+
+    /** @return list<string> */
+    public function autocomplete(string $prefix, int $limit): array
+    {
+        $escaped = $this->escapeLike(strtolower($prefix));
+        $rows = $this->db->fetchAll(
+            "SELECT DISTINCT name FROM products WHERE LOWER(name) LIKE ? ESCAPE '!' ORDER BY name ASC LIMIT ?",
+            [$escaped . '%', $limit]
+        );
+        return array_map(static fn (array $r): string => (string) $r['name'], $rows);
+    }
+
+    private function escapeLike(string $value): string
+    {
+        // ! als Escape-Zeichen verwenden, um Backslash-Verwirrung in SQL-String-Literalen zu vermeiden
+        return str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $value);
+    }
+}
+```
+
+### RouteRegistrar (Auszug)
+
+```php
+public function register(Router $router): void
+{
+    $router->get('/search', $this->handleSearch(...));
+    $router->get('/autocomplete', $this->handleAutocomplete(...));
+}
+
+private function handleSearch(ServerRequestInterface $request): ResponseInterface
+{
+    $params = $request->getQueryParams();
+    $q      = isset($params['q']) ? trim((string) $params['q']) : '';
+    $errors = $this->validateQuery($q);
+
+    $limit  = $this->clamp((int) ($params['limit'] ?? 10), 1, 50);
+    $offset = max(0, (int) ($params['offset'] ?? 0));
+    $cat    = isset($params['category']) && trim((string) $params['category']) !== ''
+                ? trim((string) $params['category']) : null;
+
+    if ($errors !== []) {
+        throw new ValidationException($errors);
+    }
+
+    $result = $this->repo->search($q, $cat, $limit, $offset);
+
+    return $this->json->create([
+        'query'    => $q,
+        'category' => $cat,
+        'total'    => $result['total'],
+        'limit'    => $limit,
+        'offset'   => $offset,
+        'items'    => array_map($this->formatProduct(...), $result['items']),
+    ]);
+}
+```
+
+---
+
+## Design-Punkte
+
+### LIKE-Sonderzeichen-Escaping
+
+`%` und `_` sind SQL LIKE-Wildcards. Wenn Benutzereingaben direkt übergeben werden, können unbeabsichtigte Vollständigkeits-Treffer oder SQL-Injection-ähnliches Verhalten entstehen.
+
+```php
+// Falsch: wenn Benutzer "%_" eingibt, werden alle Einträge gefunden
+$this->db->fetchAll('SELECT * FROM products WHERE name LIKE ?', ['%' . $query . '%']);
+
+// Richtig: Sonderzeichen escapen
+private function escapeLike(string $value): string
+{
+    return str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $value);
+}
+// SQL: WHERE name LIKE ? ESCAPE '!'
+```
+
+`!` als Escape-Zeichen verwenden, um die doppelte Escaping-Hölle (SQL/PHP) mit Backslashes zu vermeiden.
+
+### Relevanzbewertung
+
+LIKE-Suche gibt allen Ergebnissen dasselbe Gewicht, aber `CASE WHEN` fügt eine einfache Bewertung hinzu:
+
+| Score | Bedingung | Beispiel |
+|-------|-----------|---------|
+| 0 | Exakte Namensübereinstimmung | "Apple iPhone 15" mit "apple iphone 15" suchen |
+| 1 | Name beginnt mit Anfrage | Produkte, die mit "Apple" beginnen |
+| 2 | Name/Beschreibung/Kategorie enthält | Beschreibung enthält "ergonomic" |
+
+```sql
+CASE WHEN LOWER(name) = ? THEN 0
+     WHEN LOWER(name) LIKE ? ESCAPE '!' THEN 1
+     ELSE 2
+END AS relevance
+```
+
+Parameter werden in der Reihenfolge `[$lq (exakter Übereinstimmungsstring), $prefix (Präfix-Muster), ...WHERE-Klausel-Parameter, $limit, $offset]` übergeben.
+
+### Autovervollständigung verwendet nur Präfixübereinstimmung
+
+Suche (`%query%`) und Autovervollständigung (`query%`) haben unterschiedliche Zwecke.
+Das Zurückgeben von "enthält"-Ergebnissen in der Autovervollständigung fühlt sich als Vorhersagetext unnatürlich an.
+
+```php
+// Nur Präfix: "Apple" → ["Apple iPhone 15", "Apple Watch Series 9"]
+$rows = $this->db->fetchAll(
+    "SELECT DISTINCT name FROM products WHERE LOWER(name) LIKE ? ESCAPE '!' ORDER BY name ASC LIMIT ?",
+    [$escaped . '%', $limit]
+);
+// "Green Apple Juice" beginnt nicht mit "Apple" und wird daher nicht eingeschlossen
+```
+
+### limit-Clamping
+
+Wenn Clients beliebige Limits senden können, ist ein vollständiger Datenabruf möglich. Immer serverseitig begrenzen.
+
+```php
+private function clamp(int $value, int $min, int $max): int
+{
+    return max($min, min($max, $value));
+}
+
+// Suche: max 50 / Autovervollständigung: max 10
+$limit = $this->clamp((int) ($params['limit'] ?? 10), 1, 50);
+```
+
+### SQLite vs. MySQL/PostgreSQL für Volltextsuche
+
+| Methode | Anwendung | Eigenschaften |
+|---------|-----------|--------------|
+| `LIKE '%query%'` | SQLite / MySQL / PgSQL | Klein bis mittel. Kein Index (Präfix `LIKE 'q%'` hat Index) |
+| SQLite FTS5 virtuelle Tabelle | SQLite | Schnelle Volltextsuche. Tokenizer-Konfiguration und Ranking integriert |
+| MySQL FULLTEXT | MySQL | `MATCH ... AGAINST` für AND/OR/Phrasensuche |
+| PostgreSQL `tsvector` | PgSQL | GIN-Index, Sprachstemming unterstützt |
+
+Für Prototypen oder kleine Systeme ist LIKE ausreichend. Bei Hunderttausenden Zeilen auf FTS umstellen.
+
+---
+
+## Antwortbeispiele
+
+### GET /search?q=apple&category=Electronics
+
+```json
+{
+  "query": "apple",
+  "category": "Electronics",
+  "total": 2,
+  "limit": 10,
+  "offset": 0,
+  "items": [
+    {
+      "id": 1,
+      "name": "Apple iPhone 15",
+      "description": "Flagship smartphone by Apple",
+      "category": "Electronics",
+      "price_cents": 129900,
+      "created_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "id": 2,
+      "name": "Apple Watch Series 9",
+      "description": "Smartwatch with health tracking",
+      "category": "Electronics",
+      "price_cents": 49900,
+      "created_at": "2026-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+### GET /autocomplete?q=Apple
+
+```json
+{
+  "query": "Apple",
+  "suggestions": [
+    "Apple iPhone 15",
+    "Apple Watch Series 9"
+  ]
+}
+```
+
+### GET /search?q=a (q zu kurz → 422)
+
+```json
+{
+  "status": 422,
+  "errors": [
+    { "field": "q", "message": "q must be at least 2 characters", "code": "too_short" }
+  ]
+}
+```
+
+---
+
+## Referenzimplementierung
+
+`../NENE2-FT/searchlog/` — FT157 Feldversuch (22 Tests)

--- a/docs/de/howto/secret-vault.md
+++ b/docs/de/howto/secret-vault.md
@@ -1,0 +1,184 @@
+# Anleitung: Persönlicher Secret-Vault API
+
+Demonstriert benutzerspezifischen Key-Value-Speicher mit HMAC-Integrität, IDOR-Prävention und admin-exklusivem Metadatenzugriff.
+Feldversuch: FT195 (`../NENE2-FT/vaultlog/`). Enthält VULN-A~L Sicherheitsaudit.
+
+---
+
+## Musterzusammenfassung
+
+| Bereich | Ansatz |
+|---|---|
+| Benutzerisolation | `WHERE user_id = :uid` bei jeder Abfrage — IDOR unmöglich |
+| Admin sieht nie Werte | Admin-Endpunkte geben nur `user_id + key` zurück |
+| HMAC-Integrität | `HMAC-SHA256(userId|key|value, secret)` pro Eintrag gespeichert |
+| Schlüssel-Validierung | `preg_match('/\A[a-z0-9_-]{1,64}\z/', $key)` — sicher, kein ReDoS-Risiko |
+| User-ID-Validierung | `ctype_digit()` + Längenschutz + `> 0`-Prüfung |
+| Admin-Key | `hash_equals()` zeitkonstant, fail-closed bei leerem Key |
+| Upsert | `UNIQUE(user_id, key_name)` → erstmals speichern (201) oder aktualisieren (200) |
+
+---
+
+## Routen
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `POST` | `/vault` | `X-User-Id` | Secret speichern oder aktualisieren |
+| `GET` | `/vault` | `X-User-Id` | Schlüsselliste des Benutzers auflisten (ohne Werte) |
+| `GET` | `/vault/{key}` | `X-User-Id` | Secret-Wert des Benutzers abrufen |
+| `DELETE` | `/vault/{key}` | `X-User-Id` | Secret des Benutzers löschen |
+| `GET` | `/admin/vault` | `X-Admin-Key` | Alle Benutzer + Schlüssel auflisten (ohne Werte) |
+| `GET` | `/admin/vault/{userId}` | `X-Admin-Key` | Schlüssel eines bestimmten Benutzers auflisten |
+
+---
+
+## Datenbankschema
+
+```sql
+CREATE TABLE vault_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    key_name   TEXT    NOT NULL,
+    value      TEXT    NOT NULL,
+    hmac       TEXT    NOT NULL,   -- HMAC-SHA256-Integritäts-Tag
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE (user_id, key_name)
+);
+```
+
+Die `UNIQUE(user_id, key_name)`-Bedingung erzwingt einen Eintrag pro (Benutzer, Schlüssel)-Paar.
+
+---
+
+## HMAC-Integrität
+
+```php
+private function computeHmac(int $userId, string $key, string $value): string
+{
+    return hash_hmac('sha256', "{$userId}|{$key}|{$value}", $this->hmacSecret);
+}
+```
+
+Beim GET überprüft der Handler den gespeicherten HMAC:
+
+```php
+if (!$this->repo->verifyIntegrity($entry)) {
+    return $this->problem(500, 'integrity-error', 'Secret integrity check failed.');
+}
+```
+
+Dies erkennt direktes DB-Tampering (z. B. wenn ein kompromittierter DBA Werte direkt ändert, ohne die API zu nutzen).
+
+---
+
+## IDOR-Prävention
+
+Jede Abfrage enthält `user_id = :uid`:
+
+```sql
+SELECT * FROM vault_entries WHERE user_id = :uid AND key_name = :key
+```
+
+Wenn Benutzer 200 den Schlüssel `private-key` von Benutzer 100 abfragt, erhält er 404 — identisch mit „nicht gefunden",
+was die Enumeration verhindert, welche Schlüssel für andere Benutzer existieren.
+
+Admin-Endpunkte geben nie `value` zurück:
+
+```php
+// Benutzer sieht seinen eigenen Wert
+public function toUserArray(): array
+{
+    return ['key' => ..., 'value' => $this->value, ...];
+}
+
+// Admin sieht nur Metadaten — keinen Wert
+public function toAdminArray(): array
+{
+    return ['user_id' => ..., 'key' => ..., ...];
+}
+```
+
+---
+
+## Schlüssel-Validierung
+
+```php
+private const string KEY_PATTERN = '/\A[a-z0-9_-]{1,64}\z/';
+```
+
+Die Anker `\A` und `\z` verhindern Teilübereinstimmungen. Die Zeichenklasse ist minimal:
+Kleinbuchstaben alphanumerisch, Bindestrich, Unterstrich. Die Länge ist auf `{1,64}` begrenzt — kein Backtracking-Amplification.
+
+Folgendes wird abgelehnt:
+- Großbuchstaben (`UPPER_CASE`)
+- Leerzeichen oder Sonderzeichen
+- Path-Traversal-Fragmente (`../etc/passwd`)
+- SQL-injizierbare Strings (`' OR '1'='1`)
+- Leerer String oder Strings > 64 Zeichen
+
+---
+
+## User-ID-Validierung
+
+```php
+private function resolveUserId(ServerRequestInterface $request): ?int
+{
+    $raw = $request->getHeaderLine('X-User-Id');
+    if ($raw === '' || !ctype_digit($raw) || strlen($raw) > 18) return null;
+    $id = (int) $raw;
+    return $id > 0 ? $id : null;
+}
+```
+
+- `ctype_digit()` lehnt negative Zahlen ab (das `-`-Zeichen ist keine Ziffer)
+- `strlen > 18` verhindert Integer-Überlauf (`PHP_INT_MAX` hat 19 Ziffern)
+- `> 0` lehnt `"0"` als ungültige User-ID ab
+
+---
+
+## Upsert-Muster
+
+```php
+public function store(int $userId, string $key, string $value): string
+{
+    $existing = $this->findEntry($userId, $key);
+    if ($existing !== null) {
+        // UPDATE ...
+        return 'updated';  // → 200
+    }
+    // INSERT ...
+    return 'stored';  // → 201
+}
+```
+
+Gibt `'stored'` (201) beim ersten Schreiben zurück, `'updated'` (200) beim Überschreiben.
+Der Handler ordnet diese HTTP-Statuscodes zu.
+
+---
+
+## VULN-A~L Ergebnisse
+
+| Prüfung | Test | Ergebnis |
+|---|---|---|
+| VULN-A | SQL-Injection im Key-Parameter / Body | BESTANDEN — Schlüssel-Validierung lehnt vor der Abfrage ab |
+| VULN-B | IDOR: Benutzer liest/löscht Schlüssel eines anderen Benutzers | BESTANDEN — 404 bei Cross-User-Zugriff |
+| VULN-C | Liste gibt nur eigene Einträge zurück | BESTANDEN — WHERE user_id gescoped |
+| VULN-D | Admin-Key Brute-Force / Bypass | BESTANDEN — hash_equals + fail-closed |
+| VULN-E | XSS im Wert | BESTANDEN — als-is gespeichert, JSON-Antwort kein HTML |
+| VULN-F | Key-Upsert-Idempotenz | BESTANDEN — letzter Schreibvorgang gewinnt, keine Duplikate |
+| VULN-G | Path-Traversal im Schlüssel | BESTANDEN — Muster lehnt `..` und Schrägstriche ab |
+| VULN-H | Negative / zero User-ID | BESTANDEN — ctype_digit + > 0-Schutz |
+| VULN-I | Sehr große User-ID (Überlauf) | BESTANDEN — strlen > 18-Schutz |
+| VULN-J | Null-Byte im Pfad | BESTANDEN — Router / Muster lehnt ab |
+| VULN-K | Überlanger Schlüssel im Body | BESTANDEN — 422-Validierung |
+| VULN-L | Leeres HMAC-Secret (kein Panic) | BESTANDEN — deterministisches HMAC mit leerem Key, kein Absturz |
+
+---
+
+## Testhinweise
+
+- `AppFactory::create(?PDO, ?string adminKey, ?string hmacSecret)` — alles injizierbar für Unit-Tests.
+- `withParsedBody($body)` ist in Test-Helfern erforderlich (Nyholm PSR-7 parst JSON nicht automatisch).
+- IDOR-Tests: als Benutzer 100 speichern, Zugriff als Benutzer 200 versuchen → muss 404 zurückgeben.
+- Admin-Tests: sicherstellen, dass `value`-Schlüssel in jedem Antwort-Array fehlt.

--- a/docs/de/howto/service-status-page.md
+++ b/docs/de/howto/service-status-page.md
@@ -1,0 +1,225 @@
+# Anleitung: Service-Statusseiten-API
+
+> **NENE2 Feldversuch 185** — Komponentenzustandsverfolgung, Incident-Lifecycle-Management,
+> Admin-Key-Schutz mit `V::secret()` + `hash_equals()`.
+
+---
+
+## Was dieser Feldversuch beweist
+
+Eine Service-Statusseiten-API benötigt:
+1. **Komponentenstatuserfassung** — operational / degraded / partial_outage / major_outage
+2. **Incident-Lifecycle** — investigating → identified → monitoring → resolved
+3. **Unveränderlichkeitsschutz** — gelöste Incidents können nicht aktualisiert werden (Wiedereröffnung verhindern)
+4. **Admin-Key-Schutz** — `V::secret()` erzwingt zeitkonstanten Vergleich für Schreiboperationen
+5. **Status-Enum-Durchsetzung** — `V::enum()`-Allowlist verhindert Injektion unbekannter Werte
+
+---
+
+## API
+
+| Methode | Pfad | Auth | Beschreibung |
+|---|---|---|---|
+| `GET` | `/components` | — | Alle Komponenten auflisten (öffentlich) |
+| `POST` | `/components` | X-Admin-Key | Komponente erstellen |
+| `PATCH` | `/components/{id}` | X-Admin-Key | Komponentenstatus aktualisieren |
+| `GET` | `/incidents` | — | Incidents auflisten (öffentlich, `?open=1` für aktive) |
+| `GET` | `/incidents/{id}` | — | Incident-Detail mit Update-Verlauf |
+| `POST` | `/incidents` | X-Admin-Key | Incident erstellen |
+| `PATCH` | `/incidents/{id}` | X-Admin-Key | Incident-Status aktualisieren |
+| `POST` | `/incidents/{id}/updates` | X-Admin-Key | Update-Meldung hinzufügen |
+
+---
+
+## Kernmuster: Admin-Key-Auth mit `V::secret()`
+
+```php
+// V::secret() prüft: $expected !== '' && hash_equals($expected, $actual)
+private function requireAdmin(ServerRequestInterface $request): bool
+{
+    return V::secret($this->adminKey, $request->getHeaderLine('X-Admin-Key'));
+}
+
+// Verwendung in jedem Schreib-Handler:
+if (!$this->requireAdmin($request)) {
+    return $this->responseFactory->create(['error' => 'X-Admin-Key is required.'], 401);
+}
+```
+
+**Warum `V::secret()` statt `=== $key`:**
+- `===` ist Short-Circuit: Timing variiert je nach Übereinstimmungslänge → Timing-Oracle
+- `hash_equals()` ist zeitkonstant, unabhängig davon, wo Strings abweichen
+- Die `$expected !== ''`-Prüfung verhindert versehentliches Akzeptieren leerer Keys
+
+---
+
+## Status-Enum-Durchsetzung mit `V::enum()`
+
+```php
+// V::enum(mixed $raw, string $enumClass): ?\BackedEnum
+// Übergabe des Klassennamens — gibt typisierte Enum-Instanz oder null zurück
+
+$statusEnum = V::enum($body['status'] ?? null, ComponentStatus::class);
+
+if (!$statusEnum instanceof ComponentStatus) {
+    return $this->responseFactory->create(
+        ['error' => 'status must be one of: ' . implode(', ', ComponentStatus::values()) . '.'],
+        422,
+    );
+}
+
+// $statusEnum ist bereits das korrekte typisierte Enum — kein ::from() erforderlich
+$component = $this->repository->updateComponentStatus($id, $statusEnum);
+```
+
+**Warum Enum-Durchsetzung wichtig ist:**
+- Ohne sie erreichen beliebige Strings die DB
+- SQL `ORDER BY status`-Injektionsvektoren werden blockiert
+- Die Allowlist sind die eigenen Enum-Cases — immer synchron
+
+---
+
+## Incident-Lifecycle & Übergangsschutz
+
+```php
+enum IncidentStatus: string
+{
+    case Investigating = 'investigating';
+    case Identified    = 'identified';
+    case Monitoring    = 'monitoring';
+    case Resolved      = 'resolved';
+
+    public function isResolved(): bool
+    {
+        return $this === self::Resolved;
+    }
+}
+```
+
+**Übergangsschutz in jedem Schreib-Handler:**
+```php
+$incident = $this->repository->findIncidentById($id);
+
+// Gelöste Incidents sind unveränderlich — versehentliches Wiedereröffnen verhindern
+if ($incident->status->isResolved()) {
+    return $this->responseFactory->create(
+        ['error' => 'Resolved incidents cannot be updated.'],
+        409,
+    );
+}
+```
+
+**Warum 409 (Conflict) statt 422 (Unprocessable):**
+- Die Anfrage ist syntaktisch gültig
+- Der Konflikt liegt am aktuellen Zustand der Ressource
+- 409 kommuniziert „gültige Anfrage, falscher Zeitpunkt"
+
+---
+
+## Komponentenstatus-Werte
+
+```php
+enum ComponentStatus: string
+{
+    case Operational   = 'operational';    // alles läuft
+    case Degraded      = 'degraded';       // reduzierte Leistung
+    case PartialOutage = 'partial_outage'; // einige Funktionen nicht verfügbar
+    case MajorOutage   = 'major_outage';   // vollständiger Dienstausfall
+}
+```
+
+---
+
+## Automatischer `resolved_at`-Zeitstempel
+
+```php
+public function updateIncidentStatus(int $id, IncidentStatus $status): ?Incident
+{
+    $now        = $this->now();
+    $resolvedAt = $status->isResolved() ? $now : null;
+
+    $stmt = $this->pdo->prepare(
+        'UPDATE incidents SET status = :status, resolved_at = :resolved_at, updated_at = :now WHERE id = :id'
+    );
+    $stmt->execute(['status' => $status->value, 'resolved_at' => $resolvedAt, ...]);
+}
+```
+
+Der `resolved_at`-Zeitstempel wird serverseitig gesetzt — nie aus dem Request-Body.
+
+---
+
+## Integer-ID-Parsing (keine Injection)
+
+```php
+private function parseId(ServerRequestInterface $request, string $param): ?int
+{
+    $raw = Router::param($request, $param);
+
+    // ctype_digit: lehnt Negative, Floats, Strings, Path-Traversal ab
+    if ($raw === null || !ctype_digit($raw)) {
+        return null;
+    }
+
+    $id = (int) $raw;
+
+    return $id > 0 ? $id : null; // lehnt auch null ab
+}
+```
+
+---
+
+## Offener-Incident-Filter
+
+```php
+// ?open=1 filtert gelöste Incidents heraus
+$openOnly = isset($params['open']) && $params['open'] === '1';
+
+if ($openOnly) {
+    $stmt = $pdo->prepare(
+        "SELECT * FROM incidents WHERE status != 'resolved' ORDER BY created_at DESC"
+    );
+} else {
+    $stmt = $pdo->query('SELECT * FROM incidents ORDER BY created_at DESC');
+}
+```
+
+---
+
+## Vollständiges Incident-Lifecycle-Beispiel
+
+```
+POST /incidents          → 201 {status: "investigating", impact: "major"}
+POST /incidents/1/updates → 201 {message: "Root cause identified."}
+PATCH /incidents/1       → 200 {status: "identified"}
+PATCH /incidents/1       → 200 {status: "monitoring"}
+PATCH /incidents/1       → 200 {status: "resolved", resolved_at: "2026-05-26T..."}
+PATCH /incidents/1       → 409 Resolved incidents cannot be updated.
+GET /incidents?open=1    → 200 {count: 0}  — resolved wird nicht mehr angezeigt
+```
+
+---
+
+## Testergebnisse
+
+```
+46 Tests / 93 Assertions — alle BESTANDEN
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+```
+
+---
+
+## Wichtige Erkenntnisse
+
+| Muster | Regel |
+|---|---|
+| Admin-Key-Auth | `V::secret()` — zeitkonstantes `hash_equals()`, schützt vor leerem Key |
+| Enum-Validierung | `V::enum($raw, EnumClass::class)` — gibt typisiertes Enum oder null zurück |
+| Übergangsschutz | Aktuellen Zustand prüfen, bevor Änderung angewandt wird — 409 für resolved |
+| `resolved_at` | Serverseitig gesetzter Zeitstempel, nie aus dem Request-Body |
+| Integer-IDs | `ctype_digit()` + `> 0`-Schutz — lehnt Strings, Negative, null ab |
+| Öffentliches Lesen | Keine Auth für GET-Endpunkte — Statusseiten sind öffentlich gedacht |
+| Unveränderliche Historie | Incident-Updates sind nur anfügbar — kein Bearbeiten/Löschen |
+
+Vollständiges Beispiel: [`../NENE2-FT/statuslog/`](https://github.com/hideyukiMORI/NENE2-examples) im Beispiel-Repository.

--- a/docs/de/howto/session-management.md
+++ b/docs/de/howto/session-management.md
@@ -1,0 +1,237 @@
+# Anleitung: Multi-Device-Session-Manager
+
+> **Muster bewiesen durch FT186 sessionlog** — Multi-Device-Session-Tracking, IDOR-Prävention, Mass-Assignment-Schutz, timing-oracle-freie Widerrufung.
+
+---
+
+## Was abgedeckt wird
+
+Ein Multi-Device-Session-Manager ermöglicht Benutzern:
+
+1. **Sessions erstellen** beim Login (jedes Gerät erhält seinen eigenen Token)
+2. **Aktive Sessions auflisten** auf ihre User-ID begrenzt
+3. **Eine einzelne Session widerrufen** (Abmelden von einem Gerät)
+4. **Alle außer der aktuellen widerrufen** (Abmelden von allen anderen Geräten)
+
+Demonstrierte Sicherheitsgarantien:
+
+| Bereich | Technik |
+|---|---|
+| IDOR-Prävention | Alle Mutationen beschränken `WHERE token = ? AND user_id = ?` |
+| Mass Assignment | `token`, `user_id`, `created_at`, `revoked_at` nur serverseitig gesetzt |
+| Timing-Oracle | Generisches 404 für alle Fehler — kein Eigentümerschafts-Leak |
+| Integer-Überlauf | `V::queryInt()` 18-stelliger strlen-Schutz |
+| Typ-Verwirrung | `V::str()` lehnt Nicht-String `device_name`/`ip_address` ab |
+| Token-Entropie | `bin2hex(random_bytes(32))` — 256 Bit, 64 Hex-Zeichen |
+| SQL-Injection | PDO-parametrisierte Abfragen + `/^[0-9a-f]{64}$/`-Gate |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE sessions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL,
+    token       TEXT    NOT NULL UNIQUE,
+    device_name TEXT,
+    ip_address  TEXT,
+    last_active TEXT    NOT NULL,
+    created_at  TEXT    NOT NULL,
+    revoked_at  TEXT    -- NULL = aktiv
+);
+```
+
+`revoked_at IS NULL` ist das Prädikat für aktive Sessions. Soft Delete vermeidet den Verlust der Prüfhistorie.
+
+---
+
+## API-Design
+
+| Methode | Pfad | Header | Beschreibung |
+|---|---|---|---|
+| `POST` | `/sessions` | `X-User-Id` | Session erstellen |
+| `GET` | `/sessions` | `X-User-Id` | Eigene aktive Sessions auflisten |
+| `DELETE` | `/sessions/{token}` | `X-User-Id` | Eine Session widerrufen |
+| `DELETE` | `/sessions` | `X-User-Id` + `X-Current-Session` | Alle außer der aktuellen widerrufen |
+
+---
+
+## Kernmuster: 256-Bit-Token-Generierung
+
+```php
+public function create(int $userId, ?string $deviceName, ?string $ipAddress): Session
+{
+    $token = bin2hex(random_bytes(32)); // 256-Bit-Entropie, 64 Hex-Zeichen
+    $now   = $this->now();
+
+    $stmt = $this->pdo->prepare(
+        'INSERT INTO sessions (user_id, token, device_name, ip_address, last_active, created_at)
+         VALUES (:user_id, :token, :device_name, :ip_address, :now, :now2)',
+    );
+    $stmt->execute([...]);
+    // ...
+}
+```
+
+`bin2hex(random_bytes(32))` erzeugt 64 Kleinbuchstaben-Hex-Zeichen aus einer kryptografisch sicheren Quelle. Tokens niemals aus Benutzereingaben akzeptieren.
+
+---
+
+## Kernmuster: IDOR-Prävention
+
+```php
+// FALSCH — erlaubt jedem authentifizierten Benutzer, jede Session zu widerrufen
+UPDATE sessions SET revoked_at = ? WHERE token = ?
+
+// RICHTIG — muss die Session besitzen
+public function revokeForUser(string $token, int $userId): bool
+{
+    $stmt = $this->pdo->prepare(
+        'UPDATE sessions SET revoked_at = :now
+         WHERE token = :token AND user_id = :user_id AND revoked_at IS NULL',
+    );
+    $stmt->execute(['now' => $this->now(), 'token' => $token, 'user_id' => $userId]);
+
+    return $stmt->rowCount() > 0;
+}
+```
+
+`rowCount() > 0` gibt `false` zurück, wenn der Token existiert, aber einem anderen Benutzer gehört — der Handler antwortet mit einem generischen 404 (siehe Timing-Oracle-Abschnitt).
+
+---
+
+## Kernmuster: Mass-Assignment-Schutz
+
+```php
+// POST /sessions Handler — Angreifer-Body: {"token": "custom", "user_id": 999, "revoked_at": "now"}
+private function handleCreate(ServerRequestInterface $request): ResponseInterface
+{
+    // userId kommt vom X-User-Id-Header — nie vom Body
+    $userId = V::userId($request->getHeaderLine('X-User-Id'));
+
+    $body = $this->parseBody($request);
+
+    // Nur sichere, validierte Felder werden weitergegeben
+    $deviceName = V::str($body['device_name'] ?? null, 200);
+    $ipAddress  = V::str($body['ip_address'] ?? null, 45);
+
+    // token, user_id, created_at, revoked_at vom Repository gesetzt — nicht vom Body
+    $session = $this->repository->create($userId, $deviceName, $ipAddress);
+
+    return $this->responseFactory->create($session->toArray(), 201);
+}
+```
+
+---
+
+## Kernmuster: Timing-Oracle-Prävention
+
+```php
+private function handleRevokeOne(ServerRequestInterface $request): ResponseInterface
+{
+    $userId   = V::userId($request->getHeaderLine('X-User-Id'));
+    $rawToken = Router::param($request, 'token');
+
+    // VULN-I: ungültiges Format → sofort 404 (keine DB-Abfrage)
+    if ($rawToken === null || !preg_match('/^[0-9a-f]{64}$/', $rawToken)) {
+        return $this->responseFactory->create(['error' => 'Session not found.'], 404);
+    }
+
+    // IDOR-Schutz: revokeForUser gibt false zurück wenn:
+    //   - Token existiert nicht
+    //   - Token gehört einem anderen Benutzer
+    //   - Token ist bereits widerrufen
+    // Alle Fälle geben DASSELBE 404 zurück — kein Eigentümerschafts-Oracle
+    $revoked = $this->repository->revokeForUser($rawToken, $userId);
+
+    if (!$revoked) {
+        return $this->responseFactory->create(['error' => 'Session not found.'], 404);
+    }
+
+    return $this->responseFactory->create([], 204);
+}
+```
+
+Niemals „nicht gefunden" von „falscher Benutzer" in der Antwort unterscheiden. Ein Angreifer, der den Token eines Opfers kennt, darf nicht erfahren, ob dieser aktiv ist oder dem Benutzer gehört.
+
+---
+
+## Kernmuster: Alle außer der aktuellen widerrufen
+
+```php
+public function revokeAllExcept(int $userId, string $currentToken): int
+{
+    $stmt = $this->pdo->prepare(
+        'UPDATE sessions SET revoked_at = :now
+         WHERE user_id = :user_id AND token != :current AND revoked_at IS NULL',
+    );
+    $stmt->execute(['now' => $this->now(), 'user_id' => $userId, 'current' => $currentToken]);
+
+    return $stmt->rowCount();
+}
+```
+
+Der Aufrufer übergibt den `X-Current-Session`-Header. Sowohl `user_id` als auch die Ausschlussbedingung werden in der einzigen Abfrage durchgesetzt.
+
+---
+
+## Kernmuster: Überlaufsichere Limit-Validierung
+
+```php
+// VULN-A: V::queryInt lehnt >18 Ziffern ab — verhindert stillen PHP-Int-Überlauf
+// VULN-F: ctype_digit ist O(n) — kein Regex-Backtracking-Risiko
+$limit = V::queryInt($params, 'limit', 1, self::MAX_LIMIT, self::DEFAULT_LIMIT);
+
+if ($limit === null) {
+    return $this->responseFactory->create(
+        ['error' => sprintf('limit must be between 1 and %d.', self::MAX_LIMIT)],
+        422,
+    );
+}
+```
+
+`V::queryInt()` lehnt negative Zahlen, Floats, Hex-Strings (`0x10`) und Zahlen > 18 Stellen ab.
+
+---
+
+## Routen-Token-Validierung
+
+Das Token-Format immer auf der Routen-Ebene validieren, bevor die DB abgefragt wird:
+
+```php
+private const TOKEN_PATTERN = '/^[0-9a-f]{64}$/';
+
+// Im Handler:
+if ($rawToken === null || !preg_match(self::TOKEN_PATTERN, $rawToken)) {
+    return $this->responseFactory->create(['error' => 'Session not found.'], 404);
+}
+```
+
+Dies blockiert SQL-Injection-Strings, Path-Traversal-Versuche und kurze/lange Tokens vor jeder Datenbankinteraktion.
+
+---
+
+## Testergebnisse (FT186)
+
+```
+54 Tests / 116 Assertions — alle BESTANDEN
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+```
+
+VULN-A~L-Abdeckung:
+
+| Vuln | Muster | Test |
+|---|---|---|
+| A | limit 19-stelliger Überlauf | `testVulnALimitOverflow19Digits` |
+| B | device_name Typ-Verwirrung | `testVulnBDeviceNameAsInteger` |
+| C | SQL-Injection im Token | `testVulnCSqlInjectionToken` |
+| D | negatives/float/hex limit | `testVulnDNegativeLimitRejected` |
+| E | IDOR-Widerrufung | `testVulnECannotRevokeOtherUsersSession` |
+| F | ReDoS-artiges langes limit | `testVulnFVeryLongLimitRejected` |
+| H | Timing-Oracle | `testVulnHSameResponseForAlreadyRevokedAndCrossUser` |
+| I | leerer/kurzer/Traversal-Token | `testVulnIEmptyTokenSegmentNotMatched` |
+| L | Mass Assignment | `testVulnLTokenFromBodyIsIgnored` |
+
+Quelle: [`../NENE2-FT/sessionlog/`](https://github.com/hideyukiMORI/NENE2-examples/tree/main/sessionlog)

--- a/docs/de/howto/session-token-management.md
+++ b/docs/de/howto/session-token-management.md
@@ -1,0 +1,158 @@
+# Anleitung: Session-/Token-Verwaltungs-API (ATK-01~12)
+
+Diese Anleitung demonstriert eine sichere Session-Token-API, die alle ATK-01~12-Angriffsvektoren des Cracker-Mindset-Tests abdeckt.
+
+## Musterzusammenfassung
+
+- `POST /sessions` — Einen neuen opaken Token für einen Benutzer ausstellen (`X-User-Id` erforderlich).
+- `GET /sessions/{token}` — Einen Token validieren (404 wenn widerrufen oder abgelaufen).
+- `DELETE /sessions/{token}` — Einen Token widerrufen (Eigentümer oder Admin).
+- `GET /users/{userId}/sessions` — Aktive Sessions auflisten (Eigentümer oder Admin).
+
+Tokens sind `bin2hex(random_bytes(32))` — 64 Kleinbuchstaben-Hex-Zeichen.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS sessions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token      TEXT    NOT NULL UNIQUE,
+    label      TEXT    NOT NULL DEFAULT '',
+    revoked    INTEGER NOT NULL DEFAULT 0,
+    expires_at TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_token ON sessions (token);
+CREATE INDEX IF NOT EXISTS idx_sessions_user  ON sessions (user_id, revoked);
+```
+
+## Token-Generierung
+
+```php
+$token = bin2hex(random_bytes(32));  // 64 Kleinbuchstaben-Hex-Zeichen
+```
+
+`random_bytes()` verwendet einen CSPRNG; Tokens sind nicht erratbar und nicht sequenziell.
+
+## Token-Format-Validierung
+
+Vor jedem DB-Lookup das Token-Format mit einem strengen Regex validieren:
+
+```php
+private const string TOKEN_PATTERN = '/\A[0-9a-f]{64}\z/';
+
+private function pathToken(ServerRequestInterface $req): ?string
+{
+    $token = $params['token'] ?? '';
+    if (!preg_match(self::TOKEN_PATTERN, $token)) {
+        return null;  // 404 — trifft die DB nie
+    }
+    return $token;
+}
+```
+
+Dies lehnt SQL-Injection-Payloads, übergroße Eingaben, Großbuchstaben-Hex und Nicht-Hex-Strings vor jeder DB-Abfrage ab.
+
+## ATK-01: SQL-Injection im Token-Pfad
+
+Das Token-Format-Regex lehnt `' OR '1'='1` sofort ab. Selbst wenn es passieren würde, verwendet die DB-Abfrage ein Prepared Statement:
+
+```php
+$stmt = $this->pdo->prepare('SELECT * FROM sessions WHERE token = :token');
+$stmt->execute([':token' => $token]);
+```
+
+## ATK-02~04: Token-Format-Angriffe
+
+Alle vom Regex `/\A[0-9a-f]{64}\z/` abgelehnt:
+- Leerer String (Länge 0 ≠ 64)
+- Überlanger String (256 Zeichen ≠ 64)
+- Nicht-Hex-Zeichen (`g`, `A`–`F` Großbuchstaben, Sonderzeichen)
+- Falsche Länge (63 oder 65 Zeichen)
+
+## ATK-05: Integer-Überlauf in X-User-Id
+
+```php
+if ($raw === '' || !ctype_digit($raw) || strlen($raw) > 18) {
+    return null;
+}
+```
+
+Ein 19-stelliger Integer überschreitet das 18-Zeichen-Limit und wird vor jedem `(int)`-Cast abgelehnt.
+
+## ATK-06: Negative / Null-User-ID
+
+```php
+$id = (int) $raw;
+return $id > 0 ? $id : null;
+```
+
+`0` und negative Werte geben `null` zurück, was 400 auslöst.
+
+## ATK-07: Admin-Key Fail-Closed
+
+Ein leerer `adminKey` gewährt nie Admin-Zugriff:
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+`hash_equals()` verhindert Timing-Angriffe beim Vergleich des Keys.
+
+## ATK-08: Auth-Bypass via X-User-Id: 0
+
+`uid()` gibt `null` für ID=0 zurück → 400, nicht 200.
+
+## ATK-09: Nicht-numerische User-ID im Listen-Pfad
+
+`ctype_digit()` lehnt `abc`, `1.5`, `-1` ab:
+
+```php
+if (!ctype_digit($raw) || strlen($raw) > 18) {
+    return $this->problem(404, 'not-found', 'User not found.');
+}
+```
+
+## ATK-10: Float-TTL
+
+`is_int()` ist PHPs strikter Typcheck — `60.5` gibt `false` zurück:
+
+```php
+if (!is_int($ttlRaw) || $ttlRaw < 1 || $ttlRaw > self::MAX_TTL) {
+    return $this->problem(422, ...);
+}
+```
+
+## ATK-11: Doppelter Widerruf gibt 404 zurück
+
+Das Repository prüft `revoked === 1` vor dem Aktualisieren:
+
+```php
+if ($session === null || (int) $session['revoked'] === 1) {
+    return false;
+}
+```
+
+Bereits widerrufene Sessions können nicht durch erneutes Senden eines DELETE „un-widerrufen" werden.
+
+## ATK-12: Brute-Force-Token-Format-Ablehnung
+
+Jeder Token, der nicht exakt 64 Kleinbuchstaben-Hex-Zeichen entspricht, wird mit 404 abgelehnt, bevor die Datenbank berührt wird. Brute-Force-Versuche treffen die Regex-Mauer, nicht die DB.
+
+## IDOR: Eigentümer vs. Admin
+
+- Nicht-Eigentümer, die die Sessions eines anderen Benutzers widerrufen oder auflisten wollen, erhalten 404 (nicht 403).
+- Admins verwenden den `X-Admin-Key`-Header; fail-closed wenn der Key nicht konfiguriert ist.
+
+## Siehe auch
+
+- FT208-Quelle: `../NENE2-FT/sessionlog/`
+- Verwandt: `docs/howto/rate-limiting.md` (FT200, ATK)
+- Verwandt: `docs/howto/coupon-redemption.md` (FT204, VULN + ATK)

--- a/docs/de/howto/shift-management.md
+++ b/docs/de/howto/shift-management.md
@@ -1,0 +1,440 @@
+# Anleitung: Schichtverwaltungs-API
+
+> **FT-Referenz**: FT43 (`NENE2-FT/shiftlog`) — Mitarbeiter-Schichtplanungs-API
+> **VULN**: FT225 — Sicherheits-/Schwachstellen-Assessment (V-01 bis V-12)
+
+Demonstriert eine Mitarbeiter-Schichtplanungs-API mit Überlappungserkennung, transaktionsbasierten
+Prüfungen, ISO 8601-Datumsvergleichen und benutzerdefinierten Exception-Handlern für Domänenfehler.
+Der VULN-Abschnitt bewertet systematisch jede Angriffsfläche und dokumentiert die Ergebnisse.
+
+---
+
+## Routen
+
+| Methode   | Pfad                          | Beschreibung                              |
+|-----------|-------------------------------|------------------------------------------|
+| `GET`    | `/employees`                  | Mitarbeiter auflisten (paginiert)         |
+| `POST`   | `/employees`                  | Mitarbeiter erstellen                     |
+| `GET`    | `/employees/{id}`             | Einzelnen Mitarbeiter abrufen             |
+| `GET`    | `/employees/{id}/shifts`      | Schichten eines Mitarbeiters auflisten (paginiert) |
+| `POST`   | `/shifts`                     | Schicht einplanen (Überlappungsprüfung)   |
+| `GET`    | `/shifts/{id}`                | Einzelne Schicht abrufen                  |
+| `DELETE` | `/shifts/{id}`                | Schicht löschen                           |
+| `GET`    | `/schedule`                   | Schichten in einem Datumsfenster (`?from=&to=`) |
+| `GET`    | `/summary/weekly`             | Stunden pro Mitarbeiter pro Woche         |
+| `GET`    | `/summary/overtime`           | Mitarbeiter über einer Stundenschwelle    |
+
+---
+
+## Mitarbeiter erstellen
+
+```php
+// POST /employees
+$body = [
+    'name'        => 'Alice',    // erforderlich, nicht-leerer String
+    'role'        => 'Barista',  // erforderlich, nicht-leerer String
+    'hourly_rate' => 18.50,      // erforderlich, numerisch > 0
+];
+```
+
+Strikte JSON-Typprüfungen mit `is_int()` / `is_string()` werden angewendet. Leere Strings werden nach `trim()` abgelehnt.
+
+```php
+if (!isset($body['hourly_rate'])
+    || !is_numeric($body['hourly_rate'])
+    || (float) $body['hourly_rate'] <= 0) {
+    $errors[] = new ValidationError('hourly_rate', 'hourly_rate must be a positive number.', 'required');
+}
+```
+
+> **Hinweis**: Das Schema hat auch `CHECK(hourly_rate > 0)` auf DB-Ebene als Defense-in-Depth-Backstop. Auf App-Ebene zuerst validieren, um ein ordentliches 422 zurückzugeben.
+
+---
+
+## Schichten einplanen mit Überlappungserkennung
+
+Die Überlappungserkennung läuft innerhalb einer Datenbanktransaktion, um Race Conditions zu verhindern:
+
+```php
+return $this->txManager->transactional(
+    function (DatabaseQueryExecutorInterface $tx) use ($employeeId, $startsAt, $endsAt, $location, $now): Shift {
+        $txRepo   = new self($tx, $this->txManager);
+        $employee = $txRepo->findEmployeeById($employeeId);
+
+        // Überlappung: jede vorhandene Schicht, die [$startsAt, $endsAt) überschneidet
+        $overlap = $tx->fetchOne(
+            "SELECT id FROM shifts
+             WHERE employee_id = ?
+               AND starts_at < ?
+               AND ends_at   > ?",
+            [$employeeId, $endsAt, $startsAt],
+        );
+
+        if ($overlap !== null) {
+            throw new ShiftOverlapException($employee->name, $startsAt, $endsAt);
+        }
+
+        $id = $tx->insert(
+            'INSERT INTO shifts (employee_id, starts_at, ends_at, location, created_at) VALUES (?, ?, ?, ?, ?)',
+            [$employeeId, $startsAt, $endsAt, $location, $now],
+        );
+        // ...
+    },
+);
+```
+
+Die Überlappungsbedingung `starts_at < $endsAt AND ends_at > $startsAt` behandelt alle vier Überlappungskonfigurationen korrekt (links teilweise, rechts teilweise, enthalten, enthaltend).
+
+**Warum transaktional?** Ohne eine Transaktion können zwei gleichzeitige Anfragen beide die Überlappungsprüfung bestehen und konflikthafte Schichten erstellen. Die Transaktion serialisiert die Lesen-Prüfen-Schreiben-Sequenz.
+
+---
+
+## ends_at > starts_at Validierung
+
+Die Anwendung validiert die Zeitreihenfolge vor der DB:
+
+```php
+if ($endsAt <= $startsAt) {
+    throw new ValidationException([
+        new ValidationError('ends_at', 'ends_at must be after starts_at.', 'invalid_range'),
+    ]);
+}
+```
+
+Das Schema fügt `CHECK(ends_at > starts_at)` als Backstop hinzu. Beide Ebenen zusammen stellen sicher, dass ungültige Bereiche nie den Datenspeicher erreichen.
+
+---
+
+## ISO 8601-Datumsstring-Vergleich
+
+Schichtzeiten werden als ISO 8601-Strings (`2026-05-27T09:00:00+09:00`) gespeichert und lexikografisch in SQL verglichen. Dies funktioniert korrekt **nur wenn alle Zeiten denselben Zeitzonenoffset oder UTC verwenden**. Gemischte-Offset-Vergleiche können falsche Ergebnisse liefern:
+
+```
+"2026-05-27T09:00:00+09:00" < "2026-05-27T01:00:00Z"  → falsch (gleicher Moment)
+```
+
+**Empfehlung**: Alle Datetimes vor der Speicherung auf UTC normalisieren:
+
+```php
+$utc      = new \DateTimeZone('UTC');
+$startsAt = (new \DateTimeImmutable($raw))->setTimezone($utc)->format(\DateTimeInterface::ATOM);
+```
+
+---
+
+## Benutzerdefinierte Exception → HTTP-Antwort-Zuordnung
+
+Domain-Exceptions werden über Handler auf strukturierte Problem-Details-Antworten abgebildet:
+
+```php
+final readonly class ShiftOverlapExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function supports(\Throwable $exception): bool
+    {
+        return $exception instanceof ShiftOverlapException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->factory->create(
+            $request,
+            'shift-overlap',
+            'Shift overlaps with an existing shift.',
+            409,
+            $exception->getMessage(),
+        );
+    }
+}
+```
+
+Separate Handler existieren für `ShiftNotFoundException` → 404, `EmployeeNotFoundException` → 404 und `ShiftOverlapException` → 409. Die Registrierung in `RuntimeApplicationFactory` hält Controller frei von `try/catch`-Boilerplate.
+
+---
+
+## Aggregat-Abfragen: Wochenzusammenfassung und Überstunden
+
+```php
+// GET /summary/weekly?from=2026-05-19&to=2026-05-25
+// GET /summary/overtime?from=2026-05-19&to=2026-05-25&threshold=40
+```
+
+Die Überstundenschwelle ist standardmäßig 40 Stunden:
+
+```php
+$threshold = (float) (QueryStringParser::int($request, 'threshold') ?? 40);
+if ($threshold <= 0) {
+    throw new ValidationException([...]);
+}
+```
+
+Hinweis: `QueryStringParser::int()` wird zuerst verwendet (lehnt nicht-numerische Strings ab), dann wird auf `float` gecastet. Dies verhindert, dass `NaN` / `Infinity` die Business-Layer erreichen.
+
+---
+
+## Schema: Cascade-Delete und DB-Level-Bedingungen
+
+```sql
+CREATE TABLE employees (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL,
+    role        TEXT    NOT NULL,
+    hourly_rate REAL    NOT NULL CHECK(hourly_rate > 0),
+    created_at  TEXT    NOT NULL
+);
+
+CREATE TABLE shifts (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    employee_id INTEGER NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+    starts_at   TEXT    NOT NULL,
+    ends_at     TEXT    NOT NULL,
+    location    TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL,
+    CHECK(ends_at > starts_at)
+);
+```
+
+`ON DELETE CASCADE` entfernt die Schichten eines Mitarbeiters, wenn der Mitarbeiter gelöscht wird. DB-Level-`CHECK`-Bedingungen sind Defense-in-Depth-Backstops, nicht die primäre Validierungsebene — App-Level-Validierung muss 422 zurückgeben, bevor ein DB-INSERT ausgeführt wird.
+
+---
+
+## VULN — Sicherheitsassessment (FT225)
+
+Jedes Ergebnis dokumentiert den Angriffsvektor, das beobachtete Ergebnis und das Urteil:
+**BLOCKED** (sicher), **EXPOSED** (echte Schwachstelle), **PARTIALLY EXPOSED** (teilweise exponiert),
+oder **ACCEPTED BY DESIGN** (akzeptiert nach Design).
+
+### V-01 — Keine Authentifizierung bei keinem Endpunkt
+
+**Angriff**: Mitarbeiter erstellen, Schichten planen oder Schichten ohne Anmeldedaten löschen.
+
+```http
+POST /employees
+{"name": "Attacker", "role": "Ghost", "hourly_rate": 0.01}
+
+DELETE /shifts/1
+```
+
+**Beobachtet**: Beide erfolgreich. Kein Token, keine Session und kein API-Key erforderlich.
+
+**Urteil**: **EXPOSED** (nach Design für FT43-Demo).
+Produktions-Planungssysteme MÜSSEN Mutationen hinter Authentifizierung sperren.
+`MachineApiKeyMiddleware` (env: `NENE2_MACHINE_API_KEY`) oder JWT Bearer verwenden.
+
+---
+
+### V-02 — Keine Autorisierung: Jeder kann jede Schicht löschen
+
+**Angriff**: Eine Schicht löschen, die einem anderen Mitarbeiter gehört, ohne Eigentümerschaftsprüfung.
+
+```http
+DELETE /shifts/1   # gelingt für jeden authentifizierten oder nicht-authentifizierten Aufrufer
+```
+
+**Beobachtet**: `204 No Content` unabhängig von der Aufruferidentität.
+
+**Urteil**: **EXPOSED** (nach Design für FT43-Demo).
+Eine Manager/Admin-Rollenprüfung vor dem Löschen hinzufügen oder Schichten an einen anfragenden Benutzer binden.
+
+---
+
+### V-03 — SQL-Injection über parametrisierte Abfragen
+
+**Angriff**: SQL durch `name`, `role`, `starts_at` oder `location` injizieren.
+
+```json
+{"name": "x'; DROP TABLE employees; --", "role": "Admin", "hourly_rate": 1}
+{"starts_at": "2026-01-01' OR '1'='1", "ends_at": "2026-01-02", "employee_id": 1}
+```
+
+**Beobachtet**: Mitarbeiter mit dem Injection-String als Namen erstellt. `starts_at` der Schicht wird in einer parametrisierten Abfrage verwendet, daher tritt keine SQL-Injection auf.
+
+**Urteil**: **BLOCKED** — alle Abfragen verwenden PDO-parametrisierte Statements. Der gespeicherte String ist in der DB harmlos; das einzige Risiko wäre, wenn er später als HTML gerendert würde.
+
+---
+
+### V-04 — Race Condition bei der Schicht-Überlappungserkennung
+
+**Angriff**: Zwei gleichzeitige `POST /shifts`-Anfragen mit überlappenden Fenstern für denselben Mitarbeiter senden.
+
+**Beobachtet**: Die Überlappungsprüfung läuft innerhalb von `transactional()`. SQLite serialisiert Schreibvorgänge mit WAL-Mode-Locking; MySQL/PostgreSQL verwenden `REPEATABLE READ` oder `SERIALIZABLE`-Isolation, wenn der Transaction Manager korrekt konfiguriert ist. Beide gleichzeitigen Inserts können nicht beide die Überlappungsprüfung bestehen.
+
+**Urteil**: **BLOCKED** — transaktionale Überlappungsprüfung verhindert Doppelbuchungen unter Nebenläufigkeit. Isolationslevel verifizieren, dass er zum DB-Engine passt; SQLites WAL-Standard ist für Single-Node-Deployments ausreichend.
+
+---
+
+### V-05 — ends_at ≤ starts_at akzeptiert
+
+**Angriff**: Eine Schicht einreichen, bei der die Endzeit vor oder gleich der Startzeit liegt.
+
+```json
+{"employee_id": 1, "starts_at": "2026-05-27T10:00:00Z", "ends_at": "2026-05-27T09:00:00Z"}
+{"employee_id": 1, "starts_at": "2026-05-27T10:00:00Z", "ends_at": "2026-05-27T10:00:00Z"}
+```
+
+**Beobachtet**: `422 Unprocessable Entity` — die App vergleicht Strings (`$endsAt <= $startsAt`) vor dem Einfügen. Das DB `CHECK(ends_at > starts_at)` ist ein Backstop.
+
+**Urteil**: **BLOCKED** — zweischichtige Validierung (App + DB-Bedingung).
+
+---
+
+### V-06 — hourly_rate-Validierungslücke
+
+**Angriff**: Einen negativen, null- oder String-Wert für `hourly_rate` einreichen.
+
+```json
+{"name": "X", "role": "Y", "hourly_rate": -10}
+{"name": "X", "role": "Y", "hourly_rate": 0}
+{"name": "X", "role": "Y", "hourly_rate": "free"}
+```
+
+**Beobachtet**:
+- Negativ/null: Die Anwendung validiert `hourly_rate > 0` NICHT auf Controller-Ebene. Ein negativer Wert umgeht die App-Prüfung und trifft das DB `CHECK(hourly_rate > 0)`, das eine DB-Exception auslöst. Ohne expliziten Handler wird dies zu einem 500.
+- String `"free"`: `is_numeric()` gibt false zurück, daher wird dies mit 422 abgelehnt.
+
+**Urteil**: **PARTIALLY EXPOSED** — App-Layer-Validierung vor dem DB-Insert hinzufügen:
+```php
+if (!isset($body['hourly_rate'])
+    || !is_numeric($body['hourly_rate'])
+    || (float) $body['hourly_rate'] <= 0) {
+    $errors[] = new ValidationError('hourly_rate', 'hourly_rate must be a positive number.', 'out_of_range');
+}
+```
+
+---
+
+### V-07 — Semantisch ungültiges ISO 8601-Datetime
+
+**Angriff**: Eine Schicht mit einem strukturell plausiblen, aber kalendarisch ungültigen Datetime einreichen.
+
+```json
+{"starts_at": "2026-02-30T00:00:00Z", "ends_at": "2026-02-30T08:00:00Z", "employee_id": 1}
+```
+
+**Beobachtet**: Akzeptiert und gespeichert. Die Anwendung prüft `trim() === ''`, parst das Datum jedoch nicht. `DateTimeImmutable` normalisiert `2026-02-30` stillschweigend auf `2026-03-02` und korrumpiert so den gespeicherten Wert.
+
+**Urteil**: **EXPOSED** — eine Roundtrip-Prüfung sowohl für `starts_at` als auch für `ends_at` hinzufügen:
+```php
+$dt = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $raw);
+if ($dt === false || $dt->format(DateTimeInterface::ATOM) !== $raw) {
+    $errors[] = new ValidationError('starts_at', 'starts_at must be a valid ISO 8601 datetime.', 'invalid_format');
+}
+```
+
+---
+
+### V-08 — Unbegrenzter Datumsbereich in Aggregat-Abfragen
+
+**Angriff**: Eine Zusammenfassung über einen beliebig großen Datumsbereich anfordern, um den Speicher zu erschöpfen oder eine langsame Abfrage zu verursachen.
+
+```http
+GET /summary/weekly?from=1900-01-01&to=2099-12-31
+```
+
+**Beobachtet**: Abfrage läuft über alle Zeilen in der Tabelle. Bei einem großen Datensatz kann dies zu übermäßiger Speichernutzung oder einer mehrsekundigen Antwort führen.
+
+**Urteil**: **EXPOSED** — den maximalen erlaubten Bereich auf Controller-Ebene begrenzen (z. B. 90 Tage):
+```php
+$maxDays = 90;
+$diff    = (new DateTimeImmutable($to))->diff(new DateTimeImmutable($from));
+if ($diff->days > $maxDays) {
+    return $this->json->create(['error' => "Date range must not exceed {$maxDays} days."], 422);
+}
+```
+
+---
+
+### V-09 — Unbegrenzte Länge von Mitarbeitername / Rolle
+
+**Angriff**: Einen Mitarbeiter mit einem Namen oder einer Rolle mit zehntausenden Zeichen erstellen.
+
+```json
+{"name": "AAAA... (50000 Zeichen)", "role": "Y", "hourly_rate": 10}
+```
+
+**Beobachtet**: `201 Created` — SQLite TEXT ist unbegrenzt; die Zeile wird eingefügt.
+
+**Urteil**: **EXPOSED** — `mb_strlen()`-Prüfungen hinzufügen und 422 zurückgeben:
+```php
+if (mb_strlen($name) > 100) {
+    $errors[] = new ValidationError('name', 'name must not exceed 100 characters.', 'max_length');
+}
+```
+
+---
+
+### V-10 — Unbegrenzter Ort-String
+
+**Angriff**: Eine Schicht mit einem Ort-String beliebiger Länge einplanen.
+
+```json
+{"employee_id": 1, "starts_at": "...", "ends_at": "...", "location": "BBBB... (50000 Zeichen)"}
+```
+
+**Beobachtet**: `201 Created` — kein Längenlimit wird durchgesetzt.
+
+**Urteil**: **EXPOSED** — `mb_strlen($location) <= 200`-Prüfung hinzufügen.
+
+---
+
+### V-11 — XSS-Payload in Name / Rolle / Ort
+
+**Angriff**: Ein `<script>`-Tag in einem beliebigen Freitextfeld speichern.
+
+```json
+{"name": "<script>alert(1)</script>", "role": "Admin", "hourly_rate": 1}
+```
+
+**Beobachtet**: `201 Created`. Wert wird in JSON-Antworten unverändert zurückgegeben.
+
+**Urteil**: **ACCEPTED BY DESIGN** — dies ist eine JSON-API; Escaping ist die Verantwortung des HTML-Rendering-Clients. Der Server gibt aus diesen Feldern kein HTML aus. Den Vertrag in der OpenAPI-Spezifikation dokumentieren.
+
+---
+
+### V-12 — Nicht-numerische Pfad-IDs
+
+**Angriff**: Nicht-Ziffern- oder negative Werte als `{id}` übergeben.
+
+```http
+GET /shifts/abc
+GET /shifts/-1
+DELETE /employees/0
+```
+
+**Beobachtet**: `404 Not Found` in jedem Fall. `(int) "abc"` = `0`; keine Schicht/kein Mitarbeiter mit ID 0 oder negativ existiert, daher wirft `findShiftById(0)` `ShiftNotFoundException`, die der Handler auf 404 abbildet.
+
+**Urteil**: **BLOCKED** in der Praxis. Hinweis: `(int) "9abc"` = `9` — wenn ein Datensatz mit ID 9 existiert, würde er zurückgegeben. `ctype_digit()` für strikte Pfad-ID-Validierung verwenden, wenn der Unterschied wichtig ist.
+
+---
+
+## VULN-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|----------------|--------|
+| V-01 | Keine Authentifizierung | EXPOSED (nach Design) |
+| V-02 | Keine Autorisierung / jede Schicht löschbar | EXPOSED (nach Design) |
+| V-03 | SQL-Injection | BLOCKED |
+| V-04 | Überlappungs-Race-Condition | BLOCKED |
+| V-05 | ends_at ≤ starts_at | BLOCKED |
+| V-06 | Negative hourly_rate umgeht App-Prüfung | PARTIALLY EXPOSED |
+| V-07 | Semantisch ungültiges ISO 8601-Datetime | EXPOSED |
+| V-08 | Unbegrenzter Datumsbereich in Aggregat-Abfragen | EXPOSED |
+| V-09 | Unbegrenzte Mitarbeitername/Rolle | EXPOSED |
+| V-10 | Unbegrenzter Ort-String | EXPOSED |
+| V-11 | XSS-Payload-Speicherung | ACCEPTED BY DESIGN |
+| V-12 | Nicht-numerische Pfad-IDs | BLOCKED |
+
+**Echte Schwachstellen, die vor der Produktion behoben werden müssen**:
+1. **V-01/02** — Authentifizierung und rollenbasierte Autorisierung hinzufügen
+2. **V-06** — `hourly_rate > 0`-Validierung auf App-Ebene hinzufügen
+3. **V-07** — ISO 8601-Roundtrip-Validierung für Datetime-Felder hinzufügen
+4. **V-08** — Maximalen Datumsbereich in Aggregat-Endpunkten begrenzen (z. B. 90 Tage)
+5. **V-09/10** — `mb_strlen()`-Max-Längen-Prüfungen für alle Freitextfelder hinzufügen
+
+---
+
+## Verwandte Anleitungen
+
+- [`notification-inbox.md`](notification-inbox.md) — IDOR-Schutzmuster (404 bei nicht autorisiertem Lesen/Schreiben)
+- [`prevent-double-booking.md`](prevent-double-booking.md) — transaktionale Doppelbuchungs-Prävention
+- [`expense-tracker.md`](expense-tracker.md) — ISO 8601-Roundtrip-Datumsvalidierung
+- [`resource-booking.md`](resource-booking.md) — Datumsbereichsbegrenzung und Zeitfenster-Abfragen

--- a/docs/de/howto/shopping-cart-api.md
+++ b/docs/de/howto/shopping-cart-api.md
@@ -1,0 +1,312 @@
+# Anleitung: Warenkorb-API
+
+> **FT-Referenz**: FT269 (`NENE2-FT/cartlog`) — Warenkorb: UNIQUE (user_id, product_id) Pro-Benutzer-Warenkorb, Upsert-Artikel-Hinzufügen (Mengenkumulierung), quantity=0 Auto-Entfernen-Semantik, Integer-Preis/Zwischensumme, X-User-Id-Header-Identifikation
+>
+> Auch validiert in FT155 (`NENE2-FT/cartlog` Vorläufer) — gleiches Warenkorbmuster, SQLite, PHP 8.4.
+
+Demonstriert einen zustandsbehafteten Pro-Benutzer-Warenkorb: Artikel hinzufügen (mit Mengenkumulierung bei erneutem Hinzufügen), Mengen aktualisieren, Artikel entfernen und eine laufende Summe anzeigen. Alle Preise werden als Integer (Cent oder Basiseinheiten) gespeichert — niemals als Floats.
+
+---
+
+## Routen
+
+| Methode   | Pfad                        | Beschreibung                              |
+|-----------|-----------------------------|------------------------------------------|
+| `GET`    | `/cart`                     | Warenkorbinhalt mit Zwischensummen und Gesamtsumme auflisten |
+| `POST`   | `/cart/items`               | Produkt hinzufügen (Menge kumuliert sich, wenn bereits im Warenkorb) |
+| `PUT`    | `/cart/items/{productId}`   | Menge setzen (0 = Artikel entfernen)     |
+| `DELETE` | `/cart/items/{productId}`   | Einen bestimmten Artikel entfernen       |
+| `DELETE` | `/cart`                     | Gesamten Warenkorb leeren                |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE products (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    price      INTEGER NOT NULL CHECK (price >= 0),
+    stock      INTEGER NOT NULL DEFAULT 0 CHECK (stock >= 0),
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE cart_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    product_id INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL CHECK (quantity > 0),
+    added_at   TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE (user_id, product_id),
+    FOREIGN KEY (user_id)    REFERENCES users(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+```
+
+Wichtige Designentscheidungen:
+- `UNIQUE (user_id, product_id)` — eine Zeile pro (Benutzer, Produkt)-Paar. Das erneute Hinzufügen desselben Produkts kumuliert die Menge statt einer Duplikatzeile einzufügen.
+- `price INTEGER` — gespeichert in kleinster Währungseinheit (z. B. Cent). Niemals `FLOAT` für Geld verwenden.
+- `quantity INTEGER CHECK (quantity > 0)` — Zeilen mit Menge null werden gelöscht, nicht gespeichert.
+- Kein FK für `cart_items.price` — der Preis wird zum Abfragezeitpunkt aus `products.price` gelesen (JOIN), nicht im Warenkorb gespeichert. Wenn sich der Produktpreis ändert, spiegelt der Warenkorb den neuen Preis wider.
+
+---
+
+## Upsert-Artikel-Hinzufügen-Muster
+
+Das Hinzufügen eines Artikels, der bereits im Warenkorb ist, kumuliert die Menge:
+
+```php
+public function addItem(int $userId, int $productId, int $quantity, string $now): void
+{
+    $existing = $this->db->fetchOne(
+        'SELECT id, quantity FROM cart_items WHERE user_id = ? AND product_id = ?',
+        [$userId, $productId],
+    );
+
+    if ($existing !== null) {
+        $newQty = (int) $existing['quantity'] + $quantity;
+        $this->db->execute(
+            'UPDATE cart_items SET quantity = ?, updated_at = ? WHERE id = ?',
+            [$newQty, $now, $existing['id']],
+        );
+    } else {
+        $this->db->execute(
+            'INSERT INTO cart_items (user_id, product_id, quantity, added_at, updated_at)
+             VALUES (?, ?, ?, ?, ?)',
+            [$userId, $productId, $quantity, $now, $now],
+        );
+    }
+}
+```
+
+Das SELECT-then-INSERT/UPDATE-Muster vermeidet `INSERT OR REPLACE` (das `id` und `added_at` ändert) und vermeidet `ON CONFLICT DO UPDATE` (nicht portabel über alle DB-Engines). Die `UNIQUE (user_id, product_id)`-Bedingung schützt weiterhin vor einem Race-Condition-Duplikat-INSERT.
+
+Antwortstatus: `201 Created` wenn der Artikel neu war; `200 OK` wenn die Menge bei einem vorhandenen Artikel kumuliert wurde.
+
+---
+
+## Menge=0 Auto-Entfernen-Semantik
+
+`PUT /cart/items/{productId}` mit `quantity: 0` entfernt den Artikel statt einer Null-Menge-Zeile zu speichern:
+
+```php
+if ($quantity === 0) {
+    $this->repo->removeItem($userId, $productId);
+    return $this->json->createEmpty(204);
+}
+
+$this->repo->updateQuantity($userId, $productId, $quantity, $now);
+```
+
+Dies entspricht gängiger Warenkorb-UX: das Stepper auf null ziehen entfernt den Artikel. Das DB-`CHECK (quantity > 0)` erzwingt dies auch auf Speicherebene.
+
+---
+
+## Warenkorb-Gesamtsumme: JOIN + Schleifenberechnung
+
+Die Warenkorbantwort enthält eine Echtzeit-Gesamtsumme, die aus dem JOIN-Ergebnis berechnet wird:
+
+```php
+public function getCart(int $userId): array
+{
+    return $this->db->fetchAll(
+        'SELECT ci.id, ci.product_id, ci.quantity, ci.added_at, ci.updated_at,
+                p.name AS product_name, p.price
+         FROM cart_items ci
+         JOIN products p ON p.id = ci.product_id
+         WHERE ci.user_id = ?
+         ORDER BY ci.added_at ASC, ci.id ASC',
+        [$userId],
+    );
+}
+```
+
+```php
+$items = $this->repo->getCart($userId);
+$total = 0;
+$formatted = [];
+
+foreach ($items as $item) {
+    $subtotal = (int) $item['price'] * (int) $item['quantity'];
+    $total   += $subtotal;
+    $formatted[] = $this->formatItem($item, $subtotal);
+}
+
+return $this->json->create([
+    'items' => $formatted,
+    'total' => $total,
+    'count' => count($formatted),
+]);
+```
+
+Sowohl `price` als auch `subtotal` sind Integer. Der API-Consumer dividiert durch 100 zur Anzeige (z. B. `1999` → `19,99 €`).
+
+---
+
+## Benutzeridentifikation über X-User-Id-Header
+
+Der FT verwendet einen einfachen `X-User-Id`-Header (kein JWT) zur Identifikation des Warenkorbeigentümers:
+
+```php
+private function requireUserId(ServerRequestInterface $request): ?int
+{
+    $header = $request->getHeaderLine('X-User-Id');
+    if ($header === '') {
+        return null;
+    }
+    $id = (int) $header;
+    return $id > 0 ? $id : null;
+}
+```
+
+Der Handler überprüft, dass der Benutzer in der `users`-Tabelle existiert, bevor er fortfährt:
+```php
+if ($this->repo->findUserById($userId) === null) {
+    return $this->json->create(['error' => 'User not found'], 404);
+}
+```
+
+**Produktionshinweis**: `X-User-Id` durch einen verifizierten JWT oder Session-Token ersetzen. Der Header ist trivial fälschbar — jeder Aufrufer kann jede `user_id` beanspruchen. `X-User-Id` nur in vertrauenswürdigen internen Service-to-Service-Kontexten verwenden, niemals für öffentliche APIs.
+
+---
+
+## Validierung
+
+```php
+// POST /cart/items Body-Validierung
+private function parseAddBody(array $body): array
+{
+    $errors = [];
+
+    if (!isset($body['product_id']) || !is_int($body['product_id'])) {
+        $errors[] = new ValidationError('product_id', 'product_id must be an integer', 'invalid_type');
+    }
+
+    $productId = isset($body['product_id']) && is_int($body['product_id']) ? $body['product_id'] : 0;
+    if ($productId <= 0 && $errors === []) {
+        $errors[] = new ValidationError('product_id', 'product_id must be positive', 'invalid_value');
+    }
+
+    if (!isset($body['quantity']) || !is_int($body['quantity'])) {
+        $errors[] = new ValidationError('quantity', 'quantity must be an integer', 'invalid_type');
+    }
+
+    $quantity = isset($body['quantity']) && is_int($body['quantity']) ? $body['quantity'] : 0;
+    if ($quantity <= 0 && !isset($errors[1])) {
+        $errors[] = new ValidationError('quantity', 'quantity must be positive', 'invalid_value');
+    }
+
+    return [$productId, $quantity, $errors];
+}
+```
+
+Typprüfungen (`is_int`) lehnen Float- oder String-Mengen ab — `"3"` und `3.0` sind beide ungültig.
+
+---
+
+## Beispielantworten
+
+**GET /cart**:
+```json
+{
+    "items": [
+        {
+            "id": 1,
+            "product_id": 5,
+            "product_name": "Widget",
+            "price": 999,
+            "quantity": 2,
+            "subtotal": 1998,
+            "added_at": "2026-01-01T10:00:00Z",
+            "updated_at": "2026-01-01T10:00:00Z"
+        }
+    ],
+    "total": 1998,
+    "count": 1
+}
+```
+
+---
+
+## AppFactory-Verdrahtungsbeispiel
+
+Die App für Tests oder einen leichtgewichtigen Einstiegspunkt bootstrap:
+
+```php
+class AppFactory
+{
+    public static function createSqlite(string $dbFile): RequestHandlerInterface
+    {
+        $dbConfig = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: '',
+            port: 1,
+            name: $dbFile,
+            user: '',
+            password: '',
+            charset: '',
+        );
+        return self::build($dbConfig);
+    }
+
+    private static function build(DatabaseConfig $dbConfig): RequestHandlerInterface
+    {
+        $factory    = new PdoConnectionFactory($dbConfig);
+        $executor   = new PdoDatabaseQueryExecutor($factory);
+        $psr17      = new Psr17Factory();
+        $repo       = new CartRepository($executor);
+        $json       = new JsonResponseFactory($psr17, $psr17);
+        $registrar  = new RouteRegistrar($repo, $json);
+
+        return (new RuntimeApplicationFactory(
+            $psr17,
+            $psr17,
+            routeRegistrars: [static fn (Router $router) => $registrar->register($router)],
+        ))->create();
+    }
+}
+```
+
+Die Verwendung von `RuntimeApplicationFactory` stellt automatisch bereit: ValidationException → 422-Zuordnung, Fehlerbehandlung und Sicherheits-Header.
+
+---
+
+## Testmuster
+
+```php
+// Dasselbe Produkt erneut hinzufügen kumuliert die Menge
+$this->req('POST', '/cart/items', ['X-User-Id' => '1'], ['product_id' => 1, 'quantity' => 2]);
+$res = $this->req('POST', '/cart/items', ['X-User-Id' => '1'], ['product_id' => 1, 'quantity' => 3]);
+$this->assertSame(200, $res->getStatusCode());
+$data = $this->json($res);
+$this->assertSame(5, $data['quantity']);
+
+// Jeder Benutzer-Warenkorb ist isoliert
+$this->req('POST', '/cart/items', ['X-User-Id' => '1'], ['product_id' => 1, 'quantity' => 3]);
+$res = $this->req('GET', '/cart', ['X-User-Id' => '2']);
+$this->assertSame(0, $this->json($res)['count']);
+```
+
+> **SQLite-FK-Einschränkung**: `PdoConnectionFactory` setzt `PRAGMA foreign_keys = ON`. Wenn Testdaten über eine separate PDO-Instanz geseedet werden, dasselbe Pragma auf dieser Verbindung setzen — sonst lassen JOINs stillschweigend Zeilen fallen, deren FK-Ziele über ein anderes Verbindungs-Handle eingefügt wurden.
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `price` beim Hinzufügen in `cart_items` speichern | Veralteter Preis bei Produktpreisänderung; Rückerstattungs-/Überzahlungsstreitigkeiten |
+| `FLOAT` für Preise verwenden | Gleitkommafehler in finanziellen Gesamtsummen |
+| `X-User-Id` in einer öffentlichen API verwenden | Trivial fälschbar; stattdessen JWT/Session verwenden |
+| `quantity: 0` als Null-Zeile speichern lassen | Verstößt gegen `CHECK (quantity > 0)`; verwirrende Semantik |
+| `INSERT OR REPLACE` für Upsert verwenden | Setzt `id` und `added_at` zurück; bricht die reihenfolgeerhaltende Sortierung |
+| Keine `UNIQUE (user_id, product_id)`-Bedingung | Race Condition erstellt Duplikat-Warenkorbzeilen |

--- a/docs/de/howto/signed-url-download.md
+++ b/docs/de/howto/signed-url-download.md
@@ -1,0 +1,180 @@
+# Anleitung: Signierte URLs für sichere Downloads
+
+> **FT-Referenz**: FT338 (`NENE2-FT/signedlog`) — HMAC-SHA256-signierte URL-Generierung mit TTL, Manipulationserkennung (401), Ablauf (410 Gone), ressourcengebundene Tokens und Ablehnung bei falschem Secret, 16 Tests / 40+ Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie zeitlich begrenzte signierte URLs generiert werden, die einen nicht authentifizierten Download privater Dateien ermöglichen — ohne langlebige Anmeldedaten preiszugeben.
+
+## Schema
+
+```sql
+CREATE TABLE files (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    owner_id   INTEGER NOT NULL,
+    mime_type  TEXT    NOT NULL DEFAULT 'application/octet-stream',
+    created_at TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/files` | Dateidatensatz registrieren |
+| `POST` | `/files/{id}/sign` | Signierte Download-URL generieren |
+| `GET`  | `/download?token=...` | Mit signiertem Token herunterladen |
+
+## Datei registrieren
+
+```php
+POST /files
+{"name": "report.pdf", "owner_id": 1}
+→ 201
+{
+  "id": 1,
+  "name": "report.pdf",
+  "owner_id": 1,
+  "mime_type": "application/octet-stream",
+  "created_at": "..."
+}
+
+// Benutzerdefinierter MIME-Typ
+POST /files  {"name": "image.png", "owner_id": 2, "mime_type": "image/png"}
+→ 201  {"mime_type": "image/png", ...}
+
+// Validierung
+POST /files  {"owner_id": 1}     → 422  // name erforderlich
+POST /files  {"name": "f.pdf"}   → 422  // owner_id erforderlich
+```
+
+## Signierte URL generieren
+
+```php
+POST /files/1/sign
+{"ttl_seconds": 300}
+→ 200
+{
+  "token": "1|2026-05-27 09:05:00|a3f9e2...",
+  "expires_at": "2026-05-27T09:05:00Z",
+  "url": "/download?token=1%7C2026-05-27+09%3A05%3A00%7Ca3f9e2...",
+  "ttl_seconds": 300
+}
+
+// Standard-TTL = 3600 (1 Stunde) wenn weggelassen
+POST /files/1/sign  {}
+→ 200  {"ttl_seconds": 3600}
+
+// Unbekannte Datei
+POST /files/999/sign  {"ttl_seconds": 60}
+→ 404
+```
+
+## Download mit Token
+
+```php
+GET /download?token=1|2026-05-27+09:05:00|a3f9e2...
+→ 200  {"id": 1, "name": "report.pdf", "mime_type": "application/octet-stream"}
+
+// Fehlender Token
+GET /download
+→ 401
+
+// Manipulierter Token (letzte 4 Zeichen geändert)
+GET /download?token=1|2026-05-27+09:05:00|XXXX
+→ 401
+
+// Abgelaufener Token (expires_at in der Vergangenheit)
+GET /download?token=1|2020-01-01+00:00:00|...valid_hmac...
+→ 410 Gone
+
+// Zufälliger Müll
+GET /download?token=totally-invalid-garbage
+→ 401
+```
+
+**410 Gone** (nicht 401) für abgelaufene Tokens: Die URL existierte und war gültig — sie ist einfach abgelaufen. Dies ermöglicht es Clients, „nie gültig" von „einmal gültig, jetzt veraltet" zu unterscheiden.
+
+## Token-Format — HMAC-SHA256
+
+```
+token = "{file_id}|{expires_at}|{hmac}"
+
+hmac = HMAC-SHA256(key=server_secret, message="{file_id}|{expires_at}")
+```
+
+```php
+class HmacSigner
+{
+    public function __construct(private readonly string $secret)
+    {
+    }
+
+    public function sign(int $fileId, string $expiresAt): string
+    {
+        $payload = "{$fileId}|{$expiresAt}";
+        $hmac    = hash_hmac('sha256', $payload, $this->secret);
+        return "{$payload}|{$hmac}";
+    }
+
+    public function verify(string $token, string $now): ?int
+    {
+        $parts = explode('|', $token, 3);
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        [$fileIdStr, $expiresAt, $receivedHmac] = $parts;
+        $fileId  = (int) $fileIdStr;
+        $payload = "{$fileId}|{$expiresAt}";
+
+        // Zeitkonstanter Vergleich
+        $expected = hash_hmac('sha256', $payload, $this->secret);
+        if (!hash_equals($expected, $receivedHmac)) {
+            return null;  // manipuliert oder falsches Secret
+        }
+
+        // Ablauf NACH Verifizierung des HMAC prüfen
+        if ($expiresAt < $now) {
+            return -1;  // abgelaufen — Aufrufer gibt 410 zurück
+        }
+
+        return $fileId;
+    }
+}
+```
+
+**Kritische Reihenfolge**: Immer den HMAC verifizieren, bevor der Ablauf geprüft wird. Den Ablauf zuerst bei einem ungültigen Token zu prüfen ermöglicht Angreifern, das Ablaufverhalten auszuspähen.
+
+### Ressourcenbindung
+
+Jeder Token kodiert die `file_id`. Tokens für verschiedene Dateien erzeugen unterschiedliche HMAC-Digests:
+
+```php
+$token1 = $signer->sign(1, $future);
+$token2 = $signer->sign(2, $future);
+// $token1 !== $token2 — Datei-1-Token kann nicht für Zugriff auf Datei-2 wiederverwendet werden
+```
+
+### Falsches Secret
+
+Ein Token, der mit einem anderen Secret signiert wurde, gibt bei `verify()` null zurück:
+
+```php
+$otherSigner = new HmacSigner('different-secret');
+$token = $otherSigner->sign(1, $future);
+$signer->verify($token, $now);  // null — HMAC-Mismatch
+```
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `===` statt `hash_equals()` für HMAC-Vergleich verwenden | Timing-Angriff gibt HMAC-Byte für Byte preis |
+| Ablauf vor HMAC-Verifizierung prüfen | Angreifer spioniert Ablauf bei gefälschten Tokens aus, um die Server-Uhr zu erfahren |
+| user_id nur im Token-Payload einschließen, nicht file_id | Token für Benutzer-1-Datei-1 ist für Zugriff auf Benutzer-1-Datei-2 wiederverwendbar |
+| `md5()` oder `sha1()` statt HMAC-SHA256 verwenden | Schlüssel-Hash erforderlich; ungeschlüsselter Hash ist trivial fälschbar |
+| 401 für abgelaufene Tokens zurückgeben | 410 teilt dem Client mit „Token war echt, aber veraltet"; ermöglicht korrekten Re-Sign-Flow |
+| Token-Wert in Zugriffsprotokollen protokollieren | Token gewährt Zugriff — wie ein Passwort behandeln; in Logs maskieren oder weglassen |
+| Schwaches oder vorhersehbares Secret verwenden | Key muss mindestens 32 zufällige Bytes sein; niemals von Zeitstempel oder Hostname ableiten |

--- a/docs/de/howto/signed-urls.md
+++ b/docs/de/howto/signed-urls.md
@@ -1,0 +1,151 @@
+# Signierte URLs
+
+Signierte URLs bieten zeitlich begrenzten, ressourcengebundenen Zugriff auf geschützte Ressourcen, ohne dass der Aufrufer sich mit einem Konto authentifizieren muss. Das Muster wird für Datei-Downloads, vorsignierte Upload-Slots und alle Fälle verwendet, in denen temporärer Zugriff mit einem Dritten geteilt werden soll.
+
+## Kernkonzept
+
+Eine signierte URL enthält alles, was zur Autorisierung des Zugriffs benötigt wird: die Ressourcen-ID, die Ablaufzeit und eine HMAC-Signatur, die beweist, dass die URL von einem vertrauenswürdigen Server generiert wurde. Der Server benötigt nur seinen geheimen Schlüssel zur Verifizierung — kein Datenbankaufruf erforderlich.
+
+## Token-Format
+
+```
+base64url({resource_id}|{expires_at}|{hmac-sha256(resource_id|expires_at, secret)})
+```
+
+Das HMAC deckt `resource_id|expires_at` zusammen ab. Das Ändern eines der Teile macht die Signatur ungültig. Dies bindet den Token an genau eine Ressource und ein Ablaufzeitfenster.
+
+## Signer-Implementierung
+
+```php
+final readonly class HmacSigner
+{
+    private const string ALGO = 'sha256';
+
+    public function __construct(
+        private string $secret,
+    ) {}
+
+    public function sign(int $resourceId, string $expiresAt): string
+    {
+        $payload = $resourceId . '|' . $expiresAt;
+        $mac     = hash_hmac(self::ALGO, $payload, $this->secret);
+
+        return $this->base64UrlEncode($payload . '|' . $mac);
+    }
+
+    public function verify(string $token, string $now): ?int
+    {
+        $decoded = $this->base64UrlDecode($token);
+        if ($decoded === null) {
+            return null;
+        }
+
+        $parts = explode('|', $decoded, 3);
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        [$resourceId, $expiresAt, $storedMac] = $parts;
+
+        $expectedMac = hash_hmac(self::ALGO, $resourceId . '|' . $expiresAt, $this->secret);
+
+        // hash_equals() ist obligatorisch — die Verwendung von === gibt Timing-Informationen preis
+        if (!hash_equals($expectedMac, $storedMac)) {
+            return null;
+        }
+
+        if ($expiresAt < $now) {
+            return null;
+        }
+
+        return (int) $resourceId;
+    }
+}
+```
+
+`hash_equals()` ist nicht verhandelbar. Ein String-Gleichheitsvergleich bricht beim ersten Unterschied ab und gibt preis, wie viele Zeichen des HMAC übereinstimmen. Ein Angreifer kann dies ausnutzen, um Signaturen Byte für Byte zu fälschen. `hash_equals()` vergleicht immer alle Zeichen.
+
+## 410 Gone vs. 401 Unauthorized für abgelaufene Tokens
+
+Benutzer profitieren davon zu wissen, ob ihr Link abgelaufen ist (und sie einen neuen anfordern sollten) gegenüber dem Fall, dass der Link nie gültig war. Der Signer verifiziert zunächst den HMAC, dann den Ablauf. Um diese in der HTTP-Antwort zu unterscheiden:
+
+```php
+$resourceId = $this->signer->verify($token, $now);
+
+if ($resourceId === null) {
+    // Ablauf ohne HMAC-Verifizierung extrahieren
+    $expiresAt = $this->signer->extractExpiresAt($token);
+    if ($expiresAt !== null && $expiresAt < $now) {
+        return $problems->create($request, 'gone', 'This link has expired.', 410, '');
+    }
+    return $problems->create($request, 'unauthorized', 'Invalid or expired token.', 401, '');
+}
+```
+
+`extractExpiresAt()` decodiert nur Base64 und teilt bei `|` — es verifiziert NICHT den HMAC. Dies ist sicher, weil:
+1. Der Ablauf ist kein Geheimnis (er ist in der signierten URL sowieso sichtbar).
+2. Ein Angreifer kann keinen gültigen Token mit einem manipulierten Ablauf fälschen, weil `verify()` ihn ablehnt.
+3. Die 410-Antwort liefert keine Informationen, die beim Fälschen von Tokens helfen.
+
+NICHT verschiedene Fehlermeldungen für „HMAC-Mismatch" vs. „Ablauf vergangen" ausgeben — das würde einem Angreifer ermöglichen, zunächst gültige Signaturen für beliebige Ablaufwerte zu konstruieren und diese dann zur Timing-Sondierung zu verwenden.
+
+## Signierte URLs generieren
+
+```php
+// POST /files/{id}/sign
+$expiresAt = (new \DateTimeImmutable())
+    ->add(new \DateInterval("PT{$ttlSeconds}S"))
+    ->format('Y-m-d H:i:s');
+
+$token = $this->signer->sign($file->id, $expiresAt);
+
+return $json->create([
+    'token'       => $token,
+    'expires_at'  => $expiresAt,
+    'ttl_seconds' => $ttlSeconds,
+    'url'         => '/download?token=' . urlencode($token),
+]);
+```
+
+Den Token immer mit `urlencode()` kodieren, bevor er in URLs eingebettet wird — Base64url-Zeichen sind URL-sicher, aber das `=`-Padding (falls vorhanden) ist es nicht, und das `|`-Trennzeichen im decodierten Payload darf nicht in der codierten Form erscheinen.
+
+## Secret-Key-Verwaltung
+
+- Das Secret aus einer Umgebungsvariablen injizieren — niemals hartcodieren.
+- Mindestens 32 Byte Zufallsdaten verwenden (`random_bytes(32)` → Hex oder Base64).
+- Für die Secret-Rotation mehrere Secrets gleichzeitig zur Verifizierung unterstützen (jedes ausprobieren, bis eines erfolgreich ist), dann das alte Secret auslaufen lassen.
+
+```php
+// Multi-Secret-Unterstützung während der Rotation
+public function verifyWithRotation(string $token, string $now, array $secrets): ?int
+{
+    foreach ($secrets as $secret) {
+        $signer = new HmacSigner($secret);
+        $id = $signer->verify($token, $now);
+        if ($id !== null) {
+            return $id;
+        }
+    }
+    return null;
+}
+```
+
+## Zustandslose vs. zustandsbehaftete signierte URLs
+
+Dieses Muster ist **zustandslos** — der Server verfolgt ausgestellte Tokens nicht. Dies ist der Hauptvorteil (kein DB-Lookup bei jedem Download), bedeutet aber:
+
+- Signierte URLs können nicht vor ihrem Ablauf widerrufen werden.
+- Wenn das Secret rotiert wird, werden alle zuvor ausgestellten Tokens sofort ungültig.
+
+Für widerrufbare Tokens eine Blocklist-Tabelle (`revoked_tokens`) pflegen und während der Verifizierung prüfen. Dies tauscht den zustandslosen Vorteil gegen Widerrufbarkeit ein.
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| `===` oder `strcmp()` für HMAC-Vergleich verwenden | Timing-Angriff — ermöglicht das Fälschen von Signaturen |
+| Nur `resource_id` ohne Ablauf signieren | Tokens sind dauerhaft — können nicht ablaufen |
+| Nur `expires_at` ohne resource_id signieren | Ein Token gewährt Zugriff auf alle Ressourcen |
+| Ablauf zur Unterscheidung von „manipuliert" vs. „abgelaufen" verwenden | Ermöglicht Oracle-Angriff auf HMAC |
+| Rohen Schlüssel im Token einbetten | Macht den Zweck zunichte — Token muss opak sein |
+| Lange TTLs (Tage/Wochen) | Erhöht das Expositionsfenster bei Token-Leak |

--- a/docs/de/howto/sliding-window-rate-limiter.md
+++ b/docs/de/howto/sliding-window-rate-limiter.md
@@ -1,0 +1,149 @@
+# Anleitung: Sliding-Window-Rate-Limiter
+
+## Überblick
+
+Diese Anleitung erklärt den Aufbau eines Pro-Benutzer-Pro-Endpunkt-Sliding-Window-Rate-Limiters mit NENE2. Anfragen werden innerhalb eines gleitenden Zeitfensters gezählt; sobald das Limit erreicht ist, werden weitere Anfragen mit `429 Too Many Requests` abgelehnt.
+
+**Referenzimplementierung**: `../NENE2-FT/ratelog/`
+
+---
+
+## Schema-Design
+
+```sql
+CREATE TABLE IF NOT EXISTS rate_events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    endpoint   TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_events_user_endpoint
+    ON rate_events (user_id, endpoint, created_at);
+```
+
+Der Index auf `(user_id, endpoint, created_at)` macht die COUNT-Abfrage bei Skalierung schnell.
+
+---
+
+## Routentabelle
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|-------------|
+| `POST` | `/rate/check` | Benutzer | Anfrage erfassen; gibt 429 zurück wenn über dem Limit |
+| `GET` | `/rate/status` | Benutzer | Aktuelle Nutzung für einen Benutzer/Endpunkt |
+| `DELETE` | `/rate/reset/{userId}` | Admin | Zähler für einen Benutzer zurücksetzen |
+
+---
+
+## Kerналгоритmus
+
+```php
+private const int LIMIT = 10;
+private const int WINDOW_SECONDS = 60;
+
+public function check(int $userId, string $endpoint): string
+{
+    $since = $this->windowStart();   // now() - 60s
+    $count = $this->countInWindow($userId, $endpoint, $since);
+
+    if ($count >= self::LIMIT) {
+        return 'rate_limited';
+    }
+
+    $this->recordEvent($userId, $endpoint);
+    return 'ok';
+}
+```
+
+**Sliding Window**: jedes `check()` schaut genau `WINDOW_SECONDS` vom aktuellen Moment zurück, sodass alte Ereignisse natürlich aus dem Geltungsbereich fallen.
+
+---
+
+## Admin-Reset mit Fail-Closed-Muster
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;     // fail-closed: nicht konfigurierter Key blockiert alle Admin-Zugriffe
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+Alle Zähler für einen Benutzer zurücksetzen (alle Endpunkte):
+```sql
+DELETE FROM rate_events WHERE user_id = :uid
+```
+
+Zurücksetzen für einen bestimmten Endpunkt:
+```sql
+DELETE FROM rate_events WHERE user_id = :uid AND endpoint = :ep
+```
+
+---
+
+## Pfadparameter-Extraktion (ohne Router::param())
+
+Wenn `Router::param()` in der installierten Version nicht verfügbar ist, das Attribut direkt verwenden:
+
+```php
+/** @var array<string, string> $params */
+$params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+$raw    = $params['userId'] ?? '';
+```
+
+---
+
+## Validierung
+
+- `endpoint`: nicht-leerer String, max. 128 Zeichen
+- `X-User-Id`: `ctype_digit()` + positive Integer
+- Pfad `userId`: `ctype_digit()` + positive Integer (Fehler → 404)
+- Admin-Key: `hash_equals()`-Vergleich (Fehler → 403)
+
+---
+
+## HTTP-Statuscodes
+
+| Situation | Status |
+|-----------|--------|
+| Anfrage erlaubt | 200 |
+| Status abgerufen | 200 |
+| Zähler zurückgesetzt | 200 |
+| Kein X-User-Id | 400 |
+| Kein Body | 400 |
+| Leerer / fehlender Endpunkt | 422 |
+| Endpunkt zu lang | 422 |
+| Kein Admin-Key | 403 |
+| Falscher Admin-Key | 403 |
+| Ungültige userId im Pfad | 404 |
+| Rate-Limit überschritten | 429 |
+
+---
+
+## Abgedeckte ATK-Angriffsmuster
+
+| ATK | Muster | Verteidigung |
+|-----|--------|--------------|
+| ATK-01 | Fehlendes X-User-Id | 400 mit Meldung |
+| ATK-02 | Leerer Endpunkt-String | 422-Validierung |
+| ATK-03 | 129-Zeichen-Endpunkt (DoS) | Längenlimit 422 |
+| ATK-04 | SQL-Injection im Endpunkt | Parametrisierte Abfragen |
+| ATK-05 | Nicht-Admin-Reset-Versuch | 403 fail-closed |
+| ATK-06 | Falscher Admin-Key | 403 hash_equals() |
+| ATK-07 | Negative userId im Pfad | 404 |
+| ATK-08 | Null-userId | 404 |
+| ATK-09 | Nicht-Ziffern-userId (`abc`) | 404 ctype_digit |
+| ATK-10 | Status ohne Endpunkt-Parameter | 422 |
+| ATK-11 | Check ohne Body | 400 |
+| ATK-12 | Body ohne Endpunkt-Schlüssel | 422 |
+
+---
+
+## Hinweise
+
+- **Nebenläufigkeit**: Das Sliding Window hat ein kleines TOCTOU-Fenster. Für hochnebenläufige Produktionsnutzung atomare Zähler in Betracht ziehen (Redis INCR + EXPIRE) oder Datenbank-Level-Locking.
+- **Uhrzeit-Drift**: Alle Zeitstempel sollten UTC verwenden, um DST- oder Zeitzonenüberraschungen zu vermeiden.
+- **Speicherwachstum**: Alte Ereignisse akkumulieren sich. Einen periodischen Bereinigungsjob hinzufügen: `DELETE FROM rate_events WHERE created_at < :cutoff`.

--- a/docs/de/howto/slug-management.md
+++ b/docs/de/howto/slug-management.md
@@ -1,0 +1,193 @@
+# Slug-Verwaltung — Eindeutige URL-Slugs mit Kollisionsauflösung und Historie
+
+URL-sichere Slugs aus Titeln generieren, Kollisionen automatisch auflösen und eine
+**Slug-Historientabelle** pflegen, sodass alte Slugs auf die kanonische URL weiterleiten,
+ohne eingehende Links zu unterbrechen.
+
+**Referenzimplementierung:** `FT174 sluglog` in
+[hideyukiMORI/NENE2-examples](https://github.com/hideyukiMORI/NENE2-examples)
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    slug       TEXT    NOT NULL UNIQUE,   -- aktueller kanonischer Slug
+    body       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+-- Alte Slugs für Weiterleitungsunterstützung beibehalten
+CREATE TABLE slug_history (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    article_id  INTEGER NOT NULL,
+    old_slug    TEXT    NOT NULL UNIQUE,  -- Weiterleitungsquelle; UNIQUE verhindert Duplikate
+    replaced_at TEXT    NOT NULL,
+    FOREIGN KEY (article_id) REFERENCES articles(id)
+);
+```
+
+---
+
+## Slug-Generierung
+
+```php
+final class SlugHelper
+{
+    public static function fromTitle(string $title): string
+    {
+        $slug = mb_strtolower($title);
+        $slug = (string) preg_replace('/[^a-z0-9]+/', '-', $slug);
+        $slug = trim($slug, '-');
+        return $slug !== '' ? $slug : 'untitled';
+    }
+
+    /**
+     * @param callable(string): bool $exists  Gibt true zurück, wenn der Slug belegt ist.
+     */
+    public static function makeUnique(string $base, callable $exists): string
+    {
+        if (!$exists($base)) {
+            return $base;
+        }
+        $counter = 2;
+        while ($exists("{$base}-{$counter}")) {
+            $counter++;
+        }
+        return "{$base}-{$counter}";
+    }
+}
+```
+
+### Eindeutigkeitsprüfung — Beide Tabellen einbeziehen
+
+Beim Prüfen, ob ein Slug „belegt" ist, **beide** Tabellen `articles.slug` und
+`slug_history.old_slug` prüfen. Andernfalls könnte ein neuer Artikel einen Slug beanspruchen,
+der noch als aktive Weiterleitungsquelle genutzt wird:
+
+```php
+private function slugExists(string $slug): bool
+{
+    return $this->db->fetchOne('SELECT id FROM articles WHERE slug = ?', [$slug]) !== null
+        || $this->db->fetchOne('SELECT id FROM slug_history WHERE old_slug = ?', [$slug]) !== null;
+}
+```
+
+---
+
+## Slug-Lookup mit Weiterleitungshinweis
+
+```php
+public function findBySlugWithRedirect(string $slug): ?array
+{
+    // 1. Aktuellen Slug prüfen (200 OK)
+    $article = $this->findBySlug($slug);
+    if ($article !== null) {
+        return ['found' => $article, 'redirect' => false];
+    }
+
+    // 2. Slug-Historie prüfen (301-Weiterleitungshinweis)
+    $row = $this->db->fetchOne(
+        'SELECT article_id FROM slug_history WHERE old_slug = ?', [$slug],
+    );
+    if ($row === null) {
+        return null;  // 404
+    }
+
+    $article = $this->findById((int) $row['article_id']);
+    return $article !== null ? ['found' => $article, 'redirect' => true] : null;
+}
+```
+
+Der Handler gibt dann HTTP 301 mit `canonical_slug` und `data` zurück:
+
+```json
+// GET /articles/by-slug/old-title  →  301
+{
+  "redirect": true,
+  "canonical_slug": "new-title",
+  "data": { "id": 1, "slug": "new-title", ... }
+}
+```
+
+---
+
+## Slug-Aktualisierung — Historie erfassen
+
+Wenn ein Artikel umbenannt wird, den alten Slug in `slug_history` verschieben:
+
+```php
+if ($newSlug !== $article->slug) {
+    // Nur einfügen, wenn noch nicht in der Historie (idempotent)
+    $alreadyIn = $this->db->fetchOne(
+        'SELECT id FROM slug_history WHERE old_slug = ?', [$article->slug],
+    );
+    if ($alreadyIn === null) {
+        $this->db->insert(
+            'INSERT INTO slug_history (article_id, old_slug, replaced_at) VALUES (?, ?, ?)',
+            [$id, $article->slug, $now],
+        );
+    }
+}
+```
+
+### Kollisionsbehandlung bei Aktualisierung
+
+Bei der Berechnung des neuen Slugs für einen aktualisierten Artikel den **aktuellen** Slug des Artikels
+von der „Existiert"-Prüfung ausschließen — sonst würde er unnötigerweise auf `-2` hochzählen:
+
+```php
+$newSlug = SlugHelper::makeUnique(
+    $newSlugBase,
+    fn (string $s): bool => $s !== $article->slug && $this->slugExists($s),
+);
+```
+
+---
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `POST` | `/articles` | Artikel erstellen — Slug wird automatisch aus dem Titel abgeleitet |
+| `GET` | `/articles/{id}` | Per numerischer ID abrufen |
+| `GET` | `/articles/by-slug/{slug}` | Per Slug abrufen (200 aktuell / 301 historisch / 404) |
+| `PUT` | `/articles/{id}` | Titel/Body/Slug aktualisieren; alter Slug → Historie |
+| `GET` | `/articles/{id}/slug-history` | Historische Slugs auflisten |
+
+---
+
+## Kollisionsszenarien
+
+| Szenario | Ergebnis |
+|---|---|
+| Erstes „Hello World" | `hello-world` |
+| Zweites „Hello World" | `hello-world-2` |
+| Drittes „Hello World" | `hello-world-3` |
+| Artikel von `hello` auf bereits belegten Slug umbenannt | `taken-slug-2` |
+| Gleicher Titel, keine Slug-Änderung | Kein Historie-Eintrag, Slug unverändert |
+| Alter Slug entspricht einem Historie-Eintrag | 301-Weiterleitungsantwort |
+
+---
+
+## Domain-Layer-Struktur
+
+```
+src/Article/
+├── Article.php
+├── ArticleRepository.php   # create / findBySlug / findBySlugWithRedirect / update / slugHistory
+├── SlugHelper.php          # fromTitle() + makeUnique()
+└── ArticleNotFoundException.php
+```
+
+---
+
+## Siehe auch
+
+- [Soft Delete](./soft-delete.md) — Slug-Historie mit soft-deleted Datensätzen kombinieren
+- [Content Versioning](./content-versioning.md) — Versionshistorie neben Slug-Historie
+- [Content Draft Lifecycle](./content-draft-lifecycle.md) — Slug-Verhalten über Entwurfszustände

--- a/docs/de/howto/slug-url-history.md
+++ b/docs/de/howto/slug-url-history.md
@@ -1,0 +1,280 @@
+# Anleitung: Slug-URL-Verwaltung mit Historie
+
+> **FT-Referenz**: FT339 (`NENE2-FT/sluglog`) — Automatisch generierte Slugs aus Titeln, Kollisionszähler, Slug-Historie für alte-Slug-301-Weiterleitungen, explizite Slug-Überschreibung, Schwachstellen-Assessment, 17 Tests / 50+ Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie saubere URL-Slugs aus Inhaltstiteln generiert werden, Kollisionen mit sequenziellen Suffixen behandelt werden, alte Slugs in einer Historientabelle für permanente Weiterleitungen gespeichert werden und häufige Angriffsvektoren verhindert werden.
+
+## Schema
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    slug       TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+CREATE TABLE slug_history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    article_id INTEGER NOT NULL REFERENCES articles(id),
+    old_slug   TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/articles` | Artikel erstellen (automatischer Slug aus Titel) |
+| `PUT`  | `/articles/{id}` | Artikel aktualisieren (Slug wird bei Titeländerung neu generiert) |
+| `GET`  | `/articles/by-slug/{slug}` | Per aktuellem oder altem Slug abrufen |
+| `GET`  | `/articles/{id}/slug-history` | Slug-Historie auflisten |
+
+## Slug-Generierung
+
+### `SlugHelper::fromTitle()`
+
+```php
+SlugHelper::fromTitle('Hello World')          // → "hello-world"
+SlugHelper::fromTitle('PHP 8.4: New Features!') // → "php-8-4-new-features"
+SlugHelper::fromTitle('  --Hello--  ')        // → "hello"
+SlugHelper::fromTitle('')                     // → "untitled"
+SlugHelper::fromTitle('---')                  // → "untitled"
+```
+
+Regeln:
+1. Alles in Kleinbuchstaben umwandeln
+2. Nicht-alphanumerische Zeichen durch `-` ersetzen
+3. Aufeinanderfolgende Bindestriche zusammenfassen
+4. Führende/nachfolgende Bindestriche trimmen
+5. `"untitled"` zurückgeben wenn das Ergebnis leer ist
+
+```php
+public static function fromTitle(string $title): string
+{
+    $slug = strtolower($title);
+    $slug = preg_replace('/[^a-z0-9]+/', '-', $slug) ?? '';
+    $slug = trim($slug, '-');
+    return $slug !== '' ? $slug : 'untitled';
+}
+```
+
+### Kollisionsauflösung
+
+```php
+POST /articles  {"title": "Hello", "body": "..."}  → 201  {"slug": "hello"}
+POST /articles  {"title": "Hello", "body": "..."}  → 201  {"slug": "hello-2"}
+POST /articles  {"title": "Hello", "body": "..."}  → 201  {"slug": "hello-3"}
+```
+
+```php
+public static function makeUnique(string $base, callable $isTaken): string
+{
+    if (!$isTaken($base)) {
+        return $base;
+    }
+
+    $i = 2;
+    while ($isTaken("{$base}-{$i}")) {
+        $i++;
+    }
+
+    return "{$base}-{$i}";
+}
+```
+
+`$isTaken` ist ein DB-Lookup-Callback: `fn(string $s): bool => (bool) $repo->findBySlug($s)`.
+
+## Artikel erstellen
+
+```php
+POST /articles
+{"title": "My First Post", "body": "Content here."}
+→ 201
+{
+  "id": 1,
+  "title": "My First Post",
+  "slug": "my-first-post",
+  "body": "...",
+  "created_at": "..."
+}
+```
+
+## Artikel aktualisieren
+
+```php
+PUT /articles/1
+{"title": "New Title", "body": "Updated content."}
+→ 200  {"slug": "new-title", ...}
+```
+
+Wenn sich der Titel ändert, wird der neue Slug abgeleitet und der alte Slug in `slug_history` gespeichert.
+
+```php
+// Gleicher Titel — Slug unverändert, kein Historie-Eintrag
+PUT /articles/1  {"title": "New Title", "body": "Different body."}
+→ 200  {"slug": "new-title"}  // gleicher Slug
+
+// Explizite Slug-Überschreibung
+PUT /articles/1  {"title": "New Title", "body": "Body.", "slug": "custom-url-here"}
+→ 200  {"slug": "custom-url-here"}
+
+// Kollision bei Aktualisierung — automatisch aufgelöst
+// (wenn "popular" existiert, wird in "popular-2" umbenannt)
+PUT /articles/2  {"title": "Popular", "body": "Body."}
+→ 200  {"slug": "popular-2"}
+
+// Unbekannter Artikel
+PUT /articles/9999  {"title": "X", "body": "Y"}
+→ 404
+```
+
+## Per Slug abrufen
+
+```php
+// Aktueller Slug → 200
+GET /articles/by-slug/new-title
+→ 200  {"id": 1, "slug": "new-title", "title": "New Title", ...}
+
+// Alter Slug → 301-Weiterleitung
+GET /articles/by-slug/my-first-post
+→ 301
+{
+  "redirect": true,
+  "canonical_slug": "new-title"
+}
+
+// Unbekannt → 404
+GET /articles/by-slug/does-not-exist
+→ 404
+```
+
+301-Antworten teilen Crawlern/Clients mit, ihre Links zum kanonischen Slug zu aktualisieren.
+
+## Slug-Historie
+
+```php
+GET /articles/1/slug-history
+→ 200
+{
+  "current_slug": "new-title",
+  "slug_history": [
+    {"old_slug": "my-first-post", "created_at": "..."}
+  ]
+}
+
+// Neuer Artikel — leere Historie
+{"current_slug": "fresh", "slug_history": []}
+
+// Unbekannter Artikel → 404
+GET /articles/9999/slug-history → 404
+```
+
+Historie-Einträge akkumulieren sich nur, wenn der Slug tatsächlich geändert wird. Das Aktualisieren des Bodys ohne Titeländerung lässt die Historie unberührt.
+
+---
+
+## Schwachstellen-Assessment
+
+### V-01 — Path-Traversal via Slug ✅ SAFE
+
+**Risiko**: Angreifer sendet `GET /articles/by-slug/../../../etc/passwd`, um Serververzeichnisse zu traversieren.
+**Ergebnis**: SAFE — Slug-Lookups sind SQL `WHERE slug = ?` mit gebundenem Parameter. Das Pfadsegment wird nie als Dateisystempfad interpretiert. Das Routing parst den Pfad bevor er den Controller erreicht; `../` in einem URL-Pfad wird von der HTTP-Schicht kanonisiert.
+
+---
+
+### V-02 — SQL-Injection via Slug in URL ✅ SAFE
+
+**Risiko**: `GET /articles/by-slug/' OR '1'='1` gibt alle Artikel preis.
+**Ergebnis**: SAFE — Slug wird als gebundener Parameter in `WHERE slug = ?` übergeben. SQL-Injection ist unabhängig vom Slug-Wert unmöglich.
+
+---
+
+### V-03 — Slug-Enumeration (Brute-Force-Entdeckung) ⚠️ EXPOSED
+
+**Risiko**: Angreifer iteriert häufige Slugs (`/articles/by-slug/admin`, `/articles/by-slug/secret-doc`), um private Artikel zu entdecken.
+**Ergebnis**: EXPOSED — Slugs sind vorhersehbare Ableitungen von menschenlesbaren Titeln. Kein Rate-Limiting oder Authentifizierung wird für `GET /articles/by-slug/{slug}` durchgesetzt. Abhilfe: Authentifizierung für private Inhalte erfordern; Pro-IP-Rate-Limiting hinzufügen; opake IDs für sensible Ressourcen in Betracht ziehen.
+
+---
+
+### V-04 — Slug-Historie IDOR ✅ SAFE
+
+**Risiko**: Angreifer ruft `GET /articles/{id}/slug-history` für den Artikel eines anderen Benutzers auf, um vergangene Titel zu entdecken.
+**Ergebnis**: SAFE — Slug-Historie sind öffentliche Metadaten. Wenn Artikel öffentlich sind, ist ihre Historie es auch. Wenn Artikel Autorisierung erfordern, dieselbe Auth-Prüfung konsistent auf den `/slug-history`-Endpunkt anwenden.
+
+---
+
+### V-05 — Unendliche Weiterleitungsschleife via Slug-Historie ✅ SAFE
+
+**Risiko**: Artikel A wird in Slug B umbenannt; Artikel B wird in Slug A umbenannt — `GET /by-slug/a` → Weiterleitung zu B → Weiterleitung zu A (unendliche Schleife).
+**Ergebnis**: SAFE — Die Implementierung sucht den **aktuellen** Slug in `articles.slug`, dann prüft `slug_history` nur für alte Slugs. Eine 301-Antwort zeigt immer auf das aktuelle Kanonische. Clients, die Weiterleitungen folgen, erreichen das Kanonische in einem Hop.
+
+---
+
+### V-06 — Slug-Kollisions-Missbrauch (Sequenzieller Zähler-Erschöpfung) ⚠️ EXPOSED
+
+**Risiko**: Angreifer erstellt tausende Artikel mit dem Titel „popular", um „popular-2" bis „popular-9999" zu reservieren und dann zu löschen — oder um teures Zähler-Scanning zu erzwingen.
+**Ergebnis**: EXPOSED — Kein Rate-Limiting für die Artikelerstellung. Das `makeUnique`-Zähler-Scan ist O(n) DB-Abfragen. Abhilfe: Rate-Limit POST /articles pro Benutzer; Slug-Zähler bei einem vernünftigen Limit begrenzen (z. B. 99); nach Schwellenwert zufälliges Suffix verwenden.
+
+---
+
+### V-07 — Explizite Slug-Injektion (Überschreiben des Slugs eines anderen Artikels) ✅ SAFE
+
+**Risiko**: Angreifer verwendet `PUT /articles/2  {"slug": "popular"}`, wo „popular" Artikel 1 gehört.
+**Ergebnis**: SAFE — `articles.slug` hat eine `UNIQUE`-Bedingung. Der Versuch, einen bereits von einem anderen Artikel beanspruchten Slug zu setzen, löst eine DB-Bedingungsverletzung aus, die in 409 Conflict übersetzt wird.
+
+---
+
+### V-08 — Unicode/Homograph-Slug-Angriff ⚠️ EXPOSED
+
+**Risiko**: Angreifer erstellt einen Artikel mit einem Unicode-Titel, der auf dieselben Bytes wie ein vorhandener ASCII-Slug normalisiert (z. B. `café` → `caf-`), um eine visuell verwirrende URL zu erstellen.
+**Ergebnis**: EXPOSED — `SlugHelper::fromTitle()` verwendet `preg_replace('/[^a-z0-9]+/', '-', strtolower($title))`. Nicht-ASCII-Zeichen werden durch `-` ersetzt, was unerwartete Kollisionen oder leere Slugs verursachen kann. Abhilfe: Unicode vor der Slug-Generierung auf ASCII-Transliteration normalisieren (z. B. `iconv`); alle Nicht-ASCII nach der Normalisierung als `-` behandeln.
+
+---
+
+### V-09 — XSS via Titel im Slug gespeichert ✅ SAFE
+
+**Risiko**: Titel `<script>alert(1)</script>` erzeugt Slug `script-alert-1-script` — sichere alphanumerische Ausgabe.
+**Ergebnis**: SAFE — `SlugHelper::fromTitle()` entfernt alle nicht-alphanumerischen Zeichen zu `-`. Die Slug-Ausgabe ist immer `[a-z0-9-]`, was HTML-Injection durch den Slug unmöglich macht.
+
+---
+
+### V-10 — Alter Slug enthüllt umbenannten Inhalt ⚠️ EXPOSED
+
+**Risiko**: Artikel von „secret-plan-v1" in „public-announcement" umbenannt; Angreifer verwendet alten Slug, um den Originaltitel über die Weiterleitungsantwort `canonical_slug` zu entdecken.
+**Ergebnis**: EXPOSED — Die 301-Antwort gibt den neuen kanonischen Slug preis, der den umbenannten Inhalt enthüllen kann. Der Slug-Historie-Endpunkt gibt auch alle alten Namen preis. Für sensible Umbenennungen alte Slugs als Tombstone markieren ohne den neuen Ort preiszugeben; oder opake Slugs verwenden.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Ergebnis |
+|----|---------------|---------|
+| V-01 | Path-Traversal via Slug | ✅ SAFE |
+| V-02 | SQL-Injection via Slug | ✅ SAFE |
+| V-03 | Slug-Enumeration | ⚠️ EXPOSED |
+| V-04 | Slug-Historie IDOR | ✅ SAFE |
+| V-05 | Unendliche Weiterleitungsschleife | ✅ SAFE |
+| V-06 | Kollisionszähler-Erschöpfung | ⚠️ EXPOSED |
+| V-07 | Explizite Slug-Überschreibung | ✅ SAFE |
+| V-08 | Unicode-Homograph-Angriff | ⚠️ EXPOSED |
+| V-09 | XSS via Titel | ✅ SAFE |
+| V-10 | Alter Slug enthüllt umbenannten Inhalt | ⚠️ EXPOSED |
+
+**6 SAFE, 4 EXPOSED** — Artikelerstellung rate-limitieren; Authentifizierung für private Inhalte hinzufügen; Unicode vor der Slug-Generierung normalisieren; für sensible Umbenennungen nur Tombstone-Slug-Historie in Betracht ziehen.
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Slug direkt in SQL interpolieren | SQL-Injection via Slug-Pfadparameter |
+| Slug-Historie bei Artikellöschung hart löschen | Alte URLs geben 404 statt 301 zurück; SEO und Link-Rot |
+| Keine `UNIQUE`-Bedingung auf `articles.slug` | Gleichzeitige Inserts erstellen doppelte Slugs |
+| Alten Slug bei Titelaktualisierung unverändert zurückgeben | Slug-Drift — URL spiegelt den Inhalt nicht mehr wider |
+| Kein Zähler-Cap in `makeUnique` | Angreifer erschöpft Zähler durch Massenerstellung |
+| `!==` zum Vergleich vorhandener Slugs verwenden | Typ-Konvertierungs-Überraschungen; für Slug-Vergleich immer `===` verwenden |

--- a/docs/de/howto/soft-delete-restore-permanent.md
+++ b/docs/de/howto/soft-delete-restore-permanent.md
@@ -1,0 +1,162 @@
+# Anleitung: Soft Delete, Wiederherstellen und dauerhaftes Löschen
+
+> **FT-Referenz**: `NENE2-FT/softdelete` — Soft Delete über `deleted_at`-Zeitstempel, Wiederherstellen (nur soft-gelöschte Notizen können wiederhergestellt werden), dauerhaftes Hard Delete (nur soft-gelöschte Notizen können dauerhaft gelöscht werden), 14 Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie drei Löschzustände implementiert werden: aktiv, soft-gelöscht (wiederherstellbar) und dauerhaft gelöscht (weg). Vergleiche mit `docs/howto/soft-delete-trash-restore.md` (FT340 softdeletelog), das eine dedizierte Papierkorb-Ansicht und Massen-Bereinigung hinzufügt.
+
+## Schema
+
+```sql
+CREATE TABLE notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    deleted_at TEXT             -- NULL = aktiv; Zeitstempel = soft-gelöscht
+);
+
+CREATE INDEX idx_notes_deleted ON notes(deleted_at);
+```
+
+`deleted_at IS NULL` → aktiv. `deleted_at IS NOT NULL` → soft-gelöscht.
+
+## Endpunkte
+
+| Methode   | Pfad                     | Beschreibung                      |
+|-----------|--------------------------|-----------------------------------|
+| `POST`   | `/notes`                 | Notiz erstellen                    |
+| `GET`    | `/notes`                 | Nur aktive Notizen auflisten       |
+| `GET`    | `/notes/{id}`            | Notiz abrufen (404 wenn gelöscht)  |
+| `DELETE` | `/notes/{id}`            | Soft Delete (setzt deleted_at)     |
+| `POST`   | `/notes/{id}/restore`    | Soft-gelöschte Notiz wiederherstellen |
+| `DELETE` | `/notes/{id}/permanent`  | Soft-gelöschte Notiz dauerhaft löschen |
+
+## Notiz erstellen
+
+```php
+POST /notes  {"title": "My Note", "body": "Some content"}
+
+→ 201
+{
+  "id": 1,
+  "title": "My Note",
+  "body": "Some content",
+  "deleted_at": null,    // ← null = aktiv
+  "created_at": "..."
+}
+```
+
+## Aktive Notizen auflisten
+
+```php
+GET /notes
+→ 200  {"items": [{...aktive Notizen...}], "total": 2}
+```
+
+Gibt nur Notizen mit `deleted_at IS NULL` zurück. Soft-gelöschte Notizen sind hier unsichtbar.
+
+## Soft Delete
+
+```php
+DELETE /notes/1
+→ 200  // setzt deleted_at = now
+
+// Soft-gelöschte Notiz verschwindet aus aktiver Liste
+GET /notes
+→ 200  {"items": [], "total": 0}
+
+// Und aus direktem GET
+GET /notes/1
+→ 404
+```
+
+```sql
+UPDATE notes SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL
+```
+
+## Wiederherstellen
+
+```php
+// Soft-gelöschte Notiz wiederherstellen
+POST /notes/1/restore
+→ 200  {"id": 1, "title": "My Note", "deleted_at": null, ...}  // zurück auf aktiv
+
+// Wiederhergestellte Notiz erscheint wieder in aktiver Liste
+GET /notes
+→ 200  {"items": [{...}], "total": 1}
+```
+
+### Wiederherstellen einer aktiven Notiz → 404
+
+```php
+// Versuch, eine aktive (nicht soft-gelöschte) Notiz wiederherzustellen → 404
+POST /notes/2/restore   // Notiz 2 wurde nie gelöscht
+→ 404
+```
+
+Nur soft-gelöschte Notizen können wiederhergestellt werden. Aktive Notizen geben 404 beim Wiederherstellen zurück.
+
+```sql
+UPDATE notes SET deleted_at = NULL WHERE id = ? AND deleted_at IS NOT NULL
+-- Wenn 0 Zeilen betroffen → Notiz ist aktiv oder existiert nicht → 404
+```
+
+## Dauerhaftes Löschen
+
+```php
+// Muss zuerst soft-gelöscht werden
+DELETE /notes/1   // soft delete
+POST /notes/1/restore  // wiederherstellen (optional)
+
+// Soft-gelöschte Notiz dauerhaft löschen
+DELETE /notes/1          // zuerst soft-löschen
+DELETE /notes/1/permanent
+→ 200  {"permanent": true}
+
+GET /notes/1
+→ 404  // für immer weg
+```
+
+### Dauerhaftes Löschen einer aktiven Notiz → 404
+
+```php
+// Dauerhaftes Löschen einer aktiven Notiz → 404
+// Muss zuerst soft-löschen, dann dauerhaft löschen
+DELETE /notes/2/permanent   // Notiz 2 ist aktiv
+→ 404
+```
+
+```sql
+DELETE FROM notes WHERE id = ? AND deleted_at IS NOT NULL
+-- Wenn 0 Zeilen betroffen → Notiz ist aktiv oder existiert nicht → 404
+```
+
+## Zustandsdiagramm
+
+```
+Aktiv
+  │
+  │ DELETE /notes/{id}     (soft delete)
+  ▼
+Soft-gelöscht
+  │           │
+  │ POST      │ DELETE
+  │ /restore  │ /permanent
+  ▼           ▼
+Aktiv      Weg (hart gelöscht)
+```
+
+**Die wesentliche Invariante**: Dauerhaftes Löschen erfordert ein vorheriges Soft Delete. Dies verhindert versehentliche Hard Deletes aus dem aktiven Zustand.
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Dauerhaftes Löschen einer aktiven Notiz erlauben | Überspringt das Soft-Delete-Sicherheitsnetz; Daten sind ohne Wiederherstellungsfenster weg |
+| 200 beim Wiederherstellen einer aktiven Notiz zurückgeben | Aufrufer können nicht feststellen, ob die Wiederherstellung benötigt wurde; 404 verwenden, um „nicht im Papierkorb" zu signalisieren |
+| Kein Index auf `deleted_at` | Vollständiger Tabellenscan für jede Listenabfrage; `WHERE deleted_at IS NULL` ist ohne Index langsam |
+| Sofortiges Hard Delete bei `DELETE /notes/{id}` | Keine Wiederherstellung möglich; zuerst Soft Delete verwenden |
+| `deleted_at` in aktiver Liste exponieren | Clients sehen das Feld; überfüllt Antworten visuell; herausfiltern oder `null` verwenden |

--- a/docs/de/howto/soft-delete-trash-purge.md
+++ b/docs/de/howto/soft-delete-trash-purge.md
@@ -1,0 +1,273 @@
+# Anleitung: Soft Delete, Papierkorb und dauerhaftes Bereinigen
+
+> **FT-Referenz**: FT257 (`NENE2-FT/softdeletelog`) — Soft Delete / Papierkorb / dauerhaftes Bereinigen mit `deleted_at`-Spalte
+
+Demonstriert einen dreistufigen Lebenszyklus für Datensätze: aktiv → soft-gelöscht (Papierkorb) → dauerhaft bereinigt.
+Aktive Listen schließen gelöschte Datensätze automatisch aus. Ein dedizierter Papierkorb-Endpunkt listet nur gelöschte Datensätze auf.
+Wiederherstellen gibt einen Datensatz vom Papierkorb zurück in den aktiven Zustand. Bereinigen entfernt den Datensatz physisch aus der Datenbank
+(nur erlaubt wenn im Papierkorb).
+
+---
+
+## Routen
+
+| Methode   | Pfad                   | Beschreibung                                  |
+|-----------|------------------------|----------------------------------------------|
+| `POST`   | `/notes`               | Notiz erstellen                               |
+| `GET`    | `/notes`               | Aktive Notizen auflisten (schließt soft-gelöschte aus) |
+| `GET`    | `/notes/trash`         | Nur Papierkorb-Notizen auflisten              |
+| `GET`    | `/notes/{id}`          | Eine einzelne aktive Notiz abrufen            |
+| `DELETE` | `/notes/{id}`          | Notiz soft-löschen (in Papierkorb verschieben) |
+| `POST`   | `/notes/{id}/restore`  | Aus Papierkorb in aktiven Zustand wiederherstellen |
+| `DELETE` | `/notes/{id}/purge`    | Dauerhaft löschen (nur aus Papierkorb)        |
+
+> **Routenreihenfolge**: `/notes/trash` muss vor `/notes/{id}` registriert werden, damit das wörtliche Segment
+> `trash` nicht als Pfadparameter erfasst wird.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT NULL
+);
+```
+
+`deleted_at TEXT NULL` ist der Soft-Delete-Marker. Wenn `NULL`, ist der Datensatz aktiv; wenn auf einen
+ISO-Zeitstempel gesetzt, befindet sich der Datensatz im Papierkorb. Kein separates `is_deleted`-Boolean wird benötigt — der Zeitstempel
+erfasst auch _wann_ das Löschen stattfand, was für Prüfpfade und TTL-basierte Bereinigungsjobs nützlich ist.
+
+---
+
+## Domain-Objekt
+
+```php
+final readonly class Note
+{
+    public function __construct(
+        public int     $id,
+        public string  $title,
+        public string  $body,
+        public string  $createdAt,
+        public string  $updatedAt,
+        public ?string $deletedAt,     // null = aktiv, nicht-null = im Papierkorb
+    ) {}
+
+    public function isDeleted(): bool
+    {
+        return $this->deletedAt !== null;
+    }
+}
+```
+
+`isDeleted()` kapselt die Null-Prüfung, sodass Aufrufer das Implementierungsdetail nicht kennen müssen.
+
+---
+
+## Repository: das `includeTrashed`-Flag
+
+```php
+public function findById(int $id, bool $includeTrashed = false): ?Note
+{
+    $sql = $includeTrashed
+        ? 'SELECT * FROM notes WHERE id = ?'
+        : 'SELECT * FROM notes WHERE id = ? AND deleted_at IS NULL';
+
+    $rows = $this->executor->fetchAll($sql, [$id]);
+    return $rows === [] ? null : $this->hydrate($rows[0]);
+}
+```
+
+Der Standard (`includeTrashed: false`) wendet den `deleted_at IS NULL`-Filter an, sodass Aufrufer das
+sichere Verhalten automatisch erhalten. Nur Wiederherstellen und Bereinigen müssen Papierkorb-Datensätze sehen und übergeben
+`includeTrashed: true` explizit.
+
+**Warum keine separate `findByIdIncludingTrashed()`-Methode?**
+
+Ein benannter Boolean-Parameter ist an der Aufrufstelle selbstdokumentierend:
+- `findById($id)` — eindeutig nur-aktiv
+- `findById($id, includeTrashed: true)` — eindeutig papierkorb-bewusst
+
+Eine separate Methode würde die Hydrationslogik duplizieren oder einen internen gemeinsamen Helfer erfordern.
+
+---
+
+## Auflisten: aktiv vs. Papierkorb
+
+```php
+public function listActive(): array
+{
+    return $this->executor->fetchAll(
+        'SELECT * FROM notes WHERE deleted_at IS NULL ORDER BY created_at DESC',
+        [],
+    );
+}
+
+public function listTrashed(): array
+{
+    return $this->executor->fetchAll(
+        'SELECT * FROM notes WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC',
+        [],
+    );
+}
+```
+
+Aktive Notizen werden nach Erstellungszeit sortiert (neueste zuerst). Papierkorb-Notizen werden nach Löschzeit sortiert
+(zuletzt gelöscht zuerst), was für eine „Kürzlich gelöscht"-Benutzeroberfläche natürlich ist.
+
+---
+
+## Soft Delete
+
+```php
+public function softDelete(int $id, string $now): ?Note
+{
+    $note = $this->findById($id);   // nur-aktiver Lookup
+    if ($note === null) {
+        return null;   // nicht gefunden ODER bereits im Papierkorb → 404
+    }
+
+    $this->executor->execute(
+        'UPDATE notes SET deleted_at = ? WHERE id = ?',
+        [$now, $id],
+    );
+
+    return new Note($note->id, $note->title, $note->body, $note->createdAt, $note->updatedAt, $now);
+}
+```
+
+`findById($id)` ohne `includeTrashed` bedeutet, dass das Aufrufen von `DELETE /notes/{id}` auf einer bereits im Papierkorb befindlichen
+Notiz `null` → 404 zurückgibt. Dies verhindert Doppellösch-Verwirrung: Ein Client kann aus einem 404 nicht erkennen,
+ob die Notiz aktiv und fehlend war oder bereits im Papierkorb.
+
+---
+
+## Wiederherstellen
+
+```php
+public function restore(int $id): ?Note
+{
+    $note = $this->findById($id, includeTrashed: true);
+    if ($note === null || !$note->isDeleted()) {
+        return null;   // nicht gefunden ODER bereits aktiv → 404
+    }
+
+    $this->executor->execute(
+        'UPDATE notes SET deleted_at = NULL WHERE id = ?',
+        [$id],
+    );
+
+    return new Note($note->id, $note->title, $note->body, $note->createdAt, $note->updatedAt, null);
+}
+```
+
+`includeTrashed: true` ist hier erforderlich — die Notiz IST gelöscht, sodass der Standardfilter sie ausblenden würde.
+Der `!$note->isDeleted()`-Schutz lehnt eine aktive Notiz ab: Das Aufrufen von Restore auf einer aktiven Notiz gibt `null`
+→ 404 zurück. Dies macht Restore im „bereits wiederhergestellt"-Pfad idempotent: Ein Client, der Restore zweimal aufruft,
+erhält beim ersten Aufruf 200 und beim zweiten 404.
+
+---
+
+## Bereinigen (dauerhaftes Löschen)
+
+```php
+public function purge(int $id): bool
+{
+    $note = $this->findById($id, includeTrashed: true);
+    if ($note === null || !$note->isDeleted()) {
+        return false;   // nicht gefunden ODER noch aktiv → 404
+    }
+
+    $this->executor->execute('DELETE FROM notes WHERE id = ?', [$id]);
+    return true;
+}
+```
+
+`purge()` funktioniert nur bei Papierkorb-Datensätzen (`isDeleted()` muss true sein). Das Aufrufen von `DELETE /notes/{id}/purge`
+auf einer aktiven Notiz gibt `false` → 404 zurück. Dies schützt vor versehentlichem Datenverlust über den falschen
+Endpunkt — ein Client muss explizit soft-löschen, bevor er bereinigen kann.
+
+---
+
+## Zustandsmaschine
+
+```
+           POST /notes
+               │
+               ▼
+           [aktiv]  ←──────── POST /notes/{id}/restore ────────┐
+               │                                                  │
+    DELETE /notes/{id}                                           │
+               │                                                  │
+               ▼                                                  │
+           [Papierkorb]  ──────────────────────────────────────┘
+               │
+    DELETE /notes/{id}/purge
+               │
+               ▼
+          [weg — physisches DELETE]
+```
+
+`aktiv → Papierkorb` ist reversibel. `Papierkorb → weg` ist irreversibel. Es gibt keinen direkten Pfad von
+`aktiv → weg`: Bereinigen erfordert einen vorherigen Soft-Delete-Schritt.
+
+---
+
+## Controller: Routenregistrierungsreihenfolge
+
+```php
+public function register(Router $router): void
+{
+    $router->post('/notes',              $this->create(...));
+    $router->get('/notes',               $this->listActive(...));
+    $router->get('/notes/trash',         $this->listTrashed(...));   // ← muss vor {id} kommen
+    $router->get('/notes/{id}',          $this->get(...));
+    $router->delete('/notes/{id}',       $this->softDelete(...));
+    $router->post('/notes/{id}/restore', $this->restore(...));
+    $router->delete('/notes/{id}/purge', $this->purge(...));
+}
+```
+
+`/notes/trash` muss vor `/notes/{id}` registriert werden. Wenn die Reihenfolge umgekehrt wäre, würde eine `GET /notes/trash`-
+Anfrage `{id}` mit `id = "trash"` matchen, den Integer-Cast scheitern lassen und 404 oder 200 mit leerem
+Body zurückgeben statt der Papierkorbliste.
+
+---
+
+## HTTP-Semantik
+
+| Aktion        | Methode   | Warum                                                            |
+|---------------|-----------|------------------------------------------------------------------|
+| Soft Delete   | `DELETE` | Client beabsichtigt, die Ressource aus seiner Sicht zu entfernen  |
+| Wiederherstellen | `POST` | Nicht idempotent (zweiter Aufruf gibt 404 zurück); `POST` ist angemessen |
+| Bereinigen    | `DELETE` | Client beabsichtigt dauerhafte Entfernung                         |
+
+`PATCH /notes/{id}` mit `{"deleted_at": null}` ist eine Alternative für Wiederherstellen, aber `POST /restore`
+ist expliziter und vermeidet die Preisgabe des internen Spaltennamens im API-Vertrag.
+
+---
+
+## Design-Vergleich
+
+| Ansatz | Aktiv-Filter | Gelöscht-Marker | Wiederherstellen | Bereinigen |
+|---|---|---|---|---|
+| `deleted_at`-Zeitstempel | `WHERE deleted_at IS NULL` | Zeitstempel + Prüfpfad | `SET deleted_at = NULL` | Physisches `DELETE` |
+| `is_deleted`-Boolean | `WHERE is_deleted = 0` | Nur Boolean | `SET is_deleted = 0` | Physisches `DELETE` |
+| Separate `deleted_notes`-Tabelle | Kein Filter nötig | Zeile in andere Tabelle verschieben | Zeile zurückverschieben | Aus `deleted_notes` löschen |
+
+`deleted_at` ist das häufigste Muster: Eine Spalte, minimale Schemaänderung und ein eingebauter Prüf-
+Zeitstempel ohne Mehraufwand.
+
+---
+
+## Verwandte Anleitungen
+
+- [`article-versioning-api.md`](article-versioning-api.md) — Versionshistorie für Inhalte (Prüfpfad-Muster)
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — explizite DTO-Whitelisting zur Verhinderung von Feldinjektion
+- [`transaction-scope-pattern.md`](transaction-scope-pattern.md) — atomare Multi-Schreib-Operationen

--- a/docs/de/howto/soft-delete-trash-restore.md
+++ b/docs/de/howto/soft-delete-trash-restore.md
@@ -1,0 +1,278 @@
+# Anleitung: Soft Delete, Papierkorb & Wiederherstellungs-API
+
+> **FT-Referenz**: FT340 (`NENE2-FT/softlog`) — Notizen-API mit Soft Delete (deleted_at), Papierkorb-Ansicht, Wiederherstellen, dauerhaftem Hard Delete, Massen-Bereinigung, angeheftet-zuerst-Sortierung und ATK Cracker-Mindset-Angriffsbewertung, 26 Tests / 60+ Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein zweistufiger Lösch-Lebenszyklus implementiert wird: Elemente werden zunächst soft-gelöscht (in den Papierkorb verschoben) und können wiederhergestellt werden, dann dauerhaft über explizites Hard Delete oder Massen-Bereinigung gelöscht.
+
+## Schema
+
+```sql
+CREATE TABLE notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    is_pinned  INTEGER NOT NULL DEFAULT 0,
+    deleted_at TEXT,               -- NULL = aktiv; ISO 8601 wenn soft-gelöscht
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+`deleted_at IS NULL` = aktiv; `deleted_at IS NOT NULL` = soft-gelöscht (im Papierkorb).
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|-------------|
+| `POST` | `/notes` | Notiz erstellen |
+| `GET`  | `/notes` | Aktive Notizen auflisten (angeheftete zuerst) |
+| `GET`  | `/notes/{id}` | Aktive Notiz abrufen |
+| `PUT`  | `/notes/{id}` | Aktive Notiz aktualisieren |
+| `DELETE` | `/notes/{id}` | Soft Delete (→ Papierkorb) |
+| `GET`  | `/notes/trash` | Papierkorb-Notizen auflisten |
+| `POST` | `/notes/{id}/restore` | Aus Papierkorb wiederherstellen |
+| `DELETE` | `/notes/{id}/permanent` | Hard Delete (dauerhaft) |
+| `POST` | `/notes/trash/purge` | Gesamten Papierkorb bereinigen |
+
+## Notiz erstellen
+
+```php
+POST /notes
+{"title": "My Note", "body": "Content", "is_pinned": false}
+→ 201
+{
+  "id": 1,
+  "title": "My Note",
+  "body": "Content",
+  "is_pinned": false,
+  "deleted_at": null,
+  "created_at": "..."
+}
+
+POST /notes  {"body": "No title"}  → 422  // title erforderlich
+```
+
+## Aktive Notizen auflisten (angeheftete zuerst)
+
+```php
+GET /notes
+→ 200
+{
+  "total": 3,
+  "items": [
+    {"id": 2, "title": "Pinned", "is_pinned": true, ...},
+    {"id": 1, "title": "Normal A", ...},
+    {"id": 3, "title": "Normal B", ...}
+  ]
+}
+```
+
+```sql
+SELECT * FROM notes WHERE deleted_at IS NULL
+ORDER BY is_pinned DESC, created_at DESC
+```
+
+Soft-gelöschte Notizen werden nie in der aktiven Liste zurückgegeben.
+
+## Notiz abrufen
+
+```php
+GET /notes/1
+→ 200  {"id": 1, "title": "My Note", ...}
+
+// Soft-gelöscht oder unbekannt → gleiches 404
+GET /notes/9999    → 404
+GET /notes/1 (nach DELETE /notes/1)  → 404
+```
+
+## Notiz aktualisieren
+
+```php
+PUT /notes/1
+{"title": "Updated", "body": "New body", "is_pinned": true}
+→ 200  {"title": "Updated", "is_pinned": true, ...}
+
+// Soft-gelöschte Notiz ist nicht aktualisierbar
+PUT /notes/1  (nach DELETE /notes/1)  → 404
+```
+
+## Soft Delete
+
+```php
+DELETE /notes/1
+→ 204  (kein Body)
+
+// Notiz verschwindet aus GET /notes und GET /notes/1
+// Erscheint aber in GET /notes/trash
+
+DELETE /notes/9999  → 404  // nicht gefunden
+```
+
+## Papierkorb-Ansicht
+
+```php
+GET /notes/trash
+→ 200
+{
+  "total": 1,
+  "items": [
+    {"id": 1, "title": "Gone", "deleted_at": "2026-05-27T10:00:00Z", ...}
+  ]
+}
+
+// Aktive Notizen sind NICHT im Papierkorb
+```
+
+`deleted_at` ist für alle Papierkorb-Elemente nicht null.
+
+## Wiederherstellen
+
+```php
+POST /notes/1/restore
+→ 200  {"id": 1, "title": "Restore Me", "deleted_at": null, ...}
+
+// Wiederhergestellte Notiz erscheint wieder in GET /notes
+// POST /notes/9999/restore  → 404
+```
+
+## Hard Delete (dauerhaft)
+
+```php
+DELETE /notes/1/permanent
+→ 204  (kein Body; Notiz ist aus DB weg)
+
+// Auch aus Papierkorb weg
+// DELETE /notes/9999/permanent  → 404
+```
+
+## Papierkorb bereinigen
+
+```php
+POST /notes/trash/purge
+→ 200  {"purged": 2}
+
+// Leerer Papierkorb
+POST /notes/trash/purge  → 200  {"purged": 0}
+```
+
+`purge` gibt `DELETE FROM notes WHERE deleted_at IS NOT NULL` aus und gibt die Zeilenanzahl zurück.
+
+---
+
+## ATK Assessment — Cracker-Mindset-Angrifftest
+
+### ATK-01 — Hard Delete ohne vorheriges Soft Delete 🚫 BLOCKED
+
+**Angriff**: Angreifer ruft `DELETE /notes/1/permanent` auf einer aktiven (noch nicht soft-gelöschten) Notiz auf.
+**Ergebnis**: BLOCKED — `DELETE /notes/{id}/permanent` prüft `deleted_at IS NOT NULL` vor dem Fortfahren. Aktive Notizen geben 404 am dauerhaft-löschen-Endpunkt zurück; nur Papierkorb-Elemente können hart gelöscht werden.
+
+---
+
+### ATK-02 — Auf soft-gelöschte Notiz via direktem GET zugreifen ✅ SAFE
+
+**Angriff**: Angreifer weiß, dass Notiz ID 5 soft-gelöscht wurde und ruft `GET /notes/5` auf, um geschützte Inhalte zu lesen.
+**Ergebnis**: SAFE — `GET /notes/{id}` fragt `WHERE id = ? AND deleted_at IS NULL` ab. Soft-gelöschte Notizen geben 404 identisch zu unbekannten Notizen zurück — kein Existenzhinweis.
+
+---
+
+### ATK-03 — Papierkorb ohne Auth bereinigen (Massenzerstörung) ⚠️ EXPOSED
+
+**Angriff**: Jeder Client ruft `POST /notes/trash/purge` auf, um alle Papierkorb-Notizen aller Benutzer dauerhaft zu zerstören.
+**Ergebnis**: EXPOSED — Keine Authentifizierungsprüfung für `POST /notes/trash/purge`. Ohne Pro-Benutzer-Scoping kann ein nicht-authentifizierter Client irreversibel alle Papierkorb-Daten aller Benutzer löschen. Abhilfe: Authentifizierung erfordern; Bereinigung auf den Papierkorb des authentifizierten Benutzers beschränken; Admin-Rolle für globale Bereinigung erfordern.
+
+---
+
+### ATK-04 — Doppeltes Soft Delete korrumpiert deleted_at ✅ SAFE
+
+**Angriff**: Angreifer sendet `DELETE /notes/1` zweimal, in der Hoffnung, dass der zweite Aufruf `deleted_at` auf einen späteren Zeitstempel zurücksetzt.
+**Ergebnis**: SAFE — Das erste Löschen setzt `deleted_at`. Das zweite Löschen findet `deleted_at IS NULL = false`, sodass der Lookup 0 Zeilen zurückgibt → 404. Der Zeitstempel wird nicht geändert.
+
+---
+
+### ATK-05 — Aktive Notiz wiederherstellen (Zustand korrumpieren) 🚫 BLOCKED
+
+**Angriff**: Angreifer ruft `POST /notes/1/restore` auf einer aktiven (nicht-gelöschten) Notiz auf, um `deleted_at = null` bedingungslos zu erzwingen.
+**Ergebnis**: BLOCKED — `restore` fragt `WHERE id = ? AND deleted_at IS NOT NULL` ab. Aktive Notizen passen nicht → 404. Idempotent: Eine bereits aktive Notiz wiederherzustellen ist ein No-op 404.
+
+---
+
+### ATK-06 — SQL-Injection via Titel beim Erstellen ✅ SAFE
+
+**Angriff**: Angreifer reicht `{"title": "'; DROP TABLE notes; --"}` ein, um die Datenbank zu korrumpieren.
+**Ergebnis**: SAFE — Alle Schreibvorgänge verwenden parametrisierte Statements. Titel wird als Literal-String gespeichert.
+
+---
+
+### ATK-07 — Notiz-ID-Überlauf zum Umgehen der Validierung 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `GET /notes/99999999999999999999` (20-stellig), um PHP-Integer zu überlaufen und unbeabsichtigte IDs zu erreichen.
+**Ergebnis**: BLOCKED — Notiz-IDs werden mit `ctype_digit` + `strlen <= 18` vor der Konvertierung validiert. Überlaufwerte → 422.
+
+---
+
+### ATK-08 — Gelöschte Notiz aktualisieren (Ghost-Schreiben) 🚫 BLOCKED
+
+**Angriff**: Angreifer hat einen veralteten Session-Verweis auf eine gelöschte Notiz und reicht PUT ein, um sie zu ändern.
+**Ergebnis**: BLOCKED — `PUT /notes/{id}` fragt `WHERE id = ? AND deleted_at IS NULL` ab. Soft-gelöschte Notizen scheitern an dieser Prüfung → 404. Die Aktualisierung wird abgelehnt.
+
+---
+
+### ATK-09 — Race: Wiederherstellen, dann sofort Bereinigen 🚫 BLOCKED
+
+**Angriff**: Angreifer lässt `POST /notes/1/restore` und `POST /notes/trash/purge` gleichzeitig laufen, um eine Notiz während der Wiederherstellung zu zerstören.
+**Ergebnis**: BLOCKED — Jede Operation ist eine einzelne atomare DB-Transaktion. Die Bereinigung gibt `DELETE WHERE deleted_at IS NOT NULL` aus; die Wiederherstellung setzt `deleted_at = NULL`. Einer gewinnt und die Notiz endet in einem konsistenten Zustand.
+
+---
+
+### ATK-10 — Gleichzeitiges Soft Delete hinterlässt Waise ✅ SAFE
+
+**Angriff**: Zwei Anfragen rufen gleichzeitig `DELETE /notes/1` auf. Beide prüfen `deleted_at IS NULL`, sehen beide null und versuchen beide `deleted_at` zu setzen.
+**Ergebnis**: SAFE — Das erste Update gelingt. Das zweite findet `deleted_at IS NOT NULL` (oder 0 aktualisierte Zeilen) → 404. SQLite serialisiert Schreibvorgänge; der zweite Aufruf ist auf DB-Ebene idempotent.
+
+---
+
+### ATK-11 — Titel zu lang (Speichermissbrauch) ⚠️ EXPOSED
+
+**Angriff**: Angreifer reicht einen 10 MB-Titel-String ein, um den Datenbankspeicher zu erschöpfen.
+**Ergebnis**: EXPOSED — Keine Maximallänge wird für `title` oder `body` durchgesetzt. Abhilfe: `MAX_TITLE_LENGTH` (z. B. 500 Zeichen) und `MAX_BODY_LENGTH` (z. B. 100.000 Zeichen) hinzufügen und 422 zurückgeben wenn überschritten. Request-Size-Middleware bietet einen sekundären Schutz.
+
+---
+
+### ATK-12 — Angeheftet-Überflutung (Viele angeheftete Notizen) ⚠️ EXPOSED
+
+**Angriff**: Angreifer erstellt tausende angehefteter Notizen, um alle echten Notizen aus der aktiven Liste nach unten zu verdrängen.
+**Ergebnis**: EXPOSED — Kein Limit für die Anzahl angehefteter Notizen. Jede Notiz kann mit `is_pinned: true` erstellt werden. Abhilfe: Maximale Anzahl angehefteter Notizen pro Benutzer begrenzen (z. B. 10); 422 zurückgeben wenn überschritten.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|---------|
+| ATK-01 | Hard Delete ohne Soft Delete | 🚫 BLOCKED |
+| ATK-02 | Auf soft-gelöschte via GET zugreifen | ✅ SAFE |
+| ATK-03 | Papierkorb ohne Auth bereinigen | ⚠️ EXPOSED |
+| ATK-04 | Doppeltes Soft Delete | ✅ SAFE |
+| ATK-05 | Aktive Notiz wiederherstellen | 🚫 BLOCKED |
+| ATK-06 | SQL-Injection via Titel | ✅ SAFE |
+| ATK-07 | Notiz-ID-Überlauf | 🚫 BLOCKED |
+| ATK-08 | Soft-gelöschte Notiz aktualisieren | 🚫 BLOCKED |
+| ATK-09 | Race: Wiederherstellen + Bereinigen | 🚫 BLOCKED |
+| ATK-10 | Gleichzeitiges Soft Delete | ✅ SAFE |
+| ATK-11 | Titel zu lang | ⚠️ EXPOSED |
+| ATK-12 | Angeheftet-Überflutung | ⚠️ EXPOSED |
+
+**7 BLOCKED, 2 SAFE, 3 EXPOSED** — Kritisch: Bereinigung authentifizieren und auf eigene Daten des Akteurs beschränken; Titel/Body-Längenbeschränkungen hinzufügen; angeheftete Notiz-Anzahl pro Benutzer begrenzen.
+
+---
+
+## Was man nicht tun sollte
+
+| Anti-Muster | Risiko |
+|---|---|
+| Hard Delete beim ersten DELETE | Kein Wiederherstellungspfad; versehentliches Löschen ist dauerhaft |
+| Kein `deleted_at IS NULL`-Filter in Listen/Get-Abfragen | Soft-gelöschte Elemente erscheinen wieder als noch aktiv |
+| `PUT` auf soft-gelöschten Notizen erlauben | Ghost-Schreibvorgänge — Benutzer bearbeiten Daten, die sie für gelöscht hielten |
+| Keine Auth für `POST /trash/purge` | Jeder Client zerstört irreversibel alle Papierkorb-Daten |
+| 403 für soft-gelöschte Notiz-GET zurückgeben | Enthüllt, dass die Notiz existiert; 404 verhindert Existenz-Enumeration |
+| Keine Zeilenanzahl-Prüfung nach Soft Delete | Stilles 200 wenn Notiz nicht gefunden; betroffene Zeilen immer prüfen |

--- a/docs/de/howto/soft-delete.md
+++ b/docs/de/howto/soft-delete.md
@@ -1,0 +1,192 @@
+# Soft Delete (Logisches Löschen)
+
+Soft Delete behält einen Datensatz in der Datenbank, markiert ihn jedoch als gelöscht, indem ein `deleted_at`-Zeitstempel gesetzt wird. Dies ermöglicht:
+- Rückgängig machen / Wiederherstellen von Funktionen
+- Prüfpfade (wer was wann gelöscht hat)
+- Referenzielle Integrität (Datensätze können noch referenziert werden, bis sie bereinigt werden)
+
+## Schema
+
+Eine `deleted_at`-Spalte hinzufügen, die für aktive Datensätze `NULL` ist und für gelöschte Datensätze einen Zeitstempel enthält:
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT NULL          -- NULL = aktiv, Zeitstempel = gelöscht
+);
+```
+
+## Die kritische Regel: deleted_at immer filtern
+
+**Jede Abfrage, die nur aktive Datensätze zurückgeben soll, muss `AND deleted_at IS NULL` enthalten.** Das Fehlen dieses Filters ist der häufigste Fehler — der Code funktioniert, aber gelöschte Daten werden in API-Antworten durchgesickert.
+
+```php
+// ❌ Fehlender Filter — gibt auch gelöschte Datensätze zurück
+$rows = $this->executor->fetchAll('SELECT * FROM articles WHERE id = ?', [$id]);
+
+// ✅ Gelöschte ausschließen
+$rows = $this->executor->fetchAll(
+    'SELECT * FROM articles WHERE id = ? AND deleted_at IS NULL',
+    [$id],
+);
+```
+
+Dies gilt für jede Abfrage: `findById`, `findAll`, `findByUser`, Paginierungsabfragen und JOIN-Ziele.
+
+## Entity
+
+```php
+final readonly class Article
+{
+    public function __construct(
+        public int $id,
+        public string $title,
+        public string $body,
+        public string $createdAt,
+        public string $updatedAt,
+        public ?string $deletedAt,
+    ) {
+    }
+
+    public function isDeleted(): bool
+    {
+        return $this->deletedAt !== null;
+    }
+}
+```
+
+## Repository-Muster
+
+Ein `$includeTrashed = false`-Flag verwenden. Der Standard `false` bedeutet, dass Aufrufer explizit einwilligen müssen, gelöschte Datensätze zu sehen, was versehentliche Preisgabe verhindert:
+
+```php
+final class ArticleRepository
+{
+    public function findById(int $id, bool $includeTrashed = false): ?Article
+    {
+        $sql = $includeTrashed
+            ? 'SELECT * FROM articles WHERE id = ?'
+            : 'SELECT * FROM articles WHERE id = ? AND deleted_at IS NULL';
+
+        $row = $this->executor->fetchOne($sql, [$id]);
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    /** @return list<Article> */
+    public function findActive(): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT * FROM articles WHERE deleted_at IS NULL ORDER BY created_at DESC',
+        );
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    /** @return list<Article> */
+    public function findTrashed(): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT * FROM articles WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC',
+        );
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function softDelete(int $id): ?Article
+    {
+        $article = $this->findById($id); // nur aktiv
+        if ($article === null) {
+            return null;
+        }
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $this->executor->execute('UPDATE articles SET deleted_at = ? WHERE id = ?', [$now, $id]);
+        return new Article($article->id, $article->title, $article->body, $article->createdAt, $article->updatedAt, $now);
+    }
+
+    public function restore(int $id): ?Article
+    {
+        $article = $this->findById($id, includeTrashed: true);
+        if ($article === null || !$article->isDeleted()) {
+            return null; // nicht gefunden oder nicht im Papierkorb
+        }
+        $this->executor->execute('UPDATE articles SET deleted_at = NULL WHERE id = ?', [$id]);
+        return new Article($article->id, $article->title, $article->body, $article->createdAt, $article->updatedAt, null);
+    }
+
+    /** Dauerhaft löschen — nur aus Papierkorb erlaubt. */
+    public function purge(int $id): bool
+    {
+        $article = $this->findById($id, includeTrashed: true);
+        if ($article === null || !$article->isDeleted()) {
+            return false; // Schutz: muss zuerst im Papierkorb sein
+        }
+        $this->executor->execute('DELETE FROM articles WHERE id = ?', [$id]);
+        return true;
+    }
+}
+```
+
+### `insert()` für INSERT verwenden
+
+Beim Erstellen von Datensätzen `insert()` verwenden (nicht `execute()` + `lastInsertId()`):
+
+```php
+// ❌ Zwei Aufrufe
+$this->executor->execute('INSERT INTO articles ...', [...]);
+$id = $this->executor->lastInsertId();
+
+// ✅ Ein Aufruf — gibt die eingefügte Zeilen-ID zurück
+$id = $this->executor->insert('INSERT INTO articles ...', [...]);
+```
+
+## Endpunkte
+
+Eine typische Soft-Delete-API:
+
+| Methode | Pfad | Beschreibung |
+|---|---|---|
+| `POST` | `/articles` | Erstellen |
+| `GET` | `/articles` | Nur aktive Datensätze |
+| `GET` | `/articles/trash` | Nur gelöschte Datensätze |
+| `GET` | `/articles/{id}` | Einen abrufen (404 wenn gelöscht) |
+| `DELETE` | `/articles/{id}` | Soft Delete → 404 wenn bereits gelöscht |
+| `POST` | `/articles/{id}/restore` | Wiederherstellen → 404 wenn nicht im Papierkorb |
+| `DELETE` | `/articles/{id}/purge` | Hard Delete → 404 wenn nicht im Papierkorb |
+
+**Hinweis zur REST-Semantik:** `DELETE /articles/{id}` verhält sich als Soft Delete, nicht als dauerhafte Entfernung. Wenn dies Clients überrascht, dies klar in der OpenAPI-Spezifikation dokumentieren oder `POST /articles/{id}/trash` für die Soft-Delete-Aktion verwenden.
+
+## `deleted_at` immer in Antworten einschließen
+
+`deleted_at` in jede Antwort einschließen, damit Clients den Ressourcenzustand ohne zusätzliche Anfragen bestimmen können:
+
+```php
+return $this->json->create([
+    'id'         => $article->id,
+    'title'      => $article->title,
+    'body'       => $article->body,
+    'created_at' => $article->createdAt,
+    'updated_at' => $article->updatedAt,
+    'deleted_at' => $article->deletedAt, // null = aktiv; Zeitstempel = gelöscht
+]);
+```
+
+## Foreign Keys und Soft Delete
+
+Wenn andere Tabellen auf einen soft-gelöschten Datensatz verweisen:
+- Soft Deletion unterbricht keine Foreign-Key-Bedingungen — die Zeile existiert noch
+- Hard Delete (Bereinigung) kann Bedingungen verletzen, wenn verweisende Zeilen existieren
+- Vor der Bereinigung auf abhängige Datensätze prüfen oder Soft Delete auf Abhängige kaskadieren
+
+## Code-Review-Checkliste
+
+- [ ] Jede Abfrage für aktive Datensätze enthält `AND deleted_at IS NULL`
+- [ ] `findById()`-Standard ist `$includeTrashed = false` — Aufrufer müssen explizit einwilligen
+- [ ] `purge()` schützt vor Hard Delete von aktiven Datensätzen (Prüfung `isDeleted()`)
+- [ ] `restore()` gibt `null` (→ 404) zurück, wenn der Datensatz nicht im Papierkorb ist
+- [ ] JOIN-Abfragen auf soft-gelöschten Tabellen filtern auch `deleted_at IS NULL` auf der verknüpften Tabelle
+- [ ] `deleted_at` ist in API-Antworten enthalten, damit Clients den Zustand bestimmen können
+- [ ] Das Verhalten von `DELETE /articles/{id}` (soft vs. hart) ist in OpenAPI dokumentiert
+- [ ] Tests decken ab: Löschen → 404 bei GET, Liste schließt gelöschte aus, Wiederherstellen → wieder sichtbar, Bereinigen → überall weg, Doppellöschen → 404, aktives Bereinigen → 404
+- [ ] `insert()` wird für INSERT verwendet (nicht `execute()` + `lastInsertId()`)

--- a/docs/de/howto/sql-injection-defence.md
+++ b/docs/de/howto/sql-injection-defence.md
@@ -1,0 +1,324 @@
+# Anleitung: SQL-Injection-Abwehr
+
+> **FT-Referenz**: FT264 (`NENE2-FT/injectionlog`) — SQL-Injection-Abwehr: parametrisierte Abfragen, LIKE-Injection, ORDER BY-Allowlist
+> **ATK**: FT264 — Cracker-Mindset-Angrifftest (ATK-01 bis ATK-12)
+
+Demonstriert die drei Haupt-SQL-Injection-Vektoren in einer PHP-API — Wertinjektion, LIKE-Wildcard-
+Injektion und ORDER BY-Spalteninjektion — und die korrekte Abwehr für jeden. Enthält ein vollständiges
+Cracker-Mindset-Angriffs-Assessment.
+
+---
+
+## Routen
+
+| Methode   | Pfad            | Beschreibung                              |
+|-----------|-----------------|------------------------------------------|
+| `GET`    | `/products`     | Produkte auflisten/suchen (filterbar, sortierbar) |
+| `POST`   | `/products`     | Produkt erstellen                         |
+| `GET`    | `/products/{id}`| Einzelnes Produkt abrufen                 |
+| `DELETE` | `/products/{id}`| Produkt löschen                           |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL,
+    category    TEXT    NOT NULL,
+    price       REAL    NOT NULL DEFAULT 0.0,
+    description TEXT    NOT NULL DEFAULT ''
+);
+```
+
+---
+
+## Die drei SQL-Injection-Angriffsflächen
+
+### 1. Wertinjektion: parametrisierte Abfragen
+
+```php
+// ❌ String-Interpolation — injizierbar
+$rows = $db->fetchAll("SELECT * FROM products WHERE id = {$id}");
+
+// ✅ Parametrisiert — der Treiber escaped alle Werte
+$rows = $db->fetchAll('SELECT * FROM products WHERE id = ?', [$id]);
+```
+
+PDOs `?`-Platzhalter bindet den Wert als typisierter Parameter. Der Wert wird nie in den SQL-String interpoliert. Ein Angreifer, der `id = "1; DROP TABLE products; --"` sendet, hat seine gesamte Eingabe als wörtliche String-Bindung gespeichert — das SQL wird nicht modifiziert.
+
+### 2. LIKE-Wildcard-Injektion: parametrisierte Wildcards
+
+```php
+// ❌ Interpoliertes LIKE — injizierbar UND Wildcard-escaped
+$rows = $db->fetchAll("SELECT * FROM products WHERE name LIKE '%{$q}%'");
+
+// ✅ Parametrisierte Wildcard — der ?-Wert wird nach || Verkettung gebunden
+$rows = $db->fetchAll(
+    "SELECT * FROM products WHERE name LIKE '%' || ? || '%' OR description LIKE '%' || ? || '%'",
+    [$q, $q],
+);
+```
+
+`'%' || ? || '%'` ist Standard-SQL-String-Verkettung (SQLite, PostgreSQL). Der `?`-Wert wird als Parameter gebunden — die `%`-Wildcards sind Literale im SQL-String, nicht aus Benutzereingaben.
+
+**LIKE-Metazeichen-Escaping**: `%` und `_` in der Benutzereingabe `$q` werden in dieser
+Implementierung NICHT escaped. Eine Suche nach `%` würde alles treffen. Für die Produktion LIKE-Metazeichen escapen:
+
+```php
+$escaped = str_replace(['%', '_', '\\'], ['\\%', '\\_', '\\\\'], $q);
+$rows = $db->fetchAll("... WHERE name LIKE '%' || ? || '%' ESCAPE '\\'", [$escaped, $escaped]);
+```
+
+### 3. ORDER BY-Injektion: Spalten-Allowlist
+
+```php
+private const array ALLOWED_SORT_FIELDS = ['id', 'name', 'category', 'price'];
+
+public function search(string $query = '', string $sortField = 'id', string $sortDir = 'asc'): array
+{
+    if (!in_array($sortField, self::ALLOWED_SORT_FIELDS, true)) {
+        throw new InvalidSortFieldException("Invalid sort field: {$sortField}");
+    }
+
+    $sortDir    = strtolower($sortDir) === 'desc' ? 'DESC' : 'ASC';
+    $sortClause = $sortField . ' ' . $sortDir;   // sicher: Allowlisted Spalte + whitelisted Richtung
+
+    $rows = $db->fetchAll(
+        "SELECT * FROM products ORDER BY {$sortClause}",
+    );
+}
+```
+
+`ORDER BY` kann keine parametrisierten Platzhalter verwenden — der Spaltenname muss interpoliert werden.
+Die korrekte Abwehr ist eine explizite Allowlist: Nur Werte in `ALLOWED_SORT_FIELDS` dürfen im SQL-String erscheinen. Jeder andere Wert wirft eine Exception (400 im Controller).
+
+`sortDir` wird auf genau `'ASC'` oder `'DESC'` abgebildet — Benutzereingaben werden nie direkt interpoliert.
+
+---
+
+## ATK — Cracker-Mindset-Angrifftest (FT264)
+
+### ATK-01 — Klassische SELECT-Injektion via GET-Parameter
+
+**Angriff**: SQL via Suchanfrage `?q=' OR '1'='1` injizieren.
+
+```
+GET /products?q=' OR '1'='1
+```
+
+**Beobachtet**: `$q` ist als `?`-Parameter in `LIKE '%' || ? || '%'` gebunden. Der gesamte String
+`' OR '1'='1` wird als Literal-Textwert zum Matchen behandelt. Keine zusätzlichen Zeilen werden zurückgegeben.
+
+**Urteil**: **BLOCKED** — parametrisiertes LIKE verhindert Wertinjektion.
+
+---
+
+### ATK-02 — DROP TABLE-Injektion via Suche
+
+**Angriff**: Eine destruktive Anweisung injizieren.
+
+```
+GET /products?q='; DROP TABLE products; --
+```
+
+**Beobachtet**: Der Payload ist als LIKE-Muster gebunden. `'; DROP TABLE products; --` wird als Literal-Text durchsucht. Die Tabelle wird nicht gelöscht.
+
+**Urteil**: **BLOCKED** — parametrisierte Abfragen können keine injizierten Anweisungen ausführen.
+
+---
+
+### ATK-03 — ORDER BY-Spalteninjektion: beliebige Spalte
+
+**Angriff**: Eine unbekannte Sortierspalte injizieren.
+
+```
+GET /products?sort=password
+```
+
+**Beobachtet**: `in_array('password', self::ALLOWED_SORT_FIELDS, true)` gibt `false` zurück.
+`InvalidSortFieldException` wird ausgelöst. Der Controller fängt es ab und gibt 400 zurück.
+
+**Urteil**: **BLOCKED** — Spalten-Allowlist lehnt unbekannte Spaltennamen ab.
+
+---
+
+### ATK-04 — ORDER BY-Injektion: Subquery-Injektion
+
+**Angriff**: Eine Subquery als Sortierspalte injizieren.
+
+```
+GET /products?sort=(SELECT%20name%20FROM%20users%20LIMIT%201)
+```
+
+**Beobachtet**: Der decodierte Wert `(SELECT name FROM users LIMIT 1)` ist nicht in `ALLOWED_SORT_FIELDS`.
+`InvalidSortFieldException` ausgelöst. 400 zurückgegeben.
+
+**Urteil**: **BLOCKED** — Allowlist lehnt jeden Wert ab, der nicht in der bekannten Spaltenliste ist, einschließlich Subqueries.
+
+---
+
+### ATK-05 — ORDER BY-Injektion: Richtungsmanipulation
+
+**Angriff**: SQL via Sortierrichtungsparameter injizieren.
+
+```
+GET /products?order=DESC;%20DROP%20TABLE%20products;--
+```
+
+**Beobachtet**: `strtolower($sortDir) === 'desc'` ist `false` für den injizierten Wert. Die Richtung
+fällt auf `'ASC'` zurück. Das injizierte SQL wird nie interpoliert. 200 mit nach ASC sortierten Produkten zurückgegeben.
+
+**Urteil**: **BLOCKED** — Richtung wird auf genau `'ASC'` oder `'DESC'` abgebildet, nie interpoliert.
+
+---
+
+### ATK-06 — UNION-Injektion via Suchanfrage
+
+**Angriff**: Ein `UNION SELECT` injizieren, um Daten zu exfiltrieren.
+
+```
+GET /products?q=' UNION SELECT id,name,email,password,'' FROM users --
+```
+
+**Beobachtet**: Der vollständige Injektions-String ist als LIKE-Parameterwert gebunden. Das `UNION SELECT`
+wird als Literal-Text in den `name`- und `description`-Spalten durchsucht. Keine Benutzerdaten werden zurückgegeben.
+
+**Urteil**: **BLOCKED** — parametrisierte Abfrage verhindert UNION-Injektion.
+
+---
+
+### ATK-07 — ID-Injektion via Pfadparameter
+
+**Angriff**: SQL via Pfadparameter injizieren.
+
+```
+GET /products/1;%20DROP%20TABLE%20products;
+```
+
+**Beobachtet**: Der Pfadparameter `{id}` wird durch `(int) $params['id']` in `int` gecastet. Das SQL
+wird zu `WHERE id = 1` — das Injektionssuffix wird durch den Cast abgeschnitten. Die Tabelle wird nicht gelöscht.
+
+**Urteil**: **BLOCKED** — `(int)`-Cast schneidet beim ersten Nicht-Ziffern-Zeichen ab.
+
+---
+
+### ATK-08 — Boolean-basierte Blind-Injektion via Suche
+
+**Angriff**: Daten über Boolean-Bedingungen preisgeben.
+
+```
+GET /products?q=' AND '1'='1
+GET /products?q=' AND '1'='2
+```
+
+**Beobachtet**: Beide Strings sind als LIKE-Parameter gebunden. Beide geben Produkte zurück, deren Name oder
+Beschreibung den Literal-Text `' AND '1'='1` enthält. Keine Abfrage ändert die SQL WHERE-Logik. Beide geben dasselbe (leere) Ergebnisset zurück.
+
+**Urteil**: **BLOCKED** — parametrisiertes Binden verhindert Boolean-Injektion.
+
+---
+
+### ATK-09 — Second-Order-Injektion: gespeicherter Payload wird später abgerufen
+
+**Angriff**: Ein Produkt mit einem SQL enthaltenden Namen erstellen, dann alle Produkte suchen.
+
+```json
+POST /products {"name": "'; DROP TABLE products; --", "category": "test", "price": 1}
+GET /products
+```
+
+**Beobachtet**: Das `INSERT` verwendet parametrisiertes `?` — der Injektions-Payload wird als Literal-Text gespeichert. Die `SELECT *`- und `LIKE`-Abfragen verwenden ebenfalls parametrisierte Abfragen. Der Payload wird als String-Wert zurückgegeben, nie als SQL ausgeführt.
+
+**Urteil**: **BLOCKED** — alle Lese- und Schreibpfade verwenden parametrisierte Abfragen.
+
+---
+
+### ATK-10 — LIKE-Metazeichen-Überflutung: `%`-Suche
+
+**Angriff**: `?q=%` senden, um alle Produkte zu matchen, wodurch eine beabsichtigte Leersuche-Vorgabe umgangen wird.
+
+```
+GET /products?q=%25   (URL-decodiert: %)
+```
+
+**Beobachtet**: `$q = '%'` ist als LIKE-Parameter gebunden. `LIKE '%' || '%' || '%'` = `LIKE '%%%'`
+was jede Zeile trifft. Alle Produkte werden zurückgegeben.
+
+**Urteil**: **EXPOSED** — `%` und `_` in Benutzereingaben werden nicht escaped. Eine Suche nach `%` trifft
+alles; eine Suche nach `_` trifft jedes einzelne Zeichen. LIKE-Metazeichen escapen oder das Verhalten als absichtlich dokumentieren.
+
+---
+
+### ATK-11 — Null-Byte-Injektion
+
+**Angriff**: Ein Null-Byte in die Suchanfrage einbetten.
+
+```
+GET /products?q=widget%00extra
+```
+
+**Beobachtet**: PHPs `?`-Bindung übergibt den rohen String einschließlich des Null-Bytes an SQLites
+parametrisierte Abfrage. SQLite behandelt das Null-Byte als Teil des Strings. `LIKE '%widget\0extra%'`
+trifft keine normalen Produktnamen. Keine Injektion tritt auf.
+
+**Urteil**: **BLOCKED** — parametrisierte Abfragen behandeln Null-Bytes als Literal-String-Inhalt.
+
+---
+
+### ATK-12 — Gestapelte Abfragen (Multi-Statement-Injektion)
+
+**Angriff**: Eine zweite Anweisung nach einem Semikolon injizieren.
+
+```
+GET /products?q=test'; INSERT INTO products VALUES (99,'hacked','x',0,''); --
+```
+
+**Beobachtet**: PDO führt nur eine Anweisung pro `query()`/`prepare()`-Aufruf aus — gestapelte Abfragen
+werden standardmäßig nicht unterstützt. Selbst wenn PDO mehrere Anweisungen erlauben würde, ist der Wert als
+Parameter gebunden (nicht interpoliert). Das injizierte INSERT wird als Literal LIKE-Suchtext gespeichert.
+
+**Urteil**: **BLOCKED** — parametrisiertes Binden + PDO-Einzelanweisungsmodus verhindern gestapelte Abfragen.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|---|---|
+| ATK-01 | Klassische SELECT-Injektion via `?q=` | BLOCKED |
+| ATK-02 | DROP TABLE via Suche | BLOCKED |
+| ATK-03 | ORDER BY unbekannte Spalte | BLOCKED |
+| ATK-04 | ORDER BY Subquery-Injektion | BLOCKED |
+| ATK-05 | Sortierrichtungs-Injektion | BLOCKED |
+| ATK-06 | UNION SELECT via Suche | BLOCKED |
+| ATK-07 | ID-Injektion via Pfadparameter | BLOCKED |
+| ATK-08 | Boolean-basierte Blind-Injektion | BLOCKED |
+| ATK-09 | Second-Order-Injektion | BLOCKED |
+| ATK-10 | LIKE-Metazeichen-Überflutung (`%`) | EXPOSED |
+| ATK-11 | Null-Byte-Injektion | BLOCKED |
+| ATK-12 | Gestapelte Abfragen | BLOCKED |
+
+**Echte Schwachstellen, die vor der Produktion behoben werden müssen**:
+1. **ATK-10** — LIKE-Metazeichen (`%`, `_`, `\`) vor dem Binden escapen, um Wildcard-Überflutung zu verhindern.
+
+---
+
+## Abwehr-Zusammenfassung
+
+| Angriffsfläche | Verwundbares Muster | Sicheres Muster |
+|---|---|---|
+| Wert in WHERE | `WHERE id = {$id}` | `WHERE id = ?` mit `[$id]` |
+| LIKE-Suche | `WHERE name LIKE '%{$q}%'` | `WHERE name LIKE '%' \|\| ? \|\| '%'` |
+| ORDER BY-Spalte | `ORDER BY {$sortField}` | `in_array($sortField, ALLOWED, true)` + interpolieren |
+| ORDER BY-Richtung | `ORDER BY col {$dir}` | `$dir === 'desc' ? 'DESC' : 'ASC'` |
+| Pfadparameter-ID | `WHERE id = {$id}` | `(int) $id` + parametrisiert |
+
+---
+
+## Verwandte Anleitungen
+
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — explizites DTO-Whitelisting als breiteres Abwehrmuster
+- [`sqlite-fts5-search.md`](sqlite-fts5-search.md) — FTS5 als Alternative zu LIKE für Volltextsuche
+- [`jwt-authentication.md`](jwt-authentication.md) — VULN-Assessment einschließlich SQL-Injection (V-08)

--- a/docs/de/howto/sql-injection.md
+++ b/docs/de/howto/sql-injection.md
@@ -1,0 +1,81 @@
+# SQL-Injection-Abwehr
+
+NEINs Datenbankwerkzeuge (`execute`, `insert`, `fetchOne`, `fetchAll`) verwenden intern PDO-Prepared Statements. Jeder Wert, der im `$parameters`-Array übergeben wird, wird als PDO-Parameter gebunden — nie in den SQL-String interpoliert.
+
+## Standardmäßig sicher: Wertparameter
+
+```php
+// Alle Werte werden durch PDO-Bindung geleitet — injection-sicher unabhängig vom Inhalt
+$product = $this->db->fetchOne(
+    'SELECT * FROM products WHERE id = ?',
+    [$userId],
+);
+
+// LIKE-Suche — Wildcard im SQL-Literal, Wert separat gebunden
+$rows = $this->db->fetchAll(
+    "SELECT * FROM products WHERE name LIKE '%' || ? || '%'",
+    [$searchQuery],
+);
+```
+
+Klassische Payloads (`' OR '1'='1`, `'; DROP TABLE products; --`, `UNION SELECT ...`) werden zu Literal-Suchstrings, da PDO sie nie in SQL interpoliert.
+
+## Die ORDER BY-Falle — Whitelist erforderlich
+
+**PDO kann Spaltennamen oder SQL-strukturelle Elemente nicht parametrisieren.** `ORDER BY ?` funktioniert nicht — es bindet einen Literal-String-Wert, keine Spaltenreferenz.
+
+Wenn ein Entwickler Benutzereingaben direkt in `ORDER BY` eingibt, wird es zu einem Injektionsvektor:
+
+```php
+// UNSICHER — dies niemals tun
+$sort = QueryStringParser::string($request, 'sort') ?? 'id';
+$rows = $this->db->fetchAll("SELECT * FROM products ORDER BY {$sort} ASC");
+// ?sort=id;+DROP+TABLE+products;+-- führt den DROP aus
+```
+
+**Vor der Interpolation von Spaltennamen immer gegen eine explizite Whitelist validieren:**
+
+```php
+private const array ALLOWED_SORT_FIELDS = ['id', 'name', 'price', 'created_at'];
+
+public function list(string $sortField, string $sortDir): array
+{
+    if (!in_array($sortField, self::ALLOWED_SORT_FIELDS, true)) {
+        throw new InvalidSortFieldException("Invalid sort field: {$sortField}");
+    }
+
+    // Nur ASC oder DESC — normalisieren, niemals rohe Benutzereingaben interpolieren
+    $dir  = strtolower($sortDir) === 'desc' ? 'DESC' : 'ASC';
+    $rows = $this->db->fetchAll(
+        "SELECT * FROM products ORDER BY {$sortField} {$dir}",
+    );
+
+    return $rows;
+}
+```
+
+Dasselbe Prinzip gilt für jedes SQL-strukturelle Element: Tabellennamen, Spaltennamen in `GROUP BY`, `HAVING`, `INSERT INTO ... (col1, col2)` — keines davon kann als PDO-Parameter gebunden werden. Vor der Interpolation Whitelist-validieren.
+
+## IN-Klausel mit variabler Länge
+
+PDO unterstützt keine direkte Bindung einer variablen Längeliste. Platzhalter-Liste explizit aufbauen:
+
+```php
+$ids          = [1, 2, 3];
+$placeholders = implode(', ', array_fill(0, count($ids), '?'));
+$rows         = $this->db->fetchAll(
+    "SELECT * FROM products WHERE id IN ({$placeholders})",
+    $ids,
+);
+```
+
+## Zusammenfassung
+
+| Eingabetyp | Sichere Methode |
+|---|---|
+| Filterwert (`WHERE col = ?`) | `?`-Platzhalter in `$parameters` |
+| LIKE-Wert | `'%' \|\| ? \|\| '%'` — Wert in `$parameters` |
+| ORDER BY-Spalte | Whitelist `in_array` + nur nach Bestehen interpolieren |
+| ORDER-Richtung | Auf Literal `'ASC'` oder `'DESC'` normalisieren |
+| IN-Liste | `?`-Platzhalter aus `count()` aufbauen, Array als Params spreaden |
+| Tabellen-/Spaltenname | Nur Whitelist — niemals aus Benutzereingaben akzeptieren |

--- a/docs/de/howto/sql-orderby-injection.md
+++ b/docs/de/howto/sql-orderby-injection.md
@@ -1,0 +1,166 @@
+# Anleitung: SQL ORDER BY-Injection verhindern
+
+SQL-`ORDER BY`-Klauseln können nicht mit Standard-Platzhaltern (`?`) parametrisiert werden. Das bedeutet,
+benutzergesteuerte Sortierspalten und -richtungen dürfen niemals direkt in SQL interpoliert werden.
+Diese Anleitung erklärt den einzig sicheren Ansatz: eine explizite Allowlist.
+
+---
+
+## Das Problem
+
+Prepared-Statement-Platzhalter schützen Spaltenwerte in `WHERE`-Klauseln, funktionieren aber **nicht**
+für Spaltennamen oder Sortierrichtungen in `ORDER BY`:
+
+```php
+// ❌ FALSCH — schützt NICHT vor Injection
+$stmt = $pdo->prepare("SELECT * FROM articles ORDER BY ? ?");
+$stmt->execute([$column, $direction]);
+// Viele Datenbanktreiber behandeln ORDER BY-Argumente als Literale, nicht als Bezeichner.
+```
+
+Ein Angreifer, der `?sort=SLEEP(5)` oder `?sort=(SELECT password FROM users LIMIT 1)` sendet, kann
+zeitbasierte Angriffe, Informationspreisgabe oder Fehler verursachen, die Schemadetails enthüllen.
+
+---
+
+## Die einzige sichere Lösung: Explizite Allowlist
+
+```php
+// ✅ SICHER — Allowlist + in_array strict
+public const array SORT_COLUMNS = ['id', 'title', 'status', 'created_at'];
+public const array SORT_DIRS    = ['asc', 'desc'];
+
+$sql = "SELECT * FROM articles ORDER BY {$sortCol} {$sortDir} LIMIT ?";
+```
+
+Die Allowlist-Werte sind **hartcodierte Strings**, die man selbst kontrolliert. Nur diese Werte erreichen jemals SQL.
+
+---
+
+## Vollständiges Routen-Handler-Muster
+
+```php
+// ── Sortierspalte — MUSS gegen Allowlist validiert werden ─────────────────────
+//
+// SICHERHEIT: ORDER BY unterstützt keine ?-Platzhalter in Standard-SQL.
+// Der EINZIGE sichere Ansatz ist eine explizite Allowlist, geprüft mit in_array strict.
+//
+$rawSort = $params['sort'] ?? null;
+
+if ($rawSort !== null) {
+    // Array-Injektion: PSR-7 kann Array für ?sort[]=id liefern
+    if (!is_string($rawSort)) {
+        return $this->responseFactory->create(['error' => 'sort must be a string.'], 422);
+    }
+
+    // Null-Byte-Prüfung — PSR-7 decodiert %00 zum tatsächlichen Null-Byte
+    if (str_contains($rawSort, "\0")) {
+        return $this->responseFactory->create(['error' => 'sort contains invalid characters.'], 422);
+    }
+
+    // Allowlist-Prüfung — strikt, case-sensitive.
+    // PSR-7 URL-decodiert Query-Strings bereits einmal (%65 → e), sodass einfach-kodierte gültige
+    // Spaltennamen akzeptiert werden. Doppelt-kodierte Werte (%2565 → %65 in $rawSort) werden NICHT
+    // ein zweites Mal decodiert, scheitern also an der Allowlist und werden abgelehnt.
+    if (!in_array($rawSort, MyRepository::SORT_COLUMNS, true)) {
+        return $this->responseFactory->create(
+            ['error' => sprintf('sort must be one of: %s.', implode(', ', MyRepository::SORT_COLUMNS))],
+            422,
+        );
+    }
+
+    $sortCol = $rawSort;
+} else {
+    $sortCol = 'created_at';  // sicherer Standard
+}
+
+// ── Sortierrichtung — nur Allowlist ───────────────────────────────────────────
+$rawOrder = $params['order'] ?? null;
+
+if ($rawOrder !== null) {
+    if (!is_string($rawOrder)) {
+        return $this->responseFactory->create(['error' => 'order must be a string.'], 422);
+    }
+
+    $dir = strtolower(trim($rawOrder));
+
+    if (!in_array($dir, MyRepository::SORT_DIRS, true)) {
+        return $this->responseFactory->create(
+            ['error' => sprintf('order must be one of: %s.', implode(', ', MyRepository::SORT_DIRS))],
+            422,
+        );
+    }
+
+    $sortDir = $dir;
+} else {
+    $sortDir = 'desc';  // sicherer Standard
+}
+```
+
+---
+
+## Repository-Layer
+
+Das Repository empfängt bereits validierte Werte und interpoliert sie direkt:
+
+```php
+/**
+ * $sortCol und $sortDir MÜSSEN vom Aufrufer Allowlist-verifiziert sein.
+ * Diese Methode vertraut ihnen und interpoliert sie direkt in SQL.
+ *
+ * @return array{data: list<Article>, total: int, sort: string, order: string, limit: int}
+ */
+public function list(string $sortCol, string $sortDir, ?ArticleStatus $status, int $limit): array
+{
+    $where  = $status !== null ? 'WHERE status = ?' : '';
+    $params = $status !== null ? [$status->value] : [];
+
+    // $sortCol und $sortDir sind vorvalidiert — sicher zu interpolieren.
+    // Niemals rohe Benutzereingaben hier einfügen.
+    $sql  = "SELECT * FROM articles {$where} ORDER BY {$sortCol} {$sortDir} LIMIT ?";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([...$params, $limit]);
+    ...
+}
+```
+
+---
+
+## Von diesem Ansatz blockierte Angriffsmuster
+
+| Angriff | Eingabe | Ergebnis |
+|---|---|---|
+| DROP TABLE-Injektion | `?sort='; DROP TABLE articles--` | 422 — nicht in Allowlist |
+| UNION SELECT-Exfiltration | `?sort=1; SELECT password` | 422 — nicht in Allowlist |
+| Subquery-Extraktion | `?sort=(SELECT name FROM sqlite_master)` | 422 — nicht in Allowlist |
+| Zeitbasierter Blind | `?sort=SLEEP(5)` | 422 — nicht in Allowlist |
+| Spaltenindex-Injektion | `?sort=1` | 422 — nicht in Allowlist |
+| Unbekannte Spalte | `?sort=password` | 422 — nicht in Allowlist |
+| Case/Kommentar-Bypass | `?sort=CREATED_AT--` | 422 — case-sensitive |
+| Null-Byte-Bypass | `?sort=created_at%00` | 422 — Null-Byte-Prüfung |
+| Array-Injektion | `?sort[]=created_at` | 422 — Typprüfung |
+| Doppelte URL-Kodierung | `?sort=cr%2565ated_at` | 422 — PSR-7 decodiert einmal; `cr%65ated_at` nicht in Allowlist |
+| Einfache URL-Kodierung (gültig) | `?sort=cr%65ated_at` | 200 — PSR-7 decodiert zu `created_at` ✓ |
+| Richtungs-Injektion | `?order=asc; UNION SELECT 1--` | 422 — nicht in Allowlist |
+
+---
+
+## Schlüsselpunkte
+
+1. **Kein `rawurldecode()` nach PSR-7**: PSR-7s `getQueryParams()` decodiert den Query-String bereits einmal. Das erneute Aufrufen von `rawurldecode()` würde es doppelt-kodierten Werten ermöglichen, die Allowlist-Prüfung zu umgehen.
+
+2. **`in_array($value, $allowlist, true)`**: Das dritte Argument `true` aktiviert strikt (typ-sicheren) Vergleich. Ohne es gibt `in_array(0, ['id', 'created_at'])` `true` zurück, weil PHP Strings zu Integers konvertiert.
+
+3. **Case-sensitive Prüfung**: Spaltennamen sollten Kleinbuchstaben sein und exakt gematcht werden. Niemals `strcasecmp` oder `strtolower` vor der Allowlist-Prüfung verwenden — `CREATED_AT` ist aus Vertrauensperspektive nicht dasselbe Token wie `created_at`.
+
+4. **Richtung: `strtolower(trim())` ist sicher**: Im Gegensatz zu Spaltennamen hat die Richtung (`asc`/`desc`) nur zwei gültige Werte. Die Normalisierung der Groß-/Kleinschreibung vor der Allowlist-Prüfung ist akzeptabel, da die Allowlist selbst erschöpfend und kleinbuchstabig ist.
+
+5. **Vertrag dokumentieren**: Die Repository-Methode muss dokumentieren, dass sie ihren Eingaben vertraut. Aufrufer dürfen niemals rohe Benutzereingaben übergeben.
+
+---
+
+## Verwandt
+
+- FT180 — sortlog: SQL ORDER BY Injection & Dynamic Sort/Filter Prevention
+- [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) — URI-Kodierung
+- [PSR-7](https://www.php-fig.org/psr/psr-7/) — `ServerRequestInterface::getQueryParams()`

--- a/docs/de/howto/sqlite-fts5-search.md
+++ b/docs/de/howto/sqlite-fts5-search.md
@@ -1,0 +1,241 @@
+# Anleitung: SQLite FTS5-Volltextsuche
+
+> **FT-Referenz**: FT254 (`NENE2-FT/ftslog`) — Volltextsuche mit SQLite FTS5
+
+Demonstriert Volltextsuche (FTS) mit SQLites eingebauter FTS5-Erweiterung. Eine virtuelle
+`posts_fts`-Tabelle spiegelt die `posts`-Tabelle und wird über Trigger synchron gehalten.
+Die Suche verwendet `MATCH` mit relevanzgeordneten Ergebnissen über `fts.rank`.
+
+---
+
+## Routen
+
+| Methode | Pfad             | Beschreibung                          |
+|---------|------------------|--------------------------------------|
+| `POST` | `/posts`         | Beitrag erstellen (automatisch indiziert) |
+| `GET`  | `/posts`         | Alle Beiträge auflisten               |
+| `GET`  | `/posts/search`  | Volltextsuche (`?q=`)                 |
+
+> **Routenreihenfolge**: `/posts/search` muss **vor** `/posts/{id}` registriert werden, damit
+> das wörtliche Segment `search` nicht als Pfadparameter erfasst wird.
+
+---
+
+## Schema: FTS5-virtuelle Tabelle + Trigger
+
+```sql
+CREATE TABLE IF NOT EXISTS posts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    tags       TEXT    NOT NULL DEFAULT '',  -- leerzeichen-getrennte Tag-Zeichenkette
+    created_at TEXT    NOT NULL
+);
+
+-- FTS5-virtuelle Tabelle: spiegelt posts für Volltextsuche
+CREATE VIRTUAL TABLE IF NOT EXISTS posts_fts USING fts5(
+    title,
+    body,
+    tags,
+    content='posts',      -- externe Inhaltstabelle
+    content_rowid='id'    -- rowid-Spalte in der Inhaltstabelle
+);
+
+-- FTS-Index mit posts synchron halten
+CREATE TRIGGER IF NOT EXISTS posts_ai AFTER INSERT ON posts BEGIN
+    INSERT INTO posts_fts(rowid, title, body, tags)
+    VALUES (new.id, new.title, new.body, new.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS posts_ad AFTER DELETE ON posts BEGIN
+    INSERT INTO posts_fts(posts_fts, rowid, title, body, tags)
+    VALUES ('delete', old.id, old.title, old.body, old.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS posts_au AFTER UPDATE ON posts BEGIN
+    INSERT INTO posts_fts(posts_fts, rowid, title, body, tags)
+    VALUES ('delete', old.id, old.title, old.body, old.tags);
+    INSERT INTO posts_fts(rowid, title, body, tags)
+    VALUES (new.id, new.title, new.body, new.tags);
+END;
+```
+
+**`content='posts'`** deklariert `posts_fts` als Inhaltstabelle — sie speichert FTS-Tokens,
+delegiert aber die eigentliche Textspeicherung an `posts`. Dies vermeidet die Duplizierung des gesamten Textes.
+
+**`content_rowid='id'`** teilt FTS5 mit, welche Spalte in `posts` die rowid für den JOIN ist.
+
+**Trigger** halten den FTS-Index synchron. Ohne sie würden Inserts und Updates in `posts`
+nicht in `posts_fts` widergespiegelt. Der Lösch-Trigger verwendet die spezielle
+`'delete'`-Befehlssyntax, um eine Zeile aus dem FTS-Index zu entfernen.
+
+---
+
+## Tags als leerzeichen-getrennte Zeichenkette
+
+```php
+$tags = isset($body['tags']) && is_string($body['tags']) ? trim($body['tags']) : '';
+// z. B. "php api backend"
+$post = $this->repo->create($title, $postBody, $tags, $now);
+```
+
+Tags werden als leerzeichen-getrennte Zeichenkette gespeichert (z. B. `"php api backend"`) statt als
+JSON-Array oder M:N-Join-Tabelle. Dies macht Tags durch FTS5 ohne JOIN durchsuchbar —
+eine Suche nach `kubernetes` trifft einen Beitrag mit dem Tag `"docker kubernetes devops"`.
+
+**Kompromiss**:
+
+| Ansatz | FTS-durchsuchbar | Exakter Tag-Filter | Kanonische Tag-Entität |
+|---|---|---|---|
+| Leerzeichen-getrennte Zeichenkette | ✅ | ❌ (LIKE benötigt) | ❌ |
+| M:N-Join-Tabelle | ❌ (JOIN erforderlich) | ✅ (IN-Klausel) | ✅ |
+| JSON-Array-Spalte | Begrenzt (`json_each`) | Begrenzt | ❌ |
+
+Den M:N-Join-Tabellen-Ansatz verwenden (siehe [`multi-value-tag-filter.md`](multi-value-tag-filter.md)),
+wenn exaktes Tag-Filtern der primäre Anwendungsfall ist.
+
+---
+
+## Volltextsuche-Abfrage: `MATCH` + `rank`
+
+```php
+public function search(string $query): array
+{
+    if (trim($query) === '') {
+        return [];
+    }
+
+    $rows = $this->executor->fetchAll(
+        'SELECT p.*, fts.rank
+         FROM posts_fts fts
+         JOIN posts p ON p.id = fts.rowid
+         WHERE posts_fts MATCH ?
+         ORDER BY fts.rank',
+        [$query],
+    );
+
+    return array_map(
+        static fn (array $row): SearchResult => new SearchResult(
+            new Post(...),
+            (float) $row['rank'],
+        ),
+        $rows,
+    );
+}
+```
+
+`WHERE posts_fts MATCH ?` durchsucht alle indizierten Spalten (`title`, `body`, `tags`).
+Der `?`-Platzhalter ist ein parametrisierter Wert — die Abfragezeichenkette wird nicht in SQL
+interpoliert, sodass sie die Abfragestruktur nicht verändern kann.
+
+`fts.rank` ist ein negativer Float — niedrigere (negativere) Werte zeigen höhere Relevanz an.
+`ORDER BY fts.rank` sortiert die besten Treffer zuerst (aufsteigend, was am relevantesten-zuerst bedeutet).
+
+---
+
+## FTS5-Abfragesyntax
+
+FTS5 unterstützt eine umfangreiche Abfragesprache, die als MATCH-Wert übergeben wird:
+
+| Abfrage | Trifft |
+|---------|---------|
+| `php` | Jeder Beitrag, der „php" enthält |
+| `php api` | Beiträge, die „php" ODER „api" enthalten (Standard: implizites OR) |
+| `php AND api` | Beiträge, die sowohl „php" als auch „api" enthalten |
+| `"quick brown"` | Beiträge, die die exakte Phrase „quick brown" enthalten |
+| `php*` | Beiträge, bei denen ein Token mit „php" beginnt (Präfixsuche) |
+| `title:php` | Beiträge, bei denen die Titelspalte „php" enthält |
+| `php NOT python` | Beiträge mit „php" aber nicht „python" |
+
+Phrasensuche (`"..."`) trifft exakte Token-Sequenzen.
+Spaltenbeschränkte Suche (`title:php`) begrenzt das Treffen auf eine Spalte.
+
+---
+
+## Behandlung ungültiger Abfragen: try-catch → 400
+
+FTS5 wirft eine `PDOException` (oder verpackt sie), wenn die Abfragesyntax ungültig ist:
+
+```php
+private function searchPosts(ServerRequestInterface $request): ResponseInterface
+{
+    $query = isset($params['q']) && is_string($params['q']) ? trim($params['q']) : '';
+
+    if ($query === '') {
+        return $this->json->create(['error' => 'q query parameter is required'], 422);
+    }
+
+    try {
+        $results = $this->repo->search($query);
+    } catch (\Exception $e) {
+        // FTS5 wirft bei Syntaxfehlern (z. B. nicht geschlossene Anführungszeichen: '"unclosed')
+        return $this->json->create(['error' => 'invalid search query'], 400);
+    }
+
+    return $this->json->create([...]);
+}
+```
+
+Ungültige FTS-Abfragen (nicht geschlossene Anführungszeichen, fehlerhafte Operatoren) führen zu einer DB-Exception.
+Das Abfangen und Zurückgeben von `400 Bad Request` verhindert, dass ein `500` zum Client durchdringt.
+
+---
+
+## Groß-/Kleinschreibungsunempfindlichkeit
+
+FTS5 ist standardmäßig für ASCII-Zeichen groß-/kleinschreibungsunempfindlich. Eine Suche nach `php` trifft
+Beiträge, die `PHP`, `Php` oder `php` enthalten. Nicht-ASCII-Groß-/Kleinschreibung erfordert einen benutzerdefinierten
+Tokenizer (`unicode61` oder `ascii`). Der Standard-`porter`-Tokenizer wendet Stemming für englische Wörter an.
+
+---
+
+## Suchantwort
+
+```json
+GET /posts/search?q=php
+
+{
+    "query": "php",
+    "total": 2,
+    "items": [
+        {
+            "id": 1,
+            "title": "PHP Framework",
+            "body": "Building APIs with PHP",
+            "tags": "php backend",
+            "created_at": "2026-05-27T10:00:00Z",
+            "rank": -1.234
+        }
+    ]
+}
+```
+
+`rank` ist in jedem Ergebnis für clientseitige Anzeige oder Sortierzwecke enthalten.
+Niedrigerer (negativerer) `rank` = höhere Relevanz.
+
+---
+
+## Vergleich: FTS5 vs. LIKE-Suche
+
+| Funktion | FTS5 MATCH | LIKE `%term%` |
+|---|---|---|
+| Indiziert | ✅ | ❌ (vollständiger Scan) |
+| Relevanz-Ranking | ✅ (`rank`) | ❌ |
+| Mehrwort-Suche | ✅ (natürlich) | ❌ (mehrere LIKE erforderlich) |
+| Phrasensuche | ✅ (`"..."`) | Teilweise (`%quick brown%`) |
+| Groß-/Kleinschreibungsunempfindlich | ✅ (ASCII) | ✅ (mit NOCASE) |
+| Präfixsuche | ✅ (`php*`) | ✅ (`php%`) |
+| Spaltenbeschränkt | ✅ (`title:php`) | ❌ |
+| Einrichtungsaufwand | FTS-virtuelle Tabelle + Trigger | Keiner |
+
+FTS5 ist für große Datensätze bevorzugt, wo Suche eine primäre Funktion ist. LIKE ist
+für kleine Tabellen oder einfache Präfix-Autovervollständigung ausreichend.
+
+---
+
+## Verwandte Anleitungen
+
+- [`use-fts5-search.md`](use-fts5-search.md) — FTS5 zu einer vorhandenen Tabelle hinzufügen
+- [`search-autocomplete.md`](search-autocomplete.md) — LIKE-basierte Präfix-Autovervollständigung (searchlog FT157)
+- [`multi-value-tag-filter.md`](multi-value-tag-filter.md) — M:N-Tag-Filterung mit AND/OR-Semantik
+- [`event-analytics-api.md`](event-analytics-api.md) — `json_extract()` für JSON-Eigenschaftssuche

--- a/docs/de/howto/state-machine-audit-log.md
+++ b/docs/de/howto/state-machine-audit-log.md
@@ -1,0 +1,388 @@
+# Anleitung: Zustandsmaschine mit Prüfprotokoll
+
+> **FT-Referenz**: FT237 (`NENE2-FT/statemachinelog`) — Zustandsmaschine mit Prüfprotokoll
+> **VULN**: FT237 — Sicherheits-/Schwachstellen-Assessment (V-01 bis V-10)
+
+Demonstriert eine Zustandsmaschinen-API, bei der jeder Übergang in einer unveränderlichen
+Prüfprotokolltabelle aufgezeichnet wird. Der aktuelle Status liegt beim Auftrag; die vollständige
+Historie liegt in einer separaten `order_transitions`-Tabelle. `InvalidTransitionException` bietet
+strukturierte 409-Antworten mit `from`- und `to`-Kontext.
+
+---
+
+## Routen
+
+| Methode | Pfad                            | Beschreibung                                   |
+|---------|--------------------------------------|-----------------------------------------------|
+| `POST` | `/orders`                       | Auftrag erstellen (beginnt als `draft`)        |
+| `GET`  | `/orders/{id}`                  | Aktuellen Auftragsstatus abrufen               |
+| `POST` | `/orders/{id}/transitions`      | Zustandsübergang anwenden                      |
+| `GET`  | `/orders/{id}/transitions`      | Vollständige Übergangshistorie auflisten        |
+
+---
+
+## Zustandsmaschine: erlaubte Übergänge
+
+```php
+enum OrderStatus: string
+{
+    case Draft     = 'draft';
+    case Submitted = 'submitted';
+    case Approved  = 'approved';
+    case Rejected  = 'rejected';
+    case Cancelled = 'cancelled';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Draft     => [self::Submitted, self::Cancelled],
+            self::Submitted => [self::Approved, self::Rejected, self::Cancelled],
+            self::Approved  => [],
+            self::Rejected  => [],
+            self::Cancelled => [],
+        };
+    }
+
+    public function canTransitionTo(self $target): bool
+    {
+        return in_array($target, $this->allowedTransitions(), true);
+    }
+}
+```
+
+Terminale Zustände (`approved`, `rejected`, `cancelled`) geben eine leere Liste zurück — sie
+können nicht weiter übergehen.
+
+---
+
+## InvalidTransitionException → 409 mit Kontext
+
+Wenn ein Aufrufer einen unerlaubten Übergang anfordert, trägt die Exception die Ausgangs- und Ziel-
+zustände als strukturierte Daten für die Fehlerantwort:
+
+```php
+final class InvalidTransitionException extends \RuntimeException
+{
+    public function __construct(OrderStatus $from, OrderStatus $to)
+    {
+        parent::__construct(
+            sprintf('Transition from "%s" to "%s" is not allowed.', $from->value, $to->value)
+        );
+    }
+}
+```
+
+Der Controller schließt `from` und `to` in die Problem-Details-Erweiterung ein:
+
+```php
+try {
+    $updated = $this->repo->transition($id, $targetEnum, $now);
+} catch (InvalidTransitionException $e) {
+    return $this->problems->create(
+        $request,
+        'invalid-transition',
+        'Invalid State Transition',
+        409,
+        $e->getMessage(),
+        ['from' => $order->status->value, 'to' => $targetEnum->value],
+    );
+}
+```
+
+Antwort:
+```json
+{
+  "type": "https://nene2.dev/problems/invalid-transition",
+  "title": "Invalid State Transition",
+  "status": 409,
+  "detail": "Transition from \"approved\" to \"submitted\" is not allowed.",
+  "from": "approved",
+  "to": "submitted"
+}
+```
+
+`from` und `to` ermöglichen es dem Aufrufer genau zu verstehen, welcher Übergang abgelehnt wurde, ohne
+den `detail`-String zu parsen.
+
+---
+
+## Übergangs-Prüfprotokoll: Zwei-Schreib-Muster
+
+Jeder erfolgreiche Übergang aktualisiert den Auftragsstatus UND fügt atomar einen Protokolleintrag ein:
+
+```php
+public function transition(int $orderId, OrderStatus $targetStatus, string $now): Order
+{
+    $order = $this->findById($orderId);
+
+    if (!$order->status->canTransitionTo($targetStatus)) {
+        throw new InvalidTransitionException($order->status, $targetStatus);
+    }
+
+    // Aktuellen Status aktualisieren
+    $this->executor->execute(
+        'UPDATE orders SET status = ?, updated_at = ? WHERE id = ?',
+        [$targetStatus->value, $now, $orderId],
+    );
+
+    // Zum Prüfprotokoll hinzufügen
+    $this->executor->execute(
+        'INSERT INTO order_transitions (order_id, from_status, to_status, transitioned_at) VALUES (?, ?, ?, ?)',
+        [$orderId, $order->status->value, $targetStatus->value, $now],
+    );
+
+    return new Order($order->id, $order->title, $targetStatus, $order->createdAt, $now);
+}
+```
+
+> **Atomizitätshinweis**: Ohne eine umschließende Transaktion hinterlässt ein Fehler zwischen UPDATE und
+> INSERT den Auftrag im neuen Zustand ohne Protokolleintrag. Beide Anweisungen in einer
+> Transaktion für echte Atomizität einwickeln. SQLites WAL-Modus macht dies unter parallelem Zugriff sicher.
+
+---
+
+## Schema: Auftragszustand + Übergangshistorie
+
+```sql
+CREATE TABLE IF NOT EXISTS orders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    status     TEXT NOT NULL DEFAULT 'draft',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS order_transitions (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id        INTEGER NOT NULL,
+    from_status     TEXT    NOT NULL,
+    to_status       TEXT    NOT NULL,
+    transitioned_at TEXT    NOT NULL,
+    FOREIGN KEY (order_id) REFERENCES orders (id)
+);
+```
+
+`order_transitions` ist nach Design nur zum Anhängen — kein UPDATE- oder DELETE-Endpunkt existiert dafür.
+Die vollständige Übergangshistorie wird für Prüfzwecke aufbewahrt.
+
+---
+
+## Übergangshistorie-Antwort
+
+```json
+{
+  "order_id": 1,
+  "transitions": [
+    {"id": 1, "order_id": 1, "from_status": "draft", "to_status": "submitted", "transitioned_at": "2026-05-27 10:00:00"},
+    {"id": 2, "order_id": 1, "from_status": "submitted", "to_status": "approved", "transitioned_at": "2026-05-27 11:00:00"}
+  ]
+}
+```
+
+Die Liste ist nach `id ASC` geordnet, sodass die Historie chronologisch ist.
+
+---
+
+## VULN — Sicherheitsassessment (FT237)
+
+### V-01 — Keine Authentifizierung bei keinem Endpunkt
+
+**Angriff**: Aufträge erstellen und Übergänge ohne Anmeldedaten anwenden.
+
+```bash
+curl -s -X POST http://localhost:8080/orders/1/transitions \
+  -H 'Content-Type: application/json' \
+  -d '{"status":"approved"}'
+```
+
+**Beobachtet**: `200 OK` — kein Token erforderlich. Jeder kann jeden Auftrag genehmigen oder stornieren.
+
+**Urteil**: **EXPOSED** (nach Design für FT237-Demo). Authentifizierung und Autorisierung hinzufügen:
+Übergänge hinter einer Rolle (Einreicher vs. Prüfer) sperren und jeden Auftrag auf seinen Eigentümer beschränken.
+
+---
+
+### V-02 — Ungültiger Status-Wert
+
+**Angriff**: Einen unbekannten Status-String senden.
+
+```json
+{"status": "hacked"}
+{"status": ""}
+```
+
+**Beobachtet**: `OrderStatus::tryFrom('hacked')` = `null` → `422` mit einem Fehler, der alle
+gültigen Statuse auflistet.
+
+**Urteil**: **BLOCKED** — backed enum `tryFrom()` lehnt unbekannte Werte ab.
+
+---
+
+### V-03 — Unerlaubter Übergang (terminaler Zustand → aktiv)
+
+**Angriff**: Versuchen, von `approved` oder `cancelled` zu einem anderen Status zu wechseln.
+
+```json
+{"status": "submitted"}   // von approved
+{"status": "draft"}       // von cancelled
+```
+
+**Beobachtet**: `canTransitionTo()` gibt `false` zurück → `InvalidTransitionException` →
+`409 Conflict` mit `from`/`to`-Kontext im Antwortbody.
+
+**Urteil**: **BLOCKED** — Zustandsmaschine erzwingt alle Übergangsregeln auf Domain-Ebene.
+
+---
+
+### V-04 — Nicht-numerische Auftrags-ID
+
+**Angriff**: Einen String oder Float als `{id}` übergeben.
+
+```
+GET /orders/abc
+GET /orders/1.5
+```
+
+**Beobachtet**: `(int) 'abc'` = 0, `(int) '1.5'` = 1. Für `abc` gibt `findById(0)`
+`null` → `404 Not Found` zurück. Für `1.5` wird Auftrag 1 zurückgegeben, wenn er existiert — stille Kürzung.
+
+**Urteil**: **PARTIALLY BLOCKED** — nicht-numerische Strings werden in 404 aufgelöst. Floats werden
+stillschweigend gekürzt. `ctype_digit()`-Schutz für strikte Validierung hinzufügen.
+
+---
+
+### V-05 — Übergangshistorie ist nicht auf den Aufrufer beschränkt
+
+**Angriff**: Die Übergangshistorie eines anderen Benutzers lesen.
+
+```
+GET /orders/1/transitions
+```
+
+**Beobachtet**: `200 OK` — vollständige Historie ohne Eigentümerschafts- oder Authentifizierungsprüfung zurückgegeben.
+Die Historie enthüllt, wer eingereicht, genehmigt oder storniert hat (über Zeitstempel, obwohl kein Akteur aufgezeichnet wird).
+
+**Urteil**: **EXPOSED** — kein Eigentumsmodell. Ein `created_by`-Feld zu Aufträgen hinzufügen und
+Historieslesungen auf den Eigentümer oder autorisierte Prüfer beschränken.
+
+---
+
+### V-06 — SQL-Injection via `status`-Body-Feld
+
+**Angriff**: SQL-Metazeichen in den `status`-Wert einbetten.
+
+```json
+{"status": "'; DROP TABLE orders; --"}
+{"status": "approved' OR '1'='1"}
+```
+
+**Beobachtet**:
+1. `OrderStatus::tryFrom("'; DROP TABLE orders; --")` = `null` → `422` vor jeglichem SQL.
+2. Selbst wenn die Prüfung umgangen würde, wird der Status als parametrisierter `?`-Wert übergeben.
+
+**Urteil**: **BLOCKED** — Doppelschicht: Enum-Allowlist + parametrisierte Abfragen.
+
+---
+
+### V-07 — Übergang zum gleichen Status (Idempotenz)
+
+**Angriff**: Einen Übergang zum aktuellen Status senden.
+
+```json
+// Auftrag ist bereits 'submitted'
+{"status": "submitted"}
+```
+
+**Beobachtet**: `allowedTransitions()` für `submitted` ist `[approved, rejected, cancelled]`
+— `submitted` ist nicht in der Liste. `canTransitionTo(submitted)` gibt `false` →
+`409 Conflict` zurück.
+
+**Urteil**: **BLOCKED** — Selbstübergänge werden implizit von der Zustandsmaschine abgelehnt.
+
+---
+
+### V-08 — Gleichzeitige Übergänge für denselben Auftrag
+
+**Angriff**: Zwei gleichzeitige Übergangsanfragen für denselben Auftrag senden.
+
+```
+POST /orders/1/transitions {"status":"approved"}  // gleichzeitige Anfrage A
+POST /orders/1/transitions {"status":"rejected"}  // gleichzeitige Anfrage B
+```
+
+**Beobachtet**: Beide Anfragen holen den Auftrag (Status = `submitted`) bevor eine der beiden
+UPDATE-Anweisungen läuft. Beide sehen `canTransitionTo()` = true. Beide UPDATE — das zweite UPDATE
+überschreibt das erste. Ein Übergangsprotokoll-Eintrag pro Anfrage wird eingefügt, aber der Auftrag
+endet im Status, der zuletzt ausgeführt wurde. Die Historie zeigt beide Übergänge, was inkonsistent ist
+(z. B. `submitted → approved`, dann `submitted → rejected`).
+
+**Urteil**: **EXPOSED** — die `findById` + `canTransitionTo` + `UPDATE` + `INSERT`-Sequenz in eine
+einzelne Transaktion einwickeln, um Race Conditions zu verhindern.
+
+---
+
+### V-09 — Nur-Leerzeichen-Titel
+
+**Angriff**: Einen Auftrag mit einem leeren Titel erstellen.
+
+```json
+{"title": "   "}
+```
+
+**Beobachtet**: `trim($body['title'])` reduziert auf `""` → `title === ''`-Prüfung greift →
+`422 Unprocessable Entity`.
+
+**Urteil**: **BLOCKED** — `trim()` vor Leerstring-Prüfung behandelt nur-Leerzeichen-Eingaben.
+
+---
+
+### V-10 — Unbegrenzte Titellänge
+
+**Angriff**: Einen Auftrag mit einem sehr langen Titel erstellen.
+
+```json
+{"title": "A".repeat(100_000)}
+```
+
+**Beobachtet**: Kein Längenlimit wird durchgesetzt — sehr lange Titel werden ohne Einschränkung in
+der `TEXT`-Spalte gespeichert.
+
+**Urteil**: **EXPOSED** — einen Längen-Schutz hinzufügen:
+```php
+if (mb_strlen($title) > 500) {
+    $errors[] = ['field' => 'title', 'code' => 'too_long', 'message' => 'title must not exceed 500 characters.'];
+}
+```
+
+---
+
+## VULN-Zusammenfassung
+
+| # | Angriffsvektor | Urteil |
+|---|---------------|--------|
+| V-01 | Keine Authentifizierung | EXPOSED |
+| V-02 | Ungültiger Status-Wert | BLOCKED |
+| V-03 | Unerlaubter Übergang von terminalem Zustand | BLOCKED |
+| V-04 | Nicht-numerische Auftrags-ID | PARTIALLY BLOCKED |
+| V-05 | Übergangshistorie nicht auf Aufrufer beschränkt | EXPOSED |
+| V-06 | SQL-Injection via Status-Body | BLOCKED |
+| V-07 | Selbst-Übergang (gleicher Status) | BLOCKED |
+| V-08 | Gleichzeitige Übergänge Race Condition | EXPOSED |
+| V-09 | Nur-Leerzeichen-Titel | BLOCKED |
+| V-10 | Unbegrenzte Titellänge | EXPOSED |
+
+**Echte Schwachstellen, die vor der Produktion behoben werden müssen**:
+1. **V-01 / V-05** — Authentifizierung und Autorisierung hinzufügen (Eigentümerschafts-Scoping)
+2. **V-08** — Übergang in einer Transaktion einwickeln
+3. **V-10** — Titellängenlimit hinzufügen
+4. **V-04** — `ctype_digit()`-Schutz für ID-Parameter hinzufügen
+
+---
+
+## Verwandte Anleitungen
+
+- [`approval-workflow.md`](approval-workflow.md) — Enum-basierte Zustandsmaschine mit separaten Aktions-Endpunkten
+- [`audit-trail.md`](audit-trail.md) — Nur-Anhänge-Prüfprotokoll-Muster
+- [`transactions.md`](transactions.md) — Multi-Schreib-Sequenzen in einer Transaktion einwickeln
+- [`enforce-resource-ownership.md`](enforce-resource-ownership.md) — IDOR-Prävention

--- a/docs/de/howto/state-machine-workflow-api.md
+++ b/docs/de/howto/state-machine-workflow-api.md
@@ -1,0 +1,262 @@
+# Anleitung: Zustandsmaschinen-Workflow-API
+
+> **FT-Referenz**: FT349 (`NENE2-FT/workflowlog`) — Zustandsmaschinen-Workflow-Instanzen mit hartcodierter Übergangs-Map, `allowed_next` in Antworten, Übergangshistorie-Log, Terminalzustand-Durchsetzung, Zustandsfilter auf Liste, 13 Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie eine Workflow-Engine mit einer Zustandsmaschine gebaut wird: erlaubte Zustandsübergänge definieren, Workflow-Instanzen erstellen, sie mit Akteursattribution durch Zustände führen und die vollständige Übergangshistorie protokollieren.
+
+## Schema
+
+```sql
+CREATE TABLE instances (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow      TEXT    NOT NULL,          -- z. B. "order"
+    current_state TEXT    NOT NULL,
+    context       TEXT    NOT NULL DEFAULT '{}',  -- JSON
+    created_at    TEXT    NOT NULL,
+    updated_at    TEXT    NOT NULL
+);
+
+CREATE TABLE transitions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
+    from_state  TEXT    NOT NULL,
+    to_state    TEXT    NOT NULL,
+    actor       TEXT    NOT NULL,
+    note        TEXT    NOT NULL DEFAULT '',
+    occurred_at TEXT    NOT NULL
+);
+```
+
+## Workflow-Definition — „order"
+
+```
+draft ──┬──► submitted ──┬──► approved ──► fulfilled (terminal)
+        │                ├──► rejected   (terminal)
+        └──► cancelled   └──► cancelled  (terminal)
+        (terminal)
+```
+
+| Von Zustand | Erlaubte Folgezustände          |
+|-------------|----------------------------------|
+| `draft`     | `submitted`, `cancelled`         |
+| `submitted` | `approved`, `cancelled`, `rejected` |
+| `approved`  | `fulfilled`                      |
+| `fulfilled` | _(terminal — keine)_             |
+| `cancelled` | _(terminal — keine)_             |
+| `rejected`  | _(terminal — keine)_             |
+
+## Endpunkte
+
+| Methode | Pfad                                           | Beschreibung                     |
+|---------|------------------------------------------------|----------------------------------|
+| `POST` | `/workflows/{workflow}/instances`              | Workflow-Instanz erstellen       |
+| `GET`  | `/workflows/{workflow}/instances`              | Instanzen auflisten              |
+| `GET`  | `/workflows/{workflow}/instances/{id}`         | Instanz mit Historie abrufen     |
+| `POST` | `/workflows/{workflow}/instances/{id}/transition` | Zustandsübergang durchführen |
+
+## Instanz erstellen
+
+```php
+POST /workflows/order/instances
+{"context": {"order_ref": "ORD-001", "amount": 99.99}}
+
+→ 201
+{
+  "id": 1,
+  "workflow": "order",
+  "current_state": "draft",
+  "context": {"order_ref": "ORD-001", "amount": 99.99},
+  "allowed_next": ["submitted", "cancelled"],  // ← nächste gültige Zustände
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+`allowed_next` wird aus der Übergangs-Map berechnet — spiegelt immer den aktuellen Zustand wider.
+
+### Unbekannter Workflow → 404
+
+```php
+POST /workflows/unknown/instances  {}
+→ 404  // Workflow nicht definiert
+```
+
+## Instanzen auflisten
+
+```php
+// Alle Instanzen des "order"-Workflows
+GET /workflows/order/instances
+→ 200  {"instances": [{...}, {...}]}
+
+// Nach aktuellem Zustand filtern
+GET /workflows/order/instances?state=draft
+→ 200  {"instances": [{...}]}  // nur Entwurf-Instanzen
+```
+
+## Instanz abrufen (mit Historie)
+
+```php
+GET /workflows/order/instances/1
+
+→ 200
+{
+  "id": 1,
+  "workflow": "order",
+  "current_state": "approved",
+  "context": {...},
+  "allowed_next": ["fulfilled"],
+  "history": [
+    {
+      "from_state": "draft",
+      "to_state": "submitted",
+      "actor": "alice",
+      "occurred_at": "..."
+    },
+    {
+      "from_state": "submitted",
+      "to_state": "approved",
+      "actor": "manager",
+      "occurred_at": "..."
+    }
+  ],
+  ...
+}
+```
+
+`history` ist immer chronologisch sortiert (ASC nach `occurred_at`). Der Listen-Endpunkt lässt `history` aus Performancegründen weg.
+
+## Übergänge durchführen
+
+```php
+// Gültiger Übergang
+POST /workflows/order/instances/1/transition
+{"to_state": "submitted", "actor": "alice"}
+
+→ 200
+{
+  "current_state": "submitted",
+  "allowed_next": ["approved", "cancelled", "rejected"],
+  "history": [
+    {"from_state": "draft", "to_state": "submitted", "actor": "alice", ...}
+  ]
+}
+```
+
+### Vollständiger Happy Path
+
+```php
+POST .../transition  {"to_state": "submitted", "actor": "alice"}    → submitted
+POST .../transition  {"to_state": "approved",  "actor": "manager"}  → approved
+POST .../transition  {"to_state": "fulfilled", "actor": "warehouse"} → fulfilled
+
+// fulfilled ist terminal
+→ {"current_state": "fulfilled", "allowed_next": [], ...}
+```
+
+### Ungültiger Übergang → 409
+
+```php
+// draft → approved (muss zuerst durch submitted gehen)
+POST .../transition  {"to_state": "approved", "actor": "alice"}
+→ 409
+{
+  "type": "https://nene2.dev/problems/invalid-transition",
+  "detail": "Transition from 'draft' to 'approved' is not allowed"
+}
+```
+
+### Terminalzustand → 409
+
+```php
+// cancelled ist terminal — keine Übergänge erlaubt
+POST .../transition  {"to_state": "draft", "actor": "alice"}
+→ 409  // "cancelled" hat keine erlaubten Übergänge
+```
+
+## Implementierung
+
+### WorkflowDefinition — Übergangs-Map
+
+```php
+final class WorkflowDefinition
+{
+    /** @var array<string, array<string, list<string>>> */
+    private static array $transitions = [
+        'order' => [
+            'draft'     => ['submitted', 'cancelled'],
+            'submitted' => ['approved', 'cancelled', 'rejected'],
+            'approved'  => ['fulfilled'],
+            'fulfilled' => [],     // terminal
+            'cancelled' => [],     // terminal
+            'rejected'  => [],     // terminal
+        ],
+    ];
+
+    /** @return list<string> */
+    public static function allowedTransitions(string $workflow, string $fromState): array
+    {
+        return self::$transitions[$workflow][$fromState] ?? [];
+    }
+
+    public static function isValidWorkflow(string $workflow): bool
+    {
+        return isset(self::$transitions[$workflow]);
+    }
+
+    public static function initialState(string $workflow): string
+    {
+        return match ($workflow) {
+            'order' => 'draft',
+            default => throw new \InvalidArgumentException("Unknown workflow: {$workflow}"),
+        };
+    }
+}
+```
+
+### Übergangs-Handler
+
+```php
+public function transition(int $id, string $toState, string $actor): ?WorkflowInstance
+{
+    $instance = $this->repo->findByIdOrNull($id);
+    if ($instance === null) {
+        return null;  // → 404
+    }
+
+    $allowed = WorkflowDefinition::allowedTransitions(
+        $instance->workflow,
+        $instance->currentState,
+    );
+
+    if (!in_array($toState, $allowed, true)) {
+        return false;  // → 409 ungültig oder terminal
+    }
+
+    // Atomar: Instanz aktualisieren + Übergangsprotokoll einfügen
+    $this->db->execute(
+        'UPDATE instances SET current_state = ?, updated_at = ? WHERE id = ?',
+        [$toState, $now, $id],
+    );
+    $this->db->execute(
+        'INSERT INTO transitions (instance_id, from_state, to_state, actor, occurred_at) VALUES (?, ?, ?, ?, ?)',
+        [$id, $instance->currentState, $toState, $actor, $now],
+    );
+
+    return $this->hydrateInstanceWithHistory($id);
+}
+```
+
+`allowed_next` wird immer aus der Übergangs-Map berechnet, nie gespeichert — bleibt konsistent mit `current_state`.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `allowed_next` in DB speichern | Veraltete Daten wenn sich die Übergangs-Map ändert; immer aus aktuellem Zustand berechnen |
+| Freie `to_state`-Eingaben ohne Allowlist-Prüfung erlauben | Angreifer kann den Zustand auf beliebige Werte setzen und die Workflow-Logik umgehen |
+| Übergangsprotokollierung überspringen | Kein Prüfpfad; Workflow-Historie kann nicht rekonstruiert oder steckengebliebene Instanzen debuggt werden |
+| Terminalzustände in `allowed_next` zurückgeben | Führt Aufrufer irre; Terminalzustände haben immer ein leeres `allowed_next` |
+| 404 für ungültigen Übergang zurückgeben | 404 verbirgt den Unterschied zwischen „Instanz nicht gefunden" und „Übergang nicht erlaubt"; 409 für Letzteres verwenden |
+| Kein `workflow`-Feld in der Instanzentabelle | Instanzen verschiedener Workflow-Typen können nicht unterschieden werden; keine workflow-übergreifende Abfrage möglich |

--- a/docs/de/howto/step-workflow-approval.md
+++ b/docs/de/howto/step-workflow-approval.md
@@ -1,0 +1,245 @@
+# Anleitung: Schrittbasierter Workflow mit Genehmigung
+
+> **FT-Referenz**: FT247 (`NENE2-FT/stepflowlog`) — Schrittbasierte Workflow-Genehmigungs-API
+
+Demonstriert ein zweistufiges Workflow-System, bei dem eine wiederverwendbare Workflow-Definition
+eine geordnete Liste von Schritten enthält und ein Workflow-Durchlauf eine Instanz dieser Definition
+ist, die durch Genehmigen/Ablehnen-Aktionen die Schritte durchläuft. Jede Aktion wird in einer
+Prüfhistorie protokolliert.
+
+---
+
+## Routen
+
+| Methode | Pfad                      | Beschreibung                                                    |
+|---------|---------------------------|----------------------------------------------------------------|
+| `POST` | `/workflows`              | Neuen Workflow definieren                                       |
+| `GET`  | `/workflows/{id}`         | Workflow mit Schritten abrufen                                  |
+| `POST` | `/workflows/{id}/steps`   | Schritt zu einem Workflow hinzufügen (automatisch sortiert)     |
+| `POST` | `/runs`                   | Durchlauf eines Workflows starten (schlägt fehl, wenn keine Schritte) |
+| `GET`  | `/runs/{id}`              | Durchlauf-Status mit Aktionshistorie abrufen                   |
+| `POST` | `/runs/{id}/approve`      | Aktuellen Schritt genehmigen (rückt vor oder schließt ab)      |
+| `POST` | `/runs/{id}/reject`       | Aktuellen Schritt ablehnen (beendet Durchlauf als abgelehnt)   |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS workflows (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL UNIQUE,
+    description TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workflow_steps (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id INTEGER NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+    name        TEXT    NOT NULL,
+    step_order  INTEGER NOT NULL,
+    UNIQUE(workflow_id, step_order)
+);
+
+CREATE TABLE IF NOT EXISTS workflow_runs (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id     INTEGER NOT NULL REFERENCES workflows(id),
+    title           TEXT    NOT NULL,
+    status          TEXT    NOT NULL DEFAULT 'pending'
+                        CHECK(status IN ('pending', 'in_progress', 'completed', 'rejected')),
+    current_step_id INTEGER REFERENCES workflow_steps(id),
+    created_at      TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workflow_actions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id     INTEGER NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    step_id    INTEGER NOT NULL REFERENCES workflow_steps(id),
+    action     TEXT    NOT NULL CHECK(action IN ('approve', 'reject')),
+    actor      TEXT    NOT NULL,
+    comment    TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL
+);
+```
+
+`UNIQUE(workflow_id, step_order)` verhindert doppelte Reihenfolgen innerhalb eines Workflows.
+`current_step_id` ist nullable — `NULL` bedeutet, der Durchlauf ist `completed` oder `rejected`
+(kein aktiver Schritt). `action` hat eine DB-Ebene `CHECK` für `approve`/`reject`.
+
+---
+
+## Automatische Schrittordnung
+
+Beim Hinzufügen eines Schritts berechnet der Controller die nächste `step_order` automatisch:
+
+```php
+$existingSteps = $this->repo->findSteps($id);
+$maxOrder      = 0;
+foreach ($existingSteps as $s) {
+    if ((int) $s['step_order'] > $maxOrder) {
+        $maxOrder = (int) $s['step_order'];
+    }
+}
+$stepOrder = $maxOrder + 1;
+$stepId    = $this->repo->addStep($id, $name, $stepOrder);
+```
+
+`step_order` beginnt bei `1` und erhöht sich für jeden neuen Schritt um `1`. Die `UNIQUE`-
+Bedingung verhindert, dass zwei Schritte dieselbe Reihenfolge teilen. Schritte werden immer
+in Ordnung zurückgegeben:
+
+```php
+$this->db->fetchAll(
+    'SELECT * FROM workflow_steps WHERE workflow_id = ? ORDER BY step_order ASC',
+    [$workflowId],
+);
+```
+
+---
+
+## Durchlauf starten: Initialisierung des ersten Schritts
+
+Ein Durchlauf wird mit dem ersten Schritt des Workflows als `current_step_id` initialisiert:
+
+```php
+$steps = $this->repo->findSteps($workflowId);
+if ($steps === []) {
+    return $this->json->create(['error' => 'Workflow has no steps'], 409);
+}
+
+$firstStep = $steps[0];
+$runId = $this->repo->createRun($workflowId, $title, (int) $firstStep['id'], $now);
+```
+
+`409 Conflict` wird zurückgegeben, wenn der Workflow keine Schritte hat — ein Durchlauf kann
+keinen schrittlosen Workflow durchlaufen. Der erste Schritt (niedrigste `step_order`) wird der aktive Schritt.
+
+---
+
+## `approve`: Zum nächsten Schritt vorrücken oder abschließen
+
+`POST /runs/{id}/approve` prüft den aktuellen Status, zeichnet die Aktion auf und findet dann
+den nächsten Schritt über `step_order`:
+
+```php
+if ((string) $run['status'] !== 'in_progress') {
+    return $this->json->create(['error' => 'Run is not in progress'], 409);
+}
+
+$this->repo->recordAction($id, $currentStepId, 'approve', $actor, $comment, $this->now());
+
+$nextStep = $this->repo->findNextStep($workflowId, $currentStepOrder);
+if ($nextStep !== null) {
+    $this->repo->updateRun($id, 'in_progress', (int) $nextStep['id'], $this->now());
+} else {
+    $this->repo->updateRun($id, 'completed', null, $this->now());
+}
+```
+
+`findNextStep` holt den Schritt mit der nächsten `step_order`:
+
+```php
+public function findNextStep(int $workflowId, int $currentOrder): ?array
+{
+    return $this->db->fetchOne(
+        'SELECT * FROM workflow_steps WHERE workflow_id = ? AND step_order > ? ORDER BY step_order ASC LIMIT 1',
+        [$workflowId, $currentOrder],
+    );
+}
+```
+
+`step_order > current` + `ORDER BY step_order ASC LIMIT 1` findet den unmittelbar folgenden
+Schritt. Wenn kein nächster Schritt existiert (letzter Schritt), gibt `findNextStep` `null` zurück
+→ der Durchlauf wird als `completed` markiert mit `current_step_id = null`.
+
+---
+
+## `reject`: Durchlauf beenden
+
+`POST /runs/{id}/reject` zeichnet die Aktion auf und markiert den Durchlauf als `rejected`:
+
+```php
+$this->repo->recordAction($id, $currentStepId, 'reject', $actor, $comment, $this->now());
+$this->repo->updateRun($id, 'rejected', null, $this->now());
+```
+
+`current_step_id` wird bei Ablehnung auf `null` gesetzt — kein aktiver Schritt verbleibt. Der Durchlauf
+ist terminal: weitere `approve`/`reject`-Aufrufe geben `409` zurück, weil `status !== 'in_progress'`.
+
+---
+
+## Aktionshistorie: JOIN mit Schrittname
+
+Die Durchlauf-Antwort enthält die vollständige Aktionshistorie:
+
+```php
+$run     = $this->repo->findRun($id);
+$actions = $this->repo->findActions($id);
+return $this->json->create(array_merge($run, ['history' => $actions]));
+```
+
+Aktionen werden mit einem `JOIN` abgerufen, um jede Zeile mit dem Schrittnamen anzureichern:
+
+```php
+$this->db->fetchAll(
+    'SELECT wa.*, ws.name AS step_name FROM workflow_actions wa
+     JOIN workflow_steps ws ON wa.step_id = ws.id
+     WHERE wa.run_id = ? ORDER BY wa.id ASC',
+    [$runId],
+);
+```
+
+`ORDER BY wa.id ASC` bewahrt die chronologische Einfügereihenfolge für den Prüfpfad.
+
+---
+
+## Durchlauf-Zustandsmaschine
+
+```
+                 POST /runs
+                     │
+                     ▼
+               in_progress  ──approve (letzter Schritt)──► completed
+                     │
+               approve (nicht letzter Schritt)
+                     │
+                     ▼
+               in_progress (nächster Schritt)
+                     │
+                  reject
+                     │
+                     ▼
+                 rejected
+```
+
+Die Zustände `completed` und `rejected` sind terminal — keine weiteren Zustandsübergänge sind erlaubt.
+Jedes `approve`/`reject` auf einem terminalen Durchlauf gibt `409 Conflict` zurück.
+
+---
+
+## `findRun` mit `current_step_name` via `LEFT JOIN`
+
+Der Durchlauf wird mit einem `LEFT JOIN` abgerufen, um den Namen des aktuellen Schritts einzuschließen:
+
+```php
+$this->db->fetchOne(
+    'SELECT wr.*, ws.name AS current_step_name, ws.step_order AS current_step_order
+     FROM workflow_runs wr
+     LEFT JOIN workflow_steps ws ON wr.current_step_id = ws.id
+     WHERE wr.id = ?',
+    [$id],
+);
+```
+
+`LEFT JOIN` (nicht `INNER JOIN`) — wenn `current_step_id` `null` ist (abgeschlossener/abgelehnter
+Durchlauf), sind `ws.*`-Spalten `null` statt die Zeile verschwinden zu lassen.
+
+---
+
+## Verwandte Anleitungen
+
+- [`approval-workflow.md`](approval-workflow.md) — Genehmigungsmuster mit pending/approved/rejected-Zuständen
+- [`state-machine-audit-log.md`](state-machine-audit-log.md) — Zustandsübergangsaufzeichnung und InvalidTransitionException
+- [`multi-step-workflow.md`](multi-step-workflow.md) — Sequenzielles mehrstufiges Formular/Prozess-Muster
+- [`audit-trail.md`](audit-trail.md) — Nur-Anhänge-Ereignisaufzeichnungsmuster

--- a/docs/de/howto/subscription-plan-management.md
+++ b/docs/de/howto/subscription-plan-management.md
@@ -1,0 +1,238 @@
+# Anleitung: Abonnementplan-Verwaltung
+
+> **FT-Referenz**: FT328 (`NENE2-FT/planlog`) — Plan-Katalog, benutzerspezifischer Abonnement-Lebenszyklus (abonnieren / wechseln / kündigen), Nur-Eigentümer-Zugriff, ATK-Assessment, 20 Tests / 69 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie eine Abonnement-Verwaltungs-API gebaut wird, bei der Benutzer einen von mehreren vordefinierten Plänen abonnieren, den Plan wechseln und kündigen können.
+
+## Schema
+
+```sql
+CREATE TABLE plans (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug       TEXT    NOT NULL UNIQUE,
+    name       TEXT    NOT NULL,
+    price_cents INTEGER NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE subscriptions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL UNIQUE,  -- ein aktives Abonnement pro Benutzer
+    plan_slug    TEXT    NOT NULL REFERENCES plans(slug),
+    status       TEXT    NOT NULL DEFAULT 'active',  -- 'active' | 'cancelled'
+    cancelled_at TEXT,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL
+);
+```
+
+Vorinstallierte Pläne: `free` (0), `pro` (980), `enterprise` (9800).
+
+## Authentifizierungsmodell
+
+Alle Abonnement-Endpunkte erfordern `X-Actor-Id: {userId}`. Das Zugreifen auf das Abonnement eines anderen Benutzers gibt **403** zurück.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `GET`    | `/plans` | Alle Pläne auflisten (öffentlich) |
+| `POST`   | `/users/{id}/subscription` | Abonnieren |
+| `GET`    | `/users/{id}/subscription` | Abonnement abrufen (nur Eigentümer) |
+| `PUT`    | `/users/{id}/subscription` | Plan wechseln (nur Eigentümer) |
+| `DELETE` | `/users/{id}/subscription` | Kündigen (nur Eigentümer) |
+
+## Pläne auflisten
+
+```php
+GET /plans
+→ 200
+{
+  "count": 3,
+  "items": [
+    {"slug": "free",       "name": "Free",       "price_cents": 0},
+    {"slug": "pro",        "name": "Pro",         "price_cents": 980},
+    {"slug": "enterprise", "name": "Enterprise",  "price_cents": 9800}
+  ]
+}
+// Geordnet nach price_cents ASC
+```
+
+## Abonnieren
+
+```php
+POST /users/1/subscription  X-Actor-Id: 1
+{"plan": "pro"}
+→ 201
+{"plan_slug": "pro", "status": "active", "cancelled_at": null}
+
+// Bereits abonniert
+POST /users/1/subscription  X-Actor-Id: 1  {"plan": "free"}
+→ 409 Conflict
+
+// Unbekannter Plan
+POST /users/1/subscription  X-Actor-Id: 1  {"plan": "platinum"}
+→ 404
+
+// Endpunkt eines anderen Benutzers
+POST /users/1/subscription  X-Actor-Id: 2  {"plan": "free"}
+→ 403 Forbidden
+```
+
+## Abonnement abrufen
+
+```php
+GET /users/1/subscription  X-Actor-Id: 1
+→ 200  {"plan_slug": "pro", "status": "active", ...}
+
+// Kein Abonnement
+GET /users/1/subscription  X-Actor-Id: 1  → 404
+
+// Anderer Benutzer
+GET /users/1/subscription  X-Actor-Id: 2  → 403
+```
+
+## Plan wechseln
+
+```php
+PUT /users/1/subscription  X-Actor-Id: 1  {"plan": "enterprise"}
+→ 200  {"plan_slug": "enterprise", "status": "active"}
+
+// Upgrade und Downgrade beide erlaubt
+PUT /users/1/subscription  X-Actor-Id: 1  {"plan": "free"}
+→ 200
+
+// Kein Abonnement zum Wechseln
+PUT /users/1/subscription  X-Actor-Id: 1  {"plan": "pro"}  → 404
+
+// Versuch, ein gekündigtes Abonnement zu wechseln
+PUT /users/1/subscription  X-Actor-Id: 1  {"plan": "pro"}  → 409
+```
+
+## Kündigen
+
+```php
+DELETE /users/1/subscription  X-Actor-Id: 1  → 204
+
+// Nach der Kündigung zeigt GET den gekündigten Status
+GET /users/1/subscription  X-Actor-Id: 1
+→ 200  {"status": "cancelled", "cancelled_at": "2026-05-27T..."}
+```
+
+---
+
+## ATK-Assessment — Cracker-Mindset-Angrifftest
+
+### ATK-01 — Anderes Benutzerkonto abonnieren 🚫 BLOCKED
+
+**Angriff**: Angreifer sendet `POST /users/1/subscription  X-Actor-Id: 2`, um ein Abonnement auf dem Konto des Opfers zu starten.
+**Ergebnis**: BLOCKED — Actor-ID wird mit Pfad-Benutzer-ID verglichen. Abweichung → 403.
+
+---
+
+### ATK-02 — Abonnement eines anderen Benutzers kündigen 🚫 BLOCKED
+
+**Angriff**: Angreifer kündigt das bezahlte Abonnement des Opfers per `DELETE /users/1/subscription  X-Actor-Id: 2`.
+**Ergebnis**: BLOCKED — Gleiche Actor/Pfad-Prüfung. 403 zurückgegeben.
+
+---
+
+### ATK-03 — Opfer auf kostenlosen Plan herabstufen 🚫 BLOCKED
+
+**Angriff**: `PUT /users/1/subscription  X-Actor-Id: 2  {"plan": "free"}`.
+**Ergebnis**: BLOCKED — 403 auf benutzerübergreifendem Pfad.
+
+---
+
+### ATK-04 — Doppeltes Abonnement zur Umgehung der Zahlung 🚫 BLOCKED
+
+**Angriff**: Zwei schnelle `POST /subscribe`-Anfragen senden, in der Hoffnung, dass eine vor der UNIQUE-Bedingung landet.
+**Ergebnis**: BLOCKED — `UNIQUE(user_id)` in der Abonnement-Tabelle verhindert doppelte Zeilen. Zweites Insert wirft Bedingungsfehler → 409.
+
+---
+
+### ATK-05 — Mit ungültigem Plan-Slug abonnieren ✅ SAFE
+
+**Angriff**: `{"plan": "'; DROP TABLE plans; --"}` oder unbekannte Slugs.
+**Ergebnis**: SAFE — Plan-Existenz wird über parametrisiertes SELECT geprüft. SQL-Injection verhindert. Unbekannter Slug → 404.
+
+---
+
+### ATK-06 — Gekündigtes Abonnement via PUT reaktivieren 🚫 BLOCKED
+
+**Angriff**: Nach der Kündigung sendet Angreifer PUT, um ohne erneutes Abonnieren zu reaktivieren (Zahlung überspringen).
+**Ergebnis**: BLOCKED — PUT auf einem gekündigten Abonnement gibt 409 zurück. Muss erneut abonnieren (POST), was Zahlungsprüfungen durchsetzen kann.
+
+---
+
+### ATK-07 — Für nicht existierenden Benutzer abonnieren 🚫 BLOCKED
+
+**Angriff**: `POST /users/9999/subscription  X-Actor-Id: 9999`.
+**Ergebnis**: BLOCKED — Benutzer-Existenz wird vor der Abonnement-Erstellung geprüft. 404 zurückgegeben.
+
+---
+
+### ATK-08 — Abonnement ohne Authentifizierung lesen 🚫 BLOCKED
+
+**Angriff**: `GET /users/1/subscription` ohne `X-Actor-Id`-Header.
+**Ergebnis**: BLOCKED — Fehlender Actor → 401.
+
+---
+
+### ATK-09 — Pfad/Actor-ID-Typverwirrung 🚫 BLOCKED
+
+**Angriff**: `X-Actor-Id: 1abc` oder `X-Actor-Id: 1.0`, um den Integer-Vergleich zu verwirren.
+**Ergebnis**: BLOCKED — Actor-ID wird als positive Integer validiert. Nicht-Ziffern → 401.
+
+---
+
+### ATK-10 — Plan-Slugs durch Ausprobieren aufzählen 🚫 BLOCKED
+
+**Angriff**: `{"plan": "internal"}`, `{"plan": "vip"}` usw. versuchen, um versteckte Pläne zu entdecken.
+**Ergebnis**: BLOCKED — Unbekannter Plan → 404. Kein Seiteneffekt wird erzeugt. Rate Limiting schützt vor Aufzählung in großem Maßstab.
+
+---
+
+### ATK-11 — Gleichen Plan abonnieren (No-Op-Angriff) 🚫 BLOCKED
+
+**Angriff**: PUT mit demselben aktuellen Plan-Slug, um ein Abrechnungsereignis auszulösen.
+**Ergebnis**: BLOCKED — Wechsel zum gleichen Plan gibt 200 zurück (No-Op oder nach Design erlaubt); kein Abrechnungsereignis wird für identischen Plan ausgelöst.
+
+---
+
+### ATK-12 — IDOR via numerische Benutzer-ID-Inkrementierung ✅ SAFE
+
+**Angriff**: Angreifer inkrementiert Benutzer-ID (`/users/1`, `/users/2`, ...), um Abonnements aufzuzählen.
+**Ergebnis**: SAFE — Alle Abonnement-Endpunkte erfordern Actor == Pfad-Benutzer. Anderer Actor → 403. Aufzählung enthüllt keine Daten.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Anderes Benutzerkonto abonnieren | 🚫 BLOCKED |
+| ATK-02 | Abonnement eines anderen kündigen | 🚫 BLOCKED |
+| ATK-03 | Anderen Benutzer herabstufen | 🚫 BLOCKED |
+| ATK-04 | Doppeltes Abonnement umgehen | 🚫 BLOCKED |
+| ATK-05 | Ungültige Plan-Slug-Injection | ✅ SAFE |
+| ATK-06 | Nach Kündigung via PUT reaktivieren | 🚫 BLOCKED |
+| ATK-07 | Nicht existierenden Benutzer abonnieren | 🚫 BLOCKED |
+| ATK-08 | Ohne Authentifizierung lesen | 🚫 BLOCKED |
+| ATK-09 | Actor-ID-Typverwirrung | 🚫 BLOCKED |
+| ATK-10 | Plan-Slug-Aufzählung | 🚫 BLOCKED |
+| ATK-11 | Gleicher-Plan-No-Op-Angriff | 🚫 BLOCKED |
+| ATK-12 | IDOR via Benutzer-ID-Inkrementierung | ✅ SAFE |
+
+**10 BLOCKED, 2 SAFE, 0 EXPOSED** — Keine kritischen Befunde.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| PUT auf gekündigtem Abonnement erlauben | Angreifer reaktiviert ohne Zahlung |
+| Kein UNIQUE-Constraint für user_id | Gleichzeitige Abonnements erstellen mehrere Zeilen |
+| 404 statt 403 für benutzerübergreifende Zugriffe zurückgeben | 404 verbirgt Existenz, verbirgt aber auch Autorisierungsfehler; 403 explizit verwenden |
+| Abonnement bei Kündigung hart löschen | Prüfpfad verlieren; `status: cancelled` + `cancelled_at` verwenden |

--- a/docs/de/howto/subscription-plan.md
+++ b/docs/de/howto/subscription-plan.md
@@ -1,0 +1,113 @@
+# Anleitung: Abonnement-/Plan-Verwaltungs-API (VULN-A~L)
+
+Diese Anleitung demonstriert eine Abonnement-Verwaltungs-API, bei der Benutzer Pläne abonnieren, mit Duplikatvermeidung, Kündigung und IDOR-Schutz.
+
+## Musterübersicht
+
+- Seed-Pläne werden beim Schema-Setup eingefügt (`free`, `starter`, `pro`, `annual`).
+- Benutzer abonnieren über `POST /subscriptions` mit einer `plan_id`.
+- Jedes (Benutzer, Plan)-Paar kann höchstens ein aktives Abonnement haben.
+- Kündigung ändert den Status auf `'cancelled'`; gekündigte Abonnements können nicht erneut gekündigt werden.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS plans (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT    NOT NULL UNIQUE,
+    price_cents INTEGER NOT NULL,
+    interval    TEXT    NOT NULL DEFAULT 'monthly'
+);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL,
+    plan_id      INTEGER NOT NULL,
+    status       TEXT    NOT NULL DEFAULT 'active',
+    started_at   TEXT    NOT NULL,
+    cancelled_at TEXT,
+    FOREIGN KEY (plan_id) REFERENCES plans(id),
+    UNIQUE (user_id, plan_id, status)
+);
+```
+
+## VULN-A: SQL-Injection
+
+Alle Abfragen verwenden PDO Prepared Statements. Plan-Namen und Benutzer-IDs werden niemals interpoliert.
+
+## VULN-C: IDOR
+
+Nicht-Admin-Benutzer können nur auf ihre eigenen Abonnements zugreifen. Der Zugriff auf das Abonnement eines anderen Benutzers gibt 404 zurück (nicht 403):
+
+```php
+if (!$isAdmin && (int) $sub['user_id'] !== $uid) {
+    return $this->problem(404, 'not-found', 'Subscription not found.');
+}
+```
+
+## VULN-D: Admin Fail-Closed
+
+```php
+private function isAdmin(ServerRequestInterface $req): bool
+{
+    if ($this->adminKey === '') {
+        return false;
+    }
+    return hash_equals($this->adminKey, $req->getHeaderLine('X-Admin-Key'));
+}
+```
+
+## VULN-G: ReDoS
+
+Pfad-IDs verwenden `ctype_digit()` + Längenlimit. Nicht-numerische Pfade (`/subscriptions/abc`) geben sofort 404 zurück.
+
+## VULN-J: Typverwirrung
+
+```php
+$planId = $body['plan_id'] ?? null;
+if (!is_int($planId) || $planId < 1) {
+    return $this->problem(422, 'validation-failed', 'plan_id must be a positive integer.');
+}
+```
+
+String `"2"`, Float `2.5` und Null geben alle 422 zurück.
+
+## Duplikatvermeidung
+
+```php
+$stmt = $this->pdo->prepare(
+    "SELECT id FROM subscriptions WHERE user_id = :uid AND plan_id = :pid AND status = 'active'"
+);
+```
+
+Ein Versuch, einen bereits aktiven Plan zu abonnieren, gibt 409 zurück.
+
+## Kündigungs-Idempotenz
+
+Die `cancel()`-Methode prüft den Status vor dem Update. Ein zweiter Kündigungsversuch bei einem `'cancelled'`-Abonnement gibt `'already_cancelled'` → 409 zurück (nicht 204).
+
+## JOIN für reichhaltige Antwort
+
+Abonnement-Details enthalten Plan-Info via JOIN:
+
+```sql
+SELECT s.*, p.name AS plan_name, p.price_cents, p.interval AS plan_interval
+FROM subscriptions s JOIN plans p ON p.id = s.plan_id
+WHERE s.id = :id
+```
+
+## Routen
+
+```
+GET    /plans                           Verfügbare Pläne auflisten (öffentlich)
+POST   /subscriptions                   Einen Plan abonnieren (X-User-Id erforderlich)
+GET    /subscriptions/{id}              Abonnement abrufen (Eigentümer oder Admin)
+POST   /subscriptions/{id}/cancel       Abonnement kündigen (Eigentümer oder Admin)
+GET    /users/{userId}/subscriptions    Benutzerabonnements auflisten (Eigentümer oder Admin)
+```
+
+## Siehe auch
+
+- FT213-Quelle: `../NENE2-FT/subscriptionlog/`
+- Verwandt: `docs/howto/coupon-redemption.md` (FT204, ebenfalls zustandsbehaftete Benutzer-Limits)
+- Verwandt: `docs/howto/wish-list-api.md` (FT207, VULN-Muster)

--- a/docs/de/howto/system-announcement-management.md
+++ b/docs/de/howto/system-announcement-management.md
@@ -1,0 +1,167 @@
+# Anleitung: Systemankündigungs-Verwaltung
+
+> **Muster nachgewiesen durch FT190 announcelog** — Zeitbasierte Systemankündigungen mit Admin-Schlüssel-Authentifizierung, benutzerspezifischem Ausblenden und Prioritätssortierung. 38 Tests / 93 Assertions BESTANDEN.
+
+---
+
+## Was abgedeckt wird
+
+Eine Systemankündigungs-API für das Übertragen von Wartungshinweisen, Funktions-Updates und Warnmeldungen:
+
+1. **Erstellen/Aktualisieren/Löschen** — Nur-Admin-Operationen via Konstantzeit-Schlüsselvergleich
+2. **Aktive auflisten** — UTC-zeitgefilterter nach `starts_at` / `ends_at`
+3. **Ausblenden** — Benutzerspezifisches Opt-out als idempotentes UPSERT gespeichert
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE announcements (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    starts_at  TEXT    NOT NULL,   -- ISO 8601 UTC
+    ends_at    TEXT    NOT NULL,   -- ISO 8601 UTC
+    priority   INTEGER NOT NULL DEFAULT 0,  -- höher = zuerst angezeigt
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+CREATE TABLE announcement_dismissals (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER NOT NULL,
+    announcement_id INTEGER NOT NULL,
+    dismissed_at    TEXT    NOT NULL,
+    UNIQUE(user_id, announcement_id)
+);
+```
+
+`UNIQUE(user_id, announcement_id)` ermöglicht idempotentes Ausblenden. `starts_at` / `ends_at` sind ISO 8601-Strings — lexikografischer Vergleich funktioniert korrekt für UTC-Datumsangaben.
+
+---
+
+## API
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|--------------|
+| `POST` | `/announcements` | `X-Admin-Key` | Ankündigung erstellen (201) |
+| `PUT` | `/announcements/{id}` | `X-Admin-Key` | Ankündigung aktualisieren (200) |
+| `DELETE` | `/announcements/{id}` | `X-Admin-Key` | Ankündigung löschen (200) |
+| `GET` | `/announcements` | optionales `X-User-Id` | Derzeit aktive Ankündigungen auflisten |
+| `POST` | `/announcements/{id}/dismiss` | `X-User-Id` | Für diesen Benutzer ausblenden (200) |
+
+---
+
+## Kernmuster: Konstantzeit-Admin-Schlüssel-Verifizierung
+
+```php
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    // Leerer adminKey-Config bedeutet kein Admin-Zugriff — fail closed
+    if ($this->adminKey === '') {
+        return false;
+    }
+
+    $provided = $request->getHeaderLine('X-Admin-Key');
+
+    // hash_equals: Konstantzeit — verhindert Timing-Angriffe auf Schlüsselvergleich
+    return $provided !== '' && hash_equals($this->adminKey, $provided);
+}
+```
+
+**Warum nicht `===`:** String-Vergleich bricht beim ersten Unterschied ab. Ein Angreifer kann Timing-Unterschiede messen, um partielle Präfix-Übereinstimmungen zu finden, dann Zeichen für Zeichen brute-forcen. `hash_equals()` braucht unabhängig davon, wo der Unterschied ist, konstante Zeit.
+
+**Fail-closed:** Eine leere `adminKey`-Konfiguration gibt immer `false` zurück — es gibt keinen versehentlichen „offenen Admin"-Modus.
+
+---
+
+## Kernmuster: UTC-zeitbasierte Filterung
+
+```php
+// Derzeit aktive Ankündigungen auflisten
+$now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DateTimeInterface::ATOM);
+
+SELECT ... FROM announcements
+WHERE starts_at <= :now AND ends_at > :now
+ORDER BY priority DESC, id DESC
+```
+
+ISO 8601-Strings in UTC sortieren lexikografisch korrekt — `'2025-06-01T...' > '2025-05-01T...'`. In der Datenbank immer UTC verwenden.
+
+Das `ends_at > :now` (strikt größer-als) bedeutet, dass eine Ankündigung genau bei `ends_at` abläuft, nicht eine Sekunde danach.
+
+---
+
+## Kernmuster: Benutzerspezifisches Ausblenden (Idempotent)
+
+```php
+// UNIQUE(user_id, announcement_id) ermöglicht sichere wiederholte Ausblenden-Aufrufe
+INSERT INTO announcement_dismissals (user_id, announcement_id, dismissed_at)
+VALUES (:user_id, :announcement_id, :now)
+ON CONFLICT(user_id, announcement_id) DO NOTHING
+```
+
+Ein Benutzer, der `POST /announcements/5/dismiss` zweimal aufruft, ist sicher — der zweite Aufruf gelingt lautlos. Der Client muss nie zuerst prüfen.
+
+---
+
+## Kernmuster: Optionaler Benutzerkontext beim Auflisten
+
+```php
+// Ohne X-User-Id: alle aktiven Ankündigungen zeigen
+// Mit X-User-Id: ausgeblendete für diesen Benutzer ausschließen
+
+// Ohne Benutzer:
+WHERE a.starts_at <= :now AND a.ends_at > :now
+
+// Mit Benutzer (LEFT JOIN + IS NULL-Filter):
+LEFT JOIN announcement_dismissals d
+  ON d.announcement_id = a.id AND d.user_id = :user_id
+WHERE a.starts_at <= :now AND a.ends_at > :now
+  AND d.id IS NULL
+```
+
+Dieser einzelne `GET /announcements`-Endpunkt behandelt sowohl unauthentifizierte (Monitoring, Admin-Ansicht) als auch authentifizierte (UI zeigt relevante Banner) Anwendungsfälle.
+
+---
+
+## Kernmuster: ends_at muss nach starts_at liegen
+
+```php
+// Server-seitige Validierung — nicht nur Client-Vertrauen
+if ($body['ends_at'] <= $body['starts_at']) {
+    return 'ends_at must be after starts_at.';
+}
+```
+
+Eine Ankündigung mit `ends_at <= starts_at` ist sofort bei der Erstellung unsichtbar — validieren und ablehnen statt stillschweigend fehlerhafte Daten akzeptieren.
+
+---
+
+## Antwort-Design
+
+| Szenario | Status | Body |
+|----------|--------|------|
+| Erstellen erfolgreich | 201 | `{announcement: {id, title, body, starts_at, ends_at, priority}}` |
+| Aktualisieren erfolgreich | 200 | `{announcement: {...}}` |
+| Löschen erfolgreich | 200 | `{deleted: true}` |
+| Aktive auflisten | 200 | `{data: [...], total: N}` |
+| Ausblenden | 200 | `{dismissed: true}` |
+| Admin-Schlüssel fehlend/falsch | 401 | `{error: "Admin key required."}` |
+| Nicht gefunden | 404 | `{error: "Announcement not found."}` |
+| Validierung fehlgeschlagen | 422 | `{error: "..."}` |
+
+`created_at` / `updated_at` sind **nicht** in der öffentlichen Antwort — sie sind interne Metadaten.
+
+---
+
+## Testergebnisse (FT190)
+
+```
+38 Tests / 93 Assertions — alle BESTANDEN
+PHPStan Level 8 — keine Fehler
+PHP CS Fixer — sauber
+```
+
+Quelle: [`../NENE2-FT/announcelog/`](https://github.com/hideyukiMORI/NENE2-examples/tree/main/announcelog)

--- a/docs/de/howto/tag-label-api.md
+++ b/docs/de/howto/tag-label-api.md
@@ -1,0 +1,124 @@
+# Anleitung: Tag-/Label-API
+
+Diese Anleitung demonstriert eine generische Entitäts-Tagging-API, bei der beliebige Tags an beliebige Entitäts-IDs angehängt werden können, mit tag-basierter Rückwärtssuche.
+
+## Musterübersicht
+
+- Tags werden global gespeichert und durch einen Slug (`a-z0-9-`, 1–50 Zeichen) identifiziert.
+- Jede Entität (identifiziert durch Integer-ID) kann mehrere Tags haben.
+- `POST /tags` — Tag erstellen oder abrufen (Find-or-Create; idempotent).
+- `GET /tags` — Alle bekannten Tags auflisten.
+- `GET /tags/{tag}/entities` — Rückwärtssuche: Welche Entitäten haben diesen Tag?
+- `POST /entities/{entityId}/tags` — Tag an eine Entität anhängen.
+- `GET /entities/{entityId}/tags` — Alle Tags für eine Entität auflisten.
+- `DELETE /entities/{entityId}/tags/{tag}` — Tag von einer Entität ablösen.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS tags (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+CREATE TABLE IF NOT EXISTS entity_tags (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id  INTEGER NOT NULL,
+    tag_id     INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE,
+    UNIQUE (entity_id, tag_id)
+);
+```
+
+## Find-or-Create-Muster
+
+Tag-Erstellung ist idempotent — `POST /tags` gibt 201 bei der ersten Erstellung zurück, 200 wenn der Tag bereits existiert:
+
+```php
+public function findOrCreate(string $name): array
+{
+    $existing = $this->findByName($name);
+    if ($existing !== null) {
+        return $existing;
+    }
+    $this->pdo->prepare(
+        'INSERT INTO tags (name, created_at) VALUES (:name, :now)'
+    )->execute([':name' => $name, ':now' => $this->now()]);
+
+    return $this->findByName($name) ?? [];
+}
+```
+
+Der `attachTag`-Handler verwendet ebenfalls Find-or-Create, sodass Clients Tags anhängen können, ohne einen separaten Erstellungsschritt durchzuführen.
+
+## Tag-Name-Validierung
+
+Tag-Namen werden in Kleinbuchstaben normalisiert und mit einem strengen Format-Regex validiert:
+
+```php
+private const string TAG_PATTERN = '/\A[a-z0-9-]{1,50}\z/';
+
+$name = strtolower(trim((string) ($body['name'] ?? '')));
+if (!preg_match(self::TAG_PATTERN, $name)) {
+    return $this->problem(422, 'validation-failed', '...');
+}
+```
+
+Leerzeichen, Großbuchstaben, Unterstriche und Sonderzeichen werden alle abgelehnt.
+
+## Rückwärtssuche (Tag → Entitäten)
+
+`GET /tags/{tag}/entities` gibt 404 zurück, wenn der Tag nicht in der Datenbank existiert, und ein leeres Array, wenn er existiert, aber nicht verwendet wird:
+
+```php
+if ($this->repo->findByName($tag) === null) {
+    return $this->problem(404, 'not-found', 'Tag not found.');
+}
+return $this->json(['tag' => $tag, 'entity_ids' => $this->repo->entitiesForTag($tag)]);
+```
+
+SQL für die Rückwärtssuche:
+
+```sql
+SELECT entity_id FROM entity_tags WHERE tag_id = :tid ORDER BY entity_id ASC
+```
+
+## Anhängen/Ablösen-Idempotenz
+
+Das zweimalige Anhängen desselben Tags an dieselbe Entität gibt 200 zurück (nicht 201) mit `"attached": false`:
+
+```php
+$attached = $this->repo->attach($entityId, (int) $tag['id']);
+return $this->json([...], $attached ? 201 : 200);
+```
+
+Das Ablösen eines Tags, das nicht angehängt ist, gibt 404 zurück.
+
+## Entitäts-ID-Validierung
+
+Entitäts-IDs werden mit `ctype_digit()` validiert, um ReDoS zu vermeiden und nicht-negative Integer sicherzustellen:
+
+```php
+if (!ctype_digit($raw) || strlen($raw) > 18) {
+    return null;
+}
+$id = (int) $raw;
+return $id > 0 ? $id : null;
+```
+
+## Routen
+
+```
+POST   /tags                           Tag erstellen oder abrufen
+GET    /tags                           Alle Tags auflisten
+GET    /tags/{tag}/entities            Rückwärtssuche: Entitäten mit diesem Tag
+POST   /entities/{entityId}/tags       Tag an Entität anhängen
+GET    /entities/{entityId}/tags       Tags für Entität auflisten
+DELETE /entities/{entityId}/tags/{tag} Tag von Entität ablösen
+```
+
+## Siehe auch
+
+- FT209-Quelle: `../NENE2-FT/taglog/`
+- Verwandt: `docs/howto/note-taking.md` (FT202, tag-basierte Notizsuche)

--- a/docs/de/howto/tagging-system.md
+++ b/docs/de/howto/tagging-system.md
@@ -1,0 +1,148 @@
+# Tagging-System (M:N)
+
+Tags an Beiträge über eine Many-to-Many-Join-Tabelle anhängen, mit atomarem Tag-Ersetzen und N+1-freiem Tag-Laden.
+
+## Übersicht
+
+Ein Tagging-System hat drei Tabellen: `posts`, `tags` und `post_tags` (die Join-Tabelle). Beiträge und Tags haben eine M:N-Beziehung — ein Beitrag hat viele Tags, ein Tag gehört zu vielen Beiträgen.
+
+## Datenbankschema
+
+```sql
+CREATE TABLE posts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE tags (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE post_tags (
+    post_id INTEGER NOT NULL,
+    tag_id  INTEGER NOT NULL,
+    PRIMARY KEY (post_id, tag_id),
+    FOREIGN KEY (post_id) REFERENCES posts(id),
+    FOREIGN KEY (tag_id)  REFERENCES tags(id)
+);
+```
+
+Der zusammengesetzte Primärschlüssel auf `(post_id, tag_id)` erzwingt Eindeutigkeit auf DB-Ebene.
+
+## Tags atomar setzen
+
+Der `PUT /posts/{id}/tags`-Endpunkt ersetzt alle Tags für einen Beitrag in einer Operation. Erst löschen, dann einfügen:
+
+```php
+public function setPostTags(int $postId, array $tagNames): array
+{
+    $this->executor->execute('DELETE FROM post_tags WHERE post_id = ?', [$postId]);
+
+    foreach ($tagNames as $name) {
+        $tag = $this->findTagByName($name);
+        if ($tag === null) {
+            continue; // Unbekannte Tag-Namen stillschweigend überspringen
+        }
+
+        $this->executor->execute(
+            'INSERT OR IGNORE INTO post_tags (post_id, tag_id) VALUES (?, ?)',
+            [$postId, $tag->id],
+        );
+    }
+
+    return $this->findTagsByPostId($postId);
+}
+```
+
+- Löschen-dann-Einfügen macht die Operation idempotent: sie zweimal mit demselben Payload aufzurufen hat dasselbe Ergebnis.
+- `INSERT OR IGNORE` verhindert einen DB-Fehler, wenn derselbe Tag-Name zweimal im Request-Body vorkommt.
+- Unbekannte Tag-Namen werden stillschweigend übersprungen — der Client muss Tags erstellen, bevor er sie zuweist.
+- Um alle Tags zu löschen, `{"tags": []}` senden.
+
+## N+1-Abfragen vermeiden
+
+Beim Laden einer Liste von Beiträgen (z. B. für tag-basierte Suche) alle Tags in einer einzelnen `IN`-Abfrage laden statt eine Abfrage pro Beitrag:
+
+```php
+private function findTagsByPostIds(array $postIds): array
+{
+    if ($postIds === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($postIds), '?'));
+    $rows = $this->executor->fetchAll(
+        "SELECT t.*, pt.post_id FROM tags t
+         INNER JOIN post_tags pt ON pt.tag_id = t.id
+         WHERE pt.post_id IN ({$placeholders})
+         ORDER BY t.name ASC",
+        $postIds,
+    );
+
+    $map = [];
+    foreach ($rows as $row) {
+        $postId         = (int) $row['post_id'];
+        $map[$postId][] = $this->hydrateTag($row);
+    }
+
+    return $map;
+}
+```
+
+Dies gibt `array<int, Tag[]>` zurück, indexiert nach Beitrags-ID. Insgesamt zwei Abfragen unabhängig von der Anzahl der Beiträge.
+
+## Tag-Eindeutigkeit
+
+Tags haben eine `UNIQUE`-Bedingung auf `name`. Doppelte Erstellung gibt 409 zurück:
+
+```php
+public function createTag(string $name, string $now): ?Tag
+{
+    try {
+        $this->executor->execute(
+            'INSERT INTO tags (name, created_at) VALUES (?, ?)',
+            [$name, $now],
+        );
+    } catch (\RuntimeException) {
+        return null; // null → Handler gibt 409 zurück
+    }
+
+    return $this->findTagByName($name);
+}
+```
+
+## Tag-basierte Suche
+
+Beiträge nach Tag über einen JOIN filtern:
+
+```sql
+SELECT p.* FROM posts p
+INNER JOIN post_tags pt ON pt.post_id = p.id
+INNER JOIN tags t ON t.id = pt.tag_id
+WHERE t.name = ?
+ORDER BY p.id DESC
+```
+
+Dann Tags für das Ergebnis-Set mit der `IN`-Abfrage oben stapelweise laden.
+
+## Routen-Übersicht
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/posts` | Beitrag erstellen |
+| `GET` | `/posts/{id}` | Beitrag mit Tags abrufen |
+| `POST` | `/tags` | Tag erstellen (Duplikat → 409) |
+| `GET` | `/tags` | Alle Tags auflisten (alphabetisch) |
+| `PUT` | `/posts/{id}/tags` | Alle Tags eines Beitrags ersetzen |
+| `GET` | `/tags/{name}/posts` | Beiträge mit einem bestimmten Tag auflisten |
+
+## Design-Hinweise
+
+- Tags sind anwendungsverwaltete Entitäten, kein freier Text. Clients erstellen Tags zuerst, dann weisen sie sie zu.
+- Unbekannte Tag-Namen in `PUT /posts/{id}/tags` werden stillschweigend ignoriert. Dies vermeidet einen Round-Trip zur Vorab-Validierung von Namen.
+- Tag-Namen sind in Antworten alphabetisch sortiert für deterministische Ausgabe.
+- `GET /tags/{name}/posts` gibt 404 zurück, wenn der Tag nicht existiert, und unterscheidet so „Tag unbekannt" von „Tag existiert, aber hat keine Beiträge" (was 200 mit leerem Array zurückgibt).

--- a/docs/de/howto/tenant-isolation-idor.md
+++ b/docs/de/howto/tenant-isolation-idor.md
@@ -1,0 +1,149 @@
+# Anleitung: Mandantenisolierung & IDOR-Prävention
+
+> **FT-Referenz**: FT318 (`NENE2-FT/isolationlog`) — Multi-Mandanten-Datenisolierung, mandantenübergreifende IDOR-Prävention, Header-Typverwirrungsabsicherung, Body-tenant_id-Injektions-Prävention, 34 Tests / 133 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie strikte mandantenebenenbasierte Datenisolierung durchgesetzt wird, sodass kein Mandant die Daten eines anderen lesen, ändern oder aufzählen kann — selbst wenn er Header oder Request-Bodies manipuliert.
+
+## Schema
+
+```sql
+CREATE TABLE tenants (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id  INTEGER NOT NULL REFERENCES tenants(id),
+    user_id    INTEGER NOT NULL,
+    content    TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+```
+
+## Authentifizierungsmodell
+
+```
+Admin-Endpunkte  → X-Admin-Key: <server_secret>       (z. B. env ADMIN_KEY)
+Mandanten-Endpunkte → X-Tenant-Id: <int>  X-User-Id: <int>
+```
+
+### Header-Validierungsregeln
+
+`X-Tenant-Id` und `X-User-Id` müssen die **strikte positive-Integer**-Validierung bestehen:
+
+| Eingabe | Ergebnis |
+|---------|----------|
+| `"1"` (gültig) | ✅ Akzeptiert |
+| `"0"` | ❌ 401 — muss > 0 sein |
+| `"-1"` | ❌ 401 — Negativ abgelehnt |
+| `"1.5"` | ❌ 401 — Float abgelehnt |
+| `"+1"` | ❌ 401 — Vorzeichen-Präfix abgelehnt |
+| `"1 OR 1=1"` | ❌ 401 — SQL-Injection-Versuch abgelehnt |
+| `""` (nicht vorhanden) | ❌ 401 — Fehlender Header |
+| `"99999999999999999999"` (20 Ziffern) | ❌ 401 — Überlauf abgelehnt |
+
+```php
+// Validierungsmuster mit ctype_digit + Bereichsprüfung
+$raw = $request->getHeaderLine('X-Tenant-Id');
+if (!ctype_digit($raw) || ($id = (int) $raw) <= 0 || strlen($raw) > 10) {
+    return $this->json->create(['error' => 'Unauthorized'], 401);
+}
+```
+
+## Admin-Endpunkte
+
+```php
+POST /tenants   X-Admin-Key: admin-secret
+{"name": "Acme Corp"}
+→ 201  {"id": 1, "name": "Acme Corp", "created_at": "..."}
+
+GET  /tenants   X-Admin-Key: admin-secret
+→ 200  {"total": 2, "tenants": [...]}
+
+GET  /tenants/1  X-Admin-Key: admin-secret
+→ 200  {"id": 1, "name": "Acme Corp", ...}
+
+// Kein Admin-Schlüssel
+POST /tenants  (kein X-Admin-Key)   → 401
+POST /tenants  X-Admin-Key: falsch  → 401
+```
+
+## Mandanten-Endpunkte — IDOR-Prävention
+
+### Notiz erstellen (server-zugewiesener Mandant)
+
+```php
+POST /notes  X-Tenant-Id: 1  X-User-Id: 42
+{"content": "Hello"}
+→ 201  {"id": 1, "tenant_id": 1, "content": "Hello", ...}
+```
+
+**Die `tenant_id` im Request-Body wird IMMER ignoriert.** Der Server verwendet nur den Header-Wert:
+
+```php
+// Angreifer sendet X-Tenant-Id: 1 aber Body versucht Mandant 2 einzuschleusen
+POST /notes  X-Tenant-Id: 1
+{"content": "Injection", "tenant_id": 2}  // ← ignoriert
+
+→ 201  {"tenant_id": 1, ...}   // aus Header zugewiesen, nicht aus Body
+```
+
+### Mandantenübergreifendes IDOR — Gibt 404 zurück
+
+```php
+// Notiz 5 gehört zu Mandant 1
+GET  /notes/5  X-Tenant-Id: 2  → 404   // IDOR blockiert
+DELETE /notes/5  X-Tenant-Id: 2 → 404  // IDOR blockiert
+
+// Eigentümer kann noch zugreifen
+GET  /notes/5  X-Tenant-Id: 1  → 200   ✅
+```
+
+Alle Abfragen enthalten `WHERE tenant_id = $tenantId`. Eine fehlende Zeile gibt 404 zurück — **nicht 403** — um Existenz-Aufzählung zu verhindern.
+
+### Listen-Isolierung
+
+```php
+// T1 hat 2 Notizen, T2 hat 1 Notiz
+GET /notes  X-Tenant-Id: 1  → {"data": [note_A, note_B], "tenant_id": 1}
+GET /notes  X-Tenant-Id: 2  → {"data": [note_X],         "tenant_id": 2}
+// T2 sieht nie die Notizen von T1
+```
+
+```sql
+SELECT * FROM notes WHERE tenant_id = ? ORDER BY id DESC LIMIT ?
+-- Immer nach tenant_id aus dem validierten Header filtern
+```
+
+### Query-Parameter-Validierung
+
+```php
+GET /notes?limit=-1       → 422  // negativ
+GET /notes?limit=10.5     → 422  // Float
+GET /notes?limit=999999   → 422  // überschreitet Maximum (z. B. 100)
+GET /notes?limit=99999999999999999999  → 422  // Überlauf
+GET /notes                → 200  // Standard-Limit angewendet
+```
+
+## Notiz für nicht existierenden Mandanten erstellen
+
+```php
+POST /notes  X-Tenant-Id: 9999  X-User-Id: 1
+{"content": "test"}
+→ 422  // Mandant 9999 existiert nicht
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `tenant_id` aus dem Request-Body vertrauen | Angreifer weist Notizen beliebigem Mandanten zu |
+| 403 statt 404 bei IDOR zurückgeben | 403 enthüllt, dass die Ressource existiert; 404 verhindert Aufzählung |
+| Header direkt casten: `(int) $header` ohne ctype_digit | `-1`, `+1`, `1.5`, Überlauf produzieren alle unerwartete Integer |
+| Kein `WHERE tenant_id = ?` in Listen-Abfragen | Vollständiges mandantenübergreifendes Datenleck |
+| Admin-Schlüssel in Client-Antworten teilen | Admin-Schlüssel muss nur serverseitig bleiben |
+| `X-Tenant-Id: 0` erlauben | Null ist oft ein Standard-/ungecetzter Zustand; nur positive Integer akzeptieren |

--- a/docs/de/howto/tenant-isolation.md
+++ b/docs/de/howto/tenant-isolation.md
@@ -1,0 +1,150 @@
+# Anleitung: Mandantenisolierung & mandantenübergreifende IDOR-Prävention
+
+**FT179 — isolationlog**
+
+Verhinderung mandantenübergreifender Datenlecks in Multi-Mandanten-APIs —
+gescope SQL-Abfragen, header-basierte Identität und Body-Injektions-Prävention.
+
+---
+
+## Die Bedrohung: Mandantenübergreifendes IDOR
+
+In einem Multi-Mandanten-System gehört jede Ressource zu einem Mandanten.
+Ein Angreifer, der ein Mandantenkonto kontrolliert, testet IDs von anderen Mandanten:
+
+```
+GET /notes/42          X-Tenant-Id: 2   ← Angreifer ist Mandant 2
+                                         Notiz 42 gehört zu Mandant 1
+```
+
+Wenn der Server die Notiz zurückgibt, hat der Angreifer die Daten eines anderen Mandanten gelesen —
+eine **Insecure Direct Object Reference (IDOR)** an der Mandantengrenze.
+
+---
+
+## Das Isolierungsmuster
+
+### 1. Alle Lesevorgänge auf SQL-Ebene scopen
+
+Niemals nur nach ID abfragen. Immer `AND tenant_id = ?` hinzufügen:
+
+```php
+// ❌ FALSCH — ID allein, mandantenübergreifend lesbar
+'SELECT * FROM notes WHERE id = ?'
+
+// ✅ KORREKT — ID + Mandant in SQL durchgesetzt
+'SELECT * FROM notes WHERE id = ? AND tenant_id = ?'
+```
+
+Dies gibt `null` für mandantenübergreifenden Zugriff zurück, was zu einem 404 wird.
+Der Angreifer erfährt nichts über Notiz 42 — nicht einmal ob sie existiert.
+
+### 2. Listen-Abfragen sind immer gescoped
+
+```php
+// ❌ FALSCH — könnte mit ?tenant_id=... Injektion ergänzt werden
+'SELECT * FROM notes ORDER BY id DESC LIMIT ?'
+
+// ✅ KORREKT — WHERE tenant_id = ? ist nie optional
+'SELECT * FROM notes WHERE tenant_id = ? ORDER BY id DESC LIMIT ?'
+```
+
+### 3. Löschen verwendet dasselbe Muster
+
+```sql
+DELETE FROM notes WHERE id = ? AND tenant_id = ?
+```
+
+`rowCount()` gibt 0 zurück, wenn die Notiz nicht zum Mandanten gehört → 404.
+
+---
+
+## Header-basierte Mandantenidentität
+
+`X-Tenant-Id` + `X-User-Id`-Header für mandantenabgegrenzte Endpunkte verwenden.
+Beide mit `V::userId()` validieren (ctype_digit + Überlaufschutz + > 0):
+
+```php
+private function resolveTenantUser(ServerRequestInterface $request): array
+{
+    $tenantId = V::userId($request->getHeaderLine('X-Tenant-Id'));
+    $userId   = V::userId($request->getHeaderLine('X-User-Id'));
+
+    return [$tenantId, $userId];
+}
+```
+
+`V::userId()` lehnt ab:
+- Leerer String (`ctype_digit('') === false`)
+- Null (`id <= 0`)
+- Negativ (`'-'` schlägt bei `ctype_digit` fehl)
+- Float-String (`'1.5'` schlägt bei `ctype_digit` fehl)
+- 20+ Ziffern Überlauf (strlen > 18 Schutz)
+- SQL-Injection-Versuche (`'1 OR 1=1'` schlägt bei `ctype_digit` fehl)
+
+---
+
+## Body-Injektions-Prävention
+
+Angreifer können `tenant_id` im POST-Body einschließen, um zu versuchen, eine
+Ressource einem anderen Mandanten zuzuweisen:
+
+```json
+POST /notes
+X-Tenant-Id: 1
+{ "content": "Injection", "tenant_id": 99 }
+```
+
+**Niemals `tenant_id` aus dem Body lesen.** Immer den server-validierten Header verwenden:
+
+```php
+// ATK-04: body['tenant_id'] wird nie gelesen — immer $tenantId aus Header verwenden
+$note = $this->notes->create($tenantId, $userId, $content, date('c'));
+//                            ^^^^^^^^^
+//                            von V::userId(X-Tenant-Id), nicht von $body
+```
+
+---
+
+## Mandanten-Existenzprüfung beim Schreiben
+
+Vor dem Erstellen einer Ressource prüfen, ob der Mandant existiert:
+
+```php
+if (!$this->tenants->exists($tenantId)) {
+    return $this->responseFactory->create(['error' => 'Tenant not found.'], 422);
+}
+```
+
+Ohne diese Prüfung würden Notizen für Ghost-Mandanten-IDs erstellt, die nicht in der
+Mandanten-Tabelle existieren, was die referenzielle Integrität bricht.
+
+---
+
+## Angriffs-Checkliste (ATK-01 bis ATK-12)
+
+| # | Test | Erwartung |
+|---|------|-----------|
+| ATK-01 | Keine Auth-Header | 401 |
+| ATK-02 | Mandantenübergreifendes GET (IDOR) | 404 — Notiz existiert, aber nicht für diesen Mandanten |
+| ATK-03 | X-Tenant-Id: `"1"`, `1.5`, `+1`, `1 OR 1=1` | 401 — V::userId lehnt ab |
+| ATK-04 | POST-Body enthält `tenant_id: 99` | 201 — Body-tenant_id ignoriert |
+| ATK-05 | Mandantenübergreifendes DELETE | 404 — Notiz nicht gelöscht |
+| ATK-06 | X-Tenant-Id: `0`, `-1` | 401 |
+| ATK-07 | X-Tenant-Id: 20-stelliger Überlauf | 401 |
+| ATK-08 | Mandantenerstellung ohne X-Admin-Key | 401 |
+| ATK-09 | Falscher X-Admin-Key | 401 |
+| ATK-10 | Notiz für nicht existierende Mandanten-ID | 422 |
+| ATK-11 | Liste: T1 sieht nur T1-Notizen, nicht T2's | Durch SQL WHERE tenant_id durchgesetzt |
+| ATK-12 | `?limit=-1`, `?limit=10.5`, 20-stelliges Limit | 422 — V::queryInt-Guards |
+
+---
+
+## Antwortstrategie: 404 nicht 403
+
+Wenn ein mandantenübergreifendes IDOR erkannt wird, **404** zurückgeben — nicht 403 Verboten.
+
+- `403` lüftet Existenz: „die Ressource existiert, aber Sie können nicht darauf zugreifen"
+- `404` enthüllt nichts: „keine solche Ressource für diesen Mandanten"
+
+Dies verhindert Mandanten-Aufzählungsangriffe.

--- a/docs/de/howto/threaded-comments-api.md
+++ b/docs/de/howto/threaded-comments-api.md
@@ -1,0 +1,201 @@
+# Anleitung: Threaded-Comments-API
+
+> **FT-Referenz**: FT343 (`NENE2-FT/threadlog`) — Zweistufiges Kommentar-Thread-System mit Tombstone-Löschung (Inhalt ersetzt durch `[deleted]`), Antwort-Tiefenbegrenzung, beitragsbezogene Isolierung und Prävention von Antworten auf gelöschte Kommentare, 14 Tests / 40+ Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Kommentarsystem mit einer Antwortebene gebaut wird: Root-Kommentare können Antworten erhalten, aber Antworten können nicht beantwortet werden (maximale Tiefe = 1). Gelöschte Kommentare werden tombstoniert, um die Thread-Struktur zu erhalten.
+
+## Schema
+
+```sql
+CREATE TABLE comments (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    post_id    TEXT    NOT NULL,           -- opaker Beitragsbezeichner
+    parent_id  INTEGER REFERENCES comments(id),  -- NULL = Root-Kommentar
+    author     TEXT    NOT NULL,
+    content    TEXT    NOT NULL,
+    deleted    INTEGER NOT NULL DEFAULT 0,
+    deleted_at TEXT,
+    created_at TEXT    NOT NULL
+);
+```
+
+`parent_id IS NULL` = Root-Kommentar; `parent_id IS NOT NULL` = Antwort.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/posts/{postId}/comments` | Root-Kommentar erstellen |
+| `GET`  | `/posts/{postId}/comments` | Kommentare mit Antworten auflisten |
+| `GET`  | `/posts/{postId}/comments/{id}` | Einzelnen Kommentar abrufen |
+| `POST` | `/posts/{postId}/comments/{id}/replies` | Antwort hinzufügen |
+| `DELETE` | `/posts/{postId}/comments/{id}` | Soft Delete (Tombstone) |
+
+## Root-Kommentar erstellen
+
+```php
+POST /posts/post-1/comments
+{"author": "alice", "content": "Great post!"}
+→ 201
+{
+  "id": 1,
+  "author": "alice",
+  "content": "Great post!",
+  "parent_id": null,
+  "replies": [],
+  "deleted": false,
+  "created_at": "..."
+}
+
+// Fehlende Felder
+POST /posts/post-1/comments  {"author": "alice"}
+→ 422  // Inhalt erforderlich
+```
+
+## Kommentare auflisten
+
+```php
+GET /posts/post-1/comments
+→ 200
+{
+  "comments": [
+    {
+      "id": 1,
+      "author": "alice",
+      "content": "Root comment",
+      "replies": [
+        {"id": 2, "author": "bob", "content": "My reply", "parent_id": 1}
+      ]
+    }
+  ]
+}
+```
+
+Kommentare sind auf `post_id` bezogen. Kommentare von `post-1` erscheinen nie in der Liste von `post-2`.
+
+## Einzelnen Kommentar abrufen
+
+```php
+GET /posts/post-1/comments/1
+→ 200
+{
+  "id": 1,
+  "author": "alice",
+  "content": "Root comment",
+  "reply_count": 2,
+  "replies": [...]
+}
+
+GET /posts/post-1/comments/999
+→ 404
+```
+
+## Antwort hinzufügen (Maximale Tiefe = 1)
+
+```php
+POST /posts/post-1/comments/1/replies
+{"author": "bob", "content": "My reply"}
+→ 201
+{
+  "id": 2,
+  "parent_id": 1,
+  "author": "bob",
+  "content": "My reply"
+}
+
+// Antwort auf eine Antwort wird abgelehnt (Tiefe würde 2 sein)
+POST /posts/post-1/comments/2/replies  {"author": "charlie", "content": "Deep reply"}
+→ 409  // Tiefenlimit überschritten
+
+// Antwort auf nicht existierenden Kommentar
+POST /posts/post-1/comments/999/replies  {"author": "bob", "content": "X"}
+→ 404
+
+// Antwort auf gelöschten Kommentar
+// (Kommentar 1 bereits gelöscht)
+POST /posts/post-1/comments/1/replies  {"author": "bob", "content": "X"}
+→ 409  // Kann nicht auf gelöschten Kommentar antworten
+
+// Fehlende Felder → 422
+```
+
+### Tiefen-Check-Implementierung
+
+```php
+public function canReceiveReply(int $commentId): bool
+{
+    $row = $this->findById($commentId);
+    if ($row === null) {
+        throw new CommentNotFoundException($commentId);
+    }
+    if ($row['deleted']) {
+        throw new CommentDeletedException($commentId);
+    }
+    // Nur Root-Kommentare (parent_id = null) können Antworten haben
+    return $row['parent_id'] === null;
+}
+```
+
+409 zurückgeben, wenn `canReceiveReply()` false zurückgibt.
+
+## Tombstone-Löschung
+
+```php
+DELETE /posts/post-1/comments/1
+→ 200
+{
+  "deleted": true,
+  "author": "[deleted]",
+  "content": "[deleted]"
+}
+
+// Gelöschter Kommentar erscheint noch in der Liste (Tombstone)
+GET /posts/post-1/comments
+→ 200
+{
+  "comments": [
+    {
+      "id": 1,
+      "author": "[deleted]",
+      "content": "[deleted]",
+      "deleted": true,
+      "replies": [{"id": 2, "author": "bob", ...}]  // Antworten noch sichtbar
+    }
+  ]
+}
+```
+
+Tombstoning bewahrt die Thread-Struktur. Antworten bleiben sichtbar, auch nachdem der Elternkommentar gelöscht wurde.
+
+```php
+// Bereits gelöschten Kommentar löschen → 404
+DELETE /posts/post-1/comments/1  (bereits gelöscht)
+→ 404
+
+// Unbekannter Kommentar → 404
+DELETE /posts/post-1/comments/999
+→ 404
+```
+
+### Tombstone-SQL
+
+```sql
+UPDATE comments
+SET deleted = 1, author = '[deleted]', content = '[deleted]', deleted_at = ?
+WHERE id = ? AND deleted = 0
+-- Trifft nur nicht-gelöschte Zeilen
+-- 0 Zeilen aktualisiert → 404
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Elternkommentar hart löschen | Antworten werden zu Waisen; Thread-Struktur bricht zusammen |
+| Unbegrenzte Verschachtelungstiefe erlauben | Tiefe Ketten erzeugen rekursive SQL-Abfragen oder Stack Overflows |
+| 404 für Antwort-auf-Gelöschtes zurückgeben | Den Elternzustand zu verstecken verwirrt Clients; 409 mit klarem `detail` ist besser |
+| Kein `post_id`-Scope in Abfragen | Kommentare von anderen Beiträgen erscheinen in der Liste |
+| Tiefe nur client-seitig prüfen | Angreifer umgeht die Prüfung durch direkte API-Anfragen |
+| Autor/Inhalt des gelöschten Kommentars anzeigen | Macht den Zweck der Löschung zunichte; immer tombstonen |

--- a/docs/de/howto/threaded-comments.md
+++ b/docs/de/howto/threaded-comments.md
@@ -1,0 +1,128 @@
+# Threaded Comments
+
+Selbstreferenzierende Kommentar-Threads mit Tiefenlimits und Soft Delete implementieren.
+
+## Übersicht
+
+Ein Threaded-Comment-System hat eine Tabelle, die auf sich selbst verweist. Jeder Kommentar kennt seine `parent_id` (null für Top-Level), seine `depth` (0-basiert) und seinen `status`. Antworten werden in der Antwortstruktur innerhalb ihres Elternkommentars verschachtelt.
+
+## Datenbankschema
+
+```sql
+CREATE TABLE comments (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    post_id     INTEGER NOT NULL,
+    parent_id   INTEGER,
+    author_name TEXT    NOT NULL,
+    body        TEXT    NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'published',
+    depth       INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT    NOT NULL,
+    FOREIGN KEY (post_id)   REFERENCES posts(id),
+    FOREIGN KEY (parent_id) REFERENCES comments(id)
+);
+```
+
+`depth` ist in der Zeile denormalisiert, um rekursive Vorfahren-Abfragen bei jedem Insert zu vermeiden.
+
+## Maximale Tiefe
+
+Ein Tiefenlimit beim Schreiben durchsetzen:
+
+```php
+public const int MAX_DEPTH = 3;
+
+public function canHaveReplies(): bool
+{
+    return $this->depth < self::MAX_DEPTH;
+}
+```
+
+Im Routen-Handler vor dem Einfügen prüfen:
+
+```php
+if (!$parent->canHaveReplies()) {
+    return $this->problems->create($request, 'unprocessable-entity', 'Maximum comment depth reached.', 422, '');
+}
+
+$comment = $this->repo->addComment(
+    $parent->postId, $parentId, $authorName, $body, $parent->depth + 1, $now,
+);
+```
+
+## Soft Delete
+
+Soft Delete ersetzt den Body durch `[deleted]` und setzt `status = 'deleted'`. Kindkommentare bleiben erhalten:
+
+```php
+public function softDelete(int $id): void
+{
+    $this->executor->execute(
+        "UPDATE comments SET status = 'deleted', body = '[deleted]' WHERE id = ?",
+        [$id],
+    );
+}
+```
+
+Der Baumlade-Vorgang gibt gelöschte Kommentare mit `[deleted]`-Bodies zurück, damit die Thread-Struktur kohärent bleibt — Leser sehen einen Platzhalter, wo der gelöschte Kommentar war, und seine Kindkommentare sind noch sichtbar.
+
+Ein Versuch, auf einen gelöschten Kommentar zu antworten, gibt 409 zurück:
+
+```php
+if ($parent->isDeleted()) {
+    return $this->problems->create($request, 'conflict', 'Cannot reply to a deleted comment.', 409, '');
+}
+```
+
+## Kommentarbaum ohne N+1 aufbauen
+
+Alle Kommentare für einen Beitrag in einer einzelnen Abfrage laden, geordnet nach ID (Eltern haben immer niedrigere IDs als ihre Kinder). Dann den Baum in PHP mit zwei Durchläufen zusammenbauen:
+
+```php
+// Durchlauf 1: Rohzeilen-Map und Kinder-ID-Adjazenzliste aufbauen
+foreach ($rows as $row) {
+    $rowMap[(int) $row['id']]   = $row;
+    $childIds[(int) $row['id']] = [];
+}
+
+foreach ($rowMap as $id => $row) {
+    $parentId = isset($row['parent_id']) ? (int) $row['parent_id'] : null;
+    if ($parentId === null) {
+        $roots[] = $id;
+    } elseif (isset($childIds[$parentId])) {
+        $childIds[$parentId][] = $id;
+    }
+}
+
+// Durchlauf 2: Rekursiv Comment-Value-Objekte von Wurzeln aufbauen
+return $this->buildTree($roots, $rowMap, $childIds);
+```
+
+Rohzeilen und `int[]`-Kinder-ID-Listen von `Comment`-Value-Objekten zu trennen vermeidet PHPStan-Typverwirrung beim Arbeiten mit `readonly`-Klassen.
+
+## Zeilendaten von Value-Objekten trennen
+
+Wenn man einen Baum von readonly Value-Objekten rekursiv zusammenbaut, braucht PHPStan klare Typgrenzen. Das funktionierende Muster:
+
+1. **Durchlauf 1** — `array<int, array<string, mixed>> $rowMap` und `array<int, int[]> $childIds` aus Rohzeilen aufbauen. Noch keine Value-Objekte.
+2. **Durchlauf 2** — `buildTree()` nimmt nur `int[]`-IDs und die zwei Maps, rekursiert und hydratisiert `Comment`-Objekte mit vollständig zusammengebauten Kinder-Arrays.
+
+Dies vermeidet das Mischen von `Comment`-Objekten und `int`-IDs im selben Array, was einen Union-Typ erzeugen würde, den PHPStan nicht einengen kann.
+
+## Routen-Zusammenfassung
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/posts` | Beitrag erstellen |
+| `GET` | `/posts/{id}` | Beitrag abrufen |
+| `POST` | `/posts/{id}/comments` | Top-Level-Kommentar hinzufügen |
+| `GET` | `/posts/{id}/comments` | Kommentarbaum abrufen |
+| `POST` | `/comments/{id}/replies` | Auf Kommentar antworten |
+| `DELETE` | `/comments/{id}` | Kommentar soft löschen |
+
+## Design-Hinweise
+
+- `depth` ist in der Zeile gespeichert (denormalisiert), um rekursive Vorfahren-Abfragen bei jedem Insert zu vermeiden.
+- `ORDER BY id ASC` garantiert, dass Eltern vor ihren Kindern beim Laden der flachen Liste erscheinen.
+- Soft Delete bewahrt die Thread-Struktur — Hard Delete würde Kindkommentare zu Waisen machen.
+- Auf einen gelöschten Kommentar zu antworten ist gesperrt (409), um Ghost-Threads zu verhindern.

--- a/docs/de/howto/time-tracking.md
+++ b/docs/de/howto/time-tracking.md
@@ -1,0 +1,252 @@
+# Anleitung: Zeiterfassungs-API
+
+> **FT-Referenz**: FT246 (`NENE2-FT/timelog`) — Zeiterfassungs-API
+
+Demonstriert eine Stoppuhr-basierte Zeiterfassungs-API, bei der ein Zeiterfassungs-Eintrag eine `start_time`
+und eine nullable `end_time` hat (`NULL` = läuft, nicht-`NULL` = gestoppt), nur ein Timer gleichzeitig
+laufen kann, die Dauer über SQLites `julianday()` berechnet wird und tägliche Zusammenfassungen
+die gesamten erfassten Sekunden pro Kalendertag aggregieren.
+
+---
+
+## Routen
+
+| Methode   | Pfad              | Beschreibung                                                      |
+|-----------|-------------------|------------------------------------------------------------------|
+| `POST`   | `/timers/start`   | Neuen Timer starten (schlägt fehl, wenn einer bereits läuft)     |
+| `POST`   | `/timers/stop`    | Den aktuell laufenden Timer stoppen                               |
+| `GET`    | `/timers/running` | Den aktuell laufenden Timer abrufen (oder `running: false`)       |
+| `GET`    | `/timers/summary` | Tägliche Zusammenfassung: Gesamtsekunden und Eintragsanzahl pro Tag |
+| `GET`    | `/timers`         | Einträge auflisten (paginiert, filterbar nach Label und Datum)   |
+| `GET`    | `/timers/{id}`    | Einen einzelnen Zeiterfassungs-Eintrag abrufen                   |
+| `DELETE` | `/timers/{id}`    | Einen Zeiterfassungs-Eintrag löschen (`204 No Content`)          |
+
+> **Statische Routen zuerst**: `/timers/start`, `/timers/stop`, `/timers/running`,
+> `/timers/summary` werden alle vor `/timers/{id}` registriert, damit Literal-Pfade
+> nicht als parametrisierte Segmente erfasst werden.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS time_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    label      TEXT NOT NULL,
+    start_time TEXT NOT NULL,
+    end_time   TEXT,              -- NULL = läuft
+    created_at TEXT NOT NULL
+);
+```
+
+`end_time` ist nullable — `NULL` bedeutet, der Timer läuft noch. `NOT NULL` bedeutet, er wurde gestoppt.
+Es gibt keine separate `status`-Spalte; das Vorhandensein oder Fehlen von `end_time` kodiert den Laufzustand.
+
+---
+
+## Laufzustand: `end_time IS NULL`
+
+Der Laufzustand des Timers wird ausschließlich aus der `end_time`-Spalte erkannt:
+
+```php
+final readonly class TimeEntry
+{
+    public function isRunning(): bool
+    {
+        return $this->endTime === null;
+    }
+
+    public function durationSeconds(): ?int
+    {
+        if ($this->endTime === null) {
+            return null;  // läuft noch — noch keine Dauer
+        }
+        $start = new \DateTimeImmutable($this->startTime);
+        $end   = new \DateTimeImmutable($this->endTime);
+        return (int) $end->getTimestamp() - (int) $start->getTimestamp();
+    }
+}
+```
+
+`isRunning()` gibt `true` zurück, wenn `endTime` `null` ist. `durationSeconds()` gibt
+`null` für laufende Timer zurück — die Dauer kann erst berechnet werden, wenn der Timer gestoppt wird.
+Die Antwort enthält `"running": true` und `"duration_seconds": null` für aktive Einträge.
+
+---
+
+## Singleton-Timer: nur einer kann gleichzeitig laufen
+
+`start()` prüft auf einen laufenden Timer, bevor ein neuer erstellt wird:
+
+```php
+public function start(string $label, string $startTime, string $createdAt): TimeEntry
+{
+    $running = $this->findRunning();
+    if ($running !== null) {
+        throw new TimerAlreadyRunningException($running->id);
+    }
+
+    $this->executor->execute(
+        'INSERT INTO time_entries (label, start_time, end_time, created_at) VALUES (?, ?, NULL, ?)',
+        [$label, $startTime, $createdAt],
+    );
+
+    return $this->findById($this->executor->lastInsertId());
+}
+```
+
+Wenn ein Timer bereits läuft, wird `TimerAlreadyRunningException` geworfen → `409 Conflict`.
+`end_time` wird als Literal-`NULL`-SQL-Wert eingefügt.
+
+Die Suche nach dem laufenden Timer:
+
+```php
+public function findRunning(): ?TimeEntry
+{
+    $row = $this->executor->fetchOne(
+        'SELECT * FROM time_entries WHERE end_time IS NULL ORDER BY start_time DESC LIMIT 1',
+        [],
+    );
+    return $row !== null ? $this->hydrate($row) : null;
+}
+```
+
+`WHERE end_time IS NULL` — Standard-SQL-`NULL`-Vergleich (nicht `= NULL`). `LIMIT 1`
+schützt davor, mehrere Zeilen zurückzugeben, wenn die Invariante jemals verletzt wird.
+
+---
+
+## Timer stoppen: `stop()`
+
+```php
+public function stop(string $endTime): TimeEntry
+{
+    $running = $this->findRunning();
+    if ($running === null) {
+        throw new NoRunningTimerException();
+    }
+
+    $this->executor->execute(
+        'UPDATE time_entries SET end_time = ? WHERE id = ?',
+        [$endTime, $running->id],
+    );
+
+    return $this->findById($running->id);
+}
+```
+
+`stop()` findet den laufenden Timer, setzt `end_time` und gibt den aktualisierten Eintrag mit
+der berechneten Dauer zurück. `NoRunningTimerException` wird geworfen, wenn kein Timer läuft →
+`409 Conflict`.
+
+---
+
+## Dauerberechnung: `julianday()` in SQL
+
+Für aggregierte Zusammenfassungen wird die Dauer in SQL über SQLites `julianday()`-Funktion berechnet:
+
+```sql
+SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds
+```
+
+`julianday()` konvertiert einen ISO-Datumszeit-String in eine Julianische Tagesnummer (eine reelle Zahl,
+die Tage seit Mittag des 1. Januar 4713 v. Chr. darstellt). Das Subtrahieren zweier Julianischer Tagesnummern
+ergibt die Differenz in Tagen. Das Multiplizieren mit `86400` konvertiert Tage in Sekunden.
+`CAST(... AS INTEGER)` kürzt auf ganze Sekunden.
+
+`SUM(...)` summiert alle abgeschlossenen Einträge für den Tag. `WHERE end_time IS NOT NULL`
+filtert alle noch laufenden Timer aus der Zusammenfassung.
+
+Die PHP-seitige Berechnung für einzelne Einträge:
+
+```php
+$start = new \DateTimeImmutable($this->startTime);
+$end   = new \DateTimeImmutable($this->endTime);
+return (int) $end->getTimestamp() - (int) $start->getTimestamp();
+```
+
+Beide Ansätze produzieren dasselbe Ergebnis für UTC-Zeitstempel. Der SQL-Ansatz wird für Aggregation
+verwendet (er vermeidet das Abrufen aller Zeilen zum Summieren); der PHP-Ansatz wird für die
+Serialisierung einzelner Einträge verwendet.
+
+---
+
+## Tägliche Zusammenfassungsaggregation
+
+```php
+$sql = 'SELECT date(start_time) AS day,
+               SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds,
+               COUNT(*) AS entry_count
+          FROM time_entries
+         WHERE ' . implode(' AND ', $where) . '
+         GROUP BY day
+         ORDER BY day DESC';
+```
+
+`date(start_time)` extrahiert das Kalenderdatum aus dem `start_time`-ISO-String.
+`GROUP BY day` gruppiert alle abgeschlossenen Einträge für denselben Tag.
+`ORDER BY day DESC` gibt die neuesten Tage zuerst zurück.
+
+Die `$where`-Klausel beginnt immer mit `['end_time IS NOT NULL']`, um laufende Timer auszuschließen,
+und fügt dann optional `date(start_time) >= ?` und `date(start_time) <= ?` für den Datumsbereichsfilter hinzu.
+
+---
+
+## `date()`-Funktion für datumsbasierte Filterung
+
+Das Filtern von Einträgen nach Kalenderdatum verwendet SQLites `date()`-Funktion:
+
+```php
+if ($date !== null) {
+    $where[]  = "date(start_time) = ?";
+    $params[] = $date;
+}
+```
+
+`date(start_time)` extrahiert nur `YYYY-MM-DD` aus dem ISO-Datumszeit-String.
+`= ?` vergleicht das extrahierte Datum mit dem Filterwert. Dies trifft korrekt alle
+Einträge, die am angegebenen Tag begonnen haben, unabhängig von der Zeitkomponente.
+
+---
+
+## Label-Filterung mit `LIKE`
+
+```php
+if ($label !== null) {
+    $where[]  = 'label LIKE ?';
+    $params[] = '%' . $label . '%';
+}
+```
+
+`LIKE '%label%'` führt einen Groß-/Kleinschreibungsunempfindlichen Teilstring-Vergleich in SQLites
+Standard-Kollation durch. Sonderzeichen `%` und `_` in `$label` werden als LIKE-Wildcards interpretiert
+— escapen wenn strikt-literales Matching erforderlich ist.
+
+---
+
+## `GET /timers/running`-Antwortvertrag
+
+Der Laufend-Endpunkt gibt eine konsistente Form zurück, ob ein Timer aktiv ist oder nicht:
+
+```php
+if ($entry === null) {
+    return $this->json->create(['running' => false, 'entry' => null]);
+}
+return $this->json->create(['running' => true, 'entry' => $this->serialize($entry)]);
+```
+
+`running: false, entry: null` — kein Timer aktiv.
+`running: true, entry: {...}` — aktiver Timer mit `end_time: null` und `duration_seconds: null`.
+
+Dies vermeidet ein `404` für „kein laufender Timer" — `404` impliziert, die Ressource existiert nicht,
+aber das Konzept „laufender Timer" existiert immer (es ist nur leer). `running: false` zu verwenden
+ist semantisch sauberer.
+
+---
+
+## Verwandte Anleitungen
+
+- [`shift-management.md`](shift-management.md) — Schicht-Ein-/Ausstempeln mit nullable Endzeit
+- [`scheduled-reminders.md`](scheduled-reminders.md) — Zeitzonen-bewusste Datumszeit-Validierung
+- [`aggregate-reporting.md`](aggregate-reporting.md) — `GROUP BY date`-Aggregationsmuster
+- [`handle-timezones.md`](handle-timezones.md) — UTC-Speicherung und Zeitzonen-Konvertierung

--- a/docs/de/howto/timezone-aware-scheduling.md
+++ b/docs/de/howto/timezone-aware-scheduling.md
@@ -1,0 +1,158 @@
+# Anleitung: Zeitzonen-bewusste Ereignisplanung
+
+> **FT-Referenz**: FT286 (`NENE2-FT/schedulelog`) — Zeitzonen-bewusste Planung: UTC-Speicherung + Lokalzeit-Konvertierung, IANA-Zeitzonen-Validierung via DateTimeZone::listIdentifiers(), InvalidTimezoneException, dynamischer ?timezone-Abfrageparameter, 19 Tests / 39 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie eine Ereignisplanungs-API gebaut wird, die Zeiten in UTC speichert und sie in jeder Zeitzone darstellt, die der Client anfordert.
+
+## Warum in UTC speichern?
+
+UTC ist der universelle Referenzpunkt. Lokalzeiten sind mehrdeutig (Sommerzeitwechsel, Zeitzonen-Regeländerungen) und variieren nach Client-Standort. Durch Speicherung in UTC:
+- Sortierung und Vergleich sind immer korrekt
+- Clients können in ihrer lokalen Zeitzone anzeigen
+- Sommerzeitübergänge schaffen keine Mehrdeutigkeit in historischen Daten
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    title       TEXT    NOT NULL,
+    timezone    TEXT    NOT NULL,      -- IANA-Zeitzone des Event-Erstellers
+    start_utc   TEXT    NOT NULL,      -- UTC ISO 8601: 2026-05-20T15:00:00Z
+    start_local TEXT    NOT NULL,      -- Lokal ISO 8601: 2026-05-20T10:00:00
+    created_at  TEXT    NOT NULL
+);
+```
+
+Sowohl `start_utc` als auch `start_local` werden gespeichert. `start_utc` ist maßgeblich; `start_local` ist ein Convenience-Cache für die Zeitzone des Erstellers.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/events` | Ereignis erstellen (Zeitzone + lokale Startzeit → UTC) |
+| `GET` | `/events` | Ereignisse auflisten (optional `?timezone=America/New_York`) |
+| `GET` | `/events/{id}` | Ereignis abrufen (optional `?timezone=`) |
+
+## IANA-Zeitzonen-Validierung
+
+PHPs `DateTimeZone`-Konstruktor akzeptiert einige ungültige Bezeichner stillschweigend. Explizit validieren:
+
+```php
+final class TimezoneConverter
+{
+    public static function localToUtc(string $localDatetime, string $ianaTimezone): \DateTimeImmutable
+    {
+        try {
+            $tz = new \DateTimeZone($ianaTimezone);
+        } catch (\Exception) {
+            throw new InvalidTimezoneException("Unknown timezone: $ianaTimezone");
+        }
+
+        // PHP akzeptiert in manchen Versionen ungültige Abkürzungen wie "EST" —
+        // explizit gegen die kanonische IANA-Liste validieren.
+        $valid = \DateTimeZone::listIdentifiers();
+        if (!in_array($ianaTimezone, $valid, true)) {
+            throw new InvalidTimezoneException("Unknown timezone: $ianaTimezone");
+        }
+
+        $local = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $localDatetime, $tz);
+
+        if ($local === false) {
+            throw new \InvalidArgumentException("Cannot parse datetime: $localDatetime");
+        }
+
+        return $local->setTimezone(new \DateTimeZone('UTC'));
+    }
+}
+```
+
+`DateTimeZone::listIdentifiers()` gibt die PHP-kompilierte Liste von IANA-Bezeichnern zurück. Nicht-IANA-Strings (wie `EST`, `GMT+5`) werden abgelehnt.
+
+## Ereignis erstellen: Lokal → UTC
+
+```php
+try {
+    $utc = TimezoneConverter::localToUtc($start, $timezone);
+} catch (InvalidTimezoneException) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'timezone', 'code' => 'invalid', 'message' => "Unknown timezone: $timezone"]],
+    ]);
+} catch (\InvalidArgumentException) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'start', 'code' => 'invalid', 'message' => "Cannot parse datetime: $start"]],
+    ]);
+}
+
+$startUtc   = TimezoneConverter::formatUtc($utc);                              // "2026-05-20T15:00:00Z"
+$startLocal = TimezoneConverter::formatLocal($utc->setTimezone(new \DateTimeZone($timezone)));  // "2026-05-20T10:00:00"
+```
+
+## Ereignisse auflisten: Dynamische Zeitzonen-Konvertierung
+
+Der `?timezone=`-Abfrageparameter konvertiert alle Ereignisse sofort in die Zeitzone des Clients:
+
+```php
+$viewTz = isset($params['timezone']) && $params['timezone'] !== '' ? $params['timezone'] : null;
+
+$items = array_map(static function (Event $e) use ($viewTz): array {
+    $data = $e->toArray();
+    if ($viewTz !== null) {
+        try {
+            $local = TimezoneConverter::utcToLocal($e->startUtc, $viewTz);
+            $data['start_local'] = TimezoneConverter::formatLocal($local);
+            $data['view_timezone'] = $viewTz;
+        } catch (InvalidTimezoneException) {
+            // Ungültige Ansichts-Zeitzone: stillschweigend UTC zurückgeben
+            $data['view_timezone'] = 'UTC';
+        }
+    }
+    return $data;
+}, $events);
+```
+
+Ungültige `?timezone=`-Werte fallen stillschweigend auf das gespeicherte `start_local` zurück, statt einen Fehler zurückzugeben — eine Designentscheidung, die für schreibgeschützte Ansichten geeignet ist.
+
+## UTC-Format: ISO 8601 mit Z-Suffix
+
+```php
+public static function formatUtc(\DateTimeImmutable $dt): string
+{
+    return $dt->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z');
+    //                                                                           ^ Literal Z
+}
+```
+
+Das `Z`-Suffix zeigt explizit UTC an (gemäß ISO 8601 / RFC 3339). `+00:00` zu verwenden oder den Offset wegzulassen sind akzeptable Alternativen, aber `Z` ist kompakter und universell erkannt.
+
+## DST-sichere Konvertierung
+
+```
+Beispiel: Asia/Tokyo ist UTC+9 (keine Sommerzeit)
+Lokal: 2026-05-20T10:00:00  Asia/Tokyo
+UTC:   2026-05-20T01:00:00Z
+
+Beispiel: America/New_York (Sommerzeit)
+Lokal: 2026-05-20T10:00:00  America/New_York (EDT = UTC-4 im Sommer)
+UTC:   2026-05-20T14:00:00Z
+
+Lokal: 2026-01-20T10:00:00  America/New_York (EST = UTC-5 im Winter)
+UTC:   2026-01-20T15:00:00Z
+```
+
+`DateTimeImmutable` mit einer benannten IANA-Zeitzone behandelt Sommerzeit automatisch. Es verwendet den Offset, der an diesem bestimmten Datum aktiv ist, nicht einen festen Offset.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Lokalzeit ohne Zeitzonen-Spalte speichern | Kann später nicht in UTC konvertiert werden; historische Daten werden nach Sommerzeitwechseln mehrdeutig |
+| `EST`, `PST`, `GMT+5` als Zeitzone akzeptieren | Mehrdeutige Abkürzungen; einige sind mehreren IANA-Zonen zugeordnet; `DateTimeZone::listIdentifiers()` lehnt diese ab |
+| `new DateTimeZone($tz)` ohne Prüfung von `listIdentifiers()` verwenden | PHP akzeptiert stillschweigend einige ungültige oder veraltete Bezeichner; kanonische Validierung erfasst sie |
+| UTC-Offset (`+09:00`) statt IANA-Name speichern | Offset allein kann Sommerzeit nicht behandeln; `Asia/Tokyo` ist immer +9, aber `America/New_York` variiert |
+| Ereignisse nach `start_local` sortieren | Lexikografische Sortierung nach Lokalzeiten ignoriert Zeitzonenunterschiede; immer nach `start_utc` sortieren |
+| Zeitzone bei jeder Abfrage konvertieren | Teuer für große Datensätze; Caching oder Vorberechnung häufiger Ansichts-Zeitzonen in Betracht ziehen |
+| 422 für ungültiges `?timezone=` in GET zurückgeben | Schreibgeschützte Abfragen sollten gracefully degradieren; auf UTC zurückfallen statt Fehler |
+| `date()` statt `DateTimeImmutable` verwenden | `date()` verwendet die Standard-Zeitzone des Servers; `DateTimeImmutable` mit expliziten Zonen ist vorhersehbar |

--- a/docs/de/howto/token-lifecycle-api.md
+++ b/docs/de/howto/token-lifecycle-api.md
@@ -1,0 +1,283 @@
+# Anleitung: API-Token-Lifecycle-Verwaltung
+
+> **FT-Referenz**: FT272 (`NENE2-FT/tokenlog`) — API-Token-Lebenszyklus: SHA-256-Hash-Speicherung (Klartext wird nie gespeichert), Scope-Enum (read/write/admin) mit DB-CHECK-Bedingung, IDOR-Guard (actorId muss userId entsprechen), Soft-Revoke via revoked_at, Verifizierungs-Endpunkt gibt valid/user_id/scope zurück, 29 Tests / 70 Assertions BESTANDEN.
+>
+> **ATK-Assessment**: ATK-01 bis ATK-12 am Ende dieses Dokuments.
+
+Demonstriert ein scope-basiertes API-Token-System: Tokens für einen Benutzer ausgeben, auflisten/widerrufen und einen Rohtoken beim Zugriffszeitpunkt verifizieren. Tokens werden nur als SHA-256-Hashes gespeichert — der Klartext wird einmal bei der Ausgabe zurückgegeben und nie gespeichert.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE tokens (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token_hash TEXT    NOT NULL UNIQUE,
+    scope      TEXT    NOT NULL DEFAULT 'read',
+    label      TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    revoked_at TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    CHECK (scope IN ('read', 'write', 'admin'))
+);
+```
+
+Wesentliche Designentscheidungen:
+- `token_hash UNIQUE` — verhindert versehentliche doppelte Ausgabe; auch der Lookup-Schlüssel beim Verifizieren
+- `CHECK (scope IN (...))` — DB-Ebene Durchsetzung des Scope-Enums
+- `revoked_at TEXT` — Soft-Revoke; `NULL` bedeutet aktiv, nicht-NULL bedeutet widerrufen
+
+---
+
+## Routen
+
+| Methode   | Pfad                                | Beschreibung                              |
+|-----------|-------------------------------------|------------------------------------------|
+| `POST`   | `/users`                            | Benutzer erstellen                        |
+| `POST`   | `/users/{userId}/tokens`            | Token ausgeben (nur Eigentümer)           |
+| `GET`    | `/users/{userId}/tokens`            | Tokens für einen Benutzer auflisten (nur Eigentümer) |
+| `DELETE` | `/users/{userId}/tokens/{tokenId}`  | Token widerrufen (nur Eigentümer)         |
+| `POST`   | `/tokens/verify`                    | Rohtoken verifizieren                     |
+
+---
+
+## Nur-Hash-Speicherung
+
+Der Rohtoken wird einmal bei der Ausgabe zurückgegeben und nie gespeichert:
+
+```php
+public function issueToken(int $userId, TokenScope $scope, string $label, string $now): string
+{
+    $raw  = bin2hex(random_bytes(32));   // 64 Hex-Zeichen — 256 Bits Entropie
+    $hash = hash('sha256', $raw);
+
+    $this->executor->execute(
+        'INSERT INTO tokens (user_id, token_hash, scope, label, created_at) VALUES (?, ?, ?, ?, ?)',
+        [$userId, $hash, $scope->value, $label, $now],
+    );
+
+    return $raw; // an Aufrufer zurückgegeben, nie gespeichert
+}
+```
+
+Beim Verifizieren liefert der Aufrufer den Rohtoken; der Hash wird neu berechnet und nachgeschlagen:
+
+```php
+public function verifyToken(string $rawToken): ?array
+{
+    $hash = hash('sha256', $rawToken);
+    $row  = $this->executor->fetchOne(
+        'SELECT id, user_id, scope, revoked_at FROM tokens WHERE token_hash = ?',
+        [$hash],
+    );
+
+    if ($row === null) {
+        return null; // nicht gefunden → Aufrufer gibt {valid: false} zurück
+    }
+
+    return [
+        'valid'   => !isset($arr['revoked_at']),
+        'user_id' => (int) $arr['user_id'],
+        'scope'   => (string) $arr['scope'],
+    ];
+}
+```
+
+---
+
+## Scope-Durchsetzung
+
+`TokenScope` ist ein PHP-backed Enum; `tryFrom()` lehnt unbekannte Werte vor jedem DB-Zugriff ab:
+
+```php
+enum TokenScope: string
+{
+    case Read  = 'read';
+    case Write = 'write';
+    case Admin = 'admin';
+}
+
+// Im Routen-Handler:
+$scope = TokenScope::tryFrom($scopeValue);
+if ($scope === null) {
+    return $this->responseFactory->create(['error' => 'invalid scope, must be read/write/admin'], 422);
+}
+```
+
+Die DB-`CHECK`-Bedingung bietet eine zweite Durchsetzungsschicht.
+
+---
+
+## IDOR-Guard
+
+Token-Ausgabe, Auflistung und Widerruf erfordern, dass der Akteur der Eigentümer ist:
+
+```php
+$actorId = $this->resolveActorId($request); // aus X-User-Id-Header
+
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+Der Widerruf überprüft auch, dass das Token zu `userId` gehört, nicht nur irgendein Token:
+
+```php
+if ($token['user_id'] !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+---
+
+## Widerruf
+
+Soft-Revoke setzt `revoked_at`; das UPDATE gilt nur, wenn `revoked_at IS NULL`:
+
+```php
+public function revokeToken(int $tokenId, string $now): bool
+{
+    $count = $this->executor->execute(
+        'UPDATE tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL',
+        [$now, $tokenId],
+    );
+    return $count > 0;
+}
+```
+
+Wenn das Token bereits widerrufen wurde, gibt der Routen-Handler 409 Conflict zurück:
+
+```php
+if ($token['revoked']) {
+    return $this->responseFactory->create(['error' => 'token already revoked'], 409);
+}
+```
+
+---
+
+## ATK-Assessment — Cracker-Mindset-Angrifftest
+
+### ATK-01 — Token-Replay nach Widerruf 🚫 BLOCKED
+
+**Angriff**: Token widerrufen, dann denselben Rohtoken-Wert bei `/tokens/verify` verwenden.
+**Ergebnis**: BLOCKED — `verifyToken()` schlägt `revoked_at` in der Zeile nach; ein nicht-NULL `revoked_at` verursacht `valid: false`. Das widerrufene Token wird nicht gelöscht, also wird es aufgelöst, aber gibt `{valid: false}` zurück.
+
+---
+
+### ATK-02 — Brute-Force-Token-Raten 🚫 BLOCKED
+
+**Angriff**: Zufällige 64-Zeichen-Hex-Strings an `/tokens/verify` senden, in der Hoffnung, einen gültigen Token-Hash zu treffen.
+**Ergebnis**: BLOCKED — Tokens sind `bin2hex(random_bytes(32))` = 256 Bits Entropie. Wahrscheinlichkeit einer erfolgreichen Rate: `1 / 2^256`. Kein Rate Limiting in diesem FT, aber die Entropie allein macht Brute-Force rechnerisch unmöglich.
+
+---
+
+### ATK-03 — IDOR: Zugriff auf die Token-Liste eines anderen Benutzers 🚫 BLOCKED
+
+**Angriff**: `X-User-Id: 1` setzen und `GET /users/2/tokens` anfordern.
+**Ergebnis**: BLOCKED — `actorId (1) !== userId (2)` → 403 Forbidden.
+
+---
+
+### ATK-04 — IDOR: Token eines anderen Benutzers widerrufen 🚫 BLOCKED
+
+**Angriff**: Als Benutzer 1 `DELETE /users/2/tokens/{tokenId}` aufrufen.
+**Ergebnis**: BLOCKED — der Routen-Handler prüft `actorId !== userId` → 403, bevor das Token abgerufen wird.
+
+---
+
+### ATK-05 — Benutzerübergreifender Token-Widerruf (geteilte Token-ID) 🚫 BLOCKED
+
+**Angriff**: Als Benutzer 2 `DELETE /users/2/tokens/{tokenId}` aufrufen, wobei `tokenId` Benutzer 1 gehört.
+**Ergebnis**: BLOCKED — nachdem die IDOR-Prüfung passiert (actorId = userId = 2), gibt `findTokenById` das Token zurück, dann `$token['user_id'] !== $userId` → 403. Doppelte Eigentümerschaftsprüfung verhindert benutzerübergreifenden Widerruf.
+
+---
+
+### ATK-06 — Ungültige Scope-Injektion 🚫 BLOCKED
+
+**Angriff**: POST `/users/{id}/tokens` mit `{"scope": "superadmin"}`.
+**Ergebnis**: BLOCKED — `TokenScope::tryFrom('superadmin')` gibt `null` zurück → 422. Die DB-CHECK-Bedingung würde es auch blockieren, wenn die Anwendungsschicht es irgendwie durchließe.
+
+---
+
+### ATK-07 — Token-Klartext-Extraktion aus DB 🚫 BLOCKED
+
+**Angriff**: Wenn ein Angreifer Lesezugriff auf die `tokens`-Tabelle erhält, kann er funktionierende Tokens erhalten?
+**Ergebnis**: BLOCKED — nur `token_hash` (SHA-256) wird gespeichert. SHA-256 umzukehren ist rechnerisch unmöglich. Der Rohtoken wird einmal bei der Ausgabe zurückgegeben und serverseitig verworfen.
+
+---
+
+### ATK-08 — Verifizieren mit leerem/fehlerhaftem Token 🚫 BLOCKED
+
+**Angriff**: POST `/tokens/verify` mit `{"token": ""}` oder `{"token": null}`.
+**Ergebnis**: BLOCKED — Leerstring-Prüfung: `if ($token === '') → 422`. `null` wird durch `is_string()`-Prüfung abgelehnt. Der SHA-256 eines leeren Strings würde ohnehin mit keinem gespeicherten Hash übereinstimmen.
+
+---
+
+### ATK-09 — Token-Ausgabe für nicht existierenden Benutzer 🚫 BLOCKED
+
+**Angriff**: POST `/users/9999/tokens`, wobei Benutzer 9999 nicht existiert.
+**Ergebnis**: BLOCKED — `findUserById(9999)` gibt `false` zurück → 404, bevor irgendein Token erstellt wird.
+
+---
+
+### ATK-10 — Doppelter Widerruf (Idempotenz) 🚫 BLOCKED
+
+**Angriff**: Denselben Token zweimal schnell nacheinander widerrufen.
+**Ergebnis**: BLOCKED — `revokeToken` verwendet `WHERE revoked_at IS NULL`; der zweite Aufruf gibt 0 betroffene Zeilen zurück. Der Routen-Handler liest `$token['revoked'] === true`, bevor er das Repo aufruft → 409 Conflict. Kein Race-Condition-Fenster für erfolgreichen Doppelwiderruf.
+
+---
+
+### ATK-11 — Negative oder String-userId im Pfad 🚫 BLOCKED
+
+**Angriff**: `GET /users/-1/tokens` oder `GET /users/abc/tokens`.
+**Ergebnis**: BLOCKED — `is_numeric($params['userId'])` → `(int)`-Cast. `-1` wird zu -1; `findUserById(-1)` gibt false zurück → 404. `abc` ist nicht numerisch → `userId = 0` → 404.
+
+---
+
+### ATK-12 — Scope-Herabstufung bei Verifizierungs-Antwort 🚫 BLOCKED
+
+**Angriff**: Nach Erhalt eines `read`-scoped Tokens versuchen, `scope: write` in der Verifizierungsantwort zu fälschen, indem ein modifizierter Request-Body gesendet wird.
+**Ergebnis**: BLOCKED — `/tokens/verify` akzeptiert nur einen Rohtoken-String; der Scope wird aus der DB-Zeile gelesen, nicht aus einem client-gelieferten Feld. Der Client kann den zurückgegebenen Scope nicht beeinflussen.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Widerrufenes Token wiederholen | 🚫 BLOCKED |
+| ATK-02 | Brute-Force-Token-Raten | 🚫 BLOCKED |
+| ATK-03 | IDOR: Token-Liste eines anderen lesen | 🚫 BLOCKED |
+| ATK-04 | IDOR: Tokens eines anderen widerrufen | 🚫 BLOCKED |
+| ATK-05 | Benutzerübergreifender Token-Widerruf | 🚫 BLOCKED |
+| ATK-06 | Ungültige Scope-Injektion | 🚫 BLOCKED |
+| ATK-07 | Klartext-Extraktion aus DB | 🚫 BLOCKED |
+| ATK-08 | Leerer/fehlerhafter Token bei Verifizierung | 🚫 BLOCKED |
+| ATK-09 | Token-Ausgabe für nicht existierenden Benutzer | 🚫 BLOCKED |
+| ATK-10 | Doppelter Widerruf Race Condition | 🚫 BLOCKED |
+| ATK-11 | Negative/String-userId im Pfad | 🚫 BLOCKED |
+| ATK-12 | Scope-Herabstufung via Verifizierungs-Body | 🚫 BLOCKED |
+
+**12 BLOCKED / SAFE, 0 EXPOSED**
+Keine kritischen Befunde. Die Nur-Hash-Speicherung, Scope-Enum-Durchsetzung und dualen IDOR-Prüfungen bilden eine robuste Verteidigungsoberfläche.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Rohtoken in DB speichern | DB-Leseleck exponiert alle Tokens; Tokens können nicht ohne Benutzeraktion rotiert werden |
+| MD5/SHA-1 für Token-Hash verwenden | Kollisionsangriffe; SHA-256 oder BLAKE2 bevorzugen |
+| Beliebige Scope-Strings akzeptieren | Ohne `tryFrom()`-Validierung können `superadmin`-Scopes ausgegeben werden |
+| Keine Eigentümerschaftsprüfung beim Widerruf | Jeder authentifizierte Benutzer kann beliebige Tokens widerrufen (IDOR) |
+| Tokens bei Widerruf hart löschen | Prüfpfad geht verloren; keine Möglichkeit, Replay eines widerrufenen Tokens zu erkennen |
+| 404 bei bereits widerrufenem Token zurückgeben | Macht es unmöglich, „nicht gefunden" von „bereits widerrufen" zu unterscheiden; 409 verwenden |

--- a/docs/de/howto/totp-authentication.md
+++ b/docs/de/howto/totp-authentication.md
@@ -1,0 +1,194 @@
+# TOTP-Zwei-Faktor-Authentifizierung Implementierungsanleitung
+
+## Übersicht
+
+Diese Anleitung erklärt, wie RFC 6238 TOTP (Time-based One-Time Password) Zwei-Faktor-Authentifizierung mit NENE2 implementiert wird. Es werden Google Authenticator/Authy-kompatible Geheimnis-Generierung, Code-Verifizierung, Replay-Angriff-Prävention und Brute-Force-Lockout bereitgestellt.
+
+---
+
+## DB-Schema
+
+```sql
+CREATE TABLE totp_secrets (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER NOT NULL UNIQUE,
+    secret          TEXT    NOT NULL,
+    is_enabled      INTEGER NOT NULL DEFAULT 0,
+    failed_attempts INTEGER NOT NULL DEFAULT 0,
+    locked_until    TEXT,
+    created_at      TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE used_totp_steps (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    time_step  INTEGER NOT NULL,
+    used_at    TEXT    NOT NULL,
+    UNIQUE (user_id, time_step),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+Die `used_totp_steps`-Tabelle ist der Kern der **Replay-Angriff-Prävention**. Sie zeichnet verwendete Zeitschritte auf.
+
+---
+
+## Endpunkt-Design
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| POST | `/users/{id}/totp/setup` | TOTP-Geheimnis generieren (nach Rückgabe in App registrieren) |
+| POST | `/users/{id}/totp/enable` | Code verifizieren und 2FA aktivieren |
+| POST | `/users/{id}/totp/verify` | Code verifizieren (Login-Flow) |
+| DELETE | `/users/{id}/totp` | 2FA deaktivieren (gültiger Code erforderlich) |
+| GET | `/users/{id}/totp` | 2FA-Status abrufen |
+
+---
+
+## RFC 6238 TOTP-Implementierung
+
+```php
+class TotpGenerator
+{
+    private const int DIGITS = 6;
+    private const int PERIOD = 30; // Sekunden
+
+    public function computeCode(string $base32Secret, int $timeStep): string
+    {
+        $secret = $this->base32Decode($base32Secret);
+
+        // Zeitschritt als 8-Byte big-endian verpacken
+        $msg = pack('N*', 0) . pack('N*', $timeStep);
+        $hash = hash_hmac('sha1', $msg, $secret, true);
+
+        // Dynamisches Trunkieren (RFC 4226 §5.4)
+        $offset = ord($hash[19]) & 0x0F;
+        $code = ((ord($hash[$offset]) & 0x7F) << 24)
+              | ((ord($hash[$offset + 1]) & 0xFF) << 16)
+              | ((ord($hash[$offset + 2]) & 0xFF) << 8)
+              | (ord($hash[$offset + 3]) & 0xFF);
+
+        return str_pad((string) ($code % (10 ** self::DIGITS)), self::DIGITS, '0', STR_PAD_LEFT);
+    }
+
+    public function verify(string $base32Secret, string $code, int $window = 1): ?int
+    {
+        $t = (int) floor(time() / self::PERIOD);
+        for ($offset = -$window; $offset <= $window; $offset++) {
+            $step = $t + $offset;
+            $expected = $this->computeCode($base32Secret, $step);
+            if (hash_equals($expected, $code)) {   // Timing-Angriff-Prävention
+                return $step;
+            }
+        }
+        return null;
+    }
+}
+```
+
+---
+
+## Designpunkte
+
+### Replay-Angriff-Prävention
+
+TOTP-Codes sind 30 Sekunden lang gültig. Wenn derselbe Code zweimal verwendet wird, ist Identitätsbetrug möglich.
+Die `used_totp_steps`-Tabelle zeichnet verwendete time_steps auf und verweigert die Wiederverwendung.
+
+```php
+$matchedStep = $this->totp->verify($secret, $code);
+if ($matchedStep === null) {
+    // Code ungültig
+    return 401;
+}
+if ($this->repo->isStepUsed($userId, $matchedStep)) {
+    // Code für denselben time_step bereits verwendet → Replay-Angriff
+    return 401;
+}
+// Als verwendet markieren
+$this->repo->markStepUsed($userId, $matchedStep, $now);
+```
+
+### Timing-Angriff-Prävention
+
+Für den Vergleich von TOTP-Codes `hash_equals()` verwenden. `===` oder `strcmp()` beenden den String-Vergleich vorzeitig, sodass aus der Antwortzeit auf die Anzahl übereinstimmender Stellen geschlossen werden kann.
+
+```php
+// Nicht korrekt: anfällig für Timing-Angriffe
+if ($expected === $inputCode) { ... }
+
+// Korrekt: Konstantzeit-Vergleich
+if (hash_equals($expected, $inputCode)) { ... }
+```
+
+### Fenstergröße (Zeitversatz-Toleranz)
+
+`window = 1` erlaubt aktuellen Schritt ± 1 (= ±30 Sekunden).
+Zeitversätze bei Smartphones liegen fast immer in diesem Bereich.
+Das Fenster zu vergrößern verringert die Sicherheit; 1 wird empfohlen.
+
+### Brute-Force-Lockout
+
+Nach 3 Fehlversuchen 15 Minuten sperren (423 Locked).
+Während der Sperre wird auch ein korrekter Code abgelehnt (Timing-Oracle-Prävention):
+
+```php
+if ($this->repo->isLocked($userId, $now)) {
+    return 423; // Gesperrt — korrekten Code nicht prüfen
+}
+```
+
+### Setup-Flow
+
+1. `POST /users/{id}/totp/setup` zum Geheimnis generieren
+2. Das `secret` (Base32) oder `otpauth_uri` aus der Antwort in der Authenticator-App registrieren
+3. `POST /users/{id}/totp/enable` mit dem ersten Code zum Aktivieren aufrufen
+4. Vor der Aktivierung ist das Geheimnis in der DB gespeichert, aber `is_enabled = false`
+
+```
+otpauth://totp/NENE2:alice?secret=JBSWY3DPEHPK3PXP&issuer=NENE2&algorithm=SHA1&digits=6&period=30
+```
+
+### Re-Setup macht altes Geheimnis ungültig
+
+Ein erneuter Aufruf von `POST /users/{id}/totp/setup` überschreibt das alte Geheimnis,
+und `used_totp_steps` wird ebenfalls gelöscht. Codes des alten Geheimnisses können nicht mehr authentifiziert werden.
+
+---
+
+## Sicherheits-Checkliste (12 Schwachstellen-Diagnosen alle bestanden)
+
+| # | Prüfpunkt | Gegenmaßnahme |
+|---|-----------|---------------|
+| A | Replay-Angriff | Verwendete time_steps in `used_totp_steps` aufzeichnen |
+| B | Brute-Force | Nach 3 Fehlversuchen 15 Minuten sperren (423) |
+| C | Korrekter Code während Sperre | Zuerst Sperrprüfung durchführen, Code überhaupt nicht verifizieren |
+| D | Unbefugte 2FA-Deaktivierung | DELETE erfordert ebenfalls gültigen Code |
+| E | Unbefugte 2FA-Aktivierung | Code-Verifizierung bei enable erforderlich |
+| F | Missbrauch alten Geheimnisses | Bei Re-Setup altes Geheimnis und verwendete Schritte löschen |
+| G | IDOR | Codes werden pro Benutzer mit unabhängigem secret verifiziert |
+| H | Geheimnis-Exposure | secret nicht in verify/enable-Antworten einschließen |
+| I | Fehlerhafter Code-Format | Nicht übereinstimmend → 401 (Format-Validierung optional) |
+| J | Leerer Code | Required-Validierung gibt 422 zurück |
+| K | verify ohne Aktivierung | `is_enabled`-Prüfung gibt 409 zurück |
+| L | Nicht existierender Benutzer | findUser() → null → 404 |
+
+---
+
+## Hinweise zum Testen
+
+Da TOTP-Codes zeitabhängig sind, wird derselbe Code nacheinander als Replay behandelt.
+In Tests `TotpGenerator::computeCode($secret, $gen->currentTimeStep() + N)` verwenden, um Codes verschiedener Schritte zu generieren:
+
+```php
+$enableCode  = $gen->computeCode($secret, $gen->currentTimeStep());     // für enable verwenden
+$verifyCode  = $gen->computeCode($secret, $gen->currentTimeStep() + 1); // für verify verwenden
+$disableCode = $gen->computeCode($secret, $gen->currentTimeStep() + 2); // für disable verwenden
+```
+
+---
+
+## Referenzimplementierung
+
+`../NENE2-FT/totplog/` — FT159 Field Trial (21 Tests + 12 Schwachstellen-Diagnosen = 32 Tests)

--- a/docs/de/howto/transaction-scope-pattern.md
+++ b/docs/de/howto/transaction-scope-pattern.md
@@ -1,0 +1,238 @@
+# Anleitung: Transaktions-Scope-Muster
+
+> **FT-Referenz**: FT253 (`NENE2-FT/txlog`) — Datenbanktransaktionsgrenzen: atomare Bestellung-mit-Inventar
+
+Demonstriert das korrekte Muster für `DatabaseTransactionManagerInterface::transactional()`
+in NENE2. Repositories müssen **innerhalb** des Callbacks mit dem transaktionsbezogenen Executor
+instanziiert werden — vorab injizierte Repositories operieren auf einer anderen Verbindung
+und ihre Schreibvorgänge werden **nicht** rückgängig gemacht, wenn die Transaktion fehlschlägt.
+
+---
+
+## Routen
+
+| Methode | Pfad      | Beschreibung                                            |
+|---------|-----------|---------------------------------------------------------|
+| `POST` | `/orders` | Bestellung aufgeben (atomarer Inventar-Abzug + Bestellung erstellen) |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS inventory (
+    product_id   INTEGER PRIMARY KEY,
+    product_name TEXT    NOT NULL,
+    stock        INTEGER NOT NULL CHECK (stock >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    status     TEXT    NOT NULL DEFAULT 'placed',
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id   INTEGER NOT NULL REFERENCES orders(id),
+    product_id INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL
+);
+```
+
+`CHECK(stock >= 0)` ist ein DB-Sicherheitsnetz, das verhindert, dass der Bestand negativ wird,
+auch wenn die Anwendungslogik einen Fehler hat. Die Anwendung validiert den Bestand auch vor dem
+Dekrementieren, sodass die Bedingung im Normalbetrieb nie ausgelöst wird.
+
+---
+
+## Die Executor-Scope-Falle
+
+`DatabaseTransactionManagerInterface::transactional()` öffnet eine Transaktion und übergibt einen
+**transaktionsbezogenen Executor** an den Callback. Schreibvorgänge über diesen Executor sind
+Teil der Transaktion und werden bei einer Exception zurückgerollt.
+
+**❌ Falsch: Repository vor der Transaktion injiziert**
+
+```php
+final class OrderService
+{
+    public function __construct(
+        private readonly InventoryRepository $inventory, // verwendet äußeren Executor
+        private readonly OrderRepository     $orders,    // verwendet äußeren Executor
+        private readonly DatabaseTransactionManagerInterface $tx,
+    ) {}
+
+    public function placeOrder(array $items): int
+    {
+        return $this->tx->transactional(function ($txExecutor) use ($items): int {
+            // FEHLER: $this->inventory und $this->orders verwenden den äußeren Executor,
+            // nicht $txExecutor. Ihre Schreibvorgänge sind auf einer anderen Verbindung.
+            // Wenn die Transaktion zurückrollt, werden ihre Änderungen NICHT rückgängig gemacht.
+            foreach ($items as $item) {
+                $this->inventory->decrement($item['product_id'], $item['quantity']);
+            }
+            return $this->orders->create($items);
+        });
+    }
+}
+```
+
+**✅ Korrekt: Repositories innerhalb des Callbacks erstellt**
+
+```php
+final class OrderService
+{
+    public function __construct(
+        private readonly DatabaseTransactionManagerInterface $tx,
+        // Nur den Transaction Manager injizieren, nicht die Repositories.
+    ) {}
+
+    public function placeOrder(array $items): int
+    {
+        return $this->tx->transactional(function ($executor) use ($items): int {
+            // Repositories werden mit dem transaktionsbezogenen Executor instanziiert.
+            // Alle Lese- und Schreibvorgänge gehen durch dieselbe Verbindung, in derselben Transaktion.
+            $inventory = new InventoryRepository($executor);
+            $orders    = new OrderRepository($executor);
+
+            foreach ($items as $item) {
+                // Wirft InsufficientStockException → löst Rollback aus
+                $inventory->decrement($item['product_id'], $item['quantity']);
+            }
+
+            return $orders->create($items);
+        });
+    }
+}
+```
+
+Der transaktionsbezogene `$executor`, der von `transactional()` übergeben wird, teilt dieselbe PDO-
+Verbindung und denselben Transaktionskontext. Das Erstellen von Repositories innerhalb des Callbacks
+mit diesem Executor stellt sicher, dass alle ihre Schreibvorgänge an derselben atomaren Transaktion teilnehmen.
+
+---
+
+## Inventar-Dekrement mit Anwendungsebene-Prüfung
+
+```php
+public function decrement(int $productId, int $qty): void
+{
+    $current = $this->getStock($productId);
+    if ($current < $qty) {
+        throw new InsufficientStockException($productId, $qty, $current);
+    }
+    $this->executor->execute(
+        'UPDATE inventory SET stock = stock - ? WHERE product_id = ?',
+        [$qty, $productId],
+    );
+}
+```
+
+Das Lesen-dann-Schreiben-Muster (`getStock()` + `UPDATE`) ist von sich aus nicht atomar —
+eine gleichzeitige Anfrage könnte denselben Bestand lesen und beide erfolgreich sein. Für den
+Produktionseinsatz in einem `SELECT ... FOR UPDATE` (MySQL) einwickeln oder `UPDATE ... WHERE stock >= ?`
+als optimistische Prüfung verwenden:
+
+```sql
+UPDATE inventory SET stock = stock - ? WHERE product_id = ? AND stock >= ?
+-- dann betroffene Zeilen == 1 prüfen; wenn 0, InsufficientStockException werfen
+```
+
+SQLite unterstützt kein `SELECT FOR UPDATE`, daher fängt die `CHECK(stock >= 0)`-Bedingung
+gleichzeitige Races auf DB-Ebene auf — das zweite Update würde eine Constraint-Verletzung werfen,
+die als Exception propagiert und Rollback auslöst.
+
+---
+
+## Multi-Element-Atomizität: Teilfehler löst vollständigen Rollback aus
+
+```php
+foreach ($items as $item) {
+    $inventory->decrement($item['product_id'], $item['quantity']); // kann werfen
+}
+return $orders->create($items); // nur erreicht, wenn alle Decrements erfolgreich sind
+```
+
+Wenn das **erste** Element fehlschlägt, werden keine Inventaränderungen vorgenommen. Wenn das **letzte**
+Element fehlschlägt, werden alle vorherigen Decrements zurückgerollt. Die Test-Suite verifiziert beide Fälle:
+
+```php
+// Widget: 10 Bestand; Gadget: 1 Bestand. Bestellung [Widget×3, Gadget×5] schlägt bei Gadget fehl.
+$this->assertSame(10, $inventory->getStock(1)); // Widget auf 10 wiederhergestellt
+$this->assertSame(0, $orders->count());          // Keine Bestellung erstellt
+```
+
+---
+
+## Exception → Rollback → 422-Mapping
+
+Die Exception, die innerhalb von `transactional()` geworfen wird, propagiert zum Aufrufer:
+
+```php
+try {
+    $orderId = $this->service->placeOrder($items);
+    return $this->json->create(['order_id' => $orderId, 'status' => 'placed'], 201);
+} catch (InsufficientStockException $e) {
+    return $this->problems->create(
+        $request,
+        'insufficient-stock',
+        'Insufficient stock.',
+        422,
+        $e->getMessage(),
+    );
+}
+```
+
+`transactional()` fängt die Exception ab, ruft `ROLLBACK` auf, dann wirft es erneut. Der Aufrufer
+fängt die erneut geworfene Exception ab und ordnet sie einer Problem-Details-Antwort zu.
+
+---
+
+## Eingabe-Validierung: Striktes `is_int` für Mengen
+
+```php
+foreach ($body['items'] as $i => $item) {
+    if (
+        !is_array($item) ||
+        !isset($item['product_id'], $item['quantity']) ||
+        !is_int($item['product_id']) ||
+        !is_int($item['quantity']) ||
+        $item['quantity'] < 1
+    ) {
+        return $this->problems->create(
+            $request,
+            'validation-failed',
+            'Validation failed.',
+            422,
+            null,
+            ['errors' => [['field' => "items.{$i}", 'code' => 'invalid', ...]]],
+        );
+    }
+}
+```
+
+`is_int()` lehnt JSON-Floats (`1.0`) und Strings (`"3"`) ab. PHPs JSON-Decoder konvertiert
+JSON-Integer-Werte zu PHP `int`, daher funktioniert `is_int()` korrekt für JSON-Eingaben.
+`is_numeric()` nur für Query-String-Parameter verwenden (die immer Strings sind).
+
+---
+
+## `transactional()`-Verwendungs-Zusammenfassung
+
+| Tun | Nicht tun |
+|-----|-----------|
+| Repositories innerhalb des Callbacks erstellen | Repositories bei der Klasseninitialisierung injizieren |
+| `$executor` aus dem Callback an neue Repositories weitergeben | `$this->executor` verwenden, das im Konstruktor injiziert wurde |
+| Exceptions propagieren lassen, um Rollback auszulösen | Exceptions stillschweigend innerhalb des Callbacks fangen |
+| Einen Wert aus dem Callback zurückgeben | `void` zurückgeben, wenn die eingefügte ID benötigt wird |
+
+---
+
+## Verwandte Anleitungen
+
+- [`transactions.md`](transactions.md) — `DatabaseTransactionManagerInterface`-API-Referenz
+- [`use-transactions.md`](use-transactions.md) — Transaktionen zu einem bestehenden Endpunkt hinzufügen
+- [`budget-tracking.md`](budget-tracking.md) — Geldmittel mit Transaktion übertragen (Zwei-Konto-Bilanznaktualisierung)
+- [`order-management.md`](order-management.md) — Vollständiger Bestell-Lebenszyklus (erstellen, Status, stornieren)
+- [`optimistic-locking.md`](optimistic-locking.md) — Race-Condition-Prävention ohne Transaktionen

--- a/docs/de/howto/transactions.md
+++ b/docs/de/howto/transactions.md
@@ -1,0 +1,151 @@
+# Datenbanktransaktionen
+
+`DatabaseTransactionManagerInterface::transactional()` für atomare mehrstufige Operationen verwenden.
+Wenn ein Schritt wirft, werden alle Änderungen im Callback automatisch zurückgerollt.
+
+## Die kritische Regel: Repositories innerhalb des Callbacks instanziieren
+
+> **Warnung:** Repositories, die bei der Initialisierung injiziert werden, verwenden eine *andere* PDO-Verbindung und werden **außerhalb der Transaktion** ausgeführt. Rollbacks machen ihre Änderungen nicht rückgängig.
+
+`PdoConnectionFactory` erstellt bei jedem Aufruf eine neue Verbindung. Wenn `transactional()` eine Transaktion öffnet, öffnet es sie auf einer *neuen* Verbindung. Jedes Repository, das vor diesem Aufruf erstellt wurde (z. B. über Konstruktor-DI injiziert), hält eine andere Verbindung — eine, die nicht Teil der Transaktion ist.
+
+### Korrektes Muster
+
+```php
+final class OrderService
+{
+    public function __construct(
+        private readonly DatabaseTransactionManagerInterface $tx,
+    ) {}
+
+    public function placeOrder(array $items): int
+    {
+        return $this->tx->transactional(function ($executor) use ($items): int {
+            // ✅ Repositories INNERHALB des Callbacks mit dem tx-scoped Executor instanziieren
+            $inventory = new InventoryRepository($executor);
+            $orders    = new OrderRepository($executor);
+
+            foreach ($items as $item) {
+                // wirft InsufficientStockException → Rollback automatisch ausgelöst
+                $inventory->decrement($item['product_id'], $item['quantity']);
+            }
+
+            return $orders->create($items);
+        });
+    }
+}
+```
+
+### Falsches Muster (Änderungen werden NICHT zurückgerollt)
+
+```php
+// ❌ Diese Repos halten eine andere Verbindung — nicht Teil der Transaktion
+public function __construct(
+    private readonly InventoryRepository $inventory,
+    private readonly OrderRepository $orders,
+    private readonly DatabaseTransactionManagerInterface $tx,
+) {}
+
+public function placeOrder(array $items): int
+{
+    return $this->tx->transactional(function ($executor) use ($items): int {
+        foreach ($items as $item) {
+            $this->inventory->decrement(...); // ← andere Verbindung, außerhalb der Transaktion!
+        }
+        return $this->orders->create($items); // ← gleiches Problem
+        // Wenn eine Exception geworfen wird, werden $this->inventory-Änderungen NICHT rückgängig gemacht
+    });
+}
+```
+
+Dies ist ein stiller Fehler: Der Code kompiliert, PHPStan kann ihn nicht erkennen, und Tests könnten bestehen, außer sie verifizieren das Rollback-Verhalten explizit.
+
+---
+
+## Rollback-Verhalten
+
+`transactional()` fängt `Throwable`, rollt zurück, dann wirft es erneut. Der Aufrufer erhält die ursprüngliche Exception.
+
+```php
+try {
+    $this->orderService->placeOrder($items);
+} catch (InsufficientStockException $e) {
+    // Alle Inventar-Decrements aus diesem Aufruf sind rückgängig gemacht
+    // Keine Bestellung wurde erstellt
+}
+```
+
+---
+
+## Vor-Validierung + Atomarer-Operations-Muster
+
+Das schnell-scheiternde Muster oben stoppt beim ersten nicht vorrätigen Element und lässt den Client über andere Fehler im Unklaren.
+Wenn UX wichtig ist, zuerst alle Fehler sammeln, dann atomar ausführen:
+
+```php
+public function placeOrder(array $items): int
+{
+    // Phase 1: alle Elemente außerhalb der Transaktion validieren (schreibgeschützt)
+    $errors = [];
+    foreach ($items as $item) {
+        $stock = $this->getStockSnapshot($item['product_id']);
+        if ($stock < $item['quantity']) {
+            $errors[] = [
+                'product_id' => $item['product_id'],
+                'requested'  => $item['quantity'],
+                'available'  => $stock,
+            ];
+        }
+    }
+
+    if ($errors !== []) {
+        throw new InsufficientStockException($errors);
+    }
+
+    // Phase 2: atomares Dekrement — innerhalb immer noch den tx-scoped Executor verwenden
+    return $this->tx->transactional(function ($executor) use ($items): int {
+        $inventory = new InventoryRepository($executor);
+        $orders    = new OrderRepository($executor);
+
+        foreach ($items as $item) {
+            // DB-CHECK-Bedingung ist das letzte Sicherheitsnetz für Races
+            $inventory->decrement($item['product_id'], $item['quantity']);
+        }
+
+        return $orders->create($items);
+    });
+}
+```
+
+**Kompromisse:**
+- Das Lesen in Phase 1 ist nicht Teil der Transaktion, sodass eine gleichzeitige Anfrage den Bestand zwischen Phase 1 und Phase 2 erschöpfen kann. Die Datenbankbedingung `CHECK (stock >= 0)` (oder `decrement()` wirft bei negativem Bestand) fängt diesen Race auf.
+- Für die meisten Anwendungen ist dies akzeptabel. Für strikte Korrektheit `SELECT ... FOR UPDATE` oder ein serialisierbares Isolationsniveau verwenden (nicht in SQLite verfügbar).
+
+---
+
+## Rollback-Korrektheit testen
+
+Immer verifizieren, dass das Inventar nach einer fehlgeschlagenen Bestellung unverändert ist:
+
+```php
+$this->inventory->seed(1, 'Widget', 10);
+$this->inventory->seed(2, 'Gadget', 1);
+
+// Widget-Dekrement würde erfolgreich sein, aber Gadget schlägt fehl → beide müssen zurückrollen
+$res = $this->post('/orders', ['items' => [
+    ['product_id' => 1, 'quantity' => 3],
+    ['product_id' => 2, 'quantity' => 5], // nur 1 auf Lager
+]]);
+
+assertSame(422, $res->getStatusCode());
+assertSame(10, $this->inventory->getStock(1), 'Widget muss auf 10 zurückgerollt werden');
+assertSame(0, $this->orders->count(), 'Keine Bestellung erstellt');
+```
+
+Unit-Tests, die Repositories mocken, können diese Klasse von Fehler nicht erfassen — nur Integrationstests, die dieselbe SQLite/MySQL-Verbindung teilen, können die Rollback-Korrektheit verifizieren.
+
+---
+
+## Laravel vs. NENE2
+
+Laravels `DB::transaction()` funktioniert mit injizierten Modellen, weil es transparent eine Verbindung über die Anfrage hinweg teilt. NENE2s `PdoConnectionFactory` gibt bei jedem Aufruf eine neue Verbindung zurück — eine bewusste Designentscheidung für Testbarkeit und explizite Verbindungskontrolle. Die Konsequenz ist, dass das Callback-scoped Executor-Muster in NENE2 **erforderlich** ist.

--- a/docs/de/howto/unicode-aware-text-api.md
+++ b/docs/de/howto/unicode-aware-text-api.md
@@ -1,0 +1,304 @@
+# Anleitung: Unicode-bewusste Text-API
+
+> **FT-Referenz**: FT345 (`NENE2-FT/unicodelog`) — Profil-API mit Unicode-sicherer Validierung: mb_strlen für Zeichenzählung, Null-Byte-Ablehnung, Multi-Skript-Unterstützung (Japanisch, Emoji, ZWJ-Sequenzen, Arabisch, gemischt), JSON_UNESCAPED_UNICODE-Behandlung, 22 Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie Unicode-Text in einer API sicher behandelt wird: Zeichen korrekt zählen (nicht Bytes), Null-Bytes ablehnen, mehrsprachige Eingaben akzeptieren und kodierungsbezogene Schwachstellen verhindern.
+
+## Schema
+
+```sql
+CREATE TABLE profiles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    bio        TEXT    NOT NULL DEFAULT '',
+    tags       TEXT    NOT NULL DEFAULT '[]',  -- JSON-Array als Text gespeichert
+    created_at TEXT    NOT NULL
+);
+```
+
+`tags` wird als JSON-Array-String gespeichert. SQLite TEXT behandelt beliebiges UTF-8 nativ.
+
+## Endpunkte
+
+| Methode   | Pfad              | Beschreibung         |
+|-----------|-------------------|--------------------|
+| `POST`   | `/profiles`       | Profil erstellen    |
+| `GET`    | `/profiles`       | Alle Profile auflisten |
+| `GET`    | `/profiles/{id}`  | Profil abrufen      |
+| `PATCH`  | `/profiles/{id}`  | Profil aktualisieren |
+| `DELETE` | `/profiles/{id}`  | Profil löschen      |
+
+## Limits
+
+| Feld   | Limit                         |
+|--------|-------------------------------|
+| `name` | 1–50 Unicode-Codepoints       |
+| `bio`  | 0–500 Unicode-Codepoints      |
+| `tags` | 0–10 Elemente, jeweils 1–30 Codepoints |
+
+## Profil erstellen
+
+```php
+POST /profiles
+{
+  "name": "田中太郎",
+  "bio": "プログラマーです。PHPが大好きです！",
+  "tags": ["エンジニア", "PHP"]
+}
+
+→ 201
+{
+  "id": 1,
+  "name": "田中太郎",
+  "bio": "プログラマーです。PHPが大好きです！",
+  "tags": ["エンジニア", "PHP"],
+  "created_at": "2026-05-27T09:00:00Z"
+}
+```
+
+Multi-Skript-Eingaben werden akzeptiert:
+
+```php
+POST /profiles
+{"name": "🎉 Yuki 🎊", "bio": "I love emojis! 🚀✨", "tags": ["🎨", "🎵"]}
+→ 201
+
+POST /profiles
+{"name": "محمد علي", "bio": "مبرمج ويب من مصر", "tags": ["مطور"]}
+→ 201
+
+POST /profiles
+{"name": "André García 鈴木", "bio": "Café résumé naïve", "tags": ["日本語", "español"]}
+→ 201
+```
+
+## Unicode-Längen-Validierung — `mb_strlen` vs. `strlen`
+
+**Immer `mb_strlen($value, 'UTF-8')` für Zeichenlimits verwenden.** `strlen()` zählt Bytes, nicht Zeichen.
+
+```php
+// "あ" ist 3 Bytes in UTF-8. strlen("あ") = 3, mb_strlen("あ", 'UTF-8') = 1.
+$name50 = str_repeat('あ', 50);  // 150 Bytes, 50 Zeichen
+// strlen würde dies ablehnen (150 > 50) — FALSCH
+// mb_strlen sieht korrekt 50 — KORREKT → 201 Created
+
+$name51 = str_repeat('あ', 51);  // 51 Zeichen → 422 (too_long)
+```
+
+### Validierungs-Implementierung
+
+```php
+function validateUnicodeField(string $value, string $field, int $maxChars): void
+{
+    // Erst Null-Bytes ablehnen
+    if (str_contains($value, "\x00")) {
+        throw new ValidationException($field, 'invalid', 'Null bytes are not allowed');
+    }
+
+    $length = mb_strlen($value, 'UTF-8');
+    if ($length === 0 && $field === 'name') {
+        throw new ValidationException($field, 'required', 'Field is required');
+    }
+    if ($length > $maxChars) {
+        throw new ValidationException($field, 'too_long', "Max {$maxChars} characters");
+    }
+}
+```
+
+### Emoji und ZWJ-Sequenzen
+
+```php
+// Jedes Emoji ist 1 Codepoint (4 Bytes). 50 Emoji = 200 Bytes, mb_strlen = 50 → BESTANDEN
+$name = str_repeat('🎉', 50);
+→ 201 Created
+
+// ZWJ-Sequenz 👨‍👩‍👧 = U+1F468 U+200D U+1F469 U+200D U+1F467
+// mb_strlen zählt dies als 5 Codepoints, nicht 1 Graphem-Cluster
+// Unverändert speichern und zurückgeben — nicht normalisieren
+$familyEmoji = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+→ 201 Created  // korrekt gespeichert und zurückgegeben
+```
+
+## Null-Byte-Ablehnung
+
+Null-Bytes (`\x00`) in Textfeldern sind ein Injektionsvektor — sie können Strings in C-basierten Bibliotheken abschneiden und in manchen Parsern die Validierung umgehen.
+
+```php
+POST /profiles  {"name": "Alice\x00Bob", "bio": "test", "tags": []}
+→ 422
+{"errors": [{"field": "name", "code": "invalid", "detail": "Null bytes are not allowed"}]}
+
+POST /profiles  {"name": "Valid", "bio": "bio with \x00 null", "tags": []}
+→ 422  // Null-Byte in bio
+
+POST /profiles  {"name": "Valid", "bio": "", "tags": ["tag\x00bad"]}
+→ 422  // Null-Byte in Tag-Wert
+```
+
+Null-Bytes **vor** der Längen-Validierung und **vor** der Speicherung ablehnen.
+
+## Tag-Validierung
+
+```php
+// Zu viele Tags (max 10)
+POST /profiles  {"name": "Valid", "bio": "", "tags": [... 11 Tags ...]}
+→ 422
+{"errors": [{"field": "tags", "code": "too_many", "detail": "Maximum 10 tags"}]}
+
+// Tag zu lang (max 30 Unicode-Zeichen)
+POST /profiles  {"name": "Valid", "bio": "", "tags": ["あ" × 31]}
+→ 422
+{"errors": [{"field": "tags[0]", "code": "too_long", "detail": "Max 30 characters"}]}
+
+// Nicht-String-Tag-Wert
+POST /profiles  {"name": "Valid", "bio": "", "tags": [42]}
+→ 422
+
+// Leerer Name
+POST /profiles  {"name": "", "bio": "", "tags": []}
+→ 422
+```
+
+### Tags-Implementierung
+
+```php
+$rawTags = $input['tags'] ?? [];
+if (!is_array($rawTags)) {
+    throw new ValidationException('tags', 'invalid', 'Tags must be an array');
+}
+if (count($rawTags) > 10) {
+    throw new ValidationException('tags', 'too_many', 'Maximum 10 tags');
+}
+$tags = [];
+foreach ($rawTags as $i => $tag) {
+    if (!is_string($tag)) {
+        throw new ValidationException("tags[{$i}]", 'invalid', 'Each tag must be a string');
+    }
+    if (str_contains($tag, "\x00")) {
+        throw new ValidationException("tags[{$i}]", 'invalid', 'Null bytes not allowed');
+    }
+    if (mb_strlen($tag, 'UTF-8') > 30) {
+        throw new ValidationException("tags[{$i}]", 'too_long', 'Max 30 characters per tag');
+    }
+    $tags[] = $tag;
+}
+$tagsJson = json_encode($tags, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+```
+
+## JSON-Antwort-Kodierung
+
+NENE2s `JsonResponseFactory` verwendet standardmäßig `json_encode()` ohne `JSON_UNESCAPED_UNICODE`. Das bedeutet, der rohe Antwort-Body enthält `\uXXXX`-Escape-Sequenzen für Nicht-ASCII-Zeichen — aber dekodierte Werte sind identisch.
+
+```php
+// Roh-Antwort-Body:
+{"name":"田中太郎", ...}
+
+// json_decode()-Ergebnis:
+["name" => "田中太郎", ...]  // ← korrekt
+```
+
+Clients, die Standard-JSON-Parser verwenden, sehen die korrekten Unicode-Werte. Die `\uXXXX`-Kodierung ist per RFC 8259 gültig.
+
+---
+
+## Schwachstellen-Assessment
+
+### V-01 — Null-Byte-Injektion ✅ SAFE
+
+**Risiko**: Null-Bytes (`\x00`) können die C-String-Verarbeitung in manchen PHP-Erweiterungen abschneiden, Validierung umgehen oder unerwartetes Verhalten bei nachgelagerten Konsumenten erzeugen.
+**Befund**: SAFE — Explizite `str_contains($value, "\x00")`-Prüfung lehnt alle Null-Bytes in `name`, `bio` und jedem Tag vor der Speicherung ab. Gibt 422 zurück.
+
+---
+
+### V-02 — Byte-Count-Überlauf via Multi-Byte-Zeichen ✅ SAFE
+
+**Risiko**: Wenn `strlen()` für Limits verwendet wird, wird ein Feld mit 50 japanischen Zeichen (150 Bytes) als „zu lang" abgelehnt, wenn es eigentlich bestehen sollte.
+**Befund**: SAFE — `mb_strlen($value, 'UTF-8')` zählt Codepoints, nicht Bytes. 50 japanische Zeichen = 50 Codepoints → besteht `max: 50`. 51 japanische Zeichen = 51 → abgelehnt. Emoji (4 Bytes jeweils) korrekt als 1 Codepoint gezählt.
+
+---
+
+### V-03 — Tag-Array-Injektion ✅ SAFE
+
+**Risiko**: Angreifer sendet Nicht-String-Werte im Tags-Array (Integer, Objekte, Arrays), um Typverwirrung in nachgelagertem Code auszunutzen.
+**Befund**: SAFE — Jedes Tag-Element wird typgeprüft (`is_string()`). Nicht-String-Werte geben 422 zurück. Tag-Anzahl ist ebenfalls auf 10 begrenzt.
+
+---
+
+### V-04 — SQL-Injection via Unicode-Payload ✅ SAFE
+
+**Risiko**: Angreifer sendet SQL-Schlüsselwörter oder Injektions-Strings als Unicode-Namen/Bio/Tags, in der Hoffnung, Encoding-Normalisierung oder Dekodierung ändert den String zu etwas Gefährlichem.
+**Befund**: SAFE — Alle Abfragen verwenden PDO-Prepared-Statements. Der Test `"'; DROP TABLE profiles; --"` wird als Literal-String gespeichert, nicht als SQL interpretiert.
+
+---
+
+### V-05 — Homograph-Angriff via Unicode-Lookalikes ⚠️ EXPOSED
+
+**Risiko**: Angreifer erstellt ein Profil mit einem Namen, der visuell identisch zu einem bestehenden Benutzer ist (z. B. `аdmin` mit kyrillischem `а` statt lateinischem `a`). Menschen, die den Namen lesen, können getäuscht werden.
+**Befund**: EXPOSED — Die API speichert und gibt Namen ohne Unicode-Normalisierung (NFC/NFD) oder Confusable-Erkennung unverändert zurück. Zwei Profile mit visuell identischen, aber Codepoint-verschiedenen Namen können koexistieren. Für hochvertrauenswürdige Kontexte (Admin-Benutzernamen, reservierte Namen) `Normalizer::normalize($name, Normalizer::FORM_C)` vor der Speicherung hinzufügen und auf Confusable-Zeichen über ICU oder eine dedizierte Bibliothek prüfen.
+
+---
+
+### V-06 — Überdimensioniertes Tags-Array DoS ✅ SAFE
+
+**Risiko**: Angreifer sendet `"tags": [1000 Elemente]`, um übermäßige Speicherzuteilung während der Verarbeitung auszulösen.
+**Befund**: SAFE — `count($rawTags) > 10`-Prüfung lehnt das Array bei 11+ Elementen vor jeder Elementverarbeitung ab. Gibt sofort 422 zurück.
+
+---
+
+### V-07 — JSON-Antwort-Kodierungs-Leck ✅ SAFE
+
+**Risiko**: Wenn der JSON-Encoder Literal-Nicht-ASCII-Bytes ohne ordnungsgemäße Content-Type-Charset-Deklaration ausgibt, könnten manche Clients die Kodierung falsch interpretieren.
+**Befund**: SAFE — Antwort hat `Content-Type: application/json` (Charset impliziert als UTF-8 per RFC 8259). `\uXXXX`-escapierte Ausgabe ist gültiges JSON und eindeutig.
+
+---
+
+### V-08 — ZWJ-Sequenz-Längen-Umgehung ✅ SAFE
+
+**Risiko**: Angreifer packt viele Graphem-Cluster in einen Namen, den `mb_strlen` als viele Codepoints zählt, in der Hoffnung, das Limit ist höher als die visuelle Darstellung.
+**Befund**: SAFE — `mb_strlen` zählt Codepoints, nicht Graphem-Cluster. `👨‍👩‍👧` (ZWJ-Sequenz von 5 Codepoints) zählt als 5, nicht 1.
+
+---
+
+### V-09 — Right-to-Left-Override (RTLO)-Injektion ✅ SAFE
+
+**Risiko**: Angreifer bettet Unicode-Steuerzeichen (U+202E, U+200F) in einen Namen ein, um angezeigten Text umzukehren und visuelle Täuschung in der UI zu erzeugen.
+**Befund**: SAFE — Die API speichert Text unverändert; Display-Layer-Sanitierung liegt in der Verantwortung des Frontends. Validierung lehnt Null-Bytes, aber keine anderen Unicode-Steuerzeichen ab. Für Admin-UIs U+202E, U+200F, U+2066–U+2069 vor dem Rendern entfernen oder escapen.
+
+---
+
+### V-10 — Unicode-Normalisierungs-Kollision ✅ SAFE
+
+**Risiko**: Zwei Namen, die identisch aussehen, aber sich in der Normalisierungsform (NFC vs. NFD) unterscheiden, könnten als verschiedene Benutzer behandelt werden.
+**Befund**: SAFE — Die API erzwingt keine NFC-Normalisierung; sie speichert, was sie empfängt. Für Anwendungsfälle, die kanonische Eindeutigkeit erfordern (E-Mail-äquivalente Felder), vor der Speicherung zu NFC normalisieren und auf der normalisierten Form einen Unique-Index setzen.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|--------|
+| V-01 | Null-Byte-Injektion | ✅ SAFE |
+| V-02 | Byte-Count-Überlauf via Multi-Byte-Zeichen | ✅ SAFE |
+| V-03 | Tag-Array-Typ-Injektion | ✅ SAFE |
+| V-04 | SQL-Injection via Unicode-Payload | ✅ SAFE |
+| V-05 | Homograph / visuell identischer Name | ⚠️ EXPOSED |
+| V-06 | Überdimensioniertes Tags-Array DoS | ✅ SAFE |
+| V-07 | JSON-Antwort-Kodierungs-Leck | ✅ SAFE |
+| V-08 | ZWJ-Sequenz-Längen-Umgehung | ✅ SAFE |
+| V-09 | RTLO-Richtungs-Override-Injektion | ✅ SAFE |
+| V-10 | Unicode-Normalisierungs-Kollision | ✅ SAFE |
+
+**9 SAFE, 1 EXPOSED** — V-05 (Homograph-Angriff) ist eine bekannte Einschränkung. Mit `Normalizer::normalize()` + Confusable-Erkennung für hochvertrauenswürdige Namensfelder abschwächen.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `strlen($name) > 50` für Zeichenlimit | Lehnt gültige 50-Zeichen-japanische Eingabe ab (150 Bytes); lässt 150-Zeichen-ASCII zu (unter Byte-Limit) |
+| Keine Null-Byte-Prüfung | `"Alice\x00Bob"` kann in C-String-Kontexten als `"Alice"` gespeichert werden; umgeht Eindeutigkeits-Prüfungen |
+| `preg_match('/^\w+$/', $name)` für Unicode-Namen | `\w` ist nur ASCII in PHP ohne das `u`-Flag; lehnt alle Nicht-ASCII-Eingaben ab |
+| ZWJ-Sequenzen in Länge ignorieren | ZWJ-Sequenzen zählen als mehrere Codepoints; erwartetes Verhalten mit `mb_strlen` |
+| Tags als komma-getrennte Zeichenkette speichern | Kann nicht zuverlässig bei Kommas in Tag-Werten aufgeteilt werden; JSON-Array verwenden |
+| Tags als JSON-String statt Array zurückgeben | Clients müssen doppelt dekodieren; gespeichertes JSON immer vor der Antwort dekodieren |

--- a/docs/de/howto/upvote-downvote-api.md
+++ b/docs/de/howto/upvote-downvote-api.md
@@ -1,0 +1,231 @@
+# Anleitung: Upvote-/Downvote-API
+
+> **FT-Referenz**: FT347 (`NENE2-FT/votelog`) — Benutzer-spezifisches Upvote/Downvote mit Toggle-Off (gleiche Richtung zweimal entfernt Stimme), Richtungswechsel (auf→ab atomar), Score-Aggregation (Upvotes − Downvotes), UNIQUE(user_id, item_id)-Bedingung, 15 Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Reddit/Stack Overflow-ähnliches Abstimmungssystem implementiert wird: Jeder Benutzer kann eine Stimme pro Element abgeben, sie durch erneute Abstimmung in derselben Richtung ausschalten oder die Richtung ändern.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE votes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    direction  TEXT    NOT NULL CHECK (direction IN ('up', 'down')),
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, item_id),
+    FOREIGN KEY (user_id)  REFERENCES users(id),
+    FOREIGN KEY (item_id)  REFERENCES items(id)
+);
+```
+
+`UNIQUE(user_id, item_id)` erzwingt eine Stimme pro Benutzer pro Element. `CHECK(direction IN ('up', 'down'))` lehnt jeden anderen Wert auf DB-Ebene ab.
+
+## Endpunkte
+
+| Methode | Pfad                          | Beschreibung                       |
+|---------|-------------------------------|------------------------------------|
+| `POST` | `/items/{id}/vote`            | Stimme abgeben, umschalten oder ändern |
+| `GET`  | `/items/{id}/score`           | Element-Score abrufen              |
+| `GET`  | `/items/{id}/vote/{userId}`   | Aktuelle Stimme des Benutzers abrufen |
+
+## Stimme abgeben
+
+```php
+POST /items/1/vote
+{"user_id": 42, "direction": "up"}
+
+→ 200
+{
+  "vote": "up",
+  "score": {
+    "upvotes": 1,
+    "downvotes": 0,
+    "score": 1
+  }
+}
+```
+
+```php
+POST /items/1/vote
+{"user_id": 43, "direction": "down"}
+→ 200  {"vote": "down", "score": {"upvotes": 1, "downvotes": 1, "score": 0}}
+```
+
+## Toggle-Off (Gleiche Richtung zweimal)
+
+In **derselben Richtung** ein zweites Mal abstimmen entfernt die Stimme:
+
+```php
+// Erste Stimme
+POST /items/1/vote  {"user_id": 42, "direction": "up"}
+→ 200  {"vote": "up", "score": {"score": 1}}
+
+// Zweite Stimme in gleicher Richtung → Toggle-Off
+POST /items/1/vote  {"user_id": 42, "direction": "up"}
+→ 200  {"vote": null, "score": {"score": 0}}
+```
+
+`vote: null` bedeutet, der Benutzer hat keine aktive Stimme für dieses Element.
+
+## Richtungswechsel
+
+In die **entgegengesetzte Richtung** abstimmen kippt die bestehende Stimme atomar:
+
+```php
+// Mit Upvote beginnen
+POST /items/1/vote  {"user_id": 42, "direction": "up"}
+→ 200  {"vote": "up", "score": {"upvotes": 1, "downvotes": 0, "score": 1}}
+
+// Zu Downvote wechseln
+POST /items/1/vote  {"user_id": 42, "direction": "down"}
+→ 200  {"vote": "down", "score": {"upvotes": 0, "downvotes": 1, "score": -1}}
+```
+
+## Score abrufen
+
+```php
+GET /items/1/score
+
+→ 200
+{
+  "upvotes": 2,
+  "downvotes": 1,
+  "score": 1         // Upvotes − Downvotes
+}
+```
+
+Score für ein Element ohne Stimmen:
+
+```php
+GET /items/1/score   // noch keine Stimmen
+→ 200  {"upvotes": 0, "downvotes": 0, "score": 0}
+```
+
+## Benutzer-Stimm-Status abrufen
+
+```php
+// Noch keine Stimme abgegeben
+GET /items/1/vote/42
+→ 200  {"vote": null}
+
+// Nach Upvote
+GET /items/1/vote/42
+→ 200  {"vote": "up"}
+
+// Nach Toggle-Off
+GET /items/1/vote/42
+→ 200  {"vote": null}
+```
+
+## Implementierung
+
+### Stimm-Handler-Logik
+
+```php
+public function vote(int $itemId, int $userId, string $direction): array
+{
+    $item = $this->repo->findItem($itemId);
+    if ($item === null) {
+        throw new ItemNotFoundException($itemId);
+    }
+
+    $existing = $this->repo->findVote($userId, $itemId);
+
+    if ($existing !== null && $existing['direction'] === $direction) {
+        // Gleiche Richtung → Toggle-Off
+        $this->repo->deleteVote($userId, $itemId);
+        $activeDirection = null;
+    } elseif ($existing !== null) {
+        // Andere Richtung → an Ort und Stelle aktualisieren
+        $this->repo->updateVote($userId, $itemId, $direction, $now);
+        $activeDirection = $direction;
+    } else {
+        // Neue Stimme
+        $this->repo->insertVote($userId, $itemId, $direction, $now);
+        $activeDirection = $direction;
+    }
+
+    $score = $this->repo->getScore($itemId);
+
+    return [
+        'vote'  => $activeDirection,
+        'score' => $score,
+    ];
+}
+```
+
+### Score-Aggregations-SQL
+
+```sql
+SELECT
+    COALESCE(SUM(CASE WHEN direction = 'up'   THEN 1 ELSE 0 END), 0) AS upvotes,
+    COALESCE(SUM(CASE WHEN direction = 'down' THEN 1 ELSE 0 END), 0) AS downvotes,
+    COALESCE(SUM(CASE WHEN direction = 'up'   THEN 1 ELSE -1 END), 0) AS score
+FROM votes
+WHERE item_id = ?
+```
+
+`COALESCE(..., 0)` stellt Null-Werte sicher, wenn keine Stimmen existieren (SUM einer leeren Menge gibt NULL zurück).
+
+### Stimm-UPSERT-Muster
+
+```sql
+-- Neue Stimme einfügen
+INSERT INTO votes (user_id, item_id, direction, created_at) VALUES (?, ?, ?, ?)
+
+-- Richtung aktualisieren (UNIQUE-Bedingung verhindert Duplikat)
+UPDATE votes SET direction = ? WHERE user_id = ? AND item_id = ?
+
+-- Löschen (Toggle-Off)
+DELETE FROM votes WHERE user_id = ? AND item_id = ?
+```
+
+## Validierung
+
+```php
+// Ungültige Richtung
+POST /items/1/vote  {"user_id": 42, "direction": "sideways"}
+→ 422  // Richtung muss 'up' oder 'down' sein
+
+// Element existiert nicht
+POST /items/9999/vote  {"user_id": 42, "direction": "up"}
+→ 404
+```
+
+## Mehrere Benutzer
+
+```php
+// Drei Benutzer stimmen für dasselbe Element
+POST /items/1/vote  {"user_id": 1, "direction": "up"}
+POST /items/1/vote  {"user_id": 2, "direction": "up"}
+POST /items/1/vote  {"user_id": 3, "direction": "down"}
+
+GET /items/1/score
+→ 200  {"upvotes": 2, "downvotes": 1, "score": 1}
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Kein `UNIQUE(user_id, item_id)` | Benutzer können mehrmals abstimmen und Scores aufblähen |
+| `INSERT OR REPLACE` für Richtungswechsel | Generiert neue `id` und `created_at`; verliert Abstimmungshistorie; bricht Prüfpfade |
+| 409 bei Toggle-Off zurückgeben | Toggle-Off ist erwartetes Verhalten, kein Fehler; neuen (null) Stimm-Status zurückgeben |
+| Score in Anwendung durch Laden aller Stimmen berechnen | O(N) pro Anfrage; SQL-Aggregation mit einzelner Abfrage verwenden |
+| `direction: null` im Body zum Entfernen der Stimme erlauben | Mehrdeutig; Toggle-Muster (gleiche Richtung zweimal) oder separaten DELETE-Endpunkt verwenden |
+| `COALESCE` in Score-Aggregation weglassen | `SUM()` gibt `NULL` zurück, wenn keine Zeilen übereinstimmen; `null − null` verursacht Abstürze oder falschen Typ |

--- a/docs/de/howto/url-bookmark-api.md
+++ b/docs/de/howto/url-bookmark-api.md
@@ -1,0 +1,176 @@
+# Anleitung: URL-Lesezeichen-API mit Tag-Filterung
+
+> **FT-Referenz**: FT265 (`NENE2-FT/linklog`) — URL-Lesezeichen-API: UNIQUE-URL-Bedingung, komma-getrennte Tag-Speicherung, LIKE-basiertes Tag-Matching
+
+Demonstriert eine Lesezeichen-API, die URLs mit Tags als komma-getrennte TEXT-Spalte speichert.
+Doppelte URLs werden über eine `UNIQUE`-Bedingung erkannt und als `DuplicateUrlException`
+auf 409 Conflict abgebildet. Tag-Filterung verwendet vier LIKE-Muster, um einen Tag unabhängig
+von seiner Position in der komma-getrennten Zeichenkette zu treffen.
+
+---
+
+## Routen
+
+| Methode   | Pfad          | Beschreibung                                       |
+|-----------|---------------|----------------------------------------------------|
+| `POST`   | `/links`      | Lesezeichen erstellen                              |
+| `GET`    | `/links`      | Lesezeichen auflisten (Suche + Tag-Filter, paginiert) |
+| `GET`    | `/links/{id}` | Einzelnes Lesezeichen abrufen                      |
+| `DELETE` | `/links/{id}` | Lesezeichen löschen                                |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS links (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    url         TEXT    NOT NULL UNIQUE,
+    title       TEXT    NOT NULL,
+    description TEXT    NOT NULL DEFAULT '',
+    tags        TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL
+);
+```
+
+`url TEXT NOT NULL UNIQUE` erzwingt ein Lesezeichen pro URL auf DB-Ebene.
+`tags TEXT` speichert eine komma-getrennte Liste (z. B. `"php,api,rest"`). Dies vermeidet eine separate
+`link_tags`-Join-Tabelle für kleine Anwendungsfälle.
+
+---
+
+## Tags: Komma-getrennte TEXT vs. M:N-Join-Tabelle
+
+| Ansatz | Abfrage-Komplexität | Wann verwenden |
+|--------|---------------------|----------------|
+| Komma-getrennte TEXT | LIKE-Muster (4 pro Tag) | Kleine Datensätze; seltene Tag-Abfragen |
+| M:N-Join-Tabelle (`link_tags`) | JOIN + GROUP BY oder IN | Große Datensätze; häufige AND/OR-Filterung |
+| FTS5 mit Tags-Spalte | `WHERE fts MATCH ?` | Volltextsuche über mehrere Spalten |
+
+Komma-getrennte TEXT ist einfacher zu implementieren und geeignet, wenn die Anzahl der Links und Tags
+gering ist. Für Datensätze mit Tausenden von Links und komplexen Tag-Abfragen (AND-Filter, exakte
+Anzahlen) ist eine Join-Tabelle (siehe [`multi-value-tag-filter.md`](multi-value-tag-filter.md)) vorzuziehen.
+
+---
+
+## Tag-LIKE-Matching: Vier Muster
+
+Ein in einer komma-getrennten Spalte gespeicherter Tag kann an vier Positionen erscheinen:
+1. **Exakte Übereinstimmung**: `tags = 'php'` (einziger Tag)
+2. **Am Anfang**: `tags LIKE 'php,%'` (erster von mehreren)
+3. **In der Mitte**: `tags LIKE '%,php,%'` (nicht erster, nicht letzter)
+4. **Am Ende**: `tags LIKE '%,php'` (letzter von mehreren)
+
+```php
+if ($tags !== null) {
+    foreach ($tags as $tag) {
+        $sql      .= ' AND (tags = ? OR tags LIKE ? OR tags LIKE ? OR tags LIKE ?)';
+        $params[]  = $tag;            // exakt: "php"
+        $params[]  = $tag . ',%';     // Präfix: "php,..."
+        $params[]  = '%,' . $tag . ',%';  // Mitte: "...,php,..."
+        $params[]  = '%,' . $tag;     // Suffix: "...,php"
+    }
+}
+```
+
+Alle vier Muster sind pro Tag mit AND verknüpft: Ein Link muss alle angeforderten Tags erfüllen. Dies implementiert
+einen AND-Filter über Tags. Jedes `?` ist eine parametrisierte Bindung — kein Injektionsrisiko.
+
+**Einschränkung**: Eine Abfrage nach Tag `ph` würde KEINEN gespeicherten Tag `php` treffen, weil
+die Muster exakte Begrenzer (`,` oder Zeichenkettengrenzen) prüfen. Tags werden durch exakten
+Zeichenkettenwert verglichen, nicht durch Teilzeichenkette.
+
+---
+
+## Komma-getrennte Tag-Serialisierung und Deserialisierung
+
+**Speichern**: `implode(',', $tags)` — `['php', 'api', 'rest']` → `'php,api,rest'`
+
+**Lesen**: 
+```php
+$tagsStr = (string) $row['tags'];
+$tags    = $tagsStr === '' ? [] : array_values(array_filter(explode(',', $tagsStr)));
+```
+
+`array_filter()` entfernt leere Strings, die durch führende/nachfolgende Kommas oder Doppelkommas erstellt werden.
+`array_values()` reindiziert auf eine `list<string>`.
+
+**Tag-Abfrage-Parsing**: `?tags=php,api` → nach Komma aufteilen → `['php', 'api']`
+
+```php
+$rawTags = QueryStringParser::string($request, 'tags');
+$tags    = $rawTags !== null
+    ? array_values(array_filter(array_map('trim', explode(',', $rawTags))))
+    : null;
+```
+
+---
+
+## Doppelte URL: Benutzerdefinierte Exception + Handler
+
+```php
+public function create(string $url, ...): Link
+{
+    try {
+        $this->executor->execute(
+            'INSERT INTO links (url, title, description, tags, created_at) VALUES (?, ?, ?, ?, ?)',
+            [$url, $title, $description, implode(',', $tags), $createdAt],
+        );
+    } catch (DatabaseConnectionException $e) {
+        $previous = $e->getPrevious();
+        if ($previous !== null && str_contains($previous->getMessage(), 'UNIQUE constraint failed')) {
+            throw new DuplicateUrlException($url);
+        }
+        throw $e;
+    }
+
+    return new Link($this->executor->lastInsertId(), ...);
+}
+```
+
+Das Repository fängt die generische `DatabaseConnectionException` (vom Framework geworfen, wenn eine
+PDO-Exception auftritt), untersucht die Meldung der vorherigen Exception nach `UNIQUE constraint failed`
+und wirft erneut als domänenspezifische `DuplicateUrlException`. Dies hält die Domänensprache
+(`DuplicateUrlException`) von dem Infrastrukturdetail (`PDOException`) getrennt.
+
+Das `DuplicateUrlExceptionHandler`-Middleware fängt `DuplicateUrlException` ab und gibt
+409 Conflict Problem Details zurück:
+
+```php
+return $this->problems->create($request, 'duplicate-url', 'URL already exists.', 409, $e->url);
+```
+
+---
+
+## Suche: LIKE auf Titel und URL
+
+```php
+if ($search !== null) {
+    $sql      .= ' AND (title LIKE ? OR url LIKE ?)';
+    $params[]  = '%' . $search . '%';
+    $params[]  = '%' . $search . '%';
+}
+```
+
+Die Suchanfrage wird sowohl auf `title`- als auch auf `url`-Spalten angewendet. Eine einzelne `$search`-Bindung
+wird für beide Spalten wiederholt. Wie bei der Tag-Filterung ist der Wildcard `%` ein SQL-Literal in
+der Abfragezeichenkette, nicht aus Benutzereingaben — der Suchbegriff des Benutzers wird als Parameter gebunden.
+
+---
+
+## Beispiel: Tag-AND-Filter
+
+**Anfrage**: `GET /links?tags=php,api`
+
+Trifft Links, die BEIDE `php` UND `api` in ihrer `tags`-Spalte haben:
+- `"php,api"` ✓ (php: Präfix-Match, api: Suffix-Match)
+- `"rest,php,api"` ✓ (php: Mitte-Match, api: Suffix-Match)
+- `"php"` ✗ (fehlendes `api`)
+
+---
+
+## Verwandte Anleitungen
+
+- [`multi-value-tag-filter.md`](multi-value-tag-filter.md) — M:N-Join-Tabelle mit AND/OR-Tag-Filterung (für größere Datensätze)
+- [`sqlite-fts5-search.md`](sqlite-fts5-search.md) — FTS5-Volltextsuche als Alternative zu LIKE
+- [`sql-injection-defence.md`](sql-injection-defence.md) — Parametrisierte LIKE-Muster und Injektions-Abwehr

--- a/docs/de/howto/url-shortener-ssrf-prevention.md
+++ b/docs/de/howto/url-shortener-ssrf-prevention.md
@@ -1,0 +1,257 @@
+# Anleitung: URL-Verkürzer mit SSRF-Prävention
+
+> **FT-Referenz**: FT337 (`NENE2-FT/shortlog`) — URL-Verkürzer mit SSRF-Blocking (private IPs, Loopback, Link-Local, gefährliche Schemata), Slug-Validierung, Mass-Assignment-Prävention, ISO 8601-Datumsvalidierung, ReDoS-sichere Limit-Parsing, 50+ Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie ein URL-Verkürzer gebaut wird, der nur sichere öffentliche URLs akzeptiert, Slugs validiert, Mass Assignment verhindert und vor Server-Side Request Forgery (SSRF) schützt.
+
+## Schema
+
+```sql
+CREATE TABLE links (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL,
+    slug         TEXT    NOT NULL UNIQUE,
+    original_url TEXT    NOT NULL,
+    expires_at   TEXT,               -- ISO 8601, nullable
+    click_count  INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/links` | Kurzlink erstellen |
+| `GET`  | `/links` | Eigene Links auflisten |
+| `GET`  | `/links/{slug}` | Link nach Slug abrufen |
+| `DELETE` | `/links/{slug}` | Eigenen Link löschen |
+
+## Kurzlink erstellen
+
+```php
+POST /links
+X-User-Id: 1
+{
+  "original_url": "https://example.com/very/long/path",
+  "slug": "my-link",
+  "expires_at": "2030-12-31T23:59:59+09:00"
+}
+→ 201
+{
+  "id": 1,
+  "user_id": 1,
+  "slug": "my-link",
+  "original_url": "https://example.com/very/long/path",
+  "expires_at": "2030-12-31T23:59:59+09:00",
+  "click_count": 0,
+  "created_at": "..."
+}
+```
+
+`slug` ist optional — automatisch generiert (`[a-z0-9_-]+`), wenn weggelassen.
+
+### Fehlende Authentifizierung
+
+```php
+POST /links  (kein X-User-Id-Header)
+→ 401
+```
+
+### Doppelter Slug
+
+```php
+POST /links  {"slug": "my-link"}  // existiert bereits
+→ 409
+```
+
+## Slug-Validierung
+
+```
+Gültig: Kleinbuchstaben, Ziffern, Bindestriche, Unterstriche
+Länge: 3–20 Zeichen
+
+Gültige Beispiele: "abc", "my-link", "link123", "test-link-01"
+```
+
+```php
+POST /links  {"slug": "ab"}          → 422  // zu kurz (min 3)
+POST /links  {"slug": "a".repeat(21)} → 422  // zu lang (max 20)
+POST /links  {"slug": "MySlug"}       → 422  // Großbuchstaben nicht erlaubt
+POST /links  {"slug": "sl@g!"}        → 422  // Sonderzeichen
+POST /links  {"slug": "my slug"}      → 422  // Leerzeichen nicht erlaubt
+POST /links  {"slug": 42}             → 422  // Typ muss String sein (VULN-B)
+```
+
+## URL-Validierung
+
+```php
+POST /links  {"original_url": ""}              → 422  // leer
+POST /links  {}                                → 422  // fehlend
+POST /links  {"original_url": 42}              → 422  // kein String (VULN-B)
+POST /links  {"original_url": true}            → 422  // bool (VULN-B)
+POST /links  {"original_url": null}            → 422  // null (VULN-B)
+POST /links  {"original_url": "https://..."+"x".repeat(2030)}  → 422  // zu lang
+```
+
+## SSRF-Prävention
+
+URLs blockieren, die den Server dazu bringen würden, interne Infrastruktur aufzurufen:
+
+### Blockierte Schemata
+
+```php
+POST /links  {"original_url": "javascript:alert(1)"}  → 422
+POST /links  {"original_url": "file:///etc/passwd"}   → 422
+POST /links  {"original_url": "ftp://example.com/"}   → 422
+```
+
+Nur `http://` und `https://` sind erlaubt.
+
+### Blockierte IP-Bereiche
+
+```php
+// Loopback
+POST /links  {"original_url": "http://127.0.0.1/admin"}     → 422
+POST /links  {"original_url": "http://localhost/secret"}     → 422
+POST /links  {"original_url": "http://internal.localhost/"}  → 422  // *.localhost
+
+// RFC 1918 private Bereiche
+POST /links  {"original_url": "http://10.0.0.1/metadata"}    → 422
+POST /links  {"original_url": "http://192.168.1.1/router"}   → 422
+POST /links  {"original_url": "http://172.16.0.1/internal"}  → 422
+
+// Link-Local (AWS-Metadata, etc.)
+POST /links  {"original_url": "http://169.254.169.254/latest/meta-data/"}  → 422
+
+// Öffentliche IP — akzeptiert
+POST /links  {"original_url": "https://8.8.8.8/"}            → 201  ✅
+```
+
+### DNS-Rebinding-Prävention
+
+Hostnamen, die auf private IPs aufgelöst werden, sind ebenfalls blockiert:
+
+```php
+// "private.internal" löst auf 10.0.0.1 → blockiert
+POST /links  {"original_url": "http://private.internal/data"}  → 422
+
+// "public.example.com" löst auf 93.184.216.34 → erlaubt
+POST /links  {"original_url": "https://public.example.com/page"}  → 201  ✅
+```
+
+### Implementierung
+
+```php
+private const BLOCKED_RANGES = [
+    '127.',          // Loopback
+    '10.',           // RFC 1918
+    '172.16.', '172.17.', '172.18.', '172.19.',
+    '172.20.', '172.21.', '172.22.', '172.23.',
+    '172.24.', '172.25.', '172.26.', '172.27.',
+    '172.28.', '172.29.', '172.30.', '172.31.',  // RFC 1918
+    '192.168.',      // RFC 1918
+    '169.254.',      // Link-Local
+];
+
+private const ALLOWED_SCHEMES = ['http', 'https'];
+
+public function validate(string $url): bool
+{
+    $parsed = parse_url($url);
+    if (!$parsed || !in_array($parsed['scheme'] ?? '', self::ALLOWED_SCHEMES, true)) {
+        return false;
+    }
+
+    $host = $parsed['host'] ?? '';
+
+    // *.localhost blockieren
+    if ($host === 'localhost' || str_ends_with($host, '.localhost')) {
+        return false;
+    }
+
+    // Hostnamen zu IP auflösen
+    $ip = ($this->dnsResolver)($host);
+
+    foreach (self::BLOCKED_RANGES as $prefix) {
+        if (str_starts_with($ip, $prefix)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+```
+
+## Mass-Assignment-Prävention
+
+```php
+// Angreifer versucht click_count oder created_at zu setzen
+POST /links
+{
+  "original_url": "https://example.com",
+  "slug": "attack",
+  "click_count": 999999,
+  "created_at": "2000-01-01T00:00:00+00:00"
+}
+→ 201  {"click_count": 0, "created_at": "2026-..."}  // ignorierte Felder
+```
+
+Nur `original_url`, `slug`, `expires_at` aus dem Request-Body auf die Allowlist setzen. Niemals `click_count`, `created_at` oder `user_id` aus dem Body lesen.
+
+## ISO 8601-Datumsvalidierung
+
+```php
+// Ungültige Kalenderdaten
+POST /links  {"expires_at": "2024-02-30T00:00:00+00:00"}  → 422  // Feb 30
+POST /links  {"expires_at": "2024-13-01T00:00:00+00:00"}  → 422  // Monat 13
+POST /links  {"expires_at": "2030-06-01T00:00:00+25:00"}  → 422  // +25:00 Offset
+
+// Gültig
+POST /links  {"expires_at": "2030-06-01T00:00:00+09:00"}  → 201  ✅
+```
+
+Validierungsmuster: mit `DateTimeImmutable::createFromFormat()` parsen und den Round-Trip verifizieren:
+
+```php
+$dt = DateTimeImmutable::createFromFormat(DATE_RFC3339, $value);
+if ($dt === false) return false;
+// Round-Trip-Prüfung fängt "2024-02-30" ab, das PHP zu "2024-03-01" normalisiert
+return $dt->format(DATE_RFC3339) === $value;
+```
+
+## ReDoS-sichere Limit-Validierung
+
+```php
+// ctype_digit für O(n) — immun gegen ReDoS
+GET /links?limit=10       → 200  ✅
+GET /links?limit=999999   → 422  // überschreitet MAX_LIMIT
+GET /links?limit=9...9 (19 Ziffern)  → 422  // Überlaufschutz
+GET /links?limit=111...1x (51 Zeichen mit x)  → 422, <100ms  // ReDoS-Payload
+```
+
+## IDOR-Prävention
+
+```php
+// Benutzer 2 versucht den Link von Benutzer 1 zu löschen
+DELETE /links/user1-link
+X-User-Id: 2
+→ 404  // NICHT 403 — verhindert Aufzählung
+```
+
+Der Link existiert, aber der Lookup ist auf `WHERE slug = ? AND user_id = ?` begrenzt. Eine Abweichung gibt 404 zurück, als ob der Link nicht existiert.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `http://localhost` oder `http://127.0.0.1` erlauben | Server ruft seinen eigenen Admin-Endpunkt über den Kurzlink auf |
+| DNS-Auflösungs-Prüfung überspringen | Angreifer registriert `evil.example.com` → A-Eintrag `10.0.0.1`, um IP-Literal-Prüfung zu umgehen |
+| `javascript:`-Schema erlauben | XSS über Kurzlink in jedem Browser, der die Weiterleitung öffnet |
+| `file://`-Schema erlauben | Server liest `/etc/passwd`, wenn der Verkürzer die URL bei der Erstellung abruft |
+| `click_count` aus dem Request-Body akzeptieren | Angreifer bläst Klick-Metriken auf |
+| Keine Slug-Längen-/Zeichensatz-Einschränkung | `slug = "' OR 1=1--"` besteht Validierung, erreicht SQL |
+| Regex `/^\d+$/` für Limit-Validierung verwenden | ReDoS auf langen gemischten Ziffern-Payloads |
+| `created_at` aus dem Request-Body zurückgeben | Zeitspoofing korrumpiert Prüfpfad |

--- a/docs/de/howto/url-shortener-ssrf.md
+++ b/docs/de/howto/url-shortener-ssrf.md
@@ -1,0 +1,354 @@
+# URL-Verkürzer-API & SSRF-Prävention
+
+**FT183** — `shortlog`-Field-Trial (Schwachstellen-Diagnose VULN-A～L).
+
+Ein URL-Verkürzer lässt Benutzer beliebige URLs als Weiterleitungsziele einreichen. Wenn die
+Weiterleitung serverseitig (z. B. für Link-Vorschau oder Analysen) ohne Validierung verfolgt wird,
+können Angreifer sie auf interne Dienste zeigen — dies ist ein **Server-Side Request Forgery (SSRF)**-Angriff.
+
+Diese Anleitung behandelt SSRF-Prävention neben der vollständigen VULN-A～L-Sicherheitsüberprüfung
+der Shortlog-Implementierung.
+
+---
+
+## SSRF: Das Kernrisiko
+
+Ein URL-Verkürzer speichert und ruft möglicherweise eine angreifer-kontrollierte URL ab. SSRF
+ermöglicht einem Angreifer:
+
+- Interne Dienste zu erreichen: `http://10.0.0.1/admin`, `http://192.168.1.1/`
+- Cloud-Metadaten zu treffen: `http://169.254.169.254/latest/meta-data/` (AWS IMDS)
+- Lokale Dateien zu lesen: `file:///etc/passwd`
+- Browser-Skripte auszuführen: `javascript:alert(1)`
+- Loopback-Dienste zuzugreifen: `http://127.0.0.1:8080/`
+
+**Die Lösung:** Das Schema der URL _und_ die Ziel-IP vor der Speicherung validieren.
+
+---
+
+## URL-Validierungsstrategie (VULN-K)
+
+### Schritt 1 — Schema-Allowlist
+
+`filter_var($url, FILTER_VALIDATE_URL)` allein ist **nicht ausreichend** — es akzeptiert
+`javascript:alert(1)` und `ftp://` als gültige URLs. `parse_url()` und eine
+explizite Schema-Allowlist verwenden:
+
+```php
+$parts = parse_url($url);
+
+if ($parts === false || !isset($parts['scheme'], $parts['host'])) {
+    return false;   // Fehlerhafte URL — kein Schema oder Host
+}
+
+if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+    return false;   // Lehnt ab: javascript:, file://, ftp://, data:, etc.
+}
+```
+
+`parse_url()` ist kein Regex — er kann nicht für ReDoS ausgenutzt werden (VULN-F).
+
+### Schritt 2 — Host-/IP-Validierung
+
+```php
+$host = strtolower($parts['host']);
+
+// IPv6-Klammern entfernen: [::1] → ::1
+if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
+    $host = substr($host, 1, -1);
+}
+
+// Localhost und *.localhost-Aliase blockieren
+if ($host === 'localhost' || str_ends_with($host, '.localhost')) {
+    return false;
+}
+
+// Wenn Host ein IP-Literal ist, direkt prüfen
+if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+    return !isBlockedIp($host);
+}
+
+// Andernfalls Hostnamen auflösen → aufgelöste IP prüfen
+$resolved = gethostbyname($host);
+
+if ($resolved !== $host) {   // false wenn nicht auflösbar
+    return !isBlockedIp($resolved);
+}
+// Nicht auflösbarer Hostname → erlauben (kann eine gültige Domain sein, die vom Server nicht erreichbar ist)
+return true;
+```
+
+### Schritt 3 — Private-/reservierte-IP-Prüfung
+
+```php
+function isBlockedIp(string $ip): bool
+{
+    // IPv6-Loopback
+    if ($ip === '::1') return true;
+
+    // FILTER_FLAG_NO_PRIV_RANGE: blockiert 10.x, 172.16-31.x, 192.168.x
+    // FILTER_FLAG_NO_RES_RANGE:  blockiert 127.x, 169.254.x, 0.x, 240.x+
+    return filter_var(
+        $ip,
+        FILTER_VALIDATE_IP,
+        FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+    ) === false;
+}
+```
+
+### DNS-Rebinding-Vorsicht
+
+DNS-Rebinding-Angriffe ändern die IP einer Domain _nach_ der Validierung. Für
+kritische Anwendungsfälle die URL auch _zum Abrufzeitpunkt_ validieren (nicht nur beim Speichern),
+oder eine Netzwerk-Ebene-Egress-Firewall verwenden, die private Bereiche blockiert.
+
+---
+
+## Resolver für Tests injizieren
+
+DNS-Aufrufe in Unit-Tests sind langsam und nicht-deterministisch. Den Resolver
+injizierbar machen:
+
+```php
+final class UrlValidator
+{
+    /** @param (callable(string): string)|null $ipResolver */
+    public function __construct(private readonly mixed $ipResolver = null)
+    {
+    }
+
+    private function resolveHost(string $host): string
+    {
+        /** @var callable(string): string $resolver */
+        $resolver = $this->ipResolver ?? static fn (string $h): string => gethostbyname($h);
+        return $resolver($host);
+    }
+}
+```
+
+In Tests:
+
+```php
+$stubResolver = static function (string $host): string {
+    return match ($host) {
+        'private.internal'   => '10.0.0.1',       // privat → blockiert
+        'public.example.com' => '93.184.216.34',  // öffentlich → erlaubt
+        default              => $host,             // nicht auflösbar → erlaubt
+    };
+};
+
+$validator = new UrlValidator($stubResolver);
+```
+
+---
+
+## VULN-A～L-Assessment-Ergebnisse
+
+### VULN-A — Integer-Überlauf (`limit`-Query-Parameter)
+
+`V::queryInt()` verwendet `ctype_digit()` + `strlen() > 18`-Guard.
+20-stellige und 19-stellige Strings werden vor dem `(int)`-Cast abgelehnt.
+
+```
+✅ BESTANDEN — Überlaufschutz verhindert stillen PHP_INT_MAX-Wrap
+```
+
+### VULN-B — Typverwirrung (URL / Slug aus JSON-Body)
+
+`V::str()` erzwingt `is_string()` — lehnt `int 42`, `bool true`, `null` ab.
+
+```php
+V::str($body['original_url'] ?? null, 2048)  // → null für Nicht-String
+V::str($body['slug'] ?? null, 20)            // → null für Nicht-String
+```
+
+```
+✅ BESTANDEN — String-Typ vor jeder URL- oder Slug-Validierung durchgesetzt
+```
+
+### VULN-C — SQL-Injection
+
+Alle Abfragen verwenden PDO-parametrisierte Statements:
+
+```php
+'SELECT ... FROM links WHERE slug = :slug LIMIT 1'
+// → $stmt->execute([':slug' => $slug])
+```
+
+`'; DROP TABLE links; --'` schlägt bei Slug-Format-Validierung (SLUG_PATTERN) fehl,
+bevor die DB erreicht wird. Selbst wenn sie die DB erreichte, verhindern parametrisierte Abfragen
+die Ausführung.
+
+```
+✅ BESTANDEN — parametrisierte Abfragen + Slug-Allowlist
+```
+
+### VULN-D — Parameter-Pollution
+
+PSR-7 `getQueryParams()` ruft PHPs `parse_str()` auf, das den _letzten_
+Wert für doppelte Schlüssel nimmt. `?limit=10&limit=999999` senden → `limit=999999`,
+was die `V::queryInt()`-Bereichsprüfung fehlschlägt (> MAX_LIMIT).
+
+```
+✅ BESTANDEN — Bereichsprüfung fängt jeden einzelnen Wert; kein Absturz
+```
+
+### VULN-E — IDOR (benutzerübergreifender Link-Zugriff)
+
+DELETE verwendet `deleteForUser($slug, $userId)`:
+
+```sql
+DELETE FROM links WHERE slug = :slug AND user_id = :user_id
+```
+
+`DELETE /links/user-a-slug` von Benutzer B mit seiner eigenen `X-User-Id` gibt 404 zurück
+(die Zeile ist nicht gelöscht; sie entspricht einfach nicht der WHERE-Klausel).
+
+```
+✅ BESTANDEN — Eigentümerschaft auf DB-Ebene durchgesetzt; 404 vermeidet Aufzählung
+```
+
+### VULN-F — ReDoS-Immunität
+
+URL-Validierung verwendet `parse_url()` (C-Erweiterung, kein Backtracking).
+Slug-Validierung verwendet einen einfachen verankerten Regex ohne Alternationsgruppen.
+`V::queryInt()` verwendet `ctype_digit()` (O(n), immun gegen Backtracking).
+
+```
+✅ BESTANDEN — kein exponentieller-Backtracking-Regex auf nicht-vertrauenswürdiger Eingabe
+```
+
+### VULN-G — Pfad-Traversal
+
+Kein Dateisystemzugriff in dieser API. Nicht anwendbar.
+
+```
+N/A
+```
+
+### VULN-H — Timing-Angriffe auf Geheimnis-Vergleich
+
+`V::secret()` delegiert an `hash_equals()` — Konstantzeit unabhängig davon, wo
+Strings sich unterscheiden. Vermeidet Early-Exit-String-Vergleich, der Längen-/Präfixinformationen
+über Timing leckt.
+
+```
+✅ BESTANDEN — hash_equals() verhindert Timing-Oracle
+```
+
+### VULN-I — Leeres-erwartetes-Geheimnis-Bypass
+
+`V::secret('', '')` → `false`. Ein unkonfigurierter API-Schlüssel gewährt niemals Zugriff:
+
+```php
+return $expected !== '' && hash_equals($expected, $actual);
+```
+
+```
+✅ BESTANDEN — leeres Erwartetes gibt immer false zurück
+```
+
+### VULN-J — ISO 8601-Datums-Überlauf in `expires_at`
+
+`V::isoDatetime()` verwendet `DateTimeImmutable::createFromFormat(DATE_ATOM, ...)` +
+Round-Trip-Vergleich. `2024-02-30T00:00:00+00:00` rollt in PHP zu Mär. 1;
+der neu formatierte String entspricht nicht der Eingabe → null.
+
+`+25:00` Offset: von expliziter `$tzHours > 14` Bereichsprüfung abgefangen.
+
+```
+✅ BESTANDEN — Round-Trip fängt Überlauf-Daten; explizite Offset-Bereichsprüfung fängt +25:00
+```
+
+### VULN-K — SSRF
+
+Ohne URL-Validierung: `http://127.0.0.1/admin`, `http://169.254.169.254/`,
+`http://10.0.0.1/`, `javascript:alert(1)`, `file:///etc/passwd` würden alle
+gespeichert und möglicherweise abgerufen.
+
+Mit `UrlValidator`:
+
+| Eingabe | Blockiergrund |
+|---------|---------------|
+| `http://127.0.0.1/` | Loopback-IP (`NO_RES_RANGE`) |
+| `http://localhost/` | exakte Übereinstimmung `'localhost'` |
+| `http://internal.localhost/` | `.localhost`-Suffix |
+| `http://10.0.0.1/` | Private IP (`NO_PRIV_RANGE`) |
+| `http://192.168.1.1/` | Private IP |
+| `http://169.254.169.254/` | Reservierte IP (`NO_RES_RANGE`) |
+| `http://private.internal/` | Löst auf 10.0.0.1 → blockiert |
+| `javascript:alert(1)` | Schema nicht in `['http','https']` |
+| `file:///etc/passwd` | Schema nicht in Allowlist |
+| `ftp://example.com/` | Schema nicht in Allowlist |
+
+```
+✅ BESTANDEN — Schema-Allowlist + IP-Bereichsfilter blockiert alle SSRF-Vektoren
+```
+
+### VULN-L — Mass Assignment
+
+`click_count` und `created_at` werden serverseitig in `LinkRepository::create()` gesetzt.
+Request-Body-Schlüssel `click_count: 999999` und `created_at: "2000-01-01..."` werden
+einfach ignoriert — der Controller liest sie nie.
+
+```
+✅ BESTANDEN — serverseitige Felder im Repository gesetzt, nie aus dem Request-Body
+```
+
+---
+
+## VULN-Assessment-Zusammenfassung
+
+| ID | Schwachstelle | Status |
+|----|---------------|--------|
+| VULN-A | Integer-Überlauf | ✅ BESTANDEN |
+| VULN-B | Typverwirrung | ✅ BESTANDEN |
+| VULN-C | SQL-Injection | ✅ BESTANDEN |
+| VULN-D | Parameter-Pollution | ✅ BESTANDEN |
+| VULN-E | IDOR | ✅ BESTANDEN |
+| VULN-F | ReDoS | ✅ BESTANDEN |
+| VULN-G | Pfad-Traversal | N/A |
+| VULN-H | Timing-Angriffe | ✅ BESTANDEN |
+| VULN-I | Leeres-Geheimnis-Bypass | ✅ BESTANDEN |
+| VULN-J | DateTime-Überlauf | ✅ BESTANDEN |
+| VULN-K | SSRF | ✅ BESTANDEN |
+| VULN-L | Mass Assignment | ✅ BESTANDEN |
+
+**Alle anwendbaren Schwachstellen: BESTANDEN (11/11)**
+
+---
+
+## Slug-Sicherheit (VULN-A, C)
+
+Slugs müssen auf einen sicheren Zeichensatz beschränkt werden, um sowohl Injection als auch
+unerwartetes Routing zu verhindern:
+
+```php
+// Muster: Kleinbuchstaben-Alphanumerisch + Bindestriche/Unterstriche, 3–20 Zeichen
+// Muss mit Alphanumerisch beginnen und enden
+private const SLUG_PATTERN = '/^[a-z0-9][a-z0-9_-]{1,18}[a-z0-9]$|^[a-z0-9]{3}$/';
+
+if (!preg_match(self::SLUG_PATTERN, $rawSlug)) {
+    return 422;
+}
+```
+
+Dieser einzelne Regex ist verankert und hat keine Alternationsgruppen mit überlappenden
+Match-Pfaden — er kann nicht für ReDoS ausgenutzt werden.
+
+**Abgelehnte Slugs**: `'; DROP TABLE links; --'` · `../../etc` · `MySlug`
+· `sl@g!` · `a` (zu kurz) · 21-Zeichen-String (zu lang)
+
+---
+
+## Wichtigste Erkenntnisse
+
+| Muster | Implementierung |
+|--------|-----------------|
+| SSRF-Prävention | `parse_url()`-Schema-Allowlist + `filter_var NO_PRIV_RANGE` |
+| DNS-Auflösung in Tests | Injizierbarer `ipResolver`-Callback |
+| Slug-Sicherheit | Zeichensatz-Allowlist-Regex (verankert, kein Backtracking) |
+| URL-Typ-Durchsetzung | `V::str()` → `is_string()` vor URL-Parsing |
+| Ablauf-Validierung | `V::isoDatetime()` mit Round-Trip + Offset-Bereichsprüfung |
+| IDOR-Prävention | `WHERE slug = ? AND user_id = ?` in jeder Schreib-Abfrage |
+| Mass Assignment | Serverseitige Felder im Repository gesetzt, im Controller ignoriert |

--- a/docs/de/howto/use-bearer-auth.md
+++ b/docs/de/howto/use-bearer-auth.md
@@ -1,0 +1,117 @@
+# Bearer-Token-Authentifizierung verwenden
+
+NENE2 enthält `BearerTokenMiddleware` und `LocalBearerTokenVerifier` für JWT-basierte Authentifizierung. Diese Anleitung behandelt Einrichtung, Konfiguration, Token-Ausstellung und häufige Fallstricke.
+
+## Einrichtung
+
+Das Middleware in `RuntimeApplicationFactory` mit dem benannten Parameter `authMiddleware` einbinden:
+
+```php
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+
+$secret   = getenv('NENE2_LOCAL_JWT_SECRET') ?: 'change-me';
+$verifier = new LocalBearerTokenVerifier($secret);
+$bearer   = new BearerTokenMiddleware($problemDetails, $verifier);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [static fn (Router $r) => $registrar->register($r)],
+    authMiddleware:  $bearer, // ← benannter Parameter ist authMiddleware, nicht middlewares
+))->create();
+```
+
+> **Hinweis:** Der Parametername lautet `authMiddleware`, nicht `middlewares`. Die Verwendung von `middlewares:` verursacht einen Laufzeit-`Error: Unknown named parameter`.
+
+## Alle Routen vs. selektiver Schutz
+
+`BearerTokenMiddleware` unterstützt vier Pfad-Matching-Modi (erste Übereinstimmung gewinnt):
+
+```php
+// 1. Nur bestimmte Pfade schützen (Allowlist)
+new BearerTokenMiddleware($problems, $verifier, protectedPaths: ['/me', '/entries']);
+
+// 2. Pfade mit einem Präfix schützen (Präfix-Allowlist)
+new BearerTokenMiddleware($problems, $verifier, protectedPathPrefixes: ['/api/', '/me/']);
+
+// 3. Alles außer aufgeführten Pfaden schützen (Blocklist — gängiges Muster)
+new BearerTokenMiddleware($problems, $verifier, excludedPaths: ['/auth/login', '/auth/register', '/health']);
+
+// 4. Alle Pfade schützen (Standard — keine Arrays angegeben)
+new BearerTokenMiddleware($problems, $verifier);
+```
+
+## Claims in einem Handler lesen
+
+Nach erfolgreicher Verifikation werden Claims als Request-Attribut gespeichert:
+
+```php
+/** @var array<string, mixed> $claims */
+$claims  = $request->getAttribute('nene2.auth.claims') ?? [];
+$ownerId = (string) ($claims['sub'] ?? '');
+```
+
+Der Credential-Typ wird separat gespeichert:
+
+```php
+$credType = $request->getAttribute('nene2.auth.credential_type'); // 'bearer'
+```
+
+## Tokens ausstellen (lokal / Test)
+
+`LocalBearerTokenVerifier` implementiert auch `TokenIssuerInterface`:
+
+```php
+$token = $verifier->issue([
+    'sub' => 'user-123',
+    'iat' => time(),
+    'exp' => time() + 3600, // ← exp immer einschließen
+]);
+```
+
+> **`exp` immer einschließen.** Tokens ohne `exp` werden als nicht ablaufend behandelt. Das ist für Tests sicher, aber gefährlich, wenn solche Tokens die Produktion erreichen. Fehlt `exp`, überspringt der Verifier die Ablaufprüfung.
+
+## Fehlerantworten
+
+Bei einem Fehler gibt `BearerTokenMiddleware` eine `401 Unauthorized` Problem Details-Antwort mit einem `WWW-Authenticate`-Header zurück:
+
+```
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer realm="NENE2", error="invalid_token", error_description="Token has expired."
+Content-Type: application/problem+json
+```
+
+Fehlercodes in `WWW-Authenticate`:
+- `missing_token` — kein `Authorization`-Header
+- `invalid_token` — falsches Schema, abgelaufen, ungültige Signatur, fehlerhaft, falscher Algorithmus, `nbf` in der Zukunft
+
+## Sicherheitseigenschaften von `LocalBearerTokenVerifier`
+
+| Bedrohung | Schutz |
+|-----------|--------|
+| Signaturfälschung | HMAC-HS256, konstantzeit `hash_equals` |
+| Algorithmus-Substitution (`alg:none`) | Nur `HS256` akzeptiert |
+| Abgelaufenes Token | `exp`-Claim wird geprüft |
+| Noch-nicht-gültiges Token | `nbf`-Claim wird geprüft |
+| Manipuliertes Payload | Signatur deckt Header + Payload ab; Manipulation bricht Signatur |
+
+> `LocalBearerTokenVerifier` ist für lokale Entwicklung und Tests gedacht. Für die Produktion eine bibliotheksgestützte Implementierung von `TokenVerifierInterface` (z. B. firebase/php-jwt) injizieren, die Key-Rotation und asymmetrische Algorithmen unterstützt.
+
+## Testmuster
+
+```php
+// In setUp(): Verifier mit Test-Secret erstellen
+$this->verifier = new LocalBearerTokenVerifier('test-secret');
+
+// Gültiges Token für einen Benutzer ausstellen
+$token = $this->verifier->issue(['sub' => 'alice', 'exp' => time() + 3600]);
+
+// Abgelaufenes Token ausstellen (für Negativtest)
+$expired = $this->verifier->issue(['sub' => 'alice', 'exp' => time() - 1]);
+
+// Noch-nicht-gültiges Token ausstellen
+$future = $this->verifier->issue(['sub' => 'alice', 'nbf' => time() + 3600, 'exp' => time() + 7200]);
+```

--- a/docs/de/howto/use-fts5-search.md
+++ b/docs/de/howto/use-fts5-search.md
@@ -1,0 +1,216 @@
+# SQLite FTS5 Volltextsuche verwenden
+
+SQLites FTS5-Erweiterung bietet Volltextsuche über einen invertierten Index. Diese Anleitung behandelt das Schema-Muster, triggerbasierte Synchronisation und die Abfragesyntax-Fallstricke bei der Verarbeitung von Benutzereingaben.
+
+---
+
+## 1. Schema: virtuelle Tabelle + externer Inhalt + Trigger
+
+`content=<table>` verwenden, um Daten in einer normalen Tabelle zu halten und FTS5 nur den Suchindex pflegen zu lassen:
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    author     TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE articles_fts USING fts5(
+    title,
+    body,
+    author,
+    content=articles,   -- FTS5 liest Inhalt aus der articles-Tabelle
+    content_rowid=id    -- mappt FTS5 rowid auf articles.id
+);
+
+-- FTS-Index mit der Basistabelle synchron halten
+CREATE TRIGGER articles_ai AFTER INSERT ON articles BEGIN
+    INSERT INTO articles_fts(rowid, title, body, author)
+    VALUES (new.id, new.title, new.body, new.author);
+END;
+
+CREATE TRIGGER articles_au AFTER UPDATE ON articles BEGIN
+    -- Alte Zeile aus Index löschen, dann aktualisierte Zeile einfügen
+    INSERT INTO articles_fts(articles_fts, rowid, title, body, author)
+    VALUES ('delete', old.id, old.title, old.body, old.author);
+    INSERT INTO articles_fts(rowid, title, body, author)
+    VALUES (new.id, new.title, new.body, new.author);
+END;
+
+CREATE TRIGGER articles_ad AFTER DELETE ON articles BEGIN
+    INSERT INTO articles_fts(articles_fts, rowid, title, body, author)
+    VALUES ('delete', old.id, old.title, old.body, old.author);
+END;
+```
+
+> **Warum Trigger?** FTS5 mit `content=` verfolgt Änderungen nicht automatisch — der Index muss mit Triggern gepflegt werden. Das Muster `INSERT INTO fts(fts, rowid, ...) VALUES ('delete', ...)` ist FTS5s Weg, eine Zeile aus dem Index zu entfernen.
+
+---
+
+## 2. Suchabfrage
+
+```php
+$rows = $this->executor->fetchAll(
+    "SELECT a.*, snippet(articles_fts, 1, '<b>', '</b>', '…', 10) AS snippet, rank
+     FROM articles_fts
+     JOIN articles a ON a.id = articles_fts.rowid
+     WHERE articles_fts MATCH ?
+     ORDER BY rank
+     LIMIT ? OFFSET ?",
+    [$query, $limit, $offset],
+);
+```
+
+- `rank` ist eine von FTS5 bereitgestellte virtuelle Spalte. Niedrigere (negativere) Werte sind relevanter. `ORDER BY rank` stellt die besten Treffer zuerst.
+- `snippet(table, column_index, open, close, ellipsis, token_count)` gibt ein hervorgehobenes Fragment zurück. Der Spaltenindex ist 0-basiert: `0` = title, `1` = body.
+
+---
+
+## 3. Abfragesyntax-Fallstricke
+
+### 3.1 Bindestrich ist ein Spaltenfilter-Präfix — kein Phrasentrennzeichen
+
+**Dies ist die häufigste Fehlerquelle bei der Verarbeitung von Benutzereingaben.**
+
+FTS5 interpretiert `word-other` als Spaltenfilter: Es sucht in der Spalte namens `word` nach dem Begriff `other`. Wenn `word` keine Spalte in der FTS5-Tabelle ist, wirft SQLite einen Fehler:
+
+```
+General error: 1 no such column: text
+```
+
+```
+full-text   ← FEHLER: "Spalte 'full' nach 'text' durchsuchen" — aber 'full' ist keine Spalte
+full text   ← OK: UND-Abfrage (trifft Dokumente mit sowohl "full" ALS AUCH "text")
+"full text" ← OK: Phrasenabfrage (exakte aufeinanderfolgende Reihenfolge)
+```
+
+Dieser Fehler propagiert als `DatabaseConnectionException` und führt zu einer 500-Antwort, wenn die Eingabe nicht vorher bereinigt wird.
+
+**Benutzereingaben vor der Übergabe an FTS5 bereinigen:**
+
+```php
+private function sanitizeFtsQuery(string $query): string
+{
+    // Bindestriche durch Leerzeichen ersetzen: "full-text" wird zu "full text" (UND-Logik)
+    return str_replace('-', ' ', $query);
+}
+```
+
+Oder mit doppelten Anführungszeichen für eine Phrasenübereinstimmung escapen:
+
+```php
+private function sanitizeFtsQuery(string $query): string
+{
+    // Die gesamte Abfrage in doppelte Anführungszeichen einschließen, um Phrasenabgleich zu erzwingen
+    $escaped = str_replace('"', '""', $query);
+    return '"' . $escaped . '"';
+}
+```
+
+### 3.2 Standardmäßig kein Stemming
+
+Der Standard-Tokenizer `unicode61` führt kein Stemming durch. `framework` trifft nicht `frameworks`, und `run` trifft nicht `running`.
+
+Optionen:
+
+| Ansatz | Wie |
+|--------|-----|
+| Exakte Übereinstimmung | Exakte Wortformen in Dokumenten und Abfragen verwenden |
+| Präfix-Match | `*` an den Abfragebegriff anhängen: `framework*` trifft `framework`, `frameworks`, `framework-agnostic` |
+| Porter-Stemmer | `tokenize='porter ascii'` in der `CREATE VIRTUAL TABLE`-Anweisung deklarieren |
+
+**Präfix-Match-Beispiel:**
+
+```php
+// Benutzer tippt "frame" → * anhängen, um "framework", "frameworks" etc. zu treffen
+$query = trim($userInput) . '*';
+```
+
+**Porter-Stemmer:**
+
+```sql
+CREATE VIRTUAL TABLE articles_fts USING fts5(
+    title, body, author,
+    content=articles,
+    content_rowid=id,
+    tokenize='porter ascii'  -- Englisches Stemming
+);
+```
+
+> Der `porter`-Tokenizer ist nur verfügbar, wenn SQLite mit FTS5-Unterstützung kompiliert wurde (Standard-Builds schließen es ein). Er ist nützlich für englische Texte; für andere Sprachen externes Stemming vor der Indizierung in Betracht ziehen.
+
+### 3.3 AND / OR / NOT-Operatoren
+
+FTS5-Abfragesyntax:
+
+| Syntax | Bedeutung |
+|--------|-----------|
+| `one two` | AND: beide müssen vorhanden sein |
+| `one OR two` | OR: eines muss vorhanden sein |
+| `one NOT two` | NOT: erstes vorhanden, zweites abwesend |
+| `"one two"` | Phrase: exakte aufeinanderfolgende Reihenfolge |
+| `one*` | Präfix: trifft `one`, `ones`, `only` (Präfix-Match auf `one`) |
+| `title:query` | Spaltenfilter: Match auf die `title`-Spalte beschränken |
+
+> **Hinweis**: `NOT` muss großgeschrieben sein. Kleingeschriebenes `not` wird als Suchbegriff behandelt.
+
+---
+
+## 4. Suchergebnisse zählen
+
+Mit einer separaten Abfrage zählen — `COUNT(*)` auf dem FTS5-Match:
+
+```php
+$count = $this->executor->fetchOne(
+    'SELECT COUNT(*) AS cnt FROM articles_fts WHERE articles_fts MATCH ?',
+    [$query],
+);
+```
+
+---
+
+## 5. Vollständiges Repository-Beispiel
+
+```php
+final readonly class ArticleRepository
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $executor,
+    ) {}
+
+    /** @return list<array<string, mixed>> */
+    public function search(string $userQuery, int $limit, int $offset): array
+    {
+        $query = $this->sanitizeFtsQuery($userQuery);
+
+        return $this->executor->fetchAll(
+            "SELECT a.*, snippet(articles_fts, 1, '<b>', '</b>', '…', 10) AS snippet, rank
+             FROM articles_fts
+             JOIN articles a ON a.id = articles_fts.rowid
+             WHERE articles_fts MATCH ?
+             ORDER BY rank
+             LIMIT ? OFFSET ?",
+            [$query, $limit, $offset],
+        );
+    }
+
+    public function countSearch(string $userQuery): int
+    {
+        $query = $this->sanitizeFtsQuery($userQuery);
+        $row   = $this->executor->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM articles_fts WHERE articles_fts MATCH ?',
+            [$query],
+        );
+
+        return (int) ($row['cnt'] ?? 0);
+    }
+
+    private function sanitizeFtsQuery(string $query): string
+    {
+        // Bindestriche durch Leerzeichen ersetzen: "full-text" → "full text" (UND-Logik)
+        return str_replace('-', ' ', trim($query));
+    }
+}
+```

--- a/docs/de/howto/use-postgresql.md
+++ b/docs/de/howto/use-postgresql.md
@@ -1,0 +1,134 @@
+# PostgreSQL verwenden
+
+NENE2s `PdoConnectionFactory` unterstützt den `pgsql`-Adapter von Haus aus. Diese Anleitung behandelt die Einrichtungsschritte und PostgreSQL-spezifische Muster, die sich von MySQL und SQLite unterscheiden.
+
+## Docker Compose-Einrichtung
+
+Einen `postgres`-Service hinzufügen und die Umgebungsvariablen für den `app`-Service setzen:
+
+```yaml
+# compose.yaml
+services:
+  app:
+    environment:
+      DB_ADAPTER: pgsql
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_NAME: myapp
+      DB_USER: myapp
+      DB_PASSWORD: secret
+      DB_CHARSET: utf8    # für pgsql ignoriert — siehe Abschnitt zur Zeichenkodierung
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U myapp -d myapp"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+```
+
+## Dockerfile — pdo_pgsql-Erweiterung
+
+Die `pdo_pgsql`-Erweiterung ist im `php:8.4-cli`-Basis-Image nicht standardmäßig aktiviert. Sie zum `Dockerfile` hinzufügen:
+
+```dockerfile
+FROM php:8.4-cli
+
+RUN apt-get update && apt-get install -y libpq-dev unzip postgresql-client \
+    && docker-php-ext-install pdo pdo_pgsql \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+WORKDIR /var/www/html
+```
+
+## Phinx-Migrationskonfiguration
+
+`charset` aus der Phinx-Umgebungskonfiguration bei Verwendung von `pgsql` weglassen — PostgreSQL verwendet diesen Schlüssel nicht:
+
+```php
+// phinx.php
+$database->environment => [
+    'adapter' => $database->adapter,   // 'pgsql'
+    'host'    => $database->host,
+    'name'    => $database->name,
+    'user'    => $database->user,
+    'pass'    => $database->password,
+    'port'    => $database->port,
+    // 'charset' => ...  ← für pgsql weglassen
+],
+```
+
+Phinx mappt seine Spaltentypen automatisch auf PostgreSQL-Typen. Häufige Zuordnungen:
+
+| Phinx-Typ | PostgreSQL-Typ |
+|-----------|----------------|
+| `integer` (Primärschlüssel) | `SERIAL` |
+| `string` | `VARCHAR(n)` |
+| `text` | `TEXT` |
+| `datetime` | `TIMESTAMP(0) WITHOUT TIME ZONE` |
+| `boolean` | `BOOLEAN` |
+
+## ID nach INSERT ermitteln — RETURNING id verwenden
+
+`DatabaseQueryExecutorInterface::lastInsertId()` gibt auf PostgreSQL `0` zurück, weil `PDO::lastInsertId()` ein Sequenzname-Argument erfordert, das NENE2 nicht verfolgt.
+
+`fetchOne()` mit `RETURNING id` im INSERT-SQL verwenden, um den generierten Primärschlüssel in einem einzigen Roundtrip abzurufen:
+
+```php
+// ✓ PostgreSQL-kompatibles Muster
+$row = $this->executor->fetchOne(
+    'INSERT INTO reviews (book_title, content, rating, created_at) VALUES (?, ?, ?, ?) RETURNING id',
+    [$bookTitle, $content, $rating, $now],
+);
+$id = (int) ($row['id'] ?? 0);
+```
+
+`RETURNING id` ist standard PostgreSQL-SQL und wird auch von SQLite >= 3.35 (2021) unterstützt. Es wird von MySQL/MariaDB **nicht** unterstützt — Repository-Implementierungen DB-spezifisch halten, wenn beide Zieldatenbanken unterstützt werden sollen.
+
+### Warum nicht lastInsertId()?
+
+PostgreSQL-Sequenzen sind standardmäßig `{table}_{column}_seq` benannt (z. B. `reviews_id_seq`). `PDO::lastInsertId('reviews_id_seq')` würde funktionieren, aber `DatabaseQueryExecutorInterface` stellt keinen Sequenzname-Parameter bereit. `RETURNING id` ist sauberer und vermeidet die Kopplung.
+
+## Testdaten zwischen Tests zurücksetzen
+
+Testisolation erfordert das Zurücksetzen der Tabelle zwischen jedem Testfall. Das korrekte SQL unterscheidet sich je nach Adapter:
+
+```php
+protected function setUp(): void
+{
+    // PostgreSQL — setzt die SERIAL-Sequenz auf 1 zurück
+    $this->executor->execute('TRUNCATE reviews RESTART IDENTITY CASCADE');
+
+    // MySQL — TRUNCATE setzt AUTO_INCREMENT implizit zurück
+    // $this->executor->execute('TRUNCATE reviews');
+
+    // SQLite — TRUNCATE wird nicht unterstützt; DELETE + Sequenz-Reset verwenden
+    // $this->executor->execute('DELETE FROM reviews');
+    // $this->executor->execute("DELETE FROM sqlite_sequence WHERE name = 'reviews'");
+}
+```
+
+`TRUNCATE … RESTART IDENTITY CASCADE` ist PostgreSQL-spezifisch. `RESTART IDENTITY` setzt die Sequenz zurück, sodass das nächste INSERT `id = 1` zurückgibt und Test-Assertions deterministisch bleiben. `CASCADE` kürzt abhängige Tabellen in derselben Anweisung.
+
+## Zeichenkodierung — DB_CHARSET wird für pgsql ignoriert
+
+Der `pgsql`-DSN enthält keinen `charset`-Parameter. `DB_CHARSET` / `DatabaseConfig::charset` wird für den `pgsql`-Adapter stillschweigend ignoriert — nur der `mysql`-Adapter verwendet ihn im DSN.
+
+PostgreSQL bestimmt die Client-Kodierung aus `server_encoding` zum Verbindungszeitpunkt. Mit dem Standard-Locale erstellte Datenbanken verwenden **UTF-8**, was fast immer das Gewünschte ist.
+
+Um eine bestimmte Kodierung zu erzwingen, `DATABASE_URL` mit dem `options`-Parameter verwenden:
+
+```
+DATABASE_URL=pgsql://myapp:secret@db:5432/myapp?options=--client_encoding%3DUTF8
+```
+
+Oder nach dem Verbindungsaufbau einen `SET`-Befehl ausgeben (nicht direkt über `PdoDatabaseQueryExecutor` möglich — dafür wäre eine benutzerdefinierte Connection Factory erforderlich).

--- a/docs/de/howto/use-transactions.md
+++ b/docs/de/howto/use-transactions.md
@@ -1,0 +1,186 @@
+# Datenbanktransaktionen verwenden
+
+Diese Anleitung erklärt, wie atomare mehrstufige Operationen mit `DatabaseTransactionManagerInterface` in NENE2 durchgeführt werden.
+
+**Voraussetzung**: Ein Repository, das auf `DatabaseQueryExecutorInterface` basiert.
+Falls nicht, mit [Datenbankgestützten Endpunkt hinzufügen](./add-database-endpoint.md) beginnen.
+
+---
+
+## Warum Transaktionen in NENE2
+
+`DatabaseTransactionManagerInterface` umschließt mehrere SQL-Anweisungen in einer einzigen Transaktion: Entweder alle gelingen (Commit) oder alle werden bei einem beliebigen `Throwable` zurückgerollt.
+
+Das Interface hat eine Methode:
+
+```php
+public function transactional(callable $callback): mixed;
+```
+
+Der Callback erhält einen **frischen** `DatabaseQueryExecutorInterface`, der an die offene Transaktion gebunden ist. **Dieser Executor unterscheidet sich von dem, der zur Konstruktionszeit injiziert wird.**
+
+---
+
+## Das transaktionale Repository-Muster
+
+> **Warnung — injizierte Repositories nicht im Callback wiederverwenden.**
+>
+> Zur Konstruktionszeit injizierte Repositories halten eine **andere Verbindung** als die, auf der die Transaktion läuft. Die Verwendung im Callback bedeutet, dass ihre Abfragen außerhalb der Transaktion ausgeführt werden: Rollbacks machen diese Änderungen nicht rückgängig, und uncommittete Zeilen, die innerhalb des Callbacks geschrieben wurden, sind für sie möglicherweise nicht sichtbar.
+>
+> Dieser Fehler kompiliert und Tests können bestehen — der Bug tritt nur bei gleichzeitigen Schreibvorgängen oder wenn Rollback-Verhalten erwartet wird in Erscheinung.
+
+Da der Callback seinen eigenen Executor bereitstellt, müssen Repository-Klassen **innerhalb des Callbacks instanziiert werden**, wobei der vom Callback bereitgestellte Executor verwendet wird.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Order;
+
+use MyApp\Product\ProductNotFoundException;
+use MyApp\Product\SqliteProductRepository;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+
+final class CreateOrderUseCase
+{
+    public function __construct(
+        private readonly DatabaseTransactionManagerInterface $transactionManager,
+    ) {}
+
+    public function execute(int $productId, int $qty): Order
+    {
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($productId, $qty): Order {
+                // Konkrete Klassen hier instanziieren — der $tx-Executor ist an die
+                // Verbindung dieser Transaktion gebunden. Injizierte Instanzen verwenden einen anderen Executor.
+                $products = new SqliteProductRepository($tx);
+                $orders   = new SqliteOrderRepository($tx);
+
+                $product = $products->findById($productId)
+                    ?? throw new ProductNotFoundException($productId);
+
+                $products->decrementStock($productId, $qty);
+
+                return $orders->save($product->price * $qty, [
+                    new OrderItem($productId, $qty, $product->price),
+                ]);
+            },
+        );
+    }
+}
+```
+
+### Warum injizierte Repositories nicht wiederverwenden?
+
+`PdoDatabaseTransactionManager::transactional()` öffnet eine **neue Verbindung** über `DatabaseConnectionFactoryInterface::create()` und beginnt eine Transaktion darauf. Der Executor des Callbacks ist an diese spezifische Verbindung gebunden.
+
+Ein injiziertes `SqliteProductRepository` hält einen separaten `PdoDatabaseQueryExecutor`, der bei der ersten Verwendung träge seine eigene Verbindung öffnet. Abfragen über das injizierte Repository laufen auf dieser anderen Verbindung — außerhalb der Transaktion — sodass ein Rollback sie nicht rückgängig macht, und ein Insert über das injizierte Repository sieht möglicherweise keine uncommittierten Zeilen aus dem Callback.
+
+---
+
+## Im Front-Controller verdrahten
+
+Es werden zwei separate Objekte benötigt:
+
+| Objekt | Zweck |
+|--------|-------|
+| `PdoDatabaseQueryExecutor` | Nicht-transaktionale Lesevorgänge (z. B. `GET /products`) |
+| `PdoDatabaseTransactionManager` | Umschließt mehrstufige Schreibvorgänge in einer Transaktion |
+
+Beide teilen dieselbe `PdoConnectionFactory`:
+
+```php
+$connectionFactory = new PdoConnectionFactory($dbConfig);
+
+$executor  = new PdoDatabaseQueryExecutor($connectionFactory);  // für Read-Repositories
+$txManager = new PdoDatabaseTransactionManager($connectionFactory); // für Use Cases
+
+$products = new SqliteProductRepository($executor);  // verwendet von GET /products
+$createOrder = new CreateOrderUseCase($txManager);   // verwendet $tx intern
+```
+
+---
+
+## Mit dateibasierter SQLite-Datenbank testen
+
+In-Memory-SQLite (`sqlite::memory:`) erstellt eine **separate Datenbank pro Verbindung**, sodass `PdoDatabaseTransactionManager` (der pro `transactional()`-Aufruf eine neue Verbindung öffnet) keine vom `PdoDatabaseQueryExecutor` geschriebenen Zeilen sehen würde und umgekehrt.
+
+Stattdessen eine **temporäre Datei** verwenden:
+
+```php
+protected function setUp(): void
+{
+    $this->dbFile = sys_get_temp_dir() . '/test-' . bin2hex(random_bytes(8)) . '.sqlite';
+    $pdo = new \PDO('sqlite:' . $this->dbFile, options: [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+    $pdo->exec(file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+    unset($pdo); // Init-Verbindung schließen, bevor die Factory ihre eigene öffnet
+
+    $dbConfig = new DatabaseConfig(
+        url:         null,
+        environment: 'test',
+        adapter:     'sqlite',
+        host:        '',      // für SQLite nicht verwendet
+        port:        1,       // für SQLite nicht verwendet
+        name:        $this->dbFile,
+        user:        '',      // für SQLite nicht verwendet
+        password:    '',      // für SQLite nicht verwendet
+        charset:     '',      // für SQLite nicht verwendet
+    );
+
+    $factory   = new PdoConnectionFactory($dbConfig);
+    $executor  = new PdoDatabaseQueryExecutor($factory);
+    $txManager = new PdoDatabaseTransactionManager($factory);
+    // ... Repositories und Use Cases verdrahten
+}
+
+protected function tearDown(): void
+{
+    if (is_file($this->dbFile)) {
+        unlink($this->dbFile);
+    }
+}
+```
+
+Jeder Test erhält eine frische Datei, sowohl `PdoDatabaseQueryExecutor` als auch `PdoDatabaseTransactionManager` verbinden sich mit derselben Datei, und `tearDown` löscht sie.
+
+> **Hinweis zu SQLite `DatabaseConfig`-Feldern**: Für SQLite sind nur `adapter` und `name` erforderlich. Leere Strings für `host`, `user`, `password` und `charset` übergeben — sie werden nicht validiert, wenn `adapter` `'sqlite'` ist.
+
+> **Hinweis**: `PdoDatabaseQueryExecutor` akzeptiert kein rohes `PDO` als Konstruktorargument — es erfordert eine `DatabaseConnectionFactoryInterface`. `PdoConnectionFactory` (oben gezeigt) verwenden, um ein rohes `PDO`-Setup mit dem Executor zu verbinden.
+
+---
+
+## Rollback-Verhalten verifizieren
+
+Testen, dass ein Fehler mitten in einer Transaktion alle vorherigen Änderungen rückgängig macht:
+
+```php
+public function testTransactionRollsBackOnDomainException(): void
+{
+    // Zwei Produkte seeden
+    // ...
+
+    // Bestellung, die beim zweiten Produkt fehlschlägt (unzureichender Bestand)
+    $response = $this->request('POST', '/orders', [
+        'items' => [
+            ['product_id' => $p1Id, 'qty' => 3],   // würde gelingen
+            ['product_id' => $p2Id, 'qty' => 99],  // wird fehlschlagen
+        ],
+    ]);
+
+    self::assertSame(409, $response->getStatusCode());
+
+    // Bestand von Produkt 1 muss unverändert sein — Transaktion wurde zurückgerollt
+    $products = $this->json($this->request('GET', '/products'))['items'];
+    self::assertSame($originalStock1, $products[0]['stock']);
+}
+```
+
+---
+
+## Zukünftige Richtung
+
+Das aktuelle Muster erfordert die Instanziierung konkreter Repository-Klassen innerhalb des Callbacks, was bedeutet, dass der Use Case die Repository-Implementierung (`SqliteProductRepository`) kennt und nicht nur das Interface. Das ist eine bekannte Einschränkung.
+
+Eine `RepositoryFactory`-Abstraktion — ein von Use Cases akzeptiertes Interface, das ein Repository für einen gegebenen Executor produzieren kann — würde die vollständige Interface-only-Abhängigkeit wiederherstellen. Dies wird für eine zukünftige NENE2-Version in Betracht gezogen.

--- a/docs/de/howto/user-follow-system.md
+++ b/docs/de/howto/user-follow-system.md
@@ -1,0 +1,342 @@
+# Benutzer-Follow-System mit NENE2 aufbauen
+
+Diese Anleitung führt durch den Aufbau eines Twitter/Instagram-ähnlichen sozialen Follow-Systems — Benutzer folgen sich gegenseitig, sehen Follower-/Following-Listen und prüfen gegenseitigen Follow-Status.
+
+**Field Trial**: FT134  
+**NENE2-Version**: ^1.5  
+**Behandelte Themen**: Follow/Unfollow, idempotente Schreibvorgänge, Graph-Abfragen, Soft-Constraint-Enforcement
+
+---
+
+## Was wird gebaut
+
+Eine REST API, die Benutzern erlaubt:
+
+- Andere Benutzer zu folgen und zu entfolgen (idempotenter Follow, 204 Unfollow)
+- Follower-/Following-Listen abzufragen (geordnet nach neuesten zuerst)
+- Follower-/Following-Anzahl in einem Stat-Aufruf zu prüfen
+- Zu prüfen, ob ein bestimmter Benutzer einem anderen folgt
+
+---
+
+## Datenbankschema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE follows (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    follower_id INTEGER NOT NULL,
+    followee_id INTEGER NOT NULL,
+    created_at  TEXT    NOT NULL,
+    UNIQUE (follower_id, followee_id),
+    CHECK  (follower_id != followee_id),
+    FOREIGN KEY (follower_id) REFERENCES users(id),
+    FOREIGN KEY (followee_id) REFERENCES users(id)
+);
+```
+
+Zwei Constraints leisten die Hauptarbeit auf DB-Ebene:
+
+- `UNIQUE (follower_id, followee_id)` — verhindert doppelte Follow-Zeilen
+- `CHECK (follower_id != followee_id)` — verhindert Self-Follow auf DB-Ebene (Anwendung validiert das ebenfalls)
+
+---
+
+## API-Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzer erstellen |
+| `POST` | `/users/{followerId}/follow` | Benutzer folgen (idempotent) |
+| `DELETE` | `/users/{followerId}/follow/{followeeId}` | Benutzer entfolgen |
+| `GET` | `/users/{userId}/stats` | Follower-/Following-Anzahl abrufen |
+| `GET` | `/users/{userId}/followers` | Follower auflisten |
+| `GET` | `/users/{userId}/following` | Benutzer auflisten, denen dieser Benutzer folgt |
+| `GET` | `/users/{followerId}/is-following/{followeeId}` | Follow-Beziehung prüfen |
+
+---
+
+## Repository
+
+```php
+final class FollowRepository
+{
+    public function __construct(
+        private readonly DatabaseQueryExecutorInterface $executor,
+    ) {}
+
+    public function follow(int $followerId, int $followeeId, string $now): bool
+    {
+        if ($this->isFollowing($followerId, $followeeId)) {
+            return false; // folgt bereits — false zurückgeben, damit Handler 200 sendet
+        }
+
+        $this->executor->execute(
+            'INSERT INTO follows (follower_id, followee_id, created_at) VALUES (?, ?, ?)',
+            [$followerId, $followeeId, $now],
+        );
+
+        return true; // neuer Follow — Handler sendet 201
+    }
+
+    public function unfollow(int $followerId, int $followeeId): bool
+    {
+        $count = $this->executor->execute(
+            'DELETE FROM follows WHERE follower_id = ? AND followee_id = ?',
+            [$followerId, $followeeId],
+        );
+
+        return $count > 0;
+    }
+
+    public function isFollowing(int $followerId, int $followeeId): bool
+    {
+        return $this->executor->fetchOne(
+            'SELECT id FROM follows WHERE follower_id = ? AND followee_id = ?',
+            [$followerId, $followeeId],
+        ) !== null;
+    }
+
+    /** @return array<int, array{id: int, name: string}> */
+    public function listFollowers(int $userId): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT u.id, u.name FROM users u
+             INNER JOIN follows f ON f.follower_id = u.id
+             WHERE f.followee_id = ?
+             ORDER BY f.id DESC',
+            [$userId],
+        );
+
+        return array_map(fn(mixed $row) => $this->hydrateUser((array) $row), $rows);
+    }
+
+    /** @return array<int, array{id: int, name: string}> */
+    public function listFollowing(int $userId): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT u.id, u.name FROM users u
+             INNER JOIN follows f ON f.followee_id = u.id
+             WHERE f.follower_id = ?
+             ORDER BY f.id DESC',
+            [$userId],
+        );
+
+        return array_map(fn(mixed $row) => $this->hydrateUser((array) $row), $rows);
+    }
+}
+```
+
+Die `follow()`-Methode gibt `bool` zurück, um neu-vs-existierend zu signalisieren, damit der Handler den richtigen HTTP-Status senden kann, ohne eine zusätzliche Abfrage.
+
+---
+
+## Follow-Handler — idempotenter POST
+
+Das Knifflige ist, **201 Created** für einen neuen Follow und **200 OK** für einen wiederholten Follow zurückzugeben, während Self-Follow mit 422 abgelehnt wird.
+
+```php
+private function followUser(ServerRequestInterface $request): ResponseInterface
+{
+    $params     = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $followerId = isset($params['followerId']) && is_numeric($params['followerId'])
+        ? (int) $params['followerId'] : 0;
+
+    if ($followerId <= 0 || !$this->repo->findUserById($followerId)) {
+        return $this->responseFactory->create(['error' => 'follower not found'], 404);
+    }
+
+    $body       = JsonRequestBodyParser::parse($request);
+    $followeeId = isset($body['followee_id']) && is_int($body['followee_id'])
+        ? $body['followee_id'] : 0;
+
+    if ($followeeId <= 0 || !$this->repo->findUserById($followeeId)) {
+        return $this->responseFactory->create(['error' => 'followee not found'], 404);
+    }
+
+    if ($followerId === $followeeId) {
+        return $this->responseFactory->create(['error' => 'cannot follow yourself'], 422);
+    }
+
+    $wasNew = $this->repo->follow($followerId, $followeeId, date('Y-m-d H:i:s'));
+    $status = $wasNew ? 201 : 200;
+
+    return $this->responseFactory->create([
+        'follower_id' => $followerId,
+        'followee_id' => $followeeId,
+        'following'   => true,
+    ], $status);
+}
+```
+
+**Warum vor der Self-Follow-Prüfung validieren?** Die 404-Prüfungen kommen zuerst, sodass `POST /users/9999/follow` mit `followee_id: 9999` 404 (Benutzer existiert nicht) statt 422 (Self-Follow) zurückgibt. Existenzfehler haben Priorität.
+
+---
+
+## Unfollow-Handler — 204 oder 404
+
+```php
+private function unfollowUser(ServerRequestInterface $request): ResponseInterface
+{
+    $params     = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $followerId = isset($params['followerId']) && is_numeric($params['followerId'])
+        ? (int) $params['followerId'] : 0;
+    $followeeId = isset($params['followeeId']) && is_numeric($params['followeeId'])
+        ? (int) $params['followeeId'] : 0;
+
+    if ($followerId <= 0 || !$this->repo->findUserById($followerId)) {
+        return $this->responseFactory->create(['error' => 'follower not found'], 404);
+    }
+
+    $removed = $this->repo->unfollow($followerId, $followeeId);
+
+    if (!$removed) {
+        return $this->responseFactory->create(['error' => 'not following'], 404);
+    }
+
+    return $this->responseFactory->createEmpty(204);
+}
+```
+
+Hinweis: `createEmpty(204)` — `JsonResponseFactory` hat eine dedizierte Methode für Body-lose Antworten.
+
+---
+
+## Stats-Endpunkt
+
+```php
+private function stats(ServerRequestInterface $request): ResponseInterface
+{
+    $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $userId = isset($params['userId']) && is_numeric($params['userId'])
+        ? (int) $params['userId'] : 0;
+
+    if ($userId <= 0 || !$this->repo->findUserById($userId)) {
+        return $this->responseFactory->create(['error' => 'user not found'], 404);
+    }
+
+    return $this->responseFactory->create([
+        'user_id'         => $userId,
+        'followers_count' => $this->repo->followerCount($userId),
+        'following_count' => $this->repo->followingCount($userId),
+    ]);
+}
+```
+
+---
+
+## AppFactory
+
+```php
+final class AppFactory
+{
+    public static function createSqliteApp(string $dbPath): RequestHandlerInterface
+    {
+        $dbConfig = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: '',
+            port: 1,
+            name: $dbPath,
+            user: '',
+            password: '',
+            charset: '',
+        );
+
+        $factory  = new PdoConnectionFactory($dbConfig);
+        $executor = new PdoDatabaseQueryExecutor($factory);
+        $psr17    = new Psr17Factory();
+        $json     = new JsonResponseFactory($psr17, $psr17);
+
+        $repo      = new FollowRepository($executor);
+        $registrar = new RouteRegistrar($repo, $json);
+
+        return new RuntimeApplicationFactory(
+            $psr17,
+            $psr17,
+            routeRegistrars: [static fn(Router $r) => $registrar->register($r)],
+        )->create();
+    }
+}
+```
+
+---
+
+## Teststrategie
+
+Jeder Test läuft gegen eine frische In-Memory-SQLite-Datei, die in `setUp()` erstellt und in `tearDown()` gelöscht wird.
+
+Wichtige Testfälle:
+
+```php
+// Idempotenter Follow → 200
+public function testFollowIdempotentReturns200(): void
+{
+    $alice = $this->createUser('Alice');
+    $bob   = $this->createUser('Bob');
+
+    $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+    $res = $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+
+    $this->assertSame(200, $res->getStatusCode());
+    $this->assertTrue($this->json($res)['following']);
+}
+
+// Self-Follow → 422
+public function testFollowSelfReturns422(): void
+{
+    $alice = $this->createUser('Alice');
+    $res   = $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $alice]);
+    $this->assertSame(422, $res->getStatusCode());
+}
+
+// Entfolgen dann erneut folgen → 201
+public function testUnfollowThenRefollow(): void
+{
+    $alice = $this->createUser('Alice');
+    $bob   = $this->createUser('Bob');
+
+    $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+    $this->request('DELETE', "/users/{$alice}/follow/{$bob}");
+    $res = $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+
+    $this->assertSame(201, $res->getStatusCode());
+}
+
+// Gegenseitiger Follow
+public function testMutualFollow(): void
+{
+    $alice = $this->createUser('Alice');
+    $bob   = $this->createUser('Bob');
+
+    $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+    $this->request('POST', "/users/{$bob}/follow", ['followee_id' => $alice]);
+
+    $this->assertTrue($this->json($this->request('GET', "/users/{$alice}/is-following/{$bob}"))['following']);
+    $this->assertTrue($this->json($this->request('GET', "/users/{$bob}/is-following/{$alice}"))['following']);
+}
+```
+
+---
+
+## Sortierkonvention
+
+Sowohl `listFollowers` als auch `listFollowing` verwenden `ORDER BY f.id DESC` — der zuletzt gefolgte Benutzer erscheint zuerst. Das spiegelt das Verhalten des "Followers"-Tabs von Twitter/Instagram wider.
+
+---
+
+## Häufige Fallstricke
+
+| Fallstrick | Lösung |
+|-----------|--------|
+| 422 für unbekannten Benutzer bei Self-Follow-Prüfung zurückgeben | Benutzerexistenz *vor* der Self-Follow-Prüfung validieren |
+| `followee_id` aus dem Pfad statt aus dem Body lesen | `followee_id` ist im Request-Body; `followeeId` ist der Pfadparameter für DELETE |
+| `createJson()` verwenden | Die Methode heißt `create(array $data, int $status = 200)` |
+| `createEmpty()` für eine 200-Antwort mit Body verwenden | `createEmpty()` nur für 204 No Content verwenden |
+| `JsonRequestBodyParser::parse()` fehlt | Muss in jedem Handler, der einen JSON-Body liest, manuell aufgerufen werden |

--- a/docs/de/howto/user-invitation.md
+++ b/docs/de/howto/user-invitation.md
@@ -1,0 +1,145 @@
+# Benutzer-Einladungssystem
+
+Neue Benutzer per E-Mail einladen, Ablauf durchsetzen und Missbrauch mit tokenbasierten Einladungen verhindern.
+
+## Überblick
+
+Ein Einladungssystem lässt bestehende Benutzer neue Kontoerstellungen sponsern. Die wichtigsten Invarianten sind:
+
+- Tokens sind kryptografisch zufällig und nicht erratbar.
+- Ablauf wird sowohl beim Lesen als auch beim Schreiben geprüft.
+- Nur der ursprüngliche Einlader kann eine Einladung stornieren.
+- Akzeptierte und stornierte Tokens können nicht wiederverwendet werden.
+
+## Datenbankschema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    email      TEXT    NOT NULL UNIQUE,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE invitations (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    inviter_id  INTEGER NOT NULL,
+    email       TEXT    NOT NULL,
+    token       TEXT    NOT NULL UNIQUE,
+    status      TEXT    NOT NULL DEFAULT 'pending',
+    expires_at  TEXT    NOT NULL,
+    accepted_at TEXT,
+    created_at  TEXT    NOT NULL,
+    FOREIGN KEY (inviter_id) REFERENCES users(id)
+);
+```
+
+## Token-Generierung
+
+Immer `bin2hex(random_bytes(32))` verwenden — 64 Hex-Zeichen, 256 Bit Entropie:
+
+```php
+$token = bin2hex(random_bytes(32));
+```
+
+Niemals sequenzielle IDs, UUIDs oder kurze Strings als Einladungstoken verwenden. Ein erratbares Token lässt einen Angreifer jede ausstehende Einladung annehmen.
+
+## Einladung senden
+
+Vor der Einladungserstellung verifizieren, dass die Ziel-E-Mail noch nicht registriert ist:
+
+```php
+// Einladung bereits registrierter Benutzer verhindern
+if ($this->repo->findUserByEmail($email) !== null) {
+    return $this->problems->create($request, 'conflict', 'Email already registered.', 409, '');
+}
+
+$expiresAt = (new \DateTimeImmutable())->modify('+24 hours')->format('Y-m-d H:i:s');
+$token     = bin2hex(random_bytes(32));
+$invite    = $this->repo->createInvitation($inviterId, $email, $token, $expiresAt, $now);
+```
+
+Die Rückgabe von 409 beim Einladen einer registrierten E-Mail enthüllt den Registrierungsstatus gegenüber dem Einlader. Das ist in einladungsbasierten Systemen akzeptabel, wo Einlader vertrauenswürdige Benutzer sind. In vollständig öffentlichen Systemen sollte die Antwort auf 202 vereinheitlicht werden.
+
+## Einladung annehmen
+
+Ablauf **vor** der Statusprüfung prüfen — eine ausstehende-aber-abgelaufene Einladung muss 410 zurückgeben, nicht 409:
+
+```php
+$invite = $this->repo->findByTokenOrNull($token);
+
+if ($invite === null) {
+    return $this->problems->create($request, 'not-found', 'Invitation not found.', 404, '');
+}
+
+$now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+if ($invite->isExpired($now)) {
+    return $this->problems->create($request, 'gone', 'Invitation has expired.', 410, '');
+}
+
+if (!$invite->isPending()) {
+    return $this->problems->create($request, 'conflict', 'Invitation is no longer valid.', 409, '');
+}
+```
+
+`isExpired` vergleicht den aktuellen Timestamp-String direkt — SQLite-Datetime-Strings sortieren lexikografisch, wenn sie als `Y-m-d H:i:s` gespeichert sind:
+
+```php
+public function isExpired(string $now): bool
+{
+    return $now >= $this->expiresAt;
+}
+
+public function isPending(): bool
+{
+    return $this->status === 'pending';
+}
+```
+
+## Einladung stornieren
+
+Die Eigentümerschaft wird über die `inviter_id` aus dem Request-Body durchgesetzt (da in diesem minimalen Beispiel kein Session/JWT-Middleware vorhanden ist). In der Produktion den Akteur stattdessen aus einem authentifizierten Token ableiten:
+
+```php
+if ($invite->inviterId !== $inviterId) {
+    return $this->problems->create($request, 'forbidden', 'Only the inviter may cancel this invitation.', 403, '');
+}
+
+if (!$invite->isPending()) {
+    return $this->problems->create($request, 'conflict', 'Invitation is already ' . $invite->status . '.', 409, '');
+}
+```
+
+403 (nicht 404) zurückgeben, wenn die Eigentümerschaftsprüfung fehlschlägt — die Existenz der Einladung zu verschleiern würde die Tatsache verbergen, dass der Angreifer ein echtes Token gefunden hat, aber 403 ist hier die korrekte Semantik, da die Ressource gefunden wurde, die Aktion aber verboten ist.
+
+## Zustandsmaschine
+
+```
+pending ──accept──► accepted
+pending ──cancel──► cancelled
+```
+
+Sobald eine Einladung `pending` verlässt, sind keine weiteren Übergänge erlaubt. Der Versuch, eine `accepted`- oder `cancelled`-Einladung anzunehmen, gibt 409 zurück.
+
+## Sicherheitseigenschaften
+
+| Eigenschaft | Implementierung |
+|-------------|-----------------|
+| Token-Entropie | `bin2hex(random_bytes(32))` — 256 Bit |
+| Token-Eindeutigkeit | UNIQUE-Constraint auf `invitations.token` |
+| Ablauf beim Lesen | Im Handler vor jedem Schreibvorgang geprüft |
+| Wiederverwendungsschutz | `isPending()`-Guard vor Accept/Cancel |
+| Eigentümerdurchsetzung | `inviter_id`-Gleichheitsprüfung → 403 |
+| Kein E-Mail-PII-Leak | 409-Body enthüllt die eingeladene E-Mail nicht |
+| SQL-Injection | PDO-parametrisierte Abfragen durchgehend |
+
+## Routenübersicht
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzerkonto erstellen |
+| `POST` | `/users/{id}/invitations` | Einladung senden |
+| `GET` | `/invitations/{token}` | Einladung anzeigen |
+| `POST` | `/invitations/{token}/accept` | Einladung annehmen |
+| `DELETE` | `/invitations/{token}` | Einladung stornieren |

--- a/docs/de/howto/user-preferences-api.md
+++ b/docs/de/howto/user-preferences-api.md
@@ -1,0 +1,142 @@
+# How-to: Benutzereinstellungen-API
+
+> **FT-Referenz**: FT329 (`NENE2-FT/preflog`) — Benutzerspezifischer Einstellungsspeicher mit typisierter Wertvalidierung, Standard-Fallback, Ablehnung unbekannter Schlüssel, Nur-Eigentümer-Mutation, 20 Tests / 70 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Benutzereinstellungssystem aufgebaut wird, bei dem Einstellungen typisierte Domains, Standards und `is_default`-Flags haben, um angepasste von Standardwerten zu unterscheiden.
+
+## Schema
+
+```sql
+CREATE TABLE user_preferences (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    pref_key   TEXT    NOT NULL,
+    pref_value TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE(user_id, pref_key)
+);
+```
+
+Standardwerte leben im Anwendungscode, nicht in der DB.
+
+## Einstellungsschlüssel & Validierung
+
+| Schlüssel | Typ | Standard | Erlaubte Werte |
+|-----------|-----|----------|----------------|
+| `theme` | enum | `"light"` | `light`, `dark`, `system` |
+| `language` | enum | `"en"` | `en`, `ja`, `fr` |
+| `notifications_enabled` | Boolean-String | `"true"` | `"true"`, `"false"` |
+| `items_per_page` | Integer-String | `"20"` | `"5"` – `"100"` |
+| `timezone` | string | `"UTC"` | beliebige IANA-Zeitzone |
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `GET` | `/users/{id}/preferences` | Alle abrufen (mit Standards) |
+| `PUT` | `/users/{id}/preferences/{key}` | Einen setzen (nur Eigentümer) |
+
+## Alle Einstellungen abrufen
+
+Gibt alle 5 Schlüssel zurück — gespeicherter Wert falls gesetzt, sonst Standard:
+
+```php
+GET /users/1/preferences
+→ 200
+{
+  "user_id": 1,
+  "preferences": [
+    {"key": "theme",                 "value": "light", "is_default": true,  "updated_at": null},
+    {"key": "language",              "value": "en",    "is_default": true,  "updated_at": null},
+    {"key": "notifications_enabled", "value": "true",  "is_default": true,  "updated_at": null},
+    {"key": "items_per_page",        "value": "20",    "is_default": true,  "updated_at": null},
+    {"key": "timezone",              "value": "UTC",   "is_default": true,  "updated_at": null}
+  ]
+}
+
+// Nach dem Setzen des Themes auf dark:
+{"key": "theme", "value": "dark", "is_default": false, "updated_at": "2026-05-27T..."}
+```
+
+Benutzer nicht gefunden → 404.
+
+## Einstellung setzen
+
+```php
+PUT /users/1/preferences/theme  X-User-Id: 1
+{"value": "dark"}
+→ 200  {"key": "theme", "value": "dark", "updated_at": "..."}
+
+// Existierende aktualisieren (UPSERT)
+PUT /users/1/preferences/theme  X-User-Id: 1
+{"value": "system"}
+→ 200  // nur eine Zeile pro (user_id, pref_key)
+```
+
+### Unbekannter Schlüssel
+
+```php
+PUT /users/1/preferences/invalid_key  X-User-Id: 1
+{"value": "foo"}
+→ 422
+{"valid_keys": ["theme", "language", "notifications_enabled", "items_per_page", "timezone"]}
+```
+
+### Ungültiger Wert
+
+```php
+PUT /users/1/preferences/theme  X-User-Id: 1  {"value": "neon"}     → 422
+PUT /users/1/preferences/notifications_enabled  {"value": "yes"}    → 422  // muss "true"/"false" sein
+PUT /users/1/preferences/items_per_page  {"value": "200"}           → 422  // max 100
+PUT /users/1/preferences/items_per_page  {"value": "1"}             → 422  // min 5
+```
+
+### Autorisierung
+
+```php
+// Anderer Benutzer kann Einstellungen nicht ändern
+PUT /users/1/preferences/theme  X-User-Id: 2  {"value": "dark"}  → 403
+
+// Benutzer nicht gefunden
+PUT /users/999/preferences/theme  X-User-Id: 999  {"value": "dark"}  → 404
+```
+
+## Implementierungsmuster
+
+```php
+private const SCHEMA = [
+    'theme'                 => ['type' => 'enum',    'values' => ['light','dark','system']],
+    'language'              => ['type' => 'enum',    'values' => ['en','ja','fr']],
+    'notifications_enabled' => ['type' => 'bool_str','values' => ['true','false']],
+    'items_per_page'        => ['type' => 'int_str', 'min' => 5, 'max' => 100],
+    'timezone'              => ['type' => 'string'],
+];
+
+private function validate(string $key, string $value): ?string
+{
+    $schema = self::SCHEMA[$key] ?? null;
+    if ($schema === null) {
+        return null;  // unbekannter Schlüssel
+    }
+
+    return match ($schema['type']) {
+        'enum'     => in_array($value, $schema['values'], true) ? $value : throw ValidationException,
+        'bool_str' => in_array($value, ['true','false'], true) ? $value : throw ValidationException,
+        'int_str'  => $this->validateIntStr($value, $schema['min'], $schema['max']),
+        default    => $value,
+    };
+}
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Beliebigen String für `theme` akzeptieren | UI stürzt beim Rendern unbekannter Themes ab; Enum validieren |
+| Standards in DB speichern | Jeder neue Benutzer erfordert einen DB-Insert für jeden Standard; Code-seitige Standards verwenden |
+| Leeres Array zurückgeben, wenn keine Prefs gespeichert | Client muss "nicht gesetzt"-Fall behandeln; alle Schlüssel mit Standards zurückgeben |
+| `is_default`-Flag weglassen | Client kann Benutzerabsicht nicht von Systemstandard unterscheiden |
+| Änderung der Einstellungen anderer Benutzer erlauben | Datenschutzverletzung; Eigentümerprüfung ist obligatorisch |
+| `"yes"/"no"` für Boolean-Pref akzeptieren | Inkonsistent; auf `"true"/"false"`-Strings normalisieren |

--- a/docs/de/howto/user-preferences-management.md
+++ b/docs/de/howto/user-preferences-management.md
@@ -1,0 +1,154 @@
+# Benutzereinstellungen-Verwaltung
+
+Implementierungsanleitung für die Verwaltung von Benutzereinstellungen (Preferences).
+Einstellungswerte können für einen vordefinierten Schlüsselsatz mit typisierter Validierung gespeichert, aktualisiert und zurückgesetzt werden.
+
+## Überblick
+
+- Einstellungsschlüssel werden per Enum verwaltet (unbekannte Schlüssel → 422)
+- Werte werden pro Schlüssel typvalidiert
+- Änderung fremder Einstellungen → 403 (Eigentümerschaftsprüfung)
+- Nicht gesetzte Schlüssel geben den Standardwert zurück (`is_default: true`)
+- DELETE setzt auf Standardwert zurück
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `GET` | `/users/{id}/preferences` | Einstellungsliste abrufen (alle Schlüssel, inkl. Standards) |
+| `PUT` | `/users/{id}/preferences/{key}` | Einstellungswert aktualisieren (Upsert) |
+| `DELETE` | `/users/{id}/preferences/{key}` | Einstellung zurücksetzen (auf Standard) |
+
+## Datenbankdesign
+
+```sql
+CREATE TABLE user_preferences (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    pref_key TEXT NOT NULL,
+    pref_value TEXT NOT NULL,   -- immer als String gespeichert
+    updated_at TEXT NOT NULL,
+    UNIQUE (user_id, pref_key), -- Schlüssel pro Benutzer eindeutig
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+Werte werden immer als `TEXT` gespeichert. Die Typinterpretation erfolgt auf Client-Seite
+(`items_per_page: "20"` → Frontend macht `parseInt()`).
+
+## Einstellungsschlüssel-Enum
+
+```php
+enum PreferenceKey: string
+{
+    case Theme = 'theme';
+    case Language = 'language';
+    case NotificationsEnabled = 'notifications_enabled';
+    case ItemsPerPage = 'items_per_page';
+    case Timezone = 'timezone';
+
+    public function defaultValue(): string
+    {
+        return match ($this) {
+            self::Theme => 'light',
+            self::Language => 'en',
+            self::NotificationsEnabled => 'true',
+            self::ItemsPerPage => '20',
+            self::Timezone => 'UTC',
+        };
+    }
+
+    public function validate(string $value): bool
+    {
+        return match ($this) {
+            self::Theme => in_array($value, ['light', 'dark', 'system'], true),
+            self::Language => preg_match('/^[a-z]{2}(-[A-Z]{2})?$/', $value) === 1,
+            self::NotificationsEnabled => in_array($value, ['true', 'false'], true),
+            self::ItemsPerPage => ctype_digit($value) && (int) $value >= 5 && (int) $value <= 100,
+            self::Timezone => strlen($value) <= 64 && strlen($value) > 0,
+        };
+    }
+}
+```
+
+## GET /users/{id}/preferences Antwort
+
+```json
+{
+  "preferences": [
+    {"key": "theme", "value": "dark", "is_default": false, "updated_at": "2026-05-21T10:00:00+00:00"},
+    {"key": "language", "value": "en", "is_default": true, "updated_at": null},
+    {"key": "notifications_enabled", "value": "true", "is_default": true, "updated_at": null},
+    {"key": "items_per_page", "value": "20", "is_default": true, "updated_at": null},
+    {"key": "timezone", "value": "UTC", "is_default": true, "updated_at": null}
+  ]
+}
+```
+
+Alle Schlüssel werden zurückgegeben (gespeicherte mit ihrem Wert, nicht gespeicherte mit Standardwert).
+
+## Upsert-Muster
+
+```php
+public function upsertPreference(int $userId, string $key, string $value, string $now): void
+{
+    $existing = $this->findPreference($userId, $key);
+    if ($existing !== null) {
+        $this->executor->execute(
+            'UPDATE user_preferences SET pref_value = ?, updated_at = ? WHERE user_id = ? AND pref_key = ?',
+            [$value, $now, $userId, $key]
+        );
+    } else {
+        $this->executor->execute(
+            'INSERT INTO user_preferences (user_id, pref_key, pref_value, updated_at) VALUES (?, ?, ?, ?)',
+            [$userId, $key, $value, $now]
+        );
+    }
+}
+```
+
+In Kombination mit dem UNIQUE(user_id, pref_key)-Constraint wird 1 Zeile pro Benutzer pro Schlüssel garantiert.
+
+## Eigentümerschaftsprüfung (IDOR-Prävention)
+
+```php
+$actorId = (int) $request->getHeaderLine('X-User-Id');
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'cannot modify another user\'s preferences'], 403);
+}
+```
+
+Fremde Einstellungen können nicht geändert oder gelöscht werden. Lesen ist für alle möglich (Einstellungen sind in der Regel öffentlich).
+
+## DELETE = Zurücksetzen (physisches Löschen)
+
+DELETE löscht die Einstellungszeile aus der DB; bei GET wird wieder der Standardwert zurückgegeben:
+
+```php
+$this->repository->deletePreference($userId, $prefKey->value);
+return $this->responseFactory->create([
+    'key' => $prefKey->value,
+    'value' => $prefKey->defaultValue(),
+    'is_default' => true,
+], 200);
+```
+
+Auch wenn noch nicht gesetzt (erster DELETE), wird 200 zurückgegeben (Idempotenz).
+
+## Antwort bei unbekanntem Schlüssel
+
+```json
+{
+  "error": "unknown preference key",
+  "valid_keys": ["theme", "language", "notifications_enabled", "items_per_page", "timezone"]
+}
+```
+
+Die Rückgabe der gültigen Schlüsselliste erhöht die Selbsterklärungsfähigkeit der API.
+
+## Erweiterungsmuster
+
+- **Kategorisierung**: `PreferenceCategory`-Enum hinzufügen und nach UI, Benachrichtigungen, Anzeige etc. gruppieren
+- **Benutzertypspezifische Standards**: `defaultValue(UserType $type)` für bedingte Verzweigung
+- **Audit-Log**: `updated_at` + Änderungshistorie-Tabelle zur Verfolgung von Einstellungsänderungen
+- **Batch-Update**: `PATCH /users/{id}/preferences` zur gleichzeitigen Aktualisierung mehrerer Einstellungen

--- a/docs/de/howto/user-profile-api.md
+++ b/docs/de/howto/user-profile-api.md
@@ -1,0 +1,129 @@
+# How-to: Benutzerprofil-API
+
+> **FT-Referenz**: FT275 (`NENE2-FT/profilelog`) — Benutzerprofil: ein-Profil-pro-Benutzer (UNIQUE user_id), E-Mail validiert mit FILTER_VALIDATE_EMAIL, Feldlängenbeschränkungen (display_name 100 / bio 500 / avatar_url 2048), Nur-HTTPS-Avatar-URL, DatabaseConstraintException → 409, Eigentümerguard via X-User-Id, 32 Tests BESTANDEN.
+
+Demonstriert ein 1:1 Benutzer-zu-Profil-System: Benutzer erstellen (E-Mail eindeutig), ihr Profil erstellen/abrufen/aktualisieren. Profilfelder haben durchgesetzte Längenbeschränkungen und eine URL-Sicherheitsbeschränkung.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    email      TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE profiles (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL UNIQUE,
+    display_name TEXT    NOT NULL DEFAULT '',
+    bio          TEXT    NOT NULL DEFAULT '',
+    avatar_url   TEXT    NOT NULL DEFAULT '',
+    updated_at   TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`user_id UNIQUE` setzt die Ein-Profil-pro-Benutzer-Invariante auf DB-Ebene durch.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzer erstellen (E-Mail erforderlich, eindeutig) |
+| `POST` | `/users/{userId}/profile` | Profil für Benutzer erstellen |
+| `GET` | `/users/{userId}/profile` | Profil abrufen |
+| `PUT` | `/users/{userId}/profile` | Profil aktualisieren (nur Eigentümer) |
+
+---
+
+## E-Mail-Validierung
+
+```php
+if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    return $this->responseFactory->create(['error' => 'valid email is required'], 422);
+}
+```
+
+Bei doppelter E-Mail wird `DatabaseConstraintException` abgefangen und auf 409 gemappt:
+
+```php
+try {
+    $userId = $this->repo->createUser($email, $now);
+} catch (DatabaseConstraintException) {
+    return $this->responseFactory->create(['error' => 'email already registered'], 409);
+}
+```
+
+---
+
+## Feldgrenzen (UserProfile-Value-Object)
+
+```php
+final readonly class UserProfile
+{
+    public const int MAX_BIO_LENGTH          = 500;
+    public const int MAX_DISPLAY_NAME_LENGTH = 100;
+    public const int MAX_AVATAR_URL_LENGTH   = 2048;
+}
+```
+
+Länge wird mit `mb_strlen()` geprüft (Mehrbyte-sicher):
+
+```php
+if (mb_strlen($displayName) > UserProfile::MAX_DISPLAY_NAME_LENGTH) {
+    return [$displayName, $bio, $avatarUrl, 'display_name must not exceed 100 characters'];
+}
+```
+
+---
+
+## Nur-HTTPS-Avatar-URL
+
+```php
+private function isValidAvatarUrl(string $url): bool
+{
+    if (mb_strlen($url) > UserProfile::MAX_AVATAR_URL_LENGTH) {
+        return false;
+    }
+    // Nur HTTPS erlauben, um javascript:- und data:-URI-Schemata zu verhindern
+    if (!str_starts_with($url, 'https://')) {
+        return false;
+    }
+    return filter_var($url, FILTER_VALIDATE_URL) !== false;
+}
+```
+
+`str_starts_with('https://')` blockiert `javascript:`, `data:` und `http://` bevor `filter_var` läuft.
+
+---
+
+## Eigentümerguard
+
+Profilaktualisierungen erfordern, dass `X-User-Id` mit dem Profileigentümer übereinstimmt:
+
+```php
+$actorId = $this->resolveActorId($request); // aus X-User-Id-Header
+
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Keine E-Mail-Format-Validierung | Ungültige E-Mails gespeichert; Downstream-Sendevorgänge schlagen still fehl |
+| Kein UNIQUE auf `user_id` in Profilen | Doppelte Profile möglich; GET gibt unvorhersehbare Zeile zurück |
+| `strlen()` für display_name-Limit verwenden | Mehrbyte-Zeichen (Emoji, CJK) falsch gezählt |
+| `http://`-Avatar-URLs erlauben | Passives Mixed-Content und potenzielle Clickjacking-Fläche |
+| `javascript:`- oder `data:`-URIs erlauben | XSS wenn Avatar-URL als `<a href>` oder `<img src>` gerendert wird |
+| `DatabaseConstraintException`-Catch überspringen | UNIQUE-Verletzung wird zu 500 statt 409 |
+| Jedem Benutzer erlauben, jedes Profil zu aktualisieren | IDOR — vor dem Schreiben immer Akteur = Eigentümer prüfen |

--- a/docs/de/howto/user-profile-management.md
+++ b/docs/de/howto/user-profile-management.md
@@ -1,0 +1,136 @@
+# Benutzerprofil-Verwaltung
+
+Benutzerorientierte Profildaten speichern und aktualisieren: Anzeigename, Bio und Avatar-URL. Die Profilerstellung erfolgt getrennt von der Benutzererstellung — Benutzer existieren zuerst, dann wird ein Profil einmalig erstellt und an Ort und Stelle aktualisiert.
+
+## Überblick
+
+Eine Profilverwaltungs-API umfasst:
+- **Benutzer erstellen** — E-Mail-basierte Benutzerregistrierung (ein Profil pro Benutzer)
+- **Profil erstellen** — Erstmalige Profileinrichtung (idempotenzresistent: 409 wenn bereits vorhanden)
+- **Profil abrufen** — Aktuelle Profildaten abrufen
+- **Profil aktualisieren** — Profilfelder ersetzen (Eigentümerschaft wird durchgesetzt)
+
+## Datenbankschema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    email      TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE profiles (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL UNIQUE,
+    display_name TEXT    NOT NULL DEFAULT '',
+    bio          TEXT    NOT NULL DEFAULT '',
+    avatar_url   TEXT    NOT NULL DEFAULT '',
+    updated_at   TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`UNIQUE` auf `user_id` setzt ein Profil pro Benutzer auf DB-Ebene durch.
+
+## Umgang mit doppelter E-Mail
+
+`DatabaseConstraintException` abfangen, um 409 statt eines 500-Leaks zurückzugeben:
+
+```php
+try {
+    $userId = $this->repo->createUser($email, $now);
+} catch (DatabaseConstraintException) {
+    return $this->responseFactory->create(['error' => 'email already registered'], 409);
+}
+```
+
+Ohne diesen Catch führt eine doppelte E-Mail zu einer unbehandelten Ausnahme, die interne Fehlerdetails an den Client weitergibt.
+
+## Avatar-URL-Validierung
+
+Nur `https://`-URLs erlauben, um `javascript:`, `data:`, `file://` und `http://`-Schemata zu verhindern:
+
+```php
+private function isValidAvatarUrl(string $url): bool
+{
+    if (mb_strlen($url) > UserProfile::MAX_AVATAR_URL_LENGTH) {
+        return false;
+    }
+
+    // Nur HTTPS — blockiert javascript:, data:, file://, ftp://, http://
+    if (!str_starts_with($url, 'https://')) {
+        return false;
+    }
+
+    return filter_var($url, FILTER_VALIDATE_URL) !== false;
+}
+```
+
+Leerer String ist erlaubt (kein Avatar gesetzt). Das Limit `MAX_AVATAR_URL_LENGTH = 2048` verhindert Speichermissbrauch.
+
+## Feldlängenbeschränkungen
+
+Beschränkungen als Konstanten auf dem Value-Object definieren für eine einzige Wahrheitsquelle:
+
+```php
+final readonly class UserProfile
+{
+    public const int MAX_BIO_LENGTH          = 500;
+    public const int MAX_DISPLAY_NAME_LENGTH = 100;
+    public const int MAX_AVATAR_URL_LENGTH   = 2048;
+    ...
+}
+```
+
+`mb_strlen()` statt `strlen()` für Mehrbyte (UTF-8) Korrektheit verwenden.
+
+## Eigentümerschaftsprüfung
+
+Der `PUT /users/{userId}/profile`-Endpunkt verwendet einen `X-User-Id`-Header zur Identifikation des anfragenden Akteurs. In der Produktion durch einen JWT-Claim ersetzen:
+
+```php
+private function resolveActorId(ServerRequestInterface $request): int
+{
+    $header = $request->getHeaderLine('X-User-Id');
+    return is_numeric($header) ? (int) $header : 0;
+}
+
+// Im Handler:
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+Nicht-numerischer oder fehlender Header wird zu `0` aufgelöst, was niemals einer echten Benutzer-ID entspricht → 403.
+
+## Verhinderung doppelter Profile
+
+Vor dem Einfügen auf vorhandenes Profil prüfen und 409 zurückgeben:
+
+```php
+if ($this->repo->findByUserId($userId) !== null) {
+    return $this->responseFactory->create(['error' => 'profile already exists'], 409);
+}
+```
+
+Dies verhindert, dass ein zweiter `POST /users/{userId}/profile` ein vorhandenes Profil still überschreibt.
+
+## Sicherheitseigenschaften
+
+| Eigenschaft | Implementierung |
+|-------------|-----------------|
+| Doppelte E-Mail | `DatabaseConstraintException` abgefangen → 409 (kein Stack-Trace-Leak) |
+| avatar_url-Schema | `str_starts_with('https://')` blockiert alle Nicht-HTTPS-Schemata |
+| avatar_url-Länge | `MAX_AVATAR_URL_LENGTH = 2048` |
+| bio-Länge | `MAX_BIO_LENGTH = 500` mit `mb_strlen()` |
+| Eigentümerschaft | `X-User-Id`-Header (in Produktion durch JWT-Claim ersetzen) |
+| Ein Profil pro Benutzer | `UNIQUE (user_id)` DB-Constraint + 409-Prüfung im Handler |
+
+## Routenübersicht
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzer registrieren (E-Mail, 409 bei Duplikat) |
+| `POST` | `/users/{userId}/profile` | Profil erstellen (409 wenn bereits vorhanden) |
+| `GET` | `/users/{userId}/profile` | Profil abrufen |
+| `PUT` | `/users/{userId}/profile` | Profil aktualisieren (erfordert `X-User-Id`-Header) |

--- a/docs/de/howto/validate-unicode-input.md
+++ b/docs/de/howto/validate-unicode-input.md
@@ -1,0 +1,117 @@
+# Unicode-Eingaben validieren
+
+NENE2 speichert und gibt Strings als UTF-8 zurück. Diese Anleitung behandelt die Fallstricke der Unicode-bewussten Validierung und deren Handhabung.
+
+## `mb_strlen` für Zeichenanzahl-Limits verwenden
+
+`strlen` zählt Bytes, keine Zeichen. Japanisch, Arabisch und Emoji verwenden mehrere Bytes pro Zeichen.
+
+```php
+strlen('あ')              // 3 (Bytes)
+mb_strlen('あ', 'UTF-8') // 1 (Zeichen)
+
+strlen('🎉')              // 4 (Bytes)
+mb_strlen('🎉', 'UTF-8') // 1 (Zeichen — ein Codepoint)
+```
+
+Immer `mb_strlen($value, 'UTF-8')` verwenden, wenn ein Zeichenlimit durchgesetzt wird:
+
+```php
+private const int NAME_MAX_CHARS = 50;
+
+if (mb_strlen($name, 'UTF-8') > self::NAME_MAX_CHARS) {
+    $errors[] = ['field' => 'name', 'code' => 'too_long',
+                 'message' => 'name must be at most ' . self::NAME_MAX_CHARS . ' characters.'];
+}
+```
+
+**Warum `strlen` versagt:** Ein japanischer Name mit 50 Zeichen ist 150 Bytes. `strlen(...) > 50` würde ihn ablehnen.
+
+## Null-Bytes explizit ablehnen
+
+SQLite-TEXT-Spalten akzeptieren Null-Bytes (`\x00`). PHP-String-Operationen behandeln sie ebenfalls — aber Null-Bytes in Benutzereingaben sind fast immer Injektionsversuche oder Kodierungsfehler. Sie frühzeitig ablehnen:
+
+```php
+if (str_contains($name, "\x00")) {
+    $errors[] = ['field' => 'name', 'code' => 'invalid', 'message' => 'name must not contain null bytes.'];
+}
+```
+
+Diese Prüfung auf jedes String-Feld vor anderen Validierungen (Länge, Format etc.) anwenden.
+
+## Graphem-Cluster vs. Codepoints
+
+`mb_strlen` zählt Unicode-_Codepoints_. Ein sichtbares Glyph (Graphem-Cluster) kann aus mehreren Codepoints bestehen:
+
+| Eingabe | Codepoints | `mb_strlen` | Glyphen |
+|---------|-----------|-------------|---------|
+| `é` (präkomponiert) | 1 | 1 | 1 |
+| `é` (e + kombinierender Akzent) | 2 | 2 | 1 |
+| 👨‍👩‍👧 (ZWJ-Familie) | 5 | 5 | 1 |
+
+Für die meisten Anwendungsfälle (Benutzernamen, Bios) ist die Codepoint-Zählung ausreichend. Wenn sichtbare Zeichen gezählt werden müssen, `grapheme_strlen()` aus der `intl`-Erweiterung verwenden:
+
+```php
+grapheme_strlen('👨‍👩‍👧') // 1
+mb_strlen('👨‍👩‍👧', 'UTF-8') // 5
+```
+
+Die Zählmethode wählen, die der Benutzererwartung für das jeweilige Feld entspricht.
+
+## JSON-Antworten und Nicht-ASCII-Zeichen
+
+`JsonResponseFactory` kodiert Antworten mit `JSON_UNESCAPED_UNICODE`, sodass Nicht-ASCII-Zeichen als literales UTF-8 im Antwort-Body erscheinen:
+
+```json
+{ "name": "田中太郎" }
+```
+
+Bei einer benutzerdefinierten `json_encode`-Aufruf anderswo (z. B. Tags als JSON in einer TEXT-Spalte speichern) dasselbe Flag hinzufügen:
+
+```php
+$tagsJson = json_encode($tags, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+```
+
+Ohne `JSON_UNESCAPED_UNICODE` wäre der gespeicherte Wert `["タグ"]` statt `["タグ"]`.
+
+## Vollständiges Validierungsbeispiel
+
+```php
+private const int NAME_MAX_CHARS = 50;
+
+private function validateName(string $raw): ?string
+{
+    if ($raw === '') {
+        return 'name is required.';
+    }
+    if (str_contains($raw, "\x00")) {
+        return 'name must not contain null bytes.';
+    }
+    if (mb_strlen($raw, 'UTF-8') > self::NAME_MAX_CHARS) {
+        return 'name must be at most ' . self::NAME_MAX_CHARS . ' characters.';
+    }
+    return null; // gültig
+}
+```
+
+## Grenzwerte testen
+
+Immer Tests schreiben für:
+
+- Genau `MAX` Zeichen (sollte bestehen) — Unicode-Zeichen verwenden, um Byte-/Zeichen-Unterschied zu verifizieren:
+
+  ```php
+  $name50 = str_repeat('あ', 50); // 150 Bytes, 50 Zeichen — sollte bestehen
+  ```
+
+- `MAX + 1` Zeichen (sollte fehlschlagen):
+
+  ```php
+  $name51 = str_repeat('あ', 51); // sollte 422 mit too_long zurückgeben
+  ```
+
+- Null-Byte-Ablehnung:
+
+  ```php
+  "Valid\x00Name" // sollte 422 mit invalid zurückgeben
+  ```

--- a/docs/de/howto/voting-system.md
+++ b/docs/de/howto/voting-system.md
@@ -1,0 +1,149 @@
+# Abstimmungssystem (Upvote / Downvote)
+
+Benutzern erlauben, Elemente hoch- oder herunterzustufen. Jeder Benutzer kann pro Element maximal eine Stimme abgeben. Zweimal in dieselbe Richtung abstimmen schaltet die Stimme aus. In die entgegengesetzte Richtung abstimmen wechselt die Stimme.
+
+## Überblick
+
+Ein Abstimmungssystem umfasst:
+- **Stimme abgeben**: Element hoch- oder herunterstimmen
+- **Umschalten**: Zweimal in dieselbe Richtung abstimmen entfernt die Stimme
+- **Wechseln**: In die entgegengesetzte Richtung abstimmen ersetzt die aktuelle Stimme
+- **Score**: Upvotes − Downvotes, mit jeder Stimm-Antwort zurückgegeben
+- **Aktuelle Stimme**: Aktuelle Stimme eines Benutzers für ein Element abrufen (für UI-Hervorhebung)
+
+## Datenbankschema
+
+```sql
+CREATE TABLE votes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    direction  TEXT    NOT NULL CHECK (direction IN ('up', 'down')),
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+```
+
+Der `UNIQUE (user_id, item_id)`-Constraint setzt eine Stimme pro Benutzer pro Element auf Datenbankebene durch. `CHECK (direction IN ('up', 'down'))` verhindert ungültige Werte, auch wenn die Validierung auf Anwendungsebene umgangen wird.
+
+## Richtung als Enum
+
+Ein backed Enum verwenden, um ungültige Richtungswerte zu verhindern, bevor sie das Repository erreichen:
+
+```php
+enum VoteDirection: string
+{
+    case Up   = 'up';
+    case Down = 'down';
+}
+```
+
+Mit `VoteDirection::tryFrom($dirStr)` parsen — gibt `null` für ungültige Eingaben zurück und ermöglicht eine saubere 422-Behandlung ohne match/switch.
+
+## Toggle- und Switch-Logik
+
+Alle drei Fälle (Toggle-Off, Richtungswechsel, neue Stimme) werden im Repository behandelt:
+
+```php
+public function castVote(int $userId, int $itemId, VoteDirection $direction, string $now): ?VoteDirection
+{
+    $current = $this->getCurrentVote($userId, $itemId);
+
+    if ($current === $direction) {
+        // gleiche Richtung → Toggle-Off
+        $this->executor->execute(
+            'DELETE FROM votes WHERE user_id = ? AND item_id = ?',
+            [$userId, $itemId],
+        );
+        return null;
+    }
+
+    if ($current !== null) {
+        // andere Richtung → wechseln
+        $this->executor->execute(
+            'UPDATE votes SET direction = ?, created_at = ? WHERE user_id = ? AND item_id = ?',
+            [$direction->value, $now, $userId, $itemId],
+        );
+    } else {
+        // keine vorhandene Stimme → einfügen
+        $this->executor->execute(
+            'INSERT INTO votes (user_id, item_id, direction, created_at) VALUES (?, ?, ?, ?)',
+            [$userId, $itemId, $direction->value, $now],
+        );
+    }
+
+    return $direction;
+}
+```
+
+Der Rückgabewert `?VoteDirection` lässt den Handler wissen, ob die Stimme jetzt gesetzt (`'up'`/`'down'`) oder entfernt (`null`) ist.
+
+## Score mit jeder Stimme zurückgeben
+
+Den aktualisierten Score in die Stimmantwort einschließen, damit Clients Zähler ohne ein separates GET aktualisieren können:
+
+```php
+$result = $this->repo->castVote($userId, $itemId, $direction, $now);
+$score  = $this->repo->getScore($itemId);
+
+return $this->responseFactory->create([
+    'user_id' => $userId,
+    'item_id' => $itemId,
+    'vote'    => $result !== null ? $result->value : null,
+    'score'   => $score->toArray(),
+]);
+```
+
+## Score-Berechnung
+
+Separate COUNT-Abfragen pro Richtung sind einfacher und lesbarer als ein einzelnes GROUP BY:
+
+```php
+public function getScore(int $itemId): ItemScore
+{
+    $upRow = $this->executor->fetchOne(
+        "SELECT COUNT(*) as cnt FROM votes WHERE item_id = ? AND direction = 'up'",
+        [$itemId],
+    );
+    $downRow = $this->executor->fetchOne(
+        "SELECT COUNT(*) as cnt FROM votes WHERE item_id = ? AND direction = 'down'",
+        [$itemId],
+    );
+    ...
+}
+```
+
+`score = upvotes - downvotes`. Null ist der Ausgangszustand, bevor Stimmen abgegeben wurden.
+
+## Benutzer-Stimmstatus
+
+Ein separater Endpunkt lässt die UI zeigen, in welche Richtung der aktuelle Benutzer gestimmt hat (für Button-Hervorhebung):
+
+```php
+// GET /items/{itemId}/vote/{userId}
+$current = $this->repo->getCurrentVote($userId, $itemId);
+return ['vote' => $current !== null ? $current->value : null];
+```
+
+Gibt `null` zurück, wenn der Benutzer nicht gestimmt hat (oder seine Stimme umgeschaltet hat).
+
+## Sicherheitseigenschaften
+
+| Eigenschaft | Implementierung |
+|-------------|-----------------|
+| Eine Stimme pro Benutzer pro Element | `UNIQUE (user_id, item_id)` DB-Constraint |
+| Ungültige Richtung abgelehnt | `CHECK (direction IN ('up', 'down'))` + `VoteDirection::tryFrom()` |
+| Unbekannter Benutzer/Element | Gibt 404 zurück — keine Ressourcenexistenz geleakt |
+| Toggle-Sicherheit | Prüft aktuelle Stimme vor DELETE/UPDATE |
+
+## Routenübersicht
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzer erstellen |
+| `POST` | `/items` | Element erstellen |
+| `POST` | `/items/{itemId}/vote` | Stimme abgeben, wechseln oder umschalten |
+| `GET` | `/items/{itemId}/score` | Upvotes, Downvotes und Score abrufen |
+| `GET` | `/items/{itemId}/vote/{userId}` | Aktuelle Stimme eines Benutzers für ein Element abrufen |

--- a/docs/de/howto/waitlist-management.md
+++ b/docs/de/howto/waitlist-management.md
@@ -1,0 +1,221 @@
+# Wartelisten-Verwaltung
+
+Implementierungsanleitung für positionsbasierte Wartelisten (Warteschlangen).
+Erläutert dynamische Positionsberechnung, Zustandsmaschine, IDOR-Prävention und Admin-exklusive Endpunkte.
+
+## Überblick
+
+- Benutzer treten der Warteliste bei (optionale Notiz)
+- **Dynamische Positionsberechnung**: Position wird nicht in der DB gespeichert, sondern per `COUNT(*)` berechnet
+- Zustandsmaschine: `waiting` → `approved` / `declined` (einseitig, nicht umkehrbar)
+- Nur wartende Benutzer können austreten (`approved`/`declined` danach nicht mehr möglich)
+- Admin listet alle Einträge, genehmigt und lehnt ab (`X-Admin-Key`-Header)
+- Benutzerantwort enthält keine `user_id` (IDOR-Prävention)
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|--------------|
+| `POST` | `/waitlist` | `X-User-Id` | Warteliste beitreten |
+| `GET` | `/waitlist/me` | `X-User-Id` | Eigenen Eintrag und Position abrufen |
+| `DELETE` | `/waitlist/me` | `X-User-Id` | Warteliste verlassen |
+| `GET` | `/waitlist` | `X-Admin-Key` | Alle Einträge auflisten (Admin) |
+| `POST` | `/waitlist/{id}/approve` | `X-Admin-Key` | Eintrag genehmigen |
+| `POST` | `/waitlist/{id}/decline` | `X-Admin-Key` | Eintrag ablehnen |
+
+## Datenbankdesign
+
+```sql
+CREATE TABLE IF NOT EXISTS waitlist_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL UNIQUE,
+    status     TEXT    NOT NULL DEFAULT 'waiting',
+    note       TEXT,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+`UNIQUE` auf `user_id` stellt sicher, dass ein Benutzer nur einen Eintrag hat.
+Keine Positionsspalte (dynamische Berechnung).
+
+## Dynamische Positionsberechnung
+
+Position eines wartenden Eintrags wird relativ zur `id`-Reihenfolge berechnet:
+
+```sql
+SELECT COUNT(*) FROM waitlist_entries
+WHERE status = 'waiting' AND id <= :id
+```
+
+Vorteile:
+- Kein UPDATE aller Einträge bei Austritt/Genehmigung/Ablehnung erforderlich
+- Keine Schreibkonflikte
+- Für Einträge mit einem anderen Status als `waiting` wird `null` zurückgegeben
+
+```php
+public function positionOf(WaitlistEntry $entry): ?int
+{
+    if ($entry->status !== WaitlistStatus::Waiting) {
+        return null;
+    }
+
+    $stmt = $this->pdo->prepare(
+        "SELECT COUNT(*) FROM waitlist_entries
+         WHERE status = 'waiting' AND id <= :id",
+    );
+    $stmt->execute(['id' => $entry->id]);
+
+    return (int) $stmt->fetchColumn();
+}
+```
+
+## Zustandsmaschine
+
+```
+waiting ──→ approved
+        └─→ declined
+```
+
+- `waiting` kann nur zu `approved` oder `declined` wechseln
+- Nach Erreichen eines Terminal-Zustands keine Änderung mehr möglich (`isTerminal()`)
+- Nur wartende Benutzer können über `DELETE /waitlist/me` austreten
+
+```php
+enum WaitlistStatus: string
+{
+    case Waiting  = 'waiting';
+    case Approved = 'approved';
+    case Declined = 'declined';
+
+    public function isTerminal(): bool
+    {
+        return $this !== self::Waiting;
+    }
+}
+```
+
+## IDOR-Prävention
+
+Benutzerendpunkte (`/waitlist/me`) rufen über den `X-User-Id`-Header **nur den eigenen Eintrag** ab.
+Es gibt keinen Pfad, über den eine fremde `user_id` übergeben werden könnte, und die Antwort enthält keine `user_id`.
+
+```php
+/** Benutzerantwort (ohne user_id) */
+public function toPublicArray(): array
+{
+    return [
+        'id'         => $this->id,
+        'status'     => $this->status->value,
+        'note'       => $this->note,
+        'created_at' => $this->createdAt,
+    ];
+}
+
+/** Admin-Antwort (mit user_id) */
+public function toAdminArray(): array
+{
+    return [
+        'id'         => $this->id,
+        'user_id'    => $this->userId,
+        'status'     => $this->status->value,
+        'note'       => $this->note,
+        'created_at' => $this->createdAt,
+        'updated_at' => $this->updatedAt,
+    ];
+}
+```
+
+## Admin-Authentifizierung
+
+Den `X-Admin-Key`-Header mit `hash_equals()` in Konstantzeit vergleichen.
+Leerer adminKey gibt immer `false` zurück (Fail-Closed):
+
+```php
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    if ($this->adminKey === '') {
+        return false; // fail-closed
+    }
+
+    $provided = $request->getHeaderLine('X-Admin-Key');
+
+    return $provided !== '' && hash_equals($this->adminKey, $provided);
+}
+```
+
+## Routenreihenfolge
+
+`GET /waitlist/me` muss **vor** `GET /waitlist` registriert werden.
+Andernfalls wird `me` möglicherweise als `{id}` erfasst:
+
+```php
+$this->router->post('/waitlist',            $this->handleJoin(...));
+$this->router->get('/waitlist/me',          $this->handleMe(...));      // vor /waitlist registrieren
+$this->router->delete('/waitlist/me',       $this->handleLeave(...));
+$this->router->get('/waitlist',             $this->handleAdminList(...));
+$this->router->post('/waitlist/{id}/approve', $this->handleApprove(...));
+$this->router->post('/waitlist/{id}/decline', $this->handleDecline(...));
+```
+
+## X-User-Id-Validierung
+
+Schutz vor Integer-Überlauf, Null, negativen Zahlen und Nicht-Ziffern:
+
+```php
+private function resolveUserId(ServerRequestInterface $request): ?int
+{
+    $raw = $request->getHeaderLine('X-User-Id');
+
+    if ($raw === '' || !ctype_digit($raw) || strlen($raw) > 18) {
+        return null;
+    }
+
+    $id = (int) $raw;
+
+    return $id > 0 ? $id : null;
+}
+```
+
+## Sicherheitspunkte
+
+| Bedrohung | Gegenmaßnahme |
+|-----------|---------------|
+| IDOR | `/waitlist/me` nur für sich selbst, keine `user_id` in der Antwort |
+| Admin-Key-Abhören | `hash_equals()` für Konstantzeit-Vergleich |
+| Integer-Überlauf | `strlen > 18`-Guard |
+| Doppelte Teilnahme | `UNIQUE(user_id)`-Constraint → 409 |
+| Ungültige Zustandsübergänge | `isTerminal()` verhindert Änderungen nach Terminal-Zustand |
+| SQL-Injection | PDO Prepared Statements |
+
+## Antwortbeispiele
+
+```json
+// POST /waitlist (201)
+{
+    "entry": { "id": 1, "status": "waiting", "note": "VIP-Anfrage", "created_at": "..." },
+    "position": 1
+}
+
+// GET /waitlist/me — status approved (200)
+{
+    "entry": { "id": 1, "status": "approved", "note": "VIP-Anfrage", "created_at": "..." },
+    "position": null
+}
+
+// GET /waitlist (admin, 200)
+{
+    "data": [
+        { "id": 1, "user_id": 101, "status": "approved", "note": "VIP-Anfrage", ... },
+        { "id": 2, "user_id": 102, "status": "waiting",  "note": null,          ... }
+    ],
+    "total": 2
+}
+```
+
+## Verwandte Anleitungen
+
+- [System-Ankündigung-Verwaltung](system-announcement-management.md) — Admin-Key-Authentifizierungsmuster (ähnliches `hash_equals()`)
+- [Datenschutz-Einwilligungsverwaltung](privacy-consent-management.md) — UPSERT und idempotente Operationen
+- [Soft-Delete](soft-delete.md) — Lösch-Flag-Muster (Austritt ist physisches Löschen)
+- [Doppelbuchung verhindern](prevent-double-booking.md) — Konfliktvermeidung durch UNIQUE-Constraint

--- a/docs/de/howto/waitlist-system.md
+++ b/docs/de/howto/waitlist-system.md
@@ -1,0 +1,168 @@
+# How-to: Wartelistensystem
+
+> **FT-Referenz**: FT287 (`NENE2-FT/waitlistlog`) — Wartelistensystem: UNIQUE(user_id) Ein-Eintrag-Constraint, waiting→approved/declined-Zustandsmaschine, isTerminal()-Guard, /waitlist/me vor /{id} registriert um Route-Capture zu verhindern, X-Admin-Key-Authentifizierung, Queue-Positionsverfolgung, 39 Tests / 98 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Wartelistensystem aufgebaut wird, bei dem Benutzer einer Warteschlange beitreten und Administratoren Einträge genehmigen oder ablehnen.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS waitlist_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL UNIQUE,   -- ein Eintrag pro Benutzer
+    status     TEXT    NOT NULL DEFAULT 'waiting',  -- waiting | approved | declined
+    note       TEXT,                               -- optionale Benutzernotiz (max 500 Zeichen)
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+`user_id UNIQUE` setzt einen Eintrag pro Benutzer auf DB-Ebene durch — keine Anwendungsschicht-Prüfung für Race Conditions erforderlich.
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|--------------|
+| `POST` | `/waitlist` | `X-User-Id` | Warteliste beitreten |
+| `GET` | `/waitlist/me` | `X-User-Id` | Eigenen Status + Position abrufen |
+| `DELETE` | `/waitlist/me` | `X-User-Id` | Warteliste verlassen |
+| `GET` | `/waitlist` | `X-Admin-Key` | Admin: alle Einträge auflisten |
+| `POST` | `/waitlist/{id}/approve` | `X-Admin-Key` | Admin: Eintrag genehmigen |
+| `POST` | `/waitlist/{id}/decline` | `X-Admin-Key` | Admin: Eintrag ablehnen |
+
+## Routenregistrierungsreihenfolge
+
+`/waitlist/me` muss **vor** `/waitlist/{id}` registriert werden, um zu verhindern, dass der Pfadparameter den wörtlichen String `"me"` erfasst:
+
+```php
+// KORREKT: statischer Pfad vor dynamischem Pfad
+$this->router->get('/waitlist/me', $this->handleMe(...));
+$this->router->post('/waitlist/{id}/approve', $this->handleApprove(...));
+
+// FALSCH: {id} würde "me" erfassen
+$this->router->post('/waitlist/{id}/approve', $this->handleApprove(...));
+$this->router->get('/waitlist/me', $this->handleMe(...));  // wird nie erreicht
+```
+
+## Status-Lebenszyklus
+
+```
+waiting ──────→ approved (terminal)
+       └──────→ declined (terminal)
+```
+
+Einmal genehmigt oder abgelehnt, kann ein Eintrag nicht in einen anderen Zustand übergehen. Die `isTerminal()`-Methode schützt dies:
+
+```php
+enum WaitlistStatus: string
+{
+    case Waiting  = 'waiting';
+    case Approved = 'approved';
+    case Declined = 'declined';
+
+    public function isTerminal(): bool
+    {
+        return $this !== self::Waiting;
+    }
+}
+```
+
+## Beitreten mit 409 bei Duplikat
+
+```php
+$entry = $this->repository->join($userId, $note);
+
+if ($entry === null) {
+    return $this->responseFactory->create(['error' => 'Already on the waitlist.'], 409);
+}
+```
+
+Das Repository gibt `null` zurück, wenn `user_id` bereits existiert (aus `DatabaseConstraintException` abgefangen). Die Antwort ist 409 Conflict.
+
+## Positionsverfolgung
+
+```php
+$position = $this->repository->positionOf($entry);
+
+// positionOf() zählt Einträge mit status='waiting' und id <= $entry->id
+// SELECT COUNT(*) FROM waitlist_entries WHERE status = 'waiting' AND id <= ?
+```
+
+Position ist der 1-basierte Rang in der `waiting`-Warteschlange. Genehmigte/abgelehnte Einträge zählen nicht. Das gibt Benutzern einen aussagekräftigen Platz in der Schlange.
+
+## Admin-Übergang mit match
+
+```php
+private function handleTransition(int $id, WaitlistStatus $newStatus): ResponseInterface
+{
+    $result = $this->repository->transition($id, $newStatus);
+
+    return match ($result) {
+        'ok'               => $this->responseFactory->create(['status' => $newStatus->value]),
+        'not_found'        => $this->responseFactory->create(['error' => 'Entry not found.'], 404),
+        'already_terminal' => $this->responseFactory->create(['error' => 'Entry is already approved or declined.'], 409),
+        default            => $this->responseFactory->create(['error' => 'Unexpected error.'], 500),
+    };
+}
+```
+
+`match` ist erschöpfend — der `default`-Fall fängt unerwartete Rückgabewerte aus dem Repository ab.
+
+## Verlassen (nur im Waiting-Status)
+
+```php
+return match ($result) {
+    'removed'     => $this->responseFactory->create(['removed' => true], 200),
+    'not_found'   => $this->responseFactory->create(['error' => 'Not on the waitlist.'], 404),
+    'not_waiting' => $this->responseFactory->create(['error' => 'Cannot leave — status is no longer waiting.'], 409),
+    default       => $this->responseFactory->create(['error' => 'Unexpected error.'], 500),
+};
+```
+
+Einmal genehmigt oder abgelehnt, kann ein Benutzer die Warteliste nicht mehr verlassen — seine Entscheidung ist festgehalten. Das verhindert das Austricksen des Systems (genehmigen, dann verlassen um Tracking zu vermeiden).
+
+## Admin-Authentifizierung
+
+```php
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    if ($this->adminKey === '') {
+        return false;  // fail-closed: kein konfigurierter Schlüssel → kein Admin-Zugriff
+    }
+    return hash_equals($this->adminKey, $request->getHeaderLine('X-Admin-Key'));
+}
+```
+
+`hash_equals()` verhindert Timing-Angriffe. Leerer Admin-Key gibt immer false zurück (fail-closed).
+
+## Notiz-Validierung
+
+```php
+private const int MAX_NOTE_LEN = 500;
+
+private function resolveNote(mixed $raw): ?string
+{
+    if (!is_string($raw) || trim($raw) === '') {
+        return null;
+    }
+    return mb_strlen($raw) > self::MAX_NOTE_LEN ? mb_substr($raw, 0, self::MAX_NOTE_LEN) : $raw;
+}
+```
+
+Notizen sind optional (null wenn fehlend/leer), max 500 Zeichen, werden bei Überschreitung abgeschnitten (nicht abgelehnt).
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Kein `UNIQUE(user_id)`-Constraint | Gleichzeitige Beitritte erzeugen doppelte Einträge; Race Condition |
+| `/{id}` vor `/me` registrieren | `/waitlist/me` wird unerreichbar — von `{id}` mit `"me"` erfasst |
+| Übergang aus Terminal-Zustand erlauben | Genehmigter Eintrag nach Zugangsgewährung abgelehnt; Zustandsmaschine kaputt |
+| Verlassen aus Terminal-Zustand erlauben | Genehmigter Benutzer verlässt; Zugangsgewährung wird verwaist |
+| Position basierend auf `id ASC` mit allen Einträgen berechnen | Zählt genehmigte/abgelehnte Benutzer; Positionsnummer ist irreführend |
+| Admin-Key in DB speichern | Key-Rotation erfordert DB-Update; stattdessen Env-Var verwenden |
+| `==` statt `hash_equals()` für Admin-Key | Timing-Angriff enthüllt Key ein Zeichen nach dem anderen |
+| Kein Admin-Fail-Closed | Leerer Key in Env erlaubt unauthentifizierten Admin-Zugriff |
+| Notiz ablehnen wenn zu lang | UX: Abschneiden ist benutzerfreundlicher als Ablehnen für weiche Metadaten wie Notizen |

--- a/docs/de/howto/webhook-delivery-api.md
+++ b/docs/de/howto/webhook-delivery-api.md
@@ -1,0 +1,333 @@
+# How-to: Webhook-Zustellungs-API
+
+> **FT-Referenz**: FT348 (`NENE2-FT/webhooklog`) — Webhook-Registrierung mit URL/Secret/Event-Filter, Event-Dispatch mit Zustellungsprotokoll pro Subscriber, Secret-Maskierung, Wiederholungsmechanismus, Erfolgs-/Fehlerstatus-Verfolgung, 18 Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Webhook-Zustellungssystem aufgebaut wird: Endpoint-Subscriber registrieren, Events an passende Hooks weiterleiten, jeden Zustellversuch protokollieren und Fehler wiederholen.
+
+## Schema
+
+```sql
+CREATE TABLE webhooks (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    url        TEXT    NOT NULL,
+    secret     TEXT    NOT NULL DEFAULT '',
+    events     TEXT    NOT NULL DEFAULT '[]',  -- JSON-Array; leer = alle Events
+    is_active  INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE deliveries (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    webhook_id   INTEGER NOT NULL REFERENCES webhooks(id) ON DELETE CASCADE,
+    event_type   TEXT    NOT NULL,
+    payload      TEXT    NOT NULL DEFAULT '{}',
+    status       TEXT    NOT NULL CHECK(status IN ('pending', 'success', 'failed')),
+    http_status  INTEGER,
+    response     TEXT,
+    error        TEXT,
+    attempted_at TEXT,
+    created_at   TEXT    NOT NULL
+);
+```
+
+`events = '[]'` (leeres Array) bedeutet "alle Events abonnieren". `ON DELETE CASCADE` entfernt Zustellungseinträge wenn ein Webhook gelöscht wird.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/webhooks` | Webhook registrieren |
+| `GET` | `/webhooks` | Alle Webhooks auflisten |
+| `GET` | `/webhooks/{id}` | Einzelnen Webhook abrufen |
+| `DELETE` | `/webhooks/{id}` | Webhook löschen (+ Zustellungen) |
+| `GET` | `/webhooks/{id}/deliveries` | Zustellungen für Webhook auflisten |
+| `POST` | `/events/dispatch` | Event an Subscriber weiterleiten |
+| `POST` | `/deliveries/{id}/retry` | Fehlgeschlagene Zustellung wiederholen |
+
+## Webhook registrieren
+
+```php
+POST /webhooks
+{
+  "url": "https://example.com/hook",
+  "secret": "my-signing-secret",
+  "events": ["order.created", "order.updated"]
+}
+
+→ 201
+{
+  "id": 1,
+  "url": "https://example.com/hook",
+  "secret": "***",        // ← Secret immer maskiert in Antworten
+  "events": ["order.created", "order.updated"],
+  "is_active": true,
+  "created_at": "..."
+}
+```
+
+### Alle Events abonnieren
+
+```php
+POST /webhooks
+{"url": "https://example.com/hook", "secret": "", "events": []}
+
+→ 201  {"events": [], ...}   // leere events = alle Event-Typen empfangen
+```
+
+### Validierung
+
+```php
+POST /webhooks  {"events": []}
+→ 422  // url ist erforderlich
+```
+
+**Secret-Maskierung**: Das gespeicherte Secret wird nur für HMAC-Signierung verwendet. In jeder Antwort `"***"` zurückgeben — niemals den tatsächlichen Secret-Wert.
+
+## Event weiterleiten
+
+```php
+POST /events/dispatch
+{"event_type": "order.created", "payload": {"order_id": 42, "amount": 99.99}}
+
+→ 200
+{
+  "event_type": "order.created",
+  "dispatched_to": 2,           // Anzahl passender Webhooks
+  "deliveries": [
+    {
+      "id": 1,
+      "webhook_id": 1,
+      "event_type": "order.created",
+      "status": "success",
+      "http_status": 200,
+      "error": null
+    },
+    {
+      "id": 2,
+      "webhook_id": 3,
+      "event_type": "order.created",
+      "status": "failed",
+      "http_status": 500,
+      "error": "Connection timeout"
+    }
+  ]
+}
+```
+
+### Event-Matching
+
+Ein Webhook empfängt ein Event wenn:
+1. Sein `events`-Array leer ist (abonniert alle), **ODER**
+2. Der `event_type` in seinem `events`-Array erscheint.
+
+```php
+// Webhook A: events = ["order.created"]
+// Webhook B: events = ["user.signup"]
+// Webhook C: events = []  (alle)
+
+dispatch("order.created")
+→ dispatched_to: 2  // A und C passen, B nicht
+```
+
+### Keine passenden Webhooks
+
+```php
+POST /events/dispatch  {"event_type": "unknown.event", "payload": {}}
+→ 200  {"dispatched_to": 0, "deliveries": []}
+```
+
+### Dispatch-Implementierung
+
+```php
+public function dispatch(string $eventType, array $payload): array
+{
+    // Alle aktiven Webhooks finden, die diesem Event entsprechen
+    $hooks = $this->repo->findMatchingWebhooks($eventType);
+    $deliveries = [];
+
+    foreach ($hooks as $hook) {
+        $delivery = $this->repo->createDelivery($hook['id'], $eventType, $payload, 'pending');
+        $result = $this->client->deliver($hook['url'], $eventType, $payload, $hook['secret']);
+        $this->repo->updateDelivery(
+            $delivery['id'],
+            $result->status,        // 'success' oder 'failed'
+            $result->httpStatus,
+            $result->response,
+            $result->error,
+            $now,
+        );
+        $deliveries[] = $this->repo->findDelivery($delivery['id']);
+    }
+
+    return [
+        'event_type'    => $eventType,
+        'dispatched_to' => count($deliveries),
+        'deliveries'    => $deliveries,
+    ];
+}
+```
+
+```sql
+-- Passende Webhooks finden (aktiv + Event-Filter)
+SELECT * FROM webhooks
+WHERE is_active = 1
+  AND (events = '[]' OR events LIKE '%"' || ? || '"%')
+```
+
+## Zustellungen auflisten
+
+```php
+GET /webhooks/1/deliveries
+
+→ 200
+{
+  "total": 3,
+  "items": [
+    {"id": 1, "event_type": "order.created", "status": "success", "http_status": 200, ...},
+    {"id": 2, "event_type": "order.updated", "status": "failed",  "http_status": 500, ...},
+    {"id": 3, "event_type": "ping",           "status": "success", "http_status": 200, ...}
+  ]
+}
+
+// Webhook nicht gefunden
+GET /webhooks/9999/deliveries
+→ 404
+```
+
+## Fehlgeschlagene Zustellung wiederholen
+
+```php
+POST /deliveries/2/retry
+
+→ 200
+{
+  "id": 2,
+  "status": "success",
+  "http_status": 200,
+  "error": null
+}
+
+// Zustellung nicht gefunden
+POST /deliveries/9999/retry
+→ 404
+```
+
+---
+
+## ATK Assessment — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Secret-Extraktion via GET 🚫 BLOCKED
+
+**Attack**: Angreifer registriert einen Webhook und ruft dann `GET /webhooks/{id}` auf oder listet Webhooks auf, um das Signing-Secret abzurufen.
+**Result**: BLOCKED — Jede Antwort gibt `"secret": "***"` zurück. Das tatsächliche Secret ist in der DB gespeichert, wird aber durch keinen Endpunkt zurückgegeben. Angreifer kann das Secret nicht über die API abrufen.
+
+---
+
+### ATK-02 — Webhook mit interner/privater URL registrieren (SSRF) ⚠️ EXPOSED
+
+**Attack**: Angreifer registriert `url: "http://169.254.169.254/latest/meta-data"` (AWS-Metadaten-Endpunkt) oder `http://localhost:8080/admin`. Wenn ein Event ausgelöst wird, ruft der Server die interne URL ab.
+**Result**: EXPOSED — Das webhooklog-FT implementiert keine URL-Validierung oder SSRF-Blockierung für registrierte URLs. In der Produktion muss validiert werden, dass die URL auf eine öffentliche IP aufgelöst wird (kein Loopback, privates RFC1918, Link-Local oder Metadatendienste) vor der Registrierung. Siehe `docs/howto/url-shortener-ssrf-prevention.md` für das SSRF-Blockierungsmuster.
+
+---
+
+### ATK-03 — Dispatch an inaktiven Webhook 🚫 BLOCKED
+
+**Attack**: Angreifer löscht einen Webhook und löst dann ein Event aus, in der Hoffnung, dass die Zustellung immer noch an einem gecachten Endpoint erfolgt.
+**Result**: BLOCKED — Dispatch-Abfrage filtert `WHERE is_active = 1`. Gelöschte Webhooks werden aus der Tabelle entfernt (`ON DELETE CASCADE`), erscheinen also nie in der Matching-Abfrage.
+
+---
+
+### ATK-04 — SQL-Injection über das event_type-Feld 🚫 BLOCKED
+
+**Attack**: Angreifer sendet `{"event_type": "'; DROP TABLE webhooks; --", "payload": {}}` um Webhook-Registrierungen zu zerstören.
+**Result**: BLOCKED — Die `LIKE '%"' || ? || '"%'`-Match-Abfrage verwendet einen gebundenen Parameter für `event_type`. PDO Prepared Statements verhindern SQL-Injection. Der bösartige String wird wörtlich gespeichert/abgeglichen.
+
+---
+
+### ATK-05 — Alle Events via präpariertem events-Array abonnieren 🚫 BLOCKED
+
+**Attack**: Angreifer sendet `{"events": null}` oder `{"events": "all"}` in der Hoffnung, alle Events zu abonnieren ohne die dokumentierte Leerarray-Konvention zu verwenden.
+**Result**: BLOCKED — `events` wird als JSON-Array validiert. Nicht-Array-Werte geben 422 zurück. Nur ein wörtliches `[]` löst den "alle abonnieren"-Pfad aus.
+
+---
+
+### ATK-06 — Zustellung an HTTPS mit ungültigem Zertifikat ✅ SAFE
+
+**Attack**: Angreifer registriert eine Webhook-URL mit einem abgelaufenen oder selbst signierten TLS-Zertifikat, in der Hoffnung, dass der Zustellungsclient es trotzdem akzeptiert.
+**Result**: SAFE — Der Zustellungsclient sollte TLS-Zertifikatsverifikation durchsetzen (`CURLOPT_SSL_VERIFYPEER = true`). Dieses FT verwendet einen Stub-Client für Tests; Produktions-Clients müssen Zertifikatsvalidierung durchsetzen.
+
+---
+
+### ATK-07 — Zugestelltes Event via Retry wiederholen 🚫 BLOCKED
+
+**Attack**: Angreifer ruft `POST /deliveries/{id}/retry` für eine **erfolgreiche** Zustellung auf, um ein Event beim Subscriber zu wiederholen.
+**Result**: BLOCKED — Retry ruft den Zustellungseintrag erneut ab und postet das gespeicherte Payload erneut an die Webhook-URL. Der Subscriber muss Idempotenz-Schlüssel implementieren, um zu deduplizieren. Das Zustellungssystem selbst blockiert keine Wiederholungen erfolgreicher Zustellungen, was beabsichtigt ist (Admin-Anwendungsfall). Subscriber-seitige Idempotenz ist die Schutzmaßnahme.
+
+---
+
+### ATK-08 — Zustellungs-IDs aufzählen um auf Logs anderer Webhooks zuzugreifen 🚫 BLOCKED
+
+**Attack**: Angreifer iteriert Zustellungs-IDs via `GET /deliveries/{id}` um Zustellungslogs für Webhooks zu lesen, die ihnen nicht gehören.
+**Result**: BLOCKED — Es gibt keinen `GET /deliveries/{id}`-Endpunkt; Zustellungen sind nur scoped an einen bestimmten Webhook über `GET /webhooks/{id}/deliveries` zugänglich. Die Webhook-404-Prüfung steuert den Zugang.
+
+---
+
+### ATK-09 — events-Array überlaufen um Speicher zu erschöpfen ✅ SAFE
+
+**Attack**: Angreifer sendet `{"events": [... 10.000 Event-Typen ...]}` um Speicher beim JSON-Parsen oder Speichern zu erschöpfen.
+**Result**: SAFE — Request-Größenbeschränkungs-Middleware (Standard 1 MB) lehnt überdimensionierte Bodies ab. Anwendungsseitige Array-Längenvalidierung (z. B. `max: 50 Events`) bietet einen zweiten Guard.
+
+---
+
+### ATK-10 — Doppelte URL registrieren um mehrfache Zustellungen auszulösen ✅ SAFE
+
+**Attack**: Angreifer registriert dieselbe URL 100 Mal, um 100 Kopien jedes Events zu empfangen.
+**Result**: SAFE — Mehrfache Registrierungen derselben URL sind erlaubt (z. B. für unterschiedliche Event-Teilmengen). Rate Limiting und Authentifizierung am Registrierungsendpunkt sind die Guards gegen Missbrauch. Für die Produktion einen `UNIQUE(url)`-Constraint oder Webhook-Limits pro Benutzer hinzufügen.
+
+---
+
+### ATK-11 — Webhook eines anderen Benutzers per ID löschen 🚫 BLOCKED
+
+**Attack**: Angreifer errät eine Integer-Webhook-ID und ruft `DELETE /webhooks/{id}` auf, um den Webhook eines anderen Benutzers zu entfernen.
+**Result**: BLOCKED — Autorisierung (Eigentümerschaftsprüfung via JWT/Session) schützt das Löschen. Das FT demonstriert die Mechanik; Auth ist eine erforderliche Schicht in der Produktion.
+
+---
+
+### ATK-12 — Payload injizieren um serverseitige Daten zu exfiltrieren ✅ SAFE
+
+**Attack**: Angreifer löst ein Event mit `{"payload": {"__proto__": {"admin": true}}}` aus, in der Hoffnung, Prototype-Pollution oder Template-Injection zur Zustellung zu nutzen.
+**Result**: SAFE — `payload` wird als JSON-String gespeichert und wörtlich an den Subscriber weitergeleitet. PHP-JSON hat keine Prototype-Pollution; Template-Injection erfordert eine explizite Template-Engine. Das Payload ist opake Daten.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Secret-Extraktion via GET | 🚫 BLOCKED |
+| ATK-02 | SSRF via interne Webhook-URL | ⚠️ EXPOSED |
+| ATK-03 | Dispatch an inaktiven/gelöschten Webhook | 🚫 BLOCKED |
+| ATK-04 | SQL-Injection via event_type | 🚫 BLOCKED |
+| ATK-05 | Alle abonnieren via Nicht-Array-Events | 🚫 BLOCKED |
+| ATK-06 | Zustellung an ungültiges TLS-Zertifikat | ✅ SAFE |
+| ATK-07 | Wiederholen via Retry | 🚫 BLOCKED |
+| ATK-08 | Zustellungs-IDs über Webhooks aufzählen | 🚫 BLOCKED |
+| ATK-09 | events-Array-Speichererschöpfung | ✅ SAFE |
+| ATK-10 | Doppelte URL-Registrierung | ✅ SAFE |
+| ATK-11 | Webhook eines anderen Benutzers löschen | 🚫 BLOCKED |
+| ATK-12 | Prototype-Pollution / Template-Injection im Payload | ✅ SAFE |
+
+**8 BLOCKED, 3 SAFE, 1 EXPOSED** — ATK-02 (SSRF via Webhook-URL) erfordert Produktionsminderung: registrierte URLs gegen eine private-IP-Blocklist validieren vor der Speicherung. Siehe `docs/howto/url-shortener-ssrf-prevention.md`.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Tatsächliches Secret in einer Antwort zurückgeben | Angreifer kann Secret verwenden um gültige HMAC-Signaturen für jedes Event zu fälschen |
+| Keine URL-Validierung bei Webhook-Registrierung | SSRF: Server liefert Events an interne Metadaten-Endpunkte |
+| Kein `is_active`-Filter in Dispatch-Abfrage | Inaktive/soft-gelöschte Webhooks empfangen weiterhin Events |
+| Payload als PHP-serialisierten String speichern | Deserialisierung angreifer-kontrollierter Daten löst Remote-Code-Execution aus |
+| Kein Zustellungsprotokoll pro Webhook | Zustellungsfehler können nicht diagnostiziert oder Replay-Angriffe erkannt werden |
+| Kein Wiederholungsmechanismus | Transiente Fehler verlieren Event-Zustellungen dauerhaft |

--- a/docs/de/howto/webhook-delivery-system.md
+++ b/docs/de/howto/webhook-delivery-system.md
@@ -1,0 +1,293 @@
+# How-to: Webhook-Zustellungssystem
+
+> **FT-Referenz**: FT308 (`NENE2-FT/webhookdeliverylog`) — Webhook-Zustellungssystem: SSRF-Schutz via UrlValidator (nur HTTPS, private-IP-Blocklist, CRLF-Injection-Prävention), HMAC-SHA256-Signatur mit Timestamp-Bindung, Secret als SHA-256-Hash gespeichert (niemals Klartext), Secret nicht in GET-Antworten zurückgegeben, deaktivierte Endpunkte überspringen Zustellung, Event-Typ-Isolation, ATK-01〜12 alle BLOCKED, 31 Tests / 47 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Webhook-Zustellungssystem aufgebaut wird, bei dem Webhook-Secrets geschützt sind, URLs gegen SSRF-Angriffe validiert werden und Payloads mit Timestamps signiert werden, um Replay-Angriffe zu verhindern.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    url         TEXT    NOT NULL,
+    event_type  TEXT    NOT NULL,
+    secret_hash TEXT    NOT NULL,   -- SHA-256-Hash des rohen Secrets
+    max_retries INTEGER NOT NULL DEFAULT 3,
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_at  TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    endpoint_id   INTEGER NOT NULL REFERENCES webhook_endpoints(id),
+    event_type    TEXT    NOT NULL,
+    payload       TEXT    NOT NULL DEFAULT '{}',
+    status        TEXT    NOT NULL DEFAULT 'pending',
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_status   INTEGER,
+    last_error    TEXT,
+    delivered_at  TEXT,
+    created_at    TEXT    NOT NULL,
+    updated_at    TEXT    NOT NULL
+);
+```
+
+`secret_hash` speichert den SHA-256-Hash des rohen Secrets — niemals das Secret selbst. Das `active`-Flag ermöglicht das Soft-Deaktivieren eines Endpunkts ohne Löschen der Zustellungshistorie.
+
+## SSRF-Schutz — UrlValidator
+
+```php
+final class UrlValidator
+{
+    public function validate(string $url): ?string
+    {
+        // CRLF- und Null-Byte-Injection blockieren
+        if (str_contains($url, "\n") || str_contains($url, "\r") || str_contains($url, "\0")) {
+            return 'URL contains illegal control characters.';
+        }
+
+        $parsed = parse_url($url);
+        if ($parsed === false || !isset($parsed['scheme'], $parsed['host'])) {
+            return 'URL is not valid.';
+        }
+
+        // Nur HTTPS
+        if (strtolower($parsed['scheme']) !== 'https') {
+            return 'Only HTTPS URLs are allowed for webhook delivery.';
+        }
+
+        $host = strtolower($parsed['host']);
+
+        // Localhost und Varianten blockieren
+        if (in_array($host, ['localhost', 'ip6-localhost', 'ip6-loopback'], true)) {
+            return "Webhook URL must not target '{$host}'.";
+        }
+
+        // Interne TLDs blockieren
+        foreach (['.local', '.internal', '.test', '.example', '.invalid', '.localhost'] as $pattern) {
+            if (str_ends_with($host, $pattern)) {
+                return "Webhook URL must not target '{$pattern}' domains.";
+            }
+        }
+
+        // Private IPv4-Bereiche blockieren (127.x, 10.x, 172.16-31.x, 192.168.x)
+        $ip = trim($host, '[]');
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+                return 'Webhook URL must not target private or loopback IP addresses.';
+            }
+        }
+
+        // Private IPv6 blockieren (::1, fc00::/7, fe80::/10)
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            // ... IPv6 private Bereichsprüfungen
+        }
+
+        return null; // gültig
+    }
+}
+```
+
+Validierung blockiert:
+1. **CRLF/Null-Byte-Injection** — verhindert Header-Injection in HTTP-Anfragen an die Webhook-URL
+2. **Nicht-HTTPS-Schemata** — `http://`, `file://`, `ftp://`, `gopher://` alle blockiert
+3. **Loopback-Adressen** — `127.0.0.0/8`, `::1`
+4. **Private Bereiche** — `10.x`, `172.16-31.x`, `192.168.x`, `0.0.0.0`
+5. **Interne TLDs** — `.local`, `.internal`, `.test`, `.example`
+
+## Webhook-Signierung — HMAC-SHA256 + Timestamp
+
+```php
+final class WebhookSigner
+{
+    public function sign(string $rawSecret, string $body, string $timestamp): string
+    {
+        $payload = $timestamp . '.' . $body;  // Timestamp bindet Signatur an Zeit
+        $mac     = hash_hmac('sha256', $payload, $rawSecret);
+        return 'sha256=' . $mac;
+    }
+
+    public function hashSecret(string $rawSecret): string
+    {
+        return hash('sha256', $rawSecret);
+    }
+}
+```
+
+Das Signaturformat `sha256=<hex>` ist dasselbe Muster wie bei GitHub-Webhooks. Der **Timestamp ist im signierten Inhalt enthalten** (`timestamp.body`) — das verhindert Replay-Angriffe: eine zum Zeitpunkt T erfasste Signatur kann nicht zum Zeitpunkt T+1h wiedergegeben werden.
+
+## Secret-Speicherung — Hash, niemals Klartext
+
+```php
+// Bei Endpoint-Erstellung:
+$secretHash = $this->signer->hashSecret($rawSecret);
+$this->repo->createEndpoint($url, $eventType, $secretHash, $maxRetries);
+
+// Das rohe Secret einmalig an den Aufrufer zurückgeben:
+return $this->json->create([
+    'id'     => $endpointId,
+    'secret' => $rawSecret,  // nur bei Erstellung gezeigt
+    // gespeichert als: secret_hash = SHA-256($rawSecret)
+]);
+```
+
+Das rohe Secret wird dem Aufrufer **nur einmalig** bei der Erstellung zurückgegeben. Nachfolgende `GET /endpoints/{id}`-Antworten enthalten niemals `secret` oder `secret_hash`.
+
+```php
+// GET Endpoint-Antwort — Secret NICHT enthalten
+return $this->json->create([
+    'id'         => (int) $endpoint['id'],
+    'url'        => $endpoint['url'],
+    'event_type' => $endpoint['event_type'],
+    'active'     => (bool) $endpoint['active'],
+    'max_retries'=> (int) $endpoint['max_retries'],
+    'created_at' => $endpoint['created_at'],
+    // 'secret_hash' absichtlich weggelassen
+]);
+```
+
+## Deaktivierter Endpoint überspringen
+
+```php
+// Dispatch-Handler
+if (!(bool) $endpoint['active']) {
+    return $this->json->create(['message' => 'Endpoint is inactive, no delivery queued.'], 200);
+}
+```
+
+Deaktivierte Endpunkte erhalten keine neuen Zustellungen. Dies ermöglicht das Deaktivieren eines Webhooks ohne Löschen des Endpunkts oder seiner Zustellungshistorie.
+
+## Event-Typ-Isolation
+
+Jeder Endpunkt abonniert einen bestimmten `event_type`. Beim Dispatch:
+
+```php
+$endpoints = $this->repo->findActiveEndpointsByType($eventType);
+// Nur Endpunkte, die dem event_type entsprechen, werden beliefert
+```
+
+Ein Endpunkt, der `order.created` abonniert, empfängt keine `order.cancelled`-Events.
+
+---
+
+## ATK Assessment — Cracker-Mindset-Angriffstest
+
+### ATK-01 — SSRF via Loopback IPv4 (127.x.x.x) 🚫 BLOCKED
+
+**Attack**: Endpunkt mit `url: "https://127.0.0.1/admin"` registrieren.
+**Result**: BLOCKED — UrlValidator erkennt privaten IPv4-Bereich → 422.
+
+---
+
+### ATK-02 — SSRF via 0.0.0.0 🚫 BLOCKED
+
+**Attack**: `url: "https://0.0.0.0/internal"`.
+**Result**: BLOCKED — reservierter IP-Bereich durch `FILTER_FLAG_NO_RES_RANGE` blockiert → 422.
+
+---
+
+### ATK-03 — SSRF via privatem Bereich 10.x.x.x 🚫 BLOCKED
+
+**Attack**: `url: "https://10.0.0.1/internal"`.
+**Result**: BLOCKED — privater IPv4-Bereich → 422.
+
+---
+
+### ATK-04 — SSRF via privatem Bereich 172.16-31.x.x 🚫 BLOCKED
+
+**Attack**: `url: "https://172.16.0.1/internal"`.
+**Result**: BLOCKED — privater IPv4-Bereich → 422.
+
+---
+
+### ATK-05 — HTTP-Schema-Downgrade 🚫 BLOCKED
+
+**Attack**: `url: "http://example.com/hook"` (Nicht-HTTPS).
+**Result**: BLOCKED — Schema-Prüfung: nur `https` erlaubt → 422.
+
+---
+
+### ATK-06 — file://-Schema 🚫 BLOCKED
+
+**Attack**: `url: "file:///etc/passwd"`.
+**Result**: BLOCKED — Schema-Prüfung blockiert Nicht-HTTPS → 422.
+
+---
+
+### ATK-07 — CRLF-Injection in URL 🚫 BLOCKED
+
+**Attack**: `url: "https://example.com/\r\nX-Injected: header"`.
+**Result**: BLOCKED — `str_contains($url, "\r")`-Prüfung → 422.
+
+---
+
+### ATK-08 — Null-Byte in URL 🚫 BLOCKED
+
+**Attack**: `url: "https://example.com/\0hidden"`.
+**Result**: BLOCKED — `str_contains($url, "\0")`-Prüfung → 422.
+
+---
+
+### ATK-09 — Secret-Leak via GET-Endpoint 🚫 BLOCKED
+
+**Attack**: `GET /endpoints/{id}` um das gespeicherte Secret abzurufen.
+**Result**: BLOCKED — GET-Antwort lässt `secret`- und `secret_hash`-Felder vollständig weg.
+
+---
+
+### ATK-10 — Secret-Leak via Dispatch-Antwort 🚫 BLOCKED
+
+**Attack**: Dispatch-Antwort-Body auf Secret-Material untersuchen.
+**Result**: BLOCKED — Dispatch-Antwort enthält nur Zustellungs-Metadaten, keine Secret-Felder.
+
+---
+
+### ATK-11 — Replay-Angriff (erfasste Signatur) 🚫 BLOCKED
+
+**Attack**: Signierten Webhook erfassen und später mit derselben Signatur wiedergeben.
+**Result**: BLOCKED — Signatur ist `HMAC(timestamp.body, secret)`. Timestamp ändert sich pro Zustellung; alte Signatur passt nicht zum neuen Timestamp.
+
+---
+
+### ATK-12 — Gefälschte Signatur mit falschem Secret 🚫 BLOCKED
+
+**Attack**: HMAC mit einem geratenen/anderen Secret berechnen und als gültige Signatur einreichen.
+**Result**: BLOCKED — Empfänger validiert mit gespeichertem Secret-Hash; gefälschter HMAC passt nicht.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | SSRF Loopback IPv4 | 🚫 BLOCKED |
+| ATK-02 | SSRF 0.0.0.0 | 🚫 BLOCKED |
+| ATK-03 | SSRF privat 10.x | 🚫 BLOCKED |
+| ATK-04 | SSRF privat 172.16-31.x | 🚫 BLOCKED |
+| ATK-05 | HTTP-Schema-Downgrade | 🚫 BLOCKED |
+| ATK-06 | file://-Schema | 🚫 BLOCKED |
+| ATK-07 | CRLF-Injection in URL | 🚫 BLOCKED |
+| ATK-08 | Null-Byte in URL | 🚫 BLOCKED |
+| ATK-09 | Secret-Leak via GET | 🚫 BLOCKED |
+| ATK-10 | Secret-Leak via Dispatch | 🚫 BLOCKED |
+| ATK-11 | Replay-Angriff | 🚫 BLOCKED |
+| ATK-12 | Gefälschte Signatur | 🚫 BLOCKED |
+
+**12 BLOCKED, 0 EXPOSED**
+UrlValidator blockiert alle SSRF-Vektoren. Timestamp-gebundenes HMAC verhindert Replays. Secret als Hash gespeichert, nach Erstellung nicht mehr zurückgegeben.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Rohes Webhook-Secret in DB speichern | DB-Sicherheitsverletzung enthüllt alle Secrets; SHA-256-Hash ist Einweg |
+| Secret in GET-Antwort zurückgeben | Jedes Admin-API-Leak enthüllt alle Webhook-Secrets |
+| HMAC nur über Body (kein Timestamp) | Replay-Angriff: erfasste Signatur unbegrenzt wiederverwendbar |
+| `http://`-Webhook-URLs erlauben | Abhören von Webhook-Payloads im Netzwerkverkehr |
+| Keine SSRF-Validierung auf URL | Webhook-System wird zum Sondieren des internen Netzwerks missbraucht |
+| `127.x`, `10.x` in Webhook-URL erlauben | Server macht Anfragen an seine eigenen internen Dienste |
+| Keine CRLF-Prüfung | URL mit `\r\n` injiziert Header in ausgehende HTTP-Anfrage |
+| An inaktive Endpunkte zustellen | Deaktivierte Endpunkte empfangen weiterhin Traffic |
+| Keine Event-Typ-Filterung | Alle Event-Typen werden an alle Endpunkte zugestellt |

--- a/docs/de/howto/webhook-delivery.md
+++ b/docs/de/howto/webhook-delivery.md
@@ -1,0 +1,151 @@
+# Ausgehende Webhook-Zustellung
+
+Ausgehende Webhooks benachrichtigen Drittsysteme, wenn Ereignisse in der Anwendung auftreten. Die primären Sicherheitsbedenken sind SSRF (Anfragen an interne Infrastruktur senden), Secret-Leak und Signaturintegrität.
+
+## Kernkomponenten
+
+- **Endpoint-Registry**: speichert URL, Event-Filter und ein gehashtes Secret pro Subscriber.
+- **Delivery-Queue**: ein Datensatz pro (Endpoint, Event)-Paar, verfolgt Versuchsanzahl und Status.
+- **Signer**: generiert HMAC-SHA256-Signaturen, die der Empfänger verifizieren kann.
+- **URL-Validator**: blockiert SSRF-Ziele vor der Speicherung von Endpunkten.
+
+## Schema
+
+```sql
+CREATE TABLE webhook_endpoints (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    url         TEXT    NOT NULL,
+    event_type  TEXT    NOT NULL,
+    secret_hash TEXT    NOT NULL,       -- SHA-256 des rohen Secrets; rohes Secret wird nie gespeichert
+    max_retries INTEGER NOT NULL DEFAULT 3,
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_at  TEXT    NOT NULL
+);
+
+CREATE TABLE webhook_deliveries (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    endpoint_id   INTEGER NOT NULL,
+    event_type    TEXT    NOT NULL,
+    payload       TEXT    NOT NULL,
+    status        TEXT    NOT NULL DEFAULT 'pending',  -- pending | delivered | failed
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_status   INTEGER,                             -- letzter HTTP-Antwortcode
+    last_error    TEXT,
+    delivered_at  TEXT,
+    created_at    TEXT    NOT NULL,
+    updated_at    TEXT    NOT NULL
+);
+```
+
+Nur der SHA-256-Hash des Secrets wird gespeichert. Das rohe Secret wird nie persistiert — wenn die Datenbank kompromittiert wird, können Hashes nicht rückgängig gemacht werden, um Signaturen zu fälschen (SHA-256 ohne HMAC ist für ein zufälliges 32-Byte-Secret nicht umkehrbar).
+
+## Signaturformat
+
+```
+X-Webhook-Signature: sha256={hex}
+X-Webhook-Timestamp: {unix_timestamp}
+```
+
+Signierter Inhalt: `{timestamp}.{body}` — bindet die Signatur sowohl an das Payload als auch an einen Zeitpunkt.
+
+```php
+public function sign(string $rawSecret, string $body, string $timestamp): string
+{
+    $payload = $timestamp . '.' . $body;
+    $mac     = hash_hmac('sha256', $payload, $rawSecret);
+
+    return 'sha256=' . $mac;
+}
+```
+
+Der Timestamp im signierten Inhalt verhindert Replay-Angriffe: Ein Angreifer, der einen gültigen Webhook erfasst, kann ihn nicht später wiederverwenden, weil der Timestamp veraltet wäre. Empfänger sollten Signaturen ablehnen, die älter als ein Schwellenwert (z. B. 5 Minuten) sind.
+
+## SSRF-Prävention
+
+Jede Webhook-URL vor der Speicherung validieren. Mindestens blockieren:
+
+```php
+final class UrlValidator
+{
+    public function validate(string $url): ?string
+    {
+        // CRLF/Null-Byte-Injection blockieren
+        if (str_contains($url, "\n") || str_contains($url, "\r") || str_contains($url, "\0")) {
+            return 'URL contains illegal control characters.';
+        }
+
+        // Nur HTTPS
+        if (strtolower(parse_url($url, PHP_URL_SCHEME) ?? '') !== 'https') {
+            return 'Only HTTPS URLs are allowed.';
+        }
+
+        // Private/Loopback-IPs und reservierte Hostnamen blockieren
+        // ...
+    }
+}
+```
+
+Zu blockierende private IPv4-Bereiche: `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `0.0.0.0`.
+
+Zu blockierende Hostnamen: `localhost`, `*.local`, `*.internal`, `*.test`, `*.invalid`.
+
+IPv6: `::1`, `fc00::/7` (ULA), `fe80::/10` (link-local).
+
+**DNS-Rebinding**: Die URL nur bei der Registrierung zu validieren ist nicht ausreichend — der DNS-Eintrag könnte sich zwischen Registrierung und Zustellung ändern, um auf eine interne IP zu zeigen. Für die Produktion auch die aufgelöste IP bei der Zustellung validieren, bevor die TCP-Verbindung geöffnet wird.
+
+## Antwortfilterung — Secrets niemals preisgeben
+
+Die `toArray()`-Methode auf `WebhookEndpoint` muss sowohl `secret` als auch `secret_hash` weglassen:
+
+```php
+public function toArray(): array
+{
+    return [
+        'id', 'url', 'event_type', 'max_retries', 'active', 'created_at',
+        // secret_hash absichtlich weggelassen
+    ];
+}
+```
+
+Dies gilt für: GET /webhooks/{id}, Endpunkte auflisten und jedes Audit-Log, das Endpoint-Metadaten aufzeichnet.
+
+## Wiederholungslogik
+
+```php
+public function markFailed(int $id, string $error, ?int $httpStatus, string $now, int $maxRetries): ?WebhookDelivery
+{
+    $newCount  = $delivery->attemptCount + 1;
+    $newStatus = $newCount >= $maxRetries ? 'failed' : 'pending';
+
+    $this->executor->execute(
+        'UPDATE webhook_deliveries SET status = ?, attempt_count = ?, last_error = ?, updated_at = ? WHERE id = ?',
+        [$newStatus, $newCount, $error, $now, $id],
+    );
+}
+```
+
+- `attempt_count < max_retries` → Status bleibt `pending` → Worker nimmt ihn erneut auf.
+- `attempt_count >= max_retries` → Status wird `failed` → Keine weiteren Wiederholungen.
+
+Worker sollten exponentielles Backoff implementieren (z. B. `2^attempt_count` Sekunden), um einen kämpfenden Empfänger nicht zu überlasten.
+
+## Deaktivierung
+
+Deaktivierte Endpunkte (`active = 0`) werden beim Dispatch aus der Fan-Out-Abfrage ausgeschlossen:
+
+```sql
+SELECT * FROM webhook_endpoints WHERE event_type = ? AND active = 1
+```
+
+Das gibt Subscribern eine Möglichkeit, die Zustellung zu pausieren ohne ihre Registrierung zu löschen.
+
+## Designentscheidungen
+
+**Warum `secret_hash` statt rohes Secret speichern?**
+Wenn die DB kompromittiert wird, kann der Angreifer keine Secrets extrahieren, um an Empfänger gesendete Webhook-Signaturen zu fälschen. Das rohe Secret wird einmalig bei der Erstellung zurückgegeben und muss vom Aufrufer sicher gespeichert werden.
+
+**Warum Timestamp in der Signatur einschließen?**
+Signaturen ohne Timestamps sind unbegrenzt wiederholbar. Das Einschließen von `{timestamp}.{body}` im HMAC bedeutet, dass ein Angreifer, der einen Webhook abfängt, ihn nicht erneut senden kann — Empfänger können Timestamps außerhalb eines ±5-Minuten-Fensters ablehnen.
+
+**Warum URL bei Registrierung und nicht bei Dispatch validieren?**
+Das Blockieren ungültiger URLs bei der Registrierung gibt dem Subscriber sofortiges Feedback und verhindert, dass schlechte Daten in die Delivery-Queue gelangen. DNS-Rebinding-Angriffe erfordern zusätzliche Validierung zum Zeitpunkt der Zustellung.

--- a/docs/de/howto/webhook-signature-verification.md
+++ b/docs/de/howto/webhook-signature-verification.md
@@ -1,0 +1,382 @@
+# How-to: Webhook-Signaturverifikation mit HMAC-SHA256
+
+> **FT-Referenz**: FT260 (`NENE2-FT/hmaclog`) — Webhook-Signaturverifikation: HMAC-SHA256, timing-sicherer Vergleich, Replay-Angriff-Prävention
+> **ATK**: FT260 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert, wie eingehende Webhook-Anfragen mit einer Stripe-ähnlichen HMAC-SHA256-Signatur verifiziert werden.
+Der Signatur-Header bindet einen Timestamp an den Request-Body und verhindert sowohl Fälschung als auch Replay-Angriffe.
+`hash_equals()` wird für den Konstantzeit-Vergleich verwendet, um Timing-Angriffe zu verhindern.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/webhook` | Signierten Webhook empfangen und verifizieren |
+| `GET` | `/webhook/events` | Empfangene Webhook-Events auflisten |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS webhook_events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type   TEXT NOT NULL,
+    payload      TEXT NOT NULL,
+    delivered_at TEXT NOT NULL
+);
+```
+
+Events werden nur nach bestandener Signaturverifikation gespeichert. Ein abgelehnter Webhook wird nie persistiert.
+
+---
+
+## Signaturformat (Stripe-Style)
+
+```
+X-Webhook-Signature: t=<unix-timestamp>,v1=<hmac-hex>
+```
+
+**Signiertes Payload**: `"<timestamp>.<raw-body>"`
+
+Der Timestamp ist in der HMAC-Berechnung enthalten. Das bedeutet:
+- Eine gültige Signatur gilt nur für den Body, über den sie berechnet wurde (Body-Manipulation bricht die Signatur).
+- Eine gültige Signatur gilt nur zum Zeitpunkt ihrer Generierung (das Wiederholen einer alten, gültigen Signatur schlägt die Timestamp-Prüfung fehl, auch wenn der HMAC korrekt ist).
+
+---
+
+## Verifier
+
+```php
+final class WebhookVerifier
+{
+    private const int TOLERANCE_SECONDS = 300;
+
+    public function __construct(private readonly string $secret) {}
+
+    public function verify(ServerRequestInterface $request, string $rawBody): void
+    {
+        $header = $request->getHeaderLine('X-Webhook-Signature');
+        if ($header === '') {
+            throw new SignatureException('Missing X-Webhook-Signature header.');
+        }
+
+        ['timestamp' => $timestamp, 'signature' => $receivedSig] = $this->parseHeader($header);
+
+        $this->checkTimestamp($timestamp);
+
+        $expectedSig = $this->computeSignature($timestamp, $rawBody);
+
+        // KRITISCH: hash_equals ist Konstantzeit; === ist es NICHT
+        if (!hash_equals($expectedSig, $receivedSig)) {
+            throw new SignatureException('Signature mismatch.');
+        }
+    }
+
+    public function sign(string $rawBody, int $timestamp): string
+    {
+        return "t={$timestamp},v1={$this->computeSignature($timestamp, $rawBody)}";
+    }
+
+    private function computeSignature(int $timestamp, string $rawBody): string
+    {
+        return hash_hmac('sha256', "{$timestamp}.{$rawBody}", $this->secret);
+    }
+
+    private function checkTimestamp(int $timestamp): void
+    {
+        $age = abs(time() - $timestamp);
+        if ($age > self::TOLERANCE_SECONDS) {
+            throw new SignatureException(
+                sprintf('Webhook timestamp is %d seconds old (tolerance: %d).', $age, self::TOLERANCE_SECONDS),
+            );
+        }
+    }
+
+    private function parseHeader(string $header): array
+    {
+        $parts = [];
+        foreach (explode(',', $header) as $chunk) {
+            [$k, $v] = explode('=', $chunk, 2) + ['', ''];
+            $parts[$k] = $v;
+        }
+        if (!isset($parts['t'], $parts['v1']) || !ctype_digit($parts['t']) || $parts['v1'] === '') {
+            throw new SignatureException('Malformed X-Webhook-Signature header.');
+        }
+        return ['timestamp' => (int) $parts['t'], 'signature' => $parts['v1']];
+    }
+}
+```
+
+---
+
+## Controller: Raw-Body-Extraktion
+
+```php
+private function receive(ServerRequestInterface $request): ResponseInterface
+{
+    $rawBody = (string) $request->getBody();   // muss rohe Bytes sein, nicht geparst
+
+    try {
+        $this->verifier->verify($request, $rawBody);
+    } catch (SignatureException $e) {
+        return $this->problems->create($request, 'invalid-signature', 'Invalid webhook signature.', 401, $e->getMessage());
+    }
+
+    $body = json_decode($rawBody, true);       // nur nach Verifikation parsen
+    if (!is_array($body) || !isset($body['event_type']) || !is_string($body['event_type'])) {
+        return $this->problems->create($request, 'invalid-body', 'event_type (string) is required.', 400);
+    }
+
+    $event = $this->repo->store($body['event_type'], $rawBody);
+    return $this->json->create(['id' => $event->id, 'status' => 'accepted'], 202);
+}
+```
+
+**Kritische Reihenfolge**:
+1. Raw-Body als String lesen — der HMAC wurde über die exakten Bytes berechnet.
+2. Signatur gegen den Raw-Body verifizieren.
+3. JSON erst nach erfolgreicher Verifikation parsen.
+
+Wenn JSON zuerst geparst und dann neu serialisiert wird, kann sich der Byte-Inhalt unterscheiden (Schlüsselsortierung, Whitespace), was die HMAC-Prüfung bricht.
+
+---
+
+## ATK — Cracker-Mindset-Angriffstest (FT260)
+
+### ATK-01 — Fehlender Signatur-Header
+
+**Attack**: Webhook ohne `X-Webhook-Signature`-Header senden.
+
+```bash
+POST /webhook
+{"event_type": "user.created"}
+```
+
+**Observed**: `verify()` prüft `$header === ''` vor jeder Berechnung. Gibt 401 Problem Details zurück:
+`"Missing X-Webhook-Signature header."` Kein Event wird gespeichert.
+
+**Verdict**: **BLOCKED** — fehlender Header wird vor der Signaturberechnung abgefangen.
+
+---
+
+### ATK-02 — Manipulierte Signatur (Ein-Zeichen-Änderung)
+
+**Attack**: Eine gültige Signatur nehmen und ein Hex-Zeichen ändern.
+
+```
+X-Webhook-Signature: t=<valid-ts>,v1=<valid-hmac-but-one-char-wrong>
+```
+
+**Observed**: `hash_equals($expectedSig, $receivedSig)` gibt `false` zurück. 401 wird zurückgegeben.
+Der Vergleich ist Konstantzeit — die Antwortzeit variiert nicht damit, wie viele Zeichen übereinstimmen.
+
+**Verdict**: **BLOCKED** — `hash_equals()` verhindert Timing-Oracle während manipulierte Sigs abgelehnt werden.
+
+---
+
+### ATK-03 — Falsches Secret verwendet
+
+**Attack**: Anfrage mit einem anderen HMAC-Secret signieren.
+
+```
+X-Webhook-Signature: t=<now>,v1=<hmac-with-wrong-secret>
+```
+
+**Observed**: `computeSignature()` verwendet das Server-Secret. Der HMAC des Angreifers (mit einem anderen Secret berechnet) produziert einen anderen Hex-String. `hash_equals()` schlägt fehl. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — ohne das Secret kann keine gültige Signatur gefälscht werden.
+
+---
+
+### ATK-04 — Replay-Angriff: gültige alte Signatur
+
+**Attack**: Einen legitimen `X-Webhook-Signature`-Header erfassen und 10 Minuten später wiederholen.
+
+```
+X-Webhook-Signature: t=<timestamp-from-10-minutes-ago>,v1=<valid-hmac>
+```
+
+**Observed**: `checkTimestamp($timestamp)` berechnet `abs(time() - $timestamp)`.
+10 Minuten = 600 Sekunden > 300-Sekunden-Toleranz. `SignatureException` wird geworfen. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — Replay-Angriffe werden durch die 300-Sekunden-Timestamp-Toleranz verhindert.
+
+---
+
+### ATK-05 — Zukünftiger Timestamp: Replay-Schutz-Umgehungsversuch
+
+**Attack**: Anfrage mit einem weit zukünftigen Timestamp vorsignieren, um das Gültigkeitsfenster zu erweitern.
+
+```
+X-Webhook-Signature: t=<now + 3600>,v1=<hmac-with-future-ts>
+```
+
+**Observed**: `abs(time() - $timestamp)` = 3600 > 300. `SignatureException` geworfen. 401 zurückgegeben.
+`abs()` bedeutet, dass zukünftige Timestamps ebenfalls abgelehnt werden — die Prüfung ist symmetrisch.
+
+**Verdict**: **BLOCKED** — `abs()` stellt sicher, dass sowohl vergangene als auch zukünftige Timestamps außerhalb des Toleranzfensters abgelehnt werden.
+
+---
+
+### ATK-06 — Body-Manipulation mit gültiger Signatur
+
+**Attack**: Gültigen Webhook abfangen. `X-Webhook-Signature`-Header behalten, aber JSON-Body ändern.
+
+```
+X-Webhook-Signature: t=<valid-ts>,v1=<valid-hmac-over-original-body>
+Body: {"event_type": "user.deleted"}   ← geändert von "user.created"
+```
+
+**Observed**: Der HMAC wurde über `"<timestamp>.<original-body>"` berechnet. Der modifizierte Body
+produziert einen anderen HMAC. `hash_equals()` schlägt fehl. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — die Signatur bindet den Timestamp an den Body. Beides ändern macht die Signatur ungültig.
+
+---
+
+### ATK-07 — Malformierter Header: fehlender Timestamp
+
+**Attack**: Signatur-Header ohne `t=`-Komponente einreichen.
+
+```
+X-Webhook-Signature: v1=<some-hmac>
+```
+
+**Observed**: `parseHeader()` prüft `isset($parts['t'], $parts['v1'])`. Fehlendes `t` wirft
+`SignatureException('Malformed X-Webhook-Signature header.')`. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — Header-Parser setzt Pflichtfelder durch.
+
+---
+
+### ATK-08 — Leeres Secret auf dem Server
+
+**Attack scenario**: Der Server ist mit einem leeren HMAC-Secret (`''`) falsch konfiguriert.
+
+**Observed**: Ein leeres Secret ist in PHPs `hash_hmac()` gültig — es produziert einen deterministischen Hex-String. Ein Angreifer, der das leere Secret entdeckt, kann gültige Signaturen fälschen:
+`hash_hmac('sha256', "{$timestamp}.{$body}", '')`.
+
+**Verdict**: **EXPOSED (Fehlkonfiguration)** — der Verifier lehnt kein leeres Secret ab.
+Die Anwendungs-Konfigurationsschicht muss beim Start validieren, dass `WEBHOOK_SECRET` nicht leer ist.
+Fail-Closed-Standard: wenn das Secret leer ist, alle Webhooks ablehnen.
+
+```php
+// Empfohlener Start-Guard
+if ($secret === '') {
+    throw new \RuntimeException('WEBHOOK_SECRET must not be empty.');
+}
+```
+
+---
+
+### ATK-09 — HMAC-Bypass: `v1=` mit leerem Wert einreichen
+
+**Attack**: Signatur auf leeren String setzen: `X-Webhook-Signature: t=<now>,v1=`.
+
+**Observed**: `parseHeader()` prüft `$parts['v1'] === ''`. Ein leeres `v1` wirft
+`SignatureException('Malformed X-Webhook-Signature header.')`. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — leere Signatur wird im Parser abgelehnt, bevor `hash_equals()` aufgerufen wird.
+
+---
+
+### ATK-10 — Timestamp-Injection: Nicht-Ziffern-Timestamp
+
+**Attack**: Timestamp einreichen, der kein reiner Integer ist: `t=1234abc`.
+
+```
+X-Webhook-Signature: t=1234abc,v1=<some-hmac>
+```
+
+**Observed**: `parseHeader()` prüft `ctype_digit($parts['t'])`. Nicht-Ziffern-Zeichen verursachen
+`SignatureException('Malformed X-Webhook-Signature header.')`. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — `ctype_digit()` setzt durch, dass der Timestamp ein reiner Integer-String ist.
+
+---
+
+### ATK-11 — Header-Injection: Komma im HMAC-Hex
+
+**Attack**: Komma in den `v1`-Wert injizieren, um den Parser zu verwirren.
+
+```
+X-Webhook-Signature: t=<now>,v1=abc,def
+```
+
+**Observed**: `parseHeader()` verwendet `explode('=', $chunk, 2)` mit Limit 2. Der Header wird
+zuerst auf `,` geteilt (produziert `['t=<now>', 'v1=abc', 'def']`), dann wird jeder Chunk auf
+`=` mit Limit 2 geteilt. Der `def`-Chunk wird `['def', '']` und überschreibt nichts Kritisches.
+Der `v1`-Wert ist `abc`, kein gültiger HMAC-Hex. `hash_equals()` schlägt fehl. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — Parser-Robustheit + HMAC-Längen-Prüfung verhindert Injektionsmanipulation.
+
+---
+
+### ATK-12 — Großer Body: Payload-Größenangriff
+
+**Attack**: Webhook mit mehrmegabyte-großem Body senden.
+
+**Observed**: Der Verifier berechnet `hash_hmac('sha256', "{$timestamp}.{$rawBody}", $secret)`.
+`hash_hmac()` behandelt beliebig große Eingaben; die Ausgabe ist immer 64 Hex-Zeichen.
+Kein explizites Größenlimit wird auf Verifier-Ebene angewendet. Ein 100 MB Body würde akzeptiert wenn
+die Signatur gültig und der Timestamp frisch ist.
+
+**Verdict**: **EXPOSED** — kein Request-Größenlimit am Webhook-Endpunkt. Request-Größen-Middleware
+(z. B. 1-MB-Limit) upstream hinzufügen, um Ressourcenerschöpfung zu verhindern. Der Verifier sollte
+nicht für Größenlimits zuständig sein — das ist ein Anliegen für eine äußere Middleware-Schicht.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Ergebnis |
+|---|----------------|----------|
+| ATK-01 | Fehlender Signatur-Header | BLOCKED |
+| ATK-02 | Manipulierte Signatur (1 Zeichen) | BLOCKED |
+| ATK-03 | Falsches Secret verwendet | BLOCKED |
+| ATK-04 | Replay-Angriff (alter Timestamp) | BLOCKED |
+| ATK-05 | Zukünftiger Timestamp-Bypass | BLOCKED |
+| ATK-06 | Body-Manipulation | BLOCKED |
+| ATK-07 | Malformierter Header (kein Timestamp) | BLOCKED |
+| ATK-08 | Leeres Server-Secret (Fehlkonfiguration) | EXPOSED |
+| ATK-09 | Leerer `v1=`-Wert | BLOCKED |
+| ATK-10 | Nicht-Ziffer-Timestamp | BLOCKED |
+| ATK-11 | Header-Injection via Komma | BLOCKED |
+| ATK-12 | Großer Body / Ressourcenerschöpfung | EXPOSED |
+
+**Echte Schwachstellen vor der Produktion zu beheben**:
+1. **ATK-08** — Fail-Closed Leer-Secret-Guard beim Start (`if ($secret === '') throw`)
+2. **ATK-12** — Request-Größen-Middleware (z. B. 1-MB-Limit) upstream der Webhook-Route
+
+---
+
+## Designhinweise
+
+### Warum HMAC-SHA256 statt einfachem Bearer Token?
+
+Ein Bearer Token beweist nur, dass der Sender das Token kennt. HMAC-SHA256 beweist, dass der Sender
+das Secret kennt UND dass der Body nicht verändert wurde — Body-Integrität ist eingebaut.
+
+### Warum den Timestamp an das HMAC-Payload binden?
+
+Wenn die Signatur nur `HMAC(body)` wäre, könnte ein Angreifer, der eine gültige Anfrage erfasst, sie
+unbegrenzt wiederholen. Durch das Signieren von `"<timestamp>.<body>"` ist jede Signatur nur innerhalb
+des 300-Sekunden-Fensters und für den exakten Body, über den sie berechnet wurde, gültig.
+
+### Warum `hash_equals()` statt `===`?
+
+PHPs `===` ist ein Short-Circuit-Vergleich: er stoppt sobald zwei Zeichen sich unterscheiden. Ein Angreifer
+kann die Zeit messen, die für den Vergleich zweier Strings benötigt wird, und ableiten, wie viele führende
+Zeichen seiner Schätzung übereinstimmen — eins nach dem anderen — und das Secret byteweise brute-forcen.
+`hash_equals()` läuft in Konstantzeit unabhängig davon, wo die Strings divergieren.
+
+---
+
+## Verwandte Anleitungen
+
+- [`pin-verification-lockout.md`](pin-verification-lockout.md) — `hash_equals()` und HMAC-SHA256 für PIN-Speicherung + Sperrung
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — Cracker-Mindset-ATK-Assessment-Muster
+- [`fixed-window-rate-limiter.md`](fixed-window-rate-limiter.md) — Rate Limiting als Ergänzung zur Signaturverifikation

--- a/docs/de/howto/webhook-signature.md
+++ b/docs/de/howto/webhook-signature.md
@@ -1,0 +1,223 @@
+# Webhook-Signaturverifikation
+
+Beim Empfangen von Webhooks von externen Diensten (Stripe, GitHub etc.) immer die Signatur verifizieren, bevor das Payload verarbeitet wird. Das beweist, dass der Webhook vom erwarteten Sender kam und der Body nicht manipuliert wurde.
+
+## Signatur-Header-Format
+
+Das Stripe-kompatible Format verwenden:
+
+```
+X-Webhook-Signature: t=<unix-timestamp>,v1=<hmac-sha256-hex>
+```
+
+Das signierte Payload ist `"<timestamp>.<rawBody>"` — der Timestamp ist im signierten Inhalt enthalten, nicht nur im Header. Das bindet den Timestamp an den Body: wenn ein Angreifer den Timestamp ändert, um die Ablaufprüfung zu umgehen, wird die Signatur ungültig.
+
+## Die kritische Regel: `hash_equals()` verwenden, niemals `===`
+
+```php
+// ❌ Anfällig für Timing-Angriffe
+if ($expectedSig === $receivedSig) { ... }
+
+// ✅ Konstantzeit-Vergleich — das verwenden
+if (!hash_equals($expectedSig, $receivedSig)) {
+    throw new SignatureException('Signature mismatch.');
+}
+```
+
+**Warum `===` gefährlich ist:** PHPs `===` führt einen Short-Circuit beim ersten nicht übereinstimmenden Zeichen durch. Ein Angreifer, der Tausende von Anfragen stellen und Antwortzeiten messen kann, kann lernen, wie viele Zeichen seiner erwarteten Signatur mit seiner Schätzung übereinstimmen — ein Byte nach dem anderen — und das Secret brute-forcen. Das ist ein Timing-Angriff.
+
+`hash_equals()` vergleicht immer alle Zeichen unabhängig davon, wo Strings divergieren, sodass die Antwortzeit nichts über das Secret verrät. Es ist seit PHP 5.6 verfügbar.
+
+Dieser Bug ist von PHPStan, statischen Analysetools oder Standard-Tests nicht erkennbar. Code-Review ist das einzige Gate.
+
+## Implementierung
+
+```php
+final class WebhookVerifier
+{
+    private const int TOLERANCE_SECONDS = 300; // 5-Minuten-Replay-Fenster
+
+    public function __construct(private readonly string $secret) {}
+
+    /**
+     * @throws SignatureException wenn fehlend, malformiert, abgelaufen oder nicht übereinstimmend
+     */
+    public function verify(ServerRequestInterface $request, string $rawBody): void
+    {
+        $header = $request->getHeaderLine('X-Webhook-Signature');
+        if ($header === '') {
+            throw new SignatureException('Missing X-Webhook-Signature header.');
+        }
+
+        ['timestamp' => $timestamp, 'signature' => $receivedSig] = $this->parseHeader($header);
+        $this->checkTimestamp($timestamp);
+
+        $expectedSig = $this->computeSignature($timestamp, $rawBody);
+
+        if (!hash_equals($expectedSig, $receivedSig)) { // ← Konstantzeit
+            throw new SignatureException('Signature mismatch.');
+        }
+    }
+
+    /** Generiert den Header-Wert für ausgehende Webhooks (und Tests). */
+    public function sign(string $rawBody, int $timestamp): string
+    {
+        return "t={$timestamp},v1={$this->computeSignature($timestamp, $rawBody)}";
+    }
+
+    /** @return array{timestamp: int, signature: string} */
+    private function parseHeader(string $header): array
+    {
+        $parts = [];
+        foreach (explode(',', $header) as $chunk) {
+            [$k, $v] = explode('=', $chunk, 2) + ['', ''];
+            $parts[$k] = $v;
+        }
+        if (!isset($parts['t'], $parts['v1']) || !ctype_digit($parts['t']) || $parts['v1'] === '') {
+            throw new SignatureException('Malformed X-Webhook-Signature header.');
+        }
+        return ['timestamp' => (int) $parts['t'], 'signature' => $parts['v1']];
+    }
+
+    private function checkTimestamp(int $timestamp): void
+    {
+        $age = abs(time() - $timestamp);
+        if ($age > self::TOLERANCE_SECONDS) {
+            throw new SignatureException(
+                sprintf('Webhook timestamp is %d seconds old (tolerance: %d).', $age, self::TOLERANCE_SECONDS),
+            );
+        }
+    }
+
+    private function computeSignature(int $timestamp, string $rawBody): string
+    {
+        return hash_hmac('sha256', "{$timestamp}.{$rawBody}", $this->secret);
+    }
+}
+```
+
+## Controller-Integration
+
+Raw-Body vor jedem JSON-Parsing lesen — die Signatur wird über die rohen Bytes berechnet:
+
+```php
+private function receive(ServerRequestInterface $request): ResponseInterface
+{
+    $rawBody = (string) $request->getBody();
+
+    try {
+        $this->verifier->verify($request, $rawBody);
+    } catch (SignatureException $e) {
+        return $this->problems->create(
+            $request,
+            'invalid-signature',
+            'Invalid webhook signature.',
+            401,          // 401: Sender-Identität konnte nicht verifiziert werden
+            $e->getMessage(),
+        );
+    }
+
+    // Nach Verifikation sicher zu parsen
+    $body = json_decode($rawBody, true);
+    // ...
+}
+```
+
+401 zurückgeben (nicht 403): die Identität des Senders konnte nicht verifiziert werden, was ein Authentifizierungsfehler ist, kein Autorisierungsfehler.
+
+## Secret-Verwaltung
+
+Das Webhook-Secret in einer Umgebungsvariable speichern, niemals im Code:
+
+```php
+// Im Config-Loader
+$secret = (string) getenv('WEBHOOK_SECRET');
+if ($secret === '') {
+    throw new \RuntimeException('WEBHOOK_SECRET environment variable is required.');
+}
+
+$verifier = new WebhookVerifier($secret);
+```
+
+## Replay-Angriff-Prävention
+
+Das 5-Minuten-Timestamp-Fenster (`TOLERANCE_SECONDS = 300`) bedeutet:
+
+- Ein Angreifer, der einen gültigen Webhook abfängt, kann ihn nicht mehr als 5 Minuten später wiederholen.
+- Reale Taktverschiebung zwischen Sender und Empfänger (normalerweise < 30 Sekunden) wird toleriert.
+- `abs(time() - $timestamp)` behandelt sowohl vergangene als auch zukünftige Timestamps, sodass geringfügige Taktdrift in beide Richtungen akzeptiert wird.
+
+## Secret-Rotation
+
+Während einer Secret-Rotation Signaturen sowohl vom alten als auch vom neuen Secret für einen Übergangszeitraum akzeptieren:
+
+```php
+final class RotatingWebhookVerifier
+{
+    /** @param list<string> $secrets Aktuelles Secret zuerst, vorheriges Secret zuletzt */
+    public function __construct(private readonly array $secrets) {}
+
+    public function verify(ServerRequestInterface $request, string $rawBody): void
+    {
+        $header = $request->getHeaderLine('X-Webhook-Signature');
+        foreach ($this->secrets as $secret) {
+            $verifier = new WebhookVerifier($secret);
+            try {
+                $verifier->verify($request, $rawBody);
+                return; // erste Übereinstimmung gewinnt
+            } catch (SignatureException) {
+                // nächstes Secret versuchen
+            }
+        }
+        throw new SignatureException('Signature mismatch with all known secrets.');
+    }
+}
+```
+
+## Tests
+
+Die `sign()`-Methode auf `WebhookVerifier` macht es einfach, signierte Testanfragen zu erstellen:
+
+```php
+private function signedPost(array $payload, int $timestamp): ResponseInterface
+{
+    $rawBody   = json_encode($payload, JSON_THROW_ON_ERROR);
+    $verifier  = new WebhookVerifier('test-secret');
+    $sigHeader = $verifier->sign($rawBody, $timestamp);
+
+    $stream  = Stream::create($rawBody);
+    $request = (new ServerRequest('POST', '/webhook'))
+        ->withHeader('X-Webhook-Signature', $sigHeader)
+        ->withBody($stream);
+    return $this->app->handle($request);
+}
+
+// Replay-Prävention testen
+public function testExpiredTimestampReturns401(): void
+{
+    $res = $this->signedPost(['event_type' => 'order.created'], time() - 301);
+    $this->assertSame(401, $res->getStatusCode());
+}
+
+// Manipulierten Body testen
+public function testTamperedPayloadReturns401(): void
+{
+    $original  = '{"event_type":"order.created","amount":100}';
+    $sigHeader = (new WebhookVerifier('test-secret'))->sign($original, time());
+    $tampered  = '{"event_type":"order.created","amount":9999}';
+
+    $res = $this->postWithHeader($tampered, $sigHeader);
+    $this->assertSame(401, $res->getStatusCode());
+}
+```
+
+## Code-Review-Checkliste
+
+- [ ] `hash_equals()` wird für den Signaturvergleich verwendet, nicht `===` oder `==`
+- [ ] Timestamp ist im signierten Payload enthalten (`"<t>.<body>"`), nicht nur im Header
+- [ ] Timestamp-Fenster wird durchgesetzt (`abs(time() - $timestamp) > TOLERANCE`)
+- [ ] Raw-Body wird vor dem Parsing gelesen; Signatur wird gegen die rohen Bytes verifiziert
+- [ ] Webhook-Secret kommt aus Umgebungsvariablen, nicht hardcodiert
+- [ ] 401 wird bei Signaturfehlern zurückgegeben (nicht 403 oder 400)
+- [ ] Fehlermeldungen geben das Secret oder den erwarteten Signaturwert nicht preis
+- [ ] Tests decken ab: gültige Signatur, falsches Secret, manipulierter Body, abgelaufener Timestamp, fehlender Header


### PR DESCRIPTION
## 概要

Issue #1283 で依頼されたドイツ語 howto 翻訳の残り83件を完了。

## 変更内容

`docs/de/howto/` に83件の翻訳ファイルを追加。

### Batch 1 (22件、前セッションでコミット済み)
price-history.md, privacy-consent-management.md, product-catalog.md, product-review-system.md, project-task-management.md, quality-tools.md, quota-management.md, rate-limiting.md, rating-review-api.md, rbac-jwt-auth.md, rbac.md, refresh-token-pattern.md, refresh-token-rotation.md, request-deduplication.md, request-scoped-state.md, reservation-availability-api.md, resource-booking.md, resource-reservation-booking.md, resource-reservation.md, scheduled-publish-article.md, scheduled-reminders.md, search-autocomplete.md

### Batch 2 (30件)
secret-vault.md, service-status-page.md, session-management.md, session-token-management.md, shift-management.md, shopping-cart-api.md, signed-url-download.md, signed-urls.md, sliding-window-rate-limiter.md, slug-management.md, slug-url-history.md, soft-delete-restore-permanent.md, soft-delete-trash-purge.md, soft-delete-trash-restore.md, soft-delete.md, sql-injection-defence.md, sql-injection.md, sql-orderby-injection.md, sqlite-fts5-search.md, state-machine-audit-log.md, state-machine-workflow-api.md, step-workflow-approval.md, subscription-plan-management.md, subscription-plan.md, system-announcement-management.md, tag-label-api.md, tagging-system.md, tenant-isolation-idor.md, tenant-isolation.md, threaded-comments-api.md

### Batch 3 (31件)
threaded-comments.md, time-tracking.md, timezone-aware-scheduling.md, token-lifecycle-api.md, totp-authentication.md, transaction-scope-pattern.md, transactions.md, unicode-aware-text-api.md, upvote-downvote-api.md, url-bookmark-api.md, url-shortener-ssrf-prevention.md, url-shortener-ssrf.md, use-bearer-auth.md, use-fts5-search.md, use-postgresql.md, use-transactions.md, user-follow-system.md, user-invitation.md, user-preferences-api.md, user-preferences-management.md, user-profile-api.md, user-profile-management.md, validate-unicode-input.md, voting-system.md, waitlist-management.md, waitlist-system.md, webhook-delivery-api.md, webhook-delivery-system.md, webhook-delivery.md, webhook-signature-verification.md, webhook-signature.md

## 翻訳品質方針

- 敬体 (Sie) を使用した自然なドイツ語
- PHP/Bash コードブロックは翻訳しない
- コードコメントはドイツ語に翻訳
- 技術用語 (API, JSON, HTTP, RFC, PSR, URI, UUID 等) は英語のまま
- クラス名・メソッド名・ファイル名は翻訳しない
- Markdown 構造を維持

## 検証

- 全83件の翻訳完了を確認
- Markdown 構造・コードブロック保持を確認

Self-review: docs-policy

Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)