### PR TITLE
fix(tools): start-ft.sh の CHANGELOG 挿入を [Unreleased] 内容に頑健化 (#1341)

### DIFF
--- a/tools/start-ft.sh
+++ b/tools/start-ft.sh
@@ -96,23 +96,26 @@ CHANGELOG="${REPO_ROOT}/CHANGELOG.md"
 # [Unreleased] セクションの直後に新バージョンエントリを挿入
 ENTRY="## [${NEW_VER}] — ${TODAY}\n\n### Added\n- \`docs/howto/TODO.md\` — FT${FT_NUM} ${FT_NAME}: ${TOPIC} (#${ISSUE_NUM})\n\n---\n"
 
-# "## [Unreleased]" と "---" の間に挿入
+# 最新のリリース版見出し ("## [<数字>") の直前に挿入する。
+# [Unreleased] に未リリース項目があっても確実に動くよう、Unreleased 直後の
+# "---" に依存しない。マッチしなければ明示エラーで停止する。
 python3 - "$CHANGELOG" "$ENTRY" <<'PYEOF'
 import sys, re
 
 path = sys.argv[1]
-entry = sys.argv[2]
+# bash の二重引用符内では \n は literal なので実改行へ変換する
+entry = sys.argv[2].replace('\\n', '\n')
 
 with open(path, 'r') as f:
     content = f.read()
 
-# "[Unreleased]\n\n---\n" の直後に挿入
-new_content = re.sub(
-    r'(## \[Unreleased\]\n\n---\n)',
-    r'\1\n' + entry,
-    content,
-    count=1
-)
+m = re.search(r'^## \[\d', content, re.M)
+if m is None:
+    sys.stderr.write('start-ft.sh: CHANGELOG にリリース版見出しが見つかりません\n')
+    sys.exit(1)
+
+idx = m.start()
+new_content = content[:idx] + entry.rstrip('\n') + '\n\n' + content[idx:]
 
 with open(path, 'w') as f:
     f.write(new_content)


### PR DESCRIPTION
## 不具合

`tools/start-ft.sh` の CHANGELOG 挿入が `## \[Unreleased\]\n\n---\n` という正規表現に依存し、「[Unreleased] 直後に `---`」を前提にしていた。現在 [Unreleased] に未リリース項目が溜まっているため no-match となり、**サイレント失敗**（無変更なのに成功表示）。FT350・FT351 で連続して手動 CHANGELOG 追記が必要だった。

## 修正

- 挿入位置を最新リリース版見出し `^## \[<数字>` の直前に変更（[Unreleased] の内容有無に非依存）。
- マッチしなければ `exit 1` で明示エラー（再びサイレント失敗しない）。
- bash 由来の literal `\n` を実改行へ変換。

## 検証

- 実 `CHANGELOG.md` のコピーに対するドライランで、[Unreleased] 内容を保持しつつ最新版の直前へ正しい書式で挿入されることを確認。
- `bash -n` 構文 OK。

Closes #1341