### PR TITLE
docs(ja): 未訳 howto 10 件を翻訳

### DIFF
--- a/docs/ja/howto/category-hierarchy-api.md
+++ b/docs/ja/howto/category-hierarchy-api.md
@@ -1,0 +1,366 @@
+# How-to: カテゴリ階層ツリー API
+
+> **FT 参照**: FT344 (`NENE2-FT/treelog`) — parent_id + depth によるカテゴリツリー、直下の子の取得、再帰 SQL CTE による祖先・子孫の取得、リーフのみの削除（子がある場合は 409）、17 テスト PASS。
+
+このガイドでは、階層構造のカテゴリツリーを構築する方法を示します。任意の親付きでカテゴリを作成し、再帰 SQL CTE を使ってツリーを上方向（祖先）・下方向（子孫）にたどり、安全な削除を強制します。
+
+## スキーマ
+
+```sql
+CREATE TABLE categories (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL,
+    parent_id  INTEGER REFERENCES categories(id) ON DELETE RESTRICT,
+    depth      INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL
+);
+
+CREATE INDEX idx_categories_parent ON categories(parent_id);
+```
+
+`depth` は挿入時に計算されます: `parent.depth + 1`（ルートは 0）。`ON DELETE RESTRICT` により、子をまだ持つ親を削除できなくなります。
+
+## エンドポイント
+
+| Method   | Path                              | 説明                             |
+|----------|-----------------------------------|----------------------------------|
+| `POST`   | `/categories`                     | ルートまたは子カテゴリを作成      |
+| `GET`    | `/categories`                     | ルートカテゴリのみ一覧            |
+| `GET`    | `/categories/{id}`                | 単一カテゴリを取得                |
+| `GET`    | `/categories/{id}/children`       | 直下の子のみ                      |
+| `GET`    | `/categories/{id}/ancestors`      | ルートからノードまでの経路（パンくず） |
+| `GET`    | `/categories/{id}/descendants`    | サブツリー全ノード（任意の深さ）  |
+| `DELETE` | `/categories/{id}`                | リーフのみ削除（子がある場合は 409） |
+
+## カテゴリの作成
+
+```php
+// ルートカテゴリ（親なし）
+POST /categories
+{"name": "Electronics"}
+
+→ 201
+{"id": 1, "name": "Electronics", "parent_id": null, "depth": 0, "created_at": "..."}
+
+// 子カテゴリ
+POST /categories
+{"name": "Smartphones", "parent_id": 1}
+
+→ 201
+{"id": 2, "name": "Smartphones", "parent_id": 1, "depth": 1, "created_at": "..."}
+
+// 孫
+POST /categories
+{"name": "Android", "parent_id": 2}
+→ 201  // depth: 2
+```
+
+### バリデーション
+
+```php
+POST /categories  {"parent_id": 9999}
+→ 404  // 親が存在しない
+
+POST /categories  {"parent_id": 1}
+→ 422  // name は必須
+```
+
+### 挿入時の depth 計算
+
+```php
+$depth = 0;
+if ($parentId !== null) {
+    $parent = $this->repo->findById($parentId);
+    if ($parent === null) {
+        throw new CategoryNotFoundException($parentId);
+    }
+    $depth = $parent['depth'] + 1;
+}
+$this->repo->insert($name, $parentId, $depth, $now);
+```
+
+## ルートカテゴリ一覧
+
+```php
+GET /categories
+
+→ 200
+{
+  "items": [
+    {"id": 1, "name": "Electronics", "parent_id": null, "depth": 0, ...},
+    {"id": 5, "name": "Clothing",    "parent_id": null, "depth": 0, ...}
+  ],
+  "total": 2
+}
+```
+
+`WHERE parent_id IS NULL` のみを返します — 子カテゴリは含まれません。
+
+## 直下の子の一覧
+
+```php
+GET /categories/1/children
+
+→ 200
+{
+  "items": [
+    {"id": 2, "name": "Smartphones", "parent_id": 1, "depth": 1, ...},
+    {"id": 3, "name": "Laptops",     "parent_id": 1, "depth": 1, ...}
+  ],
+  "total": 2
+}
+```
+
+**直下のみ** — 孫はここには現れません。サブツリー全体が必要な場合は `/descendants` を使ってください。
+
+```sql
+SELECT * FROM categories WHERE parent_id = ? ORDER BY id ASC
+```
+
+## 祖先の取得（パンくず経路）— 再帰 CTE
+
+```php
+GET /categories/4/ancestors
+
+// カテゴリ 4 = "Android"（depth 2、親は "Smartphones"）
+→ 200
+{
+  "items": [
+    {"id": 1, "name": "Electronics", "depth": 0, ...},   // ルートが先頭
+    {"id": 2, "name": "Smartphones", "depth": 1, ...}    // 最も近い親が末尾
+  ],
+  "total": 2
+}
+
+// ルートカテゴリには祖先がない
+GET /categories/1/ancestors
+→ 200  {"items": [], "total": 0}
+```
+
+`depth ASC` でソート → ルートが先頭（自然なパンくず順）。
+
+### 祖先取得の再帰 CTE
+
+```sql
+WITH RECURSIVE ancestor_cte(id, name, parent_id, depth, created_at) AS (
+    -- シード: 直接の親から開始
+    SELECT c.id, c.name, c.parent_id, c.depth, c.created_at
+    FROM categories c
+    WHERE c.id = (SELECT parent_id FROM categories WHERE id = :id)
+
+    UNION ALL
+
+    -- 再帰: ルートまで上に辿る
+    SELECT c.id, c.name, c.parent_id, c.depth, c.created_at
+    FROM categories c
+    INNER JOIN ancestor_cte a ON c.id = a.parent_id
+)
+SELECT * FROM ancestor_cte ORDER BY depth ASC
+```
+
+## 子孫の取得（サブツリー全体）— 再帰 CTE
+
+```php
+GET /categories/1/descendants
+
+// "Electronics" は Smartphones、Laptops、Android（Smartphones の子）を持つ
+→ 200
+{
+  "items": [
+    {"id": 2, "name": "Smartphones", "depth": 1, ...},
+    {"id": 3, "name": "Laptops",     "depth": 1, ...},
+    {"id": 4, "name": "Android",     "depth": 2, ...}
+  ],
+  "total": 3   // 直接の子だけでなく、サブツリー全ノード
+}
+
+// リーフは空を返す
+GET /categories/4/descendants
+→ 200  {"items": [], "total": 0}
+```
+
+クエリ対象ノードの兄弟は **含まれません**。
+
+### 子孫取得の再帰 CTE
+
+```sql
+WITH RECURSIVE desc_cte(id, name, parent_id, depth, created_at) AS (
+    -- シード: 直下の子
+    SELECT id, name, parent_id, depth, created_at
+    FROM categories WHERE parent_id = :id
+
+    UNION ALL
+
+    -- 再帰: 子の子
+    SELECT c.id, c.name, c.parent_id, c.depth, c.created_at
+    FROM categories c
+    INNER JOIN desc_cte d ON c.parent_id = d.id
+)
+SELECT * FROM desc_cte ORDER BY depth ASC, id ASC
+```
+
+## カテゴリの削除
+
+```php
+// リーフノード → 204 No Content
+DELETE /categories/4   // "Android"（子なし）
+→ 204
+
+// 子を持つノード → 409 Conflict
+DELETE /categories/1   // "Electronics"（Smartphones、Laptops を持つ）
+→ 409
+{
+  "type": "https://nene2.dev/problems/has-children",
+  "title": "Category has children",
+  "status": 409,
+  "detail": "Cannot delete a category that has children"
+}
+
+// 存在しない → 404
+DELETE /categories/9999
+→ 404
+```
+
+### 削除実装
+
+```php
+public function delete(int $id): void
+{
+    $cat = $this->repo->findById($id);
+    if ($cat === null) {
+        throw new CategoryNotFoundException($id);
+    }
+    if ($this->repo->hasChildren($id)) {
+        throw new HasChildrenException($id);
+    }
+    $this->repo->delete($id);
+}
+```
+
+```sql
+-- hasChildren チェック
+SELECT COUNT(*) FROM categories WHERE parent_id = ?
+
+-- 削除
+DELETE FROM categories WHERE id = ?
+```
+
+---
+
+## ATK Assessment — Cracker-Mindset Attack Test
+
+### ATK-01 — Parent ID 操作による循環参照の作成 🚫 BLOCKED
+
+**Attack**: 攻撃者がチェーン A→B→C を作成した後、B の親を C に再割り当てして循環を作り、CTE 再帰を無限ループさせる。
+**Result**: BLOCKED — `parent_id` は作成時にのみ設定され、親を再割り当てする PATCH/PUT エンドポイントは存在しません。depth は挿入時に親の検証済み depth から一度だけ計算されます。親子関係が不変であるため、循環は構造的に不可能です。
+
+---
+
+### ATK-02 — 作成時に存在しない Parent ID 🚫 BLOCKED
+
+**Attack**: 攻撃者が `{"name": "Orphan", "parent_id": 9999}` を送り、宙ぶらりんのカテゴリを作成する。
+**Result**: BLOCKED — リポジトリは挿入前に親を検索します。親が存在しなければ `CategoryNotFoundException` をスロー → 404。孤立行は作成されません。
+
+---
+
+### ATK-03 — 非リーフを削除してサブツリーを消去 🚫 BLOCKED
+
+**Attack**: 攻撃者が `DELETE /categories/1`（多数の子を持つルート）を送り、サブツリー全体を消去する。
+**Result**: BLOCKED — `hasChildren()` チェックが true を返し → `HasChildrenException` → 409。`ON DELETE RESTRICT` も DB レイヤーで強制するため、アプリケーションロジックを回避されても FK 制約が削除を防ぎます。
+
+---
+
+### ATK-04 — 存在しないカテゴリへの CTE 走査 🚫 BLOCKED
+
+**Attack**: 攻撃者が `/categories/9999/ancestors` や `/categories/9999/descendants` を存在しない ID に対して要求し、データを探る。
+**Result**: BLOCKED — リポジトリは CTE 実行前にカテゴリの存在を確認します。存在しない場合 → `CategoryNotFoundException` → 404。データ漏洩はありません。
+
+---
+
+### ATK-05 — カテゴリ名経由の SQL インジェクション 🚫 BLOCKED
+
+**Attack**: 攻撃者が `{"name": "'; DROP TABLE categories; --"}` を送って SQL を注入する。
+**Result**: BLOCKED — 全クエリで PDO プリペアドステートメントとバインドパラメーターを使用しています。name は文字列としてそのまま保存され、SQL に補間されることはありません。
+
+---
+
+### ATK-06 — 循環による再帰 CTE 無限ループ 🚫 BLOCKED
+
+**Attack**: 攻撃者が ancestor_cte を無限ループさせる状況（A が B の親、B が A の親）を作ろうとする。
+**Result**: BLOCKED — `parent_id` は作成後不変です。`parent_id=B` で A を作成するには B が先に存在する必要がありますが、その時点では A は存在しないため、B を `parent_id=A` で作成することはできません。逐次作成の制約により循環は不可能です。
+
+---
+
+### ATK-07 — 深いチェーンによる CTE depth bomb ✅ SAFE
+
+**Attack**: 攻撃者が 1000 階層以上の深いチェーンを作り、CTE 再帰制限を使い果たす。
+**Result**: SAFE — SQLite の CTE デフォルト再帰制限は 1000 です。非常に長いチェーンはこの制限に達する可能性があります。実運用ではレート制限とリクエスト毎のノード作成コストにより実現困難です。本番運用には挿入時の `MAX_DEPTH` ガード（例: `depth > 20` を拒否）を追加してください。
+
+---
+
+### ATK-08 — GET /categories/{id} による ID 列挙 🚫 BLOCKED
+
+**Attack**: 攻撃者が整数 ID をインクリメントして、見るべきでないものを含む全カテゴリを列挙する。
+**Result**: BLOCKED — カテゴリがユーザー単位またはテナント単位の場合、認可チェック（JWT テナントクレーム / 所有権）が個別 GET を保護します。treelog はベースラインとして公開読み取りを示しているもので、スコープ制限は認可レイヤーの関心事です。
+
+---
+
+### ATK-09 — children エンドポイントが孫を返す ✅ SAFE
+
+**Attack**: 攻撃者は `/children` が意図せず多階層サブツリーデータを露出することを期待する。
+**Result**: SAFE — `/children` は直下の子のみを返します（`WHERE parent_id = ?`）。孫の取得には明示的な `/descendants` 走査が必要です。children エンドポイントを介した意図しないデータ露出はありません。
+
+---
+
+### ATK-10 — 大きな name フィールドによるメモリ枯渇 ✅ SAFE
+
+**Attack**: 攻撃者が作成ペイロードに 10 MB の `name` 値を送る。
+**Result**: SAFE — リクエストサイズ制限ミドルウェア（デフォルト 1 MB）がハンドラーに到達する前に過大なボディを拒否します。アプリケーションレベルの `name` 長さバリデーション（例: `max: 255`）が二重のガードを提供します。
+
+---
+
+### ATK-11 — 保護されたノードを削除するための逐次サブツリー剪定 ✅ SAFE
+
+**Attack**: 攻撃者が子を個別に削除して保護されたツリー中間ノードをリーフにし、それを削除する。
+**Result**: SAFE — これは正当な操作シーケンスです。子を一つずつ剪定するのはサブツリーを削除する正しい方法です。認可（所有権チェック）により、認可されていないユーザーが他人のカテゴリを削除することは防がれます。
+
+---
+
+### ATK-12 — レースコンディション: hasChildren チェックと子挿入 🚫 BLOCKED
+
+**Attack**: 2 つの同時リクエスト: 一方が `hasChildren()` をチェック（false を返す）して削除に進む。もう一方が削除実行直前に新しい子を作成する。
+**Result**: BLOCKED — DB レベルの `ON DELETE RESTRICT` FK 制約により、コミット時点で子行が存在すれば削除を防ぎます。アプリケーションレイヤーの `hasChildren()` チェックがレースしても、DB 制約が最終ガードとなります。
+
+---
+
+### ATK Summary
+
+| ID | Attack | Result |
+|----|--------|--------|
+| ATK-01 | Parent ID 操作 / 循環参照 | 🚫 BLOCKED |
+| ATK-02 | 作成時に存在しない parent ID | 🚫 BLOCKED |
+| ATK-03 | 非リーフ削除によるサブツリー消去 | 🚫 BLOCKED |
+| ATK-04 | 存在しないノードへの CTE 走査 | 🚫 BLOCKED |
+| ATK-05 | name フィールド経由の SQL インジェクション | 🚫 BLOCKED |
+| ATK-06 | 再帰 CTE の循環 / 無限ループ | 🚫 BLOCKED |
+| ATK-07 | 深いチェーンによる CTE depth bomb | ✅ SAFE（MAX_DEPTH ガード追加） |
+| ATK-08 | GET による ID 列挙 | 🚫 BLOCKED |
+| ATK-09 | children エンドポイントの意図しないサブツリー露出 | ✅ SAFE |
+| ATK-10 | 大きな name フィールドによるメモリ枯渇 | ✅ SAFE（サイズ制限ミドルウェア） |
+| ATK-11 | 逐次サブツリー剪定 | ✅ SAFE（正当な操作） |
+| ATK-12 | hasChildren と子挿入のレースコンディション | 🚫 BLOCKED |
+
+**6 BLOCKED, 4 SAFE, 0 EXPOSED** — 重大な発見なし。本番運用には挿入時の `MAX_DEPTH` ガードを追加してください。
+
+---
+
+## やってはいけないこと
+
+| アンチパターン | リスク |
+|---|---|
+| リクエストごとに祖先を数えて depth を計算する | O(depth) の N+1 クエリ。保存済みの `depth` カラムを使う |
+| サブツリー深度を再計算せずに parent_id 更新（親付け替え）を許可する | サブツリー全体の保存済み `depth` 値が古くなる/誤りになる |
+| 親 FK に `ON DELETE RESTRICT` を付けない | アプリケーションのバグが静かに子行を孤立させる |
+| 存在しないカテゴリの祖先/子孫に対して空リスト 200 を返す | 呼び出し側が「祖先なし」と「カテゴリが存在しない」を区別できない |
+| クライアント入力の `depth` を受け付ける | 攻撃者が深い子に `depth=0` を設定し、ツリー不変条件を破壊する |
+| CTE 再帰制限や挿入時の MAX_DEPTH 上限がない | 深いチェーンが SQLite の 1000 階層 CTE 制限に達する |

