### PR TITLE
docs(de): ドイツ語 howto 翻訳 完結 256件 (#1283)

### DIFF
--- a/docs/de/howto/tag-label-api.md
+++ b/docs/de/howto/tag-label-api.md
@@ -1,0 +1,124 @@
+# Anleitung: Tag-/Label-API
+
+Diese Anleitung demonstriert eine generische Entitäts-Tagging-API, bei der beliebige Tags an beliebige Entitäts-IDs angehängt werden können, mit tag-basierter Rückwärtssuche.
+
+## Musterübersicht
+
+- Tags werden global gespeichert und durch einen Slug (`a-z0-9-`, 1–50 Zeichen) identifiziert.
+- Jede Entität (identifiziert durch Integer-ID) kann mehrere Tags haben.
+- `POST /tags` — Tag erstellen oder abrufen (Find-or-Create; idempotent).
+- `GET /tags` — Alle bekannten Tags auflisten.
+- `GET /tags/{tag}/entities` — Rückwärtssuche: Welche Entitäten haben diesen Tag?
+- `POST /entities/{entityId}/tags` — Tag an eine Entität anhängen.
+- `GET /entities/{entityId}/tags` — Alle Tags für eine Entität auflisten.
+- `DELETE /entities/{entityId}/tags/{tag}` — Tag von einer Entität ablösen.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS tags (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+CREATE TABLE IF NOT EXISTS entity_tags (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id  INTEGER NOT NULL,
+    tag_id     INTEGER NOT NULL,
+    created_at TEXT    NOT NULL,
+    FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE,
+    UNIQUE (entity_id, tag_id)
+);
+```
+
+## Find-or-Create-Muster
+
+Tag-Erstellung ist idempotent — `POST /tags` gibt 201 bei der ersten Erstellung zurück, 200 wenn der Tag bereits existiert:
+
+```php
+public function findOrCreate(string $name): array
+{
+    $existing = $this->findByName($name);
+    if ($existing !== null) {
+        return $existing;
+    }
+    $this->pdo->prepare(
+        'INSERT INTO tags (name, created_at) VALUES (:name, :now)'
+    )->execute([':name' => $name, ':now' => $this->now()]);
+
+    return $this->findByName($name) ?? [];
+}
+```
+
+Der `attachTag`-Handler verwendet ebenfalls Find-or-Create, sodass Clients Tags anhängen können, ohne einen separaten Erstellungsschritt durchzuführen.
+
+## Tag-Name-Validierung
+
+Tag-Namen werden in Kleinbuchstaben normalisiert und mit einem strengen Format-Regex validiert:
+
+```php
+private const string TAG_PATTERN = '/\A[a-z0-9-]{1,50}\z/';
+
+$name = strtolower(trim((string) ($body['name'] ?? '')));
+if (!preg_match(self::TAG_PATTERN, $name)) {
+    return $this->problem(422, 'validation-failed', '...');
+}
+```
+
+Leerzeichen, Großbuchstaben, Unterstriche und Sonderzeichen werden alle abgelehnt.
+
+## Rückwärtssuche (Tag → Entitäten)
+
+`GET /tags/{tag}/entities` gibt 404 zurück, wenn der Tag nicht in der Datenbank existiert, und ein leeres Array, wenn er existiert, aber nicht verwendet wird:
+
+```php
+if ($this->repo->findByName($tag) === null) {
+    return $this->problem(404, 'not-found', 'Tag not found.');
+}
+return $this->json(['tag' => $tag, 'entity_ids' => $this->repo->entitiesForTag($tag)]);
+```
+
+SQL für die Rückwärtssuche:
+
+```sql
+SELECT entity_id FROM entity_tags WHERE tag_id = :tid ORDER BY entity_id ASC
+```
+
+## Anhängen/Ablösen-Idempotenz
+
+Das zweimalige Anhängen desselben Tags an dieselbe Entität gibt 200 zurück (nicht 201) mit `"attached": false`:
+
+```php
+$attached = $this->repo->attach($entityId, (int) $tag['id']);
+return $this->json([...], $attached ? 201 : 200);
+```
+
+Das Ablösen eines Tags, das nicht angehängt ist, gibt 404 zurück.
+
+## Entitäts-ID-Validierung
+
+Entitäts-IDs werden mit `ctype_digit()` validiert, um ReDoS zu vermeiden und nicht-negative Integer sicherzustellen:
+
+```php
+if (!ctype_digit($raw) || strlen($raw) > 18) {
+    return null;
+}
+$id = (int) $raw;
+return $id > 0 ? $id : null;
+```
+
+## Routen
+
+```
+POST   /tags                           Tag erstellen oder abrufen
+GET    /tags                           Alle Tags auflisten
+GET    /tags/{tag}/entities            Rückwärtssuche: Entitäten mit diesem Tag
+POST   /entities/{entityId}/tags       Tag an Entität anhängen
+GET    /entities/{entityId}/tags       Tags für Entität auflisten
+DELETE /entities/{entityId}/tags/{tag} Tag von Entität ablösen
+```
+
+## Siehe auch
+
+- FT209-Quelle: `../NENE2-FT/taglog/`
+- Verwandt: `docs/howto/note-taking.md` (FT202, tag-basierte Notizsuche)

--- a/docs/de/howto/tagging-system.md
+++ b/docs/de/howto/tagging-system.md
@@ -1,0 +1,148 @@
+# Tagging-System (M:N)
+
+Tags an Beiträge über eine Many-to-Many-Join-Tabelle anhängen, mit atomarem Tag-Ersetzen und N+1-freiem Tag-Laden.
+
+## Übersicht
+
+Ein Tagging-System hat drei Tabellen: `posts`, `tags` und `post_tags` (die Join-Tabelle). Beiträge und Tags haben eine M:N-Beziehung — ein Beitrag hat viele Tags, ein Tag gehört zu vielen Beiträgen.
+
+## Datenbankschema
+
+```sql
+CREATE TABLE posts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE tags (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE post_tags (
+    post_id INTEGER NOT NULL,
+    tag_id  INTEGER NOT NULL,
+    PRIMARY KEY (post_id, tag_id),
+    FOREIGN KEY (post_id) REFERENCES posts(id),
+    FOREIGN KEY (tag_id)  REFERENCES tags(id)
+);
+```
+
+Der zusammengesetzte Primärschlüssel auf `(post_id, tag_id)` erzwingt Eindeutigkeit auf DB-Ebene.
+
+## Tags atomar setzen
+
+Der `PUT /posts/{id}/tags`-Endpunkt ersetzt alle Tags für einen Beitrag in einer Operation. Erst löschen, dann einfügen:
+
+```php
+public function setPostTags(int $postId, array $tagNames): array
+{
+    $this->executor->execute('DELETE FROM post_tags WHERE post_id = ?', [$postId]);
+
+    foreach ($tagNames as $name) {
+        $tag = $this->findTagByName($name);
+        if ($tag === null) {
+            continue; // Unbekannte Tag-Namen stillschweigend überspringen
+        }
+
+        $this->executor->execute(
+            'INSERT OR IGNORE INTO post_tags (post_id, tag_id) VALUES (?, ?)',
+            [$postId, $tag->id],
+        );
+    }
+
+    return $this->findTagsByPostId($postId);
+}
+```
+
+- Löschen-dann-Einfügen macht die Operation idempotent: sie zweimal mit demselben Payload aufzurufen hat dasselbe Ergebnis.
+- `INSERT OR IGNORE` verhindert einen DB-Fehler, wenn derselbe Tag-Name zweimal im Request-Body vorkommt.
+- Unbekannte Tag-Namen werden stillschweigend übersprungen — der Client muss Tags erstellen, bevor er sie zuweist.
+- Um alle Tags zu löschen, `{"tags": []}` senden.
+
+## N+1-Abfragen vermeiden
+
+Beim Laden einer Liste von Beiträgen (z. B. für tag-basierte Suche) alle Tags in einer einzelnen `IN`-Abfrage laden statt eine Abfrage pro Beitrag:
+
+```php
+private function findTagsByPostIds(array $postIds): array
+{
+    if ($postIds === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($postIds), '?'));
+    $rows = $this->executor->fetchAll(
+        "SELECT t.*, pt.post_id FROM tags t
+         INNER JOIN post_tags pt ON pt.tag_id = t.id
+         WHERE pt.post_id IN ({$placeholders})
+         ORDER BY t.name ASC",
+        $postIds,
+    );
+
+    $map = [];
+    foreach ($rows as $row) {
+        $postId         = (int) $row['post_id'];
+        $map[$postId][] = $this->hydrateTag($row);
+    }
+
+    return $map;
+}
+```
+
+Dies gibt `array<int, Tag[]>` zurück, indexiert nach Beitrags-ID. Insgesamt zwei Abfragen unabhängig von der Anzahl der Beiträge.
+
+## Tag-Eindeutigkeit
+
+Tags haben eine `UNIQUE`-Bedingung auf `name`. Doppelte Erstellung gibt 409 zurück:
+
+```php
+public function createTag(string $name, string $now): ?Tag
+{
+    try {
+        $this->executor->execute(
+            'INSERT INTO tags (name, created_at) VALUES (?, ?)',
+            [$name, $now],
+        );
+    } catch (\RuntimeException) {
+        return null; // null → Handler gibt 409 zurück
+    }
+
+    return $this->findTagByName($name);
+}
+```
+
+## Tag-basierte Suche
+
+Beiträge nach Tag über einen JOIN filtern:
+
+```sql
+SELECT p.* FROM posts p
+INNER JOIN post_tags pt ON pt.post_id = p.id
+INNER JOIN tags t ON t.id = pt.tag_id
+WHERE t.name = ?
+ORDER BY p.id DESC
+```
+
+Dann Tags für das Ergebnis-Set mit der `IN`-Abfrage oben stapelweise laden.
+
+## Routen-Übersicht
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/posts` | Beitrag erstellen |
+| `GET` | `/posts/{id}` | Beitrag mit Tags abrufen |
+| `POST` | `/tags` | Tag erstellen (Duplikat → 409) |
+| `GET` | `/tags` | Alle Tags auflisten (alphabetisch) |
+| `PUT` | `/posts/{id}/tags` | Alle Tags eines Beitrags ersetzen |
+| `GET` | `/tags/{name}/posts` | Beiträge mit einem bestimmten Tag auflisten |
+
+## Design-Hinweise
+
+- Tags sind anwendungsverwaltete Entitäten, kein freier Text. Clients erstellen Tags zuerst, dann weisen sie sie zu.
+- Unbekannte Tag-Namen in `PUT /posts/{id}/tags` werden stillschweigend ignoriert. Dies vermeidet einen Round-Trip zur Vorab-Validierung von Namen.
+- Tag-Namen sind in Antworten alphabetisch sortiert für deterministische Ausgabe.
+- `GET /tags/{name}/posts` gibt 404 zurück, wenn der Tag nicht existiert, und unterscheidet so „Tag unbekannt" von „Tag existiert, aber hat keine Beiträge" (was 200 mit leerem Array zurückgibt).

--- a/docs/de/howto/tenant-isolation-idor.md
+++ b/docs/de/howto/tenant-isolation-idor.md
@@ -1,0 +1,149 @@
+# Anleitung: Mandantenisolierung & IDOR-Prävention
+
+> **FT-Referenz**: FT318 (`NENE2-FT/isolationlog`) — Multi-Mandanten-Datenisolierung, mandantenübergreifende IDOR-Prävention, Header-Typverwirrungsabsicherung, Body-tenant_id-Injektions-Prävention, 34 Tests / 133 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie strikte mandantenebenenbasierte Datenisolierung durchgesetzt wird, sodass kein Mandant die Daten eines anderen lesen, ändern oder aufzählen kann — selbst wenn er Header oder Request-Bodies manipuliert.
+
+## Schema
+
+```sql
+CREATE TABLE tenants (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE notes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id  INTEGER NOT NULL REFERENCES tenants(id),
+    user_id    INTEGER NOT NULL,
+    content    TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+```
+
+## Authentifizierungsmodell
+
+```
+Admin-Endpunkte  → X-Admin-Key: <server_secret>       (z. B. env ADMIN_KEY)
+Mandanten-Endpunkte → X-Tenant-Id: <int>  X-User-Id: <int>
+```
+
+### Header-Validierungsregeln
+
+`X-Tenant-Id` und `X-User-Id` müssen die **strikte positive-Integer**-Validierung bestehen:
+
+| Eingabe | Ergebnis |
+|---------|----------|
+| `"1"` (gültig) | ✅ Akzeptiert |
+| `"0"` | ❌ 401 — muss > 0 sein |
+| `"-1"` | ❌ 401 — Negativ abgelehnt |
+| `"1.5"` | ❌ 401 — Float abgelehnt |
+| `"+1"` | ❌ 401 — Vorzeichen-Präfix abgelehnt |
+| `"1 OR 1=1"` | ❌ 401 — SQL-Injection-Versuch abgelehnt |
+| `""` (nicht vorhanden) | ❌ 401 — Fehlender Header |
+| `"99999999999999999999"` (20 Ziffern) | ❌ 401 — Überlauf abgelehnt |
+
+```php
+// Validierungsmuster mit ctype_digit + Bereichsprüfung
+$raw = $request->getHeaderLine('X-Tenant-Id');
+if (!ctype_digit($raw) || ($id = (int) $raw) <= 0 || strlen($raw) > 10) {
+    return $this->json->create(['error' => 'Unauthorized'], 401);
+}
+```
+
+## Admin-Endpunkte
+
+```php
+POST /tenants   X-Admin-Key: admin-secret
+{"name": "Acme Corp"}
+→ 201  {"id": 1, "name": "Acme Corp", "created_at": "..."}
+
+GET  /tenants   X-Admin-Key: admin-secret
+→ 200  {"total": 2, "tenants": [...]}
+
+GET  /tenants/1  X-Admin-Key: admin-secret
+→ 200  {"id": 1, "name": "Acme Corp", ...}
+
+// Kein Admin-Schlüssel
+POST /tenants  (kein X-Admin-Key)   → 401
+POST /tenants  X-Admin-Key: falsch  → 401
+```
+
+## Mandanten-Endpunkte — IDOR-Prävention
+
+### Notiz erstellen (server-zugewiesener Mandant)
+
+```php
+POST /notes  X-Tenant-Id: 1  X-User-Id: 42
+{"content": "Hello"}
+→ 201  {"id": 1, "tenant_id": 1, "content": "Hello", ...}
+```
+
+**Die `tenant_id` im Request-Body wird IMMER ignoriert.** Der Server verwendet nur den Header-Wert:
+
+```php
+// Angreifer sendet X-Tenant-Id: 1 aber Body versucht Mandant 2 einzuschleusen
+POST /notes  X-Tenant-Id: 1
+{"content": "Injection", "tenant_id": 2}  // ← ignoriert
+
+→ 201  {"tenant_id": 1, ...}   // aus Header zugewiesen, nicht aus Body
+```
+
+### Mandantenübergreifendes IDOR — Gibt 404 zurück
+
+```php
+// Notiz 5 gehört zu Mandant 1
+GET  /notes/5  X-Tenant-Id: 2  → 404   // IDOR blockiert
+DELETE /notes/5  X-Tenant-Id: 2 → 404  // IDOR blockiert
+
+// Eigentümer kann noch zugreifen
+GET  /notes/5  X-Tenant-Id: 1  → 200   ✅
+```
+
+Alle Abfragen enthalten `WHERE tenant_id = $tenantId`. Eine fehlende Zeile gibt 404 zurück — **nicht 403** — um Existenz-Aufzählung zu verhindern.
+
+### Listen-Isolierung
+
+```php
+// T1 hat 2 Notizen, T2 hat 1 Notiz
+GET /notes  X-Tenant-Id: 1  → {"data": [note_A, note_B], "tenant_id": 1}
+GET /notes  X-Tenant-Id: 2  → {"data": [note_X],         "tenant_id": 2}
+// T2 sieht nie die Notizen von T1
+```
+
+```sql
+SELECT * FROM notes WHERE tenant_id = ? ORDER BY id DESC LIMIT ?
+-- Immer nach tenant_id aus dem validierten Header filtern
+```
+
+### Query-Parameter-Validierung
+
+```php
+GET /notes?limit=-1       → 422  // negativ
+GET /notes?limit=10.5     → 422  // Float
+GET /notes?limit=999999   → 422  // überschreitet Maximum (z. B. 100)
+GET /notes?limit=99999999999999999999  → 422  // Überlauf
+GET /notes                → 200  // Standard-Limit angewendet
+```
+
+## Notiz für nicht existierenden Mandanten erstellen
+
+```php
+POST /notes  X-Tenant-Id: 9999  X-User-Id: 1
+{"content": "test"}
+→ 422  // Mandant 9999 existiert nicht
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `tenant_id` aus dem Request-Body vertrauen | Angreifer weist Notizen beliebigem Mandanten zu |
+| 403 statt 404 bei IDOR zurückgeben | 403 enthüllt, dass die Ressource existiert; 404 verhindert Aufzählung |
+| Header direkt casten: `(int) $header` ohne ctype_digit | `-1`, `+1`, `1.5`, Überlauf produzieren alle unerwartete Integer |
+| Kein `WHERE tenant_id = ?` in Listen-Abfragen | Vollständiges mandantenübergreifendes Datenleck |
+| Admin-Schlüssel in Client-Antworten teilen | Admin-Schlüssel muss nur serverseitig bleiben |
+| `X-Tenant-Id: 0` erlauben | Null ist oft ein Standard-/ungecetzter Zustand; nur positive Integer akzeptieren |

--- a/docs/de/howto/tenant-isolation.md
+++ b/docs/de/howto/tenant-isolation.md
@@ -1,0 +1,150 @@
+# Anleitung: Mandantenisolierung & mandantenübergreifende IDOR-Prävention
+
+**FT179 — isolationlog**
+
+Verhinderung mandantenübergreifender Datenlecks in Multi-Mandanten-APIs —
+gescope SQL-Abfragen, header-basierte Identität und Body-Injektions-Prävention.
+
+---
+
+## Die Bedrohung: Mandantenübergreifendes IDOR
+
+In einem Multi-Mandanten-System gehört jede Ressource zu einem Mandanten.
+Ein Angreifer, der ein Mandantenkonto kontrolliert, testet IDs von anderen Mandanten:
+
+```
+GET /notes/42          X-Tenant-Id: 2   ← Angreifer ist Mandant 2
+                                         Notiz 42 gehört zu Mandant 1
+```
+
+Wenn der Server die Notiz zurückgibt, hat der Angreifer die Daten eines anderen Mandanten gelesen —
+eine **Insecure Direct Object Reference (IDOR)** an der Mandantengrenze.
+
+---
+
+## Das Isolierungsmuster
+
+### 1. Alle Lesevorgänge auf SQL-Ebene scopen
+
+Niemals nur nach ID abfragen. Immer `AND tenant_id = ?` hinzufügen:
+
+```php
+// ❌ FALSCH — ID allein, mandantenübergreifend lesbar
+'SELECT * FROM notes WHERE id = ?'
+
+// ✅ KORREKT — ID + Mandant in SQL durchgesetzt
+'SELECT * FROM notes WHERE id = ? AND tenant_id = ?'
+```
+
+Dies gibt `null` für mandantenübergreifenden Zugriff zurück, was zu einem 404 wird.
+Der Angreifer erfährt nichts über Notiz 42 — nicht einmal ob sie existiert.
+
+### 2. Listen-Abfragen sind immer gescoped
+
+```php
+// ❌ FALSCH — könnte mit ?tenant_id=... Injektion ergänzt werden
+'SELECT * FROM notes ORDER BY id DESC LIMIT ?'
+
+// ✅ KORREKT — WHERE tenant_id = ? ist nie optional
+'SELECT * FROM notes WHERE tenant_id = ? ORDER BY id DESC LIMIT ?'
+```
+
+### 3. Löschen verwendet dasselbe Muster
+
+```sql
+DELETE FROM notes WHERE id = ? AND tenant_id = ?
+```
+
+`rowCount()` gibt 0 zurück, wenn die Notiz nicht zum Mandanten gehört → 404.
+
+---
+
+## Header-basierte Mandantenidentität
+
+`X-Tenant-Id` + `X-User-Id`-Header für mandantenabgegrenzte Endpunkte verwenden.
+Beide mit `V::userId()` validieren (ctype_digit + Überlaufschutz + > 0):
+
+```php
+private function resolveTenantUser(ServerRequestInterface $request): array
+{
+    $tenantId = V::userId($request->getHeaderLine('X-Tenant-Id'));
+    $userId   = V::userId($request->getHeaderLine('X-User-Id'));
+
+    return [$tenantId, $userId];
+}
+```
+
+`V::userId()` lehnt ab:
+- Leerer String (`ctype_digit('') === false`)
+- Null (`id <= 0`)
+- Negativ (`'-'` schlägt bei `ctype_digit` fehl)
+- Float-String (`'1.5'` schlägt bei `ctype_digit` fehl)
+- 20+ Ziffern Überlauf (strlen > 18 Schutz)
+- SQL-Injection-Versuche (`'1 OR 1=1'` schlägt bei `ctype_digit` fehl)
+
+---
+
+## Body-Injektions-Prävention
+
+Angreifer können `tenant_id` im POST-Body einschließen, um zu versuchen, eine
+Ressource einem anderen Mandanten zuzuweisen:
+
+```json
+POST /notes
+X-Tenant-Id: 1
+{ "content": "Injection", "tenant_id": 99 }
+```
+
+**Niemals `tenant_id` aus dem Body lesen.** Immer den server-validierten Header verwenden:
+
+```php
+// ATK-04: body['tenant_id'] wird nie gelesen — immer $tenantId aus Header verwenden
+$note = $this->notes->create($tenantId, $userId, $content, date('c'));
+//                            ^^^^^^^^^
+//                            von V::userId(X-Tenant-Id), nicht von $body
+```
+
+---
+
+## Mandanten-Existenzprüfung beim Schreiben
+
+Vor dem Erstellen einer Ressource prüfen, ob der Mandant existiert:
+
+```php
+if (!$this->tenants->exists($tenantId)) {
+    return $this->responseFactory->create(['error' => 'Tenant not found.'], 422);
+}
+```
+
+Ohne diese Prüfung würden Notizen für Ghost-Mandanten-IDs erstellt, die nicht in der
+Mandanten-Tabelle existieren, was die referenzielle Integrität bricht.
+
+---
+
+## Angriffs-Checkliste (ATK-01 bis ATK-12)
+
+| # | Test | Erwartung |
+|---|------|-----------|
+| ATK-01 | Keine Auth-Header | 401 |
+| ATK-02 | Mandantenübergreifendes GET (IDOR) | 404 — Notiz existiert, aber nicht für diesen Mandanten |
+| ATK-03 | X-Tenant-Id: `"1"`, `1.5`, `+1`, `1 OR 1=1` | 401 — V::userId lehnt ab |
+| ATK-04 | POST-Body enthält `tenant_id: 99` | 201 — Body-tenant_id ignoriert |
+| ATK-05 | Mandantenübergreifendes DELETE | 404 — Notiz nicht gelöscht |
+| ATK-06 | X-Tenant-Id: `0`, `-1` | 401 |
+| ATK-07 | X-Tenant-Id: 20-stelliger Überlauf | 401 |
+| ATK-08 | Mandantenerstellung ohne X-Admin-Key | 401 |
+| ATK-09 | Falscher X-Admin-Key | 401 |
+| ATK-10 | Notiz für nicht existierende Mandanten-ID | 422 |
+| ATK-11 | Liste: T1 sieht nur T1-Notizen, nicht T2's | Durch SQL WHERE tenant_id durchgesetzt |
+| ATK-12 | `?limit=-1`, `?limit=10.5`, 20-stelliges Limit | 422 — V::queryInt-Guards |
+
+---
+
+## Antwortstrategie: 404 nicht 403
+
+Wenn ein mandantenübergreifendes IDOR erkannt wird, **404** zurückgeben — nicht 403 Verboten.
+
+- `403` lüftet Existenz: „die Ressource existiert, aber Sie können nicht darauf zugreifen"
+- `404` enthüllt nichts: „keine solche Ressource für diesen Mandanten"
+
+Dies verhindert Mandanten-Aufzählungsangriffe.

--- a/docs/de/howto/threaded-comments-api.md
+++ b/docs/de/howto/threaded-comments-api.md
@@ -1,0 +1,201 @@
+# Anleitung: Threaded-Comments-API
+
+> **FT-Referenz**: FT343 (`NENE2-FT/threadlog`) — Zweistufiges Kommentar-Thread-System mit Tombstone-Löschung (Inhalt ersetzt durch `[deleted]`), Antwort-Tiefenbegrenzung, beitragsbezogene Isolierung und Prävention von Antworten auf gelöschte Kommentare, 14 Tests / 40+ Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Kommentarsystem mit einer Antwortebene gebaut wird: Root-Kommentare können Antworten erhalten, aber Antworten können nicht beantwortet werden (maximale Tiefe = 1). Gelöschte Kommentare werden tombstoniert, um die Thread-Struktur zu erhalten.
+
+## Schema
+
+```sql
+CREATE TABLE comments (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    post_id    TEXT    NOT NULL,           -- opaker Beitragsbezeichner
+    parent_id  INTEGER REFERENCES comments(id),  -- NULL = Root-Kommentar
+    author     TEXT    NOT NULL,
+    content    TEXT    NOT NULL,
+    deleted    INTEGER NOT NULL DEFAULT 0,
+    deleted_at TEXT,
+    created_at TEXT    NOT NULL
+);
+```
+
+`parent_id IS NULL` = Root-Kommentar; `parent_id IS NOT NULL` = Antwort.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/posts/{postId}/comments` | Root-Kommentar erstellen |
+| `GET`  | `/posts/{postId}/comments` | Kommentare mit Antworten auflisten |
+| `GET`  | `/posts/{postId}/comments/{id}` | Einzelnen Kommentar abrufen |
+| `POST` | `/posts/{postId}/comments/{id}/replies` | Antwort hinzufügen |
+| `DELETE` | `/posts/{postId}/comments/{id}` | Soft Delete (Tombstone) |
+
+## Root-Kommentar erstellen
+
+```php
+POST /posts/post-1/comments
+{"author": "alice", "content": "Great post!"}
+→ 201
+{
+  "id": 1,
+  "author": "alice",
+  "content": "Great post!",
+  "parent_id": null,
+  "replies": [],
+  "deleted": false,
+  "created_at": "..."
+}
+
+// Fehlende Felder
+POST /posts/post-1/comments  {"author": "alice"}
+→ 422  // Inhalt erforderlich
+```
+
+## Kommentare auflisten
+
+```php
+GET /posts/post-1/comments
+→ 200
+{
+  "comments": [
+    {
+      "id": 1,
+      "author": "alice",
+      "content": "Root comment",
+      "replies": [
+        {"id": 2, "author": "bob", "content": "My reply", "parent_id": 1}
+      ]
+    }
+  ]
+}
+```
+
+Kommentare sind auf `post_id` bezogen. Kommentare von `post-1` erscheinen nie in der Liste von `post-2`.
+
+## Einzelnen Kommentar abrufen
+
+```php
+GET /posts/post-1/comments/1
+→ 200
+{
+  "id": 1,
+  "author": "alice",
+  "content": "Root comment",
+  "reply_count": 2,
+  "replies": [...]
+}
+
+GET /posts/post-1/comments/999
+→ 404
+```
+
+## Antwort hinzufügen (Maximale Tiefe = 1)
+
+```php
+POST /posts/post-1/comments/1/replies
+{"author": "bob", "content": "My reply"}
+→ 201
+{
+  "id": 2,
+  "parent_id": 1,
+  "author": "bob",
+  "content": "My reply"
+}
+
+// Antwort auf eine Antwort wird abgelehnt (Tiefe würde 2 sein)
+POST /posts/post-1/comments/2/replies  {"author": "charlie", "content": "Deep reply"}
+→ 409  // Tiefenlimit überschritten
+
+// Antwort auf nicht existierenden Kommentar
+POST /posts/post-1/comments/999/replies  {"author": "bob", "content": "X"}
+→ 404
+
+// Antwort auf gelöschten Kommentar
+// (Kommentar 1 bereits gelöscht)
+POST /posts/post-1/comments/1/replies  {"author": "bob", "content": "X"}
+→ 409  // Kann nicht auf gelöschten Kommentar antworten
+
+// Fehlende Felder → 422
+```
+
+### Tiefen-Check-Implementierung
+
+```php
+public function canReceiveReply(int $commentId): bool
+{
+    $row = $this->findById($commentId);
+    if ($row === null) {
+        throw new CommentNotFoundException($commentId);
+    }
+    if ($row['deleted']) {
+        throw new CommentDeletedException($commentId);
+    }
+    // Nur Root-Kommentare (parent_id = null) können Antworten haben
+    return $row['parent_id'] === null;
+}
+```
+
+409 zurückgeben, wenn `canReceiveReply()` false zurückgibt.
+
+## Tombstone-Löschung
+
+```php
+DELETE /posts/post-1/comments/1
+→ 200
+{
+  "deleted": true,
+  "author": "[deleted]",
+  "content": "[deleted]"
+}
+
+// Gelöschter Kommentar erscheint noch in der Liste (Tombstone)
+GET /posts/post-1/comments
+→ 200
+{
+  "comments": [
+    {
+      "id": 1,
+      "author": "[deleted]",
+      "content": "[deleted]",
+      "deleted": true,
+      "replies": [{"id": 2, "author": "bob", ...}]  // Antworten noch sichtbar
+    }
+  ]
+}
+```
+
+Tombstoning bewahrt die Thread-Struktur. Antworten bleiben sichtbar, auch nachdem der Elternkommentar gelöscht wurde.
+
+```php
+// Bereits gelöschten Kommentar löschen → 404
+DELETE /posts/post-1/comments/1  (bereits gelöscht)
+→ 404
+
+// Unbekannter Kommentar → 404
+DELETE /posts/post-1/comments/999
+→ 404
+```
+
+### Tombstone-SQL
+
+```sql
+UPDATE comments
+SET deleted = 1, author = '[deleted]', content = '[deleted]', deleted_at = ?
+WHERE id = ? AND deleted = 0
+-- Trifft nur nicht-gelöschte Zeilen
+-- 0 Zeilen aktualisiert → 404
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Elternkommentar hart löschen | Antworten werden zu Waisen; Thread-Struktur bricht zusammen |
+| Unbegrenzte Verschachtelungstiefe erlauben | Tiefe Ketten erzeugen rekursive SQL-Abfragen oder Stack Overflows |
+| 404 für Antwort-auf-Gelöschtes zurückgeben | Den Elternzustand zu verstecken verwirrt Clients; 409 mit klarem `detail` ist besser |
+| Kein `post_id`-Scope in Abfragen | Kommentare von anderen Beiträgen erscheinen in der Liste |
+| Tiefe nur client-seitig prüfen | Angreifer umgeht die Prüfung durch direkte API-Anfragen |
+| Autor/Inhalt des gelöschten Kommentars anzeigen | Macht den Zweck der Löschung zunichte; immer tombstonen |

--- a/docs/de/howto/threaded-comments.md
+++ b/docs/de/howto/threaded-comments.md
@@ -1,0 +1,128 @@
+# Threaded Comments
+
+Selbstreferenzierende Kommentar-Threads mit Tiefenlimits und Soft Delete implementieren.
+
+## Übersicht
+
+Ein Threaded-Comment-System hat eine Tabelle, die auf sich selbst verweist. Jeder Kommentar kennt seine `parent_id` (null für Top-Level), seine `depth` (0-basiert) und seinen `status`. Antworten werden in der Antwortstruktur innerhalb ihres Elternkommentars verschachtelt.
+
+## Datenbankschema
+
+```sql
+CREATE TABLE comments (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    post_id     INTEGER NOT NULL,
+    parent_id   INTEGER,
+    author_name TEXT    NOT NULL,
+    body        TEXT    NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'published',
+    depth       INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT    NOT NULL,
+    FOREIGN KEY (post_id)   REFERENCES posts(id),
+    FOREIGN KEY (parent_id) REFERENCES comments(id)
+);
+```
+
+`depth` ist in der Zeile denormalisiert, um rekursive Vorfahren-Abfragen bei jedem Insert zu vermeiden.
+
+## Maximale Tiefe
+
+Ein Tiefenlimit beim Schreiben durchsetzen:
+
+```php
+public const int MAX_DEPTH = 3;
+
+public function canHaveReplies(): bool
+{
+    return $this->depth < self::MAX_DEPTH;
+}
+```
+
+Im Routen-Handler vor dem Einfügen prüfen:
+
+```php
+if (!$parent->canHaveReplies()) {
+    return $this->problems->create($request, 'unprocessable-entity', 'Maximum comment depth reached.', 422, '');
+}
+
+$comment = $this->repo->addComment(
+    $parent->postId, $parentId, $authorName, $body, $parent->depth + 1, $now,
+);
+```
+
+## Soft Delete
+
+Soft Delete ersetzt den Body durch `[deleted]` und setzt `status = 'deleted'`. Kindkommentare bleiben erhalten:
+
+```php
+public function softDelete(int $id): void
+{
+    $this->executor->execute(
+        "UPDATE comments SET status = 'deleted', body = '[deleted]' WHERE id = ?",
+        [$id],
+    );
+}
+```
+
+Der Baumlade-Vorgang gibt gelöschte Kommentare mit `[deleted]`-Bodies zurück, damit die Thread-Struktur kohärent bleibt — Leser sehen einen Platzhalter, wo der gelöschte Kommentar war, und seine Kindkommentare sind noch sichtbar.
+
+Ein Versuch, auf einen gelöschten Kommentar zu antworten, gibt 409 zurück:
+
+```php
+if ($parent->isDeleted()) {
+    return $this->problems->create($request, 'conflict', 'Cannot reply to a deleted comment.', 409, '');
+}
+```
+
+## Kommentarbaum ohne N+1 aufbauen
+
+Alle Kommentare für einen Beitrag in einer einzelnen Abfrage laden, geordnet nach ID (Eltern haben immer niedrigere IDs als ihre Kinder). Dann den Baum in PHP mit zwei Durchläufen zusammenbauen:
+
+```php
+// Durchlauf 1: Rohzeilen-Map und Kinder-ID-Adjazenzliste aufbauen
+foreach ($rows as $row) {
+    $rowMap[(int) $row['id']]   = $row;
+    $childIds[(int) $row['id']] = [];
+}
+
+foreach ($rowMap as $id => $row) {
+    $parentId = isset($row['parent_id']) ? (int) $row['parent_id'] : null;
+    if ($parentId === null) {
+        $roots[] = $id;
+    } elseif (isset($childIds[$parentId])) {
+        $childIds[$parentId][] = $id;
+    }
+}
+
+// Durchlauf 2: Rekursiv Comment-Value-Objekte von Wurzeln aufbauen
+return $this->buildTree($roots, $rowMap, $childIds);
+```
+
+Rohzeilen und `int[]`-Kinder-ID-Listen von `Comment`-Value-Objekten zu trennen vermeidet PHPStan-Typverwirrung beim Arbeiten mit `readonly`-Klassen.
+
+## Zeilendaten von Value-Objekten trennen
+
+Wenn man einen Baum von readonly Value-Objekten rekursiv zusammenbaut, braucht PHPStan klare Typgrenzen. Das funktionierende Muster:
+
+1. **Durchlauf 1** — `array<int, array<string, mixed>> $rowMap` und `array<int, int[]> $childIds` aus Rohzeilen aufbauen. Noch keine Value-Objekte.
+2. **Durchlauf 2** — `buildTree()` nimmt nur `int[]`-IDs und die zwei Maps, rekursiert und hydratisiert `Comment`-Objekte mit vollständig zusammengebauten Kinder-Arrays.
+
+Dies vermeidet das Mischen von `Comment`-Objekten und `int`-IDs im selben Array, was einen Union-Typ erzeugen würde, den PHPStan nicht einengen kann.
+
+## Routen-Zusammenfassung
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/posts` | Beitrag erstellen |
+| `GET` | `/posts/{id}` | Beitrag abrufen |
+| `POST` | `/posts/{id}/comments` | Top-Level-Kommentar hinzufügen |
+| `GET` | `/posts/{id}/comments` | Kommentarbaum abrufen |
+| `POST` | `/comments/{id}/replies` | Auf Kommentar antworten |
+| `DELETE` | `/comments/{id}` | Kommentar soft löschen |
+
+## Design-Hinweise
+
+- `depth` ist in der Zeile gespeichert (denormalisiert), um rekursive Vorfahren-Abfragen bei jedem Insert zu vermeiden.
+- `ORDER BY id ASC` garantiert, dass Eltern vor ihren Kindern beim Laden der flachen Liste erscheinen.
+- Soft Delete bewahrt die Thread-Struktur — Hard Delete würde Kindkommentare zu Waisen machen.
+- Auf einen gelöschten Kommentar zu antworten ist gesperrt (409), um Ghost-Threads zu verhindern.

--- a/docs/de/howto/time-tracking.md
+++ b/docs/de/howto/time-tracking.md
@@ -1,0 +1,252 @@
+# Anleitung: Zeiterfassungs-API
+
+> **FT-Referenz**: FT246 (`NENE2-FT/timelog`) — Zeiterfassungs-API
+
+Demonstriert eine Stoppuhr-basierte Zeiterfassungs-API, bei der ein Zeiterfassungs-Eintrag eine `start_time`
+und eine nullable `end_time` hat (`NULL` = läuft, nicht-`NULL` = gestoppt), nur ein Timer gleichzeitig
+laufen kann, die Dauer über SQLites `julianday()` berechnet wird und tägliche Zusammenfassungen
+die gesamten erfassten Sekunden pro Kalendertag aggregieren.
+
+---
+
+## Routen
+
+| Methode   | Pfad              | Beschreibung                                                      |
+|-----------|-------------------|------------------------------------------------------------------|
+| `POST`   | `/timers/start`   | Neuen Timer starten (schlägt fehl, wenn einer bereits läuft)     |
+| `POST`   | `/timers/stop`    | Den aktuell laufenden Timer stoppen                               |
+| `GET`    | `/timers/running` | Den aktuell laufenden Timer abrufen (oder `running: false`)       |
+| `GET`    | `/timers/summary` | Tägliche Zusammenfassung: Gesamtsekunden und Eintragsanzahl pro Tag |
+| `GET`    | `/timers`         | Einträge auflisten (paginiert, filterbar nach Label und Datum)   |
+| `GET`    | `/timers/{id}`    | Einen einzelnen Zeiterfassungs-Eintrag abrufen                   |
+| `DELETE` | `/timers/{id}`    | Einen Zeiterfassungs-Eintrag löschen (`204 No Content`)          |
+
+> **Statische Routen zuerst**: `/timers/start`, `/timers/stop`, `/timers/running`,
+> `/timers/summary` werden alle vor `/timers/{id}` registriert, damit Literal-Pfade
+> nicht als parametrisierte Segmente erfasst werden.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS time_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    label      TEXT NOT NULL,
+    start_time TEXT NOT NULL,
+    end_time   TEXT,              -- NULL = läuft
+    created_at TEXT NOT NULL
+);
+```
+
+`end_time` ist nullable — `NULL` bedeutet, der Timer läuft noch. `NOT NULL` bedeutet, er wurde gestoppt.
+Es gibt keine separate `status`-Spalte; das Vorhandensein oder Fehlen von `end_time` kodiert den Laufzustand.
+
+---
+
+## Laufzustand: `end_time IS NULL`
+
+Der Laufzustand des Timers wird ausschließlich aus der `end_time`-Spalte erkannt:
+
+```php
+final readonly class TimeEntry
+{
+    public function isRunning(): bool
+    {
+        return $this->endTime === null;
+    }
+
+    public function durationSeconds(): ?int
+    {
+        if ($this->endTime === null) {
+            return null;  // läuft noch — noch keine Dauer
+        }
+        $start = new \DateTimeImmutable($this->startTime);
+        $end   = new \DateTimeImmutable($this->endTime);
+        return (int) $end->getTimestamp() - (int) $start->getTimestamp();
+    }
+}
+```
+
+`isRunning()` gibt `true` zurück, wenn `endTime` `null` ist. `durationSeconds()` gibt
+`null` für laufende Timer zurück — die Dauer kann erst berechnet werden, wenn der Timer gestoppt wird.
+Die Antwort enthält `"running": true` und `"duration_seconds": null` für aktive Einträge.
+
+---
+
+## Singleton-Timer: nur einer kann gleichzeitig laufen
+
+`start()` prüft auf einen laufenden Timer, bevor ein neuer erstellt wird:
+
+```php
+public function start(string $label, string $startTime, string $createdAt): TimeEntry
+{
+    $running = $this->findRunning();
+    if ($running !== null) {
+        throw new TimerAlreadyRunningException($running->id);
+    }
+
+    $this->executor->execute(
+        'INSERT INTO time_entries (label, start_time, end_time, created_at) VALUES (?, ?, NULL, ?)',
+        [$label, $startTime, $createdAt],
+    );
+
+    return $this->findById($this->executor->lastInsertId());
+}
+```
+
+Wenn ein Timer bereits läuft, wird `TimerAlreadyRunningException` geworfen → `409 Conflict`.
+`end_time` wird als Literal-`NULL`-SQL-Wert eingefügt.
+
+Die Suche nach dem laufenden Timer:
+
+```php
+public function findRunning(): ?TimeEntry
+{
+    $row = $this->executor->fetchOne(
+        'SELECT * FROM time_entries WHERE end_time IS NULL ORDER BY start_time DESC LIMIT 1',
+        [],
+    );
+    return $row !== null ? $this->hydrate($row) : null;
+}
+```
+
+`WHERE end_time IS NULL` — Standard-SQL-`NULL`-Vergleich (nicht `= NULL`). `LIMIT 1`
+schützt davor, mehrere Zeilen zurückzugeben, wenn die Invariante jemals verletzt wird.
+
+---
+
+## Timer stoppen: `stop()`
+
+```php
+public function stop(string $endTime): TimeEntry
+{
+    $running = $this->findRunning();
+    if ($running === null) {
+        throw new NoRunningTimerException();
+    }
+
+    $this->executor->execute(
+        'UPDATE time_entries SET end_time = ? WHERE id = ?',
+        [$endTime, $running->id],
+    );
+
+    return $this->findById($running->id);
+}
+```
+
+`stop()` findet den laufenden Timer, setzt `end_time` und gibt den aktualisierten Eintrag mit
+der berechneten Dauer zurück. `NoRunningTimerException` wird geworfen, wenn kein Timer läuft →
+`409 Conflict`.
+
+---
+
+## Dauerberechnung: `julianday()` in SQL
+
+Für aggregierte Zusammenfassungen wird die Dauer in SQL über SQLites `julianday()`-Funktion berechnet:
+
+```sql
+SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds
+```
+
+`julianday()` konvertiert einen ISO-Datumszeit-String in eine Julianische Tagesnummer (eine reelle Zahl,
+die Tage seit Mittag des 1. Januar 4713 v. Chr. darstellt). Das Subtrahieren zweier Julianischer Tagesnummern
+ergibt die Differenz in Tagen. Das Multiplizieren mit `86400` konvertiert Tage in Sekunden.
+`CAST(... AS INTEGER)` kürzt auf ganze Sekunden.
+
+`SUM(...)` summiert alle abgeschlossenen Einträge für den Tag. `WHERE end_time IS NOT NULL`
+filtert alle noch laufenden Timer aus der Zusammenfassung.
+
+Die PHP-seitige Berechnung für einzelne Einträge:
+
+```php
+$start = new \DateTimeImmutable($this->startTime);
+$end   = new \DateTimeImmutable($this->endTime);
+return (int) $end->getTimestamp() - (int) $start->getTimestamp();
+```
+
+Beide Ansätze produzieren dasselbe Ergebnis für UTC-Zeitstempel. Der SQL-Ansatz wird für Aggregation
+verwendet (er vermeidet das Abrufen aller Zeilen zum Summieren); der PHP-Ansatz wird für die
+Serialisierung einzelner Einträge verwendet.
+
+---
+
+## Tägliche Zusammenfassungsaggregation
+
+```php
+$sql = 'SELECT date(start_time) AS day,
+               SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds,
+               COUNT(*) AS entry_count
+          FROM time_entries
+         WHERE ' . implode(' AND ', $where) . '
+         GROUP BY day
+         ORDER BY day DESC';
+```
+
+`date(start_time)` extrahiert das Kalenderdatum aus dem `start_time`-ISO-String.
+`GROUP BY day` gruppiert alle abgeschlossenen Einträge für denselben Tag.
+`ORDER BY day DESC` gibt die neuesten Tage zuerst zurück.
+
+Die `$where`-Klausel beginnt immer mit `['end_time IS NOT NULL']`, um laufende Timer auszuschließen,
+und fügt dann optional `date(start_time) >= ?` und `date(start_time) <= ?` für den Datumsbereichsfilter hinzu.
+
+---
+
+## `date()`-Funktion für datumsbasierte Filterung
+
+Das Filtern von Einträgen nach Kalenderdatum verwendet SQLites `date()`-Funktion:
+
+```php
+if ($date !== null) {
+    $where[]  = "date(start_time) = ?";
+    $params[] = $date;
+}
+```
+
+`date(start_time)` extrahiert nur `YYYY-MM-DD` aus dem ISO-Datumszeit-String.
+`= ?` vergleicht das extrahierte Datum mit dem Filterwert. Dies trifft korrekt alle
+Einträge, die am angegebenen Tag begonnen haben, unabhängig von der Zeitkomponente.
+
+---
+
+## Label-Filterung mit `LIKE`
+
+```php
+if ($label !== null) {
+    $where[]  = 'label LIKE ?';
+    $params[] = '%' . $label . '%';
+}
+```
+
+`LIKE '%label%'` führt einen Groß-/Kleinschreibungsunempfindlichen Teilstring-Vergleich in SQLites
+Standard-Kollation durch. Sonderzeichen `%` und `_` in `$label` werden als LIKE-Wildcards interpretiert
+— escapen wenn strikt-literales Matching erforderlich ist.
+
+---
+
+## `GET /timers/running`-Antwortvertrag
+
+Der Laufend-Endpunkt gibt eine konsistente Form zurück, ob ein Timer aktiv ist oder nicht:
+
+```php
+if ($entry === null) {
+    return $this->json->create(['running' => false, 'entry' => null]);
+}
+return $this->json->create(['running' => true, 'entry' => $this->serialize($entry)]);
+```
+
+`running: false, entry: null` — kein Timer aktiv.
+`running: true, entry: {...}` — aktiver Timer mit `end_time: null` und `duration_seconds: null`.
+
+Dies vermeidet ein `404` für „kein laufender Timer" — `404` impliziert, die Ressource existiert nicht,
+aber das Konzept „laufender Timer" existiert immer (es ist nur leer). `running: false` zu verwenden
+ist semantisch sauberer.
+
+---
+
+## Verwandte Anleitungen
+
+- [`shift-management.md`](shift-management.md) — Schicht-Ein-/Ausstempeln mit nullable Endzeit
+- [`scheduled-reminders.md`](scheduled-reminders.md) — Zeitzonen-bewusste Datumszeit-Validierung
+- [`aggregate-reporting.md`](aggregate-reporting.md) — `GROUP BY date`-Aggregationsmuster
+- [`handle-timezones.md`](handle-timezones.md) — UTC-Speicherung und Zeitzonen-Konvertierung

--- a/docs/de/howto/timezone-aware-scheduling.md
+++ b/docs/de/howto/timezone-aware-scheduling.md
@@ -1,0 +1,158 @@
+# Anleitung: Zeitzonen-bewusste Ereignisplanung
+
+> **FT-Referenz**: FT286 (`NENE2-FT/schedulelog`) — Zeitzonen-bewusste Planung: UTC-Speicherung + Lokalzeit-Konvertierung, IANA-Zeitzonen-Validierung via DateTimeZone::listIdentifiers(), InvalidTimezoneException, dynamischer ?timezone-Abfrageparameter, 19 Tests / 39 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie eine Ereignisplanungs-API gebaut wird, die Zeiten in UTC speichert und sie in jeder Zeitzone darstellt, die der Client anfordert.
+
+## Warum in UTC speichern?
+
+UTC ist der universelle Referenzpunkt. Lokalzeiten sind mehrdeutig (Sommerzeitwechsel, Zeitzonen-Regeländerungen) und variieren nach Client-Standort. Durch Speicherung in UTC:
+- Sortierung und Vergleich sind immer korrekt
+- Clients können in ihrer lokalen Zeitzone anzeigen
+- Sommerzeitübergänge schaffen keine Mehrdeutigkeit in historischen Daten
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    title       TEXT    NOT NULL,
+    timezone    TEXT    NOT NULL,      -- IANA-Zeitzone des Event-Erstellers
+    start_utc   TEXT    NOT NULL,      -- UTC ISO 8601: 2026-05-20T15:00:00Z
+    start_local TEXT    NOT NULL,      -- Lokal ISO 8601: 2026-05-20T10:00:00
+    created_at  TEXT    NOT NULL
+);
+```
+
+Sowohl `start_utc` als auch `start_local` werden gespeichert. `start_utc` ist maßgeblich; `start_local` ist ein Convenience-Cache für die Zeitzone des Erstellers.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/events` | Ereignis erstellen (Zeitzone + lokale Startzeit → UTC) |
+| `GET` | `/events` | Ereignisse auflisten (optional `?timezone=America/New_York`) |
+| `GET` | `/events/{id}` | Ereignis abrufen (optional `?timezone=`) |
+
+## IANA-Zeitzonen-Validierung
+
+PHPs `DateTimeZone`-Konstruktor akzeptiert einige ungültige Bezeichner stillschweigend. Explizit validieren:
+
+```php
+final class TimezoneConverter
+{
+    public static function localToUtc(string $localDatetime, string $ianaTimezone): \DateTimeImmutable
+    {
+        try {
+            $tz = new \DateTimeZone($ianaTimezone);
+        } catch (\Exception) {
+            throw new InvalidTimezoneException("Unknown timezone: $ianaTimezone");
+        }
+
+        // PHP akzeptiert in manchen Versionen ungültige Abkürzungen wie "EST" —
+        // explizit gegen die kanonische IANA-Liste validieren.
+        $valid = \DateTimeZone::listIdentifiers();
+        if (!in_array($ianaTimezone, $valid, true)) {
+            throw new InvalidTimezoneException("Unknown timezone: $ianaTimezone");
+        }
+
+        $local = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $localDatetime, $tz);
+
+        if ($local === false) {
+            throw new \InvalidArgumentException("Cannot parse datetime: $localDatetime");
+        }
+
+        return $local->setTimezone(new \DateTimeZone('UTC'));
+    }
+}
+```
+
+`DateTimeZone::listIdentifiers()` gibt die PHP-kompilierte Liste von IANA-Bezeichnern zurück. Nicht-IANA-Strings (wie `EST`, `GMT+5`) werden abgelehnt.
+
+## Ereignis erstellen: Lokal → UTC
+
+```php
+try {
+    $utc = TimezoneConverter::localToUtc($start, $timezone);
+} catch (InvalidTimezoneException) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'timezone', 'code' => 'invalid', 'message' => "Unknown timezone: $timezone"]],
+    ]);
+} catch (\InvalidArgumentException) {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'start', 'code' => 'invalid', 'message' => "Cannot parse datetime: $start"]],
+    ]);
+}
+
+$startUtc   = TimezoneConverter::formatUtc($utc);                              // "2026-05-20T15:00:00Z"
+$startLocal = TimezoneConverter::formatLocal($utc->setTimezone(new \DateTimeZone($timezone)));  // "2026-05-20T10:00:00"
+```
+
+## Ereignisse auflisten: Dynamische Zeitzonen-Konvertierung
+
+Der `?timezone=`-Abfrageparameter konvertiert alle Ereignisse sofort in die Zeitzone des Clients:
+
+```php
+$viewTz = isset($params['timezone']) && $params['timezone'] !== '' ? $params['timezone'] : null;
+
+$items = array_map(static function (Event $e) use ($viewTz): array {
+    $data = $e->toArray();
+    if ($viewTz !== null) {
+        try {
+            $local = TimezoneConverter::utcToLocal($e->startUtc, $viewTz);
+            $data['start_local'] = TimezoneConverter::formatLocal($local);
+            $data['view_timezone'] = $viewTz;
+        } catch (InvalidTimezoneException) {
+            // Ungültige Ansichts-Zeitzone: stillschweigend UTC zurückgeben
+            $data['view_timezone'] = 'UTC';
+        }
+    }
+    return $data;
+}, $events);
+```
+
+Ungültige `?timezone=`-Werte fallen stillschweigend auf das gespeicherte `start_local` zurück, statt einen Fehler zurückzugeben — eine Designentscheidung, die für schreibgeschützte Ansichten geeignet ist.
+
+## UTC-Format: ISO 8601 mit Z-Suffix
+
+```php
+public static function formatUtc(\DateTimeImmutable $dt): string
+{
+    return $dt->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z');
+    //                                                                           ^ Literal Z
+}
+```
+
+Das `Z`-Suffix zeigt explizit UTC an (gemäß ISO 8601 / RFC 3339). `+00:00` zu verwenden oder den Offset wegzulassen sind akzeptable Alternativen, aber `Z` ist kompakter und universell erkannt.
+
+## DST-sichere Konvertierung
+
+```
+Beispiel: Asia/Tokyo ist UTC+9 (keine Sommerzeit)
+Lokal: 2026-05-20T10:00:00  Asia/Tokyo
+UTC:   2026-05-20T01:00:00Z
+
+Beispiel: America/New_York (Sommerzeit)
+Lokal: 2026-05-20T10:00:00  America/New_York (EDT = UTC-4 im Sommer)
+UTC:   2026-05-20T14:00:00Z
+
+Lokal: 2026-01-20T10:00:00  America/New_York (EST = UTC-5 im Winter)
+UTC:   2026-01-20T15:00:00Z
+```
+
+`DateTimeImmutable` mit einer benannten IANA-Zeitzone behandelt Sommerzeit automatisch. Es verwendet den Offset, der an diesem bestimmten Datum aktiv ist, nicht einen festen Offset.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Lokalzeit ohne Zeitzonen-Spalte speichern | Kann später nicht in UTC konvertiert werden; historische Daten werden nach Sommerzeitwechseln mehrdeutig |
+| `EST`, `PST`, `GMT+5` als Zeitzone akzeptieren | Mehrdeutige Abkürzungen; einige sind mehreren IANA-Zonen zugeordnet; `DateTimeZone::listIdentifiers()` lehnt diese ab |
+| `new DateTimeZone($tz)` ohne Prüfung von `listIdentifiers()` verwenden | PHP akzeptiert stillschweigend einige ungültige oder veraltete Bezeichner; kanonische Validierung erfasst sie |
+| UTC-Offset (`+09:00`) statt IANA-Name speichern | Offset allein kann Sommerzeit nicht behandeln; `Asia/Tokyo` ist immer +9, aber `America/New_York` variiert |
+| Ereignisse nach `start_local` sortieren | Lexikografische Sortierung nach Lokalzeiten ignoriert Zeitzonenunterschiede; immer nach `start_utc` sortieren |
+| Zeitzone bei jeder Abfrage konvertieren | Teuer für große Datensätze; Caching oder Vorberechnung häufiger Ansichts-Zeitzonen in Betracht ziehen |
+| 422 für ungültiges `?timezone=` in GET zurückgeben | Schreibgeschützte Abfragen sollten gracefully degradieren; auf UTC zurückfallen statt Fehler |
+| `date()` statt `DateTimeImmutable` verwenden | `date()` verwendet die Standard-Zeitzone des Servers; `DateTimeImmutable` mit expliziten Zonen ist vorhersehbar |

--- a/docs/de/howto/token-lifecycle-api.md
+++ b/docs/de/howto/token-lifecycle-api.md
@@ -1,0 +1,283 @@
+# Anleitung: API-Token-Lifecycle-Verwaltung
+
+> **FT-Referenz**: FT272 (`NENE2-FT/tokenlog`) — API-Token-Lebenszyklus: SHA-256-Hash-Speicherung (Klartext wird nie gespeichert), Scope-Enum (read/write/admin) mit DB-CHECK-Bedingung, IDOR-Guard (actorId muss userId entsprechen), Soft-Revoke via revoked_at, Verifizierungs-Endpunkt gibt valid/user_id/scope zurück, 29 Tests / 70 Assertions BESTANDEN.
+>
+> **ATK-Assessment**: ATK-01 bis ATK-12 am Ende dieses Dokuments.
+
+Demonstriert ein scope-basiertes API-Token-System: Tokens für einen Benutzer ausgeben, auflisten/widerrufen und einen Rohtoken beim Zugriffszeitpunkt verifizieren. Tokens werden nur als SHA-256-Hashes gespeichert — der Klartext wird einmal bei der Ausgabe zurückgegeben und nie gespeichert.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE tokens (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    token_hash TEXT    NOT NULL UNIQUE,
+    scope      TEXT    NOT NULL DEFAULT 'read',
+    label      TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    revoked_at TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    CHECK (scope IN ('read', 'write', 'admin'))
+);
+```
+
+Wesentliche Designentscheidungen:
+- `token_hash UNIQUE` — verhindert versehentliche doppelte Ausgabe; auch der Lookup-Schlüssel beim Verifizieren
+- `CHECK (scope IN (...))` — DB-Ebene Durchsetzung des Scope-Enums
+- `revoked_at TEXT` — Soft-Revoke; `NULL` bedeutet aktiv, nicht-NULL bedeutet widerrufen
+
+---
+
+## Routen
+
+| Methode   | Pfad                                | Beschreibung                              |
+|-----------|-------------------------------------|------------------------------------------|
+| `POST`   | `/users`                            | Benutzer erstellen                        |
+| `POST`   | `/users/{userId}/tokens`            | Token ausgeben (nur Eigentümer)           |
+| `GET`    | `/users/{userId}/tokens`            | Tokens für einen Benutzer auflisten (nur Eigentümer) |
+| `DELETE` | `/users/{userId}/tokens/{tokenId}`  | Token widerrufen (nur Eigentümer)         |
+| `POST`   | `/tokens/verify`                    | Rohtoken verifizieren                     |
+
+---
+
+## Nur-Hash-Speicherung
+
+Der Rohtoken wird einmal bei der Ausgabe zurückgegeben und nie gespeichert:
+
+```php
+public function issueToken(int $userId, TokenScope $scope, string $label, string $now): string
+{
+    $raw  = bin2hex(random_bytes(32));   // 64 Hex-Zeichen — 256 Bits Entropie
+    $hash = hash('sha256', $raw);
+
+    $this->executor->execute(
+        'INSERT INTO tokens (user_id, token_hash, scope, label, created_at) VALUES (?, ?, ?, ?, ?)',
+        [$userId, $hash, $scope->value, $label, $now],
+    );
+
+    return $raw; // an Aufrufer zurückgegeben, nie gespeichert
+}
+```
+
+Beim Verifizieren liefert der Aufrufer den Rohtoken; der Hash wird neu berechnet und nachgeschlagen:
+
+```php
+public function verifyToken(string $rawToken): ?array
+{
+    $hash = hash('sha256', $rawToken);
+    $row  = $this->executor->fetchOne(
+        'SELECT id, user_id, scope, revoked_at FROM tokens WHERE token_hash = ?',
+        [$hash],
+    );
+
+    if ($row === null) {
+        return null; // nicht gefunden → Aufrufer gibt {valid: false} zurück
+    }
+
+    return [
+        'valid'   => !isset($arr['revoked_at']),
+        'user_id' => (int) $arr['user_id'],
+        'scope'   => (string) $arr['scope'],
+    ];
+}
+```
+
+---
+
+## Scope-Durchsetzung
+
+`TokenScope` ist ein PHP-backed Enum; `tryFrom()` lehnt unbekannte Werte vor jedem DB-Zugriff ab:
+
+```php
+enum TokenScope: string
+{
+    case Read  = 'read';
+    case Write = 'write';
+    case Admin = 'admin';
+}
+
+// Im Routen-Handler:
+$scope = TokenScope::tryFrom($scopeValue);
+if ($scope === null) {
+    return $this->responseFactory->create(['error' => 'invalid scope, must be read/write/admin'], 422);
+}
+```
+
+Die DB-`CHECK`-Bedingung bietet eine zweite Durchsetzungsschicht.
+
+---
+
+## IDOR-Guard
+
+Token-Ausgabe, Auflistung und Widerruf erfordern, dass der Akteur der Eigentümer ist:
+
+```php
+$actorId = $this->resolveActorId($request); // aus X-User-Id-Header
+
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+Der Widerruf überprüft auch, dass das Token zu `userId` gehört, nicht nur irgendein Token:
+
+```php
+if ($token['user_id'] !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+---
+
+## Widerruf
+
+Soft-Revoke setzt `revoked_at`; das UPDATE gilt nur, wenn `revoked_at IS NULL`:
+
+```php
+public function revokeToken(int $tokenId, string $now): bool
+{
+    $count = $this->executor->execute(
+        'UPDATE tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL',
+        [$now, $tokenId],
+    );
+    return $count > 0;
+}
+```
+
+Wenn das Token bereits widerrufen wurde, gibt der Routen-Handler 409 Conflict zurück:
+
+```php
+if ($token['revoked']) {
+    return $this->responseFactory->create(['error' => 'token already revoked'], 409);
+}
+```
+
+---
+
+## ATK-Assessment — Cracker-Mindset-Angrifftest
+
+### ATK-01 — Token-Replay nach Widerruf 🚫 BLOCKED
+
+**Angriff**: Token widerrufen, dann denselben Rohtoken-Wert bei `/tokens/verify` verwenden.
+**Ergebnis**: BLOCKED — `verifyToken()` schlägt `revoked_at` in der Zeile nach; ein nicht-NULL `revoked_at` verursacht `valid: false`. Das widerrufene Token wird nicht gelöscht, also wird es aufgelöst, aber gibt `{valid: false}` zurück.
+
+---
+
+### ATK-02 — Brute-Force-Token-Raten 🚫 BLOCKED
+
+**Angriff**: Zufällige 64-Zeichen-Hex-Strings an `/tokens/verify` senden, in der Hoffnung, einen gültigen Token-Hash zu treffen.
+**Ergebnis**: BLOCKED — Tokens sind `bin2hex(random_bytes(32))` = 256 Bits Entropie. Wahrscheinlichkeit einer erfolgreichen Rate: `1 / 2^256`. Kein Rate Limiting in diesem FT, aber die Entropie allein macht Brute-Force rechnerisch unmöglich.
+
+---
+
+### ATK-03 — IDOR: Zugriff auf die Token-Liste eines anderen Benutzers 🚫 BLOCKED
+
+**Angriff**: `X-User-Id: 1` setzen und `GET /users/2/tokens` anfordern.
+**Ergebnis**: BLOCKED — `actorId (1) !== userId (2)` → 403 Forbidden.
+
+---
+
+### ATK-04 — IDOR: Token eines anderen Benutzers widerrufen 🚫 BLOCKED
+
+**Angriff**: Als Benutzer 1 `DELETE /users/2/tokens/{tokenId}` aufrufen.
+**Ergebnis**: BLOCKED — der Routen-Handler prüft `actorId !== userId` → 403, bevor das Token abgerufen wird.
+
+---
+
+### ATK-05 — Benutzerübergreifender Token-Widerruf (geteilte Token-ID) 🚫 BLOCKED
+
+**Angriff**: Als Benutzer 2 `DELETE /users/2/tokens/{tokenId}` aufrufen, wobei `tokenId` Benutzer 1 gehört.
+**Ergebnis**: BLOCKED — nachdem die IDOR-Prüfung passiert (actorId = userId = 2), gibt `findTokenById` das Token zurück, dann `$token['user_id'] !== $userId` → 403. Doppelte Eigentümerschaftsprüfung verhindert benutzerübergreifenden Widerruf.
+
+---
+
+### ATK-06 — Ungültige Scope-Injektion 🚫 BLOCKED
+
+**Angriff**: POST `/users/{id}/tokens` mit `{"scope": "superadmin"}`.
+**Ergebnis**: BLOCKED — `TokenScope::tryFrom('superadmin')` gibt `null` zurück → 422. Die DB-CHECK-Bedingung würde es auch blockieren, wenn die Anwendungsschicht es irgendwie durchließe.
+
+---
+
+### ATK-07 — Token-Klartext-Extraktion aus DB 🚫 BLOCKED
+
+**Angriff**: Wenn ein Angreifer Lesezugriff auf die `tokens`-Tabelle erhält, kann er funktionierende Tokens erhalten?
+**Ergebnis**: BLOCKED — nur `token_hash` (SHA-256) wird gespeichert. SHA-256 umzukehren ist rechnerisch unmöglich. Der Rohtoken wird einmal bei der Ausgabe zurückgegeben und serverseitig verworfen.
+
+---
+
+### ATK-08 — Verifizieren mit leerem/fehlerhaftem Token 🚫 BLOCKED
+
+**Angriff**: POST `/tokens/verify` mit `{"token": ""}` oder `{"token": null}`.
+**Ergebnis**: BLOCKED — Leerstring-Prüfung: `if ($token === '') → 422`. `null` wird durch `is_string()`-Prüfung abgelehnt. Der SHA-256 eines leeren Strings würde ohnehin mit keinem gespeicherten Hash übereinstimmen.
+
+---
+
+### ATK-09 — Token-Ausgabe für nicht existierenden Benutzer 🚫 BLOCKED
+
+**Angriff**: POST `/users/9999/tokens`, wobei Benutzer 9999 nicht existiert.
+**Ergebnis**: BLOCKED — `findUserById(9999)` gibt `false` zurück → 404, bevor irgendein Token erstellt wird.
+
+---
+
+### ATK-10 — Doppelter Widerruf (Idempotenz) 🚫 BLOCKED
+
+**Angriff**: Denselben Token zweimal schnell nacheinander widerrufen.
+**Ergebnis**: BLOCKED — `revokeToken` verwendet `WHERE revoked_at IS NULL`; der zweite Aufruf gibt 0 betroffene Zeilen zurück. Der Routen-Handler liest `$token['revoked'] === true`, bevor er das Repo aufruft → 409 Conflict. Kein Race-Condition-Fenster für erfolgreichen Doppelwiderruf.
+
+---
+
+### ATK-11 — Negative oder String-userId im Pfad 🚫 BLOCKED
+
+**Angriff**: `GET /users/-1/tokens` oder `GET /users/abc/tokens`.
+**Ergebnis**: BLOCKED — `is_numeric($params['userId'])` → `(int)`-Cast. `-1` wird zu -1; `findUserById(-1)` gibt false zurück → 404. `abc` ist nicht numerisch → `userId = 0` → 404.
+
+---
+
+### ATK-12 — Scope-Herabstufung bei Verifizierungs-Antwort 🚫 BLOCKED
+
+**Angriff**: Nach Erhalt eines `read`-scoped Tokens versuchen, `scope: write` in der Verifizierungsantwort zu fälschen, indem ein modifizierter Request-Body gesendet wird.
+**Ergebnis**: BLOCKED — `/tokens/verify` akzeptiert nur einen Rohtoken-String; der Scope wird aus der DB-Zeile gelesen, nicht aus einem client-gelieferten Feld. Der Client kann den zurückgegebenen Scope nicht beeinflussen.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Widerrufenes Token wiederholen | 🚫 BLOCKED |
+| ATK-02 | Brute-Force-Token-Raten | 🚫 BLOCKED |
+| ATK-03 | IDOR: Token-Liste eines anderen lesen | 🚫 BLOCKED |
+| ATK-04 | IDOR: Tokens eines anderen widerrufen | 🚫 BLOCKED |
+| ATK-05 | Benutzerübergreifender Token-Widerruf | 🚫 BLOCKED |
+| ATK-06 | Ungültige Scope-Injektion | 🚫 BLOCKED |
+| ATK-07 | Klartext-Extraktion aus DB | 🚫 BLOCKED |
+| ATK-08 | Leerer/fehlerhafter Token bei Verifizierung | 🚫 BLOCKED |
+| ATK-09 | Token-Ausgabe für nicht existierenden Benutzer | 🚫 BLOCKED |
+| ATK-10 | Doppelter Widerruf Race Condition | 🚫 BLOCKED |
+| ATK-11 | Negative/String-userId im Pfad | 🚫 BLOCKED |
+| ATK-12 | Scope-Herabstufung via Verifizierungs-Body | 🚫 BLOCKED |
+
+**12 BLOCKED / SAFE, 0 EXPOSED**
+Keine kritischen Befunde. Die Nur-Hash-Speicherung, Scope-Enum-Durchsetzung und dualen IDOR-Prüfungen bilden eine robuste Verteidigungsoberfläche.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Rohtoken in DB speichern | DB-Leseleck exponiert alle Tokens; Tokens können nicht ohne Benutzeraktion rotiert werden |
+| MD5/SHA-1 für Token-Hash verwenden | Kollisionsangriffe; SHA-256 oder BLAKE2 bevorzugen |
+| Beliebige Scope-Strings akzeptieren | Ohne `tryFrom()`-Validierung können `superadmin`-Scopes ausgegeben werden |
+| Keine Eigentümerschaftsprüfung beim Widerruf | Jeder authentifizierte Benutzer kann beliebige Tokens widerrufen (IDOR) |
+| Tokens bei Widerruf hart löschen | Prüfpfad geht verloren; keine Möglichkeit, Replay eines widerrufenen Tokens zu erkennen |
+| 404 bei bereits widerrufenem Token zurückgeben | Macht es unmöglich, „nicht gefunden" von „bereits widerrufen" zu unterscheiden; 409 verwenden |

--- a/docs/de/howto/totp-authentication.md
+++ b/docs/de/howto/totp-authentication.md
@@ -1,0 +1,194 @@
+# TOTP-Zwei-Faktor-Authentifizierung Implementierungsanleitung
+
+## Übersicht
+
+Diese Anleitung erklärt, wie RFC 6238 TOTP (Time-based One-Time Password) Zwei-Faktor-Authentifizierung mit NENE2 implementiert wird. Es werden Google Authenticator/Authy-kompatible Geheimnis-Generierung, Code-Verifizierung, Replay-Angriff-Prävention und Brute-Force-Lockout bereitgestellt.
+
+---
+
+## DB-Schema
+
+```sql
+CREATE TABLE totp_secrets (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER NOT NULL UNIQUE,
+    secret          TEXT    NOT NULL,
+    is_enabled      INTEGER NOT NULL DEFAULT 0,
+    failed_attempts INTEGER NOT NULL DEFAULT 0,
+    locked_until    TEXT,
+    created_at      TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE used_totp_steps (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    time_step  INTEGER NOT NULL,
+    used_at    TEXT    NOT NULL,
+    UNIQUE (user_id, time_step),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+Die `used_totp_steps`-Tabelle ist der Kern der **Replay-Angriff-Prävention**. Sie zeichnet verwendete Zeitschritte auf.
+
+---
+
+## Endpunkt-Design
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| POST | `/users/{id}/totp/setup` | TOTP-Geheimnis generieren (nach Rückgabe in App registrieren) |
+| POST | `/users/{id}/totp/enable` | Code verifizieren und 2FA aktivieren |
+| POST | `/users/{id}/totp/verify` | Code verifizieren (Login-Flow) |
+| DELETE | `/users/{id}/totp` | 2FA deaktivieren (gültiger Code erforderlich) |
+| GET | `/users/{id}/totp` | 2FA-Status abrufen |
+
+---
+
+## RFC 6238 TOTP-Implementierung
+
+```php
+class TotpGenerator
+{
+    private const int DIGITS = 6;
+    private const int PERIOD = 30; // Sekunden
+
+    public function computeCode(string $base32Secret, int $timeStep): string
+    {
+        $secret = $this->base32Decode($base32Secret);
+
+        // Zeitschritt als 8-Byte big-endian verpacken
+        $msg = pack('N*', 0) . pack('N*', $timeStep);
+        $hash = hash_hmac('sha1', $msg, $secret, true);
+
+        // Dynamisches Trunkieren (RFC 4226 §5.4)
+        $offset = ord($hash[19]) & 0x0F;
+        $code = ((ord($hash[$offset]) & 0x7F) << 24)
+              | ((ord($hash[$offset + 1]) & 0xFF) << 16)
+              | ((ord($hash[$offset + 2]) & 0xFF) << 8)
+              | (ord($hash[$offset + 3]) & 0xFF);
+
+        return str_pad((string) ($code % (10 ** self::DIGITS)), self::DIGITS, '0', STR_PAD_LEFT);
+    }
+
+    public function verify(string $base32Secret, string $code, int $window = 1): ?int
+    {
+        $t = (int) floor(time() / self::PERIOD);
+        for ($offset = -$window; $offset <= $window; $offset++) {
+            $step = $t + $offset;
+            $expected = $this->computeCode($base32Secret, $step);
+            if (hash_equals($expected, $code)) {   // Timing-Angriff-Prävention
+                return $step;
+            }
+        }
+        return null;
+    }
+}
+```
+
+---
+
+## Designpunkte
+
+### Replay-Angriff-Prävention
+
+TOTP-Codes sind 30 Sekunden lang gültig. Wenn derselbe Code zweimal verwendet wird, ist Identitätsbetrug möglich.
+Die `used_totp_steps`-Tabelle zeichnet verwendete time_steps auf und verweigert die Wiederverwendung.
+
+```php
+$matchedStep = $this->totp->verify($secret, $code);
+if ($matchedStep === null) {
+    // Code ungültig
+    return 401;
+}
+if ($this->repo->isStepUsed($userId, $matchedStep)) {
+    // Code für denselben time_step bereits verwendet → Replay-Angriff
+    return 401;
+}
+// Als verwendet markieren
+$this->repo->markStepUsed($userId, $matchedStep, $now);
+```
+
+### Timing-Angriff-Prävention
+
+Für den Vergleich von TOTP-Codes `hash_equals()` verwenden. `===` oder `strcmp()` beenden den String-Vergleich vorzeitig, sodass aus der Antwortzeit auf die Anzahl übereinstimmender Stellen geschlossen werden kann.
+
+```php
+// Nicht korrekt: anfällig für Timing-Angriffe
+if ($expected === $inputCode) { ... }
+
+// Korrekt: Konstantzeit-Vergleich
+if (hash_equals($expected, $inputCode)) { ... }
+```
+
+### Fenstergröße (Zeitversatz-Toleranz)
+
+`window = 1` erlaubt aktuellen Schritt ± 1 (= ±30 Sekunden).
+Zeitversätze bei Smartphones liegen fast immer in diesem Bereich.
+Das Fenster zu vergrößern verringert die Sicherheit; 1 wird empfohlen.
+
+### Brute-Force-Lockout
+
+Nach 3 Fehlversuchen 15 Minuten sperren (423 Locked).
+Während der Sperre wird auch ein korrekter Code abgelehnt (Timing-Oracle-Prävention):
+
+```php
+if ($this->repo->isLocked($userId, $now)) {
+    return 423; // Gesperrt — korrekten Code nicht prüfen
+}
+```
+
+### Setup-Flow
+
+1. `POST /users/{id}/totp/setup` zum Geheimnis generieren
+2. Das `secret` (Base32) oder `otpauth_uri` aus der Antwort in der Authenticator-App registrieren
+3. `POST /users/{id}/totp/enable` mit dem ersten Code zum Aktivieren aufrufen
+4. Vor der Aktivierung ist das Geheimnis in der DB gespeichert, aber `is_enabled = false`
+
+```
+otpauth://totp/NENE2:alice?secret=JBSWY3DPEHPK3PXP&issuer=NENE2&algorithm=SHA1&digits=6&period=30
+```
+
+### Re-Setup macht altes Geheimnis ungültig
+
+Ein erneuter Aufruf von `POST /users/{id}/totp/setup` überschreibt das alte Geheimnis,
+und `used_totp_steps` wird ebenfalls gelöscht. Codes des alten Geheimnisses können nicht mehr authentifiziert werden.
+
+---
+
+## Sicherheits-Checkliste (12 Schwachstellen-Diagnosen alle bestanden)
+
+| # | Prüfpunkt | Gegenmaßnahme |
+|---|-----------|---------------|
+| A | Replay-Angriff | Verwendete time_steps in `used_totp_steps` aufzeichnen |
+| B | Brute-Force | Nach 3 Fehlversuchen 15 Minuten sperren (423) |
+| C | Korrekter Code während Sperre | Zuerst Sperrprüfung durchführen, Code überhaupt nicht verifizieren |
+| D | Unbefugte 2FA-Deaktivierung | DELETE erfordert ebenfalls gültigen Code |
+| E | Unbefugte 2FA-Aktivierung | Code-Verifizierung bei enable erforderlich |
+| F | Missbrauch alten Geheimnisses | Bei Re-Setup altes Geheimnis und verwendete Schritte löschen |
+| G | IDOR | Codes werden pro Benutzer mit unabhängigem secret verifiziert |
+| H | Geheimnis-Exposure | secret nicht in verify/enable-Antworten einschließen |
+| I | Fehlerhafter Code-Format | Nicht übereinstimmend → 401 (Format-Validierung optional) |
+| J | Leerer Code | Required-Validierung gibt 422 zurück |
+| K | verify ohne Aktivierung | `is_enabled`-Prüfung gibt 409 zurück |
+| L | Nicht existierender Benutzer | findUser() → null → 404 |
+
+---
+
+## Hinweise zum Testen
+
+Da TOTP-Codes zeitabhängig sind, wird derselbe Code nacheinander als Replay behandelt.
+In Tests `TotpGenerator::computeCode($secret, $gen->currentTimeStep() + N)` verwenden, um Codes verschiedener Schritte zu generieren:
+
+```php
+$enableCode  = $gen->computeCode($secret, $gen->currentTimeStep());     // für enable verwenden
+$verifyCode  = $gen->computeCode($secret, $gen->currentTimeStep() + 1); // für verify verwenden
+$disableCode = $gen->computeCode($secret, $gen->currentTimeStep() + 2); // für disable verwenden
+```
+
+---
+
+## Referenzimplementierung
+
+`../NENE2-FT/totplog/` — FT159 Field Trial (21 Tests + 12 Schwachstellen-Diagnosen = 32 Tests)

--- a/docs/de/howto/transaction-scope-pattern.md
+++ b/docs/de/howto/transaction-scope-pattern.md
@@ -1,0 +1,238 @@
+# Anleitung: Transaktions-Scope-Muster
+
+> **FT-Referenz**: FT253 (`NENE2-FT/txlog`) — Datenbanktransaktionsgrenzen: atomare Bestellung-mit-Inventar
+
+Demonstriert das korrekte Muster für `DatabaseTransactionManagerInterface::transactional()`
+in NENE2. Repositories müssen **innerhalb** des Callbacks mit dem transaktionsbezogenen Executor
+instanziiert werden — vorab injizierte Repositories operieren auf einer anderen Verbindung
+und ihre Schreibvorgänge werden **nicht** rückgängig gemacht, wenn die Transaktion fehlschlägt.
+
+---
+
+## Routen
+
+| Methode | Pfad      | Beschreibung                                            |
+|---------|-----------|---------------------------------------------------------|
+| `POST` | `/orders` | Bestellung aufgeben (atomarer Inventar-Abzug + Bestellung erstellen) |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS inventory (
+    product_id   INTEGER PRIMARY KEY,
+    product_name TEXT    NOT NULL,
+    stock        INTEGER NOT NULL CHECK (stock >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    status     TEXT    NOT NULL DEFAULT 'placed',
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id   INTEGER NOT NULL REFERENCES orders(id),
+    product_id INTEGER NOT NULL,
+    quantity   INTEGER NOT NULL
+);
+```
+
+`CHECK(stock >= 0)` ist ein DB-Sicherheitsnetz, das verhindert, dass der Bestand negativ wird,
+auch wenn die Anwendungslogik einen Fehler hat. Die Anwendung validiert den Bestand auch vor dem
+Dekrementieren, sodass die Bedingung im Normalbetrieb nie ausgelöst wird.
+
+---
+
+## Die Executor-Scope-Falle
+
+`DatabaseTransactionManagerInterface::transactional()` öffnet eine Transaktion und übergibt einen
+**transaktionsbezogenen Executor** an den Callback. Schreibvorgänge über diesen Executor sind
+Teil der Transaktion und werden bei einer Exception zurückgerollt.
+
+**❌ Falsch: Repository vor der Transaktion injiziert**
+
+```php
+final class OrderService
+{
+    public function __construct(
+        private readonly InventoryRepository $inventory, // verwendet äußeren Executor
+        private readonly OrderRepository     $orders,    // verwendet äußeren Executor
+        private readonly DatabaseTransactionManagerInterface $tx,
+    ) {}
+
+    public function placeOrder(array $items): int
+    {
+        return $this->tx->transactional(function ($txExecutor) use ($items): int {
+            // FEHLER: $this->inventory und $this->orders verwenden den äußeren Executor,
+            // nicht $txExecutor. Ihre Schreibvorgänge sind auf einer anderen Verbindung.
+            // Wenn die Transaktion zurückrollt, werden ihre Änderungen NICHT rückgängig gemacht.
+            foreach ($items as $item) {
+                $this->inventory->decrement($item['product_id'], $item['quantity']);
+            }
+            return $this->orders->create($items);
+        });
+    }
+}
+```
+
+**✅ Korrekt: Repositories innerhalb des Callbacks erstellt**
+
+```php
+final class OrderService
+{
+    public function __construct(
+        private readonly DatabaseTransactionManagerInterface $tx,
+        // Nur den Transaction Manager injizieren, nicht die Repositories.
+    ) {}
+
+    public function placeOrder(array $items): int
+    {
+        return $this->tx->transactional(function ($executor) use ($items): int {
+            // Repositories werden mit dem transaktionsbezogenen Executor instanziiert.
+            // Alle Lese- und Schreibvorgänge gehen durch dieselbe Verbindung, in derselben Transaktion.
+            $inventory = new InventoryRepository($executor);
+            $orders    = new OrderRepository($executor);
+
+            foreach ($items as $item) {
+                // Wirft InsufficientStockException → löst Rollback aus
+                $inventory->decrement($item['product_id'], $item['quantity']);
+            }
+
+            return $orders->create($items);
+        });
+    }
+}
+```
+
+Der transaktionsbezogene `$executor`, der von `transactional()` übergeben wird, teilt dieselbe PDO-
+Verbindung und denselben Transaktionskontext. Das Erstellen von Repositories innerhalb des Callbacks
+mit diesem Executor stellt sicher, dass alle ihre Schreibvorgänge an derselben atomaren Transaktion teilnehmen.
+
+---
+
+## Inventar-Dekrement mit Anwendungsebene-Prüfung
+
+```php
+public function decrement(int $productId, int $qty): void
+{
+    $current = $this->getStock($productId);
+    if ($current < $qty) {
+        throw new InsufficientStockException($productId, $qty, $current);
+    }
+    $this->executor->execute(
+        'UPDATE inventory SET stock = stock - ? WHERE product_id = ?',
+        [$qty, $productId],
+    );
+}
+```
+
+Das Lesen-dann-Schreiben-Muster (`getStock()` + `UPDATE`) ist von sich aus nicht atomar —
+eine gleichzeitige Anfrage könnte denselben Bestand lesen und beide erfolgreich sein. Für den
+Produktionseinsatz in einem `SELECT ... FOR UPDATE` (MySQL) einwickeln oder `UPDATE ... WHERE stock >= ?`
+als optimistische Prüfung verwenden:
+
+```sql
+UPDATE inventory SET stock = stock - ? WHERE product_id = ? AND stock >= ?
+-- dann betroffene Zeilen == 1 prüfen; wenn 0, InsufficientStockException werfen
+```
+
+SQLite unterstützt kein `SELECT FOR UPDATE`, daher fängt die `CHECK(stock >= 0)`-Bedingung
+gleichzeitige Races auf DB-Ebene auf — das zweite Update würde eine Constraint-Verletzung werfen,
+die als Exception propagiert und Rollback auslöst.
+
+---
+
+## Multi-Element-Atomizität: Teilfehler löst vollständigen Rollback aus
+
+```php
+foreach ($items as $item) {
+    $inventory->decrement($item['product_id'], $item['quantity']); // kann werfen
+}
+return $orders->create($items); // nur erreicht, wenn alle Decrements erfolgreich sind
+```
+
+Wenn das **erste** Element fehlschlägt, werden keine Inventaränderungen vorgenommen. Wenn das **letzte**
+Element fehlschlägt, werden alle vorherigen Decrements zurückgerollt. Die Test-Suite verifiziert beide Fälle:
+
+```php
+// Widget: 10 Bestand; Gadget: 1 Bestand. Bestellung [Widget×3, Gadget×5] schlägt bei Gadget fehl.
+$this->assertSame(10, $inventory->getStock(1)); // Widget auf 10 wiederhergestellt
+$this->assertSame(0, $orders->count());          // Keine Bestellung erstellt
+```
+
+---
+
+## Exception → Rollback → 422-Mapping
+
+Die Exception, die innerhalb von `transactional()` geworfen wird, propagiert zum Aufrufer:
+
+```php
+try {
+    $orderId = $this->service->placeOrder($items);
+    return $this->json->create(['order_id' => $orderId, 'status' => 'placed'], 201);
+} catch (InsufficientStockException $e) {
+    return $this->problems->create(
+        $request,
+        'insufficient-stock',
+        'Insufficient stock.',
+        422,
+        $e->getMessage(),
+    );
+}
+```
+
+`transactional()` fängt die Exception ab, ruft `ROLLBACK` auf, dann wirft es erneut. Der Aufrufer
+fängt die erneut geworfene Exception ab und ordnet sie einer Problem-Details-Antwort zu.
+
+---
+
+## Eingabe-Validierung: Striktes `is_int` für Mengen
+
+```php
+foreach ($body['items'] as $i => $item) {
+    if (
+        !is_array($item) ||
+        !isset($item['product_id'], $item['quantity']) ||
+        !is_int($item['product_id']) ||
+        !is_int($item['quantity']) ||
+        $item['quantity'] < 1
+    ) {
+        return $this->problems->create(
+            $request,
+            'validation-failed',
+            'Validation failed.',
+            422,
+            null,
+            ['errors' => [['field' => "items.{$i}", 'code' => 'invalid', ...]]],
+        );
+    }
+}
+```
+
+`is_int()` lehnt JSON-Floats (`1.0`) und Strings (`"3"`) ab. PHPs JSON-Decoder konvertiert
+JSON-Integer-Werte zu PHP `int`, daher funktioniert `is_int()` korrekt für JSON-Eingaben.
+`is_numeric()` nur für Query-String-Parameter verwenden (die immer Strings sind).
+
+---
+
+## `transactional()`-Verwendungs-Zusammenfassung
+
+| Tun | Nicht tun |
+|-----|-----------|
+| Repositories innerhalb des Callbacks erstellen | Repositories bei der Klasseninitialisierung injizieren |
+| `$executor` aus dem Callback an neue Repositories weitergeben | `$this->executor` verwenden, das im Konstruktor injiziert wurde |
+| Exceptions propagieren lassen, um Rollback auszulösen | Exceptions stillschweigend innerhalb des Callbacks fangen |
+| Einen Wert aus dem Callback zurückgeben | `void` zurückgeben, wenn die eingefügte ID benötigt wird |
+
+---
+
+## Verwandte Anleitungen
+
+- [`transactions.md`](transactions.md) — `DatabaseTransactionManagerInterface`-API-Referenz
+- [`use-transactions.md`](use-transactions.md) — Transaktionen zu einem bestehenden Endpunkt hinzufügen
+- [`budget-tracking.md`](budget-tracking.md) — Geldmittel mit Transaktion übertragen (Zwei-Konto-Bilanznaktualisierung)
+- [`order-management.md`](order-management.md) — Vollständiger Bestell-Lebenszyklus (erstellen, Status, stornieren)
+- [`optimistic-locking.md`](optimistic-locking.md) — Race-Condition-Prävention ohne Transaktionen

--- a/docs/de/howto/transactions.md
+++ b/docs/de/howto/transactions.md
@@ -1,0 +1,151 @@
+# Datenbanktransaktionen
+
+`DatabaseTransactionManagerInterface::transactional()` für atomare mehrstufige Operationen verwenden.
+Wenn ein Schritt wirft, werden alle Änderungen im Callback automatisch zurückgerollt.
+
+## Die kritische Regel: Repositories innerhalb des Callbacks instanziieren
+
+> **Warnung:** Repositories, die bei der Initialisierung injiziert werden, verwenden eine *andere* PDO-Verbindung und werden **außerhalb der Transaktion** ausgeführt. Rollbacks machen ihre Änderungen nicht rückgängig.
+
+`PdoConnectionFactory` erstellt bei jedem Aufruf eine neue Verbindung. Wenn `transactional()` eine Transaktion öffnet, öffnet es sie auf einer *neuen* Verbindung. Jedes Repository, das vor diesem Aufruf erstellt wurde (z. B. über Konstruktor-DI injiziert), hält eine andere Verbindung — eine, die nicht Teil der Transaktion ist.
+
+### Korrektes Muster
+
+```php
+final class OrderService
+{
+    public function __construct(
+        private readonly DatabaseTransactionManagerInterface $tx,
+    ) {}
+
+    public function placeOrder(array $items): int
+    {
+        return $this->tx->transactional(function ($executor) use ($items): int {
+            // ✅ Repositories INNERHALB des Callbacks mit dem tx-scoped Executor instanziieren
+            $inventory = new InventoryRepository($executor);
+            $orders    = new OrderRepository($executor);
+
+            foreach ($items as $item) {
+                // wirft InsufficientStockException → Rollback automatisch ausgelöst
+                $inventory->decrement($item['product_id'], $item['quantity']);
+            }
+
+            return $orders->create($items);
+        });
+    }
+}
+```
+
+### Falsches Muster (Änderungen werden NICHT zurückgerollt)
+
+```php
+// ❌ Diese Repos halten eine andere Verbindung — nicht Teil der Transaktion
+public function __construct(
+    private readonly InventoryRepository $inventory,
+    private readonly OrderRepository $orders,
+    private readonly DatabaseTransactionManagerInterface $tx,
+) {}
+
+public function placeOrder(array $items): int
+{
+    return $this->tx->transactional(function ($executor) use ($items): int {
+        foreach ($items as $item) {
+            $this->inventory->decrement(...); // ← andere Verbindung, außerhalb der Transaktion!
+        }
+        return $this->orders->create($items); // ← gleiches Problem
+        // Wenn eine Exception geworfen wird, werden $this->inventory-Änderungen NICHT rückgängig gemacht
+    });
+}
+```
+
+Dies ist ein stiller Fehler: Der Code kompiliert, PHPStan kann ihn nicht erkennen, und Tests könnten bestehen, außer sie verifizieren das Rollback-Verhalten explizit.
+
+---
+
+## Rollback-Verhalten
+
+`transactional()` fängt `Throwable`, rollt zurück, dann wirft es erneut. Der Aufrufer erhält die ursprüngliche Exception.
+
+```php
+try {
+    $this->orderService->placeOrder($items);
+} catch (InsufficientStockException $e) {
+    // Alle Inventar-Decrements aus diesem Aufruf sind rückgängig gemacht
+    // Keine Bestellung wurde erstellt
+}
+```
+
+---
+
+## Vor-Validierung + Atomarer-Operations-Muster
+
+Das schnell-scheiternde Muster oben stoppt beim ersten nicht vorrätigen Element und lässt den Client über andere Fehler im Unklaren.
+Wenn UX wichtig ist, zuerst alle Fehler sammeln, dann atomar ausführen:
+
+```php
+public function placeOrder(array $items): int
+{
+    // Phase 1: alle Elemente außerhalb der Transaktion validieren (schreibgeschützt)
+    $errors = [];
+    foreach ($items as $item) {
+        $stock = $this->getStockSnapshot($item['product_id']);
+        if ($stock < $item['quantity']) {
+            $errors[] = [
+                'product_id' => $item['product_id'],
+                'requested'  => $item['quantity'],
+                'available'  => $stock,
+            ];
+        }
+    }
+
+    if ($errors !== []) {
+        throw new InsufficientStockException($errors);
+    }
+
+    // Phase 2: atomares Dekrement — innerhalb immer noch den tx-scoped Executor verwenden
+    return $this->tx->transactional(function ($executor) use ($items): int {
+        $inventory = new InventoryRepository($executor);
+        $orders    = new OrderRepository($executor);
+
+        foreach ($items as $item) {
+            // DB-CHECK-Bedingung ist das letzte Sicherheitsnetz für Races
+            $inventory->decrement($item['product_id'], $item['quantity']);
+        }
+
+        return $orders->create($items);
+    });
+}
+```
+
+**Kompromisse:**
+- Das Lesen in Phase 1 ist nicht Teil der Transaktion, sodass eine gleichzeitige Anfrage den Bestand zwischen Phase 1 und Phase 2 erschöpfen kann. Die Datenbankbedingung `CHECK (stock >= 0)` (oder `decrement()` wirft bei negativem Bestand) fängt diesen Race auf.
+- Für die meisten Anwendungen ist dies akzeptabel. Für strikte Korrektheit `SELECT ... FOR UPDATE` oder ein serialisierbares Isolationsniveau verwenden (nicht in SQLite verfügbar).
+
+---
+
+## Rollback-Korrektheit testen
+
+Immer verifizieren, dass das Inventar nach einer fehlgeschlagenen Bestellung unverändert ist:
+
+```php
+$this->inventory->seed(1, 'Widget', 10);
+$this->inventory->seed(2, 'Gadget', 1);
+
+// Widget-Dekrement würde erfolgreich sein, aber Gadget schlägt fehl → beide müssen zurückrollen
+$res = $this->post('/orders', ['items' => [
+    ['product_id' => 1, 'quantity' => 3],
+    ['product_id' => 2, 'quantity' => 5], // nur 1 auf Lager
+]]);
+
+assertSame(422, $res->getStatusCode());
+assertSame(10, $this->inventory->getStock(1), 'Widget muss auf 10 zurückgerollt werden');
+assertSame(0, $this->orders->count(), 'Keine Bestellung erstellt');
+```
+
+Unit-Tests, die Repositories mocken, können diese Klasse von Fehler nicht erfassen — nur Integrationstests, die dieselbe SQLite/MySQL-Verbindung teilen, können die Rollback-Korrektheit verifizieren.
+
+---
+
+## Laravel vs. NENE2
+
+Laravels `DB::transaction()` funktioniert mit injizierten Modellen, weil es transparent eine Verbindung über die Anfrage hinweg teilt. NENE2s `PdoConnectionFactory` gibt bei jedem Aufruf eine neue Verbindung zurück — eine bewusste Designentscheidung für Testbarkeit und explizite Verbindungskontrolle. Die Konsequenz ist, dass das Callback-scoped Executor-Muster in NENE2 **erforderlich** ist.

--- a/docs/de/howto/unicode-aware-text-api.md
+++ b/docs/de/howto/unicode-aware-text-api.md
@@ -1,0 +1,304 @@
+# Anleitung: Unicode-bewusste Text-API
+
+> **FT-Referenz**: FT345 (`NENE2-FT/unicodelog`) — Profil-API mit Unicode-sicherer Validierung: mb_strlen für Zeichenzählung, Null-Byte-Ablehnung, Multi-Skript-Unterstützung (Japanisch, Emoji, ZWJ-Sequenzen, Arabisch, gemischt), JSON_UNESCAPED_UNICODE-Behandlung, 22 Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie Unicode-Text in einer API sicher behandelt wird: Zeichen korrekt zählen (nicht Bytes), Null-Bytes ablehnen, mehrsprachige Eingaben akzeptieren und kodierungsbezogene Schwachstellen verhindern.
+
+## Schema
+
+```sql
+CREATE TABLE profiles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    bio        TEXT    NOT NULL DEFAULT '',
+    tags       TEXT    NOT NULL DEFAULT '[]',  -- JSON-Array als Text gespeichert
+    created_at TEXT    NOT NULL
+);
+```
+
+`tags` wird als JSON-Array-String gespeichert. SQLite TEXT behandelt beliebiges UTF-8 nativ.
+
+## Endpunkte
+
+| Methode   | Pfad              | Beschreibung         |
+|-----------|-------------------|--------------------|
+| `POST`   | `/profiles`       | Profil erstellen    |
+| `GET`    | `/profiles`       | Alle Profile auflisten |
+| `GET`    | `/profiles/{id}`  | Profil abrufen      |
+| `PATCH`  | `/profiles/{id}`  | Profil aktualisieren |
+| `DELETE` | `/profiles/{id}`  | Profil löschen      |
+
+## Limits
+
+| Feld   | Limit                         |
+|--------|-------------------------------|
+| `name` | 1–50 Unicode-Codepoints       |
+| `bio`  | 0–500 Unicode-Codepoints      |
+| `tags` | 0–10 Elemente, jeweils 1–30 Codepoints |
+
+## Profil erstellen
+
+```php
+POST /profiles
+{
+  "name": "田中太郎",
+  "bio": "プログラマーです。PHPが大好きです！",
+  "tags": ["エンジニア", "PHP"]
+}
+
+→ 201
+{
+  "id": 1,
+  "name": "田中太郎",
+  "bio": "プログラマーです。PHPが大好きです！",
+  "tags": ["エンジニア", "PHP"],
+  "created_at": "2026-05-27T09:00:00Z"
+}
+```
+
+Multi-Skript-Eingaben werden akzeptiert:
+
+```php
+POST /profiles
+{"name": "🎉 Yuki 🎊", "bio": "I love emojis! 🚀✨", "tags": ["🎨", "🎵"]}
+→ 201
+
+POST /profiles
+{"name": "محمد علي", "bio": "مبرمج ويب من مصر", "tags": ["مطور"]}
+→ 201
+
+POST /profiles
+{"name": "André García 鈴木", "bio": "Café résumé naïve", "tags": ["日本語", "español"]}
+→ 201
+```
+
+## Unicode-Längen-Validierung — `mb_strlen` vs. `strlen`
+
+**Immer `mb_strlen($value, 'UTF-8')` für Zeichenlimits verwenden.** `strlen()` zählt Bytes, nicht Zeichen.
+
+```php
+// "あ" ist 3 Bytes in UTF-8. strlen("あ") = 3, mb_strlen("あ", 'UTF-8') = 1.
+$name50 = str_repeat('あ', 50);  // 150 Bytes, 50 Zeichen
+// strlen würde dies ablehnen (150 > 50) — FALSCH
+// mb_strlen sieht korrekt 50 — KORREKT → 201 Created
+
+$name51 = str_repeat('あ', 51);  // 51 Zeichen → 422 (too_long)
+```
+
+### Validierungs-Implementierung
+
+```php
+function validateUnicodeField(string $value, string $field, int $maxChars): void
+{
+    // Erst Null-Bytes ablehnen
+    if (str_contains($value, "\x00")) {
+        throw new ValidationException($field, 'invalid', 'Null bytes are not allowed');
+    }
+
+    $length = mb_strlen($value, 'UTF-8');
+    if ($length === 0 && $field === 'name') {
+        throw new ValidationException($field, 'required', 'Field is required');
+    }
+    if ($length > $maxChars) {
+        throw new ValidationException($field, 'too_long', "Max {$maxChars} characters");
+    }
+}
+```
+
+### Emoji und ZWJ-Sequenzen
+
+```php
+// Jedes Emoji ist 1 Codepoint (4 Bytes). 50 Emoji = 200 Bytes, mb_strlen = 50 → BESTANDEN
+$name = str_repeat('🎉', 50);
+→ 201 Created
+
+// ZWJ-Sequenz 👨‍👩‍👧 = U+1F468 U+200D U+1F469 U+200D U+1F467
+// mb_strlen zählt dies als 5 Codepoints, nicht 1 Graphem-Cluster
+// Unverändert speichern und zurückgeben — nicht normalisieren
+$familyEmoji = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+→ 201 Created  // korrekt gespeichert und zurückgegeben
+```
+
+## Null-Byte-Ablehnung
+
+Null-Bytes (`\x00`) in Textfeldern sind ein Injektionsvektor — sie können Strings in C-basierten Bibliotheken abschneiden und in manchen Parsern die Validierung umgehen.
+
+```php
+POST /profiles  {"name": "Alice\x00Bob", "bio": "test", "tags": []}
+→ 422
+{"errors": [{"field": "name", "code": "invalid", "detail": "Null bytes are not allowed"}]}
+
+POST /profiles  {"name": "Valid", "bio": "bio with \x00 null", "tags": []}
+→ 422  // Null-Byte in bio
+
+POST /profiles  {"name": "Valid", "bio": "", "tags": ["tag\x00bad"]}
+→ 422  // Null-Byte in Tag-Wert
+```
+
+Null-Bytes **vor** der Längen-Validierung und **vor** der Speicherung ablehnen.
+
+## Tag-Validierung
+
+```php
+// Zu viele Tags (max 10)
+POST /profiles  {"name": "Valid", "bio": "", "tags": [... 11 Tags ...]}
+→ 422
+{"errors": [{"field": "tags", "code": "too_many", "detail": "Maximum 10 tags"}]}
+
+// Tag zu lang (max 30 Unicode-Zeichen)
+POST /profiles  {"name": "Valid", "bio": "", "tags": ["あ" × 31]}
+→ 422
+{"errors": [{"field": "tags[0]", "code": "too_long", "detail": "Max 30 characters"}]}
+
+// Nicht-String-Tag-Wert
+POST /profiles  {"name": "Valid", "bio": "", "tags": [42]}
+→ 422
+
+// Leerer Name
+POST /profiles  {"name": "", "bio": "", "tags": []}
+→ 422
+```
+
+### Tags-Implementierung
+
+```php
+$rawTags = $input['tags'] ?? [];
+if (!is_array($rawTags)) {
+    throw new ValidationException('tags', 'invalid', 'Tags must be an array');
+}
+if (count($rawTags) > 10) {
+    throw new ValidationException('tags', 'too_many', 'Maximum 10 tags');
+}
+$tags = [];
+foreach ($rawTags as $i => $tag) {
+    if (!is_string($tag)) {
+        throw new ValidationException("tags[{$i}]", 'invalid', 'Each tag must be a string');
+    }
+    if (str_contains($tag, "\x00")) {
+        throw new ValidationException("tags[{$i}]", 'invalid', 'Null bytes not allowed');
+    }
+    if (mb_strlen($tag, 'UTF-8') > 30) {
+        throw new ValidationException("tags[{$i}]", 'too_long', 'Max 30 characters per tag');
+    }
+    $tags[] = $tag;
+}
+$tagsJson = json_encode($tags, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+```
+
+## JSON-Antwort-Kodierung
+
+NENE2s `JsonResponseFactory` verwendet standardmäßig `json_encode()` ohne `JSON_UNESCAPED_UNICODE`. Das bedeutet, der rohe Antwort-Body enthält `\uXXXX`-Escape-Sequenzen für Nicht-ASCII-Zeichen — aber dekodierte Werte sind identisch.
+
+```php
+// Roh-Antwort-Body:
+{"name":"田中太郎", ...}
+
+// json_decode()-Ergebnis:
+["name" => "田中太郎", ...]  // ← korrekt
+```
+
+Clients, die Standard-JSON-Parser verwenden, sehen die korrekten Unicode-Werte. Die `\uXXXX`-Kodierung ist per RFC 8259 gültig.
+
+---
+
+## Schwachstellen-Assessment
+
+### V-01 — Null-Byte-Injektion ✅ SAFE
+
+**Risiko**: Null-Bytes (`\x00`) können die C-String-Verarbeitung in manchen PHP-Erweiterungen abschneiden, Validierung umgehen oder unerwartetes Verhalten bei nachgelagerten Konsumenten erzeugen.
+**Befund**: SAFE — Explizite `str_contains($value, "\x00")`-Prüfung lehnt alle Null-Bytes in `name`, `bio` und jedem Tag vor der Speicherung ab. Gibt 422 zurück.
+
+---
+
+### V-02 — Byte-Count-Überlauf via Multi-Byte-Zeichen ✅ SAFE
+
+**Risiko**: Wenn `strlen()` für Limits verwendet wird, wird ein Feld mit 50 japanischen Zeichen (150 Bytes) als „zu lang" abgelehnt, wenn es eigentlich bestehen sollte.
+**Befund**: SAFE — `mb_strlen($value, 'UTF-8')` zählt Codepoints, nicht Bytes. 50 japanische Zeichen = 50 Codepoints → besteht `max: 50`. 51 japanische Zeichen = 51 → abgelehnt. Emoji (4 Bytes jeweils) korrekt als 1 Codepoint gezählt.
+
+---
+
+### V-03 — Tag-Array-Injektion ✅ SAFE
+
+**Risiko**: Angreifer sendet Nicht-String-Werte im Tags-Array (Integer, Objekte, Arrays), um Typverwirrung in nachgelagertem Code auszunutzen.
+**Befund**: SAFE — Jedes Tag-Element wird typgeprüft (`is_string()`). Nicht-String-Werte geben 422 zurück. Tag-Anzahl ist ebenfalls auf 10 begrenzt.
+
+---
+
+### V-04 — SQL-Injection via Unicode-Payload ✅ SAFE
+
+**Risiko**: Angreifer sendet SQL-Schlüsselwörter oder Injektions-Strings als Unicode-Namen/Bio/Tags, in der Hoffnung, Encoding-Normalisierung oder Dekodierung ändert den String zu etwas Gefährlichem.
+**Befund**: SAFE — Alle Abfragen verwenden PDO-Prepared-Statements. Der Test `"'; DROP TABLE profiles; --"` wird als Literal-String gespeichert, nicht als SQL interpretiert.
+
+---
+
+### V-05 — Homograph-Angriff via Unicode-Lookalikes ⚠️ EXPOSED
+
+**Risiko**: Angreifer erstellt ein Profil mit einem Namen, der visuell identisch zu einem bestehenden Benutzer ist (z. B. `аdmin` mit kyrillischem `а` statt lateinischem `a`). Menschen, die den Namen lesen, können getäuscht werden.
+**Befund**: EXPOSED — Die API speichert und gibt Namen ohne Unicode-Normalisierung (NFC/NFD) oder Confusable-Erkennung unverändert zurück. Zwei Profile mit visuell identischen, aber Codepoint-verschiedenen Namen können koexistieren. Für hochvertrauenswürdige Kontexte (Admin-Benutzernamen, reservierte Namen) `Normalizer::normalize($name, Normalizer::FORM_C)` vor der Speicherung hinzufügen und auf Confusable-Zeichen über ICU oder eine dedizierte Bibliothek prüfen.
+
+---
+
+### V-06 — Überdimensioniertes Tags-Array DoS ✅ SAFE
+
+**Risiko**: Angreifer sendet `"tags": [1000 Elemente]`, um übermäßige Speicherzuteilung während der Verarbeitung auszulösen.
+**Befund**: SAFE — `count($rawTags) > 10`-Prüfung lehnt das Array bei 11+ Elementen vor jeder Elementverarbeitung ab. Gibt sofort 422 zurück.
+
+---
+
+### V-07 — JSON-Antwort-Kodierungs-Leck ✅ SAFE
+
+**Risiko**: Wenn der JSON-Encoder Literal-Nicht-ASCII-Bytes ohne ordnungsgemäße Content-Type-Charset-Deklaration ausgibt, könnten manche Clients die Kodierung falsch interpretieren.
+**Befund**: SAFE — Antwort hat `Content-Type: application/json` (Charset impliziert als UTF-8 per RFC 8259). `\uXXXX`-escapierte Ausgabe ist gültiges JSON und eindeutig.
+
+---
+
+### V-08 — ZWJ-Sequenz-Längen-Umgehung ✅ SAFE
+
+**Risiko**: Angreifer packt viele Graphem-Cluster in einen Namen, den `mb_strlen` als viele Codepoints zählt, in der Hoffnung, das Limit ist höher als die visuelle Darstellung.
+**Befund**: SAFE — `mb_strlen` zählt Codepoints, nicht Graphem-Cluster. `👨‍👩‍👧` (ZWJ-Sequenz von 5 Codepoints) zählt als 5, nicht 1.
+
+---
+
+### V-09 — Right-to-Left-Override (RTLO)-Injektion ✅ SAFE
+
+**Risiko**: Angreifer bettet Unicode-Steuerzeichen (U+202E, U+200F) in einen Namen ein, um angezeigten Text umzukehren und visuelle Täuschung in der UI zu erzeugen.
+**Befund**: SAFE — Die API speichert Text unverändert; Display-Layer-Sanitierung liegt in der Verantwortung des Frontends. Validierung lehnt Null-Bytes, aber keine anderen Unicode-Steuerzeichen ab. Für Admin-UIs U+202E, U+200F, U+2066–U+2069 vor dem Rendern entfernen oder escapen.
+
+---
+
+### V-10 — Unicode-Normalisierungs-Kollision ✅ SAFE
+
+**Risiko**: Zwei Namen, die identisch aussehen, aber sich in der Normalisierungsform (NFC vs. NFD) unterscheiden, könnten als verschiedene Benutzer behandelt werden.
+**Befund**: SAFE — Die API erzwingt keine NFC-Normalisierung; sie speichert, was sie empfängt. Für Anwendungsfälle, die kanonische Eindeutigkeit erfordern (E-Mail-äquivalente Felder), vor der Speicherung zu NFC normalisieren und auf der normalisierten Form einen Unique-Index setzen.
+
+---
+
+### VULN-Zusammenfassung
+
+| ID | Schwachstelle | Befund |
+|----|---------------|--------|
+| V-01 | Null-Byte-Injektion | ✅ SAFE |
+| V-02 | Byte-Count-Überlauf via Multi-Byte-Zeichen | ✅ SAFE |
+| V-03 | Tag-Array-Typ-Injektion | ✅ SAFE |
+| V-04 | SQL-Injection via Unicode-Payload | ✅ SAFE |
+| V-05 | Homograph / visuell identischer Name | ⚠️ EXPOSED |
+| V-06 | Überdimensioniertes Tags-Array DoS | ✅ SAFE |
+| V-07 | JSON-Antwort-Kodierungs-Leck | ✅ SAFE |
+| V-08 | ZWJ-Sequenz-Längen-Umgehung | ✅ SAFE |
+| V-09 | RTLO-Richtungs-Override-Injektion | ✅ SAFE |
+| V-10 | Unicode-Normalisierungs-Kollision | ✅ SAFE |
+
+**9 SAFE, 1 EXPOSED** — V-05 (Homograph-Angriff) ist eine bekannte Einschränkung. Mit `Normalizer::normalize()` + Confusable-Erkennung für hochvertrauenswürdige Namensfelder abschwächen.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `strlen($name) > 50` für Zeichenlimit | Lehnt gültige 50-Zeichen-japanische Eingabe ab (150 Bytes); lässt 150-Zeichen-ASCII zu (unter Byte-Limit) |
+| Keine Null-Byte-Prüfung | `"Alice\x00Bob"` kann in C-String-Kontexten als `"Alice"` gespeichert werden; umgeht Eindeutigkeits-Prüfungen |
+| `preg_match('/^\w+$/', $name)` für Unicode-Namen | `\w` ist nur ASCII in PHP ohne das `u`-Flag; lehnt alle Nicht-ASCII-Eingaben ab |
+| ZWJ-Sequenzen in Länge ignorieren | ZWJ-Sequenzen zählen als mehrere Codepoints; erwartetes Verhalten mit `mb_strlen` |
+| Tags als komma-getrennte Zeichenkette speichern | Kann nicht zuverlässig bei Kommas in Tag-Werten aufgeteilt werden; JSON-Array verwenden |
+| Tags als JSON-String statt Array zurückgeben | Clients müssen doppelt dekodieren; gespeichertes JSON immer vor der Antwort dekodieren |

--- a/docs/de/howto/upvote-downvote-api.md
+++ b/docs/de/howto/upvote-downvote-api.md
@@ -1,0 +1,231 @@
+# Anleitung: Upvote-/Downvote-API
+
+> **FT-Referenz**: FT347 (`NENE2-FT/votelog`) — Benutzer-spezifisches Upvote/Downvote mit Toggle-Off (gleiche Richtung zweimal entfernt Stimme), Richtungswechsel (auf→ab atomar), Score-Aggregation (Upvotes − Downvotes), UNIQUE(user_id, item_id)-Bedingung, 15 Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Reddit/Stack Overflow-ähnliches Abstimmungssystem implementiert wird: Jeder Benutzer kann eine Stimme pro Element abgeben, sie durch erneute Abstimmung in derselben Richtung ausschalten oder die Richtung ändern.
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE votes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    direction  TEXT    NOT NULL CHECK (direction IN ('up', 'down')),
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, item_id),
+    FOREIGN KEY (user_id)  REFERENCES users(id),
+    FOREIGN KEY (item_id)  REFERENCES items(id)
+);
+```
+
+`UNIQUE(user_id, item_id)` erzwingt eine Stimme pro Benutzer pro Element. `CHECK(direction IN ('up', 'down'))` lehnt jeden anderen Wert auf DB-Ebene ab.
+
+## Endpunkte
+
+| Methode | Pfad                          | Beschreibung                       |
+|---------|-------------------------------|------------------------------------|
+| `POST` | `/items/{id}/vote`            | Stimme abgeben, umschalten oder ändern |
+| `GET`  | `/items/{id}/score`           | Element-Score abrufen              |
+| `GET`  | `/items/{id}/vote/{userId}`   | Aktuelle Stimme des Benutzers abrufen |
+
+## Stimme abgeben
+
+```php
+POST /items/1/vote
+{"user_id": 42, "direction": "up"}
+
+→ 200
+{
+  "vote": "up",
+  "score": {
+    "upvotes": 1,
+    "downvotes": 0,
+    "score": 1
+  }
+}
+```
+
+```php
+POST /items/1/vote
+{"user_id": 43, "direction": "down"}
+→ 200  {"vote": "down", "score": {"upvotes": 1, "downvotes": 1, "score": 0}}
+```
+
+## Toggle-Off (Gleiche Richtung zweimal)
+
+In **derselben Richtung** ein zweites Mal abstimmen entfernt die Stimme:
+
+```php
+// Erste Stimme
+POST /items/1/vote  {"user_id": 42, "direction": "up"}
+→ 200  {"vote": "up", "score": {"score": 1}}
+
+// Zweite Stimme in gleicher Richtung → Toggle-Off
+POST /items/1/vote  {"user_id": 42, "direction": "up"}
+→ 200  {"vote": null, "score": {"score": 0}}
+```
+
+`vote: null` bedeutet, der Benutzer hat keine aktive Stimme für dieses Element.
+
+## Richtungswechsel
+
+In die **entgegengesetzte Richtung** abstimmen kippt die bestehende Stimme atomar:
+
+```php
+// Mit Upvote beginnen
+POST /items/1/vote  {"user_id": 42, "direction": "up"}
+→ 200  {"vote": "up", "score": {"upvotes": 1, "downvotes": 0, "score": 1}}
+
+// Zu Downvote wechseln
+POST /items/1/vote  {"user_id": 42, "direction": "down"}
+→ 200  {"vote": "down", "score": {"upvotes": 0, "downvotes": 1, "score": -1}}
+```
+
+## Score abrufen
+
+```php
+GET /items/1/score
+
+→ 200
+{
+  "upvotes": 2,
+  "downvotes": 1,
+  "score": 1         // Upvotes − Downvotes
+}
+```
+
+Score für ein Element ohne Stimmen:
+
+```php
+GET /items/1/score   // noch keine Stimmen
+→ 200  {"upvotes": 0, "downvotes": 0, "score": 0}
+```
+
+## Benutzer-Stimm-Status abrufen
+
+```php
+// Noch keine Stimme abgegeben
+GET /items/1/vote/42
+→ 200  {"vote": null}
+
+// Nach Upvote
+GET /items/1/vote/42
+→ 200  {"vote": "up"}
+
+// Nach Toggle-Off
+GET /items/1/vote/42
+→ 200  {"vote": null}
+```
+
+## Implementierung
+
+### Stimm-Handler-Logik
+
+```php
+public function vote(int $itemId, int $userId, string $direction): array
+{
+    $item = $this->repo->findItem($itemId);
+    if ($item === null) {
+        throw new ItemNotFoundException($itemId);
+    }
+
+    $existing = $this->repo->findVote($userId, $itemId);
+
+    if ($existing !== null && $existing['direction'] === $direction) {
+        // Gleiche Richtung → Toggle-Off
+        $this->repo->deleteVote($userId, $itemId);
+        $activeDirection = null;
+    } elseif ($existing !== null) {
+        // Andere Richtung → an Ort und Stelle aktualisieren
+        $this->repo->updateVote($userId, $itemId, $direction, $now);
+        $activeDirection = $direction;
+    } else {
+        // Neue Stimme
+        $this->repo->insertVote($userId, $itemId, $direction, $now);
+        $activeDirection = $direction;
+    }
+
+    $score = $this->repo->getScore($itemId);
+
+    return [
+        'vote'  => $activeDirection,
+        'score' => $score,
+    ];
+}
+```
+
+### Score-Aggregations-SQL
+
+```sql
+SELECT
+    COALESCE(SUM(CASE WHEN direction = 'up'   THEN 1 ELSE 0 END), 0) AS upvotes,
+    COALESCE(SUM(CASE WHEN direction = 'down' THEN 1 ELSE 0 END), 0) AS downvotes,
+    COALESCE(SUM(CASE WHEN direction = 'up'   THEN 1 ELSE -1 END), 0) AS score
+FROM votes
+WHERE item_id = ?
+```
+
+`COALESCE(..., 0)` stellt Null-Werte sicher, wenn keine Stimmen existieren (SUM einer leeren Menge gibt NULL zurück).
+
+### Stimm-UPSERT-Muster
+
+```sql
+-- Neue Stimme einfügen
+INSERT INTO votes (user_id, item_id, direction, created_at) VALUES (?, ?, ?, ?)
+
+-- Richtung aktualisieren (UNIQUE-Bedingung verhindert Duplikat)
+UPDATE votes SET direction = ? WHERE user_id = ? AND item_id = ?
+
+-- Löschen (Toggle-Off)
+DELETE FROM votes WHERE user_id = ? AND item_id = ?
+```
+
+## Validierung
+
+```php
+// Ungültige Richtung
+POST /items/1/vote  {"user_id": 42, "direction": "sideways"}
+→ 422  // Richtung muss 'up' oder 'down' sein
+
+// Element existiert nicht
+POST /items/9999/vote  {"user_id": 42, "direction": "up"}
+→ 404
+```
+
+## Mehrere Benutzer
+
+```php
+// Drei Benutzer stimmen für dasselbe Element
+POST /items/1/vote  {"user_id": 1, "direction": "up"}
+POST /items/1/vote  {"user_id": 2, "direction": "up"}
+POST /items/1/vote  {"user_id": 3, "direction": "down"}
+
+GET /items/1/score
+→ 200  {"upvotes": 2, "downvotes": 1, "score": 1}
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| Kein `UNIQUE(user_id, item_id)` | Benutzer können mehrmals abstimmen und Scores aufblähen |
+| `INSERT OR REPLACE` für Richtungswechsel | Generiert neue `id` und `created_at`; verliert Abstimmungshistorie; bricht Prüfpfade |
+| 409 bei Toggle-Off zurückgeben | Toggle-Off ist erwartetes Verhalten, kein Fehler; neuen (null) Stimm-Status zurückgeben |
+| Score in Anwendung durch Laden aller Stimmen berechnen | O(N) pro Anfrage; SQL-Aggregation mit einzelner Abfrage verwenden |
+| `direction: null` im Body zum Entfernen der Stimme erlauben | Mehrdeutig; Toggle-Muster (gleiche Richtung zweimal) oder separaten DELETE-Endpunkt verwenden |
+| `COALESCE` in Score-Aggregation weglassen | `SUM()` gibt `NULL` zurück, wenn keine Zeilen übereinstimmen; `null − null` verursacht Abstürze oder falschen Typ |

