### PR TITLE
docs(site): Development サイドバーに howto-frontmatter リンクを追加 (#1335)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -88,6 +88,7 @@ function sidebar(t: {
           { text: 'Authentication',         link: `${p}/development/authentication-boundary` },
           { text: 'Test database strategy', link: `${p}/development/test-database-strategy` },
           { text: 'Client project start',   link: `${p}/development/client-project-start` },
+          { text: 'Howto frontmatter',      link: `${p}/development/howto-frontmatter` },
         ],
       },
       {


### PR DESCRIPTION
## 目的

#1331 で追加した `docs/development/howto-frontmatter.md`（howto frontmatter スキーマの正本）は VitePress サイトにビルドされている（`/development/howto-frontmatter.html` は HTTP 200）が、Development サイドバーに入っておらずブラウザから辿れない孤児ページだった。サイドバーに導線を 1 件追加する。

## 変更点

- `.vitepress/config.mts` の Development サイドバー（全ロケール共通）に `Howto frontmatter` → `${p}/development/howto-frontmatter` を追加。

## 検証

- VitePress 本番ビルド成功（`build complete`、デッドリンクエラーなし）。

Self-review: docs-policy

Refs #1331
Closes #1335