--- a/docs/ja/howto/circuit-breaker.md
+++ b/docs/ja/howto/circuit-breaker.md
@@ -1,0 +1,141 @@
+# How-to: Circuit Breaker
+
+> **FT 参照**: FT298 (`NENE2-FT/circuitlog`) — サーキットブレーカーパターン: closed/open/half_open の 3 状態マシン、設定可能な失敗閾値、タイムアウトベースの自動 half_open 遷移、open 回路での 503 Service Unavailable、`isCallAllowed()` 読み取り専用チェック、15 テスト / 28 アサーション PASS。
+
+サーキットブレーカーパターンは、外部サービスを呼ぶ際の連鎖障害を防ぎます。遅い・失敗した呼び出しが積み上がるのを放置するのではなく、回路を open にトリップさせ、依存先が回復するまで呼び出しを即座に拒否します。
+
+## 3 つの状態
+
+```
+Closed ──(N 回連続失敗)──▶ Open ──(タイムアウト経過)──▶ Half-Open
+  ▲                                                          │
+  └──────────────────(成功)──────────────────────────────────┘
+  Half-Open ──(失敗)──▶ Open
+```
+
+| 状態 | 振る舞い |
+|---|---|
+| **Closed** | 通常 — 呼び出しはそのまま通過します。エラー毎に失敗カウントを増加。 |
+| **Open** | 呼び出しは即座に 503 で拒否されます。`failure_threshold` 回連続失敗の後、`timeout_seconds` の間 open になります。 |
+| **Half-Open** | 単一のプローブ呼び出しが許可されます。成功 → Closed（リセット）。失敗 → 再び Open。 |
+
+## スキーマ
+
+```sql
+CREATE TABLE IF NOT EXISTS circuits (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    name              TEXT    NOT NULL UNIQUE,
+    state             TEXT    NOT NULL DEFAULT 'closed',
+    failure_count     INTEGER NOT NULL DEFAULT 0,
+    failure_threshold INTEGER NOT NULL DEFAULT 5,
+    open_until        TEXT,
+    half_open_at      TEXT,
+    last_failure_at   TEXT,
+    updated_at        TEXT    NOT NULL
+);
+```
+
+回路名は通常、外部サービス識別子です（例: `payment-gateway`、`email-svc`）。複数の独立した回路が共存できます。
+
+## 結果の記録
+
+```php
+// 外部サービスへの成功した呼び出しの後:
+$this->repo->recordSuccess($circuitName, $now);
+
+// 失敗した呼び出しの後:
+$this->repo->recordFailure($circuitName, $now, timeoutSeconds: 30);
+```
+
+`recordFailure()` が遷移を決定します:
+- `failure_count + 1 >= failure_threshold` の場合 → 状態を `open` に設定し、`open_until = now + timeout` を計算。
+- 閾値未満の場合 → `failure_count` を増加し、`closed` のまま。
+- `half_open` 状態の場合 → どんな失敗でも即座に再 open。
+
+## 呼び出しが許可されているかチェック
+
+```php
+$circuit = $this->repo->maybeTransitionToHalfOpen($name, $now);
+
+if (!$circuit->isCallAllowed($now)) {
+    // 外部サービスを呼ばずに即座に 503 を返す
+    return $problems->create($request, 'service-unavailable', 'Circuit is open.', 503);
+}
+
+// 呼び出しを試行...
+```
+
+毎リクエスト、`isCallAllowed()` チェックの前に `maybeTransitionToHalfOpen()` を呼んでください。これは `open_until` が経過した時に `Open → Half-Open` へ遷移させ、プローブ呼び出しを通過させます。
+
+```php
+public function isCallAllowed(string $now): bool
+{
+    return match ($this->state) {
+        CircuitState::Closed   => true,
+        CircuitState::Open     => $now >= ($this->openUntil ?? ''),
+        CircuitState::HalfOpen => true,
+    };
+}
+```
+
+## Half-Open のタイミング
+
+`Open → Half-Open` 遷移は遅延型です: `open_until` が経過した後、次に `maybeTransitionToHalfOpen()` が呼ばれた時点で発生します。これは意図的な設計で、バックグラウンドタイマーを避け、状態変化を到来するリクエストに紐づけます。
+
+## 失敗閾値とタイムアウトのチューニング
+
+| 依存タイプ | 推奨閾値 | 推奨タイムアウト |
+|---|---|---|
+| データベース（クリティカル） | 3–5 | 10–30s |
+| 外部 API | 5–10 | 30–60s |
+| 非クリティカルサービス | 10–20 | 60–120s |
+
+閾値が高いほど偽陽性（一時的なグリッチ）を減らせます。タイムアウトが長いほど依存先に回復時間を与えますが、顧客に見える機能低下も長くなります。
+
+## サービスごとの複数回路
+
+異なる失敗ドメインには別々の回路名を使ってください:
+
+```
+payment-gateway/charge
+payment-gateway/refund
+email-svc/transactional
+email-svc/marketing
+```
+
+これにより refund エンドポイントの失敗が charge の試行をブロックすることを防げます。
+
+## 回路が Open の時のレスポンス
+
+`open_until` を指す `Retry-After` ヘッダー付きで `503 Service Unavailable` を返します:
+
+```php
+return $problems->create($request, 'service-unavailable', 'Circuit is open.', 503, null, [
+    'open_until' => $circuit->openUntil,
+]);
+```
+
+`503` を尊重するクライアントやロードバランサーは、回路が open の間、このインスタンスへのルーティングを停止できます。
+
+## 設計判断
+
+**なぜインメモリではなく DB バック状態か?** インメモリ状態は再起動時に失われ、PHP-FPM ワーカー間で共有されません。DB 状態は全ワーカー間で一貫し、再起動を生き残ります。代わりに保護された呼び出し毎に DB クエリが 1 つ追加されます。高スループット経路ではアトミックインクリメント操作を備えた Redis を検討してください。
+
+**なぜ遅延型 Half-Open 遷移か?** 能動的なバックグラウンド遷移はスケジューラーやデーモンを必要とします。遅延遷移はよりシンプルで、スケジューラー視点ではステートレスで、リクエスト量がチェックの実行を担保するほとんどの Web API には十分です。
+
+**なぜ `failure_count` は成功でリセットされるのか?** これは「連続失敗」セマンティクスです。代替案は「スライディングウィンドウでの失敗率」（例: 直近 60 秒で 50% 超失敗）です。スライディングウィンドウは低頻度だが安定したトラフィックのサービスにはより正確ですが、連続失敗の方がシンプルで、上か下かが明確なサービスには十分です。
+
+---
+
+## やってはいけないこと
+
+| アンチパターン | リスク |
+|---|---|
+| `UNIQUE(name)` 制約がない | 同時作成で同じ回路に複数行ができる |
+| open 回路にタイムアウトがない | 閾値超過後、回路が永久に open のまま |
+| half_open 状態がない | 回路が open → closed に直接遷移し、プローブ後検証ができない |
+| 回路 open 時に 200 を返す | 呼び出し側が成功と勘違いし、ダウンストリームエラーが隠れる |
+| 503 レスポンスに `open_until` がない | 呼び出し側が即座に再試行（thundering herd）。リトライタイミングを含めること |
+| 文字列 `"true"` を成功として受け入れる | JSON 型混同。`is_bool()` を厳密に使う |
+| `maybeTransitionToHalfOpen()` を先に呼ばずに `isCallAllowed()` をチェック | open 回路が half_open にならず、永久にスタックする |
+| インメモリ状態のみ | ワーカー再起動で状態消失。PHP-FPM ワーカー間で共有なし |

