### PR TITLE
fix(validation): 日時ヘルパーのオフセット範囲と未来判定を修正 (#1351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - `docs/adr/0009-v1.0-public-api-scope.md` — stable public API 表に `Nene2\Testing\DatabaseTestKit` 行を追加
 
+### Fixed
+- `Nene2\Validation\V::isoDatetime()` — 範囲外の UTC オフセット（`+25:00` / `+99:00` 等、正規表現が時間部 00–99 を通すため）を許容していたバグを修正。絶対値が `±14:00` を超えるオフセットを拒否（実在 TZ は全て範囲内）。分 ≥ 60 は従来どおり round-trip で拒否（#1351）
+- `Nene2\Validation\V::futureDatetime()` — ISO 文字列の字句比較で未来判定していたため、`$raw` と `$now` の TZ オフセットが異なると瞬時の前後が逆転しても誤判定するバグを修正。`DateTimeImmutable` の instant 比較に変更し、異なるオフセット間でも正しく比較。`$now` がパース不能な場合は `null` を返す（#1351）
+
 ---
 
 ## [1.5.326] — 2026-05-29

--- a/src/Validation/V.php
+++ b/src/Validation/V.php
@@ -140,6 +140,14 @@ final class V
             return null;
         }
 
+        // Reject out-of-range UTC offsets. The regex alone accepts e.g. "+25:00"
+        // or "+99:00" (hours 00-99); every real timezone offset is within ±14:00.
+        // (Offset minutes ≥ 60 are already rejected by the round-trip below.)
+        $offsetTotalMinutes = ((int) substr($raw, -5, 2)) * 60 + (int) substr($raw, -2);
+        if ($offsetTotalMinutes > 14 * 60) {
+            return null;
+        }
+
         // createFromFormat preserves the input timezone offset; format() re-emits it.
         $dt = DateTimeImmutable::createFromFormat(DATE_ATOM, $raw);
 
@@ -157,12 +165,14 @@ final class V
     /**
      * Validates an ISO 8601 datetime that must be strictly after $now.
      *
-     * $now should be the current moment in the same format (e.g., date('c')).
-     * String comparison is used — both strings must share the same timezone
-     * offset for the comparison to be meaningful; callers are responsible for
-     * normalising to a common offset when comparing across zones.
+     * $now should be the current moment as an ISO 8601 datetime string
+     * (e.g., date('c')). The comparison is by instant via DateTimeImmutable, so
+     * $raw and $now may carry different timezone offsets and still compare
+     * correctly — e.g. "...T00:00:00+09:00" is correctly seen as earlier than the
+     * same wall-clock time at "+00:00".
      *
-     * Returns null if the datetime is invalid or not strictly in the future.
+     * Returns null if $raw is an invalid datetime, if $now cannot be parsed, or
+     * if $raw is not strictly after $now.
      *
      * @param string $now Current moment as an ISO 8601 datetime string
      */
@@ -174,7 +184,16 @@ final class V
             return null;
         }
 
-        return $dt > $now ? $dt : null;
+        try {
+            // $dt is already validated by isoDatetime(); $now is parsed leniently
+            // (it is the server-provided current time, not untrusted input).
+            $target = new DateTimeImmutable($dt);
+            $reference = new DateTimeImmutable($now);
+        } catch (\Exception) {
+            return null;
+        }
+
+        return $target > $reference ? $dt : null;
     }
 
     /**

--- a/tests/Validation/VTest.php
+++ b/tests/Validation/VTest.php
@@ -257,6 +257,21 @@ final class VTest extends TestCase
         self::assertNull(V::isoDatetime([]));
     }
 
+    public function testIsoDatetimeRejectsOutOfRangeOffset(): void
+    {
+        // The regex accepts hours 00-99; reject offsets beyond ±14:00.
+        self::assertNull(V::isoDatetime('2026-01-01T00:00:00+25:00'));
+        self::assertNull(V::isoDatetime('2026-01-01T00:00:00+99:00'));
+        self::assertNull(V::isoDatetime('2026-01-01T00:00:00+14:30'));
+        self::assertNull(V::isoDatetime('2026-01-01T00:00:00-15:00'));
+    }
+
+    public function testIsoDatetimeAcceptsBoundaryOffsets(): void
+    {
+        self::assertSame('2026-01-01T00:00:00+14:00', V::isoDatetime('2026-01-01T00:00:00+14:00'));
+        self::assertSame('2026-01-01T00:00:00-12:00', V::isoDatetime('2026-01-01T00:00:00-12:00'));
+    }
+
     // ── V::futureDatetime ────────────────────────────────────────────────────
 
     public function testFutureDatetimeAcceptsFuture(): void
@@ -286,6 +301,24 @@ final class VTest extends TestCase
     {
         self::assertNull(V::futureDatetime('2024-01-15', '2024-01-01T00:00:00+00:00'));
         self::assertNull(V::futureDatetime(null, '2024-01-01T00:00:00+00:00'));
+    }
+
+    public function testFutureDatetimeComparesByInstantAcrossOffsets(): void
+    {
+        // raw is midnight in +09:00 = 2026-05-31T15:00:00Z, which is BEFORE $now
+        // (16:00Z). Lexicographic string compare would wrongly call it future.
+        $raw = '2026-06-01T00:00:00+09:00';
+        $now = '2026-05-31T16:00:00+00:00';
+        self::assertNull(V::futureDatetime($raw, $now));
+
+        // The same instant one hour later than $now is correctly accepted.
+        $future = '2026-06-01T02:00:00+09:00'; // = 2026-05-31T17:00:00Z
+        self::assertSame($future, V::futureDatetime($future, $now));
+    }
+
+    public function testFutureDatetimeRejectsUnparseableNow(): void
+    {
+        self::assertNull(V::futureDatetime('2026-06-01T00:00:00+00:00', 'not-a-datetime'));
     }
 
     // ── V::enum ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 目的

`V::isoDatetime()` の範囲外オフセット許容と `V::futureDatetime()` の字句比較バグを修正する。

## 問題（いずれも実測確認済み）

**Bug 1** — `isoDatetime('2026-01-01T00:00:00+25:00')` が `'+25:00'` を**有効として返す**。正規表現 `[+-]\d{2}:\d{2}` が時間部 00–99 を通すため。

**Bug 2** — `futureDatetime()` の `$dt > $now`（文字列比較）は TZ オフセットが異なると誤判定。
- `raw = 2026-06-01T00:00:00+09:00`（= 2026-05-31T15:00:00Z、過去）vs `now = 2026-05-31T16:00:00+00:00` → 字句比較は `true`（未来扱い、誤り）

## 変更点

- `isoDatetime()`: オフセット絶対値が `±14:00` を超えるものを拒否（実在 TZ は全て範囲内）。分 ≥ 60 は従来どおり round-trip 再フォーマットで拒否。
- `futureDatetime()`: `DateTimeImmutable` の instant 比較に変更。`$now` がパース不能なら `null`。docblock も更新。
- テスト追加: 範囲外/境界オフセット、クロスオフセット未来判定、パース不能 `$now`。
- CHANGELOG `[Unreleased] > Fixed` に追記。

## 検証

`composer check` 全グリーン: **441 tests / 1017 assertions**、PHPStan L8 no errors、CS clean、OpenAPI/MCP valid、version 1.5.326 consistent。VTest 単体 67 tests green。

既存の同一オフセット `futureDatetime` テストは不変で通過 — 後方互換（正しい使い方は維持、クロスオフセットが正される bugfix）。

Closes #1351

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)