### PR TITLE
docs(config): サイドバーに全 howto 256件を動的生成・非英語ロケールのサイドバー表示修正

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,8 +1,29 @@
 import { defineConfig } from 'vitepress'
+import { readdirSync, readFileSync, existsSync } from 'fs'
+import { resolve, join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const DOCS_ROOT = resolve(__dirname, '../docs')
+
+/** howto ディレクトリ内の全 .md ファイルから sidebar items を動的生成 */
+function howtoItems(langDir: string, urlPrefix: string) {
+  const howtoDir = join(langDir, 'howto')
+  if (!existsSync(howtoDir)) return []
+  return readdirSync(howtoDir)
+    .filter(f => f.endsWith('.md') && f !== 'README.md')
+    .sort()
+    .map(file => {
+      const slug = file.replace('.md', '')
+      const raw = readFileSync(join(howtoDir, file), 'utf-8')
+      const title = raw.match(/^# (.+)$/m)?.[1]?.trim() ?? slug
+      return { text: title, link: `${urlPrefix}/howto/${slug}` }
+    })
+}
 
 function nav(t: {
   tutorial: string; howto: string; explanation: string; reference: string
-}, p: string = '') {
+}, p = '') {
   return [
     { text: t.tutorial,    link: `${p}/tutorial/first-api`,     activeMatch: 'tutorial/' },
     { text: t.howto,       link: `${p}/howto/add-custom-route`, activeMatch: 'howto/' },
@@ -21,27 +42,26 @@ function nav(t: {
 
 function sidebar(t: {
   tutorialGroup: string; firstApi: string
-  howtoGroup: string; howtoIndex: string; addRoute: string; addDb: string; addEntity: string; deploy: string; addRateLimit: string; addHealthCheck: string; addPagination: string
+  howtoGroup: string; howtoIndex: string
   explGroup: string; whyPsr: string; whyDi: string; whyPd: string; whyMcp: string
   devGroup: string; intGroup: string
   refGroup: string; envVars: string; endpoints: string; problemTypes: string
-}, p: string = '') {
+}, p = '', langDir = DOCS_ROOT) {
+  // p = '' (en) or '/ja', '/de', ... (other locales)
+  // サイドバーキーにロケールプレフィックスを含めることで確実にパスマッチする
   return {
-    '/tutorial/': [{ text: t.tutorialGroup, items: [{ text: t.firstApi, link: `${p}/tutorial/first-api` }] }],
-    '/howto/': [{
+    [`${p}/tutorial/`]: [{
+      text: t.tutorialGroup,
+      items: [{ text: t.firstApi, link: `${p}/tutorial/first-api` }],
+    }],
+    [`${p}/howto/`]: [{
       text: t.howtoGroup,
       items: [
-        { text: t.howtoIndex,     link: `${p}/howto/README` },
-        { text: t.addRoute,       link: `${p}/howto/add-custom-route` },
-        { text: t.addDb,          link: `${p}/howto/add-database-endpoint` },
-        { text: t.addEntity,      link: `${p}/howto/add-second-entity` },
-        { text: t.deploy,         link: `${p}/howto/deploy-production` },
-        { text: t.addRateLimit,   link: `${p}/howto/add-rate-limiting` },
-        { text: t.addHealthCheck, link: `${p}/howto/add-health-check` },
-        { text: t.addPagination,  link: `${p}/howto/add-pagination` },
+        { text: t.howtoIndex, link: `${p}/howto/README` },
+        ...howtoItems(langDir, p),
       ],
     }],
-    '/explanation/': [{
+    [`${p}/explanation/`]: [{
       text: t.explGroup,
       items: [
         { text: t.whyPsr,  link: `${p}/explanation/why-psr` },
@@ -50,7 +70,7 @@ function sidebar(t: {
         { text: t.whyMcp,  link: `${p}/explanation/why-mcp` },
       ],
     }],
-    '/reference/': [{
+    [`${p}/reference/`]: [{
       text: t.refGroup,
       items: [
         { text: t.envVars,      link: `${p}/reference/environment-variables` },
@@ -58,7 +78,7 @@ function sidebar(t: {
         { text: t.problemTypes, link: `${p}/reference/problem-details-types` },
       ],
     }],
-    '/development/': [
+    [`${p}/development/`]: [
       {
         text: t.devGroup,
         items: [
@@ -101,11 +121,11 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'HOWTO', explanation: 'Explanation', reference: 'Reference' }),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Your first API',
-          howtoGroup: 'HOWTO', howtoIndex: 'All guides (100)', addRoute: 'Add a custom route', addDb: 'Add a database-backed endpoint', addEntity: 'Add a second entity', deploy: 'Deploy to production', addRateLimit: 'Add rate limiting', addHealthCheck: 'Add a health check', addPagination: 'Add pagination',
+          howtoGroup: 'HOWTO', howtoIndex: 'Index',
           explGroup: 'Explanation', whyPsr: 'Why PSR standards?', whyDi: 'Why explicit wiring?', whyPd: 'Why Problem Details?', whyMcp: 'Why MCP?',
           devGroup: 'Development', intGroup: 'Integrations',
           refGroup: 'Reference', envVars: 'Environment variables', endpoints: 'HTTP endpoints', problemTypes: 'Problem Details types',
-        }, ''),
+        }, '', DOCS_ROOT),
         editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'Edit this page on GitHub' },
         footer: { message: 'Released under the MIT License.', copyright: 'Copyright © 2026 hideyukiMORI' },
       },
@@ -118,11 +138,11 @@ export default defineConfig({
         nav: nav({ tutorial: 'チュートリアル', howto: 'HOWTO', explanation: '解説', reference: 'リファレンス' }, '/ja'),
         sidebar: sidebar({
           tutorialGroup: 'チュートリアル', firstApi: '最初の API を動かす',
-          howtoGroup: 'HOWTO', howtoIndex: '全ガイド一覧（100）', addRoute: 'カスタムルートを追加する', addDb: 'DB 付きエンドポイントを追加する', addEntity: '2 つ目のエンティティを追加する', deploy: '本番環境へデプロイする', addRateLimit: 'レート制限を追加する', addHealthCheck: 'ヘルスチェックを追加する', addPagination: 'ページネーションを追加する',
+          howtoGroup: 'HOWTO', howtoIndex: 'インデックス',
           explGroup: '解説', whyPsr: 'なぜ PSR 標準？', whyDi: 'なぜ明示的 DI？', whyPd: 'なぜ Problem Details？', whyMcp: 'なぜ MCP？',
           devGroup: '開発ガイド', intGroup: 'インテグレーション',
           refGroup: 'リファレンス', envVars: '環境変数', endpoints: 'HTTP エンドポイント', problemTypes: 'Problem Details タイプ',
-        }, '/ja'),
+        }, '/ja', join(DOCS_ROOT, 'ja')),
         editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'GitHub でこのページを編集' },
         footer: { message: 'MIT ライセンスの下で公開されています。', copyright: 'Copyright © 2026 hideyukiMORI' },
         docFooter: { prev: '前のページ', next: '次のページ' },
@@ -140,16 +160,18 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutoriel', howto: 'Guides', explanation: 'Explication', reference: 'Référence' }, '/fr'),
         sidebar: sidebar({
           tutorialGroup: 'Tutoriel', firstApi: 'Votre première API',
-          howtoGroup: 'Guides pratiques', howtoIndex: 'Tous les guides (100)', addRoute: 'Ajouter une route', addDb: 'Ajouter un endpoint avec BDD', addEntity: 'Ajouter une deuxième entité', deploy: 'Déployer en production', addRateLimit: 'Ajouter la limitation de débit', addHealthCheck: 'Ajouter un contrôle de santé', addPagination: 'Ajouter la pagination',
+          howtoGroup: 'Guides pratiques', howtoIndex: 'Index',
           explGroup: 'Explication', whyPsr: 'Pourquoi PSR ?', whyDi: 'Pourquoi le câblage explicite ?', whyPd: 'Pourquoi Problem Details ?', whyMcp: 'Pourquoi MCP ?',
           devGroup: 'Développement', intGroup: 'Intégrations',
           refGroup: 'Référence', envVars: "Variables d'environnement", endpoints: 'Endpoints HTTP', problemTypes: 'Types Problem Details',
-        }, '/fr'),
+        }, '/fr', join(DOCS_ROOT, 'fr')),
         editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'Modifier cette page sur GitHub' },
         footer: { message: 'Publié sous licence MIT.', copyright: 'Copyright © 2026 hideyukiMORI' },
         docFooter: { prev: 'Page précédente', next: 'Page suivante' },
         outlineTitle: 'Sur cette page',
         returnToTopLabel: 'Retour en haut',
+        sidebarMenuLabel: 'Menu',
+        darkModeSwitchLabel: 'Mode sombre',
       },
     },
 
@@ -160,11 +182,11 @@ export default defineConfig({
         nav: nav({ tutorial: '教程', howto: '操作指南', explanation: '说明', reference: '参考' }, '/zh'),
         sidebar: sidebar({
           tutorialGroup: '教程', firstApi: '创建您的第一个 API',
-          howtoGroup: '操作指南', howtoIndex: '全部指南（100）', addRoute: '添加自定义路由', addDb: '添加数据库端点', addEntity: '添加第二个实体', deploy: '部署到生产环境', addRateLimit: '添加速率限制', addHealthCheck: '添加健康检查', addPagination: '添加分页',
+          howtoGroup: '操作指南', howtoIndex: '索引',
           explGroup: '说明', whyPsr: '为什么选择 PSR？', whyDi: '为什么显式依赖注入？', whyPd: '为什么使用 Problem Details？', whyMcp: '为什么选择 MCP？',
           devGroup: '开发指南', intGroup: '集成',
           refGroup: '参考', envVars: '环境变量', endpoints: 'HTTP 端点', problemTypes: 'Problem Details 类型',
-        }, '/zh'),
+        }, '/zh', join(DOCS_ROOT, 'zh')),
         editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: '在 GitHub 上编辑此页' },
         footer: { message: '基于 MIT 许可证发布。', copyright: 'Copyright © 2026 hideyukiMORI' },
         docFooter: { prev: '上一页', next: '下一页' },
@@ -182,16 +204,18 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'Guias', explanation: 'Explicação', reference: 'Referência' }, '/pt-br'),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Sua primeira API',
-          howtoGroup: 'Guias práticos', howtoIndex: 'Todos os guias (100)', addRoute: 'Adicionar uma rota', addDb: 'Adicionar endpoint com banco de dados', addEntity: 'Adicionar segunda entidade', deploy: 'Implantar em produção', addRateLimit: 'Adicionar limitação de taxa', addHealthCheck: 'Adicionar verificação de saúde', addPagination: 'Adicionar paginação',
+          howtoGroup: 'Guias práticos', howtoIndex: 'Índice',
           explGroup: 'Explicação', whyPsr: 'Por que PSR?', whyDi: 'Por que injeção explícita?', whyPd: 'Por que Problem Details?', whyMcp: 'Por que MCP?',
           devGroup: 'Desenvolvimento', intGroup: 'Integrações',
           refGroup: 'Referência', envVars: 'Variáveis de ambiente', endpoints: 'Endpoints HTTP', problemTypes: 'Tipos Problem Details',
-        }, '/pt-br'),
+        }, '/pt-br', join(DOCS_ROOT, 'pt-br')),
         editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'Editar esta página no GitHub' },
         footer: { message: 'Publicado sob a licença MIT.', copyright: 'Copyright © 2026 hideyukiMORI' },
         docFooter: { prev: 'Página anterior', next: 'Próxima página' },
         outlineTitle: 'Nesta página',
         returnToTopLabel: 'Voltar ao topo',
