### PR TITLE
feat(config): DatabaseConfig::sqlite() ファクトリメソッド追加 (IMP-04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `Nene2\Config\DatabaseConfig::sqlite(string $path, string $environment = 'local')` — テスト・小規模スクリプト向けの SQLite 設定ファクトリ。9 引数コンストラクタを 1 行に短縮（IMP-04 / #1303）
+
 ---
 
 ## [1.5.323] — 2026-05-27

--- a/src/Config/DatabaseConfig.php
+++ b/src/Config/DatabaseConfig.php
@@ -41,6 +41,28 @@ final readonly class DatabaseConfig
         }
     }
 
+    /**
+     * Build a SQLite configuration from a file path (or `:memory:`).
+     *
+     * Convenience factory that fills the host / user / password / charset slots
+     * the SQLite adapter does not use. Intended for tests and small scripts;
+     * production configuration should still flow through {@see ConfigLoader}.
+     */
+    public static function sqlite(string $path, string $environment = 'local'): self
+    {
+        return new self(
+            url: null,
+            environment: $environment,
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: $path,
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+    }
+
     public function usesUrl(): bool
     {
         return $this->url !== null;

--- a/tests/Config/DatabaseConfigTest.php
+++ b/tests/Config/DatabaseConfigTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Config;
+
+use Nene2\Config\DatabaseConfig;
+use PHPUnit\Framework\TestCase;
+
+final class DatabaseConfigTest extends TestCase
+{
+    public function testSqliteFactoryFillsRequiredFields(): void
+    {
+        $config = DatabaseConfig::sqlite('/tmp/example.sqlite');
+
+        self::assertSame('sqlite', $config->adapter);
+        self::assertSame('/tmp/example.sqlite', $config->name);
+        self::assertSame('local', $config->environment);
+        self::assertNull($config->url);
+        self::assertFalse($config->usesUrl());
+    }
+
+    public function testSqliteFactoryAcceptsCustomEnvironment(): void
+    {
+        $config = DatabaseConfig::sqlite(':memory:', 'test');
+
+        self::assertSame('test', $config->environment);
+        self::assertSame(':memory:', $config->name);
+    }
+}


### PR DESCRIPTION
## Summary

- `Nene2\Config\DatabaseConfig::sqlite(string $path, string $environment = 'local'): self` を追加
- DX Trial 01〜26 の 78 試験で繰り返し報告された IMP-04 を解消
- 既存 9 引数コンストラクタは温存（純粋に additive・互換性 100%）

## Background

シニア・ロースキル・新卒の全ペルソナが、テストごとに `DatabaseConfig` の 9 引数コンストラクタを書く負担を訴えていた。`DatabaseConfig` の既存 docblock にも「SQLite は host/user/password/charset を要求しない」と明記されているが、それでもコンストラクタは全引数を要求していた。

## Changes

- `src/Config/DatabaseConfig.php` — `sqlite()` static factory 追加
- `tests/Config/DatabaseConfigTest.php` — 新規作成、ファクトリの動作テスト
- `CHANGELOG.md` — `[Unreleased]` に追記

## Verification

```
docker compose run --rm app composer check
# → 431 tests, 996 assertions / PHPStan 0 errors / CS 0 issues / OpenAPI valid / MCP valid / Version OK
```

## Self-review

- `docs/review/docs-policy.md`

## Related

- Closes #1303
- 後続: IMP-14 で `Nene2\Testing\DatabaseTestKit` がこのファクトリを内部利用予定
- 参照: `docs/todo/dx-trial-improvements.md` IMP-04 / `docs/adr/0009-v1.0-public-api-scope.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)