--- a/docs/de/howto/url-bookmark-api.md
+++ b/docs/de/howto/url-bookmark-api.md
@@ -1,0 +1,176 @@
+# Anleitung: URL-Lesezeichen-API mit Tag-Filterung
+
+> **FT-Referenz**: FT265 (`NENE2-FT/linklog`) — URL-Lesezeichen-API: UNIQUE-URL-Bedingung, komma-getrennte Tag-Speicherung, LIKE-basiertes Tag-Matching
+
+Demonstriert eine Lesezeichen-API, die URLs mit Tags als komma-getrennte TEXT-Spalte speichert.
+Doppelte URLs werden über eine `UNIQUE`-Bedingung erkannt und als `DuplicateUrlException`
+auf 409 Conflict abgebildet. Tag-Filterung verwendet vier LIKE-Muster, um einen Tag unabhängig
+von seiner Position in der komma-getrennten Zeichenkette zu treffen.
+
+---
+
+## Routen
+
+| Methode   | Pfad          | Beschreibung                                       |
+|-----------|---------------|----------------------------------------------------|
+| `POST`   | `/links`      | Lesezeichen erstellen                              |
+| `GET`    | `/links`      | Lesezeichen auflisten (Suche + Tag-Filter, paginiert) |
+| `GET`    | `/links/{id}` | Einzelnes Lesezeichen abrufen                      |
+| `DELETE` | `/links/{id}` | Lesezeichen löschen                                |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS links (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    url         TEXT    NOT NULL UNIQUE,
+    title       TEXT    NOT NULL,
+    description TEXT    NOT NULL DEFAULT '',
+    tags        TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL
+);
+```
+
+`url TEXT NOT NULL UNIQUE` erzwingt ein Lesezeichen pro URL auf DB-Ebene.
+`tags TEXT` speichert eine komma-getrennte Liste (z. B. `"php,api,rest"`). Dies vermeidet eine separate
+`link_tags`-Join-Tabelle für kleine Anwendungsfälle.
+
+---
+
+## Tags: Komma-getrennte TEXT vs. M:N-Join-Tabelle
+
+| Ansatz | Abfrage-Komplexität | Wann verwenden |
+|--------|---------------------|----------------|
+| Komma-getrennte TEXT | LIKE-Muster (4 pro Tag) | Kleine Datensätze; seltene Tag-Abfragen |
+| M:N-Join-Tabelle (`link_tags`) | JOIN + GROUP BY oder IN | Große Datensätze; häufige AND/OR-Filterung |
+| FTS5 mit Tags-Spalte | `WHERE fts MATCH ?` | Volltextsuche über mehrere Spalten |
+
+Komma-getrennte TEXT ist einfacher zu implementieren und geeignet, wenn die Anzahl der Links und Tags
+gering ist. Für Datensätze mit Tausenden von Links und komplexen Tag-Abfragen (AND-Filter, exakte
+Anzahlen) ist eine Join-Tabelle (siehe [`multi-value-tag-filter.md`](multi-value-tag-filter.md)) vorzuziehen.
+
+---
+
+## Tag-LIKE-Matching: Vier Muster
+
+Ein in einer komma-getrennten Spalte gespeicherter Tag kann an vier Positionen erscheinen:
+1. **Exakte Übereinstimmung**: `tags = 'php'` (einziger Tag)
+2. **Am Anfang**: `tags LIKE 'php,%'` (erster von mehreren)
+3. **In der Mitte**: `tags LIKE '%,php,%'` (nicht erster, nicht letzter)
+4. **Am Ende**: `tags LIKE '%,php'` (letzter von mehreren)
+
+```php
+if ($tags !== null) {
+    foreach ($tags as $tag) {
+        $sql      .= ' AND (tags = ? OR tags LIKE ? OR tags LIKE ? OR tags LIKE ?)';
+        $params[]  = $tag;            // exakt: "php"
+        $params[]  = $tag . ',%';     // Präfix: "php,..."
+        $params[]  = '%,' . $tag . ',%';  // Mitte: "...,php,..."
+        $params[]  = '%,' . $tag;     // Suffix: "...,php"
+    }
+}
+```
+
+Alle vier Muster sind pro Tag mit AND verknüpft: Ein Link muss alle angeforderten Tags erfüllen. Dies implementiert
+einen AND-Filter über Tags. Jedes `?` ist eine parametrisierte Bindung — kein Injektionsrisiko.
+
+**Einschränkung**: Eine Abfrage nach Tag `ph` würde KEINEN gespeicherten Tag `php` treffen, weil
+die Muster exakte Begrenzer (`,` oder Zeichenkettengrenzen) prüfen. Tags werden durch exakten
+Zeichenkettenwert verglichen, nicht durch Teilzeichenkette.
+
+---
+
+## Komma-getrennte Tag-Serialisierung und Deserialisierung
+
+**Speichern**: `implode(',', $tags)` — `['php', 'api', 'rest']` → `'php,api,rest'`
+
+**Lesen**: 
+```php
+$tagsStr = (string) $row['tags'];
+$tags    = $tagsStr === '' ? [] : array_values(array_filter(explode(',', $tagsStr)));
+```
+
+`array_filter()` entfernt leere Strings, die durch führende/nachfolgende Kommas oder Doppelkommas erstellt werden.
+`array_values()` reindiziert auf eine `list<string>`.
+
+**Tag-Abfrage-Parsing**: `?tags=php,api` → nach Komma aufteilen → `['php', 'api']`
+
+```php
+$rawTags = QueryStringParser::string($request, 'tags');
+$tags    = $rawTags !== null
+    ? array_values(array_filter(array_map('trim', explode(',', $rawTags))))
+    : null;
+```
+
+---
+
+## Doppelte URL: Benutzerdefinierte Exception + Handler
+
+```php
+public function create(string $url, ...): Link
+{
+    try {
+        $this->executor->execute(
+            'INSERT INTO links (url, title, description, tags, created_at) VALUES (?, ?, ?, ?, ?)',
+            [$url, $title, $description, implode(',', $tags), $createdAt],
+        );
+    } catch (DatabaseConnectionException $e) {
+        $previous = $e->getPrevious();
+        if ($previous !== null && str_contains($previous->getMessage(), 'UNIQUE constraint failed')) {
+            throw new DuplicateUrlException($url);
+        }
+        throw $e;
+    }
+
+    return new Link($this->executor->lastInsertId(), ...);
+}
+```
+
+Das Repository fängt die generische `DatabaseConnectionException` (vom Framework geworfen, wenn eine
+PDO-Exception auftritt), untersucht die Meldung der vorherigen Exception nach `UNIQUE constraint failed`
+und wirft erneut als domänenspezifische `DuplicateUrlException`. Dies hält die Domänensprache
+(`DuplicateUrlException`) von dem Infrastrukturdetail (`PDOException`) getrennt.
+
+Das `DuplicateUrlExceptionHandler`-Middleware fängt `DuplicateUrlException` ab und gibt
+409 Conflict Problem Details zurück:
+
+```php
+return $this->problems->create($request, 'duplicate-url', 'URL already exists.', 409, $e->url);
+```
+
+---
+
+## Suche: LIKE auf Titel und URL
+
+```php
+if ($search !== null) {
+    $sql      .= ' AND (title LIKE ? OR url LIKE ?)';
+    $params[]  = '%' . $search . '%';
+    $params[]  = '%' . $search . '%';
+}
+```
+
+Die Suchanfrage wird sowohl auf `title`- als auch auf `url`-Spalten angewendet. Eine einzelne `$search`-Bindung
+wird für beide Spalten wiederholt. Wie bei der Tag-Filterung ist der Wildcard `%` ein SQL-Literal in
+der Abfragezeichenkette, nicht aus Benutzereingaben — der Suchbegriff des Benutzers wird als Parameter gebunden.
+
+---
+
+## Beispiel: Tag-AND-Filter
+
+**Anfrage**: `GET /links?tags=php,api`
+
+Trifft Links, die BEIDE `php` UND `api` in ihrer `tags`-Spalte haben:
+- `"php,api"` ✓ (php: Präfix-Match, api: Suffix-Match)
+- `"rest,php,api"` ✓ (php: Mitte-Match, api: Suffix-Match)
+- `"php"` ✗ (fehlendes `api`)
+
+---
+
+## Verwandte Anleitungen
+
+- [`multi-value-tag-filter.md`](multi-value-tag-filter.md) — M:N-Join-Tabelle mit AND/OR-Tag-Filterung (für größere Datensätze)
+- [`sqlite-fts5-search.md`](sqlite-fts5-search.md) — FTS5-Volltextsuche als Alternative zu LIKE
+- [`sql-injection-defence.md`](sql-injection-defence.md) — Parametrisierte LIKE-Muster und Injektions-Abwehr

--- a/docs/de/howto/url-shortener-ssrf-prevention.md
+++ b/docs/de/howto/url-shortener-ssrf-prevention.md
@@ -1,0 +1,257 @@
+# Anleitung: URL-Verkürzer mit SSRF-Prävention
+
+> **FT-Referenz**: FT337 (`NENE2-FT/shortlog`) — URL-Verkürzer mit SSRF-Blocking (private IPs, Loopback, Link-Local, gefährliche Schemata), Slug-Validierung, Mass-Assignment-Prävention, ISO 8601-Datumsvalidierung, ReDoS-sichere Limit-Parsing, 50+ Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie ein URL-Verkürzer gebaut wird, der nur sichere öffentliche URLs akzeptiert, Slugs validiert, Mass Assignment verhindert und vor Server-Side Request Forgery (SSRF) schützt.
+
+## Schema
+
+```sql
+CREATE TABLE links (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL,
+    slug         TEXT    NOT NULL UNIQUE,
+    original_url TEXT    NOT NULL,
+    expires_at   TEXT,               -- ISO 8601, nullable
+    click_count  INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT    NOT NULL
+);
+```
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/links` | Kurzlink erstellen |
+| `GET`  | `/links` | Eigene Links auflisten |
+| `GET`  | `/links/{slug}` | Link nach Slug abrufen |
+| `DELETE` | `/links/{slug}` | Eigenen Link löschen |
+
+## Kurzlink erstellen
+
+```php
+POST /links
+X-User-Id: 1
+{
+  "original_url": "https://example.com/very/long/path",
+  "slug": "my-link",
+  "expires_at": "2030-12-31T23:59:59+09:00"
+}
+→ 201
+{
+  "id": 1,
+  "user_id": 1,
+  "slug": "my-link",
+  "original_url": "https://example.com/very/long/path",
+  "expires_at": "2030-12-31T23:59:59+09:00",
+  "click_count": 0,
+  "created_at": "..."
+}
+```
+
+`slug` ist optional — automatisch generiert (`[a-z0-9_-]+`), wenn weggelassen.
+
+### Fehlende Authentifizierung
+
+```php
+POST /links  (kein X-User-Id-Header)
+→ 401
+```
+
+### Doppelter Slug
+
+```php
+POST /links  {"slug": "my-link"}  // existiert bereits
+→ 409
+```
+
+## Slug-Validierung
+
+```
+Gültig: Kleinbuchstaben, Ziffern, Bindestriche, Unterstriche
+Länge: 3–20 Zeichen
+
+Gültige Beispiele: "abc", "my-link", "link123", "test-link-01"
+```
+
+```php
+POST /links  {"slug": "ab"}          → 422  // zu kurz (min 3)
+POST /links  {"slug": "a".repeat(21)} → 422  // zu lang (max 20)
+POST /links  {"slug": "MySlug"}       → 422  // Großbuchstaben nicht erlaubt
+POST /links  {"slug": "sl@g!"}        → 422  // Sonderzeichen
+POST /links  {"slug": "my slug"}      → 422  // Leerzeichen nicht erlaubt
+POST /links  {"slug": 42}             → 422  // Typ muss String sein (VULN-B)
+```
+
+## URL-Validierung
+
+```php
+POST /links  {"original_url": ""}              → 422  // leer
+POST /links  {}                                → 422  // fehlend
+POST /links  {"original_url": 42}              → 422  // kein String (VULN-B)
+POST /links  {"original_url": true}            → 422  // bool (VULN-B)
+POST /links  {"original_url": null}            → 422  // null (VULN-B)
+POST /links  {"original_url": "https://..."+"x".repeat(2030)}  → 422  // zu lang
+```
+
+## SSRF-Prävention
+
+URLs blockieren, die den Server dazu bringen würden, interne Infrastruktur aufzurufen:
+
+### Blockierte Schemata
+
+```php
+POST /links  {"original_url": "javascript:alert(1)"}  → 422
+POST /links  {"original_url": "file:///etc/passwd"}   → 422
+POST /links  {"original_url": "ftp://example.com/"}   → 422
+```
+
+Nur `http://` und `https://` sind erlaubt.
+
+### Blockierte IP-Bereiche
+
+```php
+// Loopback
+POST /links  {"original_url": "http://127.0.0.1/admin"}     → 422
+POST /links  {"original_url": "http://localhost/secret"}     → 422
+POST /links  {"original_url": "http://internal.localhost/"}  → 422  // *.localhost
+
+// RFC 1918 private Bereiche
+POST /links  {"original_url": "http://10.0.0.1/metadata"}    → 422
+POST /links  {"original_url": "http://192.168.1.1/router"}   → 422
+POST /links  {"original_url": "http://172.16.0.1/internal"}  → 422
+
+// Link-Local (AWS-Metadata, etc.)
+POST /links  {"original_url": "http://169.254.169.254/latest/meta-data/"}  → 422
+
+// Öffentliche IP — akzeptiert
+POST /links  {"original_url": "https://8.8.8.8/"}            → 201  ✅
+```
+
+### DNS-Rebinding-Prävention
+
+Hostnamen, die auf private IPs aufgelöst werden, sind ebenfalls blockiert:
+
+```php
+// "private.internal" löst auf 10.0.0.1 → blockiert
+POST /links  {"original_url": "http://private.internal/data"}  → 422
+
+// "public.example.com" löst auf 93.184.216.34 → erlaubt
+POST /links  {"original_url": "https://public.example.com/page"}  → 201  ✅
+```
+
+### Implementierung
+
+```php
+private const BLOCKED_RANGES = [
+    '127.',          // Loopback
+    '10.',           // RFC 1918
+    '172.16.', '172.17.', '172.18.', '172.19.',
+    '172.20.', '172.21.', '172.22.', '172.23.',
+    '172.24.', '172.25.', '172.26.', '172.27.',
+    '172.28.', '172.29.', '172.30.', '172.31.',  // RFC 1918
+    '192.168.',      // RFC 1918
+    '169.254.',      // Link-Local
+];
+
+private const ALLOWED_SCHEMES = ['http', 'https'];
+
+public function validate(string $url): bool
+{
+    $parsed = parse_url($url);
+    if (!$parsed || !in_array($parsed['scheme'] ?? '', self::ALLOWED_SCHEMES, true)) {
+        return false;
+    }
+
+    $host = $parsed['host'] ?? '';
+
+    // *.localhost blockieren
+    if ($host === 'localhost' || str_ends_with($host, '.localhost')) {
+        return false;
+    }
+
+    // Hostnamen zu IP auflösen
+    $ip = ($this->dnsResolver)($host);
+
+    foreach (self::BLOCKED_RANGES as $prefix) {
+        if (str_starts_with($ip, $prefix)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+```
+
+## Mass-Assignment-Prävention
+
+```php
+// Angreifer versucht click_count oder created_at zu setzen
+POST /links
+{
+  "original_url": "https://example.com",
+  "slug": "attack",
+  "click_count": 999999,
+  "created_at": "2000-01-01T00:00:00+00:00"
+}
+→ 201  {"click_count": 0, "created_at": "2026-..."}  // ignorierte Felder
+```
+
+Nur `original_url`, `slug`, `expires_at` aus dem Request-Body auf die Allowlist setzen. Niemals `click_count`, `created_at` oder `user_id` aus dem Body lesen.
+
+## ISO 8601-Datumsvalidierung
+
+```php
+// Ungültige Kalenderdaten
+POST /links  {"expires_at": "2024-02-30T00:00:00+00:00"}  → 422  // Feb 30
+POST /links  {"expires_at": "2024-13-01T00:00:00+00:00"}  → 422  // Monat 13
+POST /links  {"expires_at": "2030-06-01T00:00:00+25:00"}  → 422  // +25:00 Offset
+
+// Gültig
+POST /links  {"expires_at": "2030-06-01T00:00:00+09:00"}  → 201  ✅
+```
+
+Validierungsmuster: mit `DateTimeImmutable::createFromFormat()` parsen und den Round-Trip verifizieren:
+
+```php
+$dt = DateTimeImmutable::createFromFormat(DATE_RFC3339, $value);
+if ($dt === false) return false;
+// Round-Trip-Prüfung fängt "2024-02-30" ab, das PHP zu "2024-03-01" normalisiert
+return $dt->format(DATE_RFC3339) === $value;
+```
+
+## ReDoS-sichere Limit-Validierung
+
+```php
+// ctype_digit für O(n) — immun gegen ReDoS
+GET /links?limit=10       → 200  ✅
+GET /links?limit=999999   → 422  // überschreitet MAX_LIMIT
+GET /links?limit=9...9 (19 Ziffern)  → 422  // Überlaufschutz
+GET /links?limit=111...1x (51 Zeichen mit x)  → 422, <100ms  // ReDoS-Payload
+```
+
+## IDOR-Prävention
+
+```php
+// Benutzer 2 versucht den Link von Benutzer 1 zu löschen
+DELETE /links/user1-link
+X-User-Id: 2
+→ 404  // NICHT 403 — verhindert Aufzählung
+```
+
+Der Link existiert, aber der Lookup ist auf `WHERE slug = ? AND user_id = ?` begrenzt. Eine Abweichung gibt 404 zurück, als ob der Link nicht existiert.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|---|---|
+| `http://localhost` oder `http://127.0.0.1` erlauben | Server ruft seinen eigenen Admin-Endpunkt über den Kurzlink auf |
+| DNS-Auflösungs-Prüfung überspringen | Angreifer registriert `evil.example.com` → A-Eintrag `10.0.0.1`, um IP-Literal-Prüfung zu umgehen |
+| `javascript:`-Schema erlauben | XSS über Kurzlink in jedem Browser, der die Weiterleitung öffnet |
+| `file://`-Schema erlauben | Server liest `/etc/passwd`, wenn der Verkürzer die URL bei der Erstellung abruft |
+| `click_count` aus dem Request-Body akzeptieren | Angreifer bläst Klick-Metriken auf |
+| Keine Slug-Längen-/Zeichensatz-Einschränkung | `slug = "' OR 1=1--"` besteht Validierung, erreicht SQL |
+| Regex `/^\d+$/` für Limit-Validierung verwenden | ReDoS auf langen gemischten Ziffern-Payloads |
+| `created_at` aus dem Request-Body zurückgeben | Zeitspoofing korrumpiert Prüfpfad |

