### PR TITLE
ci(docs): VitePress ビルド OOM 修正 — NODE_OPTIONS=--max-old-space-size=6144

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Build VitePress site
         run: npm run docs:build
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## 問題

256件 × 6言語 = 1500+ ページのビルドで Node.js が OOM クラッシュしていた。

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

## 修正

`NODE_OPTIONS=--max-old-space-size=6144` を追加して Node.js ヒープを 6GiB に拡張。
GitHub Actions の無料ランナーは 7GB RAM なので十分な余裕がある。

## 確認

マージ後、docs workflow が全翻訳ファイル込みで正常ビルドされることを確認する。

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)