### PR TITLE
feat(testing): Nene2\Testing\DatabaseTestKit を追加 (IMP-14 / ADR 0012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `Nene2\Testing\DatabaseTestKit` — テスト用 DB 配線ヘルパー（stable public API）。`PdoConnectionFactory` / `PdoDatabaseQueryExecutor` / `PdoDatabaseTransactionManager` をまとめて配線し、3 つのインターフェースを readonly コンストラクタプロパティで公開。`DatabaseTestKit::sqlite($path)` は `:memory:` を明示的に拒否し、`transactional()` 非互換罠（IMP-18）を構造的に塞ぐ。`fromConfig(DatabaseConfig)` で任意 adapter にも対応（IMP-14 / ADR 0012 / #1307）
+- `docs/adr/0012-sanctioned-test-database-wiring.md` — `Nene2\Testing` 名前空間導入の決定記録
 - `Nene2\Config\DatabaseConfig::sqlite(string $path, string $environment = 'local')` — テスト・小規模スクリプト向けの SQLite 設定ファクトリ。9 引数コンストラクタを 1 行に短縮（IMP-04 / #1303）
+
+### Changed
+- `docs/adr/0009-v1.0-public-api-scope.md` — stable public API 表に `Nene2\Testing\DatabaseTestKit` 行を追加
 
 ---
 

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -63,6 +63,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\Validation` | `ValidationException`, `ValidationError` |
 | `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |
 | `Nene2\Mcp` | `LocalMcpServer`, `LocalMcpToolCatalog`, `LocalMcpHttpClientInterface`, `LocalMcpHttpResponse`, `LocalMcpException` |
+| `Nene2\Testing` | `DatabaseTestKit` (constructor, public readonly properties `connectionFactory` / `queryExecutor` / `transactionManager`, factories `sqlite` / `fromConfig`) — see ADR 0012 |
 
 ### 4. Stable request attributes set by authentication middleware
 

--- a/docs/adr/0012-sanctioned-test-database-wiring.md
+++ b/docs/adr/0012-sanctioned-test-database-wiring.md
@@ -1,0 +1,108 @@
+# ADR 0012: Sanctioned Test Database Wiring via `Nene2\Testing`
+
+## Status
+
+accepted
+
+## Context
+
+ADR 0009 placed the concrete PDO adapters (`PdoConnectionFactory`,
+`PdoDatabaseQueryExecutor`, `PdoDatabaseTransactionManager`) outside the v1.0
+public API stability guarantee. The shipped `@internal` annotations make this
+boundary explicit at the IDE level.
+
+This boundary is correct for production code: applications should depend on
+`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, and
+`DatabaseTransactionManagerInterface`, not on the PDO implementations.
+
+DX Trial 01〜26 (78 trials across new-grad / low-skill / senior personas)
+revealed that **test code cannot follow the same rule** without breaking:
+
+- Test fixtures need a concrete `DatabaseQueryExecutorInterface` backed by a real
+  database. Producing one requires constructing `PdoConnectionFactory` +
+  `PdoDatabaseQueryExecutor` (and `PdoDatabaseTransactionManager` when
+  `transactional()` is exercised).
+- `PdoDatabaseQueryExecutor`'s second constructor parameter (`?PDO $connection`)
+  is the only way to inject a pre-built PDO for tests that need it, but the
+  whole class is `@internal`. Trials 13-C and 15-A worked around this with
+  anonymous-class subclasses, which is fragile.
+- Trial 17-B re-confirmed IMP-18: `:memory:` SQLite is **incompatible with
+  `transactional()`** because the transaction manager calls
+  `$connectionFactory->create()`, which opens a fresh connection to a different
+  empty in-memory database. The trap is silent (the test passes locally if it
+  doesn't touch transactions).
+
+## Decision
+
+Introduce a new public namespace `Nene2\Testing\` whose first member is
+`DatabaseTestKit`.
+
+### `DatabaseTestKit` shape
+
+```php
+namespace Nene2\Testing;
+
+final readonly class DatabaseTestKit
+{
+    public function __construct(
+        public DatabaseConnectionFactoryInterface  $connectionFactory,
+        public DatabaseQueryExecutorInterface      $queryExecutor,
+        public DatabaseTransactionManagerInterface $transactionManager,
+    ) {}
+
+    public static function sqlite(string $path): self;
+    public static function fromConfig(DatabaseConfig $config): self;
+}
+```
+
+- The three interfaces are exposed as **public readonly constructor properties**
+  so callers do not need to remember accessor names: `$kit->queryExecutor`,
+  `$kit->transactionManager`.
+- The factory methods wire `PdoConnectionFactory`, `PdoDatabaseQueryExecutor`,
+  and `PdoDatabaseTransactionManager` internally. Callers never name those
+  classes.
+- `sqlite(':memory:')` throws `InvalidArgumentException`. This converts the
+  IMP-18 silent trap into a fail-fast error at the boundary where the test
+  fixture is built.
+- `fromConfig()` is the escape hatch for MySQL/PostgreSQL fixtures.
+
+### Stability guarantee
+
+`Nene2\Testing\DatabaseTestKit` is added to the v1.0 stable public API surface
+(ADR 0009 §3 table).
+
+The PDO concrete adapters retain their `@internal` status. The kit is the
+sanctioned bridge; the adapters remain implementation detail.
+
+## Consequences
+
+**Benefits**
+
+- Test code no longer needs to reference `@internal` classes by name.
+- The `:memory:` + `transactional()` trap (IMP-18) is now structurally blocked.
+- The `DatabaseConfig::sqlite()` factory (IMP-04) and `DatabaseTestKit::sqlite()`
+  compose into a one-line test fixture.
+- Future test helpers (e.g. for fixture seeding, snapshot reset) have a clear
+  home under `Nene2\Testing\`.
+
+**Costs / follow-up work**
+
+- Existing howto pages that show direct `PdoConnectionFactory` / `PdoDatabaseQueryExecutor`
+  construction in test snippets should be migrated to `DatabaseTestKit` over
+  time (non-breaking; the old pattern still works).
+- Each new addition to `Nene2\Testing\` is a public surface and requires either
+  this ADR to be extended or a follow-up ADR.
+
+**Out of scope**
+
+- Snapshot / fixture-loading helpers — deferred until a concrete need surfaces.
+- Test database lifecycle (create temp file, drop after test) — callers manage
+  this with `sys_get_temp_dir()` and `tearDown()`. A helper may be added later.
+
+## Related
+
+- Issue: `#1307`
+- Supersedes: none
+- Related ADR: `0009-v1.0-public-api-scope.md` (`Nene2\Testing` row added in §3)
+- Related work: `docs/todo/dx-trial-improvements.md` IMP-14 / IMP-18 / IMP-04
+- Depends on: `DatabaseConfig::sqlite()` factory (#1303 / #1304)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -17,6 +17,7 @@ Architecture decisions are recorded here as lightweight ADRs. Each record captur
 | [0009](0009-v1.0-public-api-scope.md) | v1.0 public API scope and stability guarantee |
 | [0010](0010-rate-limiting.md) | Rate limiting design |
 | [0011](0011-security-review-policy.md) | Security review policy — adversarial review and HTTP security invariants |
+| [0012](0012-sanctioned-test-database-wiring.md) | Sanctioned test database wiring via `Nene2\Testing` |
 
 ## Template
 

--- a/src/Testing/DatabaseTestKit.php
+++ b/src/Testing/DatabaseTestKit.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Testing;
+
+use InvalidArgumentException;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\PdoDatabaseTransactionManager;
+
+/**
+ * Sanctioned wiring helper for database-backed tests.
+ *
+ * The shipped PDO adapters (`PdoConnectionFactory`, `PdoDatabaseQueryExecutor`,
+ * `PdoDatabaseTransactionManager`) are marked `@internal` by ADR 0009. Tests that
+ * need to drive them directly should construct this kit instead of reaching into
+ * those classes.
+ *
+ * Part of the public API stability guarantee (see ADR 0009 and ADR 0012).
+ */
+final readonly class DatabaseTestKit
+{
+    public function __construct(
+        public DatabaseConnectionFactoryInterface $connectionFactory,
+        public DatabaseQueryExecutorInterface $queryExecutor,
+        public DatabaseTransactionManagerInterface $transactionManager,
+    ) {
+    }
+
+    /**
+     * Build a kit backed by a file-based SQLite database.
+     *
+     * `:memory:` is intentionally rejected: `transactional()` opens a separate
+     * connection via the connection factory, which for `:memory:` would observe
+     * an empty database. Pass a file path under {@see sys_get_temp_dir()} for
+     * isolation, e.g. `sys_get_temp_dir() . '/' . uniqid('kit-', true) . '.sqlite'`.
+     */
+    public static function sqlite(string $path): self
+    {
+        if ($path === ':memory:') {
+            throw new InvalidArgumentException(
+                'DatabaseTestKit::sqlite() does not support ":memory:". '
+                . 'transactional() opens a separate connection that would see an empty in-memory database. '
+                . 'Use a file path (e.g. sys_get_temp_dir() . "/" . uniqid("kit-", true) . ".sqlite") instead.',
+            );
+        }
+
+        return self::fromConfig(DatabaseConfig::sqlite($path));
+    }
+
+    /**
+     * Build a kit from an arbitrary {@see DatabaseConfig}. Use this for MySQL or
+     * PostgreSQL fixtures.
+     */
+    public static function fromConfig(DatabaseConfig $config): self
+    {
+        $factory = new PdoConnectionFactory($config);
+
+        return new self(
+            connectionFactory: $factory,
+            queryExecutor: new PdoDatabaseQueryExecutor($factory),
+            transactionManager: new PdoDatabaseTransactionManager($factory),
+        );
+    }
+}

--- a/tests/Testing/DatabaseTestKitTest.php
+++ b/tests/Testing/DatabaseTestKitTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Testing;
+
+use InvalidArgumentException;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Testing\DatabaseTestKit;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class DatabaseTestKitTest extends TestCase
+{
+    private string $path = '';
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir() . '/' . uniqid('kit-', true) . '.sqlite';
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->path !== '' && is_file($this->path)) {
+            @unlink($this->path);
+        }
+    }
+
+    public function testSqliteFactoryReturnsWiredInterfaces(): void
+    {
+        $kit = DatabaseTestKit::sqlite($this->path);
+
+        self::assertInstanceOf(DatabaseConnectionFactoryInterface::class, $kit->connectionFactory);
+        self::assertInstanceOf(DatabaseQueryExecutorInterface::class, $kit->queryExecutor);
+        self::assertInstanceOf(DatabaseTransactionManagerInterface::class, $kit->transactionManager);
+    }
+
+    public function testExecutorCanCreateInsertAndSelect(): void
+    {
+        $kit = DatabaseTestKit::sqlite($this->path);
+
+        $kit->queryExecutor->execute('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+        $id = $kit->queryExecutor->insert('INSERT INTO items (name) VALUES (?)', ['first']);
+
+        self::assertSame(1, $id);
+        self::assertSame(['id' => 1, 'name' => 'first'], $kit->queryExecutor->fetchOne('SELECT * FROM items WHERE id = ?', [$id]));
+    }
+
+    public function testTransactionalCommit(): void
+    {
+        $kit = DatabaseTestKit::sqlite($this->path);
+        $kit->queryExecutor->execute('CREATE TABLE counters (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)');
+
+        $result = $kit->transactionManager->transactional(function (DatabaseQueryExecutorInterface $tx): int {
+            return $tx->insert('INSERT INTO counters (value) VALUES (?)', [42]);
+        });
+
+        self::assertSame(1, $result);
+        self::assertSame(['id' => 1, 'value' => 42], $kit->queryExecutor->fetchOne('SELECT * FROM counters WHERE id = ?', [1]));
+    }
+
+    public function testTransactionalRollback(): void
+    {
+        $kit = DatabaseTestKit::sqlite($this->path);
+        $kit->queryExecutor->execute('CREATE TABLE counters (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)');
+
+        try {
+            $kit->transactionManager->transactional(function (DatabaseQueryExecutorInterface $tx): mixed {
+                $tx->insert('INSERT INTO counters (value) VALUES (?)', [99]);
+                throw new RuntimeException('abort');
+            });
+        } catch (RuntimeException $expected) {
+            self::assertSame('abort', $expected->getMessage());
+        }
+
+        self::assertNull(
+            $kit->queryExecutor->fetchOne('SELECT * FROM counters WHERE value = ?', [99]),
+            'Rolled-back insert must not be visible after transactional() throws',
+        );
+    }
+
+    public function testSqliteFactoryRejectsInMemory(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/:memory:/');
+
+        DatabaseTestKit::sqlite(':memory:');
+    }
+
+    public function testFromConfigAcceptsArbitraryDatabaseConfig(): void
+    {
+        $kit = DatabaseTestKit::fromConfig(DatabaseConfig::sqlite($this->path));
+
+        $kit->queryExecutor->execute('CREATE TABLE pings (id INTEGER PRIMARY KEY)');
+        self::assertSame(1, $kit->queryExecutor->insert('INSERT INTO pings DEFAULT VALUES'));
+    }
+}


### PR DESCRIPTION
## Summary

- 新規 namespace `Nene2\Testing\` を導入し、`DatabaseTestKit` を **stable public API** として追加
- DX Trial で報告された **IMP-14**（具象 PDO クラスの `@internal` 境界を踏まずに DB テストを書きたい）と **IMP-18**（`:memory:` + `transactional()` の沈黙する非互換）を同時解決
- ADR 0012 として決定記録、ADR 0009 stable API 表を更新
- ADR 0009 が定める PDO 具象クラス (`PdoConnectionFactory` / `PdoDatabaseQueryExecutor` / `PdoDatabaseTransactionManager`) の `@internal` 境界は **維持**（崩さない）

## Shape

```php
namespace Nene2\Testing;

final readonly class DatabaseTestKit
{
    public function __construct(
        public DatabaseConnectionFactoryInterface  $connectionFactory,
        public DatabaseQueryExecutorInterface      $queryExecutor,
        public DatabaseTransactionManagerInterface $transactionManager,
    ) {}

    public static function sqlite(string $path): self;       // :memory: は例外で拒否
    public static function fromConfig(DatabaseConfig $c): self;
}
```

使用例:
```php
$kit = DatabaseTestKit::sqlite($tmpPath);
$id = $kit->queryExecutor->insert('INSERT INTO items (name) VALUES (?)', ['x']);
$kit->transactionManager->transactional(fn ($tx) => $tx->insert(...));
```

## Changes

- `src/Testing/DatabaseTestKit.php` — 新規（stable public API）
- `docs/adr/0012-sanctioned-test-database-wiring.md` — 新規 ADR
- `docs/adr/0009-v1.0-public-api-scope.md` — stable API 表に `Nene2\Testing` 行追加
- `docs/adr/index.md` — ADR 索引に 0012 追加
- `tests/Testing/DatabaseTestKitTest.php` — 新規（6 tests: wiring / INSERT / commit / rollback / `:memory:` 拒否 / `fromConfig`）
- `CHANGELOG.md` — `[Unreleased]` 追記

## Verification

```
docker compose run --rm app composer check
# → 437 tests, 1008 assertions / PHPStan 0 errors / CS 0 issues / OpenAPI valid / MCP valid / Version OK
```

## Self-review

- `docs/review/backend-api.md`
- `docs/review/docs-policy.md`

## Related

- Closes #1307
- Depends on: #1304 (`DatabaseConfig::sqlite()` ファクトリ)
- ADR: `docs/adr/0012-sanctioned-test-database-wiring.md`（新規）
- 参照: `docs/todo/dx-trial-improvements.md` IMP-14 / IMP-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)