--- a/docs/de/howto/url-shortener-ssrf.md
+++ b/docs/de/howto/url-shortener-ssrf.md
@@ -1,0 +1,354 @@
+# URL-Verkürzer-API & SSRF-Prävention
+
+**FT183** — `shortlog`-Field-Trial (Schwachstellen-Diagnose VULN-A～L).
+
+Ein URL-Verkürzer lässt Benutzer beliebige URLs als Weiterleitungsziele einreichen. Wenn die
+Weiterleitung serverseitig (z. B. für Link-Vorschau oder Analysen) ohne Validierung verfolgt wird,
+können Angreifer sie auf interne Dienste zeigen — dies ist ein **Server-Side Request Forgery (SSRF)**-Angriff.
+
+Diese Anleitung behandelt SSRF-Prävention neben der vollständigen VULN-A～L-Sicherheitsüberprüfung
+der Shortlog-Implementierung.
+
+---
+
+## SSRF: Das Kernrisiko
+
+Ein URL-Verkürzer speichert und ruft möglicherweise eine angreifer-kontrollierte URL ab. SSRF
+ermöglicht einem Angreifer:
+
+- Interne Dienste zu erreichen: `http://10.0.0.1/admin`, `http://192.168.1.1/`
+- Cloud-Metadaten zu treffen: `http://169.254.169.254/latest/meta-data/` (AWS IMDS)
+- Lokale Dateien zu lesen: `file:///etc/passwd`
+- Browser-Skripte auszuführen: `javascript:alert(1)`
+- Loopback-Dienste zuzugreifen: `http://127.0.0.1:8080/`
+
+**Die Lösung:** Das Schema der URL _und_ die Ziel-IP vor der Speicherung validieren.
+
+---
+
+## URL-Validierungsstrategie (VULN-K)
+
+### Schritt 1 — Schema-Allowlist
+
+`filter_var($url, FILTER_VALIDATE_URL)` allein ist **nicht ausreichend** — es akzeptiert
+`javascript:alert(1)` und `ftp://` als gültige URLs. `parse_url()` und eine
+explizite Schema-Allowlist verwenden:
+
+```php
+$parts = parse_url($url);
+
+if ($parts === false || !isset($parts['scheme'], $parts['host'])) {
+    return false;   // Fehlerhafte URL — kein Schema oder Host
+}
+
+if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+    return false;   // Lehnt ab: javascript:, file://, ftp://, data:, etc.
+}
+```
+
+`parse_url()` ist kein Regex — er kann nicht für ReDoS ausgenutzt werden (VULN-F).
+
+### Schritt 2 — Host-/IP-Validierung
+
+```php
+$host = strtolower($parts['host']);
+
+// IPv6-Klammern entfernen: [::1] → ::1
+if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
+    $host = substr($host, 1, -1);
+}
+
+// Localhost und *.localhost-Aliase blockieren
+if ($host === 'localhost' || str_ends_with($host, '.localhost')) {
+    return false;
+}
+
+// Wenn Host ein IP-Literal ist, direkt prüfen
+if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+    return !isBlockedIp($host);
+}
+
+// Andernfalls Hostnamen auflösen → aufgelöste IP prüfen
+$resolved = gethostbyname($host);
+
+if ($resolved !== $host) {   // false wenn nicht auflösbar
+    return !isBlockedIp($resolved);
+}
+// Nicht auflösbarer Hostname → erlauben (kann eine gültige Domain sein, die vom Server nicht erreichbar ist)
+return true;
+```
+
+### Schritt 3 — Private-/reservierte-IP-Prüfung
+
+```php
+function isBlockedIp(string $ip): bool
+{
+    // IPv6-Loopback
+    if ($ip === '::1') return true;
+
+    // FILTER_FLAG_NO_PRIV_RANGE: blockiert 10.x, 172.16-31.x, 192.168.x
+    // FILTER_FLAG_NO_RES_RANGE:  blockiert 127.x, 169.254.x, 0.x, 240.x+
+    return filter_var(
+        $ip,
+        FILTER_VALIDATE_IP,
+        FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+    ) === false;
+}
+```
+
+### DNS-Rebinding-Vorsicht
+
+DNS-Rebinding-Angriffe ändern die IP einer Domain _nach_ der Validierung. Für
+kritische Anwendungsfälle die URL auch _zum Abrufzeitpunkt_ validieren (nicht nur beim Speichern),
+oder eine Netzwerk-Ebene-Egress-Firewall verwenden, die private Bereiche blockiert.
+
+---
+
+## Resolver für Tests injizieren
+
+DNS-Aufrufe in Unit-Tests sind langsam und nicht-deterministisch. Den Resolver
+injizierbar machen:
+
+```php
+final class UrlValidator
+{
+    /** @param (callable(string): string)|null $ipResolver */
+    public function __construct(private readonly mixed $ipResolver = null)
+    {
+    }
+
+    private function resolveHost(string $host): string
+    {
+        /** @var callable(string): string $resolver */
+        $resolver = $this->ipResolver ?? static fn (string $h): string => gethostbyname($h);
+        return $resolver($host);
+    }
+}
+```
+
+In Tests:
+
+```php
+$stubResolver = static function (string $host): string {
+    return match ($host) {
+        'private.internal'   => '10.0.0.1',       // privat → blockiert
+        'public.example.com' => '93.184.216.34',  // öffentlich → erlaubt
+        default              => $host,             // nicht auflösbar → erlaubt
+    };
+};
+
+$validator = new UrlValidator($stubResolver);
+```
+
+---
+
+## VULN-A～L-Assessment-Ergebnisse
+
+### VULN-A — Integer-Überlauf (`limit`-Query-Parameter)
+
+`V::queryInt()` verwendet `ctype_digit()` + `strlen() > 18`-Guard.
+20-stellige und 19-stellige Strings werden vor dem `(int)`-Cast abgelehnt.
+
+```
+✅ BESTANDEN — Überlaufschutz verhindert stillen PHP_INT_MAX-Wrap
+```
+
+### VULN-B — Typverwirrung (URL / Slug aus JSON-Body)
+
+`V::str()` erzwingt `is_string()` — lehnt `int 42`, `bool true`, `null` ab.
+
+```php
+V::str($body['original_url'] ?? null, 2048)  // → null für Nicht-String
+V::str($body['slug'] ?? null, 20)            // → null für Nicht-String
+```
+
+```
+✅ BESTANDEN — String-Typ vor jeder URL- oder Slug-Validierung durchgesetzt
+```
+
+### VULN-C — SQL-Injection
+
+Alle Abfragen verwenden PDO-parametrisierte Statements:
+
+```php
+'SELECT ... FROM links WHERE slug = :slug LIMIT 1'
+// → $stmt->execute([':slug' => $slug])
+```
+
+`'; DROP TABLE links; --'` schlägt bei Slug-Format-Validierung (SLUG_PATTERN) fehl,
+bevor die DB erreicht wird. Selbst wenn sie die DB erreichte, verhindern parametrisierte Abfragen
+die Ausführung.
+
+```
+✅ BESTANDEN — parametrisierte Abfragen + Slug-Allowlist
+```
+
+### VULN-D — Parameter-Pollution
+
+PSR-7 `getQueryParams()` ruft PHPs `parse_str()` auf, das den _letzten_
+Wert für doppelte Schlüssel nimmt. `?limit=10&limit=999999` senden → `limit=999999`,
+was die `V::queryInt()`-Bereichsprüfung fehlschlägt (> MAX_LIMIT).
+
+```
+✅ BESTANDEN — Bereichsprüfung fängt jeden einzelnen Wert; kein Absturz
+```
+
+### VULN-E — IDOR (benutzerübergreifender Link-Zugriff)
+
+DELETE verwendet `deleteForUser($slug, $userId)`:
+
+```sql
+DELETE FROM links WHERE slug = :slug AND user_id = :user_id
+```
+
+`DELETE /links/user-a-slug` von Benutzer B mit seiner eigenen `X-User-Id` gibt 404 zurück
+(die Zeile ist nicht gelöscht; sie entspricht einfach nicht der WHERE-Klausel).
+
+```
+✅ BESTANDEN — Eigentümerschaft auf DB-Ebene durchgesetzt; 404 vermeidet Aufzählung
+```
+
+### VULN-F — ReDoS-Immunität
+
+URL-Validierung verwendet `parse_url()` (C-Erweiterung, kein Backtracking).
+Slug-Validierung verwendet einen einfachen verankerten Regex ohne Alternationsgruppen.
+`V::queryInt()` verwendet `ctype_digit()` (O(n), immun gegen Backtracking).
+
+```
+✅ BESTANDEN — kein exponentieller-Backtracking-Regex auf nicht-vertrauenswürdiger Eingabe
+```
+
+### VULN-G — Pfad-Traversal
+
+Kein Dateisystemzugriff in dieser API. Nicht anwendbar.
+
+```
+N/A
+```
+
+### VULN-H — Timing-Angriffe auf Geheimnis-Vergleich
+
+`V::secret()` delegiert an `hash_equals()` — Konstantzeit unabhängig davon, wo
+Strings sich unterscheiden. Vermeidet Early-Exit-String-Vergleich, der Längen-/Präfixinformationen
+über Timing leckt.
+
+```
+✅ BESTANDEN — hash_equals() verhindert Timing-Oracle
+```
+
+### VULN-I — Leeres-erwartetes-Geheimnis-Bypass
+
+`V::secret('', '')` → `false`. Ein unkonfigurierter API-Schlüssel gewährt niemals Zugriff:
+
+```php
+return $expected !== '' && hash_equals($expected, $actual);
+```
+
+```
+✅ BESTANDEN — leeres Erwartetes gibt immer false zurück
+```
+
+### VULN-J — ISO 8601-Datums-Überlauf in `expires_at`
+
+`V::isoDatetime()` verwendet `DateTimeImmutable::createFromFormat(DATE_ATOM, ...)` +
+Round-Trip-Vergleich. `2024-02-30T00:00:00+00:00` rollt in PHP zu Mär. 1;
+der neu formatierte String entspricht nicht der Eingabe → null.
+
+`+25:00` Offset: von expliziter `$tzHours > 14` Bereichsprüfung abgefangen.
+
+```
+✅ BESTANDEN — Round-Trip fängt Überlauf-Daten; explizite Offset-Bereichsprüfung fängt +25:00
+```
+
+### VULN-K — SSRF
+
+Ohne URL-Validierung: `http://127.0.0.1/admin`, `http://169.254.169.254/`,
+`http://10.0.0.1/`, `javascript:alert(1)`, `file:///etc/passwd` würden alle
+gespeichert und möglicherweise abgerufen.
+
+Mit `UrlValidator`:
+
+| Eingabe | Blockiergrund |
+|---------|---------------|
+| `http://127.0.0.1/` | Loopback-IP (`NO_RES_RANGE`) |
+| `http://localhost/` | exakte Übereinstimmung `'localhost'` |
+| `http://internal.localhost/` | `.localhost`-Suffix |
+| `http://10.0.0.1/` | Private IP (`NO_PRIV_RANGE`) |
+| `http://192.168.1.1/` | Private IP |
+| `http://169.254.169.254/` | Reservierte IP (`NO_RES_RANGE`) |
+| `http://private.internal/` | Löst auf 10.0.0.1 → blockiert |
+| `javascript:alert(1)` | Schema nicht in `['http','https']` |
+| `file:///etc/passwd` | Schema nicht in Allowlist |
+| `ftp://example.com/` | Schema nicht in Allowlist |
+
+```
+✅ BESTANDEN — Schema-Allowlist + IP-Bereichsfilter blockiert alle SSRF-Vektoren
+```
+
+### VULN-L — Mass Assignment
+
+`click_count` und `created_at` werden serverseitig in `LinkRepository::create()` gesetzt.
+Request-Body-Schlüssel `click_count: 999999` und `created_at: "2000-01-01..."` werden
+einfach ignoriert — der Controller liest sie nie.
+
+```
+✅ BESTANDEN — serverseitige Felder im Repository gesetzt, nie aus dem Request-Body
+```
+
+---
+
+## VULN-Assessment-Zusammenfassung
+
+| ID | Schwachstelle | Status |
+|----|---------------|--------|
+| VULN-A | Integer-Überlauf | ✅ BESTANDEN |
+| VULN-B | Typverwirrung | ✅ BESTANDEN |
+| VULN-C | SQL-Injection | ✅ BESTANDEN |
+| VULN-D | Parameter-Pollution | ✅ BESTANDEN |
+| VULN-E | IDOR | ✅ BESTANDEN |
+| VULN-F | ReDoS | ✅ BESTANDEN |
+| VULN-G | Pfad-Traversal | N/A |
+| VULN-H | Timing-Angriffe | ✅ BESTANDEN |
+| VULN-I | Leeres-Geheimnis-Bypass | ✅ BESTANDEN |
+| VULN-J | DateTime-Überlauf | ✅ BESTANDEN |
+| VULN-K | SSRF | ✅ BESTANDEN |
+| VULN-L | Mass Assignment | ✅ BESTANDEN |
+
+**Alle anwendbaren Schwachstellen: BESTANDEN (11/11)**
+
+---
+
+## Slug-Sicherheit (VULN-A, C)
+
+Slugs müssen auf einen sicheren Zeichensatz beschränkt werden, um sowohl Injection als auch
+unerwartetes Routing zu verhindern:
+
+```php
+// Muster: Kleinbuchstaben-Alphanumerisch + Bindestriche/Unterstriche, 3–20 Zeichen
+// Muss mit Alphanumerisch beginnen und enden
+private const SLUG_PATTERN = '/^[a-z0-9][a-z0-9_-]{1,18}[a-z0-9]$|^[a-z0-9]{3}$/';
+
+if (!preg_match(self::SLUG_PATTERN, $rawSlug)) {
+    return 422;
+}
+```
+
+Dieser einzelne Regex ist verankert und hat keine Alternationsgruppen mit überlappenden
+Match-Pfaden — er kann nicht für ReDoS ausgenutzt werden.
+
+**Abgelehnte Slugs**: `'; DROP TABLE links; --'` · `../../etc` · `MySlug`
+· `sl@g!` · `a` (zu kurz) · 21-Zeichen-String (zu lang)
+
+---
+
+## Wichtigste Erkenntnisse
+
+| Muster | Implementierung |
+|--------|-----------------|
+| SSRF-Prävention | `parse_url()`-Schema-Allowlist + `filter_var NO_PRIV_RANGE` |
+| DNS-Auflösung in Tests | Injizierbarer `ipResolver`-Callback |
+| Slug-Sicherheit | Zeichensatz-Allowlist-Regex (verankert, kein Backtracking) |
+| URL-Typ-Durchsetzung | `V::str()` → `is_string()` vor URL-Parsing |
+| Ablauf-Validierung | `V::isoDatetime()` mit Round-Trip + Offset-Bereichsprüfung |
+| IDOR-Prävention | `WHERE slug = ? AND user_id = ?` in jeder Schreib-Abfrage |
+| Mass Assignment | Serverseitige Felder im Repository gesetzt, im Controller ignoriert |

