### PR TITLE
chore(release): v1.5.328 (#1359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.5.328] — 2026-05-30
+
 ### Fixed
 - `Nene2\Http\RuntimeApplicationFactory` — framework レベルの Problem Details（`validation-failed` / 404 / 405 / 413 / 500 等）が `PROBLEM_DETAILS_BASE_URL` を無視して常に `https://nene2.dev/problems/` を返していたバグを修正。`$problemDetailsBaseUrl` コンストラクタ引数（既定 `https://nene2.dev/problems/`）を追加し、内部の `ProblemDetailsResponseFactory` へ配線。consumer は `AppConfig::$problemDetailsBaseUrl` を渡すだけで framework / domain 双方の Problem `type` namespace が揃う。既定値は据え置きのため既存 consumer は無変更で従来動作（#1355）
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.327
+  version: 1.5.328
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.327';
+    public const string VERSION = '1.5.328';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的

Closes #1359

`[Unreleased]` を `v1.5.328` として確定するリリース PR。

## 含まれる変更

- fix(http): framework レベル Problem Details の base URL を設定可能に（#1355 / #1356）
- test(http): validation-failed 経路の回帰テスト追加（#1357 / #1358）

## 変更点

- `FrameworkInfo::VERSION` → `1.5.328`
- `docs/openapi/openapi.yaml` `info.version` → `1.5.328`
- `CHANGELOG.md` `[Unreleased]` を `[1.5.328] — 2026-05-30` として確定、新しい空 `[Unreleased]` を追加

## 検証結果

```
docker compose run --rm app composer validate   → ./composer.json is valid
docker compose run --rm app composer check       → OK (443 tests, 1026 assertions) / PHPStan No errors / OpenAPI valid / MCP valid / Version consistency OK: 1.5.328
git diff --check                                 → clean
```

## Self-review

release-ci