### PR TITLE
test(http): framework Problem base URL の validation-failed 経路を検証 (#1357)

### DIFF
--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -9,6 +9,8 @@ use Nene2\Http\HealthStatus;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -63,6 +65,39 @@ final class HttpRuntimeTest extends TestCase
 
         self::assertSame(404, $response->getStatusCode());
         self::assertSame('https://example.dev/problems/not-found', $payload['type']);
+    }
+
+    public function testProblemDetailsBaseUrlAppliesToValidationFailures(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            routeRegistrars: [
+                static function (Router $router): void {
+                    $router->get(
+                        '/validate',
+                        static function (ServerRequestInterface $req): ResponseInterface {
+                            throw new ValidationException([
+                                new ValidationError('name', 'name is required', 'required'),
+                            ]);
+                        },
+                    );
+                },
+            ],
+            problemDetailsBaseUrl: 'https://example.dev/problems/',
+        ))->create();
+
+        $response = $application->handle($factory->createServerRequest('GET', 'https://example.test/validate'));
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertSame('application/problem+json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertSame('https://example.dev/problems/validation-failed', $payload['type']);
+        self::assertSame('Validation Failed', $payload['title']);
+        self::assertSame([
+            ['field' => 'name', 'message' => 'name is required', 'code' => 'required'],
+        ], $payload['errors']);
     }
 
     public function testHealthEndpointRunsThroughRuntime(): void


### PR DESCRIPTION
## 目的

Closes #1357

#1355 / #1356 で `RuntimeApplicationFactory` の `$problemDetailsBaseUrl` を framework エラーへ配線したが、回帰テストは **404（not-found）経路**のみだった。Issue #1355 が主眼に置いた **`validation-failed`（`ValidationException` → `ErrorHandlerMiddleware`）経路**を直接アサートする補強テストを追加する。

## 変更点

- `tests/HttpRuntimeTest.php` に `testProblemDetailsBaseUrlAppliesToValidationFailures` を追加。custom base（`https://example.dev/problems/`）で `ValidationException` を投げるルートを登録し、以下を検証:
  - status `422`
  - `Content-Type: application/problem+json; charset=utf-8`
  - `type = https://example.dev/problems/validation-failed`
  - `title = Validation Failed`
  - `errors` 配列の中身

テストのみの変更のため CHANGELOG / OpenAPI は無変更。

## 検証結果

```
docker compose run --rm app composer check
→ OK (443 tests, 1026 assertions) / PHPStan level 8 No errors / CS 0 / OpenAPI valid / MCP valid
```

## Self-review

backend-api