### PR TITLE
fix(http): framework エラーの Problem Details base URL を設定可能にする (#1355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `Nene2\Http\RuntimeApplicationFactory` — framework レベルの Problem Details（`validation-failed` / 404 / 405 / 413 / 500 等）が `PROBLEM_DETAILS_BASE_URL` を無視して常に `https://nene2.dev/problems/` を返していたバグを修正。`$problemDetailsBaseUrl` コンストラクタ引数（既定 `https://nene2.dev/problems/`）を追加し、内部の `ProblemDetailsResponseFactory` へ配線。consumer は `AppConfig::$problemDetailsBaseUrl` を渡すだけで framework / domain 双方の Problem `type` namespace が揃う。既定値は据え置きのため既存 consumer は無変更で従来動作（#1355）
+
 ---
 
 ## [1.5.327] — 2026-05-29

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -75,6 +75,12 @@ final readonly class RuntimeApplicationFactory
      *                                 this limit are rejected with a 413 Problem Details response.
      *                                 Defaults to 1 MiB (1 048 576 bytes). Increase for bulk-import
      *                                 or large-payload endpoints.
+     * @param string $problemDetailsBaseUrl Base URL prefixed to the `type` field of framework-level
+     *                                       Problem Details responses (validation failures, 404, 405,
+     *                                       413, 500, etc.). Pass `AppConfig::$problemDetailsBaseUrl`
+     *                                       (env `PROBLEM_DETAILS_BASE_URL`) so framework and domain
+     *                                       errors share the same `type` namespace. Defaults to
+     *                                       `https://nene2.dev/problems/` for backward compatibility.
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
@@ -94,6 +100,7 @@ final readonly class RuntimeApplicationFactory
         private array $machineApiKeyProtectedPathPrefixes = [],
         private array $machineApiKeyProtectedMethods = [],
         private int $requestMaxBodyBytes = 1_048_576,
+        private string $problemDetailsBaseUrl = 'https://nene2.dev/problems/',
     ) {
     }
 
@@ -114,7 +121,11 @@ final readonly class RuntimeApplicationFactory
         ]);
 
         $jsonResponses = new JsonResponseFactory($this->responseFactory, $this->streamFactory);
-        $problemDetails = new ProblemDetailsResponseFactory($this->responseFactory, $this->streamFactory);
+        $problemDetails = new ProblemDetailsResponseFactory(
+            $this->responseFactory,
+            $this->streamFactory,
+            $this->problemDetailsBaseUrl,
+        );
         $framework = new FrameworkInfo();
 
         $router = (new Router())

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -49,6 +49,22 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame('Not Found', $payload['title']);
     }
 
+    public function testProblemDetailsBaseUrlAppliesToFrameworkErrors(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            problemDetailsBaseUrl: 'https://example.dev/problems/',
+        ))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/missing'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertSame('https://example.dev/problems/not-found', $payload['type']);
+    }
+
     public function testHealthEndpointRunsThroughRuntime(): void
     {
         $factory = new Psr17Factory();


### PR DESCRIPTION
## 目的

Closes #1355

`RuntimeApplicationFactory::create()` が内部の `ProblemDetailsResponseFactory` を base URL 既定値固定で生成していたため、framework レベルの Problem Details（`validation-failed` / 404 / 405 / 413 / 500 等）が `PROBLEM_DETAILS_BASE_URL` を無視して常に `https://nene2.dev/problems/` を返していた。ドメインエラー（`DomainExceptionHandlerInterface` 経由）のみアプリ base に揃い、同一 API で Problem `type` namespace が食い違っていた。

## 変更点

- `RuntimeApplicationFactory` に `$problemDetailsBaseUrl` コンストラクタ引数（既定 `https://nene2.dev/problems/`）を追加。
- `create()` 内で内部 `ProblemDetailsResponseFactory` にこの値を配線。`ErrorHandlerMiddleware` / `RequestSizeLimitMiddleware` / `ApiKeyAuthenticationMiddleware` が共有する `$problemDetails` 経由で framework エラー全体に反映される。
- consumer は `AppConfig::$problemDetailsBaseUrl`（= env `PROBLEM_DETAILS_BASE_URL`）を渡すだけで framework / domain 双方の Problem `type` namespace が揃う。
- テスト追加: `testProblemDetailsBaseUrlAppliesToFrameworkErrors`（custom base で 404 の `type` が `https://example.dev/problems/not-found` になることを検証）。
- CHANGELOG `[Unreleased]` に Fixed エントリを追加。

## 後方互換性

既定値は現状どおり `https://nene2.dev/problems/` のため、引数を渡さない既存 consumer は**無変更で従来動作**。

## 検証結果

```
docker compose run --rm app composer check
→ OK (442 tests, 1020 assertions) / PHPStan level 8 0 errors / CS 0 / OpenAPI valid / MCP valid
```

## Self-review

backend-api, middleware-security