--- a/docs/de/howto/use-bearer-auth.md
+++ b/docs/de/howto/use-bearer-auth.md
@@ -1,0 +1,117 @@
+# Bearer-Token-Authentifizierung verwenden
+
+NENE2 enthält `BearerTokenMiddleware` und `LocalBearerTokenVerifier` für JWT-basierte Authentifizierung. Diese Anleitung behandelt Einrichtung, Konfiguration, Token-Ausstellung und häufige Fallstricke.
+
+## Einrichtung
+
+Das Middleware in `RuntimeApplicationFactory` mit dem benannten Parameter `authMiddleware` einbinden:
+
+```php
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+
+$secret   = getenv('NENE2_LOCAL_JWT_SECRET') ?: 'change-me';
+$verifier = new LocalBearerTokenVerifier($secret);
+$bearer   = new BearerTokenMiddleware($problemDetails, $verifier);
+
+$app = (new RuntimeApplicationFactory(
+    $psr17,
+    $psr17,
+    routeRegistrars: [static fn (Router $r) => $registrar->register($r)],
+    authMiddleware:  $bearer, // ← benannter Parameter ist authMiddleware, nicht middlewares
+))->create();
+```
+
+> **Hinweis:** Der Parametername lautet `authMiddleware`, nicht `middlewares`. Die Verwendung von `middlewares:` verursacht einen Laufzeit-`Error: Unknown named parameter`.
+
+## Alle Routen vs. selektiver Schutz
+
+`BearerTokenMiddleware` unterstützt vier Pfad-Matching-Modi (erste Übereinstimmung gewinnt):
+
+```php
+// 1. Nur bestimmte Pfade schützen (Allowlist)
+new BearerTokenMiddleware($problems, $verifier, protectedPaths: ['/me', '/entries']);
+
+// 2. Pfade mit einem Präfix schützen (Präfix-Allowlist)
+new BearerTokenMiddleware($problems, $verifier, protectedPathPrefixes: ['/api/', '/me/']);
+
+// 3. Alles außer aufgeführten Pfaden schützen (Blocklist — gängiges Muster)
+new BearerTokenMiddleware($problems, $verifier, excludedPaths: ['/auth/login', '/auth/register', '/health']);
+
+// 4. Alle Pfade schützen (Standard — keine Arrays angegeben)
+new BearerTokenMiddleware($problems, $verifier);
+```
+
+## Claims in einem Handler lesen
+
+Nach erfolgreicher Verifikation werden Claims als Request-Attribut gespeichert:
+
+```php
+/** @var array<string, mixed> $claims */
+$claims  = $request->getAttribute('nene2.auth.claims') ?? [];
+$ownerId = (string) ($claims['sub'] ?? '');
+```
+
+Der Credential-Typ wird separat gespeichert:
+
+```php
+$credType = $request->getAttribute('nene2.auth.credential_type'); // 'bearer'
+```
+
+## Tokens ausstellen (lokal / Test)
+
+`LocalBearerTokenVerifier` implementiert auch `TokenIssuerInterface`:
+
+```php
+$token = $verifier->issue([
+    'sub' => 'user-123',
+    'iat' => time(),
+    'exp' => time() + 3600, // ← exp immer einschließen
+]);
+```
+
+> **`exp` immer einschließen.** Tokens ohne `exp` werden als nicht ablaufend behandelt. Das ist für Tests sicher, aber gefährlich, wenn solche Tokens die Produktion erreichen. Fehlt `exp`, überspringt der Verifier die Ablaufprüfung.
+
+## Fehlerantworten
+
+Bei einem Fehler gibt `BearerTokenMiddleware` eine `401 Unauthorized` Problem Details-Antwort mit einem `WWW-Authenticate`-Header zurück:
+
+```
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer realm="NENE2", error="invalid_token", error_description="Token has expired."
+Content-Type: application/problem+json
+```
+
+Fehlercodes in `WWW-Authenticate`:
+- `missing_token` — kein `Authorization`-Header
+- `invalid_token` — falsches Schema, abgelaufen, ungültige Signatur, fehlerhaft, falscher Algorithmus, `nbf` in der Zukunft
+
+## Sicherheitseigenschaften von `LocalBearerTokenVerifier`
+
+| Bedrohung | Schutz |
+|-----------|--------|
+| Signaturfälschung | HMAC-HS256, konstantzeit `hash_equals` |
+| Algorithmus-Substitution (`alg:none`) | Nur `HS256` akzeptiert |
+| Abgelaufenes Token | `exp`-Claim wird geprüft |
+| Noch-nicht-gültiges Token | `nbf`-Claim wird geprüft |
+| Manipuliertes Payload | Signatur deckt Header + Payload ab; Manipulation bricht Signatur |
+
+> `LocalBearerTokenVerifier` ist für lokale Entwicklung und Tests gedacht. Für die Produktion eine bibliotheksgestützte Implementierung von `TokenVerifierInterface` (z. B. firebase/php-jwt) injizieren, die Key-Rotation und asymmetrische Algorithmen unterstützt.
+
+## Testmuster
+
+```php
+// In setUp(): Verifier mit Test-Secret erstellen
+$this->verifier = new LocalBearerTokenVerifier('test-secret');
+
+// Gültiges Token für einen Benutzer ausstellen
+$token = $this->verifier->issue(['sub' => 'alice', 'exp' => time() + 3600]);
+
+// Abgelaufenes Token ausstellen (für Negativtest)
+$expired = $this->verifier->issue(['sub' => 'alice', 'exp' => time() - 1]);
+
+// Noch-nicht-gültiges Token ausstellen
+$future = $this->verifier->issue(['sub' => 'alice', 'nbf' => time() + 3600, 'exp' => time() + 7200]);
+```