--- a/docs/ja/howto/collection-api.md
+++ b/docs/ja/howto/collection-api.md
@@ -1,0 +1,123 @@
+# How-to: コレクション API（ユーザーキュレートリスト）
+
+> **FT 参照**: FT299 (`NENE2-FT/collectionlog`) — ユーザーキュレートの記事コレクション: is_public/private による可視性（プライベートには非所有者に 404）、UNIQUE(collection_id, article_id) による重複排除、position による順序、所有者のみの書き込みアクセス、20 テスト / 34 アサーション PASS。
+
+このガイドでは、ユーザーが名前付きリストを作成し、記事を追加し、公開/非公開の可視性を制御するユーザーキュレート型コレクション API の構築方法を示します。
+
+## スキーマ
+
+```sql
+CREATE TABLE collections (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL,
+    name       TEXT    NOT NULL,
+    is_public  INTEGER NOT NULL DEFAULT 0,  -- 0=private, 1=public
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE collection_items (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    collection_id INTEGER NOT NULL,
+    article_id    INTEGER NOT NULL,
+    position      INTEGER NOT NULL,
+    added_at      TEXT    NOT NULL,
+    UNIQUE (collection_id, article_id),
+    FOREIGN KEY (collection_id) REFERENCES collections(id),
+    FOREIGN KEY (article_id)    REFERENCES articles(id)
+);
+```
+
+`UNIQUE(collection_id, article_id)` は同じ記事がコレクションに 2 回現れることを防ぎます。`position` は順序付き表示を可能にします。
+
+## エンドポイント
+
+| Method | Path | Auth | 説明 |
+|--------|------|------|-------------|
+| `POST` | `/collections` | `X-User-Id` | コレクションを作成 |
+| `GET` | `/collections/{id}` | `X-User-Id` | コレクションを取得（可視性チェック） |
+| `PUT` | `/collections/{id}` | `X-User-Id`（所有者） | 名前/可視性を更新 |
+| `DELETE` | `/collections/{id}` | `X-User-Id`（所有者） | コレクションを削除 |
+| `POST` | `/collections/{id}/items` | `X-User-Id`（所有者） | 記事を追加 |
+| `DELETE` | `/collections/{id}/items/{articleId}` | `X-User-Id`（所有者） | 記事を削除 |
+
+## 可視性 — プライベートコレクションには 404
+
+```php
+$isOwner  = (int) $collection['user_id'] === $actorId;
+$isPublic = (bool) $collection['is_public'];
+
+if (!$isOwner && !$isPublic) {
+    return $this->responseFactory->create(['error' => 'collection not found'], 404);
+}
+```
+
+非所有者がプライベートコレクションにアクセスしようとした場合、403 ではなく 404 を返します。これによりプライベートコレクションの存在を露呈することを防ぎます。
+
+## 所有者のみの書き込みアクセス
+
+```php
+if ((int) $collection['user_id'] !== $actorId) {
+    return $this->responseFactory->create(['error' => 'access denied'], 403);
+}
+```
+
+追加・削除・更新・削除操作にはアクター（操作者）がコレクション所有者であることが必要です。可視性とは異なり、書き込みアクセス失敗は 403 を返します（この時点でコレクションの存在は既知のため）。
+
+## UNIQUE(collection_id, article_id) — 重複排除
+
+DB 制約により、同じ記事がコレクションに 2 回現れることを防ぎます。アプリケーションは挿入前に重複をチェックします:
+
+```php
+// リポジトリは addItem() の前に findItem() でチェック
+if ($this->repository->findItem($id, $articleId) !== null) {
+    return $this->responseFactory->create(['error' => 'article already in collection'], 409);
+}
+$this->repository->addItem($id, $articleId, date('c'));
+```
+
+## is_public を真偽整数として扱う
+
+```php
+$isPublic = isset($body['is_public']) && $body['is_public'] === true;
+```
+
+`is_public` は SQLite では INTEGER（0/1）として保存されます。読み込み時: `(bool) $collection['is_public']`。書き込み時: 厳密な `=== true` チェックで文字列 `"true"` による公開有効化を防ぎます。
+
+## レスポンス形状
+
+```php
+private function formatCollection(array $collection, array $items): array
+{
+    return [
+        'id'         => (int)    $collection['id'],
+        'user_id'    => (int)    $collection['user_id'],
+        'name'       => (string) $collection['name'],
+        'is_public'  => (bool)   $collection['is_public'],
+        'item_count' => count($items),
+        'items'      => array_map(fn($item) => [
+            'article_id' => (int)    $item['article_id'],
+            'title'      => (string) $item['article_title'],
+            'position'   => (int)    $item['position'],
+            'added_at'   => (string) $item['added_at'],
+        ], $items),
+        'created_at' => (string) $collection['created_at'],
+        'updated_at' => (string) $collection['updated_at'],
+    ];
+}
+```
+
+---
+
+## やってはいけないこと
+
+| アンチパターン | リスク |
+|---|---|
+| プライベートコレクションアクセスに 403 を返す | 非所有者にコレクションの存在を露呈する（情報開示） |
+| 任意のユーザーが任意のコレクションにアイテム追加を許可する | 非所有者が他人のコレクションにコンテンツを注入する |
+| `UNIQUE(collection_id, article_id)` がない | 同じ記事が 2 回追加され、紛らわしい重複エントリができる |
+| `is_public` に `"true"` 文字列を受け付ける | 型混同: 緩い比較では任意の文字列が truthy になる |
+| position フィールドがない | アイテムが常に挿入順に表示され、並べ替え不可 |
+| 所有権チェックなしで DELETE collection | 任意のユーザーが任意のコレクションを削除 |
+| items を含めず `item_count` を露出する | プライベートコレクションの非所有者にもコレクションサイズが露呈する |

--- a/docs/ja/howto/comment-thread.md
+++ b/docs/ja/howto/comment-thread.md
@@ -1,0 +1,101 @@
+# How-to: コメントスレッド API
+
+このガイドでは、ページネーション・著者のみによる削除・管理者オーバーライドを備えた、リソーススコープ付きのコメントスレッドを示します。
+
+## パターン概要
+
+- コメントはリソース（整数 ID で識別）に紐付きます。
+- 認証済みユーザーは任意のリソースにコメントを投稿できます。
+- コメントは公開で読み取り可能です（一覧表示に認証不要）。
+- 著者は自分のコメントを削除できます。管理者はどれでも削除可能です。
+- `limit` と `offset` クエリパラメーターによるページネーション。
+
+## スキーマ
+
+```sql
+CREATE TABLE IF NOT EXISTS comments (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL,
+    user_id     INTEGER NOT NULL,
+    body        TEXT    NOT NULL,
+    created_at  TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_comments_resource ON comments (resource_id, id ASC);
+```
+
+## ページネーションパターン
+
+```php
+$stmt = $this->pdo->prepare(
+    'SELECT * FROM comments WHERE resource_id = :rid ORDER BY id ASC LIMIT :lim OFFSET :off'
+);
+$stmt->bindValue(':rid', $resourceId, PDO::PARAM_INT);
+$stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+$stmt->bindValue(':off', $offset, PDO::PARAM_INT);
+```
+
+レスポンスには `total`（リソースの全コメント数）、`limit`、`offset` が含まれ、クライアントがページネーションコントロールを構築できます:
+
+```json
+{
+  "comments": [...],
+  "total": 42,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+## limit のクランプ
+
+無効または範囲外の limit/offset 値は静かに安全なデフォルト値にクランプされます:
+
+```php
+private function clampInt(string $raw, int $default, int $min, int $max): int
+{
+    if (!ctype_digit($raw) && $raw !== '') {
+        return $default;
+    }
+    $val = $raw !== '' ? (int) $raw : $default;
+    return min(max($val, $min), $max);
+}
+```
+
+クエリ文字列での ReDoS を避けるため `ctype_digit()` を使用しています。
+
+## IDOR: 著者のみの削除
+
+非管理者ユーザーは自分のコメントしか削除できません。他人のコメントを削除しようとすると（403 ではなく）404 が返ります:
+
+```php
+if (!$isAdmin && (int) $comment['user_id'] !== $userId) {
+    return false;  // → 404
+}
+```
+
+## リソース分離
+
+すべてのクエリに `WHERE resource_id = :rid` を含め、リソース 1 のコメントがリソース 2 と混在しないようにします。
+
+## バリデーションルール
+
+| Field | Rule |
+|---|---|
+| `X-User-Id` | POST/DELETE で必須。`ctype_digit`、>0 |
+| `body` | 空でないこと、最大 2000 文字 |
+| `{resourceId}` パス | `ctype_digit`、最大 18 文字、>0。それ以外は 404 |
+| `limit` クエリ | 1–100 の整数。デフォルト 20 |
+| `offset` クエリ | 非負整数。デフォルト 0 |
+
+## ルート
+
+```
+POST   /resources/{resourceId}/comments  コメントを投稿（X-User-Id 必須）
+GET    /resources/{resourceId}/comments  コメント一覧（ページネーション、公開）
+DELETE /comments/{id}                   コメントを削除（著者または管理者）
+```
+
+## 関連
+
+- FT211 ソース: `../NENE2-FT/commentlog/`
+- 関連: `docs/howto/note-taking.md`（FT202、ノート CRUD）
+- 関連: `docs/howto/leaderboard-ranking.md`（FT206、リソーススコープデータ）

--- a/docs/ja/howto/contact-management.md
+++ b/docs/ja/howto/contact-management.md
@@ -1,0 +1,232 @@
+# How-to: 連絡先管理 API
+
+> **FT 参照**: FT238 (`NENE2-FT/contactlog`) — 連絡先管理 API
+
+所有者スコープ付き CRUD、多対多の連絡先グループシステム、`LIKE` 全文検索と `EXISTS` グループフィルターの組み合わせ、`DatabaseConstraintException` ハンドリングに支えられた冪等なグループメンバーシップ操作を持つ連絡先管理 API を示します。
+
+---
+
+## ルート
+
+| Method   | Path                                                   | 説明                                   |
+|----------|--------------------------------------------------------|----------------------------------------|
+| `POST`   | `/owners/{ownerId}/contacts`                           | 連絡先を作成                           |
+| `GET`    | `/owners/{ownerId}/contacts`                           | 連絡先を検索（オプションで `?q=`、`?group_id=`） |
+| `GET`    | `/owners/{ownerId}/contacts/{id}`                      | 単一連絡先を取得                       |
+| `PUT`    | `/owners/{ownerId}/contacts/{id}`                      | 連絡先を更新（完全置換）               |
+| `DELETE` | `/owners/{ownerId}/contacts/{id}`                      | 連絡先を削除                           |
+| `POST`   | `/owners/{ownerId}/groups`                             | グループを作成                         |
+| `PUT`    | `/owners/{ownerId}/contacts/{contactId}/groups/{groupId}` | 連絡先をグループに追加              |
+| `DELETE` | `/owners/{ownerId}/contacts/{contactId}/groups/{groupId}` | 連絡先をグループから削除            |
+
+`{ownerId}` はすべての操作を 1 人の所有者にスコープします — 1 人の所有者が作成した連絡先とグループは他者から見えません。
+
+---
+
+## スキーマ: contacts、groups、contact_groups
+
+```sql
+CREATE TABLE IF NOT EXISTS contacts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id   TEXT    NOT NULL,
+    name       TEXT    NOT NULL,
+    email      TEXT    NOT NULL DEFAULT '',
+    phone      TEXT    NOT NULL DEFAULT '',
+    notes      TEXT    NOT NULL DEFAULT '',
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner ON contacts (owner_id);
+
+CREATE TABLE IF NOT EXISTS groups (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id   TEXT    NOT NULL,
+    name       TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    UNIQUE(owner_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS contact_groups (
+    contact_id INTEGER NOT NULL,
+    group_id   INTEGER NOT NULL,
+    PRIMARY KEY (contact_id, group_id)
+);
+```
+
+主な設計上の選択:
+- `contact_groups` は複合 `PRIMARY KEY (contact_id, group_id)` を使用しています —
+  (contact, group) ペア毎に最大 1 行となります。重複の挿入を試みると制約エラーになります。
+- `groups.UNIQUE(owner_id, name)` は 1 人の所有者内での重複グループ名を防ぎます。
+- `email`、`phone`、`notes` は `''` をデフォルトとします — オプションフィールドの NULL ハンドリングが不要です。
+
+---
+
+## IDOR 防止: すべてのクエリに owner_id
+
+すべての読み書き操作で `WHERE` 句に `owner_id` を含めます:
+
+```php
+public function findById(int $id, string $ownerId): ?Contact
+{
+    $rows = $this->db->fetchAll(
+        'SELECT * FROM contacts WHERE id = ? AND owner_id = ?',
+        [$id, $ownerId],
+    );
+
+    return $rows !== [] ? $this->hydrateWithGroups($rows[0]) : null;
+}
+```
+
+連絡先 5 が `bob` に属している場合、`/owners/alice/contacts/5` へのリクエストは
+`null` を返し → `404 Not Found` になります。呼び出し側は「存在しない」と「あなたのものではない」を
+区別できません — これにより ID 存在確認を防ぎます。
+
+---
+
+## 検索: 動的 LIKE + EXISTS フィルター
+
+一覧エンドポイントはオプションのクエリパラメーターに基づいて動的 `WHERE` 句を構築します:
+
+```php
+public function search(string $ownerId, ?string $query, ?string $groupId): array
+{
+    $conditions = ['c.owner_id = ?'];
+    $bindings   = [$ownerId];
+
+    if ($query !== null) {
+        $conditions[] = '(c.name LIKE ? OR c.email LIKE ?)';
+        $bindings[]   = "%{$query}%";
+        $bindings[]   = "%{$query}%";
+    }
+
+    if ($groupId !== null) {
+        $conditions[] = 'EXISTS (SELECT 1 FROM contact_groups cg WHERE cg.contact_id = c.id AND cg.group_id = ?)';
+        $bindings[]   = (int) $groupId;
+    }
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+    $rows  = $this->db->fetchAll(
+        "SELECT c.* FROM contacts c {$where} ORDER BY c.name ASC",
+        $bindings,
+    );
+
+    return array_map(fn (array $row) => $this->hydrateWithGroups($row), $rows);
+}
+```
+
+使用しているパターン:
+- **動的な条件の蓄積**: 必須条件（`owner_id`）から始め、オプション条件を追加します。
+  `implode(' AND ', $conditions)` が安全に結合します。
+- **`LIKE ? OR LIKE ?`**: パラメーター化された LIKE — SQL インジェクションなし。`%` ワイルドカードは
+  PHP 文字列内にあり、ユーザー入力にはありません。ただし `$query` 自体が `%` や `_` を含む場合、
+  SQLite はそれらの文字を LIKE ワイルドカードとして解釈します — リテラルマッチが必要な場合は
+  `str_replace(['%', '_'], ['\\%', '\\_'], $query)` でエスケープしてください。
+- **`EXISTS (SELECT 1 ...)`**: 相関サブクエリにより、JOIN なしで指定グループに属する連絡先を
+  フィルターします（連絡先が複数グループに属する場合の重複行を回避）。
+
+---
+
+## グループ作成: 重複名 → 409
+
+`groups` の `UNIQUE(owner_id, name)` により、所有者内での重複グループ名は制約エラーになります。
+リポジトリはそれをキャッチして `null` を返します:
+
+```php
+public function createGroup(string $ownerId, string $name): ?array
+{
+    try {
+        $id = $this->db->insert(
+            'INSERT INTO groups (owner_id, name, created_at) VALUES (?, ?, ?)',
+            [$ownerId, $name, $now],
+        );
+    } catch (DatabaseConstraintException) {
+        return null;  // この所有者にはすでに同名のグループが存在
+    }
+    // ...
+}
+```
+
+コントローラーは `null` を `409 Conflict` にマップします:
+
+```php
+$group = $this->repo->createGroup($ownerId, $name);
+
+if ($group === null) {
+    return $this->problems->create($request, 'conflict', 'Group Already Exists', 409,
+        "Group {$name} already exists.");
+}
+```
+
+`409` が正しいステータスです — リクエストは有効ですが既存リソースと衝突しています。
+
+---
+
+## グループメンバーシップ: 制約キャッチによる冪等な追加
+
+連絡先をグループに追加する操作は冪等です — 繰り返し呼び出してもエラーなく成功します:
+
+```php
+public function addToGroup(int $contactId, int $groupId, string $ownerId): bool
+{
+    // 連絡先とグループの両方がこの所有者に属することを検証
+    $contact = $this->db->fetchOne('SELECT id FROM contacts WHERE id = ? AND owner_id = ?', [$contactId, $ownerId]);
+    $group   = $this->db->fetchOne('SELECT id FROM groups WHERE id = ? AND owner_id = ?', [$groupId, $ownerId]);
+
+    if ($contact === null || $group === null) {
+        return false;  // → 404 Not Found
+    }
+
+    try {
+        $this->db->execute(
+            'INSERT INTO contact_groups (contact_id, group_id) VALUES (?, ?)',
+            [$contactId, $groupId],
+        );
+    } catch (DatabaseConstraintException) {
+        // PRIMARY KEY 違反 — 連絡先はすでにグループに所属。成功として扱う（冪等）。
+    }
+
+    return true;
+}
+```
+
+複合 `PRIMARY KEY (contact_id, group_id)` が DB レベルで一意性を強制します。
+catch-and-ignore パターンにより操作を複数回安全に呼べるようになります — すでに存在するメンバーシップは
+呼び出し側視点ではエラーではありません。
+
+メンバーシップ挿入前に `contact` と `group` の両方が `$ownerId` に属することを検証します。
+クロス所有者メンバーシップ（alice の連絡先が bob のグループに追加される）は防がれます。
+
+---
+
+## グループメンバーシップの削除
+
+削除は連絡先の所有権を検証し、メンバーシップが存在すれば削除します:
+
+```php
+public function removeFromGroup(int $contactId, int $groupId, string $ownerId): bool
+{
+    $contact = $this->db->fetchOne('SELECT id FROM contacts WHERE id = ? AND owner_id = ?', [$contactId, $ownerId]);
+    if ($contact === null) {
+        return false;  // → 404
+    }
+
+    $count = $this->db->execute(
+        'DELETE FROM contact_groups WHERE contact_id = ? AND group_id = ?',
+        [$contactId, $groupId],
+    );
+
+    return $count > 0;  // メンバーシップが存在しなければ false → 404
+}
+```
+
+メンバーシップが存在しないときに `false` を返すと `404` になります。これは正しい動作です:
+呼び出し側は存在しないものを削除しようとしたためです。
+
+---
+
+## 関連 howto
+
+- [`group-membership-management.md`](group-membership-management.md) — ロールベースのグループメンバーシップパターン
+- [`tagging-system.md`](tagging-system.md) — 多対多のタグリレーション
+- [`enforce-resource-ownership.md`](enforce-resource-ownership.md) — IDOR 防止パターン
+- [`use-fts5-search.md`](use-fts5-search.md) — より大きなデータセット向けの全文検索

--- a/docs/ja/howto/content-approval-workflow.md
+++ b/docs/ja/howto/content-approval-workflow.md
@@ -1,0 +1,392 @@
+# How-to: コンテンツ承認ワークフロー
+
+> **FT リファレンス**: FT248 (`NENE2-FT/flowlog`) — Content Approval Workflow API
+> **ATK**: FT248 — クラッカー視点の攻撃試験 (ATK-01 から ATK-12)
+
+`PostStatus` の `BackedEnum` が `canTransitionTo()` で遷移グラフを所有し、不正な遷移は
+`InvalidTransitionException → 409` を投げ、却下にはオプションの理由を添えられる、
+投稿の公開ライフサイクルを示します。クラッカー視点による完全な攻撃評価を含みます。
+
+---
+
+## ルート
+
+| Method | Path                       | 説明                                                       |
+|--------|----------------------------|------------------------------------------------------------|
+| `POST` | `/posts`                   | 投稿を作成（常に `draft` で開始）                          |
+| `GET`  | `/posts`                   | 投稿一覧（ページネーション・ステータスフィルタ可）         |
+| `GET`  | `/posts/{id}`              | 単一投稿を取得                                             |
+| `POST` | `/posts/{id}/submit`       | 遷移: `draft → submitted`                                  |
+| `POST` | `/posts/{id}/approve`      | 遷移: `submitted → approved`                               |
+| `POST` | `/posts/{id}/reject`       | 遷移: `submitted → rejected`（理由はオプション）           |
+
+> **静的なアクションルートをパラメーター付きより先に**: `/posts/{id}/submit`、`/approve`、
+> `/reject` は `/posts/{id}` より先に登録します。これによりリテラルなサブパスが
+> パラメーターセグメントに捕捉されなくなります。
+
+---
+
+## スキーマ
+
+```sql
+CREATE TABLE IF NOT EXISTS posts (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    title         TEXT    NOT NULL,
+    body          TEXT    NOT NULL DEFAULT '',
+    author        TEXT    NOT NULL,
+    status        TEXT    NOT NULL DEFAULT 'draft'
+                           CHECK(status IN ('draft', 'submitted', 'approved', 'rejected')),
+    reject_reason TEXT,
+    created_at    TEXT    NOT NULL,
+    updated_at    TEXT    NOT NULL
+);
+```
+
+`status` はセーフティネットとして DB レベルの `CHECK` 制約を持ちますが、アプリケーションは
+書き込み前に必ず `PostStatus::canTransitionTo()` で検証します。`reject_reason` は nullable で、
+却下時のみ設定されます。
+
+---
+
+## `canTransitionTo()` を持つ `PostStatus` BackedEnum
+
+ステート遷移グラフは enum 自身が所有します。
+
+```php
+enum PostStatus: string
+{
+    case Draft     = 'draft';
+    case Submitted = 'submitted';
+    case Approved  = 'approved';
+    case Rejected  = 'rejected';
+
+    public function canTransitionTo(self $target): bool
+    {
+        return match ($this) {
+            self::Draft     => $target === self::Submitted,
+            self::Submitted => $target === self::Approved || $target === self::Rejected,
+            self::Approved,
+            self::Rejected  => false,  // 終端ステート
+        };
+    }
+}
+```
+
+遷移グラフ:
+```
+draft → submitted → approved (終端)
+                 → rejected  (終端)
+```
+
+`Approved` と `Rejected` は終端ステートで、これ以上の遷移は許可されません。
+すでに承認された投稿を再度承認しようとすると `InvalidTransitionException` を投げます。
+
+---
+
+## リポジトリの遷移メソッド
+
+```php
+public function transition(int $id, PostStatus $targetStatus, string $now, ?string $rejectReason = null): Post
+{
+    $post = $this->findById($id);
+
+    if (!$post->status->canTransitionTo($targetStatus)) {
+        throw new InvalidTransitionException($post->status, $targetStatus);
+    }
+
+    $this->executor->execute(
+        'UPDATE posts SET status = ?, reject_reason = ?, updated_at = ? WHERE id = ?',
+        [$targetStatus->value, $rejectReason, $now, $id],
+    );
+
+    return new Post($id, $post->title, $post->body, $post->author, $targetStatus, $rejectReason, $post->createdAt, $now);
+}
+```
+
+`transition()` メソッドは submit / approve / reject で共有され、各ハンドラーが異なる
+`$targetStatus` で呼び出します。`reject_reason` は approve / submit では `null` で、
+reject ではオプションで渡されます。
+
+---
+
+## `PostStatus::tryFrom()` によるステータスフィルタ
+
+```php
+$statusStr = QueryStringParser::string($request, 'status');
+
+if ($statusStr !== null) {
+    $status = PostStatus::tryFrom($statusStr);
+    if ($status === null) {
+        throw new ValidationException([
+            new ValidationError('status', "Invalid status '{$statusStr}'. Valid values: draft, submitted, approved, rejected.", 'invalid'),
+        ]);
+    }
+    $items = $this->repository->findByStatus($status, $pagination->limit, $pagination->offset);
+}
+```
+
+`BackedEnum::tryFrom()` は未知の文字列値に対して例外を投げる代わりに `null` を返します。
+明示的な `null` チェックで構造化された `422` を生成し、読みやすいエラーメッセージで
+有効な値の一覧を返します。
+
+---
+
+## オプション理由付きの却下
+
+`POST /posts/{id}/reject` はオプションの `reason` フィールドを受け付けます。
+
+```php
+$raw    = (string) $request->getBody();
+$reason = null;
+
+if ($raw !== '') {
+    $body   = JsonRequestBodyParser::parse($request);
+    $raw    = isset($body['reason']) && is_string($body['reason']) ? trim($body['reason']) : '';
+    $reason = $raw !== '' ? $raw : null;
+}
+```
+
+空のボディ `{}` や `reason` フィールドの欠落はどちらも `null` になります。空白のみの
+理由文字列も `trim()` により `null` に正規化されます。理由は nullable な
+`reject_reason` カラムに格納されます。
+
+---
+
+## ATK — クラッカー視点の攻撃試験 (FT248)
+
+### ATK-01 — 認証なし: 誰でも任意の投稿を承認・却下できる
+
+**Attack**: 認証情報なしで投稿を承認または却下する。
+
+```bash
+curl -X POST http://localhost:8080/posts/1/approve
+curl -X POST http://localhost:8080/posts/1/reject
+```
+
+**Observed**: どちらも `200 OK` で成功する。任意の呼び出し元が任意の投稿を
+任意の許可された遷移を通せる。
+
+**Verdict**: **EXPOSED** — 認証とロールベース認可を追加すべき。承認・却下できるのは
+指定されたレビュアーのみとすべき。submit には投稿の著者が認証されていることを
+要求すべき。
+
+---
+
+### ATK-02 — 不正なステート遷移: draft を approve
+
+**Attack**: まだ `draft` ステータスの投稿を承認しようとする。
+
+```bash
+curl -X POST http://localhost:8080/posts/1/approve
+# 投稿 1 は draft
+```
+
+**Observed**: `Draft` に対する `canTransitionTo(Approved)` は `false` を返す
+→ `InvalidTransitionException` → from/to のコンテキストを添えた `409 Conflict`。
+
+**Verdict**: **BLOCKED** — enum 所有の遷移グラフが不正なステートジャンプを防ぐ。
+
+---
+
+### ATK-03 — 二重承認: すでに承認された投稿を再度承認
+
+**Attack**: 投稿を 2 度承認する。
+
+```bash
+curl -X POST http://localhost:8080/posts/1/submit
+curl -X POST http://localhost:8080/posts/1/approve
+curl -X POST http://localhost:8080/posts/1/approve  # 2 回目の approve
+```
+
+**Observed**: 3 回目のリクエスト: `Approved` からの `canTransitionTo(Approved)` は `false`
+→ `409 Conflict`。投稿は `Approved` ステートのまま。
+
+**Verdict**: **BLOCKED** — `Approved` は終端ステートで、enum は終端ステートからの
+すべての遷移に対して明示的に `false` を返す。
+
+---
+
+### ATK-04 — title または body 経由の SQL インジェクション
+
+**Attack**: SQL メタ文字を埋め込む。
+
+```json
+{"title": "'; DROP TABLE posts; --", "author": "x"}
+```
+
+**Observed**: 値はパラメーター化された `?` プレースホルダー経由でバインドされる。
+インジェクションペイロードはリテラルなテキストとして保存される。
+
+**Verdict**: **BLOCKED** — パラメーター化クエリが SQL インジェクションを防ぐ。
+
+---
+
+### ATK-05 — 不正なステータスフィルタ値
+
+**Attack**: 一覧エンドポイントに未知のステータスを渡す。
+
+```
+GET /posts?status=hacked
+GET /posts?status=published
+```
+
+**Observed**: `PostStatus::tryFrom('hacked')` は `null` を返す → `ValidationException`
+→ 有効なステータス一覧を添えた `422 Unprocessable Entity`。
+
+**Verdict**: **BLOCKED** — `BackedEnum::tryFrom()` と明示的な null チェックが
+未知のステータス値を拒否する。
+
+---
+
+### ATK-06 — 著者なりすまし
+
+**Attack**: 特権を持つ著者であると主張して投稿を作成する。
+
+```json
+{"title": "Official announcement", "author": "admin"}
+```
+
+**Observed**: `201 Created` — `author` フィールドは検証なしでリクエストボディから
+そのまま取られる。任意の文字列が受け入れられる。
+
+**Verdict**: **EXPOSED** — `author` は暗号学的なバインディングなしでユーザー指定。
+本番では `author` を認証済みのセッション/トークンから導出すべきで、リクエストボディ
+から取ってはいけない。
+
+---
+
+### ATK-07 — マスアサインメント: 作成時に `status` を注入
+
+**Attack**: 作成時に `status` を直接 `approved` に設定する。
+
+```json
+{"title": "Instant publish", "author": "x", "status": "approved"}
+```
+
+**Observed**: `createPost()` はボディの `status` フィールドを無視する — 常に
+`PostStatus::Draft->value` を INSERT する。余分なキーは静かに破棄される。
+
+**Verdict**: **BLOCKED** — コントローラーはハードコードされた
+`PostStatus::Draft->value` 値で INSERT を組み立てる。どのボディフィールドも
+これを上書きできない。
+
+---
+
+### ATK-08 — title / body / author への XSS ペイロード
+
+**Attack**: script タグを保存する。
+
+```json
+{"title": "<script>alert(1)</script>", "author": "x"}
+```
+
+**Observed**: コンテンツはそのまま保存され、JSON 内でそのまま返される。API は出力を
+HTML エンコードしない。
+
+**Verdict**: **ACCEPTED BY DESIGN** — JSON API は生のコンテンツを返す。レンダリング層が
+HTML に挿入する前にサニタイズすべき。
+
+---
+
+### ATK-09 — 数値でない投稿 ID
+
+**Attack**: `{id}` に文字列または float を使う。
+
+```
+POST /posts/abc/approve
+POST /posts/1.5/approve
+```
+
+**Observed**: `(int) 'abc'` = `0`、`(int) '1.5'` = `1`。
+- `abc` → `findById(0)` → 行なし → `PostNotFoundException` → `404 Not Found`。
+- `1.5` → `findById(1)` → 投稿 1 が存在すれば、その遷移がトリガーされる。
+
+**Verdict**: **PARTIALLY BLOCKED** — 数値でない文字列は 404 にマップされる。Float 文字列は
+静かに切り詰められる。厳格な ID 検証のために `ctype_digit()` を追加すべき。
+
+---
+
+### ATK-10 — 空の title または空の author
+
+**Attack**: 空欄のフィールドで submit する。
+
+```json
+{"title": "", "author": "x"}
+{"title": "y", "author": ""}
+{"title": "   ", "author": "   "}
+```
+
+**Observed**: `trim($body['title']) === ''` と `trim($body['author']) === ''` の
+チェックが発火 → `ValidationException` → `422`。
+
+**Verdict**: **BLOCKED** — trim と空文字チェックが空文字と空白のみの値の両方を
+カバーする。
+
+---
+
+### ATK-11 — 理由を指定せずに reject
+
+**Attack**: 空ボディまたは `reason` フィールドなしで却下する。
+
+```bash
+curl -X POST http://localhost:8080/posts/1/reject
+curl -X POST http://localhost:8080/posts/1/reject -d '{}'
+curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
+```
+
+**Observed**: 3 ケースすべてで `reject_reason` は `null` になる。理由なしの却下は
+受け入れられる — カラムは nullable。
+
+**Verdict**: **ACCEPTED BY DESIGN** — `reject_reason` はオプション。理由必須の本番
+ワークフローでは `if ($reason === null) → 422` を追加すべき。
+
+---
+
+### ATK-12 — 却下済みの投稿を reject（二重却下）
+
+**Attack**: すでに却下された投稿を再度却下しようとする。
+
+```bash
+curl -X POST http://localhost:8080/posts/1/submit
+curl -X POST http://localhost:8080/posts/1/reject
+curl -X POST http://localhost:8080/posts/1/reject  # 2 回目の reject
+```
+
+**Observed**: `Rejected` からの `canTransitionTo(Rejected)` は `false` を返す
+→ `409 Conflict`。
+
+**Verdict**: **BLOCKED** — `Rejected` は終端ステートで、enum は終端ステートからの
+すべての遷移に対して明示的に `false` を返す。
+
+---
+
+## ATK サマリ
+
+| # | 攻撃ベクトル | Verdict |
+|---|---------------|---------|
+| ATK-01 | approve/reject に認証なし | EXPOSED |
+| ATK-02 | 不正な遷移（draft を approve） | BLOCKED |
+| ATK-03 | 二重承認 | BLOCKED |
+| ATK-04 | title/body 経由の SQL インジェクション | BLOCKED |
+| ATK-05 | 不正なステータスフィルタ値 | BLOCKED |
+| ATK-06 | 著者なりすまし | EXPOSED |
+| ATK-07 | 作成時の status マスアサインメント | BLOCKED |
+| ATK-08 | コンテンツへの XSS ペイロード | ACCEPTED BY DESIGN |
+| ATK-09 | 数値でない投稿 ID | PARTIALLY BLOCKED |
+| ATK-10 | 空の title または空の author | BLOCKED |
+| ATK-11 | 理由なしの reject（オプション） | ACCEPTED BY DESIGN |
+| ATK-12 | 二重却下 | BLOCKED |
+
+**本番前に修正すべき実際の脆弱性**:
+1. **ATK-01** — 認証とロールベース認可を追加（approve/reject に reviewer ロール）
+2. **ATK-06** — `author` を検証済みアイデンティティから導出し、リクエストボディから取らない
+3. **ATK-09** — ID パスパラメーターに `ctype_digit()` ガードを追加
+
+---
+
+## 関連 howto
+
+- [`state-machine-audit-log.md`](state-machine-audit-log.md) — 監査履歴付きのステート遷移と InvalidTransitionException
+- [`approval-workflow.md`](approval-workflow.md) — 複数承認者による承認リクエスト
+- [`step-workflow-approval.md`](step-workflow-approval.md) — 順序付きステップを持つマルチステップワークフロー
+- [`content-draft-lifecycle.md`](content-draft-lifecycle.md) — draft/publish ライフサイクルパターン

--- a/docs/ja/howto/content-collection.md
+++ b/docs/ja/howto/content-collection.md
@@ -1,0 +1,127 @@
+# コンテンツコレクション
+
+記事のキュレーションコレクション（公開/非公開）システムの実装ガイド。
+公開設定・IDOR 防止（存在非公開）・冪等追加・位置詰め整合を解説する。
+
+## 概要
+
+- ユーザーが名前付きコレクション（リスト）を作成
+- 各コレクションに記事を追加（最大 50 件）
+- `is_public` フラグ: 公開コレクションは誰でも閲覧可能
+- 非公開コレクションは非オーナーに 404（存在非公開パターン）
+- 記事追加は冪等（既存なら 200、新規なら 201）
+- アイテム削除後に position が自動整合
+
+## エンドポイント
+
+| Method | Path | 説明 |
+|---|---|---|
+| `POST` | `/collections` | コレクション作成 |
+| `GET` | `/collections/{id}` | コレクション取得（公開 or 自分） |
+| `PUT` | `/collections/{id}` | コレクション名・公開設定変更 |
+| `DELETE` | `/collections/{id}` | コレクション削除 |
+| `POST` | `/collections/{id}/items` | 記事を追加（冪等） |
+| `DELETE` | `/collections/{id}/items/{articleId}` | 記事を削除 |
+
+## データベース設計
+
+```sql
+CREATE TABLE collections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    is_public INTEGER NOT NULL DEFAULT 0,  -- 0=private, 1=public
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE collection_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    collection_id INTEGER NOT NULL,
+    article_id INTEGER NOT NULL,
+    position INTEGER NOT NULL,
+    added_at TEXT NOT NULL,
+    UNIQUE (collection_id, article_id),
+    FOREIGN KEY (collection_id) REFERENCES collections(id),
+    FOREIGN KEY (article_id) REFERENCES articles(id)
+);
+```
+
+## 存在非公開パターン（IDOR 防止）
+
+非公開コレクションへのアクセスは 403 でなく **404** を返す。
+403 を返すと「存在するが権限がない」という情報が漏れるため。
+
+```php
+if (!$isOwner && !$isPublic) {
+    return $this->responseFactory->create(['error' => 'collection not found'], 404);
+}
+```
+
+## 冪等アイテム追加
+
+```php
+$existing = $this->repository->findItem($id, $articleId);
+if ($existing !== null) {
+    return $this->responseFactory->create(['message' => 'already in collection', 'article_id' => $articleId], 200);
+}
+
+$count = $this->repository->countItems($id);
+if ($count >= CollectionRepository::maxItems()) {
+    return $this->responseFactory->create(['error' => 'collection is full', 'max' => 50], 422);
+}
+
+$this->repository->addItem($id, $articleId, date('c'));
+return $this->responseFactory->create(['message' => 'article added', 'article_id' => $articleId], 201);
+```
+
+上限チェックは「まだ追加されていない記事」の場合のみ実行する。
+既に追加済みの記事は上限に影響しない（冪等呼び出し）。
+
+## アイテム削除後の位置整合
+
+```php
+public function removeItem(int $collectionId, int $articleId): void
+{
+    $item = $this->findItem($collectionId, $articleId);
+    $removedPosition = (int) $item['position'];
+    $this->executor->execute('DELETE FROM collection_items WHERE collection_id = ? AND article_id = ?', ...);
+    $this->executor->execute(
+        'UPDATE collection_items SET position = position - 1 WHERE collection_id = ? AND position > ?',
+        [$collectionId, $removedPosition]
+    );
+}
+```
+
+削除された位置より後ろのアイテムを 1 つ前にシフトしてギャップを埋める。
+
+## GET /collections/{id} レスポンス例
+
+```json
+{
+  "id": 1,
+  "user_id": 1,
+  "name": "My Reading List",
+  "is_public": false,
+  "item_count": 2,
+  "items": [
+    {"article_id": 3, "title": "Article 3", "position": 1, "added_at": "2026-05-21T..."},
+    {"article_id": 1, "title": "Article 1", "position": 2, "added_at": "2026-05-21T..."}
+  ],
+  "created_at": "2026-05-21T...",
+  "updated_at": "2026-05-21T..."
+}
+```
+
+## 所有権チェックパターン
+
+全ての変更エンドポイント（PUT/DELETE/POST items）でオーナーチェックを行う:
+
+```php
+if ((int) $collection['user_id'] !== $actorId) {
+    return $this->responseFactory->create(['error' => 'access denied'], 403);
+}
+```
+
+GET の場合は公開/非公開と所有権で 404/200 を分岐させ、403 を使わない。

--- a/docs/ja/howto/content-draft-lifecycle.md
+++ b/docs/ja/howto/content-draft-lifecycle.md
@@ -1,0 +1,121 @@
+# NENE2 でコンテンツ Draft ライフサイクル（Draft → Published → Archived）を構築する
+
+このガイドでは、draft / publish / archive のステートマシンを持つ記事管理システムを構築する方法を説明します。ステート遷移は著者のみが行え、公開された記事のみが読者に見える構成です。
+
+**Field Trial**: FT142  
+**NENE2 バージョン**: ^1.5  
+**カバーするトピック**: enum によるステートマシン、遷移ガード、著者所有権チェック、ステータスフィルタ付き公開リスト、同秒ソート安定性
+
+---
+
+## 何を作るか
+
+- `POST /articles` — 記事を作成（常に `draft` で開始）
+- `GET /articles` — 公開済み記事のみを一覧
+- `GET /articles/{id}` — 記事を取得（著者は任意のステータスを見られる。他者は `published` のみ）
+- `PUT /articles/{id}` — 記事を編集（draft のみ、著者のみ）
+- `POST /articles/{id}/publish` — 遷移 `draft → published`（著者のみ）
+- `POST /articles/{id}/archive` — 遷移 `published → archived`（著者のみ）
+
+---
+
+## データベーススキーマ
+
+```sql
+CREATE TABLE articles (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    author_id    INTEGER NOT NULL,
+    title        TEXT    NOT NULL,
+    body         TEXT    NOT NULL DEFAULT '',
+    status       TEXT    NOT NULL DEFAULT 'draft',
+    published_at TEXT,
+    archived_at  TEXT,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL,
+    CHECK (status IN ('draft', 'published', 'archived')),
+    FOREIGN KEY (author_id) REFERENCES users(id)
+);
+```
+
+`published_at` と `archived_at` は nullable で、対応する遷移時のみ設定されます。
+
+---
+
+## 遷移ガードを持つ ArticleStatus enum
+
+```php
+enum ArticleStatus: string
+{
+    case Draft     = 'draft';
+    case Published = 'published';
+    case Archived  = 'archived';
+
+    public function canEdit(): bool
+    {
+        return $this === self::Draft;
+    }
+
+    public function canPublish(): bool
+    {
+        return $this === self::Draft;
+    }
+
+    public function canArchive(): bool
+    {
+        return $this === self::Published;
+    }
+}
+```
+
+ハンドラーは現在のステータスを読み取り、ガードメソッドを呼び、遷移が不正な場合は 422 を返します。
+
+```php
+$status = ArticleStatus::tryFrom($article['status']) ?? ArticleStatus::Draft;
+
+if (!$status->canPublish()) {
+    return $this->responseFactory->create(['error' => 'only draft articles can be published'], 422);
+}
+```
+
+有効な遷移:
+- `draft → published`（publish 経由）
+- `published → archived`（archive 経由）
+- draft への戻り遷移はなし。
+
+---
+
+## 著者の可視性 — draft は他者から隠す
+
+非著者は draft を読めません。記事が存在することを漏らさないために、403 ではなく 404 を返します。
+
+```php
+if ($article['status'] !== 'published' && $article['author_id'] !== $actorId) {
+    return $this->responseFactory->create(['error' => 'article not found'], 404);
+}
+```
+
+403 を返すと記事の存在が確定してしまいます。まだ公開されていないコンテンツに対しては 404 が正しい選択です。
+
+---
+
+## 同秒ソートの安定性
+
+複数の記事が同じ秒内に公開された場合、`ORDER BY published_at DESC` だけでは順序が非決定的になります。`id DESC` を tiebreaker として追加します。
+
+```sql
+SELECT ... FROM articles WHERE status = 'published' ORDER BY published_at DESC, id DESC
+```
+
+`id` が大きいほど後に作成されたことを意味するため、同秒内では実質的に挿入順でソートされます。
+
+---
+
+## よくある落とし穴
+
+| 落とし穴 | 対処 |
+|---------|-----|
+| 非著者の draft 読み取りに 403 を返す | 404 を返す — コンテンツ存在の漏洩を防ぐ |
+| `published → draft` の再オープンを許可する | `canEdit()` は `Draft` 以外で false を返す。"unpublish" エンドポイントは置かない |
+| すでに公開済みの記事を再度 publish する | `canPublish()` は `Published` に対して false → 422 |
+| draft を archive する | `canArchive()` は `Published` 以外で false → 422 |
+| 同タイムスタンプでのリスト順が非決定的 | `id DESC` を二次ソートに追加 |

--- a/docs/ja/howto/content-negotiation-api.md
+++ b/docs/ja/howto/content-negotiation-api.md
@@ -1,0 +1,109 @@
+# How-to: コンテンツネゴシエーション — JSON API
+
+> **FT リファレンス**: FT301 (`NENE2-FT/contentlog`) — JSON API のコンテンツネゴシエーション: `Accept` ヘッダーに関わらず常に `application/json` を返し、エラー (404/422/405) では `application/problem+json` を返し、POST で JSON 以外の `Content-Type` には 415 を返す。16 tests / 28 assertions PASS。
+
+このガイドでは、NENE2 のランタイムが JSON API の HTTP コンテンツネゴシエーションをどう扱うかを説明します。受け入れる `Accept` ヘッダーの値、`Content-Type` がいつ重要になるか、エラーレスポンスが `application/problem+json` をどう使うかをカバーします。
+
+## 常に JSON — Accept ヘッダーを無視
+
+NENE2 の JSON API は、クライアントが送る `Accept` ヘッダーに関わらず、成功レスポンスでは `application/json` を返します。
+
+| 送信された Accept ヘッダー | レスポンスの Content-Type |
+|---|---|
+| _(なし)_ | `application/json` |
+| `application/json` | `application/json` |
+| `*/*` | `application/json` |
+| `application/*` | `application/json` |
+| `application/json;q=0.9` | `application/json` |
+| `text/html` | `application/json` |
+| `application/xml` | `application/json` |
+| `text/plain` | `application/json` |
+
+これは純粋な API サービスに対する意図的な設計です。サーバーは API 専用エンドポイントであり、複数フォーマットをネゴシエートするサーバーではありません。`Accept: text/html` を送るクライアントも JSON を受け取ります。
+
+## エラーレスポンス — application/problem+json
+
+エラーレスポンスは、`Accept` ヘッダーに関わらず `application/problem+json` (RFC 9457) を使います。
+
+| シナリオ | ステータス | Content-Type |
+|---|---|---|
+| ルートが見つからない | 404 | `application/problem+json` |
+| メソッドが許可されていない | 405 | `application/problem+json` |
+| バリデーション失敗 | 422 | `application/problem+json` |
+
+```php
+// ProblemDetailsResponseFactory は常に application/problem+json を生成する
+return $this->problems->create($request, 'not-found', 'Article Not Found', 404, '');
+```
+
+クライアントは HTTP ステータスコードか `Content-Type: application/problem+json` のチェックでエラーを検出できます。
+
+## リクエストの Content-Type — POST ボディ
+
+JSON ボディを持つ `POST` リクエストには、NENE2 は `JsonRequestBodyParser::parse()` を使います。
+
+```php
+$body = JsonRequestBodyParser::parse($request);
+```
+
+リクエストに `Content-Type: text/plain` や類似の JSON ではない型が明示されている場合、パーサーは空配列を返すことがあります。一方、`Content-Type` ヘッダーがまったく付いていない有効な JSON ボディは、パーサーが受け入れます。
+
+```
+POST /articles (Content-Type なし、JSON ボディ) → 201 Created ✅
+POST /articles (Content-Type: text/plain) → 415 Unsupported Media Type ✅
+```
+
+## バリデーション — 必須フィールド
+
+```php
+$title = isset($body['title']) && is_string($body['title']) ? trim($body['title']) : '';
+
+if ($title === '') {
+    return $this->problems->create($request, 'validation-failed', 'Validation Failed', 422, null, [
+        'errors' => [['field' => 'title', 'code' => 'required', 'message' => 'title is required.']],
+    ]);
+}
+```
+
+`trim()` 後、空文字列はフィールド未指定と同じ扱いになります。バリデーションエラーは `field` / `code` / `message` キーを持つ構造化された `errors` 配列を返します — 標準的な RFC 9457 拡張です。
+
+## レスポンス形状
+
+```json
+// GET /articles
+{
+    "items": [
+        { "id": 1, "title": "Hello", "body": "", "created_at": "2026-01-01T00:00:00+00:00" }
+    ],
+    "total": 1
+}
+
+// POST /articles → 201
+{ "id": 1, "title": "Hello", "body": "", "created_at": "2026-01-01T00:00:00+00:00" }
+
+// GET /articles/999 → 404 (application/problem+json)
+{ "type": "https://nene2.dev/problems/not-found", "title": "Article Not Found", "status": 404 }
+```
+
+## ルート登録
+
+```php
+$router->post('/articles', $this->createArticle(...));
+$router->get('/articles', $this->listArticles(...));
+$router->get('/articles/{id}', $this->getArticle(...));
+```
+
+`GET /articles`（リスト）は `GET /articles/{id}`（単一）より先に登録されます — もっともこの場合は両方とも GET でパスが異なるため、順序による捕捉の衝突は起きません。リストルートは静的パスを使い、単一ルートは `{id}` の動的キャプチャを使います。
+
+---
+
+## やってはいけないこと
+
+| アンチパターン | リスク |
+|---|---|
+| サポートされない `Accept` ヘッダーに対して 406 を返す | API 専用サービスはすべてのクライアントに JSON を提供すべきで、拒否すべきではない |
+| `application/json` の代わりに `text/json` を使う | 非標準の MIME タイプで、一部のクライアントが認識しない |
+| エラーレスポンスに普通の `application/json` を返す | クライアントが Content-Type でエラーと成功を区別できない。`application/problem+json` を使う |
+| バリデーションエラーの `errors` 配列を省略する | クライアントがユーザーにフィールド単位のエラーメッセージを表示できない |
+| JSON ボディに `Content-Type: text/plain` を受け入れる | 入力が曖昧。受け入れるコンテンツタイプは明示すべき |
+| バリデーション後に trim する | `trim()` は空文字チェックの前に行う必要がある。先にチェックすると `" "` が通ってしまう |

--- a/docs/ja/howto/content-negotiation.md
+++ b/docs/ja/howto/content-negotiation.md
@@ -1,0 +1,90 @@
+# コンテンツネゴシエーション
+
+NENE2 は JSON ファーストのフレームワークです。コンテンツネゴシエーションは実装していません — クライアントが `Accept` ヘッダーで何を送ろうと、すべてのレスポンスは `application/json`（エラー時は `application/problem+json`）を使います。
+
+## NENE2 が行うこと
+
+| クライアントが送るもの | サーバーが返すもの |
+|---|---|
+| `Accept` ヘッダーなし | `application/json; charset=utf-8` |
+| `Accept: application/json` | `application/json; charset=utf-8` |
+| `Accept: */*` | `application/json; charset=utf-8` |
+| `Accept: text/html` | `application/json; charset=utf-8` |
+| `Accept: application/xml` | `application/json; charset=utf-8` |
+| `Accept: text/html;q=1.0, application/json;q=0.9` | `application/json; charset=utf-8` |
+
+**NENE2 は決して `406 Not Acceptable` を返しません。** RFC 7231 §6.5.6 では、受け入れ可能な型がない場合にサーバーは 406 を返すべきと書かれていますが、これは SHOULD であって MUST ではありません。JSON 専用 API サーバーにとっては、常に JSON を返すのが最もシンプルでよくある選択です。
+
+エラーレスポンスは `Accept` に関わらず `application/problem+json` (RFC 9457) を使います。
+
+```
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+```
+
+## リクエストボディの Content-Type
+
+`JsonRequestBodyParser::parse()` は受信リクエストの `Content-Type` ヘッダーをチェックしません。無条件にボディを JSON デコードしようとします。
+
+```php
+// 3 つすべてが同じ JsonRequestBodyParser::parse() に到達:
+// Content-Type: application/json → 動作する
+// Content-Type: application/x-www-form-urlencoded → 400 (フォームボディの JSON パース失敗)
+// (Content-Type なし) + JSON ボディ → 動作する
+```
+
+つまり:
+- `Content-Type` なしの有効な JSON ボディは受け入れられる — 寛容な入力ポリシー。
+- フォームエンコードされたボディ（`name=Alice&age=30`）は 400 Bad Request になる（JSON パース失敗）。415 Unsupported Media Type ではない。
+
+## 406 や 415 のレスポンスが必要な場合
+
+ルートハンドラーの前で `Accept` と `Content-Type` ヘッダーを検査するミドルウェアを追加します。
+
+```php
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class JsonOnlyMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problems,
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        // JSON のみの Accept を強制（オプション — ほとんどのクライアントは */* か application/json を送る）
+        $accept = $request->getHeaderLine('Accept');
+        if ($accept !== '' && $accept !== '*/*' && !str_contains($accept, 'application/json')) {
+            return $this->problems->create($request, 'not-acceptable', 'Not Acceptable', 406,
+                'This API only produces application/json.');
+        }
+
+        // ステート変更リクエストに JSON Content-Type を強制
+        $method      = strtoupper($request->getMethod());
+        $contentType = $request->getHeaderLine('Content-Type');
+        if (in_array($method, ['POST', 'PUT', 'PATCH'], true)
+            && $contentType !== ''
+            && !str_contains($contentType, 'application/json')
+        ) {
+            return $this->problems->create($request, 'unsupported-media-type', 'Unsupported Media Type', 415,
+                'This API only accepts application/json request bodies.');
+        }
+
+        return $handler->handle($request);
+    }
+}
+```
+
+`RuntimeApplicationFactory` 経由でワイヤリングします。
+
+```php
+new RuntimeApplicationFactory(
+    ...,
+    authMiddleware: new JsonOnlyMiddleware($problems),
+);
+```
+
+> **注**: `authMiddleware` はルーティングの前に評価されます。グローバルに適用したい場合は、コンテンツタイプ強制をここに置いてください。


### PR DESCRIPTION
## Summary

`docs/ja/howto/` を英語版 (257 件) に追従させる。これまで他言語 (fr/zh/de/pt-br) は 256 件あった一方、ja は 247 件で 10 件の差があった。

## 翻訳ファイル

| ファイル | 行数 | 備考 |
|---|---|---|
| `category-hierarchy-api.md` | 366 | ATK 12 件含む |
| `circuit-breaker.md` | 141 | |
| `collection-api.md` | 123 | |
| `comment-thread.md` | 101 | |
| `contact-management.md` | 237 | |
| `content-approval-workflow.md` | 391 | ATK 12 件含む |
| `content-collection.md` | 127 | |
| `content-draft-lifecycle.md` | 121 | |
| `content-negotiation-api.md` | 109 | |
| `content-negotiation.md` | 90 | |

合計 1802 行追加。

## 翻訳方針

既存 ja 翻訳の文体に揃え:
- 「です・ます」調の技術文書調
- コードブロック・インラインコード・SQL・OpenAPI 用語・URI は原文維持
- コード内コメント・散文・表ヘッダーは日本語化
- 専門用語（middleware/handler/registrar 等）はカタカナ化

## Self-review

- `docs/review/docs-policy.md`

## Related

- Closes #1319

🤖 Generated with [Claude Code](https://claude.com/claude-code)