### PR TITLE
docs(howto): frontmatter スキーマ確定 + 5 件で実証（Phase B-1） (#1327)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -58,3 +58,6 @@ jobs:
         run: |
           composer howto:index
           git diff --exit-code docs/howto/README.md 'docs/*/howto/README.md'
+
+      - name: Validate howto frontmatter
+        run: composer howto:frontmatter

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "openapi": "php tools/validate-openapi.php",
     "openapi:docs": "php tools/openapi-to-md.php",
     "howto:index": "php tools/build-howto-index.php",
+    "howto:frontmatter": "php tools/validate-howto-frontmatter.php",
     "mcp": "php tools/validate-mcp-tools.php",
     "version:check": "php tools/validate-version.php",
     "migrations:status": "phinx status -c phinx.php",

--- a/docs/development/howto-frontmatter.md
+++ b/docs/development/howto-frontmatter.md
@@ -1,0 +1,59 @@
+# Howto Frontmatter Schema
+
+Every guide in `docs/howto/` carries a small YAML frontmatter block so that
+category and tag indexes can be regenerated from data instead of hand-curated
+lists. The schema is intentionally minimal — rich schemas do not get filled in.
+
+See `docs/todo/howto-curation-strategy.md` for the rollout plan (Phase B).
+
+## Fields
+
+```yaml
+---
+title: Add JWT Authentication
+category: auth
+tags: [jwt, bearer, authentication]
+difficulty: intermediate
+related: [use-bearer-auth, refresh-token-rotation]
+ft: FT102
+---
+```
+
+| Field | Required | Type | Rule |
+|---|---|---|---|
+| `title` | yes | string | Human-readable title; mirror the page `# H1`. |
+| `category` | yes | enum | Exactly one of the categories below. |
+| `tags` | yes | list of strings | 1–6 lowercase kebab-case tags (`[a-z0-9-]+`). |
+| `difficulty` | yes | enum | `beginner` \| `intermediate` \| `advanced`. |
+| `related` | no | list of slugs | Other howto file names without `.md`; each must exist. |
+| `ft` | no | string | Field-trial id, `FT` followed by digits (cross-references `docs/ft-registry.md`). |
+
+Unknown keys are rejected to keep the schema tight.
+
+## Category values
+
+The seven categories mirror the manual sections in `docs/howto/README.md`:
+
+| Slug | README section |
+|---|---|
+| `getting-started` | Getting Started |
+| `auth` | Authentication & Authorization |
+| `security` | Security |
+| `database` | Database |
+| `api-design` | API Design |
+| `infrastructure` | Background & Infrastructure |
+| `product` | Product Features (Recipe Patterns) |
+
+A guide has exactly one primary `category`. Cross-cutting topics are expressed
+through `tags`, not by inventing new categories.
+
+## Validation
+
+```bash
+composer howto:frontmatter
+```
+
+During the Phase B rollout, guides without a frontmatter block are allowed and
+reported as "unannotated". Once every guide is annotated, the validator will be
+switched to require frontmatter on all guides (CI fails on a missing block).
+Guides that *do* have a block are always validated strictly.

--- a/docs/howto/add-custom-route.md
+++ b/docs/howto/add-custom-route.md
@@ -1,3 +1,11 @@
+---
+title: Add a Custom Route
+category: getting-started
+tags: [routing, http]
+difficulty: beginner
+related: [add-database-endpoint, add-health-check]
+---
+
 # Add a Custom Route
 
 This guide shows how to add GET and POST routes with path parameters to a NENE2 application.

--- a/docs/howto/add-jwt-authentication.md
+++ b/docs/howto/add-jwt-authentication.md
@@ -1,3 +1,11 @@
+---
+title: Add JWT Authentication
+category: auth
+tags: [jwt, bearer, authentication]
+difficulty: intermediate
+related: [use-bearer-auth, refresh-token-rotation, rbac]
+---
+
 # Add JWT Authentication
 
 This guide shows how to add JWT Bearer authentication to a NENE2 application — user

--- a/docs/howto/add-pagination.md
+++ b/docs/howto/add-pagination.md
@@ -1,3 +1,11 @@
+---
+title: Add pagination
+category: api-design
+tags: [pagination, query-params]
+difficulty: beginner
+related: [pagination, dynamic-filter-query]
+---
+
 # Add pagination
 
 This guide shows how to add `?limit=` / `?offset=` pagination to a collection endpoint using the

--- a/docs/howto/sql-injection.md
+++ b/docs/howto/sql-injection.md
@@ -1,3 +1,11 @@
+---
+title: SQL injection defense
+category: security
+tags: [sql-injection, pdo, validation]
+difficulty: intermediate
+related: [mass-assignment, validate-unicode-input]
+---
+
 # SQL injection defense
 
 NENE2's database methods (`execute`, `insert`, `fetchOne`, `fetchAll`) use PDO prepared statements internally. Any value passed in the `$parameters` array is bound as a PDO parameter — never interpolated into the SQL string.

--- a/docs/howto/use-transactions.md
+++ b/docs/howto/use-transactions.md
@@ -1,3 +1,11 @@
+---
+title: Use Database Transactions
+category: database
+tags: [transactions, atomicity, rollback]
+difficulty: intermediate
+related: [transactions, optimistic-locking]
+---
+
 # Use Database Transactions
 
 This guide explains how to perform atomic multi-step operations using

--- a/docs/todo/howto-curation-strategy.md
+++ b/docs/todo/howto-curation-strategy.md
@@ -148,5 +148,7 @@ tutorial / explanation / reference は別象限なので混ぜない。
 | 種別 | 番号 | 状態 |
 |---|---|---|
 | 本ドキュメント発行 | #1323 | 完了 |
-| 後続 (Phase A 実装) | #1325 | 実装中 — `tools/build-howto-index.php` + 6 ロケール全索引 + CI lock |
-| 後続 (Phase B 実装) | 未起票 | — |
+| 後続 (Phase A 実装) | #1325 | 完了 — `tools/build-howto-index.php` + 6 ロケール全索引 + CI lock |
+| 後続 (Phase B-1: スキーマ実証) | #1327 | 実装中 — frontmatter スキーマ確定 + validator + 代表 5 件で実証 |
+| 後続 (Phase B-2: 全件 annotate) | 未起票 | 残り 251 件。Agent 並列想定 |
+| 後続 (Phase B-3: 索引統合 + 必須化) | 未起票 | カテゴリ/タグ別索引を frontmatter から再生成、`--require-all` で CI 必須化 |

--- a/tools/validate-howto-frontmatter.php
+++ b/tools/validate-howto-frontmatter.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * Validates the YAML frontmatter of howto guides against the schema documented
+ * in docs/development/howto-frontmatter.md.
+ *
+ * During the Phase B rollout, guides without a frontmatter block are allowed
+ * and reported as "unannotated"; guides that have a block are validated
+ * strictly. Pass --require-all to fail when any guide is still unannotated
+ * (used once every guide is annotated).
+ *
+ * Usage: php tools/validate-howto-frontmatter.php [--require-all]
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+$root       = dirname(__DIR__);
+$howtoDir   = $root . '/docs/howto';
+$requireAll = in_array('--require-all', $argv, true);
+
+const ALLOWED_CATEGORIES = [
+    'getting-started',
+    'auth',
+    'security',
+    'database',
+    'api-design',
+    'infrastructure',
+    'product',
+];
+
+const ALLOWED_DIFFICULTY = ['beginner', 'intermediate', 'advanced'];
+
+const REQUIRED_FIELDS = ['title', 'category', 'tags', 'difficulty'];
+const OPTIONAL_FIELDS = ['related', 'ft'];
+
+/**
+ * Extract the raw YAML frontmatter block from a Markdown file, or null when the
+ * file does not open with a `---` fence.
+ */
+function extractFrontmatter(string $contents): ?string
+{
+    if (!str_starts_with($contents, "---\n") && !str_starts_with($contents, "---\r\n")) {
+        return null;
+    }
+    // Match the opening fence and the next closing fence on its own line.
+    if (preg_match('/^---\r?\n(.*?)\r?\n---\r?\n/s', $contents, $m) !== 1) {
+        return null;
+    }
+
+    return $m[1];
+}
+
+/**
+ * Build the set of valid related-link targets (every howto slug on disk).
+ *
+ * @return array<string, true>
+ */
+function knownSlugs(string $howtoDir): array
+{
+    $slugs = [];
+    foreach (glob($howtoDir . '/*.md') ?: [] as $file) {
+        $name = basename($file, '.md');
+        if ($name !== 'README') {
+            $slugs[$name] = true;
+        }
+    }
+
+    return $slugs;
+}
+
+/**
+ * Validate one parsed frontmatter map, returning a list of human-readable error
+ * messages (empty when valid).
+ *
+ * @param  array<string, mixed> $fm
+ * @param  array<string, true>  $slugs
+ * @return list<string>
+ */
+function validateFrontmatter(array $fm, array $slugs): array
+{
+    $errors = [];
+
+    foreach (REQUIRED_FIELDS as $field) {
+        if (!array_key_exists($field, $fm)) {
+            $errors[] = "missing required field `{$field}`";
+        }
+    }
+
+    $allowedKeys = [...REQUIRED_FIELDS, ...OPTIONAL_FIELDS];
+    foreach (array_keys($fm) as $key) {
+        if (!in_array($key, $allowedKeys, true)) {
+            $errors[] = "unknown field `{$key}`";
+        }
+    }
+
+    if (isset($fm['title']) && (!is_string($fm['title']) || trim($fm['title']) === '')) {
+        $errors[] = '`title` must be a non-empty string';
+    }
+
+    if (isset($fm['category']) && !in_array($fm['category'], ALLOWED_CATEGORIES, true)) {
+        $errors[] = '`category` must be one of: ' . implode(', ', ALLOWED_CATEGORIES);
+    }
+
+    if (isset($fm['difficulty']) && !in_array($fm['difficulty'], ALLOWED_DIFFICULTY, true)) {
+        $errors[] = '`difficulty` must be one of: ' . implode(', ', ALLOWED_DIFFICULTY);
+    }
+
+    if (isset($fm['tags'])) {
+        if (!is_array($fm['tags']) || $fm['tags'] === [] || array_is_list($fm['tags']) === false) {
+            $errors[] = '`tags` must be a non-empty list';
+        } else {
+            if (count($fm['tags']) > 6) {
+                $errors[] = '`tags` must have at most 6 entries';
+            }
+            foreach ($fm['tags'] as $tag) {
+                if (!is_string($tag) || preg_match('/^[a-z0-9-]+$/', $tag) !== 1) {
+                    $errors[] = 'tag `' . var_export($tag, true) . '` must be lowercase kebab-case';
+                }
+            }
+        }
+    }
+
+    if (isset($fm['related'])) {
+        if (!is_array($fm['related']) || array_is_list($fm['related']) === false) {
+            $errors[] = '`related` must be a list';
+        } else {
+            foreach ($fm['related'] as $slug) {
+                if (!is_string($slug) || !isset($slugs[$slug])) {
+                    $errors[] = 'related `' . var_export($slug, true) . '` does not match an existing howto';
+                }
+            }
+        }
+    }
+
+    if (isset($fm['ft']) && (!is_string($fm['ft']) || preg_match('/^FT\d+$/', $fm['ft']) !== 1)) {
+        $errors[] = '`ft` must look like `FT123`';
+    }
+
+    return $errors;
+}
+
+// -------------------------------------------------------------------------
+// Walk every guide
+// -------------------------------------------------------------------------
+
+$slugs       = knownSlugs($howtoDir);
+$files       = glob($howtoDir . '/*.md') ?: [];
+$files       = array_filter($files, static fn (string $f): bool => basename($f) !== 'README.md');
+sort($files, SORT_STRING);
+
+$annotated   = 0;
+$unannotated = [];
+$hasError    = false;
+
+foreach ($files as $file) {
+    $name     = basename($file);
+    $contents = (string) file_get_contents($file);
+    $raw      = extractFrontmatter($contents);
+
+    if ($raw === null) {
+        $unannotated[] = $name;
+        continue;
+    }
+
+    try {
+        $parsed = Yaml::parse($raw);
+    } catch (ParseException $e) {
+        echo "✗ {$name}: invalid YAML — {$e->getMessage()}\n";
+        $hasError = true;
+        continue;
+    }
+
+    if (!is_array($parsed)) {
+        echo "✗ {$name}: frontmatter is not a mapping\n";
+        $hasError = true;
+        continue;
+    }
+
+    /** @var array<string, mixed> $parsed */
+    $errors = validateFrontmatter($parsed, $slugs);
+    if ($errors !== []) {
+        $hasError = true;
+        foreach ($errors as $error) {
+            echo "✗ {$name}: {$error}\n";
+        }
+        continue;
+    }
+
+    $annotated++;
+}
+
+$total = count($files);
+echo sprintf("\nhowto frontmatter: %d/%d annotated, %d unannotated\n", $annotated, $total, count($unannotated));
+
+if ($requireAll && $unannotated !== []) {
+    echo "✗ --require-all: the following guides have no frontmatter:\n";
+    foreach ($unannotated as $name) {
+        echo "  - {$name}\n";
+    }
+    $hasError = true;
+}
+
+if ($hasError) {
+    echo "\nFrontmatter validation failed.\n";
+    exit(1);
+}
+
+echo "Frontmatter validation passed.\n";


### PR DESCRIPTION
## 目的

Phase A（#1325）で全 howto のフラット索引を自動生成した。**Phase B** は各 howto に最小限の YAML frontmatter を付与し、カテゴリ別・タグ別索引をデータから再生成できるようにする。方針: `docs/todo/howto-curation-strategy.md`（#1323）の推奨着手順 step 2「frontmatter スキーマを 5 件で実証（PR で前例を作る）」を実施する。

## 変更点

- **`docs/development/howto-frontmatter.md` 新規**: スキーマ定義。
  - 必須: `title` / `category` / `tags` / `difficulty`
  - 任意: `related`（実在 howto slug） / `ft`（`FT\d+`）
  - カテゴリ enum 7 種（README の手動セクションに対応）。未知キーは拒否。
- **`tools/validate-howto-frontmatter.php` 新規**: frontmatter を持つファイルのみ厳格検証し、移行期は未付与を許容（"unannotated" として集計）。`--require-all` で全件必須化（全件 annotate 後に切替）。
- **`composer howto:frontmatter`** スクリプト + CI 検証ステップ追加。
- **代表 5 件に frontmatter 付与**（各カテゴリ代表）:
  - `add-custom-route`（getting-started） / `add-jwt-authentication`（auth） / `sql-injection`（security） / `use-transactions`（database） / `add-pagination`（api-design）

## 範囲外（後続）

- Phase B-2: 残り 251 件の一括 annotate（Agent 並列想定）
- Phase B-3: カテゴリ/タグ別索引の build tool 統合 + `--require-all` での CI 必須化

## 検証

- `composer test`（437 / 1008） / `analyse`（PHPStan level 8, 0 errors） / `cs` clean。
- `composer howto:frontmatter` → 5/256 annotated, validation passed。
- frontmatter 追加が `howtoItems` の H1 抽出・`build-howto-index.php` のどちらにも影響しないことを確認（索引 drift なし）。

Self-review: docs-policy

Refs #1323
Closes #1327