--- a/docs/de/howto/use-fts5-search.md
+++ b/docs/de/howto/use-fts5-search.md
@@ -1,0 +1,216 @@
+# SQLite FTS5 Volltextsuche verwenden
+
+SQLites FTS5-Erweiterung bietet Volltextsuche über einen invertierten Index. Diese Anleitung behandelt das Schema-Muster, triggerbasierte Synchronisation und die Abfragesyntax-Fallstricke bei der Verarbeitung von Benutzereingaben.
+
+---
+
+## 1. Schema: virtuelle Tabelle + externer Inhalt + Trigger
+
+`content=<table>` verwenden, um Daten in einer normalen Tabelle zu halten und FTS5 nur den Suchindex pflegen zu lassen:
+
+```sql
+CREATE TABLE articles (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    author     TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE articles_fts USING fts5(
+    title,
+    body,
+    author,
+    content=articles,   -- FTS5 liest Inhalt aus der articles-Tabelle
+    content_rowid=id    -- mappt FTS5 rowid auf articles.id
+);
+
+-- FTS-Index mit der Basistabelle synchron halten
+CREATE TRIGGER articles_ai AFTER INSERT ON articles BEGIN
+    INSERT INTO articles_fts(rowid, title, body, author)
+    VALUES (new.id, new.title, new.body, new.author);
+END;
+
+CREATE TRIGGER articles_au AFTER UPDATE ON articles BEGIN
+    -- Alte Zeile aus Index löschen, dann aktualisierte Zeile einfügen
+    INSERT INTO articles_fts(articles_fts, rowid, title, body, author)
+    VALUES ('delete', old.id, old.title, old.body, old.author);
+    INSERT INTO articles_fts(rowid, title, body, author)
+    VALUES (new.id, new.title, new.body, new.author);
+END;
+
+CREATE TRIGGER articles_ad AFTER DELETE ON articles BEGIN
+    INSERT INTO articles_fts(articles_fts, rowid, title, body, author)
+    VALUES ('delete', old.id, old.title, old.body, old.author);
+END;
+```
+
+> **Warum Trigger?** FTS5 mit `content=` verfolgt Änderungen nicht automatisch — der Index muss mit Triggern gepflegt werden. Das Muster `INSERT INTO fts(fts, rowid, ...) VALUES ('delete', ...)` ist FTS5s Weg, eine Zeile aus dem Index zu entfernen.
+
+---
+
+## 2. Suchabfrage
+
+```php
+$rows = $this->executor->fetchAll(
+    "SELECT a.*, snippet(articles_fts, 1, '<b>', '</b>', '…', 10) AS snippet, rank
+     FROM articles_fts
+     JOIN articles a ON a.id = articles_fts.rowid
+     WHERE articles_fts MATCH ?
+     ORDER BY rank
+     LIMIT ? OFFSET ?",
+    [$query, $limit, $offset],
+);
+```
+
+- `rank` ist eine von FTS5 bereitgestellte virtuelle Spalte. Niedrigere (negativere) Werte sind relevanter. `ORDER BY rank` stellt die besten Treffer zuerst.
+- `snippet(table, column_index, open, close, ellipsis, token_count)` gibt ein hervorgehobenes Fragment zurück. Der Spaltenindex ist 0-basiert: `0` = title, `1` = body.
+
+---
+
+## 3. Abfragesyntax-Fallstricke
+
+### 3.1 Bindestrich ist ein Spaltenfilter-Präfix — kein Phrasentrennzeichen
+
+**Dies ist die häufigste Fehlerquelle bei der Verarbeitung von Benutzereingaben.**
+
+FTS5 interpretiert `word-other` als Spaltenfilter: Es sucht in der Spalte namens `word` nach dem Begriff `other`. Wenn `word` keine Spalte in der FTS5-Tabelle ist, wirft SQLite einen Fehler:
+
+```
+General error: 1 no such column: text
+```
+
+```
+full-text   ← FEHLER: "Spalte 'full' nach 'text' durchsuchen" — aber 'full' ist keine Spalte
+full text   ← OK: UND-Abfrage (trifft Dokumente mit sowohl "full" ALS AUCH "text")
+"full text" ← OK: Phrasenabfrage (exakte aufeinanderfolgende Reihenfolge)
+```
+
+Dieser Fehler propagiert als `DatabaseConnectionException` und führt zu einer 500-Antwort, wenn die Eingabe nicht vorher bereinigt wird.
+
+**Benutzereingaben vor der Übergabe an FTS5 bereinigen:**
+
+```php
+private function sanitizeFtsQuery(string $query): string
+{
+    // Bindestriche durch Leerzeichen ersetzen: "full-text" wird zu "full text" (UND-Logik)
+    return str_replace('-', ' ', $query);
+}
+```
+
+Oder mit doppelten Anführungszeichen für eine Phrasenübereinstimmung escapen:
+
+```php
+private function sanitizeFtsQuery(string $query): string
+{
+    // Die gesamte Abfrage in doppelte Anführungszeichen einschließen, um Phrasenabgleich zu erzwingen
+    $escaped = str_replace('"', '""', $query);
+    return '"' . $escaped . '"';
+}
+```
+
+### 3.2 Standardmäßig kein Stemming
+
+Der Standard-Tokenizer `unicode61` führt kein Stemming durch. `framework` trifft nicht `frameworks`, und `run` trifft nicht `running`.
+
+Optionen:
+
+| Ansatz | Wie |
+|--------|-----|
+| Exakte Übereinstimmung | Exakte Wortformen in Dokumenten und Abfragen verwenden |
+| Präfix-Match | `*` an den Abfragebegriff anhängen: `framework*` trifft `framework`, `frameworks`, `framework-agnostic` |
+| Porter-Stemmer | `tokenize='porter ascii'` in der `CREATE VIRTUAL TABLE`-Anweisung deklarieren |
+
+**Präfix-Match-Beispiel:**
+
+```php
+// Benutzer tippt "frame" → * anhängen, um "framework", "frameworks" etc. zu treffen
+$query = trim($userInput) . '*';
+```
+
+**Porter-Stemmer:**
+
+```sql
+CREATE VIRTUAL TABLE articles_fts USING fts5(
+    title, body, author,
+    content=articles,
+    content_rowid=id,
+    tokenize='porter ascii'  -- Englisches Stemming
+);
+```
+
+> Der `porter`-Tokenizer ist nur verfügbar, wenn SQLite mit FTS5-Unterstützung kompiliert wurde (Standard-Builds schließen es ein). Er ist nützlich für englische Texte; für andere Sprachen externes Stemming vor der Indizierung in Betracht ziehen.
+
+### 3.3 AND / OR / NOT-Operatoren
+
+FTS5-Abfragesyntax:
+
+| Syntax | Bedeutung |
+|--------|-----------|
+| `one two` | AND: beide müssen vorhanden sein |
+| `one OR two` | OR: eines muss vorhanden sein |
+| `one NOT two` | NOT: erstes vorhanden, zweites abwesend |
+| `"one two"` | Phrase: exakte aufeinanderfolgende Reihenfolge |
+| `one*` | Präfix: trifft `one`, `ones`, `only` (Präfix-Match auf `one`) |
+| `title:query` | Spaltenfilter: Match auf die `title`-Spalte beschränken |
+
+> **Hinweis**: `NOT` muss großgeschrieben sein. Kleingeschriebenes `not` wird als Suchbegriff behandelt.
+
+---
+
+## 4. Suchergebnisse zählen
+
+Mit einer separaten Abfrage zählen — `COUNT(*)` auf dem FTS5-Match:
+
+```php
+$count = $this->executor->fetchOne(
+    'SELECT COUNT(*) AS cnt FROM articles_fts WHERE articles_fts MATCH ?',
+    [$query],
+);
+```
+
+---
+
+## 5. Vollständiges Repository-Beispiel
+
+```php
+final readonly class ArticleRepository
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $executor,
+    ) {}
+
+    /** @return list<array<string, mixed>> */
+    public function search(string $userQuery, int $limit, int $offset): array
+    {
+        $query = $this->sanitizeFtsQuery($userQuery);
+
+        return $this->executor->fetchAll(
+            "SELECT a.*, snippet(articles_fts, 1, '<b>', '</b>', '…', 10) AS snippet, rank
+             FROM articles_fts
+             JOIN articles a ON a.id = articles_fts.rowid
+             WHERE articles_fts MATCH ?
+             ORDER BY rank
+             LIMIT ? OFFSET ?",
+            [$query, $limit, $offset],
+        );
+    }
+
+    public function countSearch(string $userQuery): int
+    {
+        $query = $this->sanitizeFtsQuery($userQuery);
+        $row   = $this->executor->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM articles_fts WHERE articles_fts MATCH ?',
+            [$query],
+        );
+
+        return (int) ($row['cnt'] ?? 0);
+    }
+
+    private function sanitizeFtsQuery(string $query): string
+    {
+        // Bindestriche durch Leerzeichen ersetzen: "full-text" → "full text" (UND-Logik)
+        return str_replace('-', ' ', trim($query));
+    }
+}
+```

--- a/docs/de/howto/use-postgresql.md
+++ b/docs/de/howto/use-postgresql.md
@@ -1,0 +1,134 @@
+# PostgreSQL verwenden
+
+NENE2s `PdoConnectionFactory` unterstützt den `pgsql`-Adapter von Haus aus. Diese Anleitung behandelt die Einrichtungsschritte und PostgreSQL-spezifische Muster, die sich von MySQL und SQLite unterscheiden.
+
+## Docker Compose-Einrichtung
+
+Einen `postgres`-Service hinzufügen und die Umgebungsvariablen für den `app`-Service setzen:
+
+```yaml
+# compose.yaml
+services:
+  app:
+    environment:
+      DB_ADAPTER: pgsql
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_NAME: myapp
+      DB_USER: myapp
+      DB_PASSWORD: secret
+      DB_CHARSET: utf8    # für pgsql ignoriert — siehe Abschnitt zur Zeichenkodierung
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U myapp -d myapp"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+```
+
+## Dockerfile — pdo_pgsql-Erweiterung
+
+Die `pdo_pgsql`-Erweiterung ist im `php:8.4-cli`-Basis-Image nicht standardmäßig aktiviert. Sie zum `Dockerfile` hinzufügen:
+
+```dockerfile
+FROM php:8.4-cli
+
+RUN apt-get update && apt-get install -y libpq-dev unzip postgresql-client \
+    && docker-php-ext-install pdo pdo_pgsql \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+WORKDIR /var/www/html
+```
+
+## Phinx-Migrationskonfiguration
+
+`charset` aus der Phinx-Umgebungskonfiguration bei Verwendung von `pgsql` weglassen — PostgreSQL verwendet diesen Schlüssel nicht:
+
+```php
+// phinx.php
+$database->environment => [
+    'adapter' => $database->adapter,   // 'pgsql'
+    'host'    => $database->host,
+    'name'    => $database->name,
+    'user'    => $database->user,
+    'pass'    => $database->password,
+    'port'    => $database->port,
+    // 'charset' => ...  ← für pgsql weglassen
+],
+```
+
+Phinx mappt seine Spaltentypen automatisch auf PostgreSQL-Typen. Häufige Zuordnungen:
+
+| Phinx-Typ | PostgreSQL-Typ |
+|-----------|----------------|
+| `integer` (Primärschlüssel) | `SERIAL` |
+| `string` | `VARCHAR(n)` |
+| `text` | `TEXT` |
+| `datetime` | `TIMESTAMP(0) WITHOUT TIME ZONE` |
+| `boolean` | `BOOLEAN` |
+
+## ID nach INSERT ermitteln — RETURNING id verwenden
+
+`DatabaseQueryExecutorInterface::lastInsertId()` gibt auf PostgreSQL `0` zurück, weil `PDO::lastInsertId()` ein Sequenzname-Argument erfordert, das NENE2 nicht verfolgt.
+
+`fetchOne()` mit `RETURNING id` im INSERT-SQL verwenden, um den generierten Primärschlüssel in einem einzigen Roundtrip abzurufen:
+
+```php
+// ✓ PostgreSQL-kompatibles Muster
+$row = $this->executor->fetchOne(
+    'INSERT INTO reviews (book_title, content, rating, created_at) VALUES (?, ?, ?, ?) RETURNING id',
+    [$bookTitle, $content, $rating, $now],
+);
+$id = (int) ($row['id'] ?? 0);
+```
+
+`RETURNING id` ist standard PostgreSQL-SQL und wird auch von SQLite >= 3.35 (2021) unterstützt. Es wird von MySQL/MariaDB **nicht** unterstützt — Repository-Implementierungen DB-spezifisch halten, wenn beide Zieldatenbanken unterstützt werden sollen.
+
+### Warum nicht lastInsertId()?
+
+PostgreSQL-Sequenzen sind standardmäßig `{table}_{column}_seq` benannt (z. B. `reviews_id_seq`). `PDO::lastInsertId('reviews_id_seq')` würde funktionieren, aber `DatabaseQueryExecutorInterface` stellt keinen Sequenzname-Parameter bereit. `RETURNING id` ist sauberer und vermeidet die Kopplung.
+
+## Testdaten zwischen Tests zurücksetzen
+
+Testisolation erfordert das Zurücksetzen der Tabelle zwischen jedem Testfall. Das korrekte SQL unterscheidet sich je nach Adapter:
+
+```php
+protected function setUp(): void
+{
+    // PostgreSQL — setzt die SERIAL-Sequenz auf 1 zurück
+    $this->executor->execute('TRUNCATE reviews RESTART IDENTITY CASCADE');
+
+    // MySQL — TRUNCATE setzt AUTO_INCREMENT implizit zurück
+    // $this->executor->execute('TRUNCATE reviews');
+
+    // SQLite — TRUNCATE wird nicht unterstützt; DELETE + Sequenz-Reset verwenden
+    // $this->executor->execute('DELETE FROM reviews');
+    // $this->executor->execute("DELETE FROM sqlite_sequence WHERE name = 'reviews'");
+}
+```
+
+`TRUNCATE … RESTART IDENTITY CASCADE` ist PostgreSQL-spezifisch. `RESTART IDENTITY` setzt die Sequenz zurück, sodass das nächste INSERT `id = 1` zurückgibt und Test-Assertions deterministisch bleiben. `CASCADE` kürzt abhängige Tabellen in derselben Anweisung.
+
+## Zeichenkodierung — DB_CHARSET wird für pgsql ignoriert
+
+Der `pgsql`-DSN enthält keinen `charset`-Parameter. `DB_CHARSET` / `DatabaseConfig::charset` wird für den `pgsql`-Adapter stillschweigend ignoriert — nur der `mysql`-Adapter verwendet ihn im DSN.
+
+PostgreSQL bestimmt die Client-Kodierung aus `server_encoding` zum Verbindungszeitpunkt. Mit dem Standard-Locale erstellte Datenbanken verwenden **UTF-8**, was fast immer das Gewünschte ist.
+
+Um eine bestimmte Kodierung zu erzwingen, `DATABASE_URL` mit dem `options`-Parameter verwenden:
+
+```
+DATABASE_URL=pgsql://myapp:secret@db:5432/myapp?options=--client_encoding%3DUTF8
+```
+
+Oder nach dem Verbindungsaufbau einen `SET`-Befehl ausgeben (nicht direkt über `PdoDatabaseQueryExecutor` möglich — dafür wäre eine benutzerdefinierte Connection Factory erforderlich).

--- a/docs/de/howto/use-transactions.md
+++ b/docs/de/howto/use-transactions.md
@@ -1,0 +1,186 @@
+# Datenbanktransaktionen verwenden
+
+Diese Anleitung erklärt, wie atomare mehrstufige Operationen mit `DatabaseTransactionManagerInterface` in NENE2 durchgeführt werden.
+
+**Voraussetzung**: Ein Repository, das auf `DatabaseQueryExecutorInterface` basiert.
+Falls nicht, mit [Datenbankgestützten Endpunkt hinzufügen](./add-database-endpoint.md) beginnen.
+
+---
+
+## Warum Transaktionen in NENE2
+
+`DatabaseTransactionManagerInterface` umschließt mehrere SQL-Anweisungen in einer einzigen Transaktion: Entweder alle gelingen (Commit) oder alle werden bei einem beliebigen `Throwable` zurückgerollt.
+
+Das Interface hat eine Methode:
+
+```php
+public function transactional(callable $callback): mixed;
+```
+
+Der Callback erhält einen **frischen** `DatabaseQueryExecutorInterface`, der an die offene Transaktion gebunden ist. **Dieser Executor unterscheidet sich von dem, der zur Konstruktionszeit injiziert wird.**
+
+---
+
+## Das transaktionale Repository-Muster
+
+> **Warnung — injizierte Repositories nicht im Callback wiederverwenden.**
+>
+> Zur Konstruktionszeit injizierte Repositories halten eine **andere Verbindung** als die, auf der die Transaktion läuft. Die Verwendung im Callback bedeutet, dass ihre Abfragen außerhalb der Transaktion ausgeführt werden: Rollbacks machen diese Änderungen nicht rückgängig, und uncommittete Zeilen, die innerhalb des Callbacks geschrieben wurden, sind für sie möglicherweise nicht sichtbar.
+>
+> Dieser Fehler kompiliert und Tests können bestehen — der Bug tritt nur bei gleichzeitigen Schreibvorgängen oder wenn Rollback-Verhalten erwartet wird in Erscheinung.
+
+Da der Callback seinen eigenen Executor bereitstellt, müssen Repository-Klassen **innerhalb des Callbacks instanziiert werden**, wobei der vom Callback bereitgestellte Executor verwendet wird.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Order;
+
+use MyApp\Product\ProductNotFoundException;
+use MyApp\Product\SqliteProductRepository;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+
+final class CreateOrderUseCase
+{
+    public function __construct(
+        private readonly DatabaseTransactionManagerInterface $transactionManager,
+    ) {}
+
+    public function execute(int $productId, int $qty): Order
+    {
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($productId, $qty): Order {
+                // Konkrete Klassen hier instanziieren — der $tx-Executor ist an die
+                // Verbindung dieser Transaktion gebunden. Injizierte Instanzen verwenden einen anderen Executor.
+                $products = new SqliteProductRepository($tx);
+                $orders   = new SqliteOrderRepository($tx);
+
+                $product = $products->findById($productId)
+                    ?? throw new ProductNotFoundException($productId);
+
+                $products->decrementStock($productId, $qty);
+
+                return $orders->save($product->price * $qty, [
+                    new OrderItem($productId, $qty, $product->price),
+                ]);
+            },
+        );
+    }
+}
+```
+
+### Warum injizierte Repositories nicht wiederverwenden?
+
+`PdoDatabaseTransactionManager::transactional()` öffnet eine **neue Verbindung** über `DatabaseConnectionFactoryInterface::create()` und beginnt eine Transaktion darauf. Der Executor des Callbacks ist an diese spezifische Verbindung gebunden.
+
+Ein injiziertes `SqliteProductRepository` hält einen separaten `PdoDatabaseQueryExecutor`, der bei der ersten Verwendung träge seine eigene Verbindung öffnet. Abfragen über das injizierte Repository laufen auf dieser anderen Verbindung — außerhalb der Transaktion — sodass ein Rollback sie nicht rückgängig macht, und ein Insert über das injizierte Repository sieht möglicherweise keine uncommittierten Zeilen aus dem Callback.
+
+---
+
+## Im Front-Controller verdrahten
+
+Es werden zwei separate Objekte benötigt:
+
+| Objekt | Zweck |
+|--------|-------|
+| `PdoDatabaseQueryExecutor` | Nicht-transaktionale Lesevorgänge (z. B. `GET /products`) |
+| `PdoDatabaseTransactionManager` | Umschließt mehrstufige Schreibvorgänge in einer Transaktion |
+
+Beide teilen dieselbe `PdoConnectionFactory`:
+
+```php
+$connectionFactory = new PdoConnectionFactory($dbConfig);
+
+$executor  = new PdoDatabaseQueryExecutor($connectionFactory);  // für Read-Repositories
+$txManager = new PdoDatabaseTransactionManager($connectionFactory); // für Use Cases
+
+$products = new SqliteProductRepository($executor);  // verwendet von GET /products
+$createOrder = new CreateOrderUseCase($txManager);   // verwendet $tx intern
+```
+
+---
+
+## Mit dateibasierter SQLite-Datenbank testen
+
+In-Memory-SQLite (`sqlite::memory:`) erstellt eine **separate Datenbank pro Verbindung**, sodass `PdoDatabaseTransactionManager` (der pro `transactional()`-Aufruf eine neue Verbindung öffnet) keine vom `PdoDatabaseQueryExecutor` geschriebenen Zeilen sehen würde und umgekehrt.
+
+Stattdessen eine **temporäre Datei** verwenden:
+
+```php
+protected function setUp(): void
+{
+    $this->dbFile = sys_get_temp_dir() . '/test-' . bin2hex(random_bytes(8)) . '.sqlite';
+    $pdo = new \PDO('sqlite:' . $this->dbFile, options: [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+    $pdo->exec(file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
+    unset($pdo); // Init-Verbindung schließen, bevor die Factory ihre eigene öffnet
+
+    $dbConfig = new DatabaseConfig(
+        url:         null,
+        environment: 'test',
+        adapter:     'sqlite',
+        host:        '',      // für SQLite nicht verwendet
+        port:        1,       // für SQLite nicht verwendet
+        name:        $this->dbFile,
+        user:        '',      // für SQLite nicht verwendet
+        password:    '',      // für SQLite nicht verwendet
+        charset:     '',      // für SQLite nicht verwendet
+    );
+
+    $factory   = new PdoConnectionFactory($dbConfig);
+    $executor  = new PdoDatabaseQueryExecutor($factory);
+    $txManager = new PdoDatabaseTransactionManager($factory);
+    // ... Repositories und Use Cases verdrahten
+}
+
+protected function tearDown(): void
+{
+    if (is_file($this->dbFile)) {
+        unlink($this->dbFile);
+    }
+}
+```
+
+Jeder Test erhält eine frische Datei, sowohl `PdoDatabaseQueryExecutor` als auch `PdoDatabaseTransactionManager` verbinden sich mit derselben Datei, und `tearDown` löscht sie.
+
+> **Hinweis zu SQLite `DatabaseConfig`-Feldern**: Für SQLite sind nur `adapter` und `name` erforderlich. Leere Strings für `host`, `user`, `password` und `charset` übergeben — sie werden nicht validiert, wenn `adapter` `'sqlite'` ist.
+
+> **Hinweis**: `PdoDatabaseQueryExecutor` akzeptiert kein rohes `PDO` als Konstruktorargument — es erfordert eine `DatabaseConnectionFactoryInterface`. `PdoConnectionFactory` (oben gezeigt) verwenden, um ein rohes `PDO`-Setup mit dem Executor zu verbinden.
+
+---
+
+## Rollback-Verhalten verifizieren
+
+Testen, dass ein Fehler mitten in einer Transaktion alle vorherigen Änderungen rückgängig macht:
+
+```php
+public function testTransactionRollsBackOnDomainException(): void
+{
+    // Zwei Produkte seeden
+    // ...
+
+    // Bestellung, die beim zweiten Produkt fehlschlägt (unzureichender Bestand)
+    $response = $this->request('POST', '/orders', [
+        'items' => [
+            ['product_id' => $p1Id, 'qty' => 3],   // würde gelingen
+            ['product_id' => $p2Id, 'qty' => 99],  // wird fehlschlagen
+        ],
+    ]);
+
+    self::assertSame(409, $response->getStatusCode());
+
+    // Bestand von Produkt 1 muss unverändert sein — Transaktion wurde zurückgerollt
+    $products = $this->json($this->request('GET', '/products'))['items'];
+    self::assertSame($originalStock1, $products[0]['stock']);
+}
+```
+
+---
+
+## Zukünftige Richtung
+
+Das aktuelle Muster erfordert die Instanziierung konkreter Repository-Klassen innerhalb des Callbacks, was bedeutet, dass der Use Case die Repository-Implementierung (`SqliteProductRepository`) kennt und nicht nur das Interface. Das ist eine bekannte Einschränkung.
+
+Eine `RepositoryFactory`-Abstraktion — ein von Use Cases akzeptiertes Interface, das ein Repository für einen gegebenen Executor produzieren kann — würde die vollständige Interface-only-Abhängigkeit wiederherstellen. Dies wird für eine zukünftige NENE2-Version in Betracht gezogen.

--- a/docs/de/howto/user-follow-system.md
+++ b/docs/de/howto/user-follow-system.md
@@ -1,0 +1,342 @@
+# Benutzer-Follow-System mit NENE2 aufbauen
+
+Diese Anleitung führt durch den Aufbau eines Twitter/Instagram-ähnlichen sozialen Follow-Systems — Benutzer folgen sich gegenseitig, sehen Follower-/Following-Listen und prüfen gegenseitigen Follow-Status.
+
+**Field Trial**: FT134  
+**NENE2-Version**: ^1.5  
+**Behandelte Themen**: Follow/Unfollow, idempotente Schreibvorgänge, Graph-Abfragen, Soft-Constraint-Enforcement
+
+---
+
+## Was wird gebaut
+
+Eine REST API, die Benutzern erlaubt:
+
+- Andere Benutzer zu folgen und zu entfolgen (idempotenter Follow, 204 Unfollow)
+- Follower-/Following-Listen abzufragen (geordnet nach neuesten zuerst)
+- Follower-/Following-Anzahl in einem Stat-Aufruf zu prüfen
+- Zu prüfen, ob ein bestimmter Benutzer einem anderen folgt
+
+---
+
+## Datenbankschema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE follows (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    follower_id INTEGER NOT NULL,
+    followee_id INTEGER NOT NULL,
+    created_at  TEXT    NOT NULL,
+    UNIQUE (follower_id, followee_id),
+    CHECK  (follower_id != followee_id),
+    FOREIGN KEY (follower_id) REFERENCES users(id),
+    FOREIGN KEY (followee_id) REFERENCES users(id)
+);
+```
+
+Zwei Constraints leisten die Hauptarbeit auf DB-Ebene:
+
+- `UNIQUE (follower_id, followee_id)` — verhindert doppelte Follow-Zeilen
+- `CHECK (follower_id != followee_id)` — verhindert Self-Follow auf DB-Ebene (Anwendung validiert das ebenfalls)
+
+---
+
+## API-Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzer erstellen |
+| `POST` | `/users/{followerId}/follow` | Benutzer folgen (idempotent) |
+| `DELETE` | `/users/{followerId}/follow/{followeeId}` | Benutzer entfolgen |
+| `GET` | `/users/{userId}/stats` | Follower-/Following-Anzahl abrufen |
+| `GET` | `/users/{userId}/followers` | Follower auflisten |
+| `GET` | `/users/{userId}/following` | Benutzer auflisten, denen dieser Benutzer folgt |
+| `GET` | `/users/{followerId}/is-following/{followeeId}` | Follow-Beziehung prüfen |
+
+---
+
+## Repository
+
+```php
+final class FollowRepository
+{
+    public function __construct(
+        private readonly DatabaseQueryExecutorInterface $executor,
+    ) {}
+
+    public function follow(int $followerId, int $followeeId, string $now): bool
+    {
+        if ($this->isFollowing($followerId, $followeeId)) {
+            return false; // folgt bereits — false zurückgeben, damit Handler 200 sendet
+        }
+
+        $this->executor->execute(
+            'INSERT INTO follows (follower_id, followee_id, created_at) VALUES (?, ?, ?)',
+            [$followerId, $followeeId, $now],
+        );
+
+        return true; // neuer Follow — Handler sendet 201
+    }
+
+    public function unfollow(int $followerId, int $followeeId): bool
+    {
+        $count = $this->executor->execute(
+            'DELETE FROM follows WHERE follower_id = ? AND followee_id = ?',
+            [$followerId, $followeeId],
+        );
+
+        return $count > 0;
+    }
+
+    public function isFollowing(int $followerId, int $followeeId): bool
+    {
+        return $this->executor->fetchOne(
+            'SELECT id FROM follows WHERE follower_id = ? AND followee_id = ?',
+            [$followerId, $followeeId],
+        ) !== null;
+    }
+
+    /** @return array<int, array{id: int, name: string}> */
+    public function listFollowers(int $userId): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT u.id, u.name FROM users u
+             INNER JOIN follows f ON f.follower_id = u.id
+             WHERE f.followee_id = ?
+             ORDER BY f.id DESC',
+            [$userId],
+        );
+
+        return array_map(fn(mixed $row) => $this->hydrateUser((array) $row), $rows);
+    }
+
+    /** @return array<int, array{id: int, name: string}> */
+    public function listFollowing(int $userId): array
+    {
+        $rows = $this->executor->fetchAll(
+            'SELECT u.id, u.name FROM users u
+             INNER JOIN follows f ON f.followee_id = u.id
+             WHERE f.follower_id = ?
+             ORDER BY f.id DESC',
+            [$userId],
+        );
+
+        return array_map(fn(mixed $row) => $this->hydrateUser((array) $row), $rows);
+    }
+}
+```
+
+Die `follow()`-Methode gibt `bool` zurück, um neu-vs-existierend zu signalisieren, damit der Handler den richtigen HTTP-Status senden kann, ohne eine zusätzliche Abfrage.
+
+---
+
+## Follow-Handler — idempotenter POST
+
+Das Knifflige ist, **201 Created** für einen neuen Follow und **200 OK** für einen wiederholten Follow zurückzugeben, während Self-Follow mit 422 abgelehnt wird.
+
+```php
+private function followUser(ServerRequestInterface $request): ResponseInterface
+{
+    $params     = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $followerId = isset($params['followerId']) && is_numeric($params['followerId'])
+        ? (int) $params['followerId'] : 0;
+
+    if ($followerId <= 0 || !$this->repo->findUserById($followerId)) {
+        return $this->responseFactory->create(['error' => 'follower not found'], 404);
+    }
+
+    $body       = JsonRequestBodyParser::parse($request);
+    $followeeId = isset($body['followee_id']) && is_int($body['followee_id'])
+        ? $body['followee_id'] : 0;
+
+    if ($followeeId <= 0 || !$this->repo->findUserById($followeeId)) {
+        return $this->responseFactory->create(['error' => 'followee not found'], 404);
+    }
+
+    if ($followerId === $followeeId) {
+        return $this->responseFactory->create(['error' => 'cannot follow yourself'], 422);
+    }
+
+    $wasNew = $this->repo->follow($followerId, $followeeId, date('Y-m-d H:i:s'));
+    $status = $wasNew ? 201 : 200;
+
+    return $this->responseFactory->create([
+        'follower_id' => $followerId,
+        'followee_id' => $followeeId,
+        'following'   => true,
+    ], $status);
+}
+```
+
+**Warum vor der Self-Follow-Prüfung validieren?** Die 404-Prüfungen kommen zuerst, sodass `POST /users/9999/follow` mit `followee_id: 9999` 404 (Benutzer existiert nicht) statt 422 (Self-Follow) zurückgibt. Existenzfehler haben Priorität.
+
+---
+
+## Unfollow-Handler — 204 oder 404
+
+```php
+private function unfollowUser(ServerRequestInterface $request): ResponseInterface
+{
+    $params     = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $followerId = isset($params['followerId']) && is_numeric($params['followerId'])
+        ? (int) $params['followerId'] : 0;
+    $followeeId = isset($params['followeeId']) && is_numeric($params['followeeId'])
+        ? (int) $params['followeeId'] : 0;
+
+    if ($followerId <= 0 || !$this->repo->findUserById($followerId)) {
+        return $this->responseFactory->create(['error' => 'follower not found'], 404);
+    }
+
+    $removed = $this->repo->unfollow($followerId, $followeeId);
+
+    if (!$removed) {
+        return $this->responseFactory->create(['error' => 'not following'], 404);
+    }
+
+    return $this->responseFactory->createEmpty(204);
+}
+```
+
+Hinweis: `createEmpty(204)` — `JsonResponseFactory` hat eine dedizierte Methode für Body-lose Antworten.
+
+---
+
+## Stats-Endpunkt
+
+```php
+private function stats(ServerRequestInterface $request): ResponseInterface
+{
+    $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $userId = isset($params['userId']) && is_numeric($params['userId'])
+        ? (int) $params['userId'] : 0;
+
+    if ($userId <= 0 || !$this->repo->findUserById($userId)) {
+        return $this->responseFactory->create(['error' => 'user not found'], 404);
+    }
+
+    return $this->responseFactory->create([
+        'user_id'         => $userId,
+        'followers_count' => $this->repo->followerCount($userId),
+        'following_count' => $this->repo->followingCount($userId),
+    ]);
+}
+```
+
+---
+
+## AppFactory
+
+```php
+final class AppFactory
+{
+    public static function createSqliteApp(string $dbPath): RequestHandlerInterface
+    {
+        $dbConfig = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: '',
+            port: 1,
+            name: $dbPath,
+            user: '',
+            password: '',
+            charset: '',
+        );
+
+        $factory  = new PdoConnectionFactory($dbConfig);
+        $executor = new PdoDatabaseQueryExecutor($factory);
+        $psr17    = new Psr17Factory();
+        $json     = new JsonResponseFactory($psr17, $psr17);
+
+        $repo      = new FollowRepository($executor);
+        $registrar = new RouteRegistrar($repo, $json);
+
+        return new RuntimeApplicationFactory(
+            $psr17,
+            $psr17,
+            routeRegistrars: [static fn(Router $r) => $registrar->register($r)],
+        )->create();
+    }
+}
+```
+
+---
+
+## Teststrategie
+
+Jeder Test läuft gegen eine frische In-Memory-SQLite-Datei, die in `setUp()` erstellt und in `tearDown()` gelöscht wird.
+
+Wichtige Testfälle:
+
+```php
+// Idempotenter Follow → 200
+public function testFollowIdempotentReturns200(): void
+{
+    $alice = $this->createUser('Alice');
+    $bob   = $this->createUser('Bob');
+
+    $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+    $res = $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+
+    $this->assertSame(200, $res->getStatusCode());
+    $this->assertTrue($this->json($res)['following']);
+}
+
+// Self-Follow → 422
+public function testFollowSelfReturns422(): void
+{
+    $alice = $this->createUser('Alice');
+    $res   = $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $alice]);
+    $this->assertSame(422, $res->getStatusCode());
+}
+
+// Entfolgen dann erneut folgen → 201
+public function testUnfollowThenRefollow(): void
+{
+    $alice = $this->createUser('Alice');
+    $bob   = $this->createUser('Bob');
+
+    $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+    $this->request('DELETE', "/users/{$alice}/follow/{$bob}");
+    $res = $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+
+    $this->assertSame(201, $res->getStatusCode());
+}
+
+// Gegenseitiger Follow
+public function testMutualFollow(): void
+{
+    $alice = $this->createUser('Alice');
+    $bob   = $this->createUser('Bob');
+
+    $this->request('POST', "/users/{$alice}/follow", ['followee_id' => $bob]);
+    $this->request('POST', "/users/{$bob}/follow", ['followee_id' => $alice]);
+
+    $this->assertTrue($this->json($this->request('GET', "/users/{$alice}/is-following/{$bob}"))['following']);
+    $this->assertTrue($this->json($this->request('GET', "/users/{$bob}/is-following/{$alice}"))['following']);
+}
+```
+
+---
+
+## Sortierkonvention
+
+Sowohl `listFollowers` als auch `listFollowing` verwenden `ORDER BY f.id DESC` — der zuletzt gefolgte Benutzer erscheint zuerst. Das spiegelt das Verhalten des "Followers"-Tabs von Twitter/Instagram wider.
+
+---
+
+## Häufige Fallstricke
+
+| Fallstrick | Lösung |
+|-----------|--------|
+| 422 für unbekannten Benutzer bei Self-Follow-Prüfung zurückgeben | Benutzerexistenz *vor* der Self-Follow-Prüfung validieren |
+| `followee_id` aus dem Pfad statt aus dem Body lesen | `followee_id` ist im Request-Body; `followeeId` ist der Pfadparameter für DELETE |
+| `createJson()` verwenden | Die Methode heißt `create(array $data, int $status = 200)` |
+| `createEmpty()` für eine 200-Antwort mit Body verwenden | `createEmpty()` nur für 204 No Content verwenden |
+| `JsonRequestBodyParser::parse()` fehlt | Muss in jedem Handler, der einen JSON-Body liest, manuell aufgerufen werden |

--- a/docs/de/howto/user-invitation.md
+++ b/docs/de/howto/user-invitation.md
@@ -1,0 +1,145 @@
+# Benutzer-Einladungssystem
+
+Neue Benutzer per E-Mail einladen, Ablauf durchsetzen und Missbrauch mit tokenbasierten Einladungen verhindern.
+
+## Überblick
+
+Ein Einladungssystem lässt bestehende Benutzer neue Kontoerstellungen sponsern. Die wichtigsten Invarianten sind:
+
+- Tokens sind kryptografisch zufällig und nicht erratbar.
+- Ablauf wird sowohl beim Lesen als auch beim Schreiben geprüft.
+- Nur der ursprüngliche Einlader kann eine Einladung stornieren.
+- Akzeptierte und stornierte Tokens können nicht wiederverwendet werden.
+
+## Datenbankschema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    email      TEXT    NOT NULL UNIQUE,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE invitations (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    inviter_id  INTEGER NOT NULL,
+    email       TEXT    NOT NULL,
+    token       TEXT    NOT NULL UNIQUE,
+    status      TEXT    NOT NULL DEFAULT 'pending',
+    expires_at  TEXT    NOT NULL,
+    accepted_at TEXT,
+    created_at  TEXT    NOT NULL,
+    FOREIGN KEY (inviter_id) REFERENCES users(id)
+);
+```
+
+## Token-Generierung
+
+Immer `bin2hex(random_bytes(32))` verwenden — 64 Hex-Zeichen, 256 Bit Entropie:
+
+```php
+$token = bin2hex(random_bytes(32));
+```
+
+Niemals sequenzielle IDs, UUIDs oder kurze Strings als Einladungstoken verwenden. Ein erratbares Token lässt einen Angreifer jede ausstehende Einladung annehmen.
+
+## Einladung senden
+
+Vor der Einladungserstellung verifizieren, dass die Ziel-E-Mail noch nicht registriert ist:
+
+```php
+// Einladung bereits registrierter Benutzer verhindern
+if ($this->repo->findUserByEmail($email) !== null) {
+    return $this->problems->create($request, 'conflict', 'Email already registered.', 409, '');
+}
+
+$expiresAt = (new \DateTimeImmutable())->modify('+24 hours')->format('Y-m-d H:i:s');
+$token     = bin2hex(random_bytes(32));
+$invite    = $this->repo->createInvitation($inviterId, $email, $token, $expiresAt, $now);
+```
+
+Die Rückgabe von 409 beim Einladen einer registrierten E-Mail enthüllt den Registrierungsstatus gegenüber dem Einlader. Das ist in einladungsbasierten Systemen akzeptabel, wo Einlader vertrauenswürdige Benutzer sind. In vollständig öffentlichen Systemen sollte die Antwort auf 202 vereinheitlicht werden.
+
+## Einladung annehmen
+
+Ablauf **vor** der Statusprüfung prüfen — eine ausstehende-aber-abgelaufene Einladung muss 410 zurückgeben, nicht 409:
+
+```php
+$invite = $this->repo->findByTokenOrNull($token);
+
+if ($invite === null) {
+    return $this->problems->create($request, 'not-found', 'Invitation not found.', 404, '');
+}
+
+$now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+if ($invite->isExpired($now)) {
+    return $this->problems->create($request, 'gone', 'Invitation has expired.', 410, '');
+}
+
+if (!$invite->isPending()) {
+    return $this->problems->create($request, 'conflict', 'Invitation is no longer valid.', 409, '');
+}
+```
+
+`isExpired` vergleicht den aktuellen Timestamp-String direkt — SQLite-Datetime-Strings sortieren lexikografisch, wenn sie als `Y-m-d H:i:s` gespeichert sind:
+
+```php
+public function isExpired(string $now): bool
+{
+    return $now >= $this->expiresAt;
+}
+
+public function isPending(): bool
+{
+    return $this->status === 'pending';
+}
+```
+
+## Einladung stornieren
+
+Die Eigentümerschaft wird über die `inviter_id` aus dem Request-Body durchgesetzt (da in diesem minimalen Beispiel kein Session/JWT-Middleware vorhanden ist). In der Produktion den Akteur stattdessen aus einem authentifizierten Token ableiten:
+
+```php
+if ($invite->inviterId !== $inviterId) {
+    return $this->problems->create($request, 'forbidden', 'Only the inviter may cancel this invitation.', 403, '');
+}
+
+if (!$invite->isPending()) {
+    return $this->problems->create($request, 'conflict', 'Invitation is already ' . $invite->status . '.', 409, '');
+}
+```
+
+403 (nicht 404) zurückgeben, wenn die Eigentümerschaftsprüfung fehlschlägt — die Existenz der Einladung zu verschleiern würde die Tatsache verbergen, dass der Angreifer ein echtes Token gefunden hat, aber 403 ist hier die korrekte Semantik, da die Ressource gefunden wurde, die Aktion aber verboten ist.
+
+## Zustandsmaschine
+
+```
+pending ──accept──► accepted
+pending ──cancel──► cancelled
+```
+
+Sobald eine Einladung `pending` verlässt, sind keine weiteren Übergänge erlaubt. Der Versuch, eine `accepted`- oder `cancelled`-Einladung anzunehmen, gibt 409 zurück.
+
+## Sicherheitseigenschaften
+
+| Eigenschaft | Implementierung |
+|-------------|-----------------|
+| Token-Entropie | `bin2hex(random_bytes(32))` — 256 Bit |
+| Token-Eindeutigkeit | UNIQUE-Constraint auf `invitations.token` |
+| Ablauf beim Lesen | Im Handler vor jedem Schreibvorgang geprüft |
+| Wiederverwendungsschutz | `isPending()`-Guard vor Accept/Cancel |
+| Eigentümerdurchsetzung | `inviter_id`-Gleichheitsprüfung → 403 |
+| Kein E-Mail-PII-Leak | 409-Body enthüllt die eingeladene E-Mail nicht |
+| SQL-Injection | PDO-parametrisierte Abfragen durchgehend |
+
+## Routenübersicht
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzerkonto erstellen |
+| `POST` | `/users/{id}/invitations` | Einladung senden |
+| `GET` | `/invitations/{token}` | Einladung anzeigen |
+| `POST` | `/invitations/{token}/accept` | Einladung annehmen |
+| `DELETE` | `/invitations/{token}` | Einladung stornieren |

--- a/docs/de/howto/user-preferences-api.md
+++ b/docs/de/howto/user-preferences-api.md
@@ -1,0 +1,142 @@
+# How-to: Benutzereinstellungen-API
+
+> **FT-Referenz**: FT329 (`NENE2-FT/preflog`) — Benutzerspezifischer Einstellungsspeicher mit typisierter Wertvalidierung, Standard-Fallback, Ablehnung unbekannter Schlüssel, Nur-Eigentümer-Mutation, 20 Tests / 70 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Benutzereinstellungssystem aufgebaut wird, bei dem Einstellungen typisierte Domains, Standards und `is_default`-Flags haben, um angepasste von Standardwerten zu unterscheiden.
+
+## Schema
+
+```sql
+CREATE TABLE user_preferences (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    pref_key   TEXT    NOT NULL,
+    pref_value TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    UNIQUE(user_id, pref_key)
+);
+```
+
+Standardwerte leben im Anwendungscode, nicht in der DB.
+
+## Einstellungsschlüssel & Validierung
+
+| Schlüssel | Typ | Standard | Erlaubte Werte |
+|-----------|-----|----------|----------------|
+| `theme` | enum | `"light"` | `light`, `dark`, `system` |
+| `language` | enum | `"en"` | `en`, `ja`, `fr` |
+| `notifications_enabled` | Boolean-String | `"true"` | `"true"`, `"false"` |
+| `items_per_page` | Integer-String | `"20"` | `"5"` – `"100"` |
+| `timezone` | string | `"UTC"` | beliebige IANA-Zeitzone |
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `GET` | `/users/{id}/preferences` | Alle abrufen (mit Standards) |
+| `PUT` | `/users/{id}/preferences/{key}` | Einen setzen (nur Eigentümer) |
+
+## Alle Einstellungen abrufen
+
+Gibt alle 5 Schlüssel zurück — gespeicherter Wert falls gesetzt, sonst Standard:
+
+```php
+GET /users/1/preferences
+→ 200
+{
+  "user_id": 1,
+  "preferences": [
+    {"key": "theme",                 "value": "light", "is_default": true,  "updated_at": null},
+    {"key": "language",              "value": "en",    "is_default": true,  "updated_at": null},
+    {"key": "notifications_enabled", "value": "true",  "is_default": true,  "updated_at": null},
+    {"key": "items_per_page",        "value": "20",    "is_default": true,  "updated_at": null},
+    {"key": "timezone",              "value": "UTC",   "is_default": true,  "updated_at": null}
+  ]
+}
+
+// Nach dem Setzen des Themes auf dark:
+{"key": "theme", "value": "dark", "is_default": false, "updated_at": "2026-05-27T..."}
+```
+
+Benutzer nicht gefunden → 404.
+
+## Einstellung setzen
+
+```php
+PUT /users/1/preferences/theme  X-User-Id: 1
+{"value": "dark"}
+→ 200  {"key": "theme", "value": "dark", "updated_at": "..."}
+
+// Existierende aktualisieren (UPSERT)
+PUT /users/1/preferences/theme  X-User-Id: 1
+{"value": "system"}
+→ 200  // nur eine Zeile pro (user_id, pref_key)
+```
+
+### Unbekannter Schlüssel
+
+```php
+PUT /users/1/preferences/invalid_key  X-User-Id: 1
+{"value": "foo"}
+→ 422
+{"valid_keys": ["theme", "language", "notifications_enabled", "items_per_page", "timezone"]}
+```
+
+### Ungültiger Wert
+
+```php
+PUT /users/1/preferences/theme  X-User-Id: 1  {"value": "neon"}     → 422
+PUT /users/1/preferences/notifications_enabled  {"value": "yes"}    → 422  // muss "true"/"false" sein
+PUT /users/1/preferences/items_per_page  {"value": "200"}           → 422  // max 100
+PUT /users/1/preferences/items_per_page  {"value": "1"}             → 422  // min 5
+```
+
+### Autorisierung
+
+```php
+// Anderer Benutzer kann Einstellungen nicht ändern
+PUT /users/1/preferences/theme  X-User-Id: 2  {"value": "dark"}  → 403
+
+// Benutzer nicht gefunden
+PUT /users/999/preferences/theme  X-User-Id: 999  {"value": "dark"}  → 404
+```
+
+## Implementierungsmuster
+
+```php
+private const SCHEMA = [
+    'theme'                 => ['type' => 'enum',    'values' => ['light','dark','system']],
+    'language'              => ['type' => 'enum',    'values' => ['en','ja','fr']],
+    'notifications_enabled' => ['type' => 'bool_str','values' => ['true','false']],
+    'items_per_page'        => ['type' => 'int_str', 'min' => 5, 'max' => 100],
+    'timezone'              => ['type' => 'string'],
+];
+
+private function validate(string $key, string $value): ?string
+{
+    $schema = self::SCHEMA[$key] ?? null;
+    if ($schema === null) {
+        return null;  // unbekannter Schlüssel
+    }
+
+    return match ($schema['type']) {
+        'enum'     => in_array($value, $schema['values'], true) ? $value : throw ValidationException,
+        'bool_str' => in_array($value, ['true','false'], true) ? $value : throw ValidationException,
+        'int_str'  => $this->validateIntStr($value, $schema['min'], $schema['max']),
+        default    => $value,
+    };
+}
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Beliebigen String für `theme` akzeptieren | UI stürzt beim Rendern unbekannter Themes ab; Enum validieren |
+| Standards in DB speichern | Jeder neue Benutzer erfordert einen DB-Insert für jeden Standard; Code-seitige Standards verwenden |
+| Leeres Array zurückgeben, wenn keine Prefs gespeichert | Client muss "nicht gesetzt"-Fall behandeln; alle Schlüssel mit Standards zurückgeben |
+| `is_default`-Flag weglassen | Client kann Benutzerabsicht nicht von Systemstandard unterscheiden |
+| Änderung der Einstellungen anderer Benutzer erlauben | Datenschutzverletzung; Eigentümerprüfung ist obligatorisch |
+| `"yes"/"no"` für Boolean-Pref akzeptieren | Inkonsistent; auf `"true"/"false"`-Strings normalisieren |

--- a/docs/de/howto/user-preferences-management.md
+++ b/docs/de/howto/user-preferences-management.md
@@ -1,0 +1,154 @@
+# Benutzereinstellungen-Verwaltung
+
+Implementierungsanleitung für die Verwaltung von Benutzereinstellungen (Preferences).
+Einstellungswerte können für einen vordefinierten Schlüsselsatz mit typisierter Validierung gespeichert, aktualisiert und zurückgesetzt werden.
+
+## Überblick
+
+- Einstellungsschlüssel werden per Enum verwaltet (unbekannte Schlüssel → 422)
+- Werte werden pro Schlüssel typvalidiert
+- Änderung fremder Einstellungen → 403 (Eigentümerschaftsprüfung)
+- Nicht gesetzte Schlüssel geben den Standardwert zurück (`is_default: true`)
+- DELETE setzt auf Standardwert zurück
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `GET` | `/users/{id}/preferences` | Einstellungsliste abrufen (alle Schlüssel, inkl. Standards) |
+| `PUT` | `/users/{id}/preferences/{key}` | Einstellungswert aktualisieren (Upsert) |
+| `DELETE` | `/users/{id}/preferences/{key}` | Einstellung zurücksetzen (auf Standard) |
+
+## Datenbankdesign
+
+```sql
+CREATE TABLE user_preferences (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    pref_key TEXT NOT NULL,
+    pref_value TEXT NOT NULL,   -- immer als String gespeichert
+    updated_at TEXT NOT NULL,
+    UNIQUE (user_id, pref_key), -- Schlüssel pro Benutzer eindeutig
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+Werte werden immer als `TEXT` gespeichert. Die Typinterpretation erfolgt auf Client-Seite
+(`items_per_page: "20"` → Frontend macht `parseInt()`).
+
+## Einstellungsschlüssel-Enum
+
+```php
+enum PreferenceKey: string
+{
+    case Theme = 'theme';
+    case Language = 'language';
+    case NotificationsEnabled = 'notifications_enabled';
+    case ItemsPerPage = 'items_per_page';
+    case Timezone = 'timezone';
+
+    public function defaultValue(): string
+    {
+        return match ($this) {
+            self::Theme => 'light',
+            self::Language => 'en',
+            self::NotificationsEnabled => 'true',
+            self::ItemsPerPage => '20',
+            self::Timezone => 'UTC',
+        };
+    }
+
+    public function validate(string $value): bool
+    {
+        return match ($this) {
+            self::Theme => in_array($value, ['light', 'dark', 'system'], true),
+            self::Language => preg_match('/^[a-z]{2}(-[A-Z]{2})?$/', $value) === 1,
+            self::NotificationsEnabled => in_array($value, ['true', 'false'], true),
+            self::ItemsPerPage => ctype_digit($value) && (int) $value >= 5 && (int) $value <= 100,
+            self::Timezone => strlen($value) <= 64 && strlen($value) > 0,
+        };
+    }
+}
+```
+
+## GET /users/{id}/preferences Antwort
+
+```json
+{
+  "preferences": [
+    {"key": "theme", "value": "dark", "is_default": false, "updated_at": "2026-05-21T10:00:00+00:00"},
+    {"key": "language", "value": "en", "is_default": true, "updated_at": null},
+    {"key": "notifications_enabled", "value": "true", "is_default": true, "updated_at": null},
+    {"key": "items_per_page", "value": "20", "is_default": true, "updated_at": null},
+    {"key": "timezone", "value": "UTC", "is_default": true, "updated_at": null}
+  ]
+}
+```
+
+Alle Schlüssel werden zurückgegeben (gespeicherte mit ihrem Wert, nicht gespeicherte mit Standardwert).
+
+## Upsert-Muster
+
+```php
+public function upsertPreference(int $userId, string $key, string $value, string $now): void
+{
+    $existing = $this->findPreference($userId, $key);
+    if ($existing !== null) {
+        $this->executor->execute(
+            'UPDATE user_preferences SET pref_value = ?, updated_at = ? WHERE user_id = ? AND pref_key = ?',
+            [$value, $now, $userId, $key]
+        );
+    } else {
+        $this->executor->execute(
+            'INSERT INTO user_preferences (user_id, pref_key, pref_value, updated_at) VALUES (?, ?, ?, ?)',
+            [$userId, $key, $value, $now]
+        );
+    }
+}
+```
+
+In Kombination mit dem UNIQUE(user_id, pref_key)-Constraint wird 1 Zeile pro Benutzer pro Schlüssel garantiert.
+
+## Eigentümerschaftsprüfung (IDOR-Prävention)
+
+```php
+$actorId = (int) $request->getHeaderLine('X-User-Id');
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'cannot modify another user\'s preferences'], 403);
+}
+```
+
+Fremde Einstellungen können nicht geändert oder gelöscht werden. Lesen ist für alle möglich (Einstellungen sind in der Regel öffentlich).
+
+## DELETE = Zurücksetzen (physisches Löschen)
+
+DELETE löscht die Einstellungszeile aus der DB; bei GET wird wieder der Standardwert zurückgegeben:
+
+```php
+$this->repository->deletePreference($userId, $prefKey->value);
+return $this->responseFactory->create([
+    'key' => $prefKey->value,
+    'value' => $prefKey->defaultValue(),
+    'is_default' => true,
+], 200);
+```
+
+Auch wenn noch nicht gesetzt (erster DELETE), wird 200 zurückgegeben (Idempotenz).
+
+## Antwort bei unbekanntem Schlüssel
+
+```json
+{
+  "error": "unknown preference key",
+  "valid_keys": ["theme", "language", "notifications_enabled", "items_per_page", "timezone"]
+}
+```
+
+Die Rückgabe der gültigen Schlüsselliste erhöht die Selbsterklärungsfähigkeit der API.
+
+## Erweiterungsmuster
+
+- **Kategorisierung**: `PreferenceCategory`-Enum hinzufügen und nach UI, Benachrichtigungen, Anzeige etc. gruppieren
+- **Benutzertypspezifische Standards**: `defaultValue(UserType $type)` für bedingte Verzweigung
+- **Audit-Log**: `updated_at` + Änderungshistorie-Tabelle zur Verfolgung von Einstellungsänderungen
+- **Batch-Update**: `PATCH /users/{id}/preferences` zur gleichzeitigen Aktualisierung mehrerer Einstellungen

--- a/docs/de/howto/user-profile-api.md
+++ b/docs/de/howto/user-profile-api.md
@@ -1,0 +1,129 @@
+# How-to: Benutzerprofil-API
+
+> **FT-Referenz**: FT275 (`NENE2-FT/profilelog`) — Benutzerprofil: ein-Profil-pro-Benutzer (UNIQUE user_id), E-Mail validiert mit FILTER_VALIDATE_EMAIL, Feldlängenbeschränkungen (display_name 100 / bio 500 / avatar_url 2048), Nur-HTTPS-Avatar-URL, DatabaseConstraintException → 409, Eigentümerguard via X-User-Id, 32 Tests BESTANDEN.
+
+Demonstriert ein 1:1 Benutzer-zu-Profil-System: Benutzer erstellen (E-Mail eindeutig), ihr Profil erstellen/abrufen/aktualisieren. Profilfelder haben durchgesetzte Längenbeschränkungen und eine URL-Sicherheitsbeschränkung.
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    email      TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE profiles (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL UNIQUE,
+    display_name TEXT    NOT NULL DEFAULT '',
+    bio          TEXT    NOT NULL DEFAULT '',
+    avatar_url   TEXT    NOT NULL DEFAULT '',
+    updated_at   TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`user_id UNIQUE` setzt die Ein-Profil-pro-Benutzer-Invariante auf DB-Ebene durch.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzer erstellen (E-Mail erforderlich, eindeutig) |
+| `POST` | `/users/{userId}/profile` | Profil für Benutzer erstellen |
+| `GET` | `/users/{userId}/profile` | Profil abrufen |
+| `PUT` | `/users/{userId}/profile` | Profil aktualisieren (nur Eigentümer) |
+
+---
+
+## E-Mail-Validierung
+
+```php
+if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    return $this->responseFactory->create(['error' => 'valid email is required'], 422);
+}
+```
+
+Bei doppelter E-Mail wird `DatabaseConstraintException` abgefangen und auf 409 gemappt:
+
+```php
+try {
+    $userId = $this->repo->createUser($email, $now);
+} catch (DatabaseConstraintException) {
+    return $this->responseFactory->create(['error' => 'email already registered'], 409);
+}
+```
+
+---
+
+## Feldgrenzen (UserProfile-Value-Object)
+
+```php
+final readonly class UserProfile
+{
+    public const int MAX_BIO_LENGTH          = 500;
+    public const int MAX_DISPLAY_NAME_LENGTH = 100;
+    public const int MAX_AVATAR_URL_LENGTH   = 2048;
+}
+```
+
+Länge wird mit `mb_strlen()` geprüft (Mehrbyte-sicher):
+
+```php
+if (mb_strlen($displayName) > UserProfile::MAX_DISPLAY_NAME_LENGTH) {
+    return [$displayName, $bio, $avatarUrl, 'display_name must not exceed 100 characters'];
+}
+```
+
+---
+
+## Nur-HTTPS-Avatar-URL
+
+```php
+private function isValidAvatarUrl(string $url): bool
+{
+    if (mb_strlen($url) > UserProfile::MAX_AVATAR_URL_LENGTH) {
+        return false;
+    }
+    // Nur HTTPS erlauben, um javascript:- und data:-URI-Schemata zu verhindern
+    if (!str_starts_with($url, 'https://')) {
+        return false;
+    }
+    return filter_var($url, FILTER_VALIDATE_URL) !== false;
+}
+```
+
+`str_starts_with('https://')` blockiert `javascript:`, `data:` und `http://` bevor `filter_var` läuft.
+
+---
+
+## Eigentümerguard
+
+Profilaktualisierungen erfordern, dass `X-User-Id` mit dem Profileigentümer übereinstimmt:
+
+```php
+$actorId = $this->resolveActorId($request); // aus X-User-Id-Header
+
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Keine E-Mail-Format-Validierung | Ungültige E-Mails gespeichert; Downstream-Sendevorgänge schlagen still fehl |
+| Kein UNIQUE auf `user_id` in Profilen | Doppelte Profile möglich; GET gibt unvorhersehbare Zeile zurück |
+| `strlen()` für display_name-Limit verwenden | Mehrbyte-Zeichen (Emoji, CJK) falsch gezählt |
+| `http://`-Avatar-URLs erlauben | Passives Mixed-Content und potenzielle Clickjacking-Fläche |
+| `javascript:`- oder `data:`-URIs erlauben | XSS wenn Avatar-URL als `<a href>` oder `<img src>` gerendert wird |
+| `DatabaseConstraintException`-Catch überspringen | UNIQUE-Verletzung wird zu 500 statt 409 |
+| Jedem Benutzer erlauben, jedes Profil zu aktualisieren | IDOR — vor dem Schreiben immer Akteur = Eigentümer prüfen |

