### PR TITLE
ci: swap 8GB + heap 7168MB で VitePress OOM を修正

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,10 +19,18 @@ jobs:
   build:
     name: Build Docs
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Configure swap space (8 GB)
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -37,7 +45,7 @@ jobs:
       - name: Build VitePress site
         run: npm run docs:build
         env:
-          NODE_OPTIONS: --max-old-space-size=6144
+          NODE_OPTIONS: --max-old-space-size=7168
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## 概要

256ファイル × 6言語（en/ja/fr/zh/pt-br/de）= 1500+ ページのVitePressビルドがOOMで失敗する問題を修正する。

## 変更内容

- GitHub Actions ランナーに **8GB swap** を追加（fallocate + mkswap + swapon）
- `NODE_OPTIONS` を `--max-old-space-size=6144` → **7168** に増量（7GB）
- `timeout-minutes` を 10 → **20** に延長

## 背景

- PR #1298 で 6144MB を設定したが、ビルドは 6016MB でクラッシュ（ヘッドルームなし）
- 7168MB + 8GB swap により、物理 7GB + 仮想 8GB = 15GB の余裕を確保
- 全 de 翻訳（256ファイル）を main にマージ済み（PR #1293〜#1297）だが、ビルド失敗のためサイトに未反映

## 検証

ローカルビルド確認済み。GitHub Actions でのビルド成功を待つ。

## 関連 Issue

Closes #1299

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)