### PR TITLE
docs(howto): time-tracking の julianday 集計を strftime に修正 (#1347)

### DIFF
--- a/docs/de/howto/time-tracking.md
+++ b/docs/de/howto/time-tracking.md
@@ -4,7 +4,7 @@
 
 Demonstriert eine Stoppuhr-basierte Zeiterfassungs-API, bei der ein Zeiterfassungs-Eintrag eine `start_time`
 und eine nullable `end_time` hat (`NULL` = läuft, nicht-`NULL` = gestoppt), nur ein Timer gleichzeitig
-laufen kann, die Dauer über SQLites `julianday()` berechnet wird und tägliche Zusammenfassungen
+laufen kann, die Dauer über SQLites `strftime('%s', ...)` berechnet wird und tägliche Zusammenfassungen
 die gesamten erfassten Sekunden pro Kalendertag aggregieren.
 
 ---
@@ -141,18 +141,23 @@ der berechneten Dauer zurück. `NoRunningTimerException` wird geworfen, wenn kei
 
 ---
 
-## Dauerberechnung: `julianday()` in SQL
+## Dauerberechnung: `strftime('%s', ...)` in SQL
 
-Für aggregierte Zusammenfassungen wird die Dauer in SQL über SQLites `julianday()`-Funktion berechnet:
+Für aggregierte Zusammenfassungen wird die Dauer in SQL über SQLites `strftime('%s', ...)`-Funktion berechnet, die die Unix-Epochensekunden eines Datumszeit-Strings als Ganzzahl zurückgibt:
 
 ```sql
-SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds
+SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds
 ```
 
-`julianday()` konvertiert einen ISO-Datumszeit-String in eine Julianische Tagesnummer (eine reelle Zahl,
-die Tage seit Mittag des 1. Januar 4713 v. Chr. darstellt). Das Subtrahieren zweier Julianischer Tagesnummern
-ergibt die Differenz in Tagen. Das Multiplizieren mit `86400` konvertiert Tage in Sekunden.
-`CAST(... AS INTEGER)` kürzt auf ganze Sekunden.
+`strftime('%s', ...)` parst den ISO-Datumszeit-String (einschließlich eines `±HH:MM`-Offsets, der nach UTC
+normalisiert wird) und gibt ganze Epochensekunden zurück. Die Subtraktion der beiden ergibt die exakte
+Dauer in Sekunden — passend zur PHP-seitigen `getTimestamp()`-Differenz.
+
+> **Fallstrick — `julianday()` nicht für Sekundengenauigkeit verwenden.** Die Formel
+> `CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)` ist verlockend, aber die
+> `julianday`-Differenz ist ein Gleitkommawert knapp unter der ganzen Sekunde, sodass das `CAST(... AS INTEGER)`
+> einen 60-Sekunden-Eintrag auf **59** kürzt. Verwenden Sie stattdessen `strftime('%s', ...)` (ganze
+> Epochensekunden) — das ist exakt. (Gefunden durch die PHPUnit-Suite des FT246-`timelog`-Beispiels.)
 
 `SUM(...)` summiert alle abgeschlossenen Einträge für den Tag. `WHERE end_time IS NOT NULL`
 filtert alle noch laufenden Timer aus der Zusammenfassung.
@@ -175,7 +180,7 @@ Serialisierung einzelner Einträge verwendet.
 
 ```php
 $sql = 'SELECT date(start_time) AS day,
-               SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds,
+               SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds,
                COUNT(*) AS entry_count
           FROM time_entries
          WHERE ' . implode(' AND ', $where) . '

--- a/docs/fr/howto/time-tracking.md
+++ b/docs/fr/howto/time-tracking.md
@@ -4,7 +4,7 @@
 
 Démontre une API de suivi du temps de type chronomètre où une entrée de minuterie a un `start_time`
 et un `end_time` nullable (`NULL` = en cours, non-`NULL` = arrêtée). Une seule minuterie peut
-tourner à la fois. La durée est calculée via `julianday()` de SQLite. Des résumés journaliers
+tourner à la fois. La durée est calculée via `strftime('%s', ...)` de SQLite. Des résumés journaliers
 agrègent le total des secondes suivies par jour calendaire.
 
 ---
@@ -143,18 +143,24 @@ la durée calculée. `NoRunningTimerException` est levée si aucune minuterie ne
 
 ---
 
-## Calcul de durée : `julianday()` en SQL
+## Calcul de durée : `strftime('%s', ...)` en SQL
 
-Pour les résumés agrégés, la durée est calculée en SQL avec la fonction `julianday()` de SQLite :
+Pour les résumés agrégés, la durée est calculée en SQL avec la fonction `strftime('%s', ...)` de SQLite, qui renvoie les secondes Unix epoch d'une chaîne datetime sous forme d'entier :
 
 ```sql
-SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds
+SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds
 ```
 
-`julianday()` convertit une chaîne datetime ISO en Nombre de Jour Julien (un nombre réel
-représentant les jours depuis midi le 1er janvier 4713 avant J.-C.). Soustraire deux Nombres de
-Jour Juliens donne la différence en jours. Multiplier par `86400` convertit les jours en secondes.
-`CAST(... AS INTEGER)` tronque aux secondes entières.
+`strftime('%s', ...)` analyse la chaîne datetime ISO (y compris un décalage `±HH:MM`, normalisé en UTC)
+et renvoie des secondes epoch entières. Soustraire les deux donne la durée exacte en secondes —
+correspondant à la différence `getTimestamp()` côté PHP.
+
+> **Piège — ne pas utiliser `julianday()` pour la précision à la seconde.** La formule
+> `CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)` est tentante, mais la
+> différence `julianday` est une valeur à virgule flottante juste en dessous de la seconde entière, donc
+> le `CAST(... AS INTEGER)` tronque une entrée de 60 secondes à **59**. Utilisez plutôt
+> `strftime('%s', ...)` (secondes epoch entières) — c'est exact. (Découvert par la suite PHPUnit de
+> l'exemple `timelog` FT246.)
 
 `SUM(...)` totalise toutes les entrées terminées pour la journée. `WHERE end_time IS NOT NULL`
 exclut les minuteries encore en cours du résumé.
@@ -177,7 +183,7 @@ l'approche PHP est utilisée pour la sérialisation des entrées individuelles.
 
 ```php
 $sql = 'SELECT date(start_time) AS day,