--- a/docs/de/howto/user-profile-management.md
+++ b/docs/de/howto/user-profile-management.md
@@ -1,0 +1,136 @@
+# Benutzerprofil-Verwaltung
+
+Benutzerorientierte Profildaten speichern und aktualisieren: Anzeigename, Bio und Avatar-URL. Die Profilerstellung erfolgt getrennt von der Benutzererstellung — Benutzer existieren zuerst, dann wird ein Profil einmalig erstellt und an Ort und Stelle aktualisiert.
+
+## Überblick
+
+Eine Profilverwaltungs-API umfasst:
+- **Benutzer erstellen** — E-Mail-basierte Benutzerregistrierung (ein Profil pro Benutzer)
+- **Profil erstellen** — Erstmalige Profileinrichtung (idempotenzresistent: 409 wenn bereits vorhanden)
+- **Profil abrufen** — Aktuelle Profildaten abrufen
+- **Profil aktualisieren** — Profilfelder ersetzen (Eigentümerschaft wird durchgesetzt)
+
+## Datenbankschema
+
+```sql
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    email      TEXT    NOT NULL UNIQUE,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE profiles (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL UNIQUE,
+    display_name TEXT    NOT NULL DEFAULT '',
+    bio          TEXT    NOT NULL DEFAULT '',
+    avatar_url   TEXT    NOT NULL DEFAULT '',
+    updated_at   TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`UNIQUE` auf `user_id` setzt ein Profil pro Benutzer auf DB-Ebene durch.
+
+## Umgang mit doppelter E-Mail
+
+`DatabaseConstraintException` abfangen, um 409 statt eines 500-Leaks zurückzugeben:
+
+```php
+try {
+    $userId = $this->repo->createUser($email, $now);
+} catch (DatabaseConstraintException) {
+    return $this->responseFactory->create(['error' => 'email already registered'], 409);
+}
+```
+
+Ohne diesen Catch führt eine doppelte E-Mail zu einer unbehandelten Ausnahme, die interne Fehlerdetails an den Client weitergibt.
+
+## Avatar-URL-Validierung
+
+Nur `https://`-URLs erlauben, um `javascript:`, `data:`, `file://` und `http://`-Schemata zu verhindern:
+
+```php
+private function isValidAvatarUrl(string $url): bool
+{
+    if (mb_strlen($url) > UserProfile::MAX_AVATAR_URL_LENGTH) {
+        return false;
+    }
+
+    // Nur HTTPS — blockiert javascript:, data:, file://, ftp://, http://
+    if (!str_starts_with($url, 'https://')) {
+        return false;
+    }
+
+    return filter_var($url, FILTER_VALIDATE_URL) !== false;
+}
+```
+
+Leerer String ist erlaubt (kein Avatar gesetzt). Das Limit `MAX_AVATAR_URL_LENGTH = 2048` verhindert Speichermissbrauch.
+
+## Feldlängenbeschränkungen
+
+Beschränkungen als Konstanten auf dem Value-Object definieren für eine einzige Wahrheitsquelle:
+
+```php
+final readonly class UserProfile
+{
+    public const int MAX_BIO_LENGTH          = 500;
+    public const int MAX_DISPLAY_NAME_LENGTH = 100;
+    public const int MAX_AVATAR_URL_LENGTH   = 2048;
+    ...
+}
+```
+
+`mb_strlen()` statt `strlen()` für Mehrbyte (UTF-8) Korrektheit verwenden.
+
+## Eigentümerschaftsprüfung
+
+Der `PUT /users/{userId}/profile`-Endpunkt verwendet einen `X-User-Id`-Header zur Identifikation des anfragenden Akteurs. In der Produktion durch einen JWT-Claim ersetzen:
+
+```php
+private function resolveActorId(ServerRequestInterface $request): int
+{
+    $header = $request->getHeaderLine('X-User-Id');
+    return is_numeric($header) ? (int) $header : 0;
+}
+
+// Im Handler:
+if ($actorId !== $userId) {
+    return $this->responseFactory->create(['error' => 'forbidden'], 403);
+}
+```
+
+Nicht-numerischer oder fehlender Header wird zu `0` aufgelöst, was niemals einer echten Benutzer-ID entspricht → 403.
+
+## Verhinderung doppelter Profile
+
+Vor dem Einfügen auf vorhandenes Profil prüfen und 409 zurückgeben:
+
+```php
+if ($this->repo->findByUserId($userId) !== null) {
+    return $this->responseFactory->create(['error' => 'profile already exists'], 409);
+}
+```
+
+Dies verhindert, dass ein zweiter `POST /users/{userId}/profile` ein vorhandenes Profil still überschreibt.
+
+## Sicherheitseigenschaften
+
+| Eigenschaft | Implementierung |
+|-------------|-----------------|
+| Doppelte E-Mail | `DatabaseConstraintException` abgefangen → 409 (kein Stack-Trace-Leak) |
+| avatar_url-Schema | `str_starts_with('https://')` blockiert alle Nicht-HTTPS-Schemata |
+| avatar_url-Länge | `MAX_AVATAR_URL_LENGTH = 2048` |
+| bio-Länge | `MAX_BIO_LENGTH = 500` mit `mb_strlen()` |
+| Eigentümerschaft | `X-User-Id`-Header (in Produktion durch JWT-Claim ersetzen) |
+| Ein Profil pro Benutzer | `UNIQUE (user_id)` DB-Constraint + 409-Prüfung im Handler |
+
+## Routenübersicht
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzer registrieren (E-Mail, 409 bei Duplikat) |
+| `POST` | `/users/{userId}/profile` | Profil erstellen (409 wenn bereits vorhanden) |
+| `GET` | `/users/{userId}/profile` | Profil abrufen |
+| `PUT` | `/users/{userId}/profile` | Profil aktualisieren (erfordert `X-User-Id`-Header) |

--- a/docs/de/howto/validate-unicode-input.md
+++ b/docs/de/howto/validate-unicode-input.md
@@ -1,0 +1,117 @@
+# Unicode-Eingaben validieren
+
+NENE2 speichert und gibt Strings als UTF-8 zurück. Diese Anleitung behandelt die Fallstricke der Unicode-bewussten Validierung und deren Handhabung.
+
+## `mb_strlen` für Zeichenanzahl-Limits verwenden
+
+`strlen` zählt Bytes, keine Zeichen. Japanisch, Arabisch und Emoji verwenden mehrere Bytes pro Zeichen.
+
+```php
+strlen('あ')              // 3 (Bytes)
+mb_strlen('あ', 'UTF-8') // 1 (Zeichen)
+
+strlen('🎉')              // 4 (Bytes)
+mb_strlen('🎉', 'UTF-8') // 1 (Zeichen — ein Codepoint)
+```
+
+Immer `mb_strlen($value, 'UTF-8')` verwenden, wenn ein Zeichenlimit durchgesetzt wird:
+
+```php
+private const int NAME_MAX_CHARS = 50;
+
+if (mb_strlen($name, 'UTF-8') > self::NAME_MAX_CHARS) {
+    $errors[] = ['field' => 'name', 'code' => 'too_long',
+                 'message' => 'name must be at most ' . self::NAME_MAX_CHARS . ' characters.'];
+}
+```
+
+**Warum `strlen` versagt:** Ein japanischer Name mit 50 Zeichen ist 150 Bytes. `strlen(...) > 50` würde ihn ablehnen.
+
+## Null-Bytes explizit ablehnen
+
+SQLite-TEXT-Spalten akzeptieren Null-Bytes (`\x00`). PHP-String-Operationen behandeln sie ebenfalls — aber Null-Bytes in Benutzereingaben sind fast immer Injektionsversuche oder Kodierungsfehler. Sie frühzeitig ablehnen:
+
+```php
+if (str_contains($name, "\x00")) {
+    $errors[] = ['field' => 'name', 'code' => 'invalid', 'message' => 'name must not contain null bytes.'];
+}
+```
+
+Diese Prüfung auf jedes String-Feld vor anderen Validierungen (Länge, Format etc.) anwenden.
+
+## Graphem-Cluster vs. Codepoints
+
+`mb_strlen` zählt Unicode-_Codepoints_. Ein sichtbares Glyph (Graphem-Cluster) kann aus mehreren Codepoints bestehen:
+
+| Eingabe | Codepoints | `mb_strlen` | Glyphen |
+|---------|-----------|-------------|---------|
+| `é` (präkomponiert) | 1 | 1 | 1 |
+| `é` (e + kombinierender Akzent) | 2 | 2 | 1 |
+| 👨‍👩‍👧 (ZWJ-Familie) | 5 | 5 | 1 |
+
+Für die meisten Anwendungsfälle (Benutzernamen, Bios) ist die Codepoint-Zählung ausreichend. Wenn sichtbare Zeichen gezählt werden müssen, `grapheme_strlen()` aus der `intl`-Erweiterung verwenden:
+
+```php
+grapheme_strlen('👨‍👩‍👧') // 1
+mb_strlen('👨‍👩‍👧', 'UTF-8') // 5
+```
+
+Die Zählmethode wählen, die der Benutzererwartung für das jeweilige Feld entspricht.
+
+## JSON-Antworten und Nicht-ASCII-Zeichen
+
+`JsonResponseFactory` kodiert Antworten mit `JSON_UNESCAPED_UNICODE`, sodass Nicht-ASCII-Zeichen als literales UTF-8 im Antwort-Body erscheinen:
+
+```json
+{ "name": "田中太郎" }
+```
+
+Bei einer benutzerdefinierten `json_encode`-Aufruf anderswo (z. B. Tags als JSON in einer TEXT-Spalte speichern) dasselbe Flag hinzufügen:
+
+```php
+$tagsJson = json_encode($tags, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+```
+
+Ohne `JSON_UNESCAPED_UNICODE` wäre der gespeicherte Wert `["タグ"]` statt `["タグ"]`.
+
+## Vollständiges Validierungsbeispiel
+
+```php
+private const int NAME_MAX_CHARS = 50;
+
+private function validateName(string $raw): ?string
+{
+    if ($raw === '') {
+        return 'name is required.';
+    }
+    if (str_contains($raw, "\x00")) {
+        return 'name must not contain null bytes.';
+    }
+    if (mb_strlen($raw, 'UTF-8') > self::NAME_MAX_CHARS) {
+        return 'name must be at most ' . self::NAME_MAX_CHARS . ' characters.';
+    }
+    return null; // gültig
+}
+```
+
+## Grenzwerte testen
+
+Immer Tests schreiben für:
+
+- Genau `MAX` Zeichen (sollte bestehen) — Unicode-Zeichen verwenden, um Byte-/Zeichen-Unterschied zu verifizieren:
+
+  ```php
+  $name50 = str_repeat('あ', 50); // 150 Bytes, 50 Zeichen — sollte bestehen
+  ```
+
+- `MAX + 1` Zeichen (sollte fehlschlagen):
+
+  ```php
+  $name51 = str_repeat('あ', 51); // sollte 422 mit too_long zurückgeben
+  ```
+
+- Null-Byte-Ablehnung:
+
+  ```php
+  "Valid\x00Name" // sollte 422 mit invalid zurückgeben
+  ```

--- a/docs/de/howto/voting-system.md
+++ b/docs/de/howto/voting-system.md
@@ -1,0 +1,149 @@
+# Abstimmungssystem (Upvote / Downvote)
+
+Benutzern erlauben, Elemente hoch- oder herunterzustufen. Jeder Benutzer kann pro Element maximal eine Stimme abgeben. Zweimal in dieselbe Richtung abstimmen schaltet die Stimme aus. In die entgegengesetzte Richtung abstimmen wechselt die Stimme.
+
+## Überblick
+
+Ein Abstimmungssystem umfasst:
+- **Stimme abgeben**: Element hoch- oder herunterstimmen
+- **Umschalten**: Zweimal in dieselbe Richtung abstimmen entfernt die Stimme
+- **Wechseln**: In die entgegengesetzte Richtung abstimmen ersetzt die aktuelle Stimme
+- **Score**: Upvotes − Downvotes, mit jeder Stimm-Antwort zurückgegeben
+- **Aktuelle Stimme**: Aktuelle Stimme eines Benutzers für ein Element abrufen (für UI-Hervorhebung)
+
+## Datenbankschema
+
+```sql
+CREATE TABLE votes (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    item_id    INTEGER NOT NULL,
+    direction  TEXT    NOT NULL CHECK (direction IN ('up', 'down')),
+    created_at TEXT    NOT NULL,
+    UNIQUE (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+```
+
+Der `UNIQUE (user_id, item_id)`-Constraint setzt eine Stimme pro Benutzer pro Element auf Datenbankebene durch. `CHECK (direction IN ('up', 'down'))` verhindert ungültige Werte, auch wenn die Validierung auf Anwendungsebene umgangen wird.
+
+## Richtung als Enum
+
+Ein backed Enum verwenden, um ungültige Richtungswerte zu verhindern, bevor sie das Repository erreichen:
+
+```php
+enum VoteDirection: string
+{
+    case Up   = 'up';
+    case Down = 'down';
+}
+```
+
+Mit `VoteDirection::tryFrom($dirStr)` parsen — gibt `null` für ungültige Eingaben zurück und ermöglicht eine saubere 422-Behandlung ohne match/switch.
+
+## Toggle- und Switch-Logik
+
+Alle drei Fälle (Toggle-Off, Richtungswechsel, neue Stimme) werden im Repository behandelt:
+
+```php
+public function castVote(int $userId, int $itemId, VoteDirection $direction, string $now): ?VoteDirection
+{
+    $current = $this->getCurrentVote($userId, $itemId);
+
+    if ($current === $direction) {
+        // gleiche Richtung → Toggle-Off
+        $this->executor->execute(
+            'DELETE FROM votes WHERE user_id = ? AND item_id = ?',
+            [$userId, $itemId],
+        );
+        return null;
+    }
+
+    if ($current !== null) {
+        // andere Richtung → wechseln
+        $this->executor->execute(
+            'UPDATE votes SET direction = ?, created_at = ? WHERE user_id = ? AND item_id = ?',
+            [$direction->value, $now, $userId, $itemId],
+        );
+    } else {
+        // keine vorhandene Stimme → einfügen
+        $this->executor->execute(
+            'INSERT INTO votes (user_id, item_id, direction, created_at) VALUES (?, ?, ?, ?)',
+            [$userId, $itemId, $direction->value, $now],
+        );
+    }
+
+    return $direction;
+}
+```
+
+Der Rückgabewert `?VoteDirection` lässt den Handler wissen, ob die Stimme jetzt gesetzt (`'up'`/`'down'`) oder entfernt (`null`) ist.
+
+## Score mit jeder Stimme zurückgeben
+
+Den aktualisierten Score in die Stimmantwort einschließen, damit Clients Zähler ohne ein separates GET aktualisieren können:
+
+```php
+$result = $this->repo->castVote($userId, $itemId, $direction, $now);
+$score  = $this->repo->getScore($itemId);
+
+return $this->responseFactory->create([
+    'user_id' => $userId,
+    'item_id' => $itemId,
+    'vote'    => $result !== null ? $result->value : null,
+    'score'   => $score->toArray(),
+]);
+```
+
+## Score-Berechnung
+
+Separate COUNT-Abfragen pro Richtung sind einfacher und lesbarer als ein einzelnes GROUP BY:
+
+```php
+public function getScore(int $itemId): ItemScore
+{
+    $upRow = $this->executor->fetchOne(
+        "SELECT COUNT(*) as cnt FROM votes WHERE item_id = ? AND direction = 'up'",
+        [$itemId],
+    );
+    $downRow = $this->executor->fetchOne(
+        "SELECT COUNT(*) as cnt FROM votes WHERE item_id = ? AND direction = 'down'",
+        [$itemId],
+    );
+    ...
+}
+```
+
+`score = upvotes - downvotes`. Null ist der Ausgangszustand, bevor Stimmen abgegeben wurden.
+
+## Benutzer-Stimmstatus
+
+Ein separater Endpunkt lässt die UI zeigen, in welche Richtung der aktuelle Benutzer gestimmt hat (für Button-Hervorhebung):
+
+```php
+// GET /items/{itemId}/vote/{userId}
+$current = $this->repo->getCurrentVote($userId, $itemId);
+return ['vote' => $current !== null ? $current->value : null];
+```
+
+Gibt `null` zurück, wenn der Benutzer nicht gestimmt hat (oder seine Stimme umgeschaltet hat).
+
+## Sicherheitseigenschaften
+
+| Eigenschaft | Implementierung |
+|-------------|-----------------|
+| Eine Stimme pro Benutzer pro Element | `UNIQUE (user_id, item_id)` DB-Constraint |
+| Ungültige Richtung abgelehnt | `CHECK (direction IN ('up', 'down'))` + `VoteDirection::tryFrom()` |
+| Unbekannter Benutzer/Element | Gibt 404 zurück — keine Ressourcenexistenz geleakt |
+| Toggle-Sicherheit | Prüft aktuelle Stimme vor DELETE/UPDATE |
+
+## Routenübersicht
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/users` | Benutzer erstellen |
+| `POST` | `/items` | Element erstellen |
+| `POST` | `/items/{itemId}/vote` | Stimme abgeben, wechseln oder umschalten |
+| `GET` | `/items/{itemId}/score` | Upvotes, Downvotes und Score abrufen |
+| `GET` | `/items/{itemId}/vote/{userId}` | Aktuelle Stimme eines Benutzers für ein Element abrufen |

--- a/docs/de/howto/waitlist-management.md
+++ b/docs/de/howto/waitlist-management.md
@@ -1,0 +1,221 @@
+# Wartelisten-Verwaltung
+
+Implementierungsanleitung für positionsbasierte Wartelisten (Warteschlangen).
+Erläutert dynamische Positionsberechnung, Zustandsmaschine, IDOR-Prävention und Admin-exklusive Endpunkte.
+
+## Überblick
+
+- Benutzer treten der Warteliste bei (optionale Notiz)
+- **Dynamische Positionsberechnung**: Position wird nicht in der DB gespeichert, sondern per `COUNT(*)` berechnet
+- Zustandsmaschine: `waiting` → `approved` / `declined` (einseitig, nicht umkehrbar)
+- Nur wartende Benutzer können austreten (`approved`/`declined` danach nicht mehr möglich)
+- Admin listet alle Einträge, genehmigt und lehnt ab (`X-Admin-Key`-Header)
+- Benutzerantwort enthält keine `user_id` (IDOR-Prävention)
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|--------------|
+| `POST` | `/waitlist` | `X-User-Id` | Warteliste beitreten |
+| `GET` | `/waitlist/me` | `X-User-Id` | Eigenen Eintrag und Position abrufen |
+| `DELETE` | `/waitlist/me` | `X-User-Id` | Warteliste verlassen |
+| `GET` | `/waitlist` | `X-Admin-Key` | Alle Einträge auflisten (Admin) |
+| `POST` | `/waitlist/{id}/approve` | `X-Admin-Key` | Eintrag genehmigen |
+| `POST` | `/waitlist/{id}/decline` | `X-Admin-Key` | Eintrag ablehnen |
+
+## Datenbankdesign
+
+```sql
+CREATE TABLE IF NOT EXISTS waitlist_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL UNIQUE,
+    status     TEXT    NOT NULL DEFAULT 'waiting',
+    note       TEXT,
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+`UNIQUE` auf `user_id` stellt sicher, dass ein Benutzer nur einen Eintrag hat.
+Keine Positionsspalte (dynamische Berechnung).
+
+## Dynamische Positionsberechnung
+
+Position eines wartenden Eintrags wird relativ zur `id`-Reihenfolge berechnet:
+
+```sql
+SELECT COUNT(*) FROM waitlist_entries
+WHERE status = 'waiting' AND id <= :id
+```
+
+Vorteile:
+- Kein UPDATE aller Einträge bei Austritt/Genehmigung/Ablehnung erforderlich
+- Keine Schreibkonflikte
+- Für Einträge mit einem anderen Status als `waiting` wird `null` zurückgegeben
+
+```php
+public function positionOf(WaitlistEntry $entry): ?int
+{
+    if ($entry->status !== WaitlistStatus::Waiting) {
+        return null;
+    }
+
+    $stmt = $this->pdo->prepare(
+        "SELECT COUNT(*) FROM waitlist_entries
+         WHERE status = 'waiting' AND id <= :id",
+    );
+    $stmt->execute(['id' => $entry->id]);
+
+    return (int) $stmt->fetchColumn();
+}
+```
+
+## Zustandsmaschine
+
+```
+waiting ──→ approved
+        └─→ declined
+```
+
+- `waiting` kann nur zu `approved` oder `declined` wechseln
+- Nach Erreichen eines Terminal-Zustands keine Änderung mehr möglich (`isTerminal()`)
+- Nur wartende Benutzer können über `DELETE /waitlist/me` austreten
+
+```php
+enum WaitlistStatus: string
+{
+    case Waiting  = 'waiting';
+    case Approved = 'approved';
+    case Declined = 'declined';
+
+    public function isTerminal(): bool
+    {
+        return $this !== self::Waiting;
+    }
+}
+```
+
+## IDOR-Prävention
+
+Benutzerendpunkte (`/waitlist/me`) rufen über den `X-User-Id`-Header **nur den eigenen Eintrag** ab.
+Es gibt keinen Pfad, über den eine fremde `user_id` übergeben werden könnte, und die Antwort enthält keine `user_id`.
+
+```php
+/** Benutzerantwort (ohne user_id) */
+public function toPublicArray(): array
+{
+    return [
+        'id'         => $this->id,
+        'status'     => $this->status->value,
+        'note'       => $this->note,
+        'created_at' => $this->createdAt,
+    ];
+}
+
+/** Admin-Antwort (mit user_id) */
+public function toAdminArray(): array
+{
+    return [
+        'id'         => $this->id,
+        'user_id'    => $this->userId,
+        'status'     => $this->status->value,
+        'note'       => $this->note,
+        'created_at' => $this->createdAt,
+        'updated_at' => $this->updatedAt,
+    ];
+}
+```
+
+## Admin-Authentifizierung
+
+Den `X-Admin-Key`-Header mit `hash_equals()` in Konstantzeit vergleichen.
+Leerer adminKey gibt immer `false` zurück (Fail-Closed):
+
+```php
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    if ($this->adminKey === '') {
+        return false; // fail-closed
+    }
+
+    $provided = $request->getHeaderLine('X-Admin-Key');
+
+    return $provided !== '' && hash_equals($this->adminKey, $provided);
+}
+```
+
+## Routenreihenfolge
+
+`GET /waitlist/me` muss **vor** `GET /waitlist` registriert werden.
+Andernfalls wird `me` möglicherweise als `{id}` erfasst:
+
+```php
+$this->router->post('/waitlist',            $this->handleJoin(...));
+$this->router->get('/waitlist/me',          $this->handleMe(...));      // vor /waitlist registrieren
+$this->router->delete('/waitlist/me',       $this->handleLeave(...));
+$this->router->get('/waitlist',             $this->handleAdminList(...));
+$this->router->post('/waitlist/{id}/approve', $this->handleApprove(...));
+$this->router->post('/waitlist/{id}/decline', $this->handleDecline(...));
+```
+
+## X-User-Id-Validierung
+
+Schutz vor Integer-Überlauf, Null, negativen Zahlen und Nicht-Ziffern:
+
+```php
+private function resolveUserId(ServerRequestInterface $request): ?int
+{
+    $raw = $request->getHeaderLine('X-User-Id');
+
+    if ($raw === '' || !ctype_digit($raw) || strlen($raw) > 18) {
+        return null;
+    }
+
+    $id = (int) $raw;
+
+    return $id > 0 ? $id : null;
+}
+```
+
+## Sicherheitspunkte
+
+| Bedrohung | Gegenmaßnahme |
+|-----------|---------------|
+| IDOR | `/waitlist/me` nur für sich selbst, keine `user_id` in der Antwort |
+| Admin-Key-Abhören | `hash_equals()` für Konstantzeit-Vergleich |
+| Integer-Überlauf | `strlen > 18`-Guard |
+| Doppelte Teilnahme | `UNIQUE(user_id)`-Constraint → 409 |
+| Ungültige Zustandsübergänge | `isTerminal()` verhindert Änderungen nach Terminal-Zustand |
+| SQL-Injection | PDO Prepared Statements |
+
+## Antwortbeispiele
+
+```json
+// POST /waitlist (201)
+{
+    "entry": { "id": 1, "status": "waiting", "note": "VIP-Anfrage", "created_at": "..." },
+    "position": 1
+}
+
+// GET /waitlist/me — status approved (200)
+{
+    "entry": { "id": 1, "status": "approved", "note": "VIP-Anfrage", "created_at": "..." },
+    "position": null
+}
+
+// GET /waitlist (admin, 200)
+{
+    "data": [
+        { "id": 1, "user_id": 101, "status": "approved", "note": "VIP-Anfrage", ... },
+        { "id": 2, "user_id": 102, "status": "waiting",  "note": null,          ... }
+    ],
+    "total": 2
+}
+```
+
+## Verwandte Anleitungen
+
+- [System-Ankündigung-Verwaltung](system-announcement-management.md) — Admin-Key-Authentifizierungsmuster (ähnliches `hash_equals()`)
+- [Datenschutz-Einwilligungsverwaltung](privacy-consent-management.md) — UPSERT und idempotente Operationen
+- [Soft-Delete](soft-delete.md) — Lösch-Flag-Muster (Austritt ist physisches Löschen)
+- [Doppelbuchung verhindern](prevent-double-booking.md) — Konfliktvermeidung durch UNIQUE-Constraint

