### PR TITLE
docs(howto): FT350 SQLite ウィンドウ関数 howto を追加 (#1337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.324] — 2026-05-29
+
+### Added
+- `docs/howto/use-window-functions.md` — FT350 windowfunc 新規作成: SQLite ウィンドウ関数 howto: ROW_NUMBER/RANK/DENSE_RANK ランキング・SUM OVER 移動合計・LAG/LEAD 期間比較・top-N-per-group CTE・readonly DTO マッピング (#1337)
+
+---
+
 ## [1.5.323] — 2026-05-27
 
 ### Added

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -139,7 +139,7 @@ Auto-generated from each guide's frontmatter (`category` / `difficulty` / `tags`
 | [URL Shortener API & SSRF Prevention](url-shortener-ssrf.md) | advanced | `ssrf` `url-shortener` `vulnerability-assessment` |
 | [Webhook Signature Verification](webhook-signature.md) | intermediate | `webhook` `hmac` `signature` `timing-safe` |
 
-### Database (17)
+### Database (18)
 
 | Guide | Difficulty | Tags |
 |---|---|---|
@@ -160,6 +160,7 @@ Auto-generated from each guide's frontmatter (`category` / `difficulty` / `tags`
 | [Soft Delete (Logical Deletion)](soft-delete.md) | beginner | `soft-delete` `deleted-at` `logical-deletion` `audit-trail` |
 | [Use Database Transactions](use-transactions.md) | intermediate | `transactions` `atomicity` `rollback` |
 | [Use SQLite FTS5 Full-Text Search](use-fts5-search.md) | intermediate | `fts5` `sqlite` `full-text-search` `inverted-index` |
+| [Use SQLite Window Functions](use-window-functions.md) | intermediate | `window-functions` `sqlite` `ranking` `running-total` `lag-lead` |
 
 ### API Design (31)
 

--- a/docs/howto/by-tag.md
+++ b/docs/howto/by-tag.md
@@ -1211,6 +1211,10 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 
 - [How-to: Tag / Label API](tag-label-api.md)
 
+## `lag-lead` (1)
+
+- [Use SQLite Window Functions](use-window-functions.md)
+
 ## `leaderboard` (5)
 
 - [How to Build a Leaderboard (Ranking System) with NENE2](leaderboard-ranking-system.md)
@@ -1801,13 +1805,14 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 - [How-to: Flash Sale API](flash-sale-api.md)
 - [How-to: Idempotency-Key Pattern](idempotency.md)
 
-## `ranking` (5)
+## `ranking` (6)
 
 - [How to Build a Leaderboard (Ranking System) with NENE2](leaderboard-ranking-system.md)
 - [How-to: Game Leaderboard & Ranking API](leaderboard-ranking.md)
 - [How-to: Game Score & Leaderboard API](game-score-leaderboard-api.md)
 - [How-to: Leaderboard & Score Tracking API](leaderboard-scores.md)
 - [How-to: Leaderboard Ranking API](leaderboard-ranking-api.md)
+- [Use SQLite Window Functions](use-window-functions.md)
 
 ## `rate-limiting` (7)
 
@@ -2009,6 +2014,10 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 
 - [Add a Custom Route](add-custom-route.md)
 
+## `running-total` (1)
+
+- [Use SQLite Window Functions](use-window-functions.md)
+
 ## `scheduling` (4)
 
 - [Content Scheduling — Time-Based Publish with Lifecycle States](content-scheduling.md)
@@ -2187,11 +2196,12 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 - [How-to: SQL Injection Defence](sql-injection-defence.md)
 - [SQL injection defense](sql-injection.md)
 
-## `sqlite` (3)
+## `sqlite` (4)
 
 - [How-to: Fixed-window Rate Limiter](fixed-window-rate-limiter.md)
 - [How-to: SQLite FTS5 Full-Text Search](sqlite-fts5-search.md)
 - [Use SQLite FTS5 Full-Text Search](use-fts5-search.md)
+- [Use SQLite Window Functions](use-window-functions.md)
 
 ## `ssrf` (4)
 
@@ -2655,6 +2665,10 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 
 - [How-to: Mass Assignment Defence with Explicit DTO](mass-assignment-defence.md)
 - [Mass Assignment Defence](mass-assignment.md)
+
+## `window-functions` (1)
+
+- [Use SQLite Window Functions](use-window-functions.md)
 
 ## `windowed-counter` (1)
 

--- a/docs/howto/use-window-functions.md
+++ b/docs/howto/use-window-functions.md
@@ -1,0 +1,200 @@
+---
+title: "Use SQLite Window Functions"
+category: database
+tags: [window-functions, sqlite, ranking, running-total, lag-lead]
+difficulty: intermediate
+related: [use-transactions, leaderboard-ranking, add-database-endpoint]
+---
+
+# Use SQLite Window Functions
+
+Window functions compute a value across a set of rows *related to the current row* without collapsing them into a single group (the way `GROUP BY` does). They are the right tool for **ranking**, **running totals**, and **period-over-period comparison** — three patterns that are awkward and slow to do in PHP after the fact.
+
+SQLite supports window functions since **3.25.0** (2018). NENE2 ships with PHP's bundled SQLite, which is well past that; MySQL 8.0+ and PostgreSQL also support the same syntax, so these queries port across the three adapters NENE2 targets.
+
+You run them through `DatabaseQueryExecutorInterface::fetchAll()` like any other read query — there is no special framework support to wire up.
+
+**Prerequisite**: You have a repository backed by `DatabaseQueryExecutorInterface`. See [Add a database-backed endpoint](add-database-endpoint.md).
+
+---
+
+## 1. The anatomy of a window
+
+```sql
+ROW_NUMBER() OVER (PARTITION BY game ORDER BY points DESC)
+```
+
+- `PARTITION BY game` — restart the window for each game (omit to treat all rows as one window).
+- `ORDER BY points DESC` — order *within* the partition; this defines what "first" and "previous" mean.
+
+When several columns reuse the same window, name it once with a `WINDOW` clause:
+
+```sql
+SELECT player, game, points,
+       ROW_NUMBER()  OVER w AS rn,
+       RANK()        OVER w AS rnk,
+       DENSE_RANK()  OVER w AS drnk
+FROM scores
+WINDOW w AS (PARTITION BY game ORDER BY points DESC)
+ORDER BY game, points DESC;
+```
+
+---
+
+## 2. Ranking: `ROW_NUMBER` vs `RANK` vs `DENSE_RANK`
+
+The three differ only in how they treat ties. Given two players tied at 150 in `chess`:
+
+| player | game  | points | `ROW_NUMBER` | `RANK` | `DENSE_RANK` |
+|--------|-------|--------|--------------|--------|--------------|
+| b      | chess | 150    | 1            | 1      | 1            |
+| c      | chess | 150    | 2            | 1      | 1            |
+| a      | chess | 100    | 3            | 3      | 2            |
+
+- **`ROW_NUMBER`** — always unique (1, 2, 3). Use it for stable pagination cursors or "pick exactly one per group".
+- **`RANK`** — ties share a rank, then it skips (1, 1, 3). Use it for leaderboards where "joint 1st" is meaningful.
+- **`DENSE_RANK`** — ties share a rank, no gap (1, 1, 2). Use it for "tier" / grade buckets.
+
+> Pick the rank function deliberately. A leaderboard that shows two "rank 2" players and no "rank 1" is almost always a `RANK`/`ROW_NUMBER` mix-up.
+
+In a repository method:
+
+```php
+/**
+ * @return list<array{player: string, game: string, points: int, rank: int}>
+ */
+public function topRankedByGame(string $game): array
+{
+    return $this->executor->fetchAll(
+        'SELECT player, game, points,
+                RANK() OVER (PARTITION BY game ORDER BY points DESC) AS rank
+         FROM scores
+         WHERE game = :game
+         ORDER BY points DESC',
+        ['game' => $game],
+    );
+}
+```
+
+---
+
+## 3. Running total: an aggregate as a window
+
+Any aggregate (`SUM`, `AVG`, `COUNT`, …) becomes a *running* aggregate when given an `OVER (...)` clause and a frame:
+
+```sql
+SELECT created_at, points,
+       SUM(points) OVER (ORDER BY created_at ROWS UNBOUNDED PRECEDING) AS running_total
+FROM scores
+ORDER BY created_at;
+```
+
+| created_at | points | running_total |
+|------------|--------|---------------|
+| 2026-01-01 | 100    | 100           |
+| 2026-01-02 | 150    | 250           |
+| 2026-01-03 | 150    | 400           |
+| 2026-01-04 | 90     | 490           |
+
+`ROWS UNBOUNDED PRECEDING` means "every row from the start of the partition up to the current row". Without an explicit frame, the default (`RANGE UNBOUNDED PRECEDING`) sums **all rows that tie on the `ORDER BY` value** into the same step — a subtle source of wrong totals when timestamps collide. Be explicit with `ROWS` when you want a true row-by-row running total.
+
+---
+
+## 4. Period-over-period: `LAG` and `LEAD`
+
+`LAG` reads a column from the *previous* row in the window; `LEAD` reads the *next* one. This computes a delta without a self-join:
+
+```sql
+SELECT created_at, points,
+       points - LAG(points) OVER (ORDER BY created_at) AS delta
+FROM scores
+ORDER BY created_at;
+```
+
+| created_at | points | delta |
+|------------|--------|-------|
+| 2026-01-01 | 100    | *null* |
+| 2026-01-02 | 150    | 50    |
+| 2026-01-03 | 150    | 0     |
+| 2026-01-04 | 90     | −60   |
+
+The first row's `delta` is `NULL` because there is no previous row. Supply a default to avoid null-handling downstream: `LAG(points, 1, 0)` returns `0` instead of `NULL` for the first row. Map `NULL` to a typed value in your DTO rather than leaking it into the JSON response.
+
+---
+
+## 5. Filtering on a window result
+
+You **cannot** put a window function in a `WHERE` clause — windows are evaluated *after* `WHERE`. Wrap the query in a subquery (or CTE) and filter on the alias:
+
+```sql
+WITH ranked AS (
+    SELECT player, game, points,
+           ROW_NUMBER() OVER (PARTITION BY game ORDER BY points DESC) AS rn
+    FROM scores
+)
+SELECT player, game, points
+FROM ranked
+WHERE rn <= 3            -- top 3 per game
+ORDER BY game, points DESC;
+```
+
+This "top-N-per-group" shape is the most common real-world use; reach for it instead of `N` separate `LIMIT` queries.
+
+---
+
+## 6. Returning it as a typed response
+
+Keep the SQL in the repository and map to a readonly DTO before it reaches the controller — do not pass the raw `array` across the boundary:
+
+```php
+final readonly class GameRanking
+{
+    public function __construct(
+        public int $rank,
+        public string $player,
+        public int $points,
+    ) {}
+}
+```
+
+```php
+/** @return list<GameRanking> */
+public function topRankedByGame(string $game): array
+{
+    $rows = $this->executor->fetchAll(
+        'SELECT player, points,
+                RANK() OVER (PARTITION BY game ORDER BY points DESC) AS rank
+         FROM scores WHERE game = :game ORDER BY points DESC',
+        ['game' => $game],
+    );
+
+    return array_map(
+        static fn (array $r): GameRanking => new GameRanking(
+            rank: (int) $r['rank'],
+            player: (string) $r['player'],
+            points: (int) $r['points'],
+        ),
+        $rows,
+    );
+}
+```
+
+SQLite returns all column values as strings over PDO, so cast (`(int)`, `(float)`) inside the mapper — the window function result (`rank`, `running_total`) is no exception.
+
+---
+
+## Gotchas
+
+- **`WHERE` cannot see window aliases** — filter in an outer query/CTE (§5).
+- **Default frame is `RANGE`, not `ROWS`** — be explicit with `ROWS UNBOUNDED PRECEDING` for running totals (§3).
+- **`LAG`/`LEAD` return `NULL` at the edges** — pass a default or map to a typed value (§4).
+- **Portability** — the syntax above is standard and runs on SQLite 3.25+, MySQL 8.0+, and PostgreSQL. If you target older MySQL (5.7), window functions are unavailable; fall back to a self-join or compute in PHP.
+- **Index the `ORDER BY` columns** — a window's `PARTITION BY` / `ORDER BY` benefits from the same indexes as a regular sort.
+
+---
+
+## Related
+
+- [Use database transactions](use-transactions.md) — atomic multi-step writes
+- [Leaderboard ranking](leaderboard-ranking.md) — a product recipe built on ranking
+- [Add a database-backed endpoint](add-database-endpoint.md) — repository + executor wiring

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.323
+  version: 1.5.324
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.323';
+    public const string VERSION = '1.5.324';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的

全 FT カバー（FT349）後の継続として **FT350（通常）** を実施。`docs/todo/current.md` の「DX シナリオ分析から抽出した howto 候補」で **最多言及（★★★・7+）** だった **SQLite ウィンドウ関数** の専用技法 howto を新規作成する。

既存の leaderboard 系 howto では `ROW_NUMBER` 等が**付随的に**使われるのみで、技法として解説する横断ガイドが無かった（重複ではなく Database 技法ガイド系列 `use-transactions` / `use-fts5-search` の仲間）。

## 変更点

- **`docs/howto/use-window-functions.md` 新規**（category: database）:
  - `ROW_NUMBER` / `RANK` / `DENSE_RANK` のタイ処理差（表で対比）
  - `SUM() OVER` 移動合計 ＋ **既定フレーム `RANGE` vs 明示 `ROWS` の罠**
  - `LAG` / `LEAD` 期間比較（NULL 端の扱い）
  - `WHERE` でウィンドウ別名は使えない → CTE で top-N-per-group
  - repository → readonly DTO マッピング（SQLite の PDO 文字列キャストに言及）
  - SQLite 3.25+/MySQL 8.0+/PostgreSQL 互換性メモ
- `composer howto:index` で README（Database）/ `by-tag.md` を再生成。
- バージョン **1.5.324**（`FrameworkInfo.php` + `openapi.yaml`）。

## 検証

- **全 SQL を SQLite 3.46.1 で実行確認**（howto 内の表の数値は実出力をそのまま使用）。
- `composer check` 全通過（test / PHPStan level 8 / cs / openapi / mcp / version 1.5.324）。
- `composer howto:frontmatter -- --require-all` → 257/257 annotated, passed。
- `composer howto:index` idempotent（drift なし）。

Self-review: docs-policy

Closes #1337