### PR TITLE
chore(release): v1.5.327

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.5.327] — 2026-05-29
+
 ### Added
 - `Nene2\Testing\DatabaseTestKit` — テスト用 DB 配線ヘルパー（stable public API）。`PdoConnectionFactory` / `PdoDatabaseQueryExecutor` / `PdoDatabaseTransactionManager` をまとめて配線し、3 つのインターフェースを readonly コンストラクタプロパティで公開。`DatabaseTestKit::sqlite($path)` は `:memory:` を明示的に拒否し、`transactional()` 非互換罠（IMP-18）を構造的に塞ぐ。`fromConfig(DatabaseConfig)` で任意 adapter にも対応（IMP-14 / ADR 0012 / #1307）
 - `docs/adr/0012-sanctioned-test-database-wiring.md` — `Nene2\Testing` 名前空間導入の決定記録

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.326
+  version: 1.5.327
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.326';
+    public const string VERSION = '1.5.327';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的

`[Unreleased]` の変更を **v1.5.327** として確定し、Packagist にリリースする準備をする。

## 含まれる変更

- **Added**: `Nene2\Testing\DatabaseTestKit`（stable public API, ADR 0012 / #1307）、`Nene2\Config\DatabaseConfig::sqlite()`（#1303）
- **Changed**: ADR 0009 の stable API 表更新
- **Fixed**: `V::isoDatetime()` の範囲外オフセット許容、`V::futureDatetime()` の字句比較バグ（#1351 / #1352）

## バージョン整合

`FrameworkInfo::VERSION` / `openapi.yaml info.version` / CHANGELOG 先頭リリース見出しを全て `1.5.327` に統一。新しい空 `[Unreleased]` を追加。

## 検証

`composer validate` OK、`composer check` 全グリーン（441 tests / 1017 assertions、PHPStan L8、CS、OpenAPI、MCP、version:check `Version consistency OK: 1.5.327`）、`git diff --check` clean。

## リリース手順（マージ後）

`main` から `v1.5.327` をタグ → `gh release create` → Packagist 反映確認。

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)