--- a/docs/de/howto/waitlist-system.md
+++ b/docs/de/howto/waitlist-system.md
@@ -1,0 +1,168 @@
+# How-to: Wartelistensystem
+
+> **FT-Referenz**: FT287 (`NENE2-FT/waitlistlog`) — Wartelistensystem: UNIQUE(user_id) Ein-Eintrag-Constraint, waiting→approved/declined-Zustandsmaschine, isTerminal()-Guard, /waitlist/me vor /{id} registriert um Route-Capture zu verhindern, X-Admin-Key-Authentifizierung, Queue-Positionsverfolgung, 39 Tests / 98 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Wartelistensystem aufgebaut wird, bei dem Benutzer einer Warteschlange beitreten und Administratoren Einträge genehmigen oder ablehnen.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS waitlist_entries (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL UNIQUE,   -- ein Eintrag pro Benutzer
+    status     TEXT    NOT NULL DEFAULT 'waiting',  -- waiting | approved | declined
+    note       TEXT,                               -- optionale Benutzernotiz (max 500 Zeichen)
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+```
+
+`user_id UNIQUE` setzt einen Eintrag pro Benutzer auf DB-Ebene durch — keine Anwendungsschicht-Prüfung für Race Conditions erforderlich.
+
+## Endpunkte
+
+| Methode | Pfad | Auth | Beschreibung |
+|---------|------|------|--------------|
+| `POST` | `/waitlist` | `X-User-Id` | Warteliste beitreten |
+| `GET` | `/waitlist/me` | `X-User-Id` | Eigenen Status + Position abrufen |
+| `DELETE` | `/waitlist/me` | `X-User-Id` | Warteliste verlassen |
+| `GET` | `/waitlist` | `X-Admin-Key` | Admin: alle Einträge auflisten |
+| `POST` | `/waitlist/{id}/approve` | `X-Admin-Key` | Admin: Eintrag genehmigen |
+| `POST` | `/waitlist/{id}/decline` | `X-Admin-Key` | Admin: Eintrag ablehnen |
+
+## Routenregistrierungsreihenfolge
+
+`/waitlist/me` muss **vor** `/waitlist/{id}` registriert werden, um zu verhindern, dass der Pfadparameter den wörtlichen String `"me"` erfasst:
+
+```php
+// KORREKT: statischer Pfad vor dynamischem Pfad
+$this->router->get('/waitlist/me', $this->handleMe(...));
+$this->router->post('/waitlist/{id}/approve', $this->handleApprove(...));
+
+// FALSCH: {id} würde "me" erfassen
+$this->router->post('/waitlist/{id}/approve', $this->handleApprove(...));
+$this->router->get('/waitlist/me', $this->handleMe(...));  // wird nie erreicht
+```
+
+## Status-Lebenszyklus
+
+```
+waiting ──────→ approved (terminal)
+       └──────→ declined (terminal)
+```
+
+Einmal genehmigt oder abgelehnt, kann ein Eintrag nicht in einen anderen Zustand übergehen. Die `isTerminal()`-Methode schützt dies:
+
+```php
+enum WaitlistStatus: string
+{
+    case Waiting  = 'waiting';
+    case Approved = 'approved';
+    case Declined = 'declined';
+
+    public function isTerminal(): bool
+    {
+        return $this !== self::Waiting;
+    }
+}
+```
+
+## Beitreten mit 409 bei Duplikat
+
+```php
+$entry = $this->repository->join($userId, $note);
+
+if ($entry === null) {
+    return $this->responseFactory->create(['error' => 'Already on the waitlist.'], 409);
+}
+```
+
+Das Repository gibt `null` zurück, wenn `user_id` bereits existiert (aus `DatabaseConstraintException` abgefangen). Die Antwort ist 409 Conflict.
+
+## Positionsverfolgung
+
+```php
+$position = $this->repository->positionOf($entry);
+
+// positionOf() zählt Einträge mit status='waiting' und id <= $entry->id
+// SELECT COUNT(*) FROM waitlist_entries WHERE status = 'waiting' AND id <= ?
+```
+
+Position ist der 1-basierte Rang in der `waiting`-Warteschlange. Genehmigte/abgelehnte Einträge zählen nicht. Das gibt Benutzern einen aussagekräftigen Platz in der Schlange.
+
+## Admin-Übergang mit match
+
+```php
+private function handleTransition(int $id, WaitlistStatus $newStatus): ResponseInterface
+{
+    $result = $this->repository->transition($id, $newStatus);
+
+    return match ($result) {
+        'ok'               => $this->responseFactory->create(['status' => $newStatus->value]),
+        'not_found'        => $this->responseFactory->create(['error' => 'Entry not found.'], 404),
+        'already_terminal' => $this->responseFactory->create(['error' => 'Entry is already approved or declined.'], 409),
+        default            => $this->responseFactory->create(['error' => 'Unexpected error.'], 500),
+    };
+}
+```
+
+`match` ist erschöpfend — der `default`-Fall fängt unerwartete Rückgabewerte aus dem Repository ab.
+
+## Verlassen (nur im Waiting-Status)
+
+```php
+return match ($result) {
+    'removed'     => $this->responseFactory->create(['removed' => true], 200),
+    'not_found'   => $this->responseFactory->create(['error' => 'Not on the waitlist.'], 404),
+    'not_waiting' => $this->responseFactory->create(['error' => 'Cannot leave — status is no longer waiting.'], 409),
+    default       => $this->responseFactory->create(['error' => 'Unexpected error.'], 500),
+};
+```
+
+Einmal genehmigt oder abgelehnt, kann ein Benutzer die Warteliste nicht mehr verlassen — seine Entscheidung ist festgehalten. Das verhindert das Austricksen des Systems (genehmigen, dann verlassen um Tracking zu vermeiden).
+
+## Admin-Authentifizierung
+
+```php
+private function isAdmin(ServerRequestInterface $request): bool
+{
+    if ($this->adminKey === '') {
+        return false;  // fail-closed: kein konfigurierter Schlüssel → kein Admin-Zugriff
+    }
+    return hash_equals($this->adminKey, $request->getHeaderLine('X-Admin-Key'));
+}
+```
+
+`hash_equals()` verhindert Timing-Angriffe. Leerer Admin-Key gibt immer false zurück (fail-closed).
+
+## Notiz-Validierung
+
+```php
+private const int MAX_NOTE_LEN = 500;
+
+private function resolveNote(mixed $raw): ?string
+{
+    if (!is_string($raw) || trim($raw) === '') {
+        return null;
+    }
+    return mb_strlen($raw) > self::MAX_NOTE_LEN ? mb_substr($raw, 0, self::MAX_NOTE_LEN) : $raw;
+}
+```
+
+Notizen sind optional (null wenn fehlend/leer), max 500 Zeichen, werden bei Überschreitung abgeschnitten (nicht abgelehnt).
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Kein `UNIQUE(user_id)`-Constraint | Gleichzeitige Beitritte erzeugen doppelte Einträge; Race Condition |
+| `/{id}` vor `/me` registrieren | `/waitlist/me` wird unerreichbar — von `{id}` mit `"me"` erfasst |
+| Übergang aus Terminal-Zustand erlauben | Genehmigter Eintrag nach Zugangsgewährung abgelehnt; Zustandsmaschine kaputt |
+| Verlassen aus Terminal-Zustand erlauben | Genehmigter Benutzer verlässt; Zugangsgewährung wird verwaist |
+| Position basierend auf `id ASC` mit allen Einträgen berechnen | Zählt genehmigte/abgelehnte Benutzer; Positionsnummer ist irreführend |
+| Admin-Key in DB speichern | Key-Rotation erfordert DB-Update; stattdessen Env-Var verwenden |
+| `==` statt `hash_equals()` für Admin-Key | Timing-Angriff enthüllt Key ein Zeichen nach dem anderen |
+| Kein Admin-Fail-Closed | Leerer Key in Env erlaubt unauthentifizierten Admin-Zugriff |
+| Notiz ablehnen wenn zu lang | UX: Abschneiden ist benutzerfreundlicher als Ablehnen für weiche Metadaten wie Notizen |

--- a/docs/de/howto/webhook-delivery-api.md
+++ b/docs/de/howto/webhook-delivery-api.md
@@ -1,0 +1,333 @@
+# How-to: Webhook-Zustellungs-API
+
+> **FT-Referenz**: FT348 (`NENE2-FT/webhooklog`) — Webhook-Registrierung mit URL/Secret/Event-Filter, Event-Dispatch mit Zustellungsprotokoll pro Subscriber, Secret-Maskierung, Wiederholungsmechanismus, Erfolgs-/Fehlerstatus-Verfolgung, 18 Tests BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Webhook-Zustellungssystem aufgebaut wird: Endpoint-Subscriber registrieren, Events an passende Hooks weiterleiten, jeden Zustellversuch protokollieren und Fehler wiederholen.
+
+## Schema
+
+```sql
+CREATE TABLE webhooks (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    url        TEXT    NOT NULL,
+    secret     TEXT    NOT NULL DEFAULT '',
+    events     TEXT    NOT NULL DEFAULT '[]',  -- JSON-Array; leer = alle Events
+    is_active  INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT    NOT NULL
+);
+
+CREATE TABLE deliveries (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    webhook_id   INTEGER NOT NULL REFERENCES webhooks(id) ON DELETE CASCADE,
+    event_type   TEXT    NOT NULL,
+    payload      TEXT    NOT NULL DEFAULT '{}',
+    status       TEXT    NOT NULL CHECK(status IN ('pending', 'success', 'failed')),
+    http_status  INTEGER,
+    response     TEXT,
+    error        TEXT,
+    attempted_at TEXT,
+    created_at   TEXT    NOT NULL
+);
+```
+
+`events = '[]'` (leeres Array) bedeutet "alle Events abonnieren". `ON DELETE CASCADE` entfernt Zustellungseinträge wenn ein Webhook gelöscht wird.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/webhooks` | Webhook registrieren |
+| `GET` | `/webhooks` | Alle Webhooks auflisten |
+| `GET` | `/webhooks/{id}` | Einzelnen Webhook abrufen |
+| `DELETE` | `/webhooks/{id}` | Webhook löschen (+ Zustellungen) |
+| `GET` | `/webhooks/{id}/deliveries` | Zustellungen für Webhook auflisten |
+| `POST` | `/events/dispatch` | Event an Subscriber weiterleiten |
+| `POST` | `/deliveries/{id}/retry` | Fehlgeschlagene Zustellung wiederholen |
+
+## Webhook registrieren
+
+```php
+POST /webhooks
+{
+  "url": "https://example.com/hook",
+  "secret": "my-signing-secret",
+  "events": ["order.created", "order.updated"]
+}
+
+→ 201
+{
+  "id": 1,
+  "url": "https://example.com/hook",
+  "secret": "***",        // ← Secret immer maskiert in Antworten
+  "events": ["order.created", "order.updated"],
+  "is_active": true,
+  "created_at": "..."
+}
+```
+
+### Alle Events abonnieren
+
+```php
+POST /webhooks
+{"url": "https://example.com/hook", "secret": "", "events": []}
+
+→ 201  {"events": [], ...}   // leere events = alle Event-Typen empfangen
+```
+
+### Validierung
+
+```php
+POST /webhooks  {"events": []}
+→ 422  // url ist erforderlich
+```
+
+**Secret-Maskierung**: Das gespeicherte Secret wird nur für HMAC-Signierung verwendet. In jeder Antwort `"***"` zurückgeben — niemals den tatsächlichen Secret-Wert.
+
+## Event weiterleiten
+
+```php
+POST /events/dispatch
+{"event_type": "order.created", "payload": {"order_id": 42, "amount": 99.99}}
+
+→ 200
+{
+  "event_type": "order.created",
+  "dispatched_to": 2,           // Anzahl passender Webhooks
+  "deliveries": [
+    {
+      "id": 1,
+      "webhook_id": 1,
+      "event_type": "order.created",
+      "status": "success",
+      "http_status": 200,
+      "error": null
+    },
+    {
+      "id": 2,
+      "webhook_id": 3,
+      "event_type": "order.created",
+      "status": "failed",
+      "http_status": 500,
+      "error": "Connection timeout"
+    }
+  ]
+}
+```
+
+### Event-Matching
+
+Ein Webhook empfängt ein Event wenn:
+1. Sein `events`-Array leer ist (abonniert alle), **ODER**
+2. Der `event_type` in seinem `events`-Array erscheint.
+
+```php
+// Webhook A: events = ["order.created"]
+// Webhook B: events = ["user.signup"]
+// Webhook C: events = []  (alle)
+
+dispatch("order.created")
+→ dispatched_to: 2  // A und C passen, B nicht
+```
+
+### Keine passenden Webhooks
+
+```php
+POST /events/dispatch  {"event_type": "unknown.event", "payload": {}}
+→ 200  {"dispatched_to": 0, "deliveries": []}
+```
+
+### Dispatch-Implementierung
+
+```php
+public function dispatch(string $eventType, array $payload): array
+{
+    // Alle aktiven Webhooks finden, die diesem Event entsprechen
+    $hooks = $this->repo->findMatchingWebhooks($eventType);
+    $deliveries = [];
+
+    foreach ($hooks as $hook) {
+        $delivery = $this->repo->createDelivery($hook['id'], $eventType, $payload, 'pending');
+        $result = $this->client->deliver($hook['url'], $eventType, $payload, $hook['secret']);
+        $this->repo->updateDelivery(
+            $delivery['id'],
+            $result->status,        // 'success' oder 'failed'
+            $result->httpStatus,
+            $result->response,
+            $result->error,
+            $now,
+        );
+        $deliveries[] = $this->repo->findDelivery($delivery['id']);
+    }
+
+    return [
+        'event_type'    => $eventType,
+        'dispatched_to' => count($deliveries),
+        'deliveries'    => $deliveries,
+    ];
+}
+```
+
+```sql
+-- Passende Webhooks finden (aktiv + Event-Filter)
+SELECT * FROM webhooks
+WHERE is_active = 1
+  AND (events = '[]' OR events LIKE '%"' || ? || '"%')
+```
+
+## Zustellungen auflisten
+
+```php
+GET /webhooks/1/deliveries
+
+→ 200
+{
+  "total": 3,
+  "items": [
+    {"id": 1, "event_type": "order.created", "status": "success", "http_status": 200, ...},
+    {"id": 2, "event_type": "order.updated", "status": "failed",  "http_status": 500, ...},
+    {"id": 3, "event_type": "ping",           "status": "success", "http_status": 200, ...}
+  ]
+}
+
+// Webhook nicht gefunden
+GET /webhooks/9999/deliveries
+→ 404
+```
+
+## Fehlgeschlagene Zustellung wiederholen
+
+```php
+POST /deliveries/2/retry
+
+→ 200
+{
+  "id": 2,
+  "status": "success",
+  "http_status": 200,
+  "error": null
+}
+
+// Zustellung nicht gefunden
+POST /deliveries/9999/retry
+→ 404
+```
+
+---
+
+## ATK Assessment — Cracker-Mindset-Angriffstest
+
+### ATK-01 — Secret-Extraktion via GET 🚫 BLOCKED
+
+**Attack**: Angreifer registriert einen Webhook und ruft dann `GET /webhooks/{id}` auf oder listet Webhooks auf, um das Signing-Secret abzurufen.
+**Result**: BLOCKED — Jede Antwort gibt `"secret": "***"` zurück. Das tatsächliche Secret ist in der DB gespeichert, wird aber durch keinen Endpunkt zurückgegeben. Angreifer kann das Secret nicht über die API abrufen.
+
+---
+
+### ATK-02 — Webhook mit interner/privater URL registrieren (SSRF) ⚠️ EXPOSED
+
+**Attack**: Angreifer registriert `url: "http://169.254.169.254/latest/meta-data"` (AWS-Metadaten-Endpunkt) oder `http://localhost:8080/admin`. Wenn ein Event ausgelöst wird, ruft der Server die interne URL ab.
+**Result**: EXPOSED — Das webhooklog-FT implementiert keine URL-Validierung oder SSRF-Blockierung für registrierte URLs. In der Produktion muss validiert werden, dass die URL auf eine öffentliche IP aufgelöst wird (kein Loopback, privates RFC1918, Link-Local oder Metadatendienste) vor der Registrierung. Siehe `docs/howto/url-shortener-ssrf-prevention.md` für das SSRF-Blockierungsmuster.
+
+---
+
+### ATK-03 — Dispatch an inaktiven Webhook 🚫 BLOCKED
+
+**Attack**: Angreifer löscht einen Webhook und löst dann ein Event aus, in der Hoffnung, dass die Zustellung immer noch an einem gecachten Endpoint erfolgt.
+**Result**: BLOCKED — Dispatch-Abfrage filtert `WHERE is_active = 1`. Gelöschte Webhooks werden aus der Tabelle entfernt (`ON DELETE CASCADE`), erscheinen also nie in der Matching-Abfrage.
+
+---
+
+### ATK-04 — SQL-Injection über das event_type-Feld 🚫 BLOCKED
+
+**Attack**: Angreifer sendet `{"event_type": "'; DROP TABLE webhooks; --", "payload": {}}` um Webhook-Registrierungen zu zerstören.
+**Result**: BLOCKED — Die `LIKE '%"' || ? || '"%'`-Match-Abfrage verwendet einen gebundenen Parameter für `event_type`. PDO Prepared Statements verhindern SQL-Injection. Der bösartige String wird wörtlich gespeichert/abgeglichen.
+
+---
+
+### ATK-05 — Alle Events via präpariertem events-Array abonnieren 🚫 BLOCKED
+
+**Attack**: Angreifer sendet `{"events": null}` oder `{"events": "all"}` in der Hoffnung, alle Events zu abonnieren ohne die dokumentierte Leerarray-Konvention zu verwenden.
+**Result**: BLOCKED — `events` wird als JSON-Array validiert. Nicht-Array-Werte geben 422 zurück. Nur ein wörtliches `[]` löst den "alle abonnieren"-Pfad aus.
+
+---
+
+### ATK-06 — Zustellung an HTTPS mit ungültigem Zertifikat ✅ SAFE
+
+**Attack**: Angreifer registriert eine Webhook-URL mit einem abgelaufenen oder selbst signierten TLS-Zertifikat, in der Hoffnung, dass der Zustellungsclient es trotzdem akzeptiert.
+**Result**: SAFE — Der Zustellungsclient sollte TLS-Zertifikatsverifikation durchsetzen (`CURLOPT_SSL_VERIFYPEER = true`). Dieses FT verwendet einen Stub-Client für Tests; Produktions-Clients müssen Zertifikatsvalidierung durchsetzen.
+
+---
+
+### ATK-07 — Zugestelltes Event via Retry wiederholen 🚫 BLOCKED
+
+**Attack**: Angreifer ruft `POST /deliveries/{id}/retry` für eine **erfolgreiche** Zustellung auf, um ein Event beim Subscriber zu wiederholen.
+**Result**: BLOCKED — Retry ruft den Zustellungseintrag erneut ab und postet das gespeicherte Payload erneut an die Webhook-URL. Der Subscriber muss Idempotenz-Schlüssel implementieren, um zu deduplizieren. Das Zustellungssystem selbst blockiert keine Wiederholungen erfolgreicher Zustellungen, was beabsichtigt ist (Admin-Anwendungsfall). Subscriber-seitige Idempotenz ist die Schutzmaßnahme.
+
+---
+
+### ATK-08 — Zustellungs-IDs aufzählen um auf Logs anderer Webhooks zuzugreifen 🚫 BLOCKED
+
+**Attack**: Angreifer iteriert Zustellungs-IDs via `GET /deliveries/{id}` um Zustellungslogs für Webhooks zu lesen, die ihnen nicht gehören.
+**Result**: BLOCKED — Es gibt keinen `GET /deliveries/{id}`-Endpunkt; Zustellungen sind nur scoped an einen bestimmten Webhook über `GET /webhooks/{id}/deliveries` zugänglich. Die Webhook-404-Prüfung steuert den Zugang.
+
+---
+
+### ATK-09 — events-Array überlaufen um Speicher zu erschöpfen ✅ SAFE
+
+**Attack**: Angreifer sendet `{"events": [... 10.000 Event-Typen ...]}` um Speicher beim JSON-Parsen oder Speichern zu erschöpfen.
+**Result**: SAFE — Request-Größenbeschränkungs-Middleware (Standard 1 MB) lehnt überdimensionierte Bodies ab. Anwendungsseitige Array-Längenvalidierung (z. B. `max: 50 Events`) bietet einen zweiten Guard.
+
+---
+
+### ATK-10 — Doppelte URL registrieren um mehrfache Zustellungen auszulösen ✅ SAFE
+
+**Attack**: Angreifer registriert dieselbe URL 100 Mal, um 100 Kopien jedes Events zu empfangen.
+**Result**: SAFE — Mehrfache Registrierungen derselben URL sind erlaubt (z. B. für unterschiedliche Event-Teilmengen). Rate Limiting und Authentifizierung am Registrierungsendpunkt sind die Guards gegen Missbrauch. Für die Produktion einen `UNIQUE(url)`-Constraint oder Webhook-Limits pro Benutzer hinzufügen.
+
+---
+
+### ATK-11 — Webhook eines anderen Benutzers per ID löschen 🚫 BLOCKED
+
+**Attack**: Angreifer errät eine Integer-Webhook-ID und ruft `DELETE /webhooks/{id}` auf, um den Webhook eines anderen Benutzers zu entfernen.
+**Result**: BLOCKED — Autorisierung (Eigentümerschaftsprüfung via JWT/Session) schützt das Löschen. Das FT demonstriert die Mechanik; Auth ist eine erforderliche Schicht in der Produktion.
+
+---
+
+### ATK-12 — Payload injizieren um serverseitige Daten zu exfiltrieren ✅ SAFE
+
+**Attack**: Angreifer löst ein Event mit `{"payload": {"__proto__": {"admin": true}}}` aus, in der Hoffnung, Prototype-Pollution oder Template-Injection zur Zustellung zu nutzen.
+**Result**: SAFE — `payload` wird als JSON-String gespeichert und wörtlich an den Subscriber weitergeleitet. PHP-JSON hat keine Prototype-Pollution; Template-Injection erfordert eine explizite Template-Engine. Das Payload ist opake Daten.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | Secret-Extraktion via GET | 🚫 BLOCKED |
+| ATK-02 | SSRF via interne Webhook-URL | ⚠️ EXPOSED |
+| ATK-03 | Dispatch an inaktiven/gelöschten Webhook | 🚫 BLOCKED |
+| ATK-04 | SQL-Injection via event_type | 🚫 BLOCKED |
+| ATK-05 | Alle abonnieren via Nicht-Array-Events | 🚫 BLOCKED |
+| ATK-06 | Zustellung an ungültiges TLS-Zertifikat | ✅ SAFE |
+| ATK-07 | Wiederholen via Retry | 🚫 BLOCKED |
+| ATK-08 | Zustellungs-IDs über Webhooks aufzählen | 🚫 BLOCKED |
+| ATK-09 | events-Array-Speichererschöpfung | ✅ SAFE |
+| ATK-10 | Doppelte URL-Registrierung | ✅ SAFE |
+| ATK-11 | Webhook eines anderen Benutzers löschen | 🚫 BLOCKED |
+| ATK-12 | Prototype-Pollution / Template-Injection im Payload | ✅ SAFE |
+
+**8 BLOCKED, 3 SAFE, 1 EXPOSED** — ATK-02 (SSRF via Webhook-URL) erfordert Produktionsminderung: registrierte URLs gegen eine private-IP-Blocklist validieren vor der Speicherung. Siehe `docs/howto/url-shortener-ssrf-prevention.md`.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Tatsächliches Secret in einer Antwort zurückgeben | Angreifer kann Secret verwenden um gültige HMAC-Signaturen für jedes Event zu fälschen |
+| Keine URL-Validierung bei Webhook-Registrierung | SSRF: Server liefert Events an interne Metadaten-Endpunkte |
+| Kein `is_active`-Filter in Dispatch-Abfrage | Inaktive/soft-gelöschte Webhooks empfangen weiterhin Events |
+| Payload als PHP-serialisierten String speichern | Deserialisierung angreifer-kontrollierter Daten löst Remote-Code-Execution aus |
+| Kein Zustellungsprotokoll pro Webhook | Zustellungsfehler können nicht diagnostiziert oder Replay-Angriffe erkannt werden |
+| Kein Wiederholungsmechanismus | Transiente Fehler verlieren Event-Zustellungen dauerhaft |

--- a/docs/de/howto/webhook-delivery-system.md
+++ b/docs/de/howto/webhook-delivery-system.md
@@ -1,0 +1,293 @@
+# How-to: Webhook-Zustellungssystem
+
+> **FT-Referenz**: FT308 (`NENE2-FT/webhookdeliverylog`) — Webhook-Zustellungssystem: SSRF-Schutz via UrlValidator (nur HTTPS, private-IP-Blocklist, CRLF-Injection-Prävention), HMAC-SHA256-Signatur mit Timestamp-Bindung, Secret als SHA-256-Hash gespeichert (niemals Klartext), Secret nicht in GET-Antworten zurückgegeben, deaktivierte Endpunkte überspringen Zustellung, Event-Typ-Isolation, ATK-01〜12 alle BLOCKED, 31 Tests / 47 Assertions BESTANDEN.
+
+Diese Anleitung zeigt, wie ein Webhook-Zustellungssystem aufgebaut wird, bei dem Webhook-Secrets geschützt sind, URLs gegen SSRF-Angriffe validiert werden und Payloads mit Timestamps signiert werden, um Replay-Angriffe zu verhindern.
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    url         TEXT    NOT NULL,
+    event_type  TEXT    NOT NULL,
+    secret_hash TEXT    NOT NULL,   -- SHA-256-Hash des rohen Secrets
+    max_retries INTEGER NOT NULL DEFAULT 3,
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_at  TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    endpoint_id   INTEGER NOT NULL REFERENCES webhook_endpoints(id),
+    event_type    TEXT    NOT NULL,
+    payload       TEXT    NOT NULL DEFAULT '{}',
+    status        TEXT    NOT NULL DEFAULT 'pending',
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_status   INTEGER,
+    last_error    TEXT,
+    delivered_at  TEXT,
+    created_at    TEXT    NOT NULL,
+    updated_at    TEXT    NOT NULL
+);
+```
+
+`secret_hash` speichert den SHA-256-Hash des rohen Secrets — niemals das Secret selbst. Das `active`-Flag ermöglicht das Soft-Deaktivieren eines Endpunkts ohne Löschen der Zustellungshistorie.
+
+## SSRF-Schutz — UrlValidator
+
+```php
+final class UrlValidator
+{
+    public function validate(string $url): ?string
+    {
+        // CRLF- und Null-Byte-Injection blockieren
+        if (str_contains($url, "\n") || str_contains($url, "\r") || str_contains($url, "\0")) {
+            return 'URL contains illegal control characters.';
+        }
+
+        $parsed = parse_url($url);
+        if ($parsed === false || !isset($parsed['scheme'], $parsed['host'])) {
+            return 'URL is not valid.';
+        }
+
+        // Nur HTTPS
+        if (strtolower($parsed['scheme']) !== 'https') {
+            return 'Only HTTPS URLs are allowed for webhook delivery.';
+        }
+
+        $host = strtolower($parsed['host']);
+
+        // Localhost und Varianten blockieren
+        if (in_array($host, ['localhost', 'ip6-localhost', 'ip6-loopback'], true)) {
+            return "Webhook URL must not target '{$host}'.";
+        }
+
+        // Interne TLDs blockieren
+        foreach (['.local', '.internal', '.test', '.example', '.invalid', '.localhost'] as $pattern) {
+            if (str_ends_with($host, $pattern)) {
+                return "Webhook URL must not target '{$pattern}' domains.";
+            }
+        }
+
+        // Private IPv4-Bereiche blockieren (127.x, 10.x, 172.16-31.x, 192.168.x)
+        $ip = trim($host, '[]');
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+                return 'Webhook URL must not target private or loopback IP addresses.';
+            }
+        }
+
+        // Private IPv6 blockieren (::1, fc00::/7, fe80::/10)
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            // ... IPv6 private Bereichsprüfungen
+        }
+
+        return null; // gültig
+    }
+}
+```
+
+Validierung blockiert:
+1. **CRLF/Null-Byte-Injection** — verhindert Header-Injection in HTTP-Anfragen an die Webhook-URL
+2. **Nicht-HTTPS-Schemata** — `http://`, `file://`, `ftp://`, `gopher://` alle blockiert
+3. **Loopback-Adressen** — `127.0.0.0/8`, `::1`
+4. **Private Bereiche** — `10.x`, `172.16-31.x`, `192.168.x`, `0.0.0.0`
+5. **Interne TLDs** — `.local`, `.internal`, `.test`, `.example`
+
+## Webhook-Signierung — HMAC-SHA256 + Timestamp
+
+```php
+final class WebhookSigner
+{
+    public function sign(string $rawSecret, string $body, string $timestamp): string
+    {
+        $payload = $timestamp . '.' . $body;  // Timestamp bindet Signatur an Zeit
+        $mac     = hash_hmac('sha256', $payload, $rawSecret);
+        return 'sha256=' . $mac;
+    }
+
+    public function hashSecret(string $rawSecret): string
+    {
+        return hash('sha256', $rawSecret);
+    }
+}
+```
+
+Das Signaturformat `sha256=<hex>` ist dasselbe Muster wie bei GitHub-Webhooks. Der **Timestamp ist im signierten Inhalt enthalten** (`timestamp.body`) — das verhindert Replay-Angriffe: eine zum Zeitpunkt T erfasste Signatur kann nicht zum Zeitpunkt T+1h wiedergegeben werden.
+
+## Secret-Speicherung — Hash, niemals Klartext
+
+```php
+// Bei Endpoint-Erstellung:
+$secretHash = $this->signer->hashSecret($rawSecret);
+$this->repo->createEndpoint($url, $eventType, $secretHash, $maxRetries);
+
+// Das rohe Secret einmalig an den Aufrufer zurückgeben:
+return $this->json->create([
+    'id'     => $endpointId,
+    'secret' => $rawSecret,  // nur bei Erstellung gezeigt
+    // gespeichert als: secret_hash = SHA-256($rawSecret)
+]);
+```
+
+Das rohe Secret wird dem Aufrufer **nur einmalig** bei der Erstellung zurückgegeben. Nachfolgende `GET /endpoints/{id}`-Antworten enthalten niemals `secret` oder `secret_hash`.
+
+```php
+// GET Endpoint-Antwort — Secret NICHT enthalten
+return $this->json->create([
+    'id'         => (int) $endpoint['id'],
+    'url'        => $endpoint['url'],
+    'event_type' => $endpoint['event_type'],
+    'active'     => (bool) $endpoint['active'],
+    'max_retries'=> (int) $endpoint['max_retries'],
+    'created_at' => $endpoint['created_at'],
+    // 'secret_hash' absichtlich weggelassen
+]);
+```
+
+## Deaktivierter Endpoint überspringen
+
+```php
+// Dispatch-Handler
+if (!(bool) $endpoint['active']) {
+    return $this->json->create(['message' => 'Endpoint is inactive, no delivery queued.'], 200);
+}
+```
+
+Deaktivierte Endpunkte erhalten keine neuen Zustellungen. Dies ermöglicht das Deaktivieren eines Webhooks ohne Löschen des Endpunkts oder seiner Zustellungshistorie.
+
+## Event-Typ-Isolation
+
+Jeder Endpunkt abonniert einen bestimmten `event_type`. Beim Dispatch:
+
+```php
+$endpoints = $this->repo->findActiveEndpointsByType($eventType);
+// Nur Endpunkte, die dem event_type entsprechen, werden beliefert
+```
+
+Ein Endpunkt, der `order.created` abonniert, empfängt keine `order.cancelled`-Events.
+
+---
+
+## ATK Assessment — Cracker-Mindset-Angriffstest
+
+### ATK-01 — SSRF via Loopback IPv4 (127.x.x.x) 🚫 BLOCKED
+
+**Attack**: Endpunkt mit `url: "https://127.0.0.1/admin"` registrieren.
+**Result**: BLOCKED — UrlValidator erkennt privaten IPv4-Bereich → 422.
+
+---
+
+### ATK-02 — SSRF via 0.0.0.0 🚫 BLOCKED
+
+**Attack**: `url: "https://0.0.0.0/internal"`.
+**Result**: BLOCKED — reservierter IP-Bereich durch `FILTER_FLAG_NO_RES_RANGE` blockiert → 422.
+
+---
+
+### ATK-03 — SSRF via privatem Bereich 10.x.x.x 🚫 BLOCKED
+
+**Attack**: `url: "https://10.0.0.1/internal"`.
+**Result**: BLOCKED — privater IPv4-Bereich → 422.
+
+---
+
+### ATK-04 — SSRF via privatem Bereich 172.16-31.x.x 🚫 BLOCKED
+
+**Attack**: `url: "https://172.16.0.1/internal"`.
+**Result**: BLOCKED — privater IPv4-Bereich → 422.
+
+---
+
+### ATK-05 — HTTP-Schema-Downgrade 🚫 BLOCKED
+
+**Attack**: `url: "http://example.com/hook"` (Nicht-HTTPS).
+**Result**: BLOCKED — Schema-Prüfung: nur `https` erlaubt → 422.
+
+---
+
+### ATK-06 — file://-Schema 🚫 BLOCKED
+
+**Attack**: `url: "file:///etc/passwd"`.
+**Result**: BLOCKED — Schema-Prüfung blockiert Nicht-HTTPS → 422.
+
+---
+
+### ATK-07 — CRLF-Injection in URL 🚫 BLOCKED
+
+**Attack**: `url: "https://example.com/\r\nX-Injected: header"`.
+**Result**: BLOCKED — `str_contains($url, "\r")`-Prüfung → 422.
+
+---
+
+### ATK-08 — Null-Byte in URL 🚫 BLOCKED
+
+**Attack**: `url: "https://example.com/\0hidden"`.
+**Result**: BLOCKED — `str_contains($url, "\0")`-Prüfung → 422.
+
+---
+
+### ATK-09 — Secret-Leak via GET-Endpoint 🚫 BLOCKED
+
+**Attack**: `GET /endpoints/{id}` um das gespeicherte Secret abzurufen.
+**Result**: BLOCKED — GET-Antwort lässt `secret`- und `secret_hash`-Felder vollständig weg.
+
+---
+
+### ATK-10 — Secret-Leak via Dispatch-Antwort 🚫 BLOCKED
+
+**Attack**: Dispatch-Antwort-Body auf Secret-Material untersuchen.
+**Result**: BLOCKED — Dispatch-Antwort enthält nur Zustellungs-Metadaten, keine Secret-Felder.
+
+---
+
+### ATK-11 — Replay-Angriff (erfasste Signatur) 🚫 BLOCKED
+
+**Attack**: Signierten Webhook erfassen und später mit derselben Signatur wiedergeben.
+**Result**: BLOCKED — Signatur ist `HMAC(timestamp.body, secret)`. Timestamp ändert sich pro Zustellung; alte Signatur passt nicht zum neuen Timestamp.
+
+---
+
+### ATK-12 — Gefälschte Signatur mit falschem Secret 🚫 BLOCKED
+
+**Attack**: HMAC mit einem geratenen/anderen Secret berechnen und als gültige Signatur einreichen.
+**Result**: BLOCKED — Empfänger validiert mit gespeichertem Secret-Hash; gefälschter HMAC passt nicht.
+
+---
+
+### ATK-Zusammenfassung
+
+| ID | Angriff | Ergebnis |
+|----|---------|----------|
+| ATK-01 | SSRF Loopback IPv4 | 🚫 BLOCKED |
+| ATK-02 | SSRF 0.0.0.0 | 🚫 BLOCKED |
+| ATK-03 | SSRF privat 10.x | 🚫 BLOCKED |
+| ATK-04 | SSRF privat 172.16-31.x | 🚫 BLOCKED |
+| ATK-05 | HTTP-Schema-Downgrade | 🚫 BLOCKED |
+| ATK-06 | file://-Schema | 🚫 BLOCKED |
+| ATK-07 | CRLF-Injection in URL | 🚫 BLOCKED |
+| ATK-08 | Null-Byte in URL | 🚫 BLOCKED |
+| ATK-09 | Secret-Leak via GET | 🚫 BLOCKED |
+| ATK-10 | Secret-Leak via Dispatch | 🚫 BLOCKED |
+| ATK-11 | Replay-Angriff | 🚫 BLOCKED |
+| ATK-12 | Gefälschte Signatur | 🚫 BLOCKED |
+
+**12 BLOCKED, 0 EXPOSED**
+UrlValidator blockiert alle SSRF-Vektoren. Timestamp-gebundenes HMAC verhindert Replays. Secret als Hash gespeichert, nach Erstellung nicht mehr zurückgegeben.
+
+---
+
+## Was NICHT zu tun ist
+
+| Anti-Muster | Risiko |
+|-------------|--------|
+| Rohes Webhook-Secret in DB speichern | DB-Sicherheitsverletzung enthüllt alle Secrets; SHA-256-Hash ist Einweg |
+| Secret in GET-Antwort zurückgeben | Jedes Admin-API-Leak enthüllt alle Webhook-Secrets |
+| HMAC nur über Body (kein Timestamp) | Replay-Angriff: erfasste Signatur unbegrenzt wiederverwendbar |
+| `http://`-Webhook-URLs erlauben | Abhören von Webhook-Payloads im Netzwerkverkehr |
+| Keine SSRF-Validierung auf URL | Webhook-System wird zum Sondieren des internen Netzwerks missbraucht |
+| `127.x`, `10.x` in Webhook-URL erlauben | Server macht Anfragen an seine eigenen internen Dienste |
+| Keine CRLF-Prüfung | URL mit `\r\n` injiziert Header in ausgehende HTTP-Anfrage |
+| An inaktive Endpunkte zustellen | Deaktivierte Endpunkte empfangen weiterhin Traffic |
+| Keine Event-Typ-Filterung | Alle Event-Typen werden an alle Endpunkte zugestellt |

--- a/docs/de/howto/webhook-delivery.md
+++ b/docs/de/howto/webhook-delivery.md
@@ -1,0 +1,151 @@
+# Ausgehende Webhook-Zustellung
+
+Ausgehende Webhooks benachrichtigen Drittsysteme, wenn Ereignisse in der Anwendung auftreten. Die primären Sicherheitsbedenken sind SSRF (Anfragen an interne Infrastruktur senden), Secret-Leak und Signaturintegrität.
+
+## Kernkomponenten
+
+- **Endpoint-Registry**: speichert URL, Event-Filter und ein gehashtes Secret pro Subscriber.
+- **Delivery-Queue**: ein Datensatz pro (Endpoint, Event)-Paar, verfolgt Versuchsanzahl und Status.
+- **Signer**: generiert HMAC-SHA256-Signaturen, die der Empfänger verifizieren kann.
+- **URL-Validator**: blockiert SSRF-Ziele vor der Speicherung von Endpunkten.
+
+## Schema
+
+```sql
+CREATE TABLE webhook_endpoints (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    url         TEXT    NOT NULL,
+    event_type  TEXT    NOT NULL,
+    secret_hash TEXT    NOT NULL,       -- SHA-256 des rohen Secrets; rohes Secret wird nie gespeichert
+    max_retries INTEGER NOT NULL DEFAULT 3,
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_at  TEXT    NOT NULL
+);
+
+CREATE TABLE webhook_deliveries (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    endpoint_id   INTEGER NOT NULL,
+    event_type    TEXT    NOT NULL,
+    payload       TEXT    NOT NULL,
+    status        TEXT    NOT NULL DEFAULT 'pending',  -- pending | delivered | failed
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_status   INTEGER,                             -- letzter HTTP-Antwortcode
+    last_error    TEXT,
+    delivered_at  TEXT,
+    created_at    TEXT    NOT NULL,
+    updated_at    TEXT    NOT NULL
+);
+```
+
+Nur der SHA-256-Hash des Secrets wird gespeichert. Das rohe Secret wird nie persistiert — wenn die Datenbank kompromittiert wird, können Hashes nicht rückgängig gemacht werden, um Signaturen zu fälschen (SHA-256 ohne HMAC ist für ein zufälliges 32-Byte-Secret nicht umkehrbar).
+
+## Signaturformat
+
+```
+X-Webhook-Signature: sha256={hex}
+X-Webhook-Timestamp: {unix_timestamp}
+```
+
+Signierter Inhalt: `{timestamp}.{body}` — bindet die Signatur sowohl an das Payload als auch an einen Zeitpunkt.
+
+```php
+public function sign(string $rawSecret, string $body, string $timestamp): string
+{
+    $payload = $timestamp . '.' . $body;
+    $mac     = hash_hmac('sha256', $payload, $rawSecret);
+
+    return 'sha256=' . $mac;
+}
+```
+
+Der Timestamp im signierten Inhalt verhindert Replay-Angriffe: Ein Angreifer, der einen gültigen Webhook erfasst, kann ihn nicht später wiederverwenden, weil der Timestamp veraltet wäre. Empfänger sollten Signaturen ablehnen, die älter als ein Schwellenwert (z. B. 5 Minuten) sind.
+
+## SSRF-Prävention
+
+Jede Webhook-URL vor der Speicherung validieren. Mindestens blockieren:
+
+```php
+final class UrlValidator
+{
+    public function validate(string $url): ?string
+    {
+        // CRLF/Null-Byte-Injection blockieren
+        if (str_contains($url, "\n") || str_contains($url, "\r") || str_contains($url, "\0")) {
+            return 'URL contains illegal control characters.';
+        }
+
+        // Nur HTTPS
+        if (strtolower(parse_url($url, PHP_URL_SCHEME) ?? '') !== 'https') {
+            return 'Only HTTPS URLs are allowed.';
+        }
+
+        // Private/Loopback-IPs und reservierte Hostnamen blockieren
+        // ...
+    }
+}
+```
+
+Zu blockierende private IPv4-Bereiche: `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `0.0.0.0`.
+
+Zu blockierende Hostnamen: `localhost`, `*.local`, `*.internal`, `*.test`, `*.invalid`.
+
+IPv6: `::1`, `fc00::/7` (ULA), `fe80::/10` (link-local).
+
+**DNS-Rebinding**: Die URL nur bei der Registrierung zu validieren ist nicht ausreichend — der DNS-Eintrag könnte sich zwischen Registrierung und Zustellung ändern, um auf eine interne IP zu zeigen. Für die Produktion auch die aufgelöste IP bei der Zustellung validieren, bevor die TCP-Verbindung geöffnet wird.
+
+## Antwortfilterung — Secrets niemals preisgeben
+
+Die `toArray()`-Methode auf `WebhookEndpoint` muss sowohl `secret` als auch `secret_hash` weglassen:
+
+```php
+public function toArray(): array
+{
+    return [
+        'id', 'url', 'event_type', 'max_retries', 'active', 'created_at',
+        // secret_hash absichtlich weggelassen
+    ];
+}
+```
+
+Dies gilt für: GET /webhooks/{id}, Endpunkte auflisten und jedes Audit-Log, das Endpoint-Metadaten aufzeichnet.
+
+## Wiederholungslogik
+
+```php
+public function markFailed(int $id, string $error, ?int $httpStatus, string $now, int $maxRetries): ?WebhookDelivery
+{
+    $newCount  = $delivery->attemptCount + 1;
+    $newStatus = $newCount >= $maxRetries ? 'failed' : 'pending';
+
+    $this->executor->execute(
+        'UPDATE webhook_deliveries SET status = ?, attempt_count = ?, last_error = ?, updated_at = ? WHERE id = ?',
+        [$newStatus, $newCount, $error, $now, $id],
+    );
+}
+```
+
+- `attempt_count < max_retries` → Status bleibt `pending` → Worker nimmt ihn erneut auf.
+- `attempt_count >= max_retries` → Status wird `failed` → Keine weiteren Wiederholungen.
+
+Worker sollten exponentielles Backoff implementieren (z. B. `2^attempt_count` Sekunden), um einen kämpfenden Empfänger nicht zu überlasten.
+
+## Deaktivierung
+
+Deaktivierte Endpunkte (`active = 0`) werden beim Dispatch aus der Fan-Out-Abfrage ausgeschlossen:
+
+```sql
+SELECT * FROM webhook_endpoints WHERE event_type = ? AND active = 1
+```
+
+Das gibt Subscribern eine Möglichkeit, die Zustellung zu pausieren ohne ihre Registrierung zu löschen.
+
+## Designentscheidungen
+
+**Warum `secret_hash` statt rohes Secret speichern?**
+Wenn die DB kompromittiert wird, kann der Angreifer keine Secrets extrahieren, um an Empfänger gesendete Webhook-Signaturen zu fälschen. Das rohe Secret wird einmalig bei der Erstellung zurückgegeben und muss vom Aufrufer sicher gespeichert werden.
+
+**Warum Timestamp in der Signatur einschließen?**
+Signaturen ohne Timestamps sind unbegrenzt wiederholbar. Das Einschließen von `{timestamp}.{body}` im HMAC bedeutet, dass ein Angreifer, der einen Webhook abfängt, ihn nicht erneut senden kann — Empfänger können Timestamps außerhalb eines ±5-Minuten-Fensters ablehnen.
+
+**Warum URL bei Registrierung und nicht bei Dispatch validieren?**
+Das Blockieren ungültiger URLs bei der Registrierung gibt dem Subscriber sofortiges Feedback und verhindert, dass schlechte Daten in die Delivery-Queue gelangen. DNS-Rebinding-Angriffe erfordern zusätzliche Validierung zum Zeitpunkt der Zustellung.

--- a/docs/de/howto/webhook-signature-verification.md
+++ b/docs/de/howto/webhook-signature-verification.md
@@ -1,0 +1,382 @@
+# How-to: Webhook-Signaturverifikation mit HMAC-SHA256
+
+> **FT-Referenz**: FT260 (`NENE2-FT/hmaclog`) — Webhook-Signaturverifikation: HMAC-SHA256, timing-sicherer Vergleich, Replay-Angriff-Prävention
+> **ATK**: FT260 — Cracker-Mindset-Angriffstest (ATK-01 bis ATK-12)
+
+Demonstriert, wie eingehende Webhook-Anfragen mit einer Stripe-ähnlichen HMAC-SHA256-Signatur verifiziert werden.
+Der Signatur-Header bindet einen Timestamp an den Request-Body und verhindert sowohl Fälschung als auch Replay-Angriffe.
+`hash_equals()` wird für den Konstantzeit-Vergleich verwendet, um Timing-Angriffe zu verhindern.
+
+---
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---------|------|--------------|
+| `POST` | `/webhook` | Signierten Webhook empfangen und verifizieren |
+| `GET` | `/webhook/events` | Empfangene Webhook-Events auflisten |
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS webhook_events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type   TEXT NOT NULL,
+    payload      TEXT NOT NULL,
+    delivered_at TEXT NOT NULL
+);
+```
+
+Events werden nur nach bestandener Signaturverifikation gespeichert. Ein abgelehnter Webhook wird nie persistiert.
+
+---
+
+## Signaturformat (Stripe-Style)
+
+```
+X-Webhook-Signature: t=<unix-timestamp>,v1=<hmac-hex>
+```
+
+**Signiertes Payload**: `"<timestamp>.<raw-body>"`
+
+Der Timestamp ist in der HMAC-Berechnung enthalten. Das bedeutet:
+- Eine gültige Signatur gilt nur für den Body, über den sie berechnet wurde (Body-Manipulation bricht die Signatur).
+- Eine gültige Signatur gilt nur zum Zeitpunkt ihrer Generierung (das Wiederholen einer alten, gültigen Signatur schlägt die Timestamp-Prüfung fehl, auch wenn der HMAC korrekt ist).
+
+---
+
+## Verifier
+
+```php
+final class WebhookVerifier
+{
+    private const int TOLERANCE_SECONDS = 300;
+
+    public function __construct(private readonly string $secret) {}
+
+    public function verify(ServerRequestInterface $request, string $rawBody): void
+    {
+        $header = $request->getHeaderLine('X-Webhook-Signature');
+        if ($header === '') {
+            throw new SignatureException('Missing X-Webhook-Signature header.');
+        }
+
+        ['timestamp' => $timestamp, 'signature' => $receivedSig] = $this->parseHeader($header);
+
+        $this->checkTimestamp($timestamp);
+
+        $expectedSig = $this->computeSignature($timestamp, $rawBody);
+
+        // KRITISCH: hash_equals ist Konstantzeit; === ist es NICHT
+        if (!hash_equals($expectedSig, $receivedSig)) {
+            throw new SignatureException('Signature mismatch.');
+        }
+    }
+
+    public function sign(string $rawBody, int $timestamp): string
+    {
+        return "t={$timestamp},v1={$this->computeSignature($timestamp, $rawBody)}";
+    }
+
+    private function computeSignature(int $timestamp, string $rawBody): string
+    {
+        return hash_hmac('sha256', "{$timestamp}.{$rawBody}", $this->secret);
+    }
+
+    private function checkTimestamp(int $timestamp): void
+    {
+        $age = abs(time() - $timestamp);
+        if ($age > self::TOLERANCE_SECONDS) {
+            throw new SignatureException(
+                sprintf('Webhook timestamp is %d seconds old (tolerance: %d).', $age, self::TOLERANCE_SECONDS),
+            );
+        }
+    }
+
+    private function parseHeader(string $header): array
+    {
+        $parts = [];
+        foreach (explode(',', $header) as $chunk) {
+            [$k, $v] = explode('=', $chunk, 2) + ['', ''];
+            $parts[$k] = $v;
+        }
+        if (!isset($parts['t'], $parts['v1']) || !ctype_digit($parts['t']) || $parts['v1'] === '') {
+            throw new SignatureException('Malformed X-Webhook-Signature header.');
+        }
+        return ['timestamp' => (int) $parts['t'], 'signature' => $parts['v1']];
+    }
+}
+```
+
+---
+
+## Controller: Raw-Body-Extraktion
+
+```php
+private function receive(ServerRequestInterface $request): ResponseInterface
+{
+    $rawBody = (string) $request->getBody();   // muss rohe Bytes sein, nicht geparst
+
+    try {
+        $this->verifier->verify($request, $rawBody);
+    } catch (SignatureException $e) {
+        return $this->problems->create($request, 'invalid-signature', 'Invalid webhook signature.', 401, $e->getMessage());
+    }
+
+    $body = json_decode($rawBody, true);       // nur nach Verifikation parsen
+    if (!is_array($body) || !isset($body['event_type']) || !is_string($body['event_type'])) {
+        return $this->problems->create($request, 'invalid-body', 'event_type (string) is required.', 400);
+    }
+
+    $event = $this->repo->store($body['event_type'], $rawBody);
+    return $this->json->create(['id' => $event->id, 'status' => 'accepted'], 202);
+}
+```
+
+**Kritische Reihenfolge**:
+1. Raw-Body als String lesen — der HMAC wurde über die exakten Bytes berechnet.
+2. Signatur gegen den Raw-Body verifizieren.
+3. JSON erst nach erfolgreicher Verifikation parsen.
+
+Wenn JSON zuerst geparst und dann neu serialisiert wird, kann sich der Byte-Inhalt unterscheiden (Schlüsselsortierung, Whitespace), was die HMAC-Prüfung bricht.
+
+---
+
+## ATK — Cracker-Mindset-Angriffstest (FT260)
+
+### ATK-01 — Fehlender Signatur-Header
+
+**Attack**: Webhook ohne `X-Webhook-Signature`-Header senden.
+
+```bash
+POST /webhook
+{"event_type": "user.created"}
+```
+
+**Observed**: `verify()` prüft `$header === ''` vor jeder Berechnung. Gibt 401 Problem Details zurück:
+`"Missing X-Webhook-Signature header."` Kein Event wird gespeichert.
+
+**Verdict**: **BLOCKED** — fehlender Header wird vor der Signaturberechnung abgefangen.
+
+---
+
+### ATK-02 — Manipulierte Signatur (Ein-Zeichen-Änderung)
+
+**Attack**: Eine gültige Signatur nehmen und ein Hex-Zeichen ändern.
+
+```
+X-Webhook-Signature: t=<valid-ts>,v1=<valid-hmac-but-one-char-wrong>
+```
+
+**Observed**: `hash_equals($expectedSig, $receivedSig)` gibt `false` zurück. 401 wird zurückgegeben.
+Der Vergleich ist Konstantzeit — die Antwortzeit variiert nicht damit, wie viele Zeichen übereinstimmen.
+
+**Verdict**: **BLOCKED** — `hash_equals()` verhindert Timing-Oracle während manipulierte Sigs abgelehnt werden.
+
+---
+
+### ATK-03 — Falsches Secret verwendet
+
+**Attack**: Anfrage mit einem anderen HMAC-Secret signieren.
+
+```
+X-Webhook-Signature: t=<now>,v1=<hmac-with-wrong-secret>
+```
+
+**Observed**: `computeSignature()` verwendet das Server-Secret. Der HMAC des Angreifers (mit einem anderen Secret berechnet) produziert einen anderen Hex-String. `hash_equals()` schlägt fehl. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — ohne das Secret kann keine gültige Signatur gefälscht werden.
+
+---
+
+### ATK-04 — Replay-Angriff: gültige alte Signatur
+
+**Attack**: Einen legitimen `X-Webhook-Signature`-Header erfassen und 10 Minuten später wiederholen.
+
+```
+X-Webhook-Signature: t=<timestamp-from-10-minutes-ago>,v1=<valid-hmac>
+```
+
+**Observed**: `checkTimestamp($timestamp)` berechnet `abs(time() - $timestamp)`.
+10 Minuten = 600 Sekunden > 300-Sekunden-Toleranz. `SignatureException` wird geworfen. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — Replay-Angriffe werden durch die 300-Sekunden-Timestamp-Toleranz verhindert.
+
+---
+
+### ATK-05 — Zukünftiger Timestamp: Replay-Schutz-Umgehungsversuch
+
+**Attack**: Anfrage mit einem weit zukünftigen Timestamp vorsignieren, um das Gültigkeitsfenster zu erweitern.
+
+```
+X-Webhook-Signature: t=<now + 3600>,v1=<hmac-with-future-ts>
+```
+
+**Observed**: `abs(time() - $timestamp)` = 3600 > 300. `SignatureException` geworfen. 401 zurückgegeben.
+`abs()` bedeutet, dass zukünftige Timestamps ebenfalls abgelehnt werden — die Prüfung ist symmetrisch.
+
+**Verdict**: **BLOCKED** — `abs()` stellt sicher, dass sowohl vergangene als auch zukünftige Timestamps außerhalb des Toleranzfensters abgelehnt werden.
+
+---
+
+### ATK-06 — Body-Manipulation mit gültiger Signatur
+
+**Attack**: Gültigen Webhook abfangen. `X-Webhook-Signature`-Header behalten, aber JSON-Body ändern.
+
+```
+X-Webhook-Signature: t=<valid-ts>,v1=<valid-hmac-over-original-body>
+Body: {"event_type": "user.deleted"}   ← geändert von "user.created"
+```
+
+**Observed**: Der HMAC wurde über `"<timestamp>.<original-body>"` berechnet. Der modifizierte Body
+produziert einen anderen HMAC. `hash_equals()` schlägt fehl. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — die Signatur bindet den Timestamp an den Body. Beides ändern macht die Signatur ungültig.
+
+---
+
+### ATK-07 — Malformierter Header: fehlender Timestamp
+
+**Attack**: Signatur-Header ohne `t=`-Komponente einreichen.
+
+```
+X-Webhook-Signature: v1=<some-hmac>
+```
+
+**Observed**: `parseHeader()` prüft `isset($parts['t'], $parts['v1'])`. Fehlendes `t` wirft
+`SignatureException('Malformed X-Webhook-Signature header.')`. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — Header-Parser setzt Pflichtfelder durch.
+
+---
+
+### ATK-08 — Leeres Secret auf dem Server
+
+**Attack scenario**: Der Server ist mit einem leeren HMAC-Secret (`''`) falsch konfiguriert.
+
+**Observed**: Ein leeres Secret ist in PHPs `hash_hmac()` gültig — es produziert einen deterministischen Hex-String. Ein Angreifer, der das leere Secret entdeckt, kann gültige Signaturen fälschen:
+`hash_hmac('sha256', "{$timestamp}.{$body}", '')`.
+
+**Verdict**: **EXPOSED (Fehlkonfiguration)** — der Verifier lehnt kein leeres Secret ab.
+Die Anwendungs-Konfigurationsschicht muss beim Start validieren, dass `WEBHOOK_SECRET` nicht leer ist.
+Fail-Closed-Standard: wenn das Secret leer ist, alle Webhooks ablehnen.
+
+```php
+// Empfohlener Start-Guard
+if ($secret === '') {
+    throw new \RuntimeException('WEBHOOK_SECRET must not be empty.');
+}
+```
+
+---
+
+### ATK-09 — HMAC-Bypass: `v1=` mit leerem Wert einreichen
+
+**Attack**: Signatur auf leeren String setzen: `X-Webhook-Signature: t=<now>,v1=`.
+
+**Observed**: `parseHeader()` prüft `$parts['v1'] === ''`. Ein leeres `v1` wirft
+`SignatureException('Malformed X-Webhook-Signature header.')`. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — leere Signatur wird im Parser abgelehnt, bevor `hash_equals()` aufgerufen wird.
+
+---
+
+### ATK-10 — Timestamp-Injection: Nicht-Ziffern-Timestamp
+
+**Attack**: Timestamp einreichen, der kein reiner Integer ist: `t=1234abc`.
+
+```
+X-Webhook-Signature: t=1234abc,v1=<some-hmac>
+```
+
+**Observed**: `parseHeader()` prüft `ctype_digit($parts['t'])`. Nicht-Ziffern-Zeichen verursachen
+`SignatureException('Malformed X-Webhook-Signature header.')`. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — `ctype_digit()` setzt durch, dass der Timestamp ein reiner Integer-String ist.
+
+---
+
+### ATK-11 — Header-Injection: Komma im HMAC-Hex
+
+**Attack**: Komma in den `v1`-Wert injizieren, um den Parser zu verwirren.
+
+```
+X-Webhook-Signature: t=<now>,v1=abc,def
+```
+
+**Observed**: `parseHeader()` verwendet `explode('=', $chunk, 2)` mit Limit 2. Der Header wird
+zuerst auf `,` geteilt (produziert `['t=<now>', 'v1=abc', 'def']`), dann wird jeder Chunk auf
+`=` mit Limit 2 geteilt. Der `def`-Chunk wird `['def', '']` und überschreibt nichts Kritisches.
+Der `v1`-Wert ist `abc`, kein gültiger HMAC-Hex. `hash_equals()` schlägt fehl. 401 zurückgegeben.
+
+**Verdict**: **BLOCKED** — Parser-Robustheit + HMAC-Längen-Prüfung verhindert Injektionsmanipulation.
+
+---
+
+### ATK-12 — Großer Body: Payload-Größenangriff
+
+**Attack**: Webhook mit mehrmegabyte-großem Body senden.
+
+**Observed**: Der Verifier berechnet `hash_hmac('sha256', "{$timestamp}.{$rawBody}", $secret)`.
+`hash_hmac()` behandelt beliebig große Eingaben; die Ausgabe ist immer 64 Hex-Zeichen.
+Kein explizites Größenlimit wird auf Verifier-Ebene angewendet. Ein 100 MB Body würde akzeptiert wenn
+die Signatur gültig und der Timestamp frisch ist.
+
+**Verdict**: **EXPOSED** — kein Request-Größenlimit am Webhook-Endpunkt. Request-Größen-Middleware
+(z. B. 1-MB-Limit) upstream hinzufügen, um Ressourcenerschöpfung zu verhindern. Der Verifier sollte
+nicht für Größenlimits zuständig sein — das ist ein Anliegen für eine äußere Middleware-Schicht.
+
+---
+
+## ATK-Zusammenfassung
+
+| # | Angriffsvektor | Ergebnis |
+|---|----------------|----------|
+| ATK-01 | Fehlender Signatur-Header | BLOCKED |
+| ATK-02 | Manipulierte Signatur (1 Zeichen) | BLOCKED |
+| ATK-03 | Falsches Secret verwendet | BLOCKED |
+| ATK-04 | Replay-Angriff (alter Timestamp) | BLOCKED |
+| ATK-05 | Zukünftiger Timestamp-Bypass | BLOCKED |
+| ATK-06 | Body-Manipulation | BLOCKED |
+| ATK-07 | Malformierter Header (kein Timestamp) | BLOCKED |
+| ATK-08 | Leeres Server-Secret (Fehlkonfiguration) | EXPOSED |
+| ATK-09 | Leerer `v1=`-Wert | BLOCKED |
+| ATK-10 | Nicht-Ziffer-Timestamp | BLOCKED |
+| ATK-11 | Header-Injection via Komma | BLOCKED |
+| ATK-12 | Großer Body / Ressourcenerschöpfung | EXPOSED |
+
+**Echte Schwachstellen vor der Produktion zu beheben**:
+1. **ATK-08** — Fail-Closed Leer-Secret-Guard beim Start (`if ($secret === '') throw`)
+2. **ATK-12** — Request-Größen-Middleware (z. B. 1-MB-Limit) upstream der Webhook-Route
+
+---
+
+## Designhinweise
+
+### Warum HMAC-SHA256 statt einfachem Bearer Token?
+
+Ein Bearer Token beweist nur, dass der Sender das Token kennt. HMAC-SHA256 beweist, dass der Sender
+das Secret kennt UND dass der Body nicht verändert wurde — Body-Integrität ist eingebaut.
+
+### Warum den Timestamp an das HMAC-Payload binden?
+
+Wenn die Signatur nur `HMAC(body)` wäre, könnte ein Angreifer, der eine gültige Anfrage erfasst, sie
+unbegrenzt wiederholen. Durch das Signieren von `"<timestamp>.<body>"` ist jede Signatur nur innerhalb
+des 300-Sekunden-Fensters und für den exakten Body, über den sie berechnet wurde, gültig.
+
+### Warum `hash_equals()` statt `===`?
+
+PHPs `===` ist ein Short-Circuit-Vergleich: er stoppt sobald zwei Zeichen sich unterscheiden. Ein Angreifer
+kann die Zeit messen, die für den Vergleich zweier Strings benötigt wird, und ableiten, wie viele führende
+Zeichen seiner Schätzung übereinstimmen — eins nach dem anderen — und das Secret byteweise brute-forcen.
+`hash_equals()` läuft in Konstantzeit unabhängig davon, wo die Strings divergieren.
+
+---
+
+## Verwandte Anleitungen
+
+- [`pin-verification-lockout.md`](pin-verification-lockout.md) — `hash_equals()` und HMAC-SHA256 für PIN-Speicherung + Sperrung
+- [`mass-assignment-defence.md`](mass-assignment-defence.md) — Cracker-Mindset-ATK-Assessment-Muster
+- [`fixed-window-rate-limiter.md`](fixed-window-rate-limiter.md) — Rate Limiting als Ergänzung zur Signaturverifikation

--- a/docs/de/howto/webhook-signature.md
+++ b/docs/de/howto/webhook-signature.md
@@ -1,0 +1,223 @@
+# Webhook-Signaturverifikation
+
+Beim Empfangen von Webhooks von externen Diensten (Stripe, GitHub etc.) immer die Signatur verifizieren, bevor das Payload verarbeitet wird. Das beweist, dass der Webhook vom erwarteten Sender kam und der Body nicht manipuliert wurde.
+
+## Signatur-Header-Format
+
+Das Stripe-kompatible Format verwenden:
+
+```
+X-Webhook-Signature: t=<unix-timestamp>,v1=<hmac-sha256-hex>
+```
+
+Das signierte Payload ist `"<timestamp>.<rawBody>"` — der Timestamp ist im signierten Inhalt enthalten, nicht nur im Header. Das bindet den Timestamp an den Body: wenn ein Angreifer den Timestamp ändert, um die Ablaufprüfung zu umgehen, wird die Signatur ungültig.
+
+## Die kritische Regel: `hash_equals()` verwenden, niemals `===`
+
+```php
+// ❌ Anfällig für Timing-Angriffe
+if ($expectedSig === $receivedSig) { ... }
+
+// ✅ Konstantzeit-Vergleich — das verwenden
+if (!hash_equals($expectedSig, $receivedSig)) {
+    throw new SignatureException('Signature mismatch.');
+}
+```
+
+**Warum `===` gefährlich ist:** PHPs `===` führt einen Short-Circuit beim ersten nicht übereinstimmenden Zeichen durch. Ein Angreifer, der Tausende von Anfragen stellen und Antwortzeiten messen kann, kann lernen, wie viele Zeichen seiner erwarteten Signatur mit seiner Schätzung übereinstimmen — ein Byte nach dem anderen — und das Secret brute-forcen. Das ist ein Timing-Angriff.
+
+`hash_equals()` vergleicht immer alle Zeichen unabhängig davon, wo Strings divergieren, sodass die Antwortzeit nichts über das Secret verrät. Es ist seit PHP 5.6 verfügbar.
+
+Dieser Bug ist von PHPStan, statischen Analysetools oder Standard-Tests nicht erkennbar. Code-Review ist das einzige Gate.
+
+## Implementierung
+
+```php
+final class WebhookVerifier
+{
+    private const int TOLERANCE_SECONDS = 300; // 5-Minuten-Replay-Fenster
+
+    public function __construct(private readonly string $secret) {}
+
+    /**
+     * @throws SignatureException wenn fehlend, malformiert, abgelaufen oder nicht übereinstimmend
+     */
+    public function verify(ServerRequestInterface $request, string $rawBody): void
+    {
+        $header = $request->getHeaderLine('X-Webhook-Signature');
+        if ($header === '') {
+            throw new SignatureException('Missing X-Webhook-Signature header.');
+        }
+
+        ['timestamp' => $timestamp, 'signature' => $receivedSig] = $this->parseHeader($header);
+        $this->checkTimestamp($timestamp);
+
+        $expectedSig = $this->computeSignature($timestamp, $rawBody);
+
+        if (!hash_equals($expectedSig, $receivedSig)) { // ← Konstantzeit
+            throw new SignatureException('Signature mismatch.');
+        }
+    }
+
+    /** Generiert den Header-Wert für ausgehende Webhooks (und Tests). */
+    public function sign(string $rawBody, int $timestamp): string
+    {
+        return "t={$timestamp},v1={$this->computeSignature($timestamp, $rawBody)}";
+    }
+
+    /** @return array{timestamp: int, signature: string} */
+    private function parseHeader(string $header): array
+    {
+        $parts = [];
+        foreach (explode(',', $header) as $chunk) {
+            [$k, $v] = explode('=', $chunk, 2) + ['', ''];
+            $parts[$k] = $v;
+        }
+        if (!isset($parts['t'], $parts['v1']) || !ctype_digit($parts['t']) || $parts['v1'] === '') {
+            throw new SignatureException('Malformed X-Webhook-Signature header.');
+        }
+        return ['timestamp' => (int) $parts['t'], 'signature' => $parts['v1']];
+    }
+
+    private function checkTimestamp(int $timestamp): void
+    {
+        $age = abs(time() - $timestamp);
+        if ($age > self::TOLERANCE_SECONDS) {
+            throw new SignatureException(
+                sprintf('Webhook timestamp is %d seconds old (tolerance: %d).', $age, self::TOLERANCE_SECONDS),
+            );
+        }
+    }
+
+    private function computeSignature(int $timestamp, string $rawBody): string
+    {
+        return hash_hmac('sha256', "{$timestamp}.{$rawBody}", $this->secret);
+    }
+}
+```
+
+## Controller-Integration
+
+Raw-Body vor jedem JSON-Parsing lesen — die Signatur wird über die rohen Bytes berechnet:
+
+```php
+private function receive(ServerRequestInterface $request): ResponseInterface
+{
+    $rawBody = (string) $request->getBody();
+
+    try {
+        $this->verifier->verify($request, $rawBody);
+    } catch (SignatureException $e) {
+        return $this->problems->create(
+            $request,
+            'invalid-signature',
+            'Invalid webhook signature.',
+            401,          // 401: Sender-Identität konnte nicht verifiziert werden
+            $e->getMessage(),
+        );
+    }
+
+    // Nach Verifikation sicher zu parsen
+    $body = json_decode($rawBody, true);
+    // ...
+}
+```
+
+401 zurückgeben (nicht 403): die Identität des Senders konnte nicht verifiziert werden, was ein Authentifizierungsfehler ist, kein Autorisierungsfehler.
+
+## Secret-Verwaltung
+
+Das Webhook-Secret in einer Umgebungsvariable speichern, niemals im Code:
+
+```php
+// Im Config-Loader
+$secret = (string) getenv('WEBHOOK_SECRET');
+if ($secret === '') {
+    throw new \RuntimeException('WEBHOOK_SECRET environment variable is required.');
+}
+
+$verifier = new WebhookVerifier($secret);
+```
+
+## Replay-Angriff-Prävention
+
+Das 5-Minuten-Timestamp-Fenster (`TOLERANCE_SECONDS = 300`) bedeutet:
+
+- Ein Angreifer, der einen gültigen Webhook abfängt, kann ihn nicht mehr als 5 Minuten später wiederholen.
+- Reale Taktverschiebung zwischen Sender und Empfänger (normalerweise < 30 Sekunden) wird toleriert.
+- `abs(time() - $timestamp)` behandelt sowohl vergangene als auch zukünftige Timestamps, sodass geringfügige Taktdrift in beide Richtungen akzeptiert wird.
+
+## Secret-Rotation
+
+Während einer Secret-Rotation Signaturen sowohl vom alten als auch vom neuen Secret für einen Übergangszeitraum akzeptieren:
+
+```php
+final class RotatingWebhookVerifier
+{
+    /** @param list<string> $secrets Aktuelles Secret zuerst, vorheriges Secret zuletzt */
+    public function __construct(private readonly array $secrets) {}
+
+    public function verify(ServerRequestInterface $request, string $rawBody): void
+    {
+        $header = $request->getHeaderLine('X-Webhook-Signature');
+        foreach ($this->secrets as $secret) {
+            $verifier = new WebhookVerifier($secret);
+            try {
+                $verifier->verify($request, $rawBody);
+                return; // erste Übereinstimmung gewinnt
+            } catch (SignatureException) {
+                // nächstes Secret versuchen
+            }
+        }
+        throw new SignatureException('Signature mismatch with all known secrets.');
+    }
+}
+```
+
+## Tests
+
+Die `sign()`-Methode auf `WebhookVerifier` macht es einfach, signierte Testanfragen zu erstellen:
+
+```php
+private function signedPost(array $payload, int $timestamp): ResponseInterface
+{
+    $rawBody   = json_encode($payload, JSON_THROW_ON_ERROR);
+    $verifier  = new WebhookVerifier('test-secret');
+    $sigHeader = $verifier->sign($rawBody, $timestamp);
+
+    $stream  = Stream::create($rawBody);
+    $request = (new ServerRequest('POST', '/webhook'))
+        ->withHeader('X-Webhook-Signature', $sigHeader)
+        ->withBody($stream);
+    return $this->app->handle($request);
+}
+
+// Replay-Prävention testen
+public function testExpiredTimestampReturns401(): void
+{
+    $res = $this->signedPost(['event_type' => 'order.created'], time() - 301);
+    $this->assertSame(401, $res->getStatusCode());
+}
+
+// Manipulierten Body testen
+public function testTamperedPayloadReturns401(): void
+{
+    $original  = '{"event_type":"order.created","amount":100}';
+    $sigHeader = (new WebhookVerifier('test-secret'))->sign($original, time());
+    $tampered  = '{"event_type":"order.created","amount":9999}';
+
+    $res = $this->postWithHeader($tampered, $sigHeader);
+    $this->assertSame(401, $res->getStatusCode());
+}
+```
+
+## Code-Review-Checkliste
+
+- [ ] `hash_equals()` wird für den Signaturvergleich verwendet, nicht `===` oder `==`
+- [ ] Timestamp ist im signierten Payload enthalten (`"<t>.<body>"`), nicht nur im Header
+- [ ] Timestamp-Fenster wird durchgesetzt (`abs(time() - $timestamp) > TOLERANCE`)
+- [ ] Raw-Body wird vor dem Parsing gelesen; Signatur wird gegen die rohen Bytes verifiziert
+- [ ] Webhook-Secret kommt aus Umgebungsvariablen, nicht hardcodiert
+- [ ] 401 wird bei Signaturfehlern zurückgegeben (nicht 403 oder 400)
+- [ ] Fehlermeldungen geben das Secret oder den erwarteten Signaturwert nicht preis
+- [ ] Tests decken ab: gültige Signatur, falsches Secret, manipulierter Body, abgelaufener Timestamp, fehlender Header


### PR DESCRIPTION
## 概要

ドイツ語 howto 翻訳の最終完結バッチ。

- **バッチ final batch 3** (31件): time-tracking.md ～ webhook-signature.md
- **補完** (5件): tag-label-api.md ～ threaded-comments-api.md (リベース時に漏れた分)

これにより全 256件のドイツ語翻訳が完了します。

## 変更内容 (36件)

tag-label-api, tagging-system, tenant-isolation-idor, tenant-isolation,
threaded-comments-api, threaded-comments, time-tracking, timezone-aware-scheduling,
token-lifecycle-api, totp-authentication, transaction-scope-pattern, transactions,
unicode-aware-text-api, upvote-downvote-api, url-bookmark-api,
url-shortener-ssrf-prevention, url-shortener-ssrf, use-bearer-auth,
use-fts5-search, use-postgresql, use-transactions, user-follow-system,
user-invitation, user-preferences-api, user-preferences-management,
user-profile-api, user-profile-management, validate-unicode-input,
voting-system, waitlist-management, waitlist-system,
webhook-delivery-api, webhook-delivery-system, webhook-delivery,
webhook-signature-verification, webhook-signature

Closes #1283

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)