### PR TITLE
ci: Node.js heap を 12288MB に増量（ランナー 15GB RAM を活用）

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build VitePress site
         run: npm run docs:build
         env:
-          NODE_OPTIONS: --max-old-space-size=7168
+          NODE_OPTIONS: --max-old-space-size=12288
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## 概要

VitePress OOM の根本原因を修正する。

## 原因分析

- swap の追加（PR #1299〜#1300）は機能したが、**V8 ヒープ OOM は swap では解決しない**
- V8 のガベージコレクションヒープは物理メモリで動作し、swap には展開されない
- `--max-old-space-size=7168` (7GB) に達してクラッシュした
- ランナーの実際の RAM は **15GB**（7GB と思っていたが実際は大きかった）

## 修正

| 項目 | 旧値 | 新値 |
|------|------|------|
| `--max-old-space-size` | 7168MB | **12288MB** (12GB) |

ランナーの 15GB RAM に対して 12GB ヒープを確保。3GB の余裕あり。
スワップ（/mnt/swapfile 8GB）は念のため維持。

## 関連

- #1299 #1300 — 先行 OOM 修正 PR（swap 追加）

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)