### PR TITLE
docs(daily): 2026-05-29 日報を追加

### DIFF
--- a/docs/daily/2026-05-29.md
+++ b/docs/daily/2026-05-29.md
@@ -1,0 +1,79 @@
+# 日報 — 2026-05-29
+
+## 作業時間帯
+
+2026-05-29（コンテキスト引き継ぎで継続）。NENE2-examples の field-trial 量産から、検出バグの本体修正・リリース・索引整備まで。
+
+---
+
+## 本日の成果
+
+### 1. NENE2-examples — field-trial 量産を完了（125 dir 到達）
+
+スタブ（README のみ）だった FT178–190 を実装で埋め、FT142 の欠番を解消。さらに distinct トピックを枯渇まで掘り切った。
+
+| FT | アプリ | テーマ |
+|----|--------|--------|
+| 142 | draftlog | コンテンツ下書きライフサイクル（enum 状態機械・存在隠蔽 404） |
+| 189 | consentlog | 同意管理（冪等 UPSERT・append-only 履歴・列挙耐性） |
+| 190 | announcelog | システムアナウンス（hash_equals admin・時刻窓・冪等 dismiss） |
+| 212 | productlog | 商品カタログ（ATK-01〜12 ハードニング） |
+| 216 | reservationlog | 予約/タイムスロット（半開区間オーバーラップ・IDOR ビュー） |
+| 217 | polllog | 投票（一人一票 UNIQUE・クロスポール option 注入防御） |
+| 233 | cqrslog | CQRS（正規化 write / VIEW read 分離・command-then-query） |
+| 246 | timelog | タイムトラッキング（end_time IS NULL・シングルトン・日次集計） |
+| 72 | deadletterlog | デッドレターキュー（指数バックオフ・DLQ・原子的 claim） |
+| 254 | ftslog | SQLite FTS5 全文検索（仮想テーブル + トリガ・MATCH/rank） |
+| 287 | waitlistlog | 順番待ち（UNIQUE 一人一エントリ・終端状態機械・位置追跡） |
+| 301 | contentlog | コンテンツネゴシエーション（常時 JSON・problem+json・415） |
+| 345 | unicodelog | Unicode 安全テキスト（mb_strlen・null バイト・VULN-01〜08） |
+| 51 | statslog | イベント分析（json_extract・strftime バケット・DAU） |
+| 250 | tagfilterlog | 複数タグフィルタ（AND/OR セマンティクス・CSV と tags[] 両対応） |
+| 85 | bulkupdatelog | 一括ステータス更新（部分成功・FT231 VULN ハードニング） |
+| — | ratelog | スライディングウィンドウ レートリミッタ（窓のスライド実証・ATK-01〜12） |
+
+各 example は **PHPUnit 緑 / PHPStan level 8 / PHP-CS-Fixer クリーン**。毎回トピック重複チェックを実施し、既存 `*log` の近重複は作らず。残り ~37 howto は全て重複と判定（マッピング表は `BACKFILL.md`）→ **backlog 完了**。
+
+### 2. 不具合検出 → 本体修正（NENE2、全マージ済み）
+
+example が検証層として実際にコア/howto バグを 3 件あぶり出した。
+
+| PR | 内容 | 検出元 |
+|----|------|--------|
+| #1348 | `time-tracking` howto の `julianday` 集計が秒数を切り捨て（60→59）→ `strftime('%s')` に修正（全6言語） | timelog |
+| #1350 | `sqlite-fts5-search` howto「暗黙 OR」誤記 → 実際は AND に訂正（全6言語） | ftslog |
+| #1352 | `V::isoDatetime` の範囲外オフセット許容 / `V::futureDatetime` の文字列比較バグ修正（instant 比較 + ±14:00 境界） | reminderlog |
+
+関連 Issue: #1347 / #1349 / #1351
+
+### 3. リリース v1.5.327（NENE2）
+
+PR #1353。リリースチェックリスト準拠：版数整合（FrameworkInfo / openapi / CHANGELOG）、`composer check` 全緑（**441 tests / 1017 assertions**、PHPStan、CS、OpenAPI、MCP）、タグ作成、GitHub Release、**Packagist 反映確認**まで完了。リリース後、`reminderlog`/`announcelog`/`reservationlog`/`timelog` の `V` 回避コードを撤去し `^1.5.327` に固定（全緑確認）。
+
+### 4. カタログ索引の自動生成化（NENE2-examples）
+
+手書き索引が 80/124 に劣化していた問題を発見。`tools/build-index.php`（composer.json の FT番号 + README から生成、`--check` で drift 検出）を新規作成し、トップ README に **全125本**の索引（FT順・🛡️ セキュリティ印・howto リンク）を生成。運用ルールを `BACKFILL.md` に記録。
+
+---
+
+## 数値
+
+- examples: **125 dir**（うち 22 本が ATK/VULN セキュリティ評価付き）
+- 本体: テスト 441 / アサーション 1017、PHPStan level 8 クリーン
+- マージ PR 4 件 / 新規 Issue 3 件 / リリース 1 件（v1.5.327）
+
+---
+
+## 残課題（次回以降）
+
+| 優先 | 内容 |
+|------|------|
+| P1 | NENE2-examples に CI が無い。`--check` / phpunit が手動頼み → GitHub Actions 導入で drift・退行を自動検知したい |
+| P2 | `composer.lock` の方針不整合（BACKFILL recipe はコミット推奨、実運用は削除）→ 統一 |
+| P3 | backfill は完了。新規 howto 追加時は `BACKFILL.md` の重複マッピング表と照合してから着手 |
+
+---
+
+## 所感
+
+派手な新機能はないが、「散らかっていたものを見つけ、根本から直し、再発しない形にした」一日。特に example が実際にコアバグを 3 件あぶり出し、「howto に書く前に検証する」という検証層としての存在意義をそのまま実証できた点に手応えあり。`#1352` はコア修正 → v1.5.327 リリース → example の回避撤去まで通し切れた。両リポジトリともクリーンで区切りは良好。


### PR DESCRIPTION
## 目的

本日（2026-05-29）の作業日報を `docs/daily/2026-05-29.md` に追加する。

## 内容

- NENE2-examples の field-trial 量産完了（**125 dir**、distinct トピック枯渇）
- example 由来のコア/howto バグ修正（#1348 julianday / #1350 FTS5 / #1352 V 日時）— 全マージ済み
- **v1.5.327 リリース**（Packagist 反映確認）と example 回避コード撤去
- カタログ索引の自動生成化（`tools/build-index.php`、NENE2-examples 側）

既存の `docs/daily/YYYY-MM-DD.md` フォーマットに準拠。ドキュメント追加のみ。

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)