### PR TITLE
docs(howto): 全 howto に frontmatter を付与（Phase B-2） (#1329)

### DIFF
--- a/docs/howto/ab-testing.md
+++ b/docs/howto/ab-testing.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: A/B Testing Framework"
+category: product
+tags: [ab-testing, experimentation, state-machine, analytics]
+difficulty: advanced
+related: [feature-flags, feature-flag-api]
+---
+
 # How-to: A/B Testing Framework
 
 > **FT reference**: FT293 (`NENE2-FT/ablog`) — A/B experiment framework: weighted deterministic variant assignment via crc32 seed, draft→active→stopped state machine, UNIQUE(experiment_id, user_id) idempotent assignment, CVR aggregation in SQL, 16 tests / 26 assertions PASS.

--- a/docs/howto/access-token-management.md
+++ b/docs/howto/access-token-management.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build Access Token Management with NENE2"
+category: auth
+tags: [access-token, pat, api-keys, sha256, scopes]
+difficulty: intermediate
+related: [api-key-management, bearer-token-middleware, use-bearer-auth]
+---
+
 # How to Build Access Token Management with NENE2
 
 This guide walks through building a personal access token (PAT) system — users issue, list, and revoke their own API tokens, each with a scope (`read`/`write`/`admin`). Tokens are never stored in plaintext; only their SHA-256 hash is kept.

--- a/docs/howto/account-lockout.md
+++ b/docs/howto/account-lockout.md
@@ -1,3 +1,11 @@
+---
+title: "Account Lockout (Brute-Force Protection)"
+category: security
+tags: [brute-force, lockout, argon2id, rate-limiting, authentication]
+difficulty: intermediate
+related: [password-auth-argon2id, add-rate-limiting, pin-verification-lockout]
+---
+
 # Account Lockout (Brute-Force Protection)
 
 > **FT reference**: FT280 (`NENE2-FT/lockoutlog`) — Account lockout: 5 failed attempts trigger 15-minute lockout (423 Locked), correct password blocked while locked, success resets counter, Argon2id password verification, MySQL integration tests, 27 tests pass / 5 skipped (MySQL), 44 assertions PASS.

--- a/docs/howto/activity-feed.md
+++ b/docs/howto/activity-feed.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Activity Feed / Timeline API"
+category: product
+tags: [activity-feed, timeline, pagination, idor-prevention]
+difficulty: intermediate
+related: [notification-inbox, follow-api, user-follow-system]
+---
+
 # How-to: Activity Feed / Timeline API
 
 > **FT reference**: FT277 (`NENE2-FT/feedlog`) — Activity feed: type-allowlisted events (9 types), JSON payload per event, user-scoped feed with IDOR → 404, pagination clamping (max 100), admin fail-closed, 24 tests / 37 assertions PASS.

--- a/docs/howto/add-database-endpoint.md
+++ b/docs/howto/add-database-endpoint.md
@@ -1,3 +1,11 @@
+---
+title: "Add a Database-backed Endpoint"
+category: getting-started
+tags: [database, endpoint, repository, usecase, dto]
+difficulty: beginner
+related: [add-second-entity, add-health-check, use-transactions]
+---
+
 # Add a Database-backed Endpoint
 
 This guide shows how to add an endpoint that reads from and writes to a database, following NENE2's domain layer pattern.

--- a/docs/howto/add-domain-exception-handler.md
+++ b/docs/howto/add-domain-exception-handler.md
@@ -1,3 +1,11 @@
+---
+title: "How to add a domain exception handler"
+category: getting-started
+tags: [error-handling, exceptions, middleware, domain]
+difficulty: intermediate
+related: [add-database-endpoint, add-health-check]
+---
+
 # How to add a domain exception handler
 
 When a route handler throws a domain exception (e.g. `OrderNotFoundException`, `InsufficientStockException`),

--- a/docs/howto/add-health-check.md
+++ b/docs/howto/add-health-check.md
@@ -1,3 +1,11 @@
+---
+title: "Add a Health Check"
+category: getting-started
+tags: [health-check, monitoring, endpoint]
+difficulty: beginner
+related: [add-database-endpoint, quality-tools]
+---
+
 # Add a Health Check
 
 This guide shows how to extend the `GET /health` endpoint with dependency health checks using

--- a/docs/howto/add-html-view.md
+++ b/docs/howto/add-html-view.md
@@ -1,3 +1,11 @@
+---
+title: "Add HTML Views"
+category: getting-started
+tags: [html, views, templates, server-rendering]
+difficulty: beginner
+related: [add-health-check, add-database-endpoint]
+---
+
 # Add HTML Views
 
 This guide shows how to add server-rendered HTML responses to a NENE2 application

--- a/docs/howto/add-mcp-tools.md
+++ b/docs/howto/add-mcp-tools.md
@@ -1,3 +1,11 @@
+---
+title: "Add MCP Tools"
+category: infrastructure
+tags: [mcp, ai-integration, tools, api-exposure]
+difficulty: intermediate
+related: [add-database-endpoint, add-health-check]
+---
+
 # Add MCP Tools
 
 This guide shows how to expose your NENE2 application's API endpoints as MCP tools,

--- a/docs/howto/add-optimistic-locking.md
+++ b/docs/howto/add-optimistic-locking.md
@@ -1,3 +1,11 @@
+---
+title: "How to add optimistic concurrency control (ETag / If-Match)"
+category: database
+tags: [optimistic-locking, etag, concurrency, lost-update]
+difficulty: intermediate
+related: [etag-conditional-requests, optimistic-locking, add-database-endpoint]
+---
+
 # How to add optimistic concurrency control (ETag / If-Match)
 
 Optimistic locking prevents the **lost update problem**: two clients read the same resource,

--- a/docs/howto/add-rate-limiting.md
+++ b/docs/howto/add-rate-limiting.md
@@ -1,3 +1,11 @@
+---
+title: "Add Rate Limiting"
+category: security
+tags: [rate-limiting, throttle, middleware, protection]
+difficulty: beginner
+related: [fixed-window-rate-limiter, sliding-window-rate-limiter, account-lockout]
+---
+
 # Add Rate Limiting
 
 This guide shows how to protect your NENE2 application with request rate limiting using

--- a/docs/howto/add-second-entity.md
+++ b/docs/howto/add-second-entity.md
@@ -1,3 +1,11 @@
+---
+title: "Add a Second Domain Entity"
+category: getting-started
+tags: [domain, entity, repository, usecase, multi-entity]
+difficulty: beginner
+related: [add-database-endpoint, use-transactions]
+---
+
 # Add a Second Domain Entity
 
 This guide shows how to add a second domain entity alongside the built-in `Note` and `Tag` examples, following NENE2's multi-entity pattern.

--- a/docs/howto/admin-report-aggregation.md
+++ b/docs/howto/admin-report-aggregation.md
@@ -1,3 +1,11 @@
+---
+title: "How to Add Admin Report Aggregation"
+category: product
+tags: [admin, reporting, aggregation, dashboard, date-range]
+difficulty: intermediate
+related: [aggregate-reporting, api-usage-metering]
+---
+
 # How to Add Admin Report Aggregation
 
 Build dashboard-style aggregation endpoints with date-range filters, grouping, and limit clamping.

--- a/docs/howto/aggregate-reporting.md
+++ b/docs/howto/aggregate-reporting.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Aggregate Reporting API"
+category: product
+tags: [reporting, aggregation, analytics, sql, grouping]
+difficulty: intermediate
+related: [admin-report-aggregation, api-usage-metering, event-analytics]
+---
+
 # How-to: Aggregate Reporting API
 
 > **FT reference**: FT245 (`NENE2-FT/agglog`) — Aggregate Reporting API

--- a/docs/howto/api-key-management.md
+++ b/docs/howto/api-key-management.md
@@ -1,3 +1,11 @@
+---
+title: "API Key Management"
+category: auth
+tags: [api-keys, sha256, scopes, rotation, authentication]
+difficulty: intermediate
+related: [access-token-management, bearer-token-middleware, use-bearer-auth]
+---
+
 # API Key Management
 
 > **FT reference**: FT266 (`NENE2-FT/apikeylog`) — API key lifecycle: generation, SHA-256 hash storage, prefix-based lookup, scope enforcement, rotation

--- a/docs/howto/api-usage-metering.md
+++ b/docs/howto/api-usage-metering.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: API Usage Metering & Quota Management"
+category: infrastructure
+tags: [metering, quota, rate-limiting, idor-prevention, usage-tracking]
+difficulty: intermediate
+related: [add-rate-limiting, quota-management, admin-report-aggregation]
+---
+
 # How-to: API Usage Metering & Quota Management
 
 > **FT reference**: FT321 (`NENE2-FT/meterlog`) — Per-user daily quota management, machine-key protected usage recording, per-endpoint breakdown, IDOR protection, remaining-never-negative guarantee, 24 tests / 92 assertions PASS.

--- a/docs/howto/api-versioning.md
+++ b/docs/howto/api-versioning.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: API Versioning"
+category: api-design
+tags: [versioning, deprecation, url-path, headers, sunset]
+difficulty: intermediate
+related: [content-negotiation, content-negotiation-api]
+---
+
 # How-to: API Versioning
 
 > **FT reference**: FT346 (`NENE2-FT/versionlog`) — URL path versioning with /v1/ and /v2/ namespaces, deprecated V1 carrying Deprecation/Sunset/Link headers, V2 with enriched response shape, shared underlying storage, 16 tests PASS.

--- a/docs/howto/application-caching.md
+++ b/docs/howto/application-caching.md
@@ -1,3 +1,11 @@
+---
+title: "Application Caching の実装ガイド"
+category: infrastructure
+tags: [caching, cache-aside, ttl, invalidation, performance]
+difficulty: intermediate
+related: [circuit-breaker, add-database-endpoint]
+---
+
 # Application Caching の実装ガイド
 
 ## 概要

--- a/docs/howto/approval-workflow.md
+++ b/docs/howto/approval-workflow.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Approval Workflow API"
+category: product
+tags: [workflow, approval, state-machine, multi-step]
+difficulty: intermediate
+related: [content-approval-workflow, step-workflow-approval, draft-publish-workflow]
+---
+
 # How-to: Approval Workflow API
 
 > **FT reference**: FT68 (`NENE2-FT/approvallog`) — Approval Workflow API

--- a/docs/howto/article-relations-api.md
+++ b/docs/howto/article-relations-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Article Relations API"
+category: product
+tags: [relations, many-to-many, self-referential, inverse, content]
+difficulty: intermediate
+related: [content-relations, article-versioning-api]
+---
+
 # How-to: Article Relations API
 
 > **FT reference**: FT334 (`NENE2-FT/relatedlog`) — Typed article-to-article relations with automatic inverse creation, symmetric and asymmetric relation types, filter-by-type, and embedded relation stubs in GET responses, 17 tests / 40+ assertions PASS.

--- a/docs/howto/article-versioning-api.md
+++ b/docs/howto/article-versioning-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Article Versioning API"
+category: product
+tags: [versioning, content, snapshot, history, draft]
+difficulty: intermediate
+related: [content-versioning, document-versioning, content-draft-lifecycle]
+---
+
 # How-to: Article Versioning API
 
 > **FT reference**: FT249 (`NENE2-FT/contentvlog`) — Article Versioning API

--- a/docs/howto/asset-checkout.md
+++ b/docs/howto/asset-checkout.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: Asset Check-out / Check-in Management"
+category: product
+tags: [asset-management, checkout, exclusive-lock, audit-log]
+difficulty: intermediate
+related: [audit-trail, resource-reservation, optimistic-locking]
+---
+
 # How-To: Asset Check-out / Check-in Management
 
 Demonstrates exclusive asset hold tracking with an append-only audit log.

--- a/docs/howto/audit-trail.md
+++ b/docs/howto/audit-trail.md
@@ -1,3 +1,11 @@
+---
+title: "HOWTO: Audit Trail — Recording Who Changed What"
+category: security
+tags: [audit-trail, immutable-log, jwt, change-tracking, compliance]
+difficulty: intermediate
+related: [asset-checkout, state-machine-audit-log]
+---
+
 # HOWTO: Audit Trail — Recording Who Changed What
 
 > **FT reference**: FT268 (`NENE2-FT/auditlog`) — append-only audit trail: JWT actor extraction, before/after payload snapshots, immutable audit table, unauthenticated audit read gap

--- a/docs/howto/batch-api-partial-success.md
+++ b/docs/howto/batch-api-partial-success.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Batch API with Partial Success"
+category: api-design
+tags: [batch, partial-success, validation, bulk-operations]
+difficulty: intermediate
+related: [bulk-operations-partial-success, implement-bulk-endpoint, bulk-status-update]
+---
+
 # How-to: Batch API with Partial Success
 
 > **FT reference**: FT294 (`NENE2-FT/batchlog`) — Batch INSERT with partial success: MAX_BATCH=50 guard, per-item independent validation with index tracking, mixed created/errors response (200 always), DB CHECK constraints, strict JSON type validation via `is_int()`, 36 tests / 79 assertions PASS.

--- a/docs/howto/bearer-token-middleware.md
+++ b/docs/howto/bearer-token-middleware.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Bearer Token Middleware (JWT Auth Edge Cases)"
+category: auth
+tags: [jwt, bearer, middleware, authentication, security]
+difficulty: advanced
+related: [use-bearer-auth, add-jwt-authentication, refresh-token-rotation]
+---
+
 # How-to: Bearer Token Middleware (JWT Auth Edge Cases)
 
 > **FT reference**: FT273 (`NENE2-FT/authlog`) — BearerTokenMiddleware JWT auth: alg=none rejection, signature tampering detection, exp/nbf enforcement, WWW-Authenticate header, per-sub data isolation, IDOR → 404, 18 tests / 26 assertions PASS.

--- a/docs/howto/bookmark-api.md
+++ b/docs/howto/bookmark-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Bookmark API"
+category: product
+tags: [bookmarks, collections, deduplication, idor-prevention]
+difficulty: beginner
+related: [bookmark-system, url-bookmark-api, content-collection]
+---
+
 # How-to: Bookmark API
 
 > **FT reference**: FT295 (`NENE2-FT/bookmarklog`) — Bookmark management: UNIQUE(user_id, item_id) prevents duplicate bookmarks, collection grouping with optional filter, user-scoped access (IDOR prevention), 409 on duplicate, 22 tests / 64 assertions PASS.

--- a/docs/howto/bookmark-system.md
+++ b/docs/howto/bookmark-system.md
@@ -1,3 +1,11 @@
+---
+title: "Bookmark System"
+category: product
+tags: [bookmarks, collections, idempotent, user-scoped]
+difficulty: beginner
+related: [bookmark-api, url-bookmark-api, wishlist-management]
+---
+
 # Bookmark System
 
 Allow users to save items into named collections. Bookmarking is idempotent — bookmarking the same item twice returns the existing bookmark without error.

--- a/docs/howto/budget-tracking.md
+++ b/docs/howto/budget-tracking.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Budget Tracking API"
+category: product
+tags: [budget, finance, tracking, spending, categories]
+difficulty: intermediate
+related: [expense-tracker, expense-tracking-api, credit-ledger]
+---
+
 # How-to: Budget Tracking API
 
 > **FT reference**: FT244 (`NENE2-FT/budgetlog`) — Budget Tracking API

--- a/docs/howto/bulk-operations-partial-success.md
+++ b/docs/howto/bulk-operations-partial-success.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Bulk Operations with Partial-Success Semantics"
+category: api-design
+tags: [bulk, partial-success, multi-status, http-207, validation]
+difficulty: intermediate
+related: [batch-api-partial-success, bulk-status-update, implement-bulk-endpoint]
+---
+
 # How-to: Bulk Operations with Partial-Success Semantics
 
 > **FT reference**: FT258 (`NENE2-FT/bulklog`) — Bulk create / bulk delete with partial-success semantics and HTTP 207 Multi-Status

--- a/docs/howto/bulk-status-update.md
+++ b/docs/howto/bulk-status-update.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Bulk Status Update API"
+category: api-design
+tags: [bulk, status-update, batch, state-machine]
+difficulty: intermediate
+related: [bulk-operations-partial-success, batch-api-partial-success, implement-bulk-endpoint]
+---
+
 # How-to: Bulk Status Update API
 
 > **FT reference**: FT85 (`NENE2-FT/bulkupdatelog`) — Bulk Status Update API

--- a/docs/howto/category-hierarchy-api.md
+++ b/docs/howto/category-hierarchy-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Category Hierarchy Tree API"
+category: product
+tags: [hierarchy, tree, recursive-cte, parent-child, categories]
+difficulty: advanced
+related: [hierarchical-data, add-second-entity]
+---
+
 # How-to: Category Hierarchy Tree API
 
 > **FT reference**: FT344 (`NENE2-FT/treelog`) — Category tree with parent_id + depth, immediate children, recursive CTE ancestors/descendants, leaf-only deletion (409 on has-children), 17 tests PASS.

--- a/docs/howto/circuit-breaker.md
+++ b/docs/howto/circuit-breaker.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Circuit Breaker"
+category: infrastructure
+tags: [circuit-breaker, resilience, state-machine, fault-tolerance]
+difficulty: advanced
+related: [job-queue, dead-letter-queue]
+---
+
 # How-to: Circuit Breaker
 
 > **FT reference**: FT298 (`NENE2-FT/circuitlog`) — Circuit breaker pattern: closed/open/half_open three-state machine, configurable failure threshold, timeout-based automatic half_open transition, 503 Service Unavailable on open circuit, `isCallAllowed()` readonly check, 15 tests / 28 assertions PASS.

--- a/docs/howto/collection-api.md
+++ b/docs/howto/collection-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Collection API (User Curated Lists)"
+category: product
+tags: [collections, curated-lists, visibility, ordering, deduplication]
+difficulty: intermediate
+related: [bookmark-api, content-collection, content-pinning]
+---
+
 # How-to: Collection API (User Curated Lists)
 
 > **FT reference**: FT299 (`NENE2-FT/collectionlog`) — User-curated article collections: is_public/private visibility (404 to non-owners for private), UNIQUE(collection_id, article_id) deduplication, position ordering, owner-only write access, 20 tests / 34 assertions PASS.

--- a/docs/howto/comment-thread.md
+++ b/docs/howto/comment-thread.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Comment Thread API"
+category: product
+tags: [comments, threads, pagination, moderation, rbac]
+difficulty: intermediate
+related: [threaded-comments, threaded-comments-api, content-report-moderation]
+---
+
 # How-to: Comment Thread API
 
 This guide demonstrates resource-scoped comment threads with pagination, author-only deletion, and admin override.

--- a/docs/howto/contact-management.md
+++ b/docs/howto/contact-management.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Contact Management API"
+category: product
+tags: [contacts, crud, many-to-many, owner-scoped, tagging]
+difficulty: intermediate
+related: [add-second-entity, note-management-ownership]
+---
+
 # How-to: Contact Management API
 
 > **FT reference**: FT238 (`NENE2-FT/contactlog`) — Contact Management API

--- a/docs/howto/content-approval-workflow.md
+++ b/docs/howto/content-approval-workflow.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Content Approval Workflow"
+category: product
+tags: [approval, workflow, state-machine, content, moderation]
+difficulty: intermediate
+related: [approval-workflow, content-draft-lifecycle, step-workflow-approval]
+---
+
 # How-to: Content Approval Workflow
 
 > **FT reference**: FT248 (`NENE2-FT/flowlog`) — Content Approval Workflow API

--- a/docs/howto/content-collection.md
+++ b/docs/howto/content-collection.md
@@ -1,3 +1,11 @@
+---
+title: "コンテンツコレクション"
+category: product
+tags: [collections, visibility, idor-prevention, idempotent, ordering]
+difficulty: intermediate
+related: [collection-api, bookmark-api, content-pinning]
+---
+
 # コンテンツコレクション
 
 記事のキュレーションコレクション（公開/非公開）システムの実装ガイド。

--- a/docs/howto/content-draft-lifecycle.md
+++ b/docs/howto/content-draft-lifecycle.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build a Content Draft Lifecycle (Draft → Published → Archived) with NENE2"
+category: product
+tags: [draft, publish, state-machine, content, lifecycle]
+difficulty: intermediate
+related: [draft-publish-workflow, content-approval-workflow, article-versioning-api]
+---
+
 # How to Build a Content Draft Lifecycle (Draft → Published → Archived) with NENE2
 
 This guide walks through building an article management system with a draft/publish/archive state machine, where only the author can transition states and only published articles are visible to readers.

--- a/docs/howto/content-negotiation-api.md
+++ b/docs/howto/content-negotiation-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Content Negotiation — JSON API"
+category: api-design
+tags: [content-negotiation, accept-header, json, problem-details]
+difficulty: beginner
+related: [content-negotiation, api-versioning]
+---
+
 # How-to: Content Negotiation — JSON API
 
 > **FT reference**: FT301 (`NENE2-FT/contentlog`) — JSON API content negotiation: always returns `application/json` regardless of `Accept` header, `application/problem+json` for errors (404/422/405), 415 on non-JSON `Content-Type` for POST, 16 tests / 28 assertions PASS.

--- a/docs/howto/content-negotiation.md
+++ b/docs/howto/content-negotiation.md
@@ -1,3 +1,11 @@
+---
+title: "Content negotiation"
+category: api-design
+tags: [content-negotiation, json, accept-header, problem-json]
+difficulty: beginner
+related: [content-negotiation-api, api-versioning]
+---
+
 # Content negotiation
 
 NENE2 is a JSON-first framework. It does not implement content negotiation — all responses use `application/json` (or `application/problem+json` for errors) regardless of what the client sends in the `Accept` header.

--- a/docs/howto/content-pinning.md
+++ b/docs/howto/content-pinning.md
@@ -1,3 +1,11 @@
+---
+title: "Content Pinning"
+category: product
+tags: [pinning, ordering, idempotent, position-management]
+difficulty: intermediate
+related: [pin-bookmark-ordering, bookmark-api, content-collection]
+---
+
 # Content Pinning
 
 コンテンツ（記事）のピン留め機能の実装ガイド。

--- a/docs/howto/content-relations.md
+++ b/docs/howto/content-relations.md
@@ -1,3 +1,11 @@
+---
+title: "Content Relations — Typed M:N Self-Referential Links"
+category: product
+tags: [relations, self-referential, many-to-many, inverse, typed-links]
+difficulty: intermediate
+related: [article-relations-api, content-collection]
+---
+
 # Content Relations — Typed M:N Self-Referential Links
 
 Link articles (or any resource) to each other using a **join table with a

--- a/docs/howto/content-report-moderation.md
+++ b/docs/howto/content-report-moderation.md
@@ -1,3 +1,11 @@
+---
+title: "Content Report & Moderation"
+category: product
+tags: [moderation, reporting, rbac, idor-prevention, state-machine]
+difficulty: intermediate
+related: [content-reporting, comment-thread]
+---
+
 # Content Report & Moderation
 
 コンテンツ（記事）の通報・モデレーションシステムの実装ガイド。

--- a/docs/howto/content-reporting.md
+++ b/docs/howto/content-reporting.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Content Reporting System"
+category: product
+tags: [reporting, moderation, enum, state-machine, idempotent]
+difficulty: intermediate
+related: [content-report-moderation, content-approval-workflow, comment-thread]
+---
+
 # How-to: Content Reporting System
 
 > **FT reference**: FT289 (`NENE2-FT/reportlog`) — Content reporting: allowlisted reasons (ReportReason enum), UNIQUE(reporter_id, article_id) with idempotent 200 on duplicate, pending→resolved/dismissed state machine, moderator-only list/resolve/dismiss, DB-level CHECK constraints, 32 tests / 58 assertions PASS.

--- a/docs/howto/content-scheduling.md
+++ b/docs/howto/content-scheduling.md
@@ -1,3 +1,11 @@
+---
+title: "Content Scheduling — Time-Based Publish with Lifecycle States"
+category: infrastructure
+tags: [scheduling, state-machine, content, cron, publish]
+difficulty: intermediate
+related: [draft-publish-workflow, content-versioning, scheduled-publish-article]
+---
+
 # Content Scheduling — Time-Based Publish with Lifecycle States
 
 Schedule content to publish at a future datetime using a `publish_at` column,

--- a/docs/howto/content-versioning.md
+++ b/docs/howto/content-versioning.md
@@ -1,3 +1,11 @@
+---
+title: "Content Versioning の実装ガイド"
+category: product
+tags: [versioning, append-only, rollback, history, content]
+difficulty: intermediate
+related: [document-versioning, article-versioning-api, draft-publish-workflow]
+---
+
 # Content Versioning の実装ガイド
 
 ## 概要

--- a/docs/howto/coupon-discount-api.md
+++ b/docs/howto/coupon-discount-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Coupon Discount Code API"
+category: product
+tags: [coupon, discount, redemption, admin, usage-limit]
+difficulty: intermediate
+related: [coupon-promo-code, coupon-redemption]
+---
+
 # How-to: Coupon Discount Code API
 
 > **FT reference**: FT302 (`NENE2-FT/couponlog`) — Coupon discount code API: admin-only creation with `X-Admin-Key` (hash_equals), CODE_PATTERN `[A-Z0-9]{4,32}` auto-normalize to uppercase, UNIQUE(coupon_id, user_id) prevents double-redeem, expired/exhausted/duplicate → 409, 26 tests / 50 assertions PASS.

--- a/docs/howto/coupon-promo-code.md
+++ b/docs/howto/coupon-promo-code.md
@@ -1,3 +1,11 @@
+---
+title: "クーポン・プロモコード管理"
+category: product
+tags: [coupon, promo-code, rbac, discount, expiry]
+difficulty: intermediate
+related: [coupon-discount-api, coupon-redemption]
+---
+
 # クーポン・プロモコード管理
 
 admin RBAC・ユーザーごとの利用追跡・有効期限・上限制御を備えたクーポンシステムの実装ガイド。

--- a/docs/howto/coupon-redemption.md
+++ b/docs/howto/coupon-redemption.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Coupon / Discount Code Redemption API"
+category: product
+tags: [coupon, redemption, discount, usage-limit, expiry]
+difficulty: intermediate
+related: [coupon-discount-api, coupon-promo-code]
+---
+
 # How-to: Coupon / Discount Code Redemption API
 
 This guide shows how to build a coupon redemption system with usage limits and expiry using NENE2.

--- a/docs/howto/cqrs-pattern.md
+++ b/docs/howto/cqrs-pattern.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: CQRS Pattern"
+category: infrastructure
+tags: [cqrs, read-model, write-model, event-sourcing, architecture]
+difficulty: advanced
+related: [event-sourcing, event-sourcing-cqrs-api, event-sourcing-ledger]
+---
+
 # How-to: CQRS Pattern
 
 > **FT reference**: FT233 (`NENE2-FT/cqrslog`) — CQRS Pattern API

--- a/docs/howto/credit-ledger.md
+++ b/docs/howto/credit-ledger.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Credit Ledger API"
+category: product
+tags: [ledger, credits, append-only, balance, idempotency]
+difficulty: intermediate
+related: [event-sourcing-ledger, multi-currency-money-ledger, point-ledger-api]
+---
+
 # How-to: Credit Ledger API
 
 > **FT reference**: FT234 (`NENE2-FT/creditslog`) — Credit Ledger API

--- a/docs/howto/csrf-and-json-api.md
+++ b/docs/howto/csrf-and-json-api.md
@@ -1,3 +1,11 @@
+---
+title: "CSRF and JSON APIs"
+category: security
+tags: [csrf, cors, json-api, security, bearer-token]
+difficulty: intermediate
+related: [enforce-resource-ownership, mass-assignment-defence]
+---
+
 # CSRF and JSON APIs
 
 ## CORS ≠ CSRF protection

--- a/docs/howto/csv-bulk-import.md
+++ b/docs/howto/csv-bulk-import.md
@@ -1,3 +1,11 @@
+---
+title: "CSV バルクインポート API の実装ガイド"
+category: api-design
+tags: [csv, bulk-import, partial-success, validation, history]
+difficulty: intermediate
+related: [bulk-operations-partial-success, batch-api-partial-success]
+---
+
 # CSV バルクインポート API の実装ガイド
 
 ## 概要

--- a/docs/howto/cursor-pagination.md
+++ b/docs/howto/cursor-pagination.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Cursor-Based Pagination"
+category: api-design
+tags: [pagination, cursor, keyset, performance]
+difficulty: intermediate
+related: [offset-cursor-pagination, add-pagination]
+---
+
 # How-to: Cursor-Based Pagination
 
 > **FT reference**: FT242 (`NENE2-FT/cursorlog`) — Cursor-Based Pagination API

--- a/docs/howto/data-export-api.md
+++ b/docs/howto/data-export-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Data Export API"
+category: security
+tags: [gdpr, data-export, pii, token, async]
+difficulty: intermediate
+related: [data-masking, personal-data-export, privacy-consent-management]
+---
+
 # How-to: Data Export API
 
 > **FT reference**: FT312 (`NENE2-FT/exportlog`) — Data export (GDPR-style): async `pending→ready` state machine via token-based download, PII exclusion via `toPublicArray()` (password_hash and phone never in GET response or export payload), ARGON2ID password hashing, 64-hex-char export token, 410 Gone for expired exports, 409 for pending download attempt, 19 tests / 32 assertions PASS.

--- a/docs/howto/data-masking.md
+++ b/docs/howto/data-masking.md
@@ -1,3 +1,11 @@
+---
+title: "How to Add Data Masking"
+category: security
+tags: [pii, masking, admin, audit, privacy]
+difficulty: intermediate
+related: [pii-masking, data-export-api, encrypted-field-storage]
+---
+
 # How to Add Data Masking
 
 Mask PII fields (email, phone, name) in API responses by default, with an audited admin unmask path.

--- a/docs/howto/dead-letter-queue.md
+++ b/docs/howto/dead-letter-queue.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Dead Letter Queue (DLQ)"
+category: infrastructure
+tags: [queue, dead-letter-queue, retry, backoff, reliability]
+difficulty: advanced
+related: [job-queue-with-retry, job-queue, notification-queue]
+---
+
 # How-to: Dead Letter Queue (DLQ)
 
 > **FT reference**: FT72 (`NENE2-FT/deadletterlog`) — Dead Letter Queue API

--- a/docs/howto/delegated-access-grants.md
+++ b/docs/howto/delegated-access-grants.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Delegated Access Grants"
+category: auth
+tags: [delegation, access-control, scoped-access, time-limited, rbac]
+difficulty: advanced
+related: [enforce-resource-ownership, rbac, api-key-management]
+---
+
 # How-to: Delegated Access Grants
 
 > **FT reference**: FT282 (`NENE2-FT/grantlog`) — Delegated access grants: scoped (read/write/admin) time-limited resource access, UNIQUE(grantor, grantee, resource) + CHECK(grantor != grantee), IDOR → 404, soft-delete revocation, use-count tracking, GrantScope.satisfies() hierarchy, 23 tests / 71 assertions PASS.

--- a/docs/howto/deploy-production.md
+++ b/docs/howto/deploy-production.md
@@ -1,3 +1,10 @@
+---
+title: "Deploy to Production"
+category: infrastructure
+tags: [deploy, docker, production, environment, reverse-proxy]
+difficulty: intermediate
+---
+
 # Deploy to Production
 
 This guide covers the minimum steps to run a NENE2-based application in a production environment: building a production image, managing environment variables securely, and placing a reverse proxy in front.

--- a/docs/howto/direct-messaging-system.md
+++ b/docs/howto/direct-messaging-system.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build a Direct Messaging System with NENE2"
+category: product
+tags: [messaging, conversation, threading, access-control, idempotency]
+difficulty: intermediate
+related: [notification-inbox, comment-thread]
+---
+
 # How to Build a Direct Messaging System with NENE2
 
 > **FT reference**: FT278 (`NENE2-FT/messagelog`) — Direct messaging: conversation threading, UNIQUE(initiator_id, recipient_id) + CHECK(initiator_id != recipient_id), participant-only access control, direction-agnostic lookup, idempotent conversation start, 31 tests / 96 assertions PASS.

--- a/docs/howto/distributed-lock.md
+++ b/docs/howto/distributed-lock.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Distributed Lock"
+category: infrastructure
+tags: [distributed-lock, concurrency, ttl, database, race-condition]
+difficulty: advanced
+related: [distributed-locking, prevent-double-booking, optimistic-locking]
+---
+
 # How-to: Distributed Lock
 
 > **FT reference**: FT288 (`NENE2-FT/distlocklog`) — Distributed lock: UNIQUE(resource) DB constraint, owner verification, TTL-based expiry, expired lock re-acquisition by design, ReleaseResult enum (Released/NotFound/Forbidden), 403 on owner mismatch, 16 tests / 27 assertions PASS.

--- a/docs/howto/distributed-locking.md
+++ b/docs/howto/distributed-locking.md
@@ -1,3 +1,11 @@
+---
+title: "Distributed Locking"
+category: infrastructure
+tags: [distributed-lock, concurrency, database, ttl, critical-section]
+difficulty: advanced
+related: [distributed-lock, prevent-double-booking, optimistic-locking]
+---
+
 # Distributed Locking
 
 A distributed lock prevents concurrent processes from executing a critical section at the same time. DB-backed locks trade throughput for simplicity — no Redis required, and the same DB that holds your data holds your locks.

--- a/docs/howto/document-template-engine.md
+++ b/docs/howto/document-template-engine.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: Document Template Engine"
+category: product
+tags: [template, substitution, admin, crud, rendering]
+difficulty: beginner
+related: [document-versioning, draft-publish-workflow]
+---
+
 # How-To: Document Template Engine
 
 Demonstrates template CRUD with `{{variable}}` substitution and admin-gated writes.

--- a/docs/howto/document-versioning.md
+++ b/docs/howto/document-versioning.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Document Versioning API"
+category: product
+tags: [versioning, append-only, rollback, transactions, document]
+difficulty: intermediate
+related: [content-versioning, article-versioning-api, draft-publish-workflow]
+---
+
 # How-to: Document Versioning API
 
 > **FT reference**: FT239 (`NENE2-FT/doclog`) — Document Versioning API

--- a/docs/howto/draft-publish-workflow.md
+++ b/docs/howto/draft-publish-workflow.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Draft → Publish → Archive Workflow"
+category: product
+tags: [state-machine, draft, publish, archive, content-lifecycle]
+difficulty: intermediate
+related: [content-scheduling, content-draft-lifecycle, content-versioning]
+---
+
 # How-to: Draft → Publish → Archive Workflow
 
 > **FT reference**: FT305 (`NENE2-FT/draftlog`) — Article lifecycle state machine: draft→published→archived one-way transitions, author-only write access, non-authors see only published articles (drafts return 404), cannot edit published articles, published list excludes drafts and archived, 20 tests / 28 assertions PASS.

--- a/docs/howto/dynamic-filter-query.md
+++ b/docs/howto/dynamic-filter-query.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Dynamic Filter Query (Dynamic WHERE Clause)"
+category: api-design
+tags: [filtering, query-params, sql, where-clause, list-endpoint]
+difficulty: beginner
+related: [dynamic-sort-order-injection, multi-value-tag-filter]
+---
+
 # How-to: Dynamic Filter Query (Dynamic WHERE Clause)
 
 > **Related scenarios**: DX Scenario 03, 18, 22, 25, 29, 30, 33, 37, 38, 41, 47, 48 — the most frequently cited missing howto across 50 DX scenarios.

--- a/docs/howto/dynamic-sort-order-injection.md
+++ b/docs/howto/dynamic-sort-order-injection.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Dynamic Sort & Filter with ORDER BY Injection Prevention"
+category: security
+tags: [sql-injection, order-by, allowlist, sorting, filtering]
+difficulty: intermediate
+related: [dynamic-filter-query, sql-orderby-injection, sql-injection-defence]
+---
+
 # How-to: Dynamic Sort & Filter with ORDER BY Injection Prevention
 
 > **FT reference**: FT341 (`NENE2-FT/sortlog`) — Dynamic sort/filter API with SQL ORDER BY injection prevention via allowlist, status filter allowlist, ReDoS-immune O(n) validation, 40+ tests covering VULN-A through VULN-L and ATK-01 through ATK-12, all PASS.

--- a/docs/howto/emoji-reaction-system.md
+++ b/docs/howto/emoji-reaction-system.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build an Emoji Reaction System with NENE2"
+category: product
+tags: [emoji, reactions, unique-constraint, group-by, social]
+difficulty: intermediate
+related: [emoji-reactions-api, emoji-reactions-toggle, upvote-downvote-api]
+---
+
 # How to Build an Emoji Reaction System with NENE2
 
 This guide walks through building a reaction system where users react to posts with emojis, with grouped counts and per-user reaction tracking.

--- a/docs/howto/emoji-reactions-api.md
+++ b/docs/howto/emoji-reactions-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Emoji Reactions API"
+category: product
+tags: [emoji, reactions, unique-constraint, social, unicode]
+difficulty: intermediate
+related: [emoji-reaction-system, emoji-reactions-toggle, upvote-downvote-api]
+---
+
 # How-to: Emoji Reactions API
 
 > **FT reference**: FT306 (`NENE2-FT/emojilog`) — Emoji reactions: UNIQUE(post_id, user_id, emoji) allows same emoji by multiple users but prevents one user reacting with the same emoji twice, mb_strlen max 8 characters, urldecode() for emoji in DELETE path, user_reactions shows the current actor's reactions, reactions ordered by count DESC, 18 tests / 28 assertions PASS.

--- a/docs/howto/emoji-reactions-toggle.md
+++ b/docs/howto/emoji-reactions-toggle.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Emoji Reactions with Toggle and Grouped Counts"
+category: product
+tags: [emoji, reactions, toggle, concurrency, unique-constraint]
+difficulty: intermediate
+related: [emoji-reactions-api, emoji-reaction-system, upvote-downvote-api]
+---
+
 # How-to: Emoji Reactions with Toggle and Grouped Counts
 
 > **FT reference**: FT263 (`NENE2-FT/reactionlog`) — Emoji reactions: toggle (add/remove), grouped counts, per-user reaction list

--- a/docs/howto/encrypted-field-storage.md
+++ b/docs/howto/encrypted-field-storage.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build Encrypted Field Storage"
+category: security
+tags: [encryption, aes-256-gcm, pii, blind-index, field-level-encryption]
+difficulty: advanced
+related: [data-masking, pii-masking, secret-vault]
+---
+
 # How to Build Encrypted Field Storage
 
 > **FT reference**: FT267 (`NENE2-FT/encryptlog`) — AES-256-GCM field-level encryption: encrypt-on-write / decrypt-on-read, blind index for searchable ciphertext, key separation between encryption and index keys

--- a/docs/howto/enforce-resource-ownership.md
+++ b/docs/howto/enforce-resource-ownership.md
@@ -1,3 +1,11 @@
+---
+title: "How to enforce resource ownership (IDOR prevention)"
+category: security
+tags: [idor, ownership, access-control, authorization, security]
+difficulty: intermediate
+related: [delegated-access-grants, mass-assignment-defence, tenant-isolation]
+---
+
 # How to enforce resource ownership (IDOR prevention)
 
 Insecure Direct Object Reference (IDOR) is the #1 API vulnerability (OWASP API Security Top 10).

--- a/docs/howto/etag-conditional-requests.md
+++ b/docs/howto/etag-conditional-requests.md
@@ -1,3 +1,11 @@
+---
+title: "ETag & Conditional Requests"
+category: api-design
+tags: [etag, conditional-request, cache, optimistic-locking, http]
+difficulty: intermediate
+related: [optimistic-locking-etag, optimistic-lock-patch-version, optimistic-locking]
+---
+
 # ETag & Conditional Requests
 
 > **FT reference**: FT307 (`NENE2-FT/etaglog`) — ETag conditional requests: `If-None-Match`→304, `If-Modified-Since`→304, `If-Match`→412 stale / 428 absent, wildcard `If-Match: *` passes, ETag changes after every update, 15 tests PASS.

--- a/docs/howto/event-analytics-api.md
+++ b/docs/howto/event-analytics-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Event Analytics API"
+category: infrastructure
+tags: [analytics, event-tracking, aggregation, json-extract, statistics]
+difficulty: intermediate
+related: [event-analytics, api-usage-metering, aggregate-reporting]
+---
+
 # How-to: Event Analytics API
 
 > **FT reference**: FT243 (`NENE2-FT/statslog`) — Event Analytics API

--- a/docs/howto/event-analytics.md
+++ b/docs/howto/event-analytics.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Event Analytics API"
+category: infrastructure
+tags: [analytics, event-tracking, aggregation, json-extract, statistics]
+difficulty: intermediate
+related: [event-analytics-api, api-usage-metering, aggregate-reporting]
+---
+
 # How-to: Event Analytics API
 
 > **FT reference**: FT51 (`NENE2-FT/statslog`) — Event Analytics API with JSON property

--- a/docs/howto/event-sourcing-cqrs-api.md
+++ b/docs/howto/event-sourcing-cqrs-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Event Sourcing & CQRS API"
+category: infrastructure
+tags: [event-sourcing, cqrs, append-only, read-model, projection]
+difficulty: advanced
+related: [event-sourcing, cqrs-pattern, event-sourcing-ledger]
+---
+
 # How-to: Event Sourcing & CQRS API
 
 > **FT reference**: `NENE2-FT/eventstore` — Append-only event log with per-aggregate sequence numbers, allowlisted event types, read-model projection rebuilt from events, balance tracking, 17 tests PASS.

--- a/docs/howto/event-sourcing-ledger.md
+++ b/docs/howto/event-sourcing-ledger.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Event Sourcing Ledger"
+category: infrastructure
+tags: [event-sourcing, ledger, append-only, balance, replay]
+difficulty: advanced
+related: [event-sourcing, event-sourcing-cqrs-api, credit-ledger]
+---
+
 # How-to: Event Sourcing Ledger
 
 > **FT reference**: FT310 (`NENE2-FT/eventsourcelog`) — Event sourcing account ledger: immutable event log (append-only), `replayBalance()` replays all events to compute current balance, deposit/withdraw events never deleted, `is_int()` strict amount validation, max amount 1,000,000,000, separate accounts don't share balance, 17 tests / 24 assertions PASS.

--- a/docs/howto/event-sourcing.md
+++ b/docs/howto/event-sourcing.md
@@ -1,3 +1,11 @@
+---
+title: "Event Sourcing (Basic)"
+category: infrastructure
+tags: [event-sourcing, append-only, immutable, replay, domain-events]
+difficulty: intermediate
+related: [event-sourcing-ledger, event-sourcing-cqrs-api, cqrs-pattern]
+---
+
 # Event Sourcing (Basic)
 
 Persist state as an immutable sequence of domain events. Derive current state by replaying the event stream.

--- a/docs/howto/event-ticket-booking.md
+++ b/docs/howto/event-ticket-booking.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: Event Ticket Booking"
+category: product
+tags: [booking, tickets, capacity, concurrency, inventory]
+difficulty: intermediate
+related: [resource-booking, prevent-double-booking, resource-reservation]
+---
+
 # How-To: Event Ticket Booking
 
 Demonstrates event capacity management with per-user ticket purchasing.

--- a/docs/howto/expense-tracker.md
+++ b/docs/howto/expense-tracker.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Expense Tracker API"
+category: product
+tags: [expense, tracker, categories, date-range, aggregation]
+difficulty: beginner
+related: [expense-tracking-api, budget-tracking, time-tracking]
+---
+
 # How-to: Expense Tracker API
 
 This guide shows how to build a personal expense tracking system with category-based filtering,

--- a/docs/howto/expense-tracking-api.md
+++ b/docs/howto/expense-tracking-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Expense Tracking API"
+category: product
+tags: [expense, tracking, pagination, patch, aggregation]
+difficulty: intermediate
+related: [expense-tracker, budget-tracking, time-tracking]
+---
+
 # How-to: Expense Tracking API
 
 > **FT reference**: FT311 (`NENE2-FT/expenselog`) — Expense tracking: YYYY-MM-DD date format validation, category string (open, no enum), monthly summary aggregation by category, offset pagination with limit/offset, PATCH partial update (only provided fields changed), date-range filter, static `/summary` route before dynamic `/{id}`, 34 tests / 67 assertions PASS.

--- a/docs/howto/feature-flag-api.md
+++ b/docs/howto/feature-flag-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Feature Flag API"
+category: infrastructure
+tags: [feature-flags, rollout, environment, override, gradual-rollout]
+difficulty: intermediate
+related: [feature-flags, ab-testing]
+---
+
 # How-to: Feature Flag API
 
 > **FT reference**: FT313 (`NENE2-FT/flaglog`) — Feature flag management: per-environment flags, rollout_percent gradual rollout, per-user overrides, evaluate endpoint with override resolution, snake_case key validation, 18 tests / 29 assertions PASS.

--- a/docs/howto/feature-flags.md
+++ b/docs/howto/feature-flags.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Feature Flags API"
+category: infrastructure
+tags: [feature-flags, rollout, percentage, kill-switch, tenant]
+difficulty: intermediate
+related: [feature-flag-api, ab-testing]
+---
+
 # How-to: Feature Flags API
 
 > **FT reference**: FT270 (`NENE2-FT/featureflaglog`) — Feature flag API: priority-chain evaluation (user target → tenant target → globally_enabled → rollout_pct hash), crc32-based deterministic bucket assignment, user/tenant kill switches, flag UNIQUE name constraint, 21 tests / 31 assertions PASS.

--- a/docs/howto/feedback-collection.md
+++ b/docs/howto/feedback-collection.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Feedback Collection API"
+category: product
+tags: [feedback, rating, aggregation, admin, score]
+difficulty: beginner
+related: [rating-review-api, product-review-system]
+---
+
 # How-to: Feedback Collection API
 
 ## Overview

--- a/docs/howto/file-metadata-sharing.md
+++ b/docs/howto/file-metadata-sharing.md
@@ -1,3 +1,11 @@
+---
+title: "ファイルメタデータ管理・共有 API の実装ガイド"
+category: product
+tags: [file-sharing, metadata, permissions, access-control, visibility]
+difficulty: intermediate
+related: [file-sharing-api, enforce-resource-ownership, delegated-access-grants]
+---
+
 # ファイルメタデータ管理・共有 API の実装ガイド
 
 ## 概要

--- a/docs/howto/file-sharing-api.md
+++ b/docs/howto/file-sharing-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: File Sharing API"
+category: product
+tags: [file-sharing, permissions, visibility, access-control, ownership]
+difficulty: intermediate
+related: [file-metadata-sharing, enforce-resource-ownership, signed-url-download]
+---
+
 # How-to: File Sharing API
 
 > **FT reference**: FT303 (`NENE2-FT/filelog`) — File sharing API: private files return 404 (not 403) to non-owners, owner-only delete/visibility-change, view-share vs edit-share permission tiers, body `user_id` ignored (ownership from header), name length limit 255, size `is_int()` strict, VULN-A〜L all SAFE, 59 tests / 82 assertions PASS.

--- a/docs/howto/file-upload-metadata.md
+++ b/docs/howto/file-upload-metadata.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: File Upload Metadata API (VULN-A~L)"
+category: security
+tags: [file-upload, metadata, vulnerability-assessment, ownership]
+difficulty: advanced
+related: [file-upload, file-metadata-sharing, file-sharing-api]
+---
+
 # How-to: File Upload Metadata API (VULN-A~L)
 
 This guide demonstrates secure file upload metadata management covering VULN-A through VULN-L.

--- a/docs/howto/file-upload.md
+++ b/docs/howto/file-upload.md
@@ -1,3 +1,11 @@
+---
+title: "File upload (base64 JSON)"
+category: api-design
+tags: [file-upload, base64, json-api, request-body]
+difficulty: beginner
+related: [file-upload-metadata, file-sharing-api]
+---
+
 # File upload (base64 JSON)
 
 NENE2 is a JSON-first framework. It does not have built-in multipart/form-data parsing. The recommended pattern for file upload in a JSON API is to receive files as base64-encoded strings in the JSON request body.

--- a/docs/howto/fixed-window-rate-limiter.md
+++ b/docs/howto/fixed-window-rate-limiter.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Fixed-window Rate Limiter"
+category: security
+tags: [rate-limiting, fixed-window, sqlite, throttle]
+difficulty: intermediate
+related: [sliding-window-rate-limiter, add-rate-limiting, rate-limiting]
+ft: FT251
+---
+
 # How-to: Fixed-window Rate Limiter
 
 > **FT reference**: FT251 (`NENE2-FT/ratelimitlog`) — Fixed-window rate limiting with SQLite upsert

--- a/docs/howto/flash-sale-api.md
+++ b/docs/howto/flash-sale-api.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Flash Sale API"
+category: product
+tags: [flash-sale, inventory, race-condition, time-window]
+difficulty: advanced
+related: [flash-sale-system, inventory-management, prevent-double-booking]
+ft: FT304
+---
+
 # How-to: Flash Sale API
 
 > **FT reference**: FT304 (`NENE2-FT/salelog`) — Flash sale API: time-window validation (sale not started → 422, ended → 422), UNIQUE(sale_id, user_id) prevents double-purchase, sold-out stock check, negative price/zero quantity → 422, inverted dates rejected, ATK-01〜12 all BLOCKED, 29 tests / 42 assertions PASS.

--- a/docs/howto/flash-sale-system.md
+++ b/docs/howto/flash-sale-system.md
@@ -1,3 +1,12 @@
+---
+title: "How to Build a Flash Sale System with NENE2"
+category: product
+tags: [flash-sale, inventory, time-window, race-condition]
+difficulty: advanced
+related: [flash-sale-api, inventory-management, prevent-double-booking]
+ft: FT140
+---
+
 # How to Build a Flash Sale System with NENE2
 
 This guide walks through building a time-limited, quantity-constrained flash sale system where users can purchase a product at a discounted price during a sale window.

--- a/docs/howto/follow-api.md
+++ b/docs/howto/follow-api.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Follow / Unfollow API"
+category: product
+tags: [follow, social, graph, pagination]
+difficulty: intermediate
+related: [user-follow-system, activity-feed, follow-api]
+ft: FT314
+---
+
 # How-to: Follow / Unfollow API
 
 > **FT reference**: FT314 (`NENE2-FT/followlog`) — Social follow graph: idempotent follow (POST 201 first time, 200 on repeat), self-follow prevention (422), unfollow (DELETE 204), followers/following counts via stats, paginated lists ordered by most-recent-first, is-following check, mutual follow support, 20 tests / 72 assertions PASS.

--- a/docs/howto/ft-registry.md
+++ b/docs/howto/ft-registry.md
@@ -1,3 +1,10 @@
+---
+title: "FT Registry"
+category: getting-started
+tags: [field-trial, registry, reference]
+difficulty: beginner
+---
+
 # FT Registry
 
 FT 番号 → プロジェクト名 → howto ファイルの台帳。

--- a/docs/howto/game-score-leaderboard-api.md
+++ b/docs/howto/game-score-leaderboard-api.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Game Score & Leaderboard API"
+category: product
+tags: [leaderboard, scores, ranking, bulk-insert, pagination]
+difficulty: intermediate
+related: [leaderboard-ranking-api, leaderboard-scores, leaderboard-ranking]
+ft: FT259
+---
+
 # How-to: Game Score & Leaderboard API
 
 > **FT reference**: FT259 (`NENE2-FT/scorelog`) — Game score submission with bulk insert (max 100, all-or-nothing), per-player leaderboard with `best_score` aggregation and `play_count`, negative score prevention, pagination, 20 tests PASS.

--- a/docs/howto/geolocation-api.md
+++ b/docs/howto/geolocation-api.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Geolocation API"
+category: api-design
+tags: [geolocation, proximity-search, coordinates, haversine]
+difficulty: intermediate
+related: [geolocation]
+ft: FT296
+---
+
 # How-to: Geolocation API
 
 > **FT reference**: FT296 (`NENE2-FT/geoloclog`) — Geolocation API: Haversine distance calculation, coordinate validation (lat ±90, lng ±180), nearby search with bounding-box pre-filter, max radius clamp (20,000 km), inverted bounding-box guard, ATK-01~12 all BLOCKED, 25 tests / 40 assertions PASS.

--- a/docs/howto/geolocation.md
+++ b/docs/howto/geolocation.md
@@ -1,3 +1,11 @@
+---
+title: "How to Add Geolocation Search"
+category: api-design
+tags: [geolocation, proximity-search, coordinates, bounding-box]
+difficulty: intermediate
+related: [geolocation-api]
+---
+
 # How to Add Geolocation Search
 
 Store latitude/longitude points and search by proximity (nearby radius) or bounding box.

--- a/docs/howto/group-member-management.md
+++ b/docs/howto/group-member-management.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Group Member Management"
+category: product
+tags: [group, membership, rbac, role-hierarchy, idor]
+difficulty: advanced
+related: [group-membership-management, rbac, enforce-resource-ownership]
+ft: FT291
+---
+
 # How-to: Group Member Management
 
 > **FT reference**: FT291 (`NENE2-FT/grouplog`) — Group membership: MemberRole enum (owner/admin/member), UNIQUE(group_id, user_id), owner-cannot-be-removed guard, cross-group IDOR prevention, canManageMembers()/canChangeRoles() role hierarchy, VULN-A~L all SAFE, 38 tests / 101 assertions PASS.

--- a/docs/howto/group-membership-management.md
+++ b/docs/howto/group-membership-management.md
@@ -1,3 +1,12 @@
+---
+title: "How to Build Group Membership Management with NENE2"
+category: product
+tags: [group, membership, roles, invitation]
+difficulty: intermediate
+related: [group-member-management, rbac, invitation-system]
+ft: FT138
+---
+
 # How to Build Group Membership Management with NENE2
 
 This guide walks through building a group system where users create groups, invite members with roles (owner/admin/member), manage membership, and control role promotion.

--- a/docs/howto/guest-order-system.md
+++ b/docs/howto/guest-order-system.md
@@ -1,3 +1,12 @@
+---
+title: "How to Build a Guest Order System (Cart → Order → Order Items) with NENE2"
+category: product
+tags: [order, cart, inventory, price-snapshot, guest]
+difficulty: intermediate
+related: [shopping-cart-api, inventory-management, inventory-stock-management]
+ft: FT139
+---
+
 # How to Build a Guest Order System (Cart → Order → Order Items) with NENE2
 
 This guide walks through building an e-commerce ordering flow where users add products to a cart, check stock, and place an order that captures price snapshots in order items.

--- a/docs/howto/habit-tracker.md
+++ b/docs/howto/habit-tracker.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Habit Tracker API"
+category: product
+tags: [habit, streak, tracking, daily]
+difficulty: intermediate
+related: [time-tracking, scheduled-reminders]
+ft: FT24
+---
+
 # How-to: Habit Tracker API
 
 > **FT reference**: FT24 (`NENE2-FT/habitlog`) — Habit Tracking API with streak calculation

--- a/docs/howto/handle-timezones.md
+++ b/docs/howto/handle-timezones.md
@@ -1,3 +1,11 @@
+---
+title: "How to handle timezones"
+category: api-design
+tags: [timezone, datetime, iso-8601, validation]
+difficulty: intermediate
+related: [iso-datetime-validation, timezone-aware-scheduling]
+---
+
 # How to handle timezones
 
 PHP's timezone handling has several silent failure modes. This guide covers the patterns and pitfalls encountered in real NENE2 field trials.

--- a/docs/howto/hierarchical-data.md
+++ b/docs/howto/hierarchical-data.md
@@ -1,3 +1,12 @@
+---
+title: "Hierarchical Data — Self-Referential FK + Materialized Path"
+category: database
+tags: [hierarchical, tree, materialized-path, self-referential]
+difficulty: advanced
+related: [category-hierarchy-api, threaded-comments, threaded-comments-api]
+ft: FT171
+---
+
 # Hierarchical Data — Self-Referential FK + Materialized Path
 
 > **FT reference**: FT171 (`NENE2-FT/hierarchylog`) — Hierarchical categories with self-referential FK and materialized path for O(1) subtree queries.

--- a/docs/howto/idempotency-key-api.md
+++ b/docs/howto/idempotency-key-api.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Idempotency Key API"
+category: api-design
+tags: [idempotency, deduplication, payment, retry]
+difficulty: intermediate
+related: [idempotency-key, idempotency, request-deduplication]
+ft: FT316
+---
+
 # How-to: Idempotency Key API
 
 > **FT reference**: FT316 (`NENE2-FT/idempotencylog`) — Idempotency key pattern for payment API: SHA-256 key hashing, X-Idempotent-Replayed header, duplicate prevention, 15 tests / 25 assertions PASS.

--- a/docs/howto/idempotency-key.md
+++ b/docs/howto/idempotency-key.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Idempotency Key (Request Deduplication)"
+category: api-design
+tags: [idempotency, deduplication, retry, ttl]
+difficulty: intermediate
+related: [idempotency-key-api, idempotency, request-deduplication]
+ft: FT292
+---
+
 # How-to: Idempotency Key (Request Deduplication)
 
 > **FT reference**: FT292 (`NENE2-FT/deduplog`) — Idempotency key deduplication: UNIQUE(idempotency_key) DB constraint, 24h TTL with re-processable expiry, `replayed: true` flag on cached responses, parameterized queries prevent injection, ATK-01~12 all BLOCKED, 24 tests / 57 assertions PASS.

--- a/docs/howto/idempotency.md
+++ b/docs/howto/idempotency.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Idempotency-Key Pattern"
+category: api-design
+tags: [idempotency, deduplication, race-condition, retry]
+difficulty: intermediate
+related: [idempotency-key, idempotency-key-api, request-deduplication]
+ft: FT276
+---
+
 # How-to: Idempotency-Key Pattern
 
 > **FT reference**: FT276 (`NENE2-FT/csrflog`) — Idempotency-Key header for state-changing requests: UNIQUE DB constraint, replay returns original result (200), body changes on replay are ignored, race condition handled by DatabaseConstraintException, 15 tests / 30 assertions PASS.

--- a/docs/howto/implement-bulk-endpoint.md
+++ b/docs/howto/implement-bulk-endpoint.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Implement a Bulk Create Endpoint"
+category: api-design
+tags: [bulk, batch, validation, partial-success]
+difficulty: intermediate
+related: [batch-api-partial-success, bulk-operations-partial-success, bulk-status-update]
+---
+
 # How-to: Implement a Bulk Create Endpoint
 
 A bulk endpoint accepts multiple resources in a single request — reducing round trips for

--- a/docs/howto/implement-patch-endpoint.md
+++ b/docs/howto/implement-patch-endpoint.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Implement a PATCH Endpoint"
+category: api-design
+tags: [patch, partial-update, json-merge-patch, dto]
+difficulty: intermediate
+related: [json-merge-patch, patch-partial-update, optimistic-lock-patch-version]
+---
+
 # How-to: Implement a PATCH Endpoint
 
 PATCH is for **partial updates**: only the fields the client sends should change.

--- a/docs/howto/inbound-webhook-gateway.md
+++ b/docs/howto/inbound-webhook-gateway.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Inbound Webhook Gateway"
+category: infrastructure
+tags: [webhook, hmac, signature-verification, idempotency]
+difficulty: intermediate
+related: [inbound-webhook-receiver, webhook-signature-verification, webhook-signature]
+ft: FT317
+---
+
 # How-to: Inbound Webhook Gateway
 
 > **FT reference**: FT317 (`NENE2-FT/inboundlog`) — Inbound webhook gateway with per-source HMAC-SHA256 signature verification, duplicate event_id idempotency, secret never exposed in responses, 17 tests / 18 assertions PASS.

--- a/docs/howto/inbound-webhook-receiver.md
+++ b/docs/howto/inbound-webhook-receiver.md
@@ -1,3 +1,11 @@
+---
+title: "How to Add an Inbound Webhook Receiver"
+category: infrastructure
+tags: [webhook, hmac, signature-verification, idempotency]
+difficulty: intermediate
+related: [inbound-webhook-gateway, webhook-signature-verification, webhook-signature]
+---
+
 # How to Add an Inbound Webhook Receiver
 
 Receive webhooks from multiple external services, validate HMAC signatures per source, and store events with idempotency.

--- a/docs/howto/inventory-management.md
+++ b/docs/howto/inventory-management.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Inventory Management API"
+category: product
+tags: [inventory, stock, adjustment, history]
+difficulty: intermediate
+related: [inventory-stock-management, order-management]
+ft: FT220
+---
+
 # How-to: Inventory Management API
 
 This guide shows how to build an inventory / stock management API with stock adjustments and history tracking using NENE2.

--- a/docs/howto/inventory-stock-management.md
+++ b/docs/howto/inventory-stock-management.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Inventory Stock Management"
+category: product
+tags: [inventory, stock, sku, transactions]
+difficulty: intermediate
+related: [inventory-management, order-management]
+---
+
 # How-to: Inventory Stock Management
 
 ## Overview

--- a/docs/howto/invitation-referral.md
+++ b/docs/howto/invitation-referral.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Invitation / Referral API"
+category: product
+tags: [invitation, referral, token, one-time-use]
+difficulty: intermediate
+related: [invitation-system, user-invitation]
+ft: FT221
+---
+
 # How-to: Invitation / Referral API
 
 This guide shows how to build a token-based invitation system with expiry and one-time use using NENE2.

--- a/docs/howto/invitation-system.md
+++ b/docs/howto/invitation-system.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Invitation System"
+category: product
+tags: [invitation, token, one-time-use, entropy]
+difficulty: intermediate
+related: [invitation-referral, user-invitation]
+ft: FT283
+---
+
 # How-to: Invitation System
 
 > **FT reference**: FT283 (`NENE2-FT/invitelog`) — Invitation code system: 32-char hex token (128-bit entropy), ISO 8601 datetime validation, pending→used status lifecycle, match expression status mapping, IDOR-protected invitation list, 23 tests / 47 assertions PASS.

--- a/docs/howto/iso-datetime-validation.md
+++ b/docs/howto/iso-datetime-validation.md
@@ -1,3 +1,11 @@
+---
+title: "How to Validate ISO 8601 Datetimes with Timezone"
+category: api-design
+tags: [datetime, iso-8601, timezone, validation]
+difficulty: intermediate
+related: [handle-timezones, timezone-aware-scheduling]
+---
+
 # How to Validate ISO 8601 Datetimes with Timezone
 
 Accepting user-controlled datetime strings requires careful validation. This guide covers

--- a/docs/howto/job-queue-with-retry.md
+++ b/docs/howto/job-queue-with-retry.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Background Job Queue with Retry and Idempotency"
+category: infrastructure
+tags: [job-queue, retry, idempotency, background-jobs]
+difficulty: intermediate
+related: [job-queue, dead-letter-queue, notification-queue]
+ft: FT255
+---
+
 # How-to: Background Job Queue with Retry and Idempotency
 
 > **FT reference**: FT255 (`NENE2-FT/queuelog`) — Background Job Queue with Retry and Idempotency

--- a/docs/howto/job-queue.md
+++ b/docs/howto/job-queue.md
@@ -1,3 +1,11 @@
+---
+title: "Background Job Queue with Retry and Idempotency"
+category: infrastructure
+tags: [job-queue, retry, idempotency, priority-queue]
+difficulty: intermediate
+related: [job-queue-with-retry, dead-letter-queue, notification-queue]
+---
+
 # Background Job Queue with Retry and Idempotency
 
 This guide covers implementing a persistent background job queue in NENE2 applications. The pattern supports priority queues, automatic retry with backoff counters, and idempotent job creation.

--- a/docs/howto/json-merge-patch.md
+++ b/docs/howto/json-merge-patch.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: JSON Merge Patch & ETag Conflict Detection"
+category: api-design
+tags: [patch, json-merge-patch, etag, conflict-detection]
+difficulty: intermediate
+related: [implement-patch-endpoint, etag-conditional-requests, optimistic-locking-etag]
+ft: FT178
+---
+
 # How-to: JSON Merge Patch & ETag Conflict Detection
 
 **FT178 — patchlog**

--- a/docs/howto/jwt-authentication.md
+++ b/docs/howto/jwt-authentication.md
@@ -1,3 +1,12 @@
+---
+title: "How-To: JWT Authentication"
+category: auth
+tags: [jwt, bearer, authentication, argon2id, password]
+difficulty: intermediate
+related: [add-jwt-authentication, refresh-token-rotation, bearer-token-middleware]
+ft: FT261
+---
+
 # How-To: JWT Authentication
 
 > **FT reference**: FT261 (`NENE2-FT/jwtlog`) — JWT Authentication with Argon2id password hashing and BearerTokenMiddleware

--- a/docs/howto/jwt-tenant-isolation.md
+++ b/docs/howto/jwt-tenant-isolation.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: JWT Multi-Tenant Isolation"
+category: auth
+tags: [jwt, multi-tenant, isolation, idor]
+difficulty: advanced
+related: [jwt-authentication, multi-tenant-isolation, tenant-isolation]
+ft: FT342
+---
+
 # How-to: JWT Multi-Tenant Isolation
 
 > **FT reference**: FT342 (`NENE2-FT/tenantlog`) — Multi-tenant notes API with JWT Bearer authentication, tenant_id embedded in token claims, strict per-tenant query scoping, cross-tenant IDOR blocked with 404, tenant_id never exposed in responses, 13 tests / 30+ assertions PASS.

--- a/docs/howto/leaderboard-ranking-api.md
+++ b/docs/howto/leaderboard-ranking-api.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Leaderboard Ranking API"
+category: product
+tags: [leaderboard, ranking, personal-best, scores]
+difficulty: intermediate
+related: [leaderboard-ranking, leaderboard-scores, game-score-leaderboard-api]
+ft: FT332
+---
+
 # How-to: Leaderboard Ranking API
 
 > **FT reference**: FT332 (`NENE2-FT/ranklog`) — Leaderboard with per-user personal-best tracking, descending ranking, own-rank lookup, score deletion, and ATK cracker-mindset attack assessment, 19 tests / 50+ assertions PASS.

--- a/docs/howto/leaderboard-ranking-system.md
+++ b/docs/howto/leaderboard-ranking-system.md
@@ -1,3 +1,12 @@
+---
+title: "How to Build a Leaderboard (Ranking System) with NENE2"
+category: product
+tags: [leaderboard, ranking, scores, personal-best]
+difficulty: intermediate
+related: [leaderboard-ranking-api, leaderboard-scores, game-score-leaderboard-api]
+ft: FT141
+---
+
 # How to Build a Leaderboard (Ranking System) with NENE2
 
 This guide walks through building a leaderboard where users submit scores, see rankings, and check their own rank. Only the best score per user per leaderboard is kept.

--- a/docs/howto/leaderboard-ranking.md
+++ b/docs/howto/leaderboard-ranking.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Game Leaderboard & Ranking API"
+category: product
+tags: [leaderboard, ranking, scores, personal-best]
+difficulty: intermediate
+related: [leaderboard-ranking-api, leaderboard-scores, game-score-leaderboard-api]
+ft: FT206
+---
+
 # How-to: Game Leaderboard & Ranking API
 
 This guide demonstrates building a leaderboard API where players submit scores per game, and the system tracks personal bests and produces ranked leaderboards.

--- a/docs/howto/leaderboard-scores.md
+++ b/docs/howto/leaderboard-scores.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Leaderboard & Score Tracking API"
+category: product
+tags: [leaderboard, scores, ranking, aggregation]
+difficulty: intermediate
+related: [leaderboard-ranking-api, leaderboard-ranking, game-score-leaderboard-api]
+ft: FT206
+---
+
 # How-to: Leaderboard & Score Tracking API
 
 This guide shows how to build a leaderboard system with score submission, top-N rankings using

--- a/docs/howto/live-poll-system.md
+++ b/docs/howto/live-poll-system.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Live Poll System"
+category: product
+tags: [poll, voting, deduplication, lifecycle]
+difficulty: intermediate
+related: [poll-survey, voting-system]
+---
+
 # How-to: Live Poll System
 
 ## Overview

--- a/docs/howto/magic-link-authentication.md
+++ b/docs/howto/magic-link-authentication.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Magic Link Authentication"
+category: auth
+tags: [magic-link, passwordless, token, ttl]
+difficulty: intermediate
+related: [passwordless-auth-magic-link, otp-authentication, session-management]
+ft: FT309
+---
+
 # How-to: Magic Link Authentication
 
 > **FT reference**: FT309 (`NENE2-FT/magiclog`) — Magic link authentication: token stored as SHA-256 hash (never plaintext), 15-minute TTL, used-at prevents reuse, expiry checked before used-at, session token 64+ hex chars SHA-256 stored, revoked/expired sessions denied, 202 always on /auth/request (user enumeration prevention), Bearer token required (X-User-Id header ignored), VULN-A〜L all SAFE, 43 tests / 91 assertions PASS.

--- a/docs/howto/mass-assignment-defence.md
+++ b/docs/howto/mass-assignment-defence.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Mass Assignment Defence with Explicit DTO"
+category: security
+tags: [mass-assignment, dto, whitelist, input-validation]
+difficulty: intermediate
+related: [mass-assignment, enforce-resource-ownership]
+ft: FT256
+---
+
 # How-to: Mass Assignment Defence with Explicit DTO
 
 > **FT reference**: FT256 (`NENE2-FT/masslog`) — Mass assignment defence pattern with explicit DTO whitelisting

--- a/docs/howto/mass-assignment.md
+++ b/docs/howto/mass-assignment.md
@@ -1,3 +1,11 @@
+---
+title: "Mass Assignment Defence"
+category: security
+tags: [mass-assignment, dto, whitelist, input-validation]
+difficulty: beginner
+related: [mass-assignment-defence, enforce-resource-ownership]
+---
+
 # Mass Assignment Defence
 
 Mass assignment is a vulnerability where an attacker adds extra fields to a request body — such as `role=admin` or `is_active=false` — and the server persists them without intending to.

--- a/docs/howto/media-watchlist.md
+++ b/docs/howto/media-watchlist.md
@@ -1,3 +1,12 @@
+---
+title: "How-to: Media Watchlist API"
+category: product
+tags: [watchlist, media, enum, status]
+difficulty: beginner
+related: [bookmark-api, bookmark-system, wish-list-api]
+ft: FT59
+---
+
 # How-to: Media Watchlist API
 
 > **FT reference**: FT59 (`NENE2-FT/watchlog`) — Media Watch List API

--- a/docs/howto/money-integer-arithmetic.md
+++ b/docs/howto/money-integer-arithmetic.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Money and Integer Arithmetic"
+category: api-design
+tags: [money, integer-arithmetic, precision, financial]
+difficulty: intermediate
+related: [credit-ledger, multi-currency-money-ledger, point-ledger-api]
+---
+
 # How-to: Money and Integer Arithmetic
 
 > **Related scenarios**: DX Scenario 10, 23, 32, 36, 40, 43, 44, 50 — the most frequently cited source of silent precision bugs across financial scenarios.

--- a/docs/howto/multi-currency-money-ledger.md
+++ b/docs/howto/multi-currency-money-ledger.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Multi-Currency Money Ledger with Integer Cents"
+category: product
+tags: [money, ledger, multi-currency, integer-arithmetic, transactions]
+difficulty: advanced
+related: [multi-currency-wallet, point-ledger-api, money-integer-arithmetic]
+---
+
 # How-to: Multi-Currency Money Ledger with Integer Cents
 
 > **FT reference**: FT262 (`NENE2-FT/moneylog`) — Multi-currency ledger API using integer minor units (cents) and a `Money` value object

--- a/docs/howto/multi-currency-wallet.md
+++ b/docs/howto/multi-currency-wallet.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: Multi-Currency Wallet"
+category: product
+tags: [wallet, multi-currency, deposit, withdraw, transfer]
+difficulty: advanced
+related: [multi-currency-money-ledger, point-ledger-api, point-loyalty-system]
+---
+
 # How-To: Multi-Currency Wallet
 
 Per-user currency balances with deposit/withdraw/transfer operations.

--- a/docs/howto/multi-step-workflow.md
+++ b/docs/howto/multi-step-workflow.md
@@ -1,3 +1,11 @@
+---
+title: "How to Add a Multi-step Workflow"
+category: product
+tags: [workflow, approval, state-machine, multi-step]
+difficulty: intermediate
+related: [approval-workflow, step-workflow-approval, content-approval-workflow]
+---
+
 # How to Add a Multi-step Workflow
 
 Model sequential approval flows where each step must be approved before advancing to the next.

--- a/docs/howto/multi-tenant-isolation.md
+++ b/docs/howto/multi-tenant-isolation.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: Multi-Tenant Isolation"
+category: security
+tags: [multi-tenant, isolation, idor, authorization, jwt]
+difficulty: advanced
+related: [tenant-isolation, jwt-tenant-isolation, tenant-isolation-idor]
+---
+
 # How-To: Multi-Tenant Isolation
 
 This guide covers building a multi-tenant API with NENE2 where each tenant's data is

--- a/docs/howto/multi-value-tag-filter.md
+++ b/docs/howto/multi-value-tag-filter.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Multi-value Tag Filter API"
+category: api-design
+tags: [filtering, tags, query-params, many-to-many]
+difficulty: intermediate
+related: [dynamic-filter-query, tagging-system, tag-label-api]
+---
+
 # How-to: Multi-value Tag Filter API
 
 > **FT reference**: FT250 (`NENE2-FT/tagfilterlog`) — Multi-value query parameter tag filtering

--- a/docs/howto/multilingual-content.md
+++ b/docs/howto/multilingual-content.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Multilingual Content API"
+category: product
+tags: [i18n, multilingual, localization, content]
+difficulty: intermediate
+related: [content-versioning, content-draft-lifecycle]
+---
+
 # How-to: Multilingual Content API
 
 > **FT reference**: FT232 (`NENE2-FT/i18nlog`) — Multilingual Content API

--- a/docs/howto/nested-json-validation.md
+++ b/docs/howto/nested-json-validation.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Nested JSON Validation"
+category: api-design
+tags: [validation, nested-json, error-paths, line-items]
+difficulty: intermediate
+related: [order-management, patch-partial-update]
+---
+
 # How-to: Nested JSON Validation
 
 > **FT reference**: FT322 (`NENE2-FT/nestedlog`) — Order API with nested items validation, `items.N.field` error paths, multi-error single response, error codes, total calculation, 19 tests / 43 assertions PASS.

--- a/docs/howto/note-management-ownership.md
+++ b/docs/howto/note-management-ownership.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Note Management with Ownership"
+category: product
+tags: [notes, ownership, idor, crud, authorization]
+difficulty: intermediate
+related: [note-management-with-tags, enforce-resource-ownership]
+---
+
 # How-to: Note Management with Ownership
 
 > **FT reference**: FT240 (`NENE2-FT/noteslog`) — Note Management API

--- a/docs/howto/note-management-with-tags.md
+++ b/docs/howto/note-management-with-tags.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Note Management with Tags"
+category: product
+tags: [notes, tags, full-text-search, ownership, crud]
+difficulty: intermediate
+related: [note-management-ownership, tagging-system]
+---
+
 # How-to: Note Management with Tags
 
 ## Overview

--- a/docs/howto/notification-inbox.md
+++ b/docs/howto/notification-inbox.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Notification Inbox API"
+category: product
+tags: [notifications, inbox, pagination, mark-as-read, idor]
+difficulty: intermediate
+related: [notification-queue, activity-feed]
+---
+
 # How-to: Notification Inbox API
 
 > **FT reference**: FT271 (`NENE2-FT/notificationlog`) — Notification inbox: type-allowlisted notification creation, per-user IDOR protection (404 not 403), admin fail-closed pattern, bulk mark-as-read, is_read idempotency, pagination clamping with PDO::PARAM_INT binding, 31 tests / 98 assertions PASS.

--- a/docs/howto/notification-queue.md
+++ b/docs/howto/notification-queue.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Notification Queue API"
+category: infrastructure
+tags: [notifications, queue, admin, messaging]
+difficulty: intermediate
+related: [notification-inbox, job-queue]
+---
+
 # How-to: Notification Queue API
 
 This guide demonstrates a notification queue where admins send targeted notifications to users, who can list, read, and delete them.

--- a/docs/howto/numeric-verification-code.md
+++ b/docs/howto/numeric-verification-code.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build Numeric Verification Code"
+category: auth
+tags: [verification-code, otp, brute-force-protection, sms, email]
+difficulty: intermediate
+related: [otp-authentication, pin-verification-lockout, one-time-secrets]
+---
+
 # How to Build Numeric Verification Code
 
 > **Pattern proven by FT188 verifylog** — 6-digit SMS/email verification code with brute-force protection, constant-time comparison, and replay prevention. ATK-01〜12 全 Pass。

--- a/docs/howto/oauth2-social-login.md
+++ b/docs/howto/oauth2-social-login.md
@@ -1,3 +1,11 @@
+---
+title: "OAuth2 Social Login の実装ガイド"
+category: auth
+tags: [oauth2, social-login, authorization-code-flow, jwt]
+difficulty: advanced
+related: [add-jwt-authentication, delegated-access-grants]
+---
+
 # OAuth2 Social Login の実装ガイド
 
 ## 概要

--- a/docs/howto/offset-cursor-pagination.md
+++ b/docs/howto/offset-cursor-pagination.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Offset & Cursor Pagination"
+category: api-design
+tags: [pagination, offset, cursor, keyset]
+difficulty: intermediate
+related: [pagination, cursor-pagination, pagination-limit-injection]
+---
+
 # How-to: Offset & Cursor Pagination
 
 > **FT reference**: FT325 (`NENE2-FT/pagelog`) — Dual pagination strategy (offset-based and cursor-based) with `next_offset`/`next_cursor`, `has_more`, category filter, 15 tests / 47 assertions PASS.

--- a/docs/howto/one-time-secrets.md
+++ b/docs/howto/one-time-secrets.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: One-Time Secret API & ATK-01~12 Cracker Attack Test"
+category: security
+tags: [one-time-secret, token, atomic-consumption, brute-force-protection]
+difficulty: advanced
+related: [numeric-verification-code, otp-authentication, secret-vault]
+---
+
 # How-To: One-Time Secret API & ATK-01~12 Cracker Attack Test
 
 > **NENE2 Field Trial 184** — Cracker Attack Test Cycle (ATK-01~12).

--- a/docs/howto/optimistic-concurrency-version.md
+++ b/docs/howto/optimistic-concurrency-version.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Optimistic Concurrency Control (Version Field)"
+category: database
+tags: [optimistic-locking, concurrency, version-field, lost-update]
+difficulty: intermediate
+related: [optimistic-locking, optimistic-lock-patch-version, optimistic-locking-etag]
+---
+
 # How-to: Optimistic Concurrency Control (Version Field)
 
 > **FT reference**: FT323 (`NENE2-FT/optimisticlog`) — Document API with version field in PUT body, 409 on stale version, lost-update prevention, 18 tests / 34 assertions PASS.

--- a/docs/howto/optimistic-lock-patch-version.md
+++ b/docs/howto/optimistic-lock-patch-version.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Optimistic Lock with PATCH + Version Field"
+category: database
+tags: [optimistic-locking, patch, version-field, concurrency]
+difficulty: intermediate
+related: [optimistic-concurrency-version, optimistic-locking-etag, patch-partial-update]
+---
+
 # How-to: Optimistic Lock with PATCH + Version Field
 
 > **FT reference**: FT324 (`NENE2-FT/optlocklog`) — PATCH-based optimistic locking, 409 includes `current_version` for zero-GET retry, strict integer version type, ATK assessment, 12 tests / 24 assertions PASS.

--- a/docs/howto/optimistic-locking-etag.md
+++ b/docs/howto/optimistic-locking-etag.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Optimistic Locking with ETag / If-Match"
+category: database
+tags: [optimistic-locking, etag, if-match, concurrency, http-headers]
+difficulty: intermediate
+related: [optimistic-locking, optimistic-concurrency-version, etag-conditional-requests]
+---
+
 # How-to: Optimistic Locking with ETag / If-Match
 
 > **FT reference**: FT320 (`NENE2-FT/locklog`) — Document versioning with ETag header, If-Match required for mutation (428), stale ETag rejection (412), lost-update prevention, 15 tests / 30 assertions PASS.

--- a/docs/howto/optimistic-locking.md
+++ b/docs/howto/optimistic-locking.md
@@ -1,3 +1,11 @@
+---
+title: "Optimistic Locking"
+category: database
+tags: [optimistic-locking, concurrency, lost-update, version-field]
+difficulty: intermediate
+related: [optimistic-concurrency-version, optimistic-locking-etag, add-optimistic-locking]
+---
+
 # Optimistic Locking
 
 Optimistic locking prevents the **lost-update problem** — when two concurrent writers both read the same record, make independent changes, and the second writer silently overwrites the first writer's changes.

--- a/docs/howto/order-management.md
+++ b/docs/howto/order-management.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Order Management API"
+category: product
+tags: [orders, status-lifecycle, line-items, idor, admin]
+difficulty: intermediate
+related: [shopping-cart-api, nested-json-validation, inventory-management]
+---
+
 # How-to: Order Management API
 
 > **FT reference**: FT274 (`NENE2-FT/orderlog`) — Order management: SKU-validated line items, total_cents auto-calculation, status lifecycle (pending→confirmed→shipped→delivered→cancelled), IDOR → 404, admin override, cancel conflict detection, 36 tests PASS.

--- a/docs/howto/otp-authentication.md
+++ b/docs/howto/otp-authentication.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: OTP Authentication System"
+category: auth
+tags: [otp, passwordless, brute-force-protection, session-token, lockout]
+difficulty: advanced
+related: [numeric-verification-code, pin-verification-lockout, passwordless-auth-magic-link]
+---
+
 # How-to: OTP Authentication System
 
 > **FT reference**: FT290 (`NENE2-FT/otplog`) — OTP authentication: 6-digit numeric code with SHA-256 hash storage, brute-force lockout (3 attempts → 10 min), OTP TTL (5 min), replay attack prevention via `used_at`, session token with SHA-256 + revocation, user enumeration prevention via always-202 request endpoint, ATK-01~12 PASS, 35 tests / 44 assertions PASS.

--- a/docs/howto/pagination-boundary-attack.md
+++ b/docs/howto/pagination-boundary-attack.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Pagination Boundary & Limit Injection"
+category: security
+tags: [pagination, limit-injection, integer-validation, boundary-attack]
+difficulty: intermediate
+related: [pagination-limit-injection, pagination, offset-cursor-pagination]
+---
+
 # How-to: Pagination Boundary & Limit Injection
 
 **FT177 — limitlog**

--- a/docs/howto/pagination-limit-injection.md
+++ b/docs/howto/pagination-limit-injection.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Pagination Boundary & Limit Injection Prevention"
+category: security
+tags: [pagination, limit-injection, integer-validation, redos]
+difficulty: intermediate
+related: [pagination-boundary-attack, pagination, offset-cursor-pagination]
+---
+
 # How-to: Pagination Boundary & Limit Injection Prevention
 
 > **FT reference**: FT319 (`NENE2-FT/limitlog`) — Offset and cursor pagination with strict limit/page validation, MAX_LIMIT cap enforcement, ReDoS-safe ctype_digit validation, 20 tests / 384 assertions PASS.

--- a/docs/howto/pagination.md
+++ b/docs/howto/pagination.md
@@ -1,3 +1,11 @@
+---
+title: "Pagination"
+category: api-design
+tags: [pagination, offset, cursor, keyset]
+difficulty: beginner
+related: [offset-cursor-pagination, cursor-pagination, add-pagination]
+---
+
 # Pagination
 
 Two patterns are available for paginating list endpoints: **OFFSET** and **cursor** (keyset). Choose based on your data volume and UI requirements.

--- a/docs/howto/password-auth-argon2id.md
+++ b/docs/howto/password-auth-argon2id.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Password Authentication with Argon2id"
+category: auth
+tags: [password, argon2id, authentication, user-enumeration-prevention, rehash]
+difficulty: intermediate
+related: [password-hashing, password-reset-flow, password-reset]
+---
+
 # How-to: Password Authentication with Argon2id
 
 > **FT reference**: FT331 (`NENE2-FT/pwdlog`) — User registration and login with Argon2id password hashing, password/hash never exposed in responses, user enumeration prevention (same 401 for wrong password and unknown email), algorithm-migration rehash, 14 tests / 40 assertions PASS.

--- a/docs/howto/password-hashing.md
+++ b/docs/howto/password-hashing.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: Password Hashing"
+category: auth
+tags: [password, hashing, argon2id, bcrypt, security]
+difficulty: beginner
+related: [password-auth-argon2id, password-reset]
+---
+
 # How-To: Password Hashing
 
 Storing and verifying passwords securely using PHP's native `password_hash()` / `password_verify()` with NENE2.

--- a/docs/howto/password-reset-flow.md
+++ b/docs/howto/password-reset-flow.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Password Reset Flow"
+category: auth
+tags: [password-reset, token, single-use, user-enumeration-prevention, argon2id]
+difficulty: intermediate
+related: [password-reset, password-auth-argon2id, one-time-secrets]
+---
+
 # How-to: Password Reset Flow
 
 > **FT reference**: FT285 (`NENE2-FT/resetlog`) — Password reset flow: user enumeration prevention (always 202), SHA-256 token hash storage, 1-hour TTL, single-use token (409 on reuse), 410 Gone on expiry, Argon2id new password hash, 15 tests / 23 assertions PASS.

--- a/docs/howto/password-reset.md
+++ b/docs/howto/password-reset.md
@@ -1,3 +1,11 @@
+---
+title: "Password Reset Flow"
+category: auth
+tags: [password-reset, token, email, security]
+difficulty: beginner
+related: [password-reset-flow, password-auth-argon2id, password-hashing]
+---
+
 # Password Reset Flow
 
 Implement a secure token-based password reset: request → verify → complete.

--- a/docs/howto/passwordless-auth-magic-link.md
+++ b/docs/howto/passwordless-auth-magic-link.md
@@ -1,3 +1,11 @@
+---
+title: "Passwordless Auth (Magic Link)"
+category: auth
+tags: [passwordless, magic-link, one-time-token, email-auth]
+difficulty: intermediate
+related: [magic-link-authentication, otp-authentication, one-time-secrets]
+---
+
 # Passwordless Auth (Magic Link)
 
 パスワードレス認証（Magic Link）の実装ガイド。メールアドレスだけで認証できる

--- a/docs/howto/patch-partial-update.md
+++ b/docs/howto/patch-partial-update.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: PATCH Partial Update (JSON Merge Patch)"
+category: api-design
+tags: [patch, json-merge-patch, partial-update, etag, immutable-fields]
+difficulty: intermediate
+related: [implement-patch-endpoint, json-merge-patch, optimistic-lock-patch-version]
+---
+
 # How-to: PATCH Partial Update (JSON Merge Patch)
 
 > **FT reference**: FT326 (`NENE2-FT/patchlog`) — JSON Merge Patch (RFC 7396) partial update: null field reset, immutable field rejection, ETag/If-Match, owner-only mutation, 42 tests / 141 assertions PASS.

--- a/docs/howto/payment-webhook.md
+++ b/docs/howto/payment-webhook.md
@@ -1,3 +1,11 @@
+---
+title: "Payment Webhook 受信の実装ガイド"
+category: infrastructure
+tags: [webhook, payment, signature-verification, idempotency]
+difficulty: intermediate
+related: [webhook-delivery, inbound-webhook-receiver, webhook-signature-verification]
+---
+
 # Payment Webhook 受信の実装ガイド
 
 ## 概要

--- a/docs/howto/personal-data-export.md
+++ b/docs/howto/personal-data-export.md
@@ -1,3 +1,11 @@
+---
+title: "Personal Data Export"
+category: security
+tags: [gdpr, data-export, pii, download-token, expiry]
+difficulty: intermediate
+related: [pii-masking, data-export-api]
+---
+
 # Personal Data Export
 
 A GDPR-style data export lets users download all their personal data. The primary concerns are: sensitive field exclusion from the export payload, secure download tokens, and expiry enforcement.

--- a/docs/howto/pii-masking.md
+++ b/docs/howto/pii-masking.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: PII Masking API"
+category: security
+tags: [pii, masking, rbac, audit-trail, data-privacy]
+difficulty: intermediate
+related: [personal-data-export, data-masking, audit-trail]
+---
+
 # How-to: PII Masking API
 
 > **FT reference**: FT297 (`NENE2-FT/masklog`) — PII masking: email/phone/name partial masking, role-based raw data access (admin only) with mandatory X-Accessor audit trail, immutable audit log, VULN-A~L all SAFE, 24 tests / 49 assertions PASS.

--- a/docs/howto/pin-bookmark-ordering.md
+++ b/docs/howto/pin-bookmark-ordering.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Pin / Bookmark with Ordering"
+category: product
+tags: [pins, bookmarks, ordering, reorder, user-isolation]
+difficulty: intermediate
+related: [bookmark-api, content-pinning, bookmark-system]
+---
+
 # How-to: Pin / Bookmark with Ordering
 
 > **FT reference**: FT327 (`NENE2-FT/pinlog`) — Per-user article pins with sequential positions, max-pin limit, gap-free recompaction on delete, reorder via PUT, user isolation, VULN assessment, 19 tests / 26 assertions PASS.

--- a/docs/howto/pin-verification-lockout.md
+++ b/docs/howto/pin-verification-lockout.md
@@ -1,3 +1,11 @@
+---
+title: "PIN 認証・ロックアウト"
+category: auth
+tags: [pin, lockout, brute-force-protection, verification]
+difficulty: intermediate
+related: [numeric-verification-code, otp-authentication, account-lockout]
+---
+
 # PIN 認証・ロックアウト
 
 > **FT reference**: FT252 (`NENE2-FT/pinverifylog`) — PIN Verification with Lockout

--- a/docs/howto/point-ledger-api.md
+++ b/docs/howto/point-ledger-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Point Ledger API"
+category: product
+tags: [points, ledger, loyalty, idempotency, overdraft-prevention]
+difficulty: intermediate
+related: [point-loyalty-system, credit-ledger, multi-currency-money-ledger]
+---
+
 # How-to: Point Ledger API
 
 > **FT reference**: FT300 (`NENE2-FT/pointlog`) — Point ledger API: earn/spend/adjust/expire transactions, balance tracking, overdraft prevention (CHECK balance_after >= 0), admin-only adjust, reference_id idempotency, MAX_EARN=10000 / MAX_ADJUST=100000 caps, ATK-01〜12 all BLOCKED, 30 tests / 66 assertions PASS.

--- a/docs/howto/point-loyalty-system.md
+++ b/docs/howto/point-loyalty-system.md
@@ -1,3 +1,11 @@
+---
+title: "ポイント・ロイヤルティシステム"
+category: product
+tags: [points, loyalty, idempotency, rbac, balance]
+difficulty: intermediate
+related: [point-ledger-api, credit-ledger]
+---
+
 # ポイント・ロイヤルティシステム
 
 ポイント付与・消費・残高管理・admin 調整を備えたロイヤルティシステムの実装ガイド。

--- a/docs/howto/poll-survey.md
+++ b/docs/howto/poll-survey.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Poll / Survey API"
+category: product
+tags: [poll, survey, voting, duplicate-prevention]
+difficulty: intermediate
+related: [voting-system, live-poll-system, feedback-collection]
+---
+
 # How-to: Poll / Survey API
 
 This guide shows how to build a poll and survey system with duplicate vote prevention using NENE2.

--- a/docs/howto/prevent-double-booking.md
+++ b/docs/howto/prevent-double-booking.md
@@ -1,3 +1,11 @@
+---
+title: "How to prevent double-booking (reservation and capacity enforcement)"
+category: database
+tags: [booking, double-booking, capacity, transactions, concurrency]
+difficulty: advanced
+related: [resource-reservation, event-ticket-booking, distributed-locking]
+---
+
 # How to prevent double-booking (reservation and capacity enforcement)
 
 Reservation systems have two distinct failure modes that must be handled separately:

--- a/docs/howto/price-history.md
+++ b/docs/howto/price-history.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Product Price History API"
+category: product
+tags: [price, history, timeline, temporal-data]
+difficulty: intermediate
+related: [product-catalog, money-integer-arithmetic]
+---
+
 # How-to: Product Price History API
 
 > **FT reference**: FT67 (`NENE2-FT/pricelog`) — Product Price History API

--- a/docs/howto/privacy-consent-management.md
+++ b/docs/howto/privacy-consent-management.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build Privacy Consent Management"
+category: security
+tags: [gdpr, consent, privacy, idor-prevention, audit-log]
+difficulty: intermediate
+related: [pii-masking, personal-data-export, data-masking]
+---
+
 # How to Build Privacy Consent Management
 
 > **Pattern proven by FT189 consentlog** — GDPR-style consent tracking with immutable history, IDOR prevention, and user enumeration resistance. VULN-A〜L 全 Pass。

--- a/docs/howto/product-catalog.md
+++ b/docs/howto/product-catalog.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Product Catalog API (ATK-01~12)"
+category: product
+tags: [catalog, soft-delete, search, admin-auth, attack-hardening]
+difficulty: intermediate
+related: [product-review-system, shopping-cart-api, soft-delete]
+---
+
 # How-to: Product Catalog API (ATK-01~12)
 
 This guide demonstrates a product catalog API with admin-only write operations, keyword search, and soft delete — covering ATK-01~12 cracker attack vectors.

--- a/docs/howto/product-review-system.md
+++ b/docs/howto/product-review-system.md
@@ -1,3 +1,11 @@
+---
+title: "Product Review & Rating System"
+category: product
+tags: [review, rating, cursor-pagination, ownership]
+difficulty: intermediate
+related: [rating-review-api, product-catalog, shopping-cart-api]
+---
+
 # Product Review & Rating System
 
 商品レビュー・評価システムを NENE2 で実装する方法。

--- a/docs/howto/project-task-management.md
+++ b/docs/howto/project-task-management.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Project and Task Management with Nested Resources"
+category: product
+tags: [nested-resources, patch, task-management, pagination]
+difficulty: intermediate
+related: [add-second-entity, implement-patch-endpoint, add-pagination]
+---
+
 # How-to: Project and Task Management with Nested Resources
 
 > **FT reference**: FT241 (`NENE2-FT/projtrack`) — Project & Task Management API

--- a/docs/howto/quality-tools.md
+++ b/docs/howto/quality-tools.md
@@ -1,3 +1,11 @@
+---
+title: "Quality Tools"
+category: getting-started
+tags: [phpstan, php-cs-fixer, static-analysis, code-style]
+difficulty: beginner
+related: [add-health-check, add-custom-route]
+---
+
 # Quality Tools
 
 This guide covers PHPStan, PHP-CS-Fixer, and common issues when running them in NENE2-based projects.

--- a/docs/howto/quota-management.md
+++ b/docs/howto/quota-management.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Quota Management API"
+category: infrastructure
+tags: [quota, rate-limiting, windowed-counter, http-429]
+difficulty: intermediate
+related: [rate-limiting, sliding-window-rate-limiter, fixed-window-rate-limiter]
+---
+
 # How-to: Quota Management API
 
 > **FT reference**: FT236 (`NENE2-FT/quotalog`) — Quota Management API

--- a/docs/howto/rate-limiting.md
+++ b/docs/howto/rate-limiting.md
@@ -1,3 +1,11 @@
+---
+title: "Rate Limiting"
+category: infrastructure
+tags: [rate-limiting, throttle, fixed-window, middleware, http-429]
+difficulty: intermediate
+related: [sliding-window-rate-limiter, fixed-window-rate-limiter, quota-management]
+---
+
 # Rate Limiting
 
 > **FT reference**: FT284 (`NENE2-FT/throttlelog`) — ThrottleMiddleware rate limiting: IP-based fixed-window, custom key extractor (user/API key), X-RateLimit-* headers, 429 Problem Details with Retry-After, InMemoryRateLimitStorage for tests, 9 tests / 33 assertions PASS.

--- a/docs/howto/rating-review-api.md
+++ b/docs/howto/rating-review-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Rating & Review API"
+category: product
+tags: [rating, review, upsert, aggregate, distribution]
+difficulty: intermediate
+related: [product-review-system, upvote-downvote-api, voting-system]
+---
+
 # How-to: Rating & Review API
 
 > **FT reference**: FT333 (`NENE2-FT/ratinglog`) — Per-item, per-user rating system with score validation (1–5), upsert semantics, summary with distribution breakdown, and vulnerability assessment, 16 tests / 40+ assertions PASS.

--- a/docs/howto/rbac-jwt-auth.md
+++ b/docs/howto/rbac-jwt-auth.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: RBAC + JWT Authentication"
+category: auth
+tags: [rbac, jwt, argon2id, bearer-token, authorization]
+difficulty: intermediate
+related: [rbac, add-jwt-authentication, bearer-token-middleware]
+---
+
 # How-to: RBAC + JWT Authentication
 
 > **FT reference**: FT279 (`NENE2-FT/rbaclog`) — Role-Based Access Control with JWT: Argon2id password hashing with timing-attack protection, role claim in JWT, 401 vs 403 distinction, BearerTokenMiddleware with manual fallback, 14 tests / 48 assertions PASS.

--- a/docs/howto/rbac.md
+++ b/docs/howto/rbac.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: Role-Based Access Control (RBAC)"
+category: auth
+tags: [rbac, jwt, bearer-token, authorization, roles]
+difficulty: intermediate
+related: [rbac-jwt-auth, add-jwt-authentication, bearer-token-middleware]
+---
+
 # How-To: Role-Based Access Control (RBAC)
 
 Implementing role-based access control with JWT claims and `BearerTokenMiddleware`.

--- a/docs/howto/refresh-token-pattern.md
+++ b/docs/howto/refresh-token-pattern.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Refresh Token Pattern"
+category: auth
+tags: [refresh-token, jwt, token-rotation, replay-attack]
+difficulty: intermediate
+related: [refresh-token-rotation, add-jwt-authentication, session-management]
+---
+
 # How-to: Refresh Token Pattern
 
 > **FT reference**: FT281 (`NENE2-FT/refreshlog`) — Refresh token pattern: short-lived access token (5 min JWT) + long-lived refresh token (7 days), SHA-256 hash storage, token rotation on use, replay attack detection (revoked token → revoke all), logout returns 204 always, 15 tests / 63 assertions PASS.

--- a/docs/howto/refresh-token-rotation.md
+++ b/docs/howto/refresh-token-rotation.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: JWT Refresh Token Rotation"
+category: auth
+tags: [refresh-token, jwt, token-rotation, replay-attack, session]
+difficulty: intermediate
+related: [refresh-token-pattern, add-jwt-authentication, session-management]
+---
+
 # How-To: JWT Refresh Token Rotation
 
 This guide covers implementing short-lived access tokens combined with long-lived refresh

--- a/docs/howto/request-deduplication.md
+++ b/docs/howto/request-deduplication.md
@@ -1,3 +1,11 @@
+---
+title: "How to Add Request Deduplication"
+category: api-design
+tags: [idempotency, deduplication, idempotency-key, retry]
+difficulty: intermediate
+related: [idempotency-key, idempotency, idempotency-key-api]
+---
+
 # How to Add Request Deduplication
 
 Prevent duplicate processing from network retries or double-clicks using an `Idempotency-Key` header. The server caches responses per key and replays them on subsequent identical requests.

--- a/docs/howto/request-scoped-state.md
+++ b/docs/howto/request-scoped-state.md
@@ -1,3 +1,11 @@
+---
+title: "How to pass request-scoped state between middleware and handlers"
+category: getting-started
+tags: [middleware, request-context, dependency-injection, holder-pattern]
+difficulty: intermediate
+related: [bearer-token-middleware, add-jwt-authentication, add-custom-route]
+---
+
 # How to pass request-scoped state between middleware and handlers
 
 Some middlewares extract a value from the incoming request — a tenant ID, a decoded JWT claim, a

--- a/docs/howto/reservation-availability-api.md
+++ b/docs/howto/reservation-availability-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Reservation & Availability API"
+category: product
+tags: [reservation, booking, availability, overlap-detection, cancel]
+difficulty: intermediate
+related: [resource-reservation-booking, resource-booking, prevent-double-booking]
+---
+
 # How-to: Reservation & Availability API
 
 > **FT reference**: FT336 (`NENE2-FT/reservelog`) — Resource reservation system with half-open interval overlap detection, status-aware availability query, cancel-and-rebook semantics, and ATK cracker-mindset attack assessment, 16 tests / 30+ assertions PASS.

--- a/docs/howto/resource-booking.md
+++ b/docs/howto/resource-booking.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Resource Booking System"
+category: product
+tags: [booking, capacity, double-booking, idor, soft-delete]
+difficulty: intermediate
+related: [resource-reservation, reservation-availability-api, prevent-double-booking]
+---
+
 # How-to: Resource Booking System
 
 ## Overview

--- a/docs/howto/resource-reservation-booking.md
+++ b/docs/howto/resource-reservation-booking.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Resource Reservation & Booking API"
+category: product
+tags: [reservation, booking, overlap-prevention, idor, admin-auth]
+difficulty: intermediate
+related: [resource-reservation, reservation-availability-api, prevent-double-booking]
+---
+
 # How-to: Resource Reservation & Booking API
 
 > **FT reference**: FT335 (`NENE2-FT/reservationlog`) — Resource time-slot booking with half-open interval overlap prevention, user_id excluded from public responses, cancel IDOR protection (403), admin/user dual-level access, 30 tests / 70+ assertions PASS.

--- a/docs/howto/resource-reservation.md
+++ b/docs/howto/resource-reservation.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Resource Reservation / Time Slot Booking API"
+category: product
+tags: [reservation, time-slot, overlap-detection, idor]
+difficulty: intermediate
+related: [resource-reservation-booking, reservation-availability-api, prevent-double-booking]
+---
+
 # How-to: Resource Reservation / Time Slot Booking API
 
 This guide shows how to build a time-slot booking system with overlap prevention using NENE2.

--- a/docs/howto/scheduled-publish-article.md
+++ b/docs/howto/scheduled-publish-article.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Scheduled Publish Article"
+category: product
+tags: [content-scheduling, state-machine, draft, publish, lifecycle]
+difficulty: intermediate
+related: [content-draft-lifecycle, state-machine-audit-log, content-scheduling]
+---
+
 # How-to: Scheduled Publish Article
 
 > **FT reference**: FT330 (`NENE2-FT/pubschedulelog`) — Article draft/schedule/publish/archive lifecycle, owner-only draft access, public published articles, scheduled publish trigger, 34 tests / 95 assertions PASS.

--- a/docs/howto/scheduled-reminders.md
+++ b/docs/howto/scheduled-reminders.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Scheduled Reminders API"
+category: product
+tags: [reminders, scheduling, timezone, idor, ownership]
+difficulty: intermediate
+related: [scheduled-publish-article, handle-timezones, timezone-aware-scheduling]
+---
+
 # How-to: Scheduled Reminders API
 
 > **FT reference**: FT235 (`NENE2-FT/reminderlog`) — Scheduled Reminders API

--- a/docs/howto/search-autocomplete.md
+++ b/docs/howto/search-autocomplete.md
@@ -1,3 +1,11 @@
+---
+title: "全文検索・オートコンプリート API の実装ガイド"
+category: api-design
+tags: [search, autocomplete, full-text-search, like-query]
+difficulty: intermediate
+related: [sqlite-fts5-search, use-fts5-search, dynamic-filter-query]
+---
+
 # 全文検索・オートコンプリート API の実装ガイド
 
 ## 概要

--- a/docs/howto/secret-vault.md
+++ b/docs/howto/secret-vault.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: Personal Secret Vault API"
+category: security
+tags: [hmac, idor-prevention, encrypted-storage, admin-auth, user-isolation]
+difficulty: intermediate
+related: [encrypted-field-storage, one-time-secrets, data-masking]
+---
+
 # How-To: Personal Secret Vault API
 
 Demonstrates per-user key-value storage with HMAC integrity, IDOR prevention, and admin-only metadata access.

--- a/docs/howto/service-status-page.md
+++ b/docs/howto/service-status-page.md
@@ -1,3 +1,11 @@
+---
+title: "How-To: Service Status Page API"
+category: product
+tags: [status-page, incident-management, admin-auth, state-machine]
+difficulty: intermediate
+related: [state-machine-audit-log, content-approval-workflow]
+---
+
 # How-To: Service Status Page API
 
 > **NENE2 Field Trial 185** — Component health tracking, incident lifecycle management,

--- a/docs/howto/session-management.md
+++ b/docs/howto/session-management.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build a Multi-Device Session Manager"
+category: auth
+tags: [session, multi-device, idor, token, revocation]
+difficulty: intermediate
+related: [session-token-management, refresh-token-pattern, access-token-management]
+---
+
 # How to Build a Multi-Device Session Manager
 
 > **Pattern proven by FT186 sessionlog** — multi-device session tracking, IDOR prevention, mass-assignment guard, timing-oracle-free revocation.

--- a/docs/howto/session-token-management.md
+++ b/docs/howto/session-token-management.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Session / Token Management API (ATK-01~12)"
+category: auth
+tags: [session, token, revocation, attack-hardening, opaque-token]
+difficulty: intermediate
+related: [session-management, access-token-management, token-lifecycle-api]
+---
+
 # How-to: Session / Token Management API (ATK-01~12)
 
 This guide demonstrates a secure session token API covering all ATK-01~12 cracker-mindset attack vectors.

--- a/docs/howto/shift-management.md
+++ b/docs/howto/shift-management.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Shift Management API"
+category: product
+tags: [scheduling, shift, overlap-detection, employee, transactions]
+difficulty: intermediate
+related: [reservation-availability-api, state-machine-audit-log, prevent-double-booking]
+---
+
 # How-to: Shift Management API
 
 > **FT reference**: FT43 (`NENE2-FT/shiftlog`) — Employee Shift Scheduling API

--- a/docs/howto/shopping-cart-api.md
+++ b/docs/howto/shopping-cart-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Shopping Cart API"
+category: product
+tags: [shopping-cart, upsert, integer-money, per-user]
+difficulty: intermediate
+related: [product-catalog, money-integer-arithmetic, order-management]
+---
+
 # How-to: Shopping Cart API
 
 > **FT reference**: FT269 (`NENE2-FT/cartlog`) — Shopping cart: UNIQUE (user_id, product_id) per-user cart, upsert add-item (quantity accumulation), quantity=0 auto-remove semantics, integer price/subtotal, X-User-Id header identification

--- a/docs/howto/signed-url-download.md
+++ b/docs/howto/signed-url-download.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Signed URL for Secure Downloads"
+category: security
+tags: [signed-url, hmac, time-limited, file-download, tamper-detection]
+difficulty: intermediate
+related: [signed-urls, file-upload, file-sharing-api]
+---
+
 # How-to: Signed URL for Secure Downloads
 
 > **FT reference**: FT338 (`NENE2-FT/signedlog`) — HMAC-SHA256 signed URL generation with TTL, tamper detection (401), expiry (410 Gone), resource-bound tokens, and wrong-secret rejection, 16 tests / 40+ assertions PASS.

--- a/docs/howto/signed-urls.md
+++ b/docs/howto/signed-urls.md
@@ -1,3 +1,11 @@
+---
+title: "Signed URLs"
+category: security
+tags: [signed-url, hmac, presigned, time-limited, token]
+difficulty: intermediate
+related: [signed-url-download, file-sharing-api, file-upload]
+---
+
 # Signed URLs
 
 Signed URLs provide time-limited, resource-scoped access to protected resources without requiring the caller to authenticate with an account. The pattern is used for file downloads, presigned upload slots, and any case where you need to share temporary access with a third party.

--- a/docs/howto/sliding-window-rate-limiter.md
+++ b/docs/howto/sliding-window-rate-limiter.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Sliding-Window Rate Limiter"
+category: infrastructure
+tags: [rate-limiting, sliding-window, http-429, per-user]
+difficulty: intermediate
+related: [rate-limiting, fixed-window-rate-limiter, quota-management]
+---
+
 # How-to: Sliding-Window Rate Limiter
 
 ## Overview

--- a/docs/howto/slug-management.md
+++ b/docs/howto/slug-management.md
@@ -1,3 +1,11 @@
+---
+title: "Slug Management — Unique URL Slugs with Collision Resolution and History"
+category: product
+tags: [slug, url, collision-resolution, redirect, history]
+difficulty: intermediate
+related: [slug-url-history, article-versioning-api, content-versioning]
+---
+
 # Slug Management — Unique URL Slugs with Collision Resolution and History
 
 Generate URL-safe slugs from titles, resolve collisions automatically, and keep

--- a/docs/howto/slug-url-history.md
+++ b/docs/howto/slug-url-history.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Slug URL Management with History"
+category: product
+tags: [slug, url, redirect, history, collision]
+difficulty: intermediate
+related: [slug-management, article-versioning-api, content-versioning]
+---
+
 # How-to: Slug URL Management with History
 
 > **FT reference**: FT339 (`NENE2-FT/sluglog`) — Auto-generated slugs from titles, collision counter, slug history for old-slug 301 redirects, explicit slug override, vulnerability assessment, 17 tests / 50+ assertions PASS.

--- a/docs/howto/soft-delete-restore-permanent.md
+++ b/docs/howto/soft-delete-restore-permanent.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Soft Delete, Restore, and Permanent Delete"
+category: database
+tags: [soft-delete, restore, hard-delete, deleted-at]
+difficulty: beginner
+related: [soft-delete, soft-delete-trash-purge, soft-delete-trash-restore]
+---
+
 # How-to: Soft Delete, Restore, and Permanent Delete
 
 > **FT reference**: `NENE2-FT/softdelete` — Soft delete via `deleted_at` timestamp, restore (only soft-deleted notes can be restored), permanent hard delete (only soft-deleted notes can be permanently deleted), 14 tests PASS.

--- a/docs/howto/soft-delete-trash-purge.md
+++ b/docs/howto/soft-delete-trash-purge.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Soft Delete, Trash Bin, and Permanent Purge"
+category: database
+tags: [soft-delete, trash, purge, deleted-at, lifecycle]
+difficulty: beginner
+related: [soft-delete, soft-delete-restore-permanent, soft-delete-trash-restore]
+---
+
 # How-to: Soft Delete, Trash Bin, and Permanent Purge
 
 > **FT reference**: FT257 (`NENE2-FT/softdeletelog`) — Soft delete / trash bin / permanent purge pattern with `deleted_at` column

--- a/docs/howto/soft-delete-trash-restore.md
+++ b/docs/howto/soft-delete-trash-restore.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Soft Delete, Trash & Restore API"
+category: database
+tags: [soft-delete, trash, restore, hard-delete, bulk-purge]
+difficulty: intermediate
+related: [soft-delete, soft-delete-trash-purge, soft-delete-restore-permanent]
+---
+
 # How-to: Soft Delete, Trash & Restore API
 
 > **FT reference**: FT340 (`NENE2-FT/softlog`) — Notes API with soft delete (deleted_at), trash view, restore, permanent hard delete, bulk purge, pinned-first ordering, and ATK cracker-mindset attack assessment, 26 tests / 60+ assertions PASS.

--- a/docs/howto/soft-delete.md
+++ b/docs/howto/soft-delete.md
@@ -1,3 +1,11 @@
+---
+title: "Soft Delete (Logical Deletion)"
+category: database
+tags: [soft-delete, deleted-at, logical-deletion, audit-trail]
+difficulty: beginner
+related: [soft-delete-restore-permanent, soft-delete-trash-purge, soft-delete-trash-restore]
+---
+
 # Soft Delete (Logical Deletion)
 
 Soft delete keeps a record in the database but marks it as deleted by setting a `deleted_at` timestamp. This enables:

--- a/docs/howto/sql-injection-defence.md
+++ b/docs/howto/sql-injection-defence.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: SQL Injection Defence"
+category: security
+tags: [sql-injection, parameterized-queries, like-injection, orderby-injection, attack-hardening]
+difficulty: intermediate
+related: [sql-orderby-injection, dynamic-sort-order-injection, mass-assignment-defence]
+---
+
 # How-to: SQL Injection Defence
 
 > **FT reference**: FT264 (`NENE2-FT/injectionlog`) — SQL injection defence: parameterized queries, LIKE injection, ORDER BY allowlist

--- a/docs/howto/sql-orderby-injection.md
+++ b/docs/howto/sql-orderby-injection.md
@@ -1,3 +1,11 @@
+---
+title: "How to Prevent SQL ORDER BY Injection"
+category: security
+tags: [sql-injection, orderby-injection, allowlist, parameterized-queries]
+difficulty: beginner
+related: [sql-injection-defence, dynamic-sort-order-injection, dynamic-filter-query]
+---
+
 # How to Prevent SQL ORDER BY Injection
 
 SQL `ORDER BY` clauses cannot be parameterized with standard placeholders (`?`). This means

--- a/docs/howto/sqlite-fts5-search.md
+++ b/docs/howto/sqlite-fts5-search.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: SQLite FTS5 Full-Text Search"
+category: database
+tags: [sqlite, fts5, full-text-search, virtual-table, triggers]
+difficulty: intermediate
+related: [use-fts5-search, search-autocomplete, dynamic-filter-query]
+---
+
 # How-to: SQLite FTS5 Full-Text Search
 
 > **FT reference**: FT254 (`NENE2-FT/ftslog`) — Full-text search with SQLite FTS5

--- a/docs/howto/state-machine-audit-log.md
+++ b/docs/howto/state-machine-audit-log.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: State Machine with Audit Log"
+category: infrastructure
+tags: [state-machine, audit-log, transitions, domain-events, workflow]
+difficulty: intermediate
+related: [state-machine-workflow-api, content-draft-lifecycle, multi-step-workflow]
+---
+
 # How-to: State Machine with Audit Log
 
 > **FT reference**: FT237 (`NENE2-FT/statemachinelog`) — State Machine with Audit Log

--- a/docs/howto/state-machine-workflow-api.md
+++ b/docs/howto/state-machine-workflow-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: State Machine Workflow API"
+category: infrastructure
+tags: [state-machine, workflow, transitions, terminal-state, audit-log]
+difficulty: intermediate
+related: [state-machine-audit-log, multi-step-workflow, approval-workflow]
+---
+
 # How-to: State Machine Workflow API
 
 > **FT reference**: FT349 (`NENE2-FT/workflowlog`) — State machine workflow instances with hardcoded transition map, `allowed_next` in responses, transition history log, terminal state enforcement, state filter on list, 13 tests PASS.

--- a/docs/howto/step-workflow-approval.md
+++ b/docs/howto/step-workflow-approval.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Step-Based Workflow with Approval"
+category: infrastructure
+tags: [workflow, state-machine, approval, multi-step]
+difficulty: advanced
+related: [multi-step-workflow, approval-workflow, content-approval-workflow]
+---
+
 # How-to: Step-Based Workflow with Approval
 
 > **FT reference**: FT247 (`NENE2-FT/stepflowlog`) — Step Workflow Approval API

--- a/docs/howto/subscription-plan-management.md
+++ b/docs/howto/subscription-plan-management.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Subscription Plan Management"
+category: product
+tags: [subscription, plan, lifecycle, billing]
+difficulty: intermediate
+related: [subscription-plan]
+---
+
 # How-to: Subscription Plan Management
 
 > **FT reference**: FT328 (`NENE2-FT/planlog`) — Plan catalog, per-user subscription lifecycle (subscribe / change / cancel), owner-only access, ATK assessment, 20 tests / 69 assertions PASS.

--- a/docs/howto/subscription-plan.md
+++ b/docs/howto/subscription-plan.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Subscription / Plan Management API (VULN-A~L)"
+category: product
+tags: [subscription, plan, idor, security-assessment]
+difficulty: advanced
+related: [subscription-plan-management]
+---
+
 # How-to: Subscription / Plan Management API (VULN-A~L)
 
 This guide demonstrates a subscription management API where users subscribe to plans, with duplicate prevention, cancellation, and IDOR protection.

--- a/docs/howto/system-announcement-management.md
+++ b/docs/howto/system-announcement-management.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build System Announcement Management"
+category: product
+tags: [announcement, admin, dismissal, priority]
+difficulty: intermediate
+related: [notification-inbox, notification-queue]
+---
+
 # How to Build System Announcement Management
 
 > **Pattern proven by FT190 announcelog** — Time-based system announcements with admin key authentication, per-user dismissal, and priority ordering. 38 tests / 93 assertions PASS。

--- a/docs/howto/tag-label-api.md
+++ b/docs/howto/tag-label-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Tag / Label API"
+category: product
+tags: [tagging, label, many-to-many, entity]
+difficulty: intermediate
+related: [tagging-system, note-management-with-tags, multi-value-tag-filter]
+---
+
 # How-to: Tag / Label API
 
 This guide demonstrates a generic entity tagging API where arbitrary tags can be attached to any entity ID, with tag-based reverse lookup.

--- a/docs/howto/tagging-system.md
+++ b/docs/howto/tagging-system.md
@@ -1,3 +1,11 @@
+---
+title: "Tagging System (M:N)"
+category: product
+tags: [tagging, many-to-many, atomic-update, n-plus-one]
+difficulty: intermediate
+related: [tag-label-api, note-management-with-tags, multi-value-tag-filter]
+---
+
 # Tagging System (M:N)
 
 Attach tags to posts using a many-to-many join table, with atomic tag replacement and N+1-free tag fetching.

--- a/docs/howto/tenant-isolation-idor.md
+++ b/docs/howto/tenant-isolation-idor.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Tenant Isolation & IDOR Prevention"
+category: security
+tags: [multi-tenant, idor, isolation, authorization]
+difficulty: advanced
+related: [tenant-isolation, jwt-tenant-isolation, enforce-resource-ownership]
+---
+
 # How-to: Tenant Isolation & IDOR Prevention
 
 > **FT reference**: FT318 (`NENE2-FT/isolationlog`) — Multi-tenant data isolation, cross-tenant IDOR prevention, header type-confusion hardening, body tenant_id injection prevention, 34 tests / 133 assertions PASS.

--- a/docs/howto/tenant-isolation.md
+++ b/docs/howto/tenant-isolation.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Tenant Isolation & Cross-Tenant IDOR Prevention"
+category: security
+tags: [multi-tenant, idor, isolation, authorization]
+difficulty: advanced
+related: [tenant-isolation-idor, jwt-tenant-isolation, enforce-resource-ownership]
+---
+
 # How-to: Tenant Isolation & Cross-Tenant IDOR Prevention
 
 **FT179 — isolationlog**

--- a/docs/howto/threaded-comments-api.md
+++ b/docs/howto/threaded-comments-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Threaded Comments API"
+category: product
+tags: [comments, threaded, tombstone, depth-limit]
+difficulty: intermediate
+related: [threaded-comments, comment-thread]
+---
+
 # How-to: Threaded Comments API
 
 > **FT reference**: FT343 (`NENE2-FT/threadlog`) — Two-level threaded comment system with tombstone deletion (content replaced with `[deleted]`), reply depth enforcement, post-scoped isolation, and reply-to-deleted prevention, 14 tests / 40+ assertions PASS.

--- a/docs/howto/threaded-comments.md
+++ b/docs/howto/threaded-comments.md
@@ -1,3 +1,11 @@
+---
+title: "Threaded Comments"
+category: product
+tags: [comments, threaded, soft-delete, depth-limit]
+difficulty: intermediate
+related: [threaded-comments-api, comment-thread]
+---
+
 # Threaded Comments
 
 Implement self-referencing comment threads with depth limits and soft delete.

--- a/docs/howto/time-tracking.md
+++ b/docs/howto/time-tracking.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Time Tracking API"
+category: product
+tags: [time-tracking, stopwatch, timer, duration]
+difficulty: intermediate
+related: [habit-tracker, shift-management]
+---
+
 # How-to: Time Tracking API
 
 > **FT reference**: FT246 (`NENE2-FT/timelog`) — Time Tracking API

--- a/docs/howto/timezone-aware-scheduling.md
+++ b/docs/howto/timezone-aware-scheduling.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Timezone-aware Event Scheduling"
+category: api-design
+tags: [timezone, utc, scheduling, datetime, iana]
+difficulty: intermediate
+related: [handle-timezones, iso-datetime-validation]
+---
+
 # How-to: Timezone-aware Event Scheduling
 
 > **FT reference**: FT286 (`NENE2-FT/schedulelog`) — Timezone-aware scheduling: UTC storage + local time conversion, IANA timezone validation via DateTimeZone::listIdentifiers(), InvalidTimezoneException, dynamic ?timezone query parameter, 19 tests / 39 assertions PASS.

--- a/docs/howto/token-lifecycle-api.md
+++ b/docs/howto/token-lifecycle-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: API Token Lifecycle Management"
+category: auth
+tags: [api-key, token, sha256, scope, revocation]
+difficulty: advanced
+related: [api-key-management, access-token-management]
+---
+
 # How-to: API Token Lifecycle Management
 
 > **FT reference**: FT272 (`NENE2-FT/tokenlog`) — API token lifecycle: SHA-256 hash storage (plaintext never persisted), scope enum (read/write/admin) with DB CHECK constraint, IDOR guard (actorId must match userId), soft-revoke via revoked_at, verify endpoint returns valid/user_id/scope, 29 tests / 70 assertions PASS.

--- a/docs/howto/totp-authentication.md
+++ b/docs/howto/totp-authentication.md
@@ -1,3 +1,11 @@
+---
+title: "TOTP 二要素認証の実装ガイド"
+category: auth
+tags: [totp, two-factor, otp, authentication]
+difficulty: advanced
+related: [otp-authentication, numeric-verification-code]
+---
+
 # TOTP 二要素認証の実装ガイド
 
 ## 概要

--- a/docs/howto/transaction-scope-pattern.md
+++ b/docs/howto/transaction-scope-pattern.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Transaction Scope Pattern"
+category: database
+tags: [transactions, atomic, database, inventory]
+difficulty: intermediate
+related: [transactions, use-transactions]
+---
+
 # How-to: Transaction Scope Pattern
 
 > **FT reference**: FT253 (`NENE2-FT/txlog`) — Database transaction boundaries: atomic order-with-inventory

--- a/docs/howto/transactions.md
+++ b/docs/howto/transactions.md
@@ -1,3 +1,11 @@
+---
+title: "Database Transactions"
+category: database
+tags: [transactions, atomic, rollback, database]
+difficulty: beginner
+related: [transaction-scope-pattern, use-transactions]
+---
+
 # Database Transactions
 
 Use `DatabaseTransactionManagerInterface::transactional()` for atomic multi-step operations.

--- a/docs/howto/unicode-aware-text-api.md
+++ b/docs/howto/unicode-aware-text-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Unicode-Aware Text API"
+category: security
+tags: [unicode, validation, encoding, null-byte, multibyte]
+difficulty: intermediate
+related: [validate-unicode-input]
+---
+
 # How-to: Unicode-Aware Text API
 
 > **FT reference**: FT345 (`NENE2-FT/unicodelog`) — Profile API with Unicode-safe validation: mb_strlen for character counting, null byte rejection, multi-script support (Japanese, emoji, ZWJ sequences, Arabic, mixed), JSON_UNESCAPED_UNICODE handling, 22 tests PASS.

--- a/docs/howto/upvote-downvote-api.md
+++ b/docs/howto/upvote-downvote-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Upvote / Downvote API"
+category: product
+tags: [voting, upvote, downvote, toggle, score]
+difficulty: intermediate
+related: [voting-system, emoji-reactions-toggle]
+---
+
 # How-to: Upvote / Downvote API
 
 > **FT reference**: FT347 (`NENE2-FT/votelog`) — Per-user upvote/downvote with toggle-off (same direction twice removes vote), direction change (up→down atomically), score aggregation (upvotes − downvotes), UNIQUE(user_id, item_id) constraint, 15 tests PASS.

--- a/docs/howto/url-bookmark-api.md
+++ b/docs/howto/url-bookmark-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: URL Bookmark API with Tag Filtering"
+category: product
+tags: [bookmark, url, tagging, filtering]
+difficulty: intermediate
+related: [bookmark-api, bookmark-system]
+---
+
 # How-to: URL Bookmark API with Tag Filtering
 
 > **FT reference**: FT265 (`NENE2-FT/linklog`) — URL Bookmark API: UNIQUE URL constraint, comma-separated tag storage, LIKE-based tag matching

--- a/docs/howto/url-shortener-ssrf-prevention.md
+++ b/docs/howto/url-shortener-ssrf-prevention.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: URL Shortener with SSRF Prevention"
+category: security
+tags: [ssrf, url-shortener, private-ip, mass-assignment]
+difficulty: advanced
+related: [url-shortener-ssrf]
+---
+
 # How-to: URL Shortener with SSRF Prevention
 
 > **FT reference**: FT337 (`NENE2-FT/shortlog`) — URL shortener with SSRF blocking (private IPs, loopback, link-local, dangerous schemes), slug validation, mass assignment prevention, ISO 8601 date validation, ReDoS-safe limit parsing, 50+ tests PASS.

--- a/docs/howto/url-shortener-ssrf.md
+++ b/docs/howto/url-shortener-ssrf.md
@@ -1,3 +1,11 @@
+---
+title: "URL Shortener API & SSRF Prevention"
+category: security
+tags: [ssrf, url-shortener, vulnerability-assessment]
+difficulty: advanced
+related: [url-shortener-ssrf-prevention]
+---
+
 # URL Shortener API & SSRF Prevention
 
 **FT183** — `shortlog` field trial (脆弱性診断 VULN-A〜L).

--- a/docs/howto/use-bearer-auth.md
+++ b/docs/howto/use-bearer-auth.md
@@ -1,3 +1,11 @@
+---
+title: "How to use Bearer token authentication"
+category: auth
+tags: [bearer, jwt, middleware, authentication]
+difficulty: beginner
+related: [add-jwt-authentication, bearer-token-middleware, jwt-authentication]
+---
+
 # How to use Bearer token authentication
 
 NENE2 ships `BearerTokenMiddleware` and `LocalBearerTokenVerifier` for JWT-based authentication. This guide covers setup, configuration, token issuance, and common pitfalls.

--- a/docs/howto/use-fts5-search.md
+++ b/docs/howto/use-fts5-search.md
@@ -1,3 +1,11 @@
+---
+title: "Use SQLite FTS5 Full-Text Search"
+category: database
+tags: [fts5, sqlite, full-text-search, inverted-index]
+difficulty: intermediate
+related: [sqlite-fts5-search, search-autocomplete]
+---
+
 # Use SQLite FTS5 Full-Text Search
 
 SQLite's FTS5 extension provides full-text search using an inverted index. This guide covers the schema pattern, trigger-based sync, and the query syntax gotchas you will encounter when accepting user input.

--- a/docs/howto/use-postgresql.md
+++ b/docs/howto/use-postgresql.md
@@ -1,3 +1,10 @@
+---
+title: "How to use PostgreSQL"
+category: database
+tags: [postgresql, pdo, adapter, database]
+difficulty: beginner
+---
+
 # How to use PostgreSQL
 
 NENE2's `PdoConnectionFactory` supports the `pgsql` adapter out of the box. This guide covers

--- a/docs/howto/user-follow-system.md
+++ b/docs/howto/user-follow-system.md
@@ -1,3 +1,11 @@
+---
+title: "How to Build a User Follow System with NENE2"
+category: product
+tags: [follow, social, mutual-follow, many-to-many]
+difficulty: intermediate
+related: [follow-api, user-invitation]
+---
+
 # How to Build a User Follow System with NENE2
 
 This guide walks through building a Twitter/Instagram-style social follow system — users follow each other, view follower/following lists, and check mutual follow status.

--- a/docs/howto/user-invitation.md
+++ b/docs/howto/user-invitation.md
@@ -1,3 +1,11 @@
+---
+title: "User Invitation System"
+category: auth
+tags: [invitation, token, expiry, email]
+difficulty: intermediate
+related: [invitation-system, invitation-referral, magic-link-authentication]
+---
+
 # User Invitation System
 
 Invite new users by email, enforce expiry, and prevent abuse with token-based invitations.

--- a/docs/howto/user-preferences-api.md
+++ b/docs/howto/user-preferences-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: User Preferences API"
+category: product
+tags: [preferences, settings, typed-values, defaults]
+difficulty: intermediate
+related: [user-preferences-management]
+---
+
 # How-to: User Preferences API
 
 > **FT reference**: FT329 (`NENE2-FT/preflog`) — Per-user preference store with typed value validation, default fallback, unknown-key rejection, owner-only mutation, 20 tests / 70 assertions PASS.

--- a/docs/howto/user-preferences-management.md
+++ b/docs/howto/user-preferences-management.md
@@ -1,3 +1,11 @@
+---
+title: "User Preferences Management"
+category: product
+tags: [preferences, settings, typed-values, ownership]
+difficulty: intermediate
+related: [user-preferences-api]
+---
+
 # User Preferences Management
 
 ユーザー設定（Preferences）管理の実装ガイド。

--- a/docs/howto/user-profile-api.md
+++ b/docs/howto/user-profile-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: User Profile API"
+category: product
+tags: [profile, user, ownership, validation, url-security]
+difficulty: intermediate
+related: [user-profile-management]
+---
+
 # How-to: User Profile API
 
 > **FT reference**: FT275 (`NENE2-FT/profilelog`) — User profile: one-profile-per-user (UNIQUE user_id), email validated with FILTER_VALIDATE_EMAIL, field length limits (display_name 100 / bio 500 / avatar_url 2048), https-only avatar URL, DatabaseConstraintException → 409, ownership guard via X-User-Id, 32 tests PASS.

--- a/docs/howto/user-profile-management.md
+++ b/docs/howto/user-profile-management.md
@@ -1,3 +1,11 @@
+---
+title: "User Profile Management"
+category: product
+tags: [profile, user, bio, avatar]
+difficulty: beginner
+related: [user-profile-api]
+---
+
 # User Profile Management
 
 Store and update user-facing profile data: display name, bio, and avatar URL. Profile creation is separate from user creation — users exist first, then a profile is created once and updated in place.

--- a/docs/howto/validate-unicode-input.md
+++ b/docs/howto/validate-unicode-input.md
@@ -1,3 +1,11 @@
+---
+title: "How to validate Unicode input"
+category: security
+tags: [unicode, validation, multibyte, encoding]
+difficulty: beginner
+related: [unicode-aware-text-api]
+---
+
 # How to validate Unicode input
 
 NENE2 stores and returns strings as UTF-8. This guide covers the pitfalls of Unicode-aware validation and how to handle them.

--- a/docs/howto/voting-system.md
+++ b/docs/howto/voting-system.md
@@ -1,3 +1,11 @@
+---
+title: "Voting System (Upvote / Downvote)"
+category: product
+tags: [voting, upvote, downvote, toggle]
+difficulty: intermediate
+related: [upvote-downvote-api]
+---
+
 # Voting System (Upvote / Downvote)
 
 Allow users to upvote or downvote items. Each user can cast at most one vote per item. Voting in the same direction twice toggles the vote off. Voting in the opposite direction switches the vote.

--- a/docs/howto/waitlist-management.md
+++ b/docs/howto/waitlist-management.md
@@ -1,3 +1,11 @@
+---
+title: "ウェイティングリスト管理"
+category: product
+tags: [waitlist, state-machine, queue, admin]
+difficulty: intermediate
+related: [waitlist-system]
+---
+
 # ウェイティングリスト管理
 
 位置ベースのウェイティングリスト（順番待ち）の実装ガイド。

--- a/docs/howto/waitlist-system.md
+++ b/docs/howto/waitlist-system.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Waitlist System"
+category: product
+tags: [waitlist, state-machine, queue, approval]
+difficulty: intermediate
+related: [waitlist-management]
+---
+
 # How-to: Waitlist System
 
 > **FT reference**: FT287 (`NENE2-FT/waitlistlog`) — Waitlist system: UNIQUE(user_id) one-entry constraint, waiting→approved/declined state machine, isTerminal() guard, /waitlist/me registered before /{id} to prevent route capture, X-Admin-Key authentication, queue position tracking, 39 tests / 98 assertions PASS.

--- a/docs/howto/webhook-delivery-api.md
+++ b/docs/howto/webhook-delivery-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Webhook Delivery API"
+category: infrastructure
+tags: [webhook, delivery, retry, event-dispatch]
+difficulty: intermediate
+related: [webhook-delivery-system, webhook-delivery, webhook-signature-verification]
+---
+
 # How-to: Webhook Delivery API
 
 > **FT reference**: FT348 (`NENE2-FT/webhooklog`) — Webhook registration with URL/secret/event filters, event dispatch with per-subscriber delivery logging, secret masking, retry mechanism, success/failed status tracking, 18 tests PASS.

--- a/docs/howto/webhook-delivery-system.md
+++ b/docs/howto/webhook-delivery-system.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Webhook Delivery System"
+category: infrastructure
+tags: [webhook, ssrf, hmac, signature, secret-hashing]
+difficulty: advanced
+related: [webhook-delivery-api, webhook-delivery, webhook-signature-verification]
+---
+
 # How-to: Webhook Delivery System
 
 > **FT reference**: FT308 (`NENE2-FT/webhookdeliverylog`) — Webhook delivery system: SSRF protection via UrlValidator (HTTPS-only, private IP blocklist, CRLF injection prevention), HMAC-SHA256 signature with timestamp binding, secret stored as SHA-256 hash (never plaintext), secret not returned in GET responses, deactivated endpoints skip delivery, event type isolation, ATK-01〜12 all BLOCKED, 31 tests / 47 assertions PASS.

--- a/docs/howto/webhook-delivery.md
+++ b/docs/howto/webhook-delivery.md
@@ -1,3 +1,11 @@
+---
+title: "Outbound Webhook Delivery"
+category: infrastructure
+tags: [webhook, outbound, ssrf, signature]
+difficulty: intermediate
+related: [webhook-delivery-api, webhook-delivery-system, webhook-signature]
+---
+
 # Outbound Webhook Delivery
 
 Outbound webhooks notify third-party systems when events occur in your application. The primary security concerns are SSRF (sending requests to internal infrastructure), secret leakage, and signature integrity.

--- a/docs/howto/webhook-signature-verification.md
+++ b/docs/howto/webhook-signature-verification.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Webhook Signature Verification with HMAC-SHA256"
+category: security
+tags: [webhook, hmac, signature, replay-attack, timing-safe]
+difficulty: advanced
+related: [webhook-signature, inbound-webhook-gateway, inbound-webhook-receiver]
+---
+
 # How-to: Webhook Signature Verification with HMAC-SHA256
 
 > **FT reference**: FT260 (`NENE2-FT/hmaclog`) — Webhook signature verification: HMAC-SHA256, timing-safe comparison, replay attack prevention

--- a/docs/howto/webhook-signature.md
+++ b/docs/howto/webhook-signature.md
@@ -1,3 +1,11 @@
+---
+title: "Webhook Signature Verification"
+category: security
+tags: [webhook, hmac, signature, timing-safe]
+difficulty: intermediate
+related: [webhook-signature-verification, inbound-webhook-receiver]
+---
+
 # Webhook Signature Verification
 
 When receiving webhooks from external services (Stripe, GitHub, etc.), always verify the signature before processing the payload. This proves the webhook came from the expected sender and the body has not been tampered with.

--- a/docs/howto/wish-list-api.md
+++ b/docs/howto/wish-list-api.md
@@ -1,3 +1,11 @@
+---
+title: "How-to: Wish List API (VULN-A~L Security Assessment)"
+category: product
+tags: [wishlist, crud, idor, security-assessment]
+difficulty: advanced
+related: [wishlist-management, media-watchlist]
+---
+
 # How-to: Wish List API (VULN-A~L Security Assessment)
 
 This guide demonstrates a personal wish list API with full CRUD, admin override, and security hardening covering VULN-A through VULN-L.

--- a/docs/howto/wishlist-management.md
+++ b/docs/howto/wishlist-management.md
@@ -1,3 +1,11 @@
+---
+title: "ウィッシュリスト管理"
+category: product
+tags: [wishlist, priority, visibility, idor]
+difficulty: intermediate
+related: [wish-list-api, media-watchlist]
+---
+
 # ウィッシュリスト管理
 
 優先度・メモ付きウィッシュリストの実装ガイド。

--- a/docs/todo/howto-curation-strategy.md
+++ b/docs/todo/howto-curation-strategy.md
@@ -149,6 +149,6 @@ tutorial / explanation / reference は別象限なので混ぜない。
 |---|---|---|
 | 本ドキュメント発行 | #1323 | 完了 |
 | 後続 (Phase A 実装) | #1325 | 完了 — `tools/build-howto-index.php` + 6 ロケール全索引 + CI lock |
-| 後続 (Phase B-1: スキーマ実証) | #1327 | 実装中 — frontmatter スキーマ確定 + validator + 代表 5 件で実証 |
-| 後続 (Phase B-2: 全件 annotate) | 未起票 | 残り 251 件。Agent 並列想定 |
-| 後続 (Phase B-3: 索引統合 + 必須化) | 未起票 | カテゴリ/タグ別索引を frontmatter から再生成、`--require-all` で CI 必須化 |
+| 後続 (Phase B-1: スキーマ実証) | #1327 | 完了 — frontmatter スキーマ確定 + validator + 代表 5 件で実証 |
+| 後続 (Phase B-2: 全件 annotate) | #1329 | 完了 — 全 256 件 annotate 済み、`--require-all` 通過 |
+| 後続 (Phase B-3: 索引統合 + 必須化) | 未起票 | カテゴリ/タグ別索引を frontmatter から再生成、CI を `--require-all` 常時必須化 |


### PR DESCRIPTION
## 目的

Phase B-1（#1327）で確定した frontmatter スキーマに従い、残り **251 件**の howto に YAML frontmatter を付与する。これで全 256 件が annotate 済みとなり、Phase B-3 でカテゴリ別・タグ別索引をデータから再生成できる。方針: `docs/todo/howto-curation-strategy.md`（#1323）。

## 変更点

- **251 件**に `title` / `category` / `tags` / `difficulty`（+ 任意 `related` / `ft`）を付与。
- カテゴリは 7 分類（getting-started / auth / security / database / api-design / infrastructure / product）。横断的トピックは tags で表現。
- 数値タグ `429` → `http-429` に修正（YAML が整数化するため）。

## 検証

- `composer howto:frontmatter -- --require-all` → **256/256 annotated, 0 unannotated, passed**。
- `composer howto:index` の索引に **drift なし**（frontmatter は H1 抽出に影響しない＝VitePress サイドバーも不変）。
- 変更は `docs/howto/*.md`（251 件）と本戦略ドキュメントのみ。PHP・設定・ツールは無変更。

## 品質メモ

- `title` はコロン・括弧を含むケースも考慮し全件ダブルクォート。
- `related` は実在 slug のみ（マスター slug リストで検証）。
- 6 並列サブエージェントで分担、中央で `--require-all` 検証して 1 件ずつのエラー（数値タグ）を修正。

## 範囲外（後続 = Phase B-3）

- カテゴリ/タグ別索引の `build-howto-index.php` 統合
- CI を `composer howto:frontmatter -- --require-all` に切替えて恒久必須化

Self-review: docs-policy

Refs #1323
Closes #1329