### PR TITLE
ci(deps): dependabot で React 関連を 1 グループにまとめる (#1384)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,10 @@ updates:
     labels:
       - dependencies
       - frontend
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"


### PR DESCRIPTION
## 目的
#1376 は `react` を上げる一方 `react-dom` を据え置き、バージョン不一致でフロントテストが失敗した（#1383 で修正）。dependabot のグルーピングで再発を防ぐ。

## 変更点
`.github/dependabot.yml` の `/frontend` npm 設定に `groups` を追加:
- `react` / `react-dom` / `@types/react` / `@types/react-dom` を 1 つの PR にまとめて更新

## 効果
React ランタイムと型定義が常に揃って bump されるため、`Incompatible React versions` 系の CI 失敗が起きなくなる。

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)