### PR TITLE
chore(release): v1.5.329 (#1361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.5.329] — 2026-05-31
+
 ### Fixed
 - `docker/php/Dockerfile` — `output_buffering=4096` / `display_errors=Off` / `log_errors=On` / `expose_php=Off` を追加。PHP 起動時 Warning がレスポンスに漏洩しセキュリティヘッダーを無効化していた問題（FIND-01 / #1361）
 - `docker/php/Dockerfile` — `ServerTokens Prod` / `ServerSignature Off` / `Header always unset X-Powered-By` を Apache に追加。サーバー構成情報（Apache バージョン・PHP バージョン）がレスポンスヘッダーに露出していた問題（FIND-03 / #1361）

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.328
+  version: 1.5.329
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.328';
+    public const string VERSION = '1.5.329';
 
     public function name(): string
     {


### PR DESCRIPTION
セキュリティ修正リリース v1.5.329 のバージョンバンプと CHANGELOG 更新。

- `src/FrameworkInfo.php` — VERSION 1.5.328 → 1.5.329
- `docs/openapi/openapi.yaml` — version 1.5.328 → 1.5.329
- `CHANGELOG.md` — [Unreleased] を [1.5.329] — 2026-05-31 に確定

Closes #1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)