-               SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds,
+               SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds,
                COUNT(*) AS entry_count
           FROM time_entries
          WHERE ' . implode(' AND ', $where) . '

--- a/docs/howto/time-tracking.md
+++ b/docs/howto/time-tracking.md
@@ -12,7 +12,7 @@ related: [habit-tracker, shift-management]
 
 Demonstrates a stopwatch-style time tracking API where a timer entry has a `start_time`
 and a nullable `end_time` (`NULL` = running, non-`NULL` = stopped), only one timer can
-run at a time, duration is computed via SQLite's `julianday()`, and daily summaries
+run at a time, duration is computed via SQLite's `strftime('%s', ...)`, and daily summaries
 aggregate total tracked seconds per calendar day.
 
 ---
@@ -150,22 +150,29 @@ the computed duration. `NoRunningTimerException` is thrown if no timer is runnin
 
 ---
 
-## Duration calculation: `julianday()` in SQL
+## Duration calculation: `strftime('%s', ...)` in SQL
 
-For aggregate summaries, duration is computed in SQL using SQLite's `julianday()`
-function:
+For aggregate summaries, duration is computed in SQL using SQLite's
+`strftime('%s', ...)` function, which returns the Unix epoch seconds of a datetime
+string as an integer:
 
 ```sql
-SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds
+SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds
 ```
 
-`julianday()` converts an ISO datetime string to a Julian Day Number (a real number
-representing days since noon on January 1, 4713 BC). Subtracting two Julian Day Numbers
-gives the difference in days. Multiplying by `86400` converts days to seconds.
-`CAST(... AS INTEGER)` truncates to whole seconds.
+`strftime('%s', ...)` parses the ISO datetime string (including any `±HH:MM` offset,
+which it normalises to UTC) and returns whole epoch seconds. Subtracting the two gives
+the exact duration in seconds — matching the PHP-side `getTimestamp()` difference.
 
 `SUM(...)` totals all completed entries for the day. `WHERE end_time IS NOT NULL`
 filters out any still-running timers from the summary.