+        sidebarMenuLabel: 'Menu',
+        darkModeSwitchLabel: 'Modo escuro',
       },
     },
 
@@ -202,11 +226,11 @@ export default defineConfig({
         nav: nav({ tutorial: 'Tutorial', howto: 'Anleitungen', explanation: 'Erklärung', reference: 'Referenz' }, '/de'),
         sidebar: sidebar({
           tutorialGroup: 'Tutorial', firstApi: 'Ihre erste API',
-          howtoGroup: 'Anleitungen', howtoIndex: 'Alle Anleitungen (100)', addRoute: 'Route hinzufügen', addDb: 'Datenbankendpunkt hinzufügen', addEntity: 'Zweite Entität hinzufügen', deploy: 'In Produktion deployen', addRateLimit: 'Rate Limiting hinzufügen', addHealthCheck: 'Health Check hinzufügen', addPagination: 'Paginierung hinzufügen',
+          howtoGroup: 'Anleitungen', howtoIndex: 'Index',
           explGroup: 'Erklärung', whyPsr: 'Warum PSR?', whyDi: 'Warum explizites Wiring?', whyPd: 'Warum Problem Details?', whyMcp: 'Warum MCP?',
           devGroup: 'Entwicklung', intGroup: 'Integrationen',
           refGroup: 'Referenz', envVars: 'Umgebungsvariablen', endpoints: 'HTTP-Endpunkte', problemTypes: 'Problem Details-Typen',
-        }, '/de'),
+        }, '/de', join(DOCS_ROOT, 'de')),
         editLink: { pattern: 'https://github.com/hideyukiMORI/NENE2/edit/main/docs/:path', text: 'Diese Seite auf GitHub bearbeiten' },
         footer: { message: 'Veröffentlicht unter der MIT-Lizenz.', copyright: 'Copyright © 2026 hideyukiMORI' },
         docFooter: { prev: 'Vorherige Seite', next: 'Nächste Seite' },


### PR DESCRIPTION
## 概要

VitePress サイドバーの2つの問題を修正する。

## 修正内容

### 1. サイドバー全件化（256ファイル）

`docs/*/howto/` を動的に読み込み、全256件の howto ファイルをサイドバーに表示する。
各言語のファイルから h1 タイトルを読み込むため、翻訳済みタイトルで表示される。

```typescript
function howtoItems(langDir: string, urlPrefix: string) {
  // docs/howto/ (en), docs/ja/howto/ (ja), docs/de/howto/ (de) ... を動的に読む
}
```

### 2. 非英語ロケールのサイドバー表示修正

サイドバーキーにロケールプレフィックスを含めることで、非英語ページでも確実にサイドバーが表示される。

**修正前:**
```
'/howto/': [...]   # de ロケールでも '/howto/' キー（パスマッチ不安定）
```

**修正後:**
```
'/de/howto/': [...]  # de ロケールは '/de/howto/' キー（確実にマッチ）
'/ja/howto/': [...]  # ja ロケールは '/ja/howto/' キー
```

## 変更ファイル

- `.vitepress/config.mts` — `howtoItems()` 動的生成関数追加、`sidebar()` 関数リファクタリング

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)