### PR TITLE
ci: swap を /mnt/swapfile に変更（ランナーの /swapfile busy 対策）

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,10 +26,10 @@ jobs:
 
       - name: Configure swap space (8 GB)
         run: |
-          sudo fallocate -l 8G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
+          sudo fallocate -l 8G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
           free -h
 
       - name: Set up Node.js


### PR DESCRIPTION
## 概要

PR #1299 の修正。`/swapfile` が `Text file busy` で失敗する問題を修正。

## 原因

`ubuntu-latest` ランナーはすでに `/swapfile` に **4GB swap** が設定済み。
`fallocate` がそのファイルに書き込もうとして「Text file busy」エラーになる。

## 修正

`/swapfile` → `/mnt/swapfile` に変更。
`/mnt` は別パーティションで空き容量が多く、swapfile に適している。

## 結果として期待されるメモリ構成

| 項目 | サイズ |
|------|--------|
| RAM | 7 GB |
| 既存 swap (/swapfile) | 4 GB |
| 追加 swap (/mnt/swapfile) | 8 GB |
| **合計仮想メモリ** | **19 GB** |
| Node.js heap 上限 | 7 GB (--max-old-space-size=7168) |

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)