+
+> **Pitfall — do not use `julianday()` for second precision.** A tempting formula is
+> `CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)`. But the
+> `julianday` difference is a floating-point value a hair below the whole second, so
+> the `CAST(... AS INTEGER)` truncation turns a 60-second entry into **59**. Use
+> `strftime('%s', ...)` (integer epoch seconds) instead — it is exact. (Found by the
+> FT246 `timelog` example's PHPUnit suite.)
 
 The PHP-side calculation for individual entries:
 
@@ -175,9 +182,9 @@ $end   = new \DateTimeImmutable($this->endTime);
 return (int) $end->getTimestamp() - (int) $start->getTimestamp();
 ```
 
-Both approaches produce the same result for UTC timestamps. The SQL approach is used
-for aggregation (it avoids fetching all rows to sum); the PHP approach is used for
-individual entry serialization.
+Both approaches produce the same result. The SQL approach is used for aggregation (it
+avoids fetching all rows to sum); the PHP approach is used for individual entry
+serialization.
 
 ---
 
@@ -185,7 +192,7 @@ individual entry serialization.
 
 ```php
 $sql = 'SELECT date(start_time) AS day,
-               SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds,
+               SUM(strftime(\'%s\', end_time) - strftime(\'%s\', start_time)) AS total_seconds,
                COUNT(*) AS entry_count
           FROM time_entries
          WHERE ' . implode(' AND ', $where) . '

--- a/docs/ja/howto/time-tracking.md
+++ b/docs/ja/howto/time-tracking.md
@@ -2,7 +2,7 @@
 
 > **FT リファレンス**: FT246 (`NENE2-FT/timelog`) — タイムトラッキング API
 
-タイマーエントリが `start_time` と nullable な `end_time`（`NULL` = 実行中、非 `NULL` = 停止済み）を持ち、一度に 1 つのタイマーしか実行できず、SQLite の `julianday()` で時間が計算され、日次サマリーがカレンダー日ごとの合計トラッキング秒数を集計するストップウォッチスタイルのタイムトラッキング API を実演します。
+タイマーエントリが `start_time` と nullable な `end_time`（`NULL` = 実行中、非 `NULL` = 停止済み）を持ち、一度に 1 つのタイマーしか実行できず、SQLite の `strftime('%s', ...)` で時間が計算され、日次サマリーがカレンダー日ごとの合計トラッキング秒数を集計するストップウォッチスタイルのタイムトラッキング API を実演します。
 
 ---
 
@@ -130,15 +130,17 @@ public function stop(string $endTime): TimeEntry
 
 ---
 
-## 時間計算: SQL での `julianday()`
+## 時間計算: SQL での `strftime('%s', ...)`
 
-集計サマリーの場合、時間は SQLite の `julianday()` 関数を使って SQL で計算されます:
+集計サマリーの場合、時間は SQLite の `strftime('%s', ...)` 関数を使って SQL で計算されます。この関数は日時文字列の Unix エポック秒を整数で返します:
 
 ```sql
-SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds
+SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds
 ```
 
-`julianday()` は ISO 日時文字列をユリウス日数（紀元前 4713 年 1 月 1 日正午からの日数を表す実数）に変換します。2 つのユリウス日数を引くと日数の差が得られます。`86400` を掛けると日数が秒数に変換されます。`CAST(... AS INTEGER)` で整数秒に切り捨てます。
+`strftime('%s', ...)` は ISO 日時文字列（`±HH:MM` オフセットがあれば UTC に正規化）を解析し、整数のエポック秒を返します。2 つを引くと正確な秒数の差が得られ、PHP 側の `getTimestamp()` の差分と一致します。
+
+> **落とし穴 — 秒精度に `julianday()` を使わないこと。** `CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)` という式を使いたくなりますが、`julianday` の差はちょうどの秒数をわずかに下回る浮動小数点値のため、`CAST(... AS INTEGER)` の切り捨てで 60 秒のエントリが **59 秒**になります。整数エポック秒を返す `strftime('%s', ...)` を使えば正確です。（FT246 `timelog` example の PHPUnit で発見）
 
 `SUM(...)` はその日のすべての完了エントリを合計します。`WHERE end_time IS NOT NULL` はサマリーからまだ実行中のタイマーをフィルタリングします。
 
@@ -158,7 +160,7 @@ return (int) $end->getTimestamp() - (int) $start->getTimestamp();
 
 ```php
 $sql = 'SELECT date(start_time) AS day,
-               SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds,
+               SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds,
                COUNT(*) AS entry_count
           FROM time_entries
          WHERE ' . implode(' AND ', $where) . '

--- a/docs/pt-br/howto/time-tracking.md
+++ b/docs/pt-br/howto/time-tracking.md
@@ -2,7 +2,7 @@
 
 > **Referência FT**: FT246 (`NENE2-FT/timelog`) — API de Controle de Tempo
 
-Demonstra uma API de controle de tempo estilo cronômetro onde uma entrada de timer tem um `start_time` e um `end_time` nullable (`NULL` = rodando, não-`NULL` = parado), apenas um timer pode rodar por vez, a duração é computada via `julianday()` do SQLite e resumos diários agregam o total de segundos rastreados por dia de calendário.
+Demonstra uma API de controle de tempo estilo cronômetro onde uma entrada de timer tem um `start_time` e um `end_time` nullable (`NULL` = rodando, não-`NULL` = parado), apenas um timer pode rodar por vez, a duração é computada via `strftime('%s', ...)` do SQLite e resumos diários agregam o total de segundos rastreados por dia de calendário.
 
 ---
 
@@ -129,15 +129,17 @@ public function stop(string $endTime): TimeEntry
 
 ---
 
-## Cálculo de Duração: `julianday()` em SQL
+## Cálculo de Duração: `strftime('%s', ...)` em SQL
 
-Para resumos agregados, a duração é computada em SQL usando a função `julianday()` do SQLite:
+Para resumos agregados, a duração é computada em SQL usando a função `strftime('%s', ...)` do SQLite, que retorna os segundos Unix epoch de uma string de datetime como inteiro:
 
 ```sql
-SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds
+SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds
 ```
 
-`julianday()` converte uma string de datetime ISO para um Número de Dia Juliano (um número real representando dias desde o meio-dia de 1º de janeiro de 4713 a.C.). Subtrair dois Números de Dia Juliano dá a diferença em dias. Multiplicar por `86400` converte dias para segundos. `CAST(... AS INTEGER)` trunca para segundos inteiros.
+`strftime('%s', ...)` analisa a string de datetime ISO (incluindo qualquer offset `±HH:MM`, que normaliza para UTC) e retorna segundos epoch inteiros. Subtrair os dois dá a duração exata em segundos — correspondendo à diferença `getTimestamp()` no lado PHP.
+
+> **Armadilha — não use `julianday()` para precisão de segundos.** Uma fórmula tentadora é `CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)`, mas a diferença `julianday` é um valor de ponto flutuante um pouco abaixo do segundo inteiro, então o `CAST(... AS INTEGER)` trunca uma entrada de 60 segundos para **59**. Use `strftime('%s', ...)` (segundos epoch inteiros) — é exato. (Encontrado pela suíte PHPUnit do exemplo `timelog` FT246.)
 
 `SUM(...)` totaliza todas as entradas concluídas do dia. `WHERE end_time IS NOT NULL` filtra quaisquer timers ainda em execução do resumo.
 
@@ -157,7 +159,7 @@ Ambas as abordagens produzem o mesmo resultado para timestamps UTC. A abordagem 
 
 ```php
 $sql = 'SELECT date(start_time) AS day,
-               SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds,
+               SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds,
                COUNT(*) AS entry_count
           FROM time_entries
          WHERE ' . implode(' AND ', $where) . '

--- a/docs/zh/howto/time-tracking.md
+++ b/docs/zh/howto/time-tracking.md
@@ -2,7 +2,7 @@
 
 > **FT 参考**：FT246（`NENE2-FT/timelog`）— 时间追踪 API
 
-演示一个秒表式时间追踪 API：计时条目有 `start_time` 和可为空的 `end_time`（`NULL` = 运行中，非 `NULL` = 已停止），同一时间只能运行一个计时器，时长通过 SQLite 的 `julianday()` 计算，每日汇总按日历日聚合追踪的总秒数。
+演示一个秒表式时间追踪 API：计时条目有 `start_time` 和可为空的 `end_time`（`NULL` = 运行中，非 `NULL` = 已停止），同一时间只能运行一个计时器，时长通过 SQLite 的 `strftime('%s', ...)` 计算，每日汇总按日历日聚合追踪的总秒数。
 
 ---
 
@@ -130,15 +130,17 @@ public function stop(string $endTime): TimeEntry
 
 ---
 
-## 时长计算：SQL 中的 `julianday()`
+## 时长计算：SQL 中的 `strftime('%s', ...)`
 
-对于聚合汇总，时长使用 SQLite 的 `julianday()` 函数在 SQL 中计算：
+对于聚合汇总，时长使用 SQLite 的 `strftime('%s', ...)` 函数在 SQL 中计算，该函数以整数形式返回 datetime 字符串的 Unix epoch 秒数：
 
 ```sql
-SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds
+SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds
 ```
 
-`julianday()` 将 ISO datetime 字符串转换为儒略日数（表示自公元前 4713 年 1 月 1 日正午以来的天数的实数）。两个儒略日数相减得到天数差。乘以 `86400` 将天数转换为秒数。`CAST(... AS INTEGER)` 截断为整秒。
+`strftime('%s', ...)` 解析 ISO datetime 字符串（包括 `±HH:MM` 偏移量，会归一化为 UTC）并返回整数 epoch 秒数。两者相减得到精确的秒数差，与 PHP 端的 `getTimestamp()` 差值一致。
+
+> **陷阱 — 不要用 `julianday()` 做秒级精度计算。** 一个诱人的公式是 `CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)`，但 `julianday` 差值是略低于整秒的浮点数，所以 `CAST(... AS INTEGER)` 截断会把 60 秒的条目变成 **59 秒**。改用 `strftime('%s', ...)`（整数 epoch 秒）才是精确的。（由 FT246 `timelog` 示例的 PHPUnit 测试发现）
 
 `SUM(...)` 汇总当天所有已完成的条目。`WHERE end_time IS NOT NULL` 从汇总中过滤掉正在运行的计时器。
 
@@ -158,7 +160,7 @@ return (int) $end->getTimestamp() - (int) $start->getTimestamp();
 
 ```php
 $sql = 'SELECT date(start_time) AS day,
-               SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds,
+               SUM(strftime('%s', end_time) - strftime('%s', start_time)) AS total_seconds,
                COUNT(*) AS entry_count
           FROM time_entries
          WHERE ' . implode(' AND ', $where) . '


### PR DESCRIPTION
## 目的

`time-tracking.md` 系 howto の日次サマリー集計が `julianday()` の浮動小数点切り捨てで秒数を 1 秒少なく計算するバグを修正する。

## 問題

```sql
SUM(CAST((julianday(end_time) - julianday(start_time)) * 86400 AS INTEGER)) AS total_seconds
```

`julianday` 差 × 86400 は整数秒をわずかに下回る float になり、`CAST(... AS INTEGER)` の切り捨てで **60 秒のエントリが 59 秒**になる。

## 変更点

- 全 6 言語の howto の 2 つの SQL コードブロックを `SUM(strftime('%s', end_time) - strftime('%s', start_time))` に置き換え（正確な整数エポック秒、PHP の `getTimestamp()` 差分と一致）
- 見出し・導入・説明文を strftime ベースに更新
- `julianday()` を秒精度に使わない理由を **落とし穴** ノートとして追記

## 検証

- NENE2-examples `timelog`（FT246）の PHPUnit でバグを再現・修正後に 60/180 秒が正しく集計されることを確認（16 tests green, PHPStan L8, CS clean）
- `git diff --check` clean

Closes #1347

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)