### PR TITLE
docs: ドキュメントの鮮度と整合性を回復（ポート 8080→8200・ガイド数 256→260）(#1393)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 PHP micro-framework: JSON APIs first, minimal server HTML, easy React starter integration, structure friendly to AI tooling.
 
-**[OpenAPI contract](https://raw.githubusercontent.com/hideyukiMORI/NENE2/main/docs/openapi/openapi.yaml)** — machine-readable API spec (OpenAPI 3.1). Live Swagger UI at `http://localhost:8080/docs/` after `docker compose up -d app`.
+**[OpenAPI contract](https://raw.githubusercontent.com/hideyukiMORI/NENE2/main/docs/openapi/openapi.yaml)** — machine-readable API spec (OpenAPI 3.1). Live Swagger UI at `http://localhost:8200/docs/` after `docker compose up -d app`.
 
 NENE2 is a small, modern PHP framework foundation designed for projects that want to ship JSON APIs quickly, keep server-rendered HTML thin, and add a React frontend starter without turning the backend into frontend build glue.
 
@@ -74,14 +74,14 @@ Start the local web runtime:
 docker compose up -d app
 ```
 
-The web entry point is served from `public_html/` at `http://localhost:8080/`.
+The web entry point is served from `public_html/` at `http://localhost:8200/`.
 
 Useful local URLs:
 
-- API health: `http://localhost:8080/health`
-- Example endpoint: `http://localhost:8080/examples/ping`
-- OpenAPI: `http://localhost:8080/openapi.php`
-- Swagger UI: `http://localhost:8080/docs/`
+- API health: `http://localhost:8200/health`
+- Example endpoint: `http://localhost:8200/examples/ping`
+- OpenAPI: `http://localhost:8200/openapi.php`
+- Swagger UI: `http://localhost:8200/docs/`
 
 Run optional real MySQL verification when database adapter behavior should be checked against a service database:
 
@@ -106,7 +106,7 @@ docker compose run --rm app composer test:database:mysql
 | OpenAPI | `docs/openapi/openapi.yaml` — `GET/POST/PUT/DELETE /examples/notes` paths |
 | Tests | `tests/Example/Note/` — unit, HTTP-level, PDO integration |
 
-All Note endpoints are live at `http://localhost:8080/examples/notes` after `docker compose up -d app`.
+All Note endpoints are live at `http://localhost:8200/examples/notes` after `docker compose up -d app`.
 
 ---
 
@@ -188,7 +188,7 @@ NENE2's quality baseline includes PHP-CS-Fixer for backend style checks and npm,
 
 ## How-to guides
 
-256 task-focused guides covering authentication, security, database patterns, API design, background jobs, and 100+ product feature recipes.
+260 task-focused guides covering authentication, security, database patterns, API design, background jobs, and 100+ product feature recipes.
 
 **[Full guide index →](docs/howto/README.md)**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Step-by-step guides that get you from zero to a working result. Follow in order.
 
 Goal-oriented guides. Pick the one that matches what you need to do.
 
-- [**Full howto index (100 guides)**](howto/README.md) — categorized catalog of all pattern guides
+- [**Full howto index (260 guides)**](howto/README.md) — categorized catalog of all pattern guides
 - [Add a custom route](howto/add-custom-route.md) — GET, POST, path parameters, query strings
 - [Add a database-backed endpoint](howto/add-database-endpoint.md) — UseCase → Repository → Handler pattern
 

--- a/docs/de/development/endpoint-scaffold.md
+++ b/docs/de/development/endpoint-scaffold.md
@@ -92,7 +92,7 @@ docker compose run --rm app composer check
 Für über Docker bereitgestellte Endpunkte einen lokalen Smoke-Check ausführen:
 
 ```bash
-curl -i http://localhost:8080/examples/ping
+curl -i http://localhost:8200/examples/ping
 ```
 
 ## Beziehung zu MCP

--- a/docs/de/development/setup.md
+++ b/docs/de/development/setup.md
@@ -52,7 +52,7 @@ docker compose up -d app
 Prüfen, ob er läuft:
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 Erwartete Antwort:
@@ -65,12 +65,12 @@ Andere nützliche lokale Endpunkte:
 
 | URL | Beschreibung |
 |---|---|
-| `http://localhost:8080/` | Framework-Informationen |
-| `http://localhost:8080/health` | Gesundheitsprüfung |
-| `http://localhost:8080/examples/ping` | Ping-Beispiel |
-| `http://localhost:8080/examples/notes/{id}` | Notiz nach ID (benötigt DB) |
-| `http://localhost:8080/openapi.php` | Raw OpenAPI JSON |
-| `http://localhost:8080/docs/` | Swagger UI |
+| `http://localhost:8200/` | Framework-Informationen |
+| `http://localhost:8200/health` | Gesundheitsprüfung |
+| `http://localhost:8200/examples/ping` | Ping-Beispiel |
+| `http://localhost:8200/examples/notes/{id}` | Notiz nach ID (benötigt DB) |
+| `http://localhost:8200/openapi.php` | Raw OpenAPI JSON |
+| `http://localhost:8200/docs/` | Swagger UI |
 
 ## 5. Server stoppen
 
@@ -97,7 +97,7 @@ Der Endpunkt `/machine/health` erfordert einen API-Schlüssel. Zum lokalen Teste
 3. Den geschützten Endpunkt aufrufen:
 
 ```bash
-curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
+curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8200/machine/health
 ```
 
 ## Optional: Frontend-Einrichtung
@@ -120,7 +120,7 @@ Jede Anfrage erzeugt eine `X-Request-Id`, die im Antwort-Header zurückgegeben u
 1. App starten: `docker compose up -d app`
 2. Anfrage senden:
    ```bash
-   curl -i http://localhost:8080/health
+   curl -i http://localhost:8200/health
    # X-Request-Id in den Antwort-Headern suchen
    ```
 3. Strukturierte Log-Ausgabe beobachten:
@@ -131,7 +131,7 @@ Jede Anfrage erzeugt eine `X-Request-Id`, die im Antwort-Header zurückgegeben u
 
 Sie können auch Ihre eigene ID angeben:
 ```bash
-curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
+curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8200/health
 ```
 
 ## Fehlerbehebung
@@ -139,11 +139,11 @@ curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
 **`composer check` schlägt bei einem sauberen Klon fehl**
 Führen Sie zuerst `docker compose run --rm app composer install` aus. Das `vendor/`-Verzeichnis ist nicht versioniert.
 
-**Port 8080 bereits belegt**
+**Port 8200 bereits belegt**
 Stoppen Sie was ihn nutzt, oder ändern Sie die Port-Zuordnung in `compose.yaml`:
 ```yaml
 ports:
-  - "8081:80"   # stattdessen 8081 verwenden
+  - "8201:80"   # stattdessen 8201 verwenden
 ```
 
 **MySQL-Verbindung bei Migrationen abgelehnt**

--- a/docs/de/howto/add-mcp-tools.md
+++ b/docs/de/howto/add-mcp-tools.md
@@ -55,7 +55,7 @@ composer mcp
 ## 4. MCP-Server starten
 
 ```bash
-NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_API_BASE_URL=http://localhost:8200 \
 NENE2_LOCAL_JWT_SECRET=your-local-secret \
 php vendor/hideyukimori/nene2/tools/local-mcp-server.php
 ```

--- a/docs/de/howto/budget-tracking.md
+++ b/docs/de/howto/budget-tracking.md
@@ -184,8 +184,8 @@ ORDER BY total DESC
 **Angriff**: Alle Konten ohne Anmeldeinformationen auflisten.
 
 ```bash
-curl -s http://localhost:8080/accounts
-curl -s http://localhost:8080/accounts/1/transactions
+curl -s http://localhost:8200/accounts
+curl -s http://localhost:8200/accounts/1/transactions
 ```
 
 **Beobachtet**: Beide Endpunkte geben Daten ohne Authentifizierung zurück. Jeder Aufrufer kann alle Konten und ihre Salden enumerieren.
@@ -316,7 +316,7 @@ Die `balance`-Spalte endet bei `20` statt dem korrekten `-60` — aber noch krit
 **Angriff**: Transaktionen lesen, die einem anderen Benutzerkonto gehören.
 
 ```bash
-curl -s http://localhost:8080/accounts/2/transactions
+curl -s http://localhost:8200/accounts/2/transactions
 ```
 
 **Beobachtet**: Der Endpunkt gibt alle Transaktionen für Konto 2 ohne Eigentümerprüfung zurück. Da keine Authentifizierung vorhanden ist, kann jeder Aufrufer jedes Konto lesen.

--- a/docs/de/howto/content-approval-workflow.md
+++ b/docs/de/howto/content-approval-workflow.md
@@ -146,8 +146,8 @@ Ein leerer Body `{}` oder ein fehlendes `reason`-Feld führen beide zu `null`. E
 **Angriff**: Einen Post ohne Anmeldedaten genehmigen oder ablehnen.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/reject
 ```
 
 **Beobachtet**: Beide gelingen mit `200 OK`. Jeder Aufrufer kann jeden Post durch jeden erlaubten Übergang schieben.
@@ -161,7 +161,7 @@ curl -X POST http://localhost:8080/posts/1/reject
 **Angriff**: Versuchen, einen Post im `draft`-Status zu genehmigen.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve
 # Post 1 befindet sich im Draft-Status
 ```
 
@@ -176,9 +176,9 @@ curl -X POST http://localhost:8080/posts/1/approve
 **Angriff**: Einen Post ein zweites Mal genehmigen.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/approve  # zweite Genehmigung
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve  # zweite Genehmigung
 ```
 
 **Beobachtet**: Dritte Anfrage: `canTransitionTo(Approved)` von `Approved` → `false` → `409 Conflict`. Der Post verbleibt im `Approved`-Status.
@@ -296,9 +296,9 @@ POST /posts/1.5/approve
 **Angriff**: Mit leerem Body oder ohne `reason`-Feld ablehnen.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject -d '{}'
-curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject -d '{}'
+curl -X POST http://localhost:8200/posts/1/reject -d '{"reason": ""}'
 ```
 
 **Beobachtet**: Alle drei Fälle erzeugen `null` für `reject_reason`. Ablehnung ohne Grund wird akzeptiert — die Spalte ist nullable.
@@ -312,9 +312,9 @@ curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
 **Angriff**: Versuchen, einen bereits abgelehnten Post abzulehnen.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject  # zweite Ablehnung
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject  # zweite Ablehnung
 ```
 
 **Beobachtet**: `canTransitionTo(Rejected)` von `Rejected` → `false` → `409 Conflict`.

--- a/docs/de/howto/multilingual-content.md
+++ b/docs/de/howto/multilingual-content.md
@@ -188,7 +188,7 @@ Wichtige Designentscheidungen:
 **Angriff**: Artikel ohne Anmeldedaten erstellen oder ändern.
 
 ```bash
-curl -s -X POST http://localhost:8080/articles \
+curl -s -X POST http://localhost:8200/articles \
   -H 'Content-Type: application/json' \
   -d '{"default_locale":"en","published":true}'
 ```
@@ -238,7 +238,7 @@ PUT /articles/1/translations/en" OR "1"="1
 
 ```bash
 # Angreifer kennt Artikel-ID 1, die von einem anderen Benutzer erstellt wurde
-curl -s -X PUT http://localhost:8080/articles/1/translations/fr \
+curl -s -X PUT http://localhost:8200/articles/1/translations/fr \
   -H 'Content-Type: application/json' \
   -d '{"title":"Hacked","body":"Attacker content"}'
 ```
@@ -327,7 +327,7 @@ PUT /articles/1/translations/fra       → Dreistelliger ISO-639-2-Code
 **Angriff**: Eine Artikel-ID angeben, die nicht existiert.
 
 ```bash
-curl -s -X PUT http://localhost:8080/articles/99999/translations/en \
+curl -s -X PUT http://localhost:8200/articles/99999/translations/en \
   -H 'Content-Type: application/json' \
   -d '{"title":"Ghost","body":"Body"}'
 ```

--- a/docs/de/howto/note-management-ownership.md
+++ b/docs/de/howto/note-management-ownership.md
@@ -115,10 +115,10 @@ CREATE INDEX IF NOT EXISTS idx_notes_owner ON notes (owner_id);
 **Angriff**: Einen anderen Benutzer imitieren, indem ihre Benutzer-ID im Header gesendet wird.
 
 ```bash
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: alice'
 
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: bob'
 ```
 
@@ -147,7 +147,7 @@ X-Auth-User: alice\r\nX-Injected: evil
 **Angriff**: Notiz-IDs eines anderen Benutzers erraten oder enumerieren.
 
 ```bash
-curl -s http://localhost:8080/notes/1 -H 'X-Auth-User: bob'
+curl -s http://localhost:8200/notes/1 -H 'X-Auth-User: bob'
 # Notiz 1 wurde von alice erstellt
 ```
 
@@ -191,7 +191,7 @@ curl -s http://localhost:8080/notes/1 -H 'X-Auth-User: bob'
 **Angriff**: Eine Anfrage ohne den `X-Auth-User`-Header senden.
 
 ```bash
-curl -s http://localhost:8080/notes
+curl -s http://localhost:8200/notes
 ```
 
 **Beobachtet**: `getHeaderLine('X-Auth-User')` gibt `""` zurück. Nach `trim()` ist es immer noch `""`. `$userId !== ''` schlägt fehl → `resolveAuthUser()` gibt `null` zurück → `401 Unauthorized` mit einer strukturierten Problem-Details-Antwort.
@@ -206,7 +206,7 @@ curl -s http://localhost:8080/notes
 
 ```bash
 # Angenommen, 'admin' ist ein spezieller Benutzer
-curl -s -X POST http://localhost:8080/notes \
+curl -s -X POST http://localhost:8200/notes \
   -H 'X-Auth-User: admin' \
   -H 'Content-Type: application/json' \
   -d '{"title":"Admin note"}'
@@ -269,8 +269,8 @@ GET /notes/1.5
 **Angriff**: Eine Notiz-ID löschen, die nicht existiert oder einem anderen Benutzer gehört.
 
 ```bash
-curl -s -X DELETE http://localhost:8080/notes/99999 -H 'X-Auth-User: alice'
-curl -s -X DELETE http://localhost:8080/notes/1    -H 'X-Auth-User: eve'
+curl -s -X DELETE http://localhost:8200/notes/99999 -H 'X-Auth-User: alice'
+curl -s -X DELETE http://localhost:8200/notes/1    -H 'X-Auth-User: eve'
 # (Notiz 1 gehört alice)
 ```
 

--- a/docs/de/howto/state-machine-audit-log.md
+++ b/docs/de/howto/state-machine-audit-log.md
@@ -192,7 +192,7 @@ Die Liste ist nach `id ASC` geordnet, sodass die Historie chronologisch ist.
 **Angriff**: Aufträge erstellen und Übergänge ohne Anmeldedaten anwenden.
 
 ```bash
-curl -s -X POST http://localhost:8080/orders/1/transitions \
+curl -s -X POST http://localhost:8200/orders/1/transitions \
   -H 'Content-Type: application/json' \
   -d '{"status":"approved"}'
 ```

--- a/docs/de/howto/webhook-delivery-api.md
+++ b/docs/de/howto/webhook-delivery-api.md
@@ -225,7 +225,7 @@ POST /deliveries/9999/retry
 
 ### ATK-02 — Webhook mit interner/privater URL registrieren (SSRF) ⚠️ EXPOSED
 
-**Attack**: Angreifer registriert `url: "http://169.254.169.254/latest/meta-data"` (AWS-Metadaten-Endpunkt) oder `http://localhost:8080/admin`. Wenn ein Event ausgelöst wird, ruft der Server die interne URL ab.
+**Attack**: Angreifer registriert `url: "http://169.254.169.254/latest/meta-data"` (AWS-Metadaten-Endpunkt) oder `http://localhost:8200/admin`. Wenn ein Event ausgelöst wird, ruft der Server die interne URL ab.
 **Result**: EXPOSED — Das webhooklog-FT implementiert keine URL-Validierung oder SSRF-Blockierung für registrierte URLs. In der Produktion muss validiert werden, dass die URL auf eine öffentliche IP aufgelöst wird (kein Loopback, privates RFC1918, Link-Local oder Metadatendienste) vor der Registrierung. Siehe `docs/howto/url-shortener-ssrf-prevention.md` für das SSRF-Blockierungsmuster.
 
 ---

--- a/docs/de/integrations/local-mcp-client-configuration.md
+++ b/docs/de/integrations/local-mcp-client-configuration.md
@@ -16,7 +16,7 @@ docker compose up -d app
 Prüfen, ob die API erreichbar ist:
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 Der MCP-Server ist ein stdio-Prozess. Kein HTTP-Server — er muss vom MCP-Client gestartet werden.

--- a/docs/de/integrations/local-mcp-server.md
+++ b/docs/de/integrations/local-mcp-server.md
@@ -23,10 +23,10 @@ NENE2 enthält einen nur-lokalen stdio-MCP-Server:
 docker compose run --rm app php tools/local-mcp-server.php
 ```
 
-Ruft standardmäßig die lokale API unter `http://localhost:8080` auf. Basis-URL bei Bedarf außerhalb des Repositories überschreiben:
+Ruft standardmäßig die lokale API unter `http://localhost:8200` auf. Basis-URL bei Bedarf außerhalb des Repositories überschreiben:
 
 ```bash
-docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8080 app php tools/local-mcp-server.php
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8200 app php tools/local-mcp-server.php
 ```
 
 Bei Ausführung des Servers in Docker gegen den Compose-`app`-Service:
@@ -68,7 +68,7 @@ Schreib-Tools (`createExampleNote`, `updateExampleNoteById`, `deleteExampleNoteB
 ## Erlaubte Operationen für Lokale Tools
 
 - Commetteten MCP-Katalog lesen
-- `http://localhost:8080/` und andere dokumentierte lokale API-Routen aufrufen
+- `http://localhost:8200/` und andere dokumentierte lokale API-Routen aufrufen
 - `X-Request-Id`-Metadaten aus HTTP-Antworten zurückgeben
 - Dokumentierte Validierungskommandos aus `docs/integrations/local-ai-commands.md` ausführen
 

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -37,14 +37,14 @@ docker compose up -d app
 Then open:
 
 ```text
-http://localhost:8080/
+http://localhost:8200/
 ```
 
 API documentation endpoints:
 
 ```text
-http://localhost:8080/openapi.php
-http://localhost:8080/docs/
+http://localhost:8200/openapi.php
+http://localhost:8200/docs/
 ```
 
 Stop it with:

--- a/docs/development/endpoint-scaffold.md
+++ b/docs/development/endpoint-scaffold.md
@@ -107,7 +107,7 @@ docker compose run --rm app composer check
 For endpoints served by Docker, run a local smoke check:
 
 ```bash
-curl -i http://localhost:8080/examples/ping
+curl -i http://localhost:8200/examples/ping
 ```
 
 ## MCP Relationship

--- a/docs/development/machine-client-smoke.md
+++ b/docs/development/machine-client-smoke.md
@@ -43,7 +43,7 @@ This passes the key through `compose.yaml` into the app container for local test
 Call the protected path without a key:
 
 ```bash
-curl -i http://localhost:8080/machine/health
+curl -i http://localhost:8200/machine/health
 ```
 
 Expected result:
@@ -58,7 +58,7 @@ Expected result:
 Call the same path with the configured key:
 
 ```bash
-curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
+curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8200/machine/health
 ```
 
 Expected result:

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -52,7 +52,7 @@ docker compose up -d app
 Verify it is running:
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 Expected response:
@@ -65,12 +65,12 @@ Other useful local endpoints:
 
 | URL | Description |
 |---|---|
-| `http://localhost:8080/` | Framework info |
-| `http://localhost:8080/health` | Health check |
-| `http://localhost:8080/examples/ping` | Ping example |
-| `http://localhost:8080/examples/notes/{id}` | Note by ID (requires DB) |
-| `http://localhost:8080/openapi.php` | Raw OpenAPI JSON |
-| `http://localhost:8080/docs/` | Swagger UI |
+| `http://localhost:8200/` | Framework info |
+| `http://localhost:8200/health` | Health check |
+| `http://localhost:8200/examples/ping` | Ping example |
+| `http://localhost:8200/examples/notes/{id}` | Note by ID (requires DB) |
+| `http://localhost:8200/openapi.php` | Raw OpenAPI JSON |
+| `http://localhost:8200/docs/` | Swagger UI |
 
 ## 5. Stop the Server
 
@@ -99,7 +99,7 @@ The `/machine/health` endpoint requires an API key. To test it locally:
 3. Call the protected endpoint:
 
 ```bash
-curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
+curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8200/machine/health
 ```
 
 See `docs/development/machine-client-smoke.md` for the full machine-client smoke workflow.
@@ -128,7 +128,7 @@ Every request generates an `X-Request-Id` that is echoed in the response header 
 1. Start the app: `docker compose up -d app`
 2. Send a request:
    ```bash
-   curl -i http://localhost:8080/health
+   curl -i http://localhost:8200/health
    # Look for X-Request-Id in the response headers
    ```
 3. Watch the structured log output:
@@ -139,7 +139,7 @@ Every request generates an `X-Request-Id` that is echoed in the response header 
 
 You can also supply your own ID:
 ```bash
-curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
+curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8200/health
 # The same id appears in the response header and in docker compose logs
 ```
 
@@ -148,11 +148,11 @@ curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
 **`composer check` fails on a clean clone**
 Run `docker compose run --rm app composer install` first. The `vendor/` directory is not committed.
 
-**Port 8080 already in use**
+**Port 8200 already in use**
 Stop whatever is using it, or change the port mapping in `compose.yaml`:
 ```yaml
 ports:
-  - "8081:80"   # use 8081 instead
+  - "8201:80"   # use 8201 instead
 ```
 
 **MySQL connection refused during migrations**

--- a/docs/fr/development/endpoint-scaffold.md
+++ b/docs/fr/development/endpoint-scaffold.md
@@ -92,7 +92,7 @@ docker compose run --rm app composer check
 Pour les endpoints servis via Docker, exécutez un smoke check local :
 
 ```bash
-curl -i http://localhost:8080/examples/ping
+curl -i http://localhost:8200/examples/ping
 ```
 
 ## Relation avec MCP

--- a/docs/fr/development/setup.md
+++ b/docs/fr/development/setup.md
@@ -52,7 +52,7 @@ docker compose up -d app
 Vérifier qu'il fonctionne :
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 Réponse attendue :
@@ -65,12 +65,12 @@ Autres endpoints locaux utiles :
 
 | URL | Description |
 |---|---|
-| `http://localhost:8080/` | Informations sur le framework |
-| `http://localhost:8080/health` | Vérification de santé |
-| `http://localhost:8080/examples/ping` | Exemple ping |
-| `http://localhost:8080/examples/notes/{id}` | Note par ID (nécessite une DB) |
-| `http://localhost:8080/openapi.php` | JSON OpenAPI brut |
-| `http://localhost:8080/docs/` | Interface Swagger |
+| `http://localhost:8200/` | Informations sur le framework |
+| `http://localhost:8200/health` | Vérification de santé |
+| `http://localhost:8200/examples/ping` | Exemple ping |
+| `http://localhost:8200/examples/notes/{id}` | Note par ID (nécessite une DB) |
+| `http://localhost:8200/openapi.php` | JSON OpenAPI brut |
+| `http://localhost:8200/docs/` | Interface Swagger |
 
 ## 5. Arrêter le serveur
 
@@ -97,7 +97,7 @@ L'endpoint `/machine/health` nécessite une clé API. Pour le tester localement 
 3. Appeler l'endpoint protégé :
 
 ```bash
-curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
+curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8200/machine/health
 ```
 
 ## Optionnel : Configuration du frontend
@@ -120,7 +120,7 @@ Chaque requête génère un `X-Request-Id` retourné dans l'en-tête de réponse
 1. Démarrer l'app : `docker compose up -d app`
 2. Envoyer une requête :
    ```bash
-   curl -i http://localhost:8080/health
+   curl -i http://localhost:8200/health
    # Chercher X-Request-Id dans les en-têtes de réponse
    ```
 3. Observer la sortie de log structurée :
@@ -131,7 +131,7 @@ Chaque requête génère un `X-Request-Id` retourné dans l'en-tête de réponse
 
 Vous pouvez aussi fournir votre propre ID :
 ```bash
-curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
+curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8200/health
 ```
 
 ## Dépannage
@@ -139,11 +139,11 @@ curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
 **`composer check` échoue sur un clone propre**
 Exécutez d'abord `docker compose run --rm app composer install`. Le répertoire `vendor/` n'est pas versionné.
 
-**Le port 8080 est déjà utilisé**
+**Le port 8200 est déjà utilisé**
 Arrêtez ce qui l'utilise, ou changez la correspondance de port dans `compose.yaml` :
 ```yaml
 ports:
-  - "8081:80"   # utiliser 8081 à la place
+  - "8201:80"   # utiliser 8201 à la place
 ```
 
 **Connexion MySQL refusée pendant les migrations**

--- a/docs/fr/howto/add-mcp-tools.md
+++ b/docs/fr/howto/add-mcp-tools.md
@@ -182,7 +182,7 @@ $authMiddleware = $secret !== null
 ## 6. Démarrer le serveur MCP
 
 ```bash
-NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_API_BASE_URL=http://localhost:8200 \
 NENE2_LOCAL_JWT_SECRET=your-local-secret \
 php vendor/hideyukimori/nene2/tools/local-mcp-server.php
 ```

--- a/docs/fr/howto/budget-tracking.md
+++ b/docs/fr/howto/budget-tracking.md
@@ -179,8 +179,8 @@ ORDER BY total DESC
 **Attaque** : Lister tous les comptes sans accréditations.
 
 ```bash
-curl -s http://localhost:8080/accounts
-curl -s http://localhost:8080/accounts/1/transactions
+curl -s http://localhost:8200/accounts
+curl -s http://localhost:8200/accounts/1/transactions
 ```
 
 **Observé** : Les deux endpoints retournent des données sans authentification. N'importe quel appelant peut énumérer tous les comptes et leurs soldes.
@@ -311,7 +311,7 @@ La colonne `balance` se retrouve à `20` au lieu du correct `-60` — mais plus 
 **Attaque** : Lire les transactions appartenant au compte d'un autre utilisateur.
 
 ```bash
-curl -s http://localhost:8080/accounts/2/transactions
+curl -s http://localhost:8200/accounts/2/transactions
 ```
 
 **Observé** : L'endpoint retourne toutes les transactions du compte 2 sans vérification de propriété. Comme il n'y a pas d'authentification, n'importe quel appelant peut lire n'importe quel compte.

--- a/docs/fr/howto/content-approval-workflow.md
+++ b/docs/fr/howto/content-approval-workflow.md
@@ -146,8 +146,8 @@ Un corps vide `{}` ou un champ `reason` manquant résultent tous deux en `null`.
 **Attaque** : Approuver ou rejeter un post sans aucune accréditation.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/reject
 ```
 
 **Observé** : Les deux réussissent avec `200 OK`. N'importe quel appelant peut pousser n'importe quel post dans n'importe quelle transition autorisée.
@@ -161,7 +161,7 @@ curl -X POST http://localhost:8080/posts/1/reject
 **Attaque** : Tenter d'approuver un post encore en statut `draft`.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve
 # le post 1 est en draft
 ```
 
@@ -176,9 +176,9 @@ curl -X POST http://localhost:8080/posts/1/approve
 **Attaque** : Approuver un post une deuxième fois.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/approve  # deuxième approbation
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve  # deuxième approbation
 ```
 
 **Observé** : Troisième requête : `canTransitionTo(Approved)` depuis `Approved` → `false` → `409 Conflict`. Le post reste dans l'état `Approved`.
@@ -296,9 +296,9 @@ POST /posts/1.5/approve
 **Attaque** : Rejeter avec un corps vide ou sans champ `reason`.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject -d '{}'
-curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject -d '{}'
+curl -X POST http://localhost:8200/posts/1/reject -d '{"reason": ""}'
 ```
 
 **Observé** : Les trois cas produisent `null` pour `reject_reason`. Le rejet sans raison est accepté — la colonne est nullable.
@@ -312,9 +312,9 @@ curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
 **Attaque** : Tenter de rejeter un post déjà rejeté.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject  # deuxième rejet
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject  # deuxième rejet
 ```
 
 **Observé** : `canTransitionTo(Rejected)` depuis `Rejected` → `false` → `409 Conflict`.

--- a/docs/fr/howto/multilingual-content.md
+++ b/docs/fr/howto/multilingual-content.md
@@ -188,7 +188,7 @@ Choix de design clés :
 **Attaque** : Créer ou modifier des articles sans aucune accréditation.
 
 ```bash
-curl -s -X POST http://localhost:8080/articles \
+curl -s -X POST http://localhost:8200/articles \
   -H 'Content-Type: application/json' \
   -d '{"default_locale":"en","published":true}'
 ```
@@ -238,7 +238,7 @@ PUT /articles/1/translations/en" OR "1"="1
 
 ```bash
 # L'attaquant connaît l'ID d'article 1 créé par un autre utilisateur
-curl -s -X PUT http://localhost:8080/articles/1/translations/fr \
+curl -s -X PUT http://localhost:8200/articles/1/translations/fr \
   -H 'Content-Type: application/json' \
   -d '{"title":"Hacked","body":"Attacker content"}'
 ```
@@ -327,7 +327,7 @@ PUT /articles/1/translations/fra       → code ISO 639-2 à trois lettres
 **Attaque** : Cibler un ID d'article qui n'existe pas.
 
 ```bash
-curl -s -X PUT http://localhost:8080/articles/99999/translations/en \
+curl -s -X PUT http://localhost:8200/articles/99999/translations/en \
   -H 'Content-Type: application/json' \
   -d '{"title":"Ghost","body":"Body"}'
 ```

--- a/docs/fr/howto/note-management-ownership.md
+++ b/docs/fr/howto/note-management-ownership.md
@@ -114,10 +114,10 @@ CREATE INDEX IF NOT EXISTS idx_notes_owner ON notes (owner_id);
 **Attaque** : Se faire passer pour un autre utilisateur en envoyant son ID dans l'en-tête.
 
 ```bash
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: alice'
 
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: bob'
 ```
 
@@ -146,7 +146,7 @@ X-Auth-User: alice\r\nX-Injected: evil
 **Attaque** : Deviner ou énumérer les IDs de notes appartenant à un autre utilisateur.
 
 ```bash
-curl -s http://localhost:8080/notes/1 -H 'X-Auth-User: bob'
+curl -s http://localhost:8200/notes/1 -H 'X-Auth-User: bob'
 # La note 1 a été créée par alice
 ```
 
@@ -190,7 +190,7 @@ curl -s http://localhost:8080/notes/1 -H 'X-Auth-User: bob'
 **Attaque** : Envoyer une requête sans l'en-tête `X-Auth-User`.
 
 ```bash
-curl -s http://localhost:8080/notes
+curl -s http://localhost:8200/notes
 ```
 
 **Observé** : `getHeaderLine('X-Auth-User')` retourne `""`. Après `trim()` c'est toujours `""`. `$userId !== ''` échoue → `resolveAuthUser()` retourne `null` → `401 Unauthorized` avec une réponse Problem Details structurée.
@@ -205,7 +205,7 @@ curl -s http://localhost:8080/notes
 
 ```bash
 # En supposant que 'admin' est un utilisateur spécial
-curl -s -X POST http://localhost:8080/notes \
+curl -s -X POST http://localhost:8200/notes \
   -H 'X-Auth-User: admin' \
   -H 'Content-Type: application/json' \
   -d '{"title":"Admin note"}'
@@ -268,8 +268,8 @@ GET /notes/1.5
 **Attaque** : DELETE d'un ID de note qui n'existe pas ou appartient à un autre utilisateur.
 
 ```bash
-curl -s -X DELETE http://localhost:8080/notes/99999 -H 'X-Auth-User: alice'
-curl -s -X DELETE http://localhost:8080/notes/1    -H 'X-Auth-User: eve'
+curl -s -X DELETE http://localhost:8200/notes/99999 -H 'X-Auth-User: alice'
+curl -s -X DELETE http://localhost:8200/notes/1    -H 'X-Auth-User: eve'
 # (la note 1 appartient à alice)
 ```
 

--- a/docs/fr/howto/quota-management.md
+++ b/docs/fr/howto/quota-management.md
@@ -188,7 +188,7 @@ La vérification stricte `is_int()` rejette les floats et les chaînes JSON. `li
 **Attaque** : Créer une politique de quota ou consommer au nom de n'importe quel utilisateur sans credentials.
 
 ```bash
-curl -s -X PUT http://localhost:8080/quotas/user-123/api-calls \
+curl -s -X PUT http://localhost:8200/quotas/user-123/api-calls \
   -H 'Content-Type: application/json' \
   -d '{"window":"daily","limit_count":10}'
 ```
@@ -249,7 +249,7 @@ POST /quotas/user-1/" OR "1"="1/consume
 **Attaque** : Appeler `POST .../consume` pour un utilisateur/ressource sans politique configurée.
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/user-ghost/api-calls/consume
+curl -s -X POST http://localhost:8200/quotas/user-ghost/api-calls/consume
 ```
 
 **Observé** : `findPolicy()` retourne `null` → `404 Not Found` avec une réponse Problem Details.
@@ -330,7 +330,7 @@ POST /quotas/user-1/; DROP TABLE quota_usage;--/consume
 **Attaque** : Réinitialiser le compteur de quota d'un utilisateur différent pour contourner leur limitation.
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/target-user/api-calls/reset
+curl -s -X POST http://localhost:8200/quotas/target-user/api-calls/reset
 ```
 
 **Observé** : `200 OK` — pas de vérification de propriété. N'importe quel appelant peut réinitialiser l'utilisation du quota de n'importe quel utilisateur, re-activant immédiatement leur accès.

--- a/docs/fr/howto/state-machine-audit-log.md
+++ b/docs/fr/howto/state-machine-audit-log.md
@@ -191,7 +191,7 @@ La liste est ordonnée par `id ASC` donc l'historique est chronologique.
 **Attaque** : Créer des commandes et appliquer des transitions sans credentials.
 
 ```bash
-curl -s -X POST http://localhost:8080/orders/1/transitions \
+curl -s -X POST http://localhost:8200/orders/1/transitions \
   -H 'Content-Type: application/json' \
   -d '{"status":"approved"}'
 ```

--- a/docs/fr/howto/webhook-delivery-api.md
+++ b/docs/fr/howto/webhook-delivery-api.md
@@ -225,7 +225,7 @@ POST /deliveries/9999/retry
 
 ### ATK-02 — Enregistrement d'un webhook avec URL interne/privée (SSRF) ⚠️ EXPOSED
 
-**Attack** : L'attaquant enregistre `url: "http://169.254.169.254/latest/meta-data"` (endpoint de métadonnées AWS) ou `http://localhost:8080/admin`. Quand un événement est dispatché, le serveur récupère l'URL interne.
+**Attack** : L'attaquant enregistre `url: "http://169.254.169.254/latest/meta-data"` (endpoint de métadonnées AWS) ou `http://localhost:8200/admin`. Quand un événement est dispatché, le serveur récupère l'URL interne.
 **Result** : EXPOSED — Le FT webhooklog n'implémente pas de validation d'URL ni de blocage SSRF sur les URLs enregistrées. En production, valider que l'URL se résout vers une IP publique (pas loopback, RFC1918 privée, lien-local, ou services de métadonnées) avant l'enregistrement. Voir `docs/howto/url-shortener-ssrf-prevention.md` pour le pattern de blocage SSRF.
 
 ---

--- a/docs/fr/integrations/local-mcp-client-configuration.md
+++ b/docs/fr/integrations/local-mcp-client-configuration.md
@@ -16,7 +16,7 @@ docker compose up -d app
 Vérifier que l'API est accessible :
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 Le serveur MCP est un processus stdio. Ce n'est pas un serveur HTTP — il doit être lancé par le client MCP.

--- a/docs/fr/integrations/local-mcp-server.md
+++ b/docs/fr/integrations/local-mcp-server.md
@@ -23,10 +23,10 @@ NENE2 inclut un serveur MCP stdio local uniquement :
 docker compose run --rm app php tools/local-mcp-server.php
 ```
 
-Par défaut, il appelle l'API locale sur `http://localhost:8080`. Remplacez l'URL de base en dehors du dépôt si nécessaire :
+Par défaut, il appelle l'API locale sur `http://localhost:8200`. Remplacez l'URL de base en dehors du dépôt si nécessaire :
 
 ```bash
-docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8080 app php tools/local-mcp-server.php
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8200 app php tools/local-mcp-server.php
 ```
 
 Lors de l'exécution du serveur dans Docker contre le service `app` Compose :
@@ -68,7 +68,7 @@ Les outils Write (`createExampleNote`, `updateExampleNoteById`, `deleteExampleNo
 ## Opérations autorisées pour les outils locaux
 
 - Lire le catalogue MCP versionné
-- Appeler `http://localhost:8080/` et autres routes API locales documentées
+- Appeler `http://localhost:8200/` et autres routes API locales documentées
 - Retourner les métadonnées `X-Request-Id` des réponses HTTP
 - Exécuter des commandes de validation documentées depuis `docs/integrations/local-ai-commands.md`
 

--- a/docs/howto/add-mcp-tools.md
+++ b/docs/howto/add-mcp-tools.md
@@ -230,7 +230,7 @@ Issue a token for the AI assistant and pass it in the MCP server configuration (
 ## 6. Start the MCP server
 
 ```bash
-NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_API_BASE_URL=http://localhost:8200 \
 NENE2_LOCAL_JWT_SECRET=your-local-secret \
 php vendor/hideyukimori/nene2/tools/local-mcp-server.php
 ```

--- a/docs/howto/budget-tracking.md
+++ b/docs/howto/budget-tracking.md
@@ -200,8 +200,8 @@ ORDER BY total DESC
 **Attack**: List all accounts without any credentials.
 
 ```bash
-curl -s http://localhost:8080/accounts
-curl -s http://localhost:8080/accounts/1/transactions
+curl -s http://localhost:8200/accounts
+curl -s http://localhost:8200/accounts/1/transactions
 ```
 
 **Observed**: Both endpoints return data without any authentication. Any caller can
@@ -354,7 +354,7 @@ and (2) wrapping the read-then-update in a DB transaction.
 **Attack**: Read transactions belonging to a different user's account.
 
 ```bash
-curl -s http://localhost:8080/accounts/2/transactions
+curl -s http://localhost:8200/accounts/2/transactions
 ```
 
 **Observed**: The endpoint returns all transactions for account 2 without any ownership

--- a/docs/howto/content-approval-workflow.md
+++ b/docs/howto/content-approval-workflow.md
@@ -168,8 +168,8 @@ nullable `reject_reason` column.
 **Attack**: Approve or reject a post without any credentials.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/reject
 ```
 
 **Observed**: Both succeed with `200 OK`. Any caller can push any post through any
@@ -186,7 +186,7 @@ the post's author to be authenticated.
 **Attack**: Try to approve a post that is still in `draft` status.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve
 # post 1 is in draft
 ```
 
@@ -202,9 +202,9 @@ curl -X POST http://localhost:8080/posts/1/approve
 **Attack**: Approve a post a second time.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/approve  # second approve
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve  # second approve
 ```
 
 **Observed**: Third request: `canTransitionTo(Approved)` from `Approved` → `false`
@@ -337,9 +337,9 @@ whitespace-only values.
 **Attack**: Reject with an empty body or no `reason` field.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject -d '{}'
-curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject -d '{}'
+curl -X POST http://localhost:8200/posts/1/reject -d '{"reason": ""}'
 ```
 
 **Observed**: All three cases produce `null` for `reject_reason`. Rejection without a
@@ -355,9 +355,9 @@ workflows requiring a mandatory rejection reason, add `if ($reason === null) →
 **Attack**: Try to reject a post that is already rejected.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject  # second reject
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject  # second reject
 ```
 
 **Observed**: `canTransitionTo(Rejected)` from `Rejected` → `false` → `409 Conflict`.

--- a/docs/howto/multilingual-content.md
+++ b/docs/howto/multilingual-content.md
@@ -208,7 +208,7 @@ Key design choices:
 **Attack**: Create or modify articles without any credentials.
 
 ```bash
-curl -s -X POST http://localhost:8080/articles \
+curl -s -X POST http://localhost:8200/articles \
   -H 'Content-Type: application/json' \
   -d '{"default_locale":"en","published":true}'
 ```
@@ -264,7 +264,7 @@ PUT /articles/1/translations/en" OR "1"="1
 
 ```bash
 # Attacker knows article ID 1 was created by another user
-curl -s -X PUT http://localhost:8080/articles/1/translations/fr \
+curl -s -X PUT http://localhost:8200/articles/1/translations/fr \
   -H 'Content-Type: application/json' \
   -d '{"title":"Hacked","body":"Attacker content"}'
 ```
@@ -360,7 +360,7 @@ PUT /articles/1/translations/fra       → three-letter ISO 639-2 code
 **Attack**: Target an article ID that does not exist.
 
 ```bash
-curl -s -X PUT http://localhost:8080/articles/99999/translations/en \
+curl -s -X PUT http://localhost:8200/articles/99999/translations/en \
   -H 'Content-Type: application/json' \
   -d '{"title":"Ghost","body":"Body"}'
 ```

--- a/docs/howto/note-management-ownership.md
+++ b/docs/howto/note-management-ownership.md
@@ -132,10 +132,10 @@ string (the `X-Auth-User` value); no foreign key to a users table exists.
 **Attack**: Impersonate another user by sending their user ID in the header.
 
 ```bash
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: alice'
 
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: bob'
 ```
 
@@ -170,7 +170,7 @@ they reach the application layer.
 **Attack**: Guess or enumerate note IDs belonging to another user.
 
 ```bash
-curl -s http://localhost:8080/notes/1 -H 'X-Auth-User: bob'
+curl -s http://localhost:8200/notes/1 -H 'X-Auth-User: bob'
 # Note 1 was created by alice
 ```
 
@@ -217,7 +217,7 @@ fires → `422 Unprocessable Entity`.
 **Attack**: Send a request without the `X-Auth-User` header.
 
 ```bash
-curl -s http://localhost:8080/notes
+curl -s http://localhost:8200/notes
 ```
 
 **Observed**: `getHeaderLine('X-Auth-User')` returns `""`. After `trim()` it's still
@@ -234,7 +234,7 @@ with a structured Problem Details response.
 
 ```bash
 # Assuming 'admin' is a special user
-curl -s -X POST http://localhost:8080/notes \
+curl -s -X POST http://localhost:8200/notes \
   -H 'X-Auth-User: admin' \
   -H 'Content-Type: application/json' \
   -d '{"title":"Admin note"}'
@@ -306,8 +306,8 @@ silently truncated. Add `ctype_digit()` guard for strict validation.
 **Attack**: DELETE a note ID that doesn't exist or belongs to another user.
 
 ```bash
-curl -s -X DELETE http://localhost:8080/notes/99999 -H 'X-Auth-User: alice'
-curl -s -X DELETE http://localhost:8080/notes/1    -H 'X-Auth-User: eve'
+curl -s -X DELETE http://localhost:8200/notes/99999 -H 'X-Auth-User: alice'
+curl -s -X DELETE http://localhost:8200/notes/1    -H 'X-Auth-User: eve'
 # (note 1 belongs to alice)
 ```
 

--- a/docs/howto/quota-management.md
+++ b/docs/howto/quota-management.md
@@ -207,7 +207,7 @@ least 1 — zero and negative values are rejected.
 **Attack**: Create a quota policy or consume on behalf of any user without credentials.
 
 ```bash
-curl -s -X PUT http://localhost:8080/quotas/user-123/api-calls \
+curl -s -X PUT http://localhost:8200/quotas/user-123/api-calls \
   -H 'Content-Type: application/json' \
   -d '{"window":"daily","limit_count":10}'
 ```
@@ -273,7 +273,7 @@ error for `window`.
 **Attack**: Call `POST .../consume` for a user/resource with no policy configured.
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/user-ghost/api-calls/consume
+curl -s -X POST http://localhost:8200/quotas/user-ghost/api-calls/consume
 ```
 
 **Observed**: `findPolicy()` returns `null` → `404 Not Found` with a Problem Details
@@ -367,7 +367,7 @@ be restricted to known values.
 **Attack**: Reset a different user's quota counter to bypass their throttling.
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/target-user/api-calls/reset
+curl -s -X POST http://localhost:8200/quotas/target-user/api-calls/reset
 ```
 
 **Observed**: `200 OK` — no ownership check. Any caller can reset any user's quota

--- a/docs/howto/state-machine-audit-log.md
+++ b/docs/howto/state-machine-audit-log.md
@@ -199,7 +199,7 @@ The list is ordered by `id ASC` so history is chronological.
 **Attack**: Create orders and apply transitions without credentials.
 
 ```bash
-curl -s -X POST http://localhost:8080/orders/1/transitions \
+curl -s -X POST http://localhost:8200/orders/1/transitions \
   -H 'Content-Type: application/json' \
   -d '{"status":"approved"}'
 ```

--- a/docs/howto/webhook-delivery-api.md
+++ b/docs/howto/webhook-delivery-api.md
@@ -233,7 +233,7 @@ POST /deliveries/9999/retry
 
 ### ATK-02 — Register Webhook with Internal/Private URL (SSRF) ⚠️ EXPOSED
 
-**Attack**: Attacker registers `url: "http://169.254.169.254/latest/meta-data"` (AWS metadata endpoint) or `http://localhost:8080/admin`. When an event is dispatched, the server fetches the internal URL.
+**Attack**: Attacker registers `url: "http://169.254.169.254/latest/meta-data"` (AWS metadata endpoint) or `http://localhost:8200/admin`. When an event is dispatched, the server fetches the internal URL.
 **Result**: EXPOSED — The webhooklog FT does not implement URL validation or SSRF blocking on registered URLs. In production, validate that the URL resolves to a public IP (not loopback, private RFC1918, link-local, or metadata services) before registering. See `docs/howto/url-shortener-ssrf-prevention.md` for the SSRF blocking pattern.
 
 ---

--- a/docs/integrations/ai-debugging.md
+++ b/docs/integrations/ai-debugging.md
@@ -16,7 +16,7 @@ When debugging a local API response:
 Example:
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 The response should include:

--- a/docs/integrations/local-ai-commands.md
+++ b/docs/integrations/local-ai-commands.md
@@ -21,9 +21,9 @@ Use `docker compose up -d app` when the local HTTP API needs to be inspected thr
 Read-only HTTP inspection may call:
 
 ```bash
-curl -fsS http://localhost:8080/
-curl -fsS http://localhost:8080/health
-curl -fsS http://localhost:8080/openapi.php
+curl -fsS http://localhost:8200/
+curl -fsS http://localhost:8200/health
+curl -fsS http://localhost:8200/openapi.php
 ```
 
 MCP smoke checks may use the helper script (requires `docker compose up -d app` first):

--- a/docs/integrations/local-mcp-client-configuration.md
+++ b/docs/integrations/local-mcp-client-configuration.md
@@ -16,7 +16,7 @@ docker compose up -d app
 Confirm the API is reachable:
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 The MCP server is a stdio process. It is not an HTTP server and should be launched by an MCP client.

--- a/docs/integrations/local-mcp-server.md
+++ b/docs/integrations/local-mcp-server.md
@@ -23,10 +23,10 @@ NENE2 includes a first local-only stdio MCP server:
 docker compose run --rm app php tools/local-mcp-server.php
 ```
 
-By default it calls the local API at `http://localhost:8080`. Override the base URL outside the repository when needed:
+By default it calls the local API at `http://localhost:8200`. Override the base URL outside the repository when needed:
 
 ```bash
-docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8080 app php tools/local-mcp-server.php
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8200 app php tools/local-mcp-server.php
 ```
 
 When running the server inside Docker against the Compose `app` service, use the service name as the API base URL:
@@ -76,7 +76,7 @@ It must not use:
 A local MCP server may:
 
 - read the committed MCP catalog
-- call `http://localhost:8080/` and other documented local API routes
+- call `http://localhost:8200/` and other documented local API routes
 - return `X-Request-Id` metadata from HTTP responses
 - run documented verification commands from `docs/integrations/local-ai-commands.md`
 - read committed project docs to answer project-structure questions
@@ -90,7 +90,7 @@ Local MCP server configuration may name environment variables, but it must not c
 Allowed examples:
 
 ```text
-NENE2_LOCAL_API_BASE_URL=http://localhost:8080
+NENE2_LOCAL_API_BASE_URL=http://localhost:8200
 NENE2_LOCAL_MCP_API_KEY=<set outside the repository>
 ```
 

--- a/docs/integrations/openapi.md
+++ b/docs/integrations/openapi.md
@@ -32,13 +32,13 @@ docs/openapi/
 Swagger UI is served from:
 
 ```text
-http://localhost:8080/docs/
+http://localhost:8200/docs/
 ```
 
 The raw OpenAPI contract is served from:
 
 ```text
-http://localhost:8080/openapi.php
+http://localhost:8200/openapi.php
 ```
 
 ## Local Verification
@@ -51,9 +51,9 @@ docker compose up -d app
 
 Then verify:
 
-- `http://localhost:8080/` returns the smoke JSON response.
-- `http://localhost:8080/openapi.php` returns the OpenAPI YAML.
-- `http://localhost:8080/docs/` loads Swagger UI.
+- `http://localhost:8200/` returns the smoke JSON response.
+- `http://localhost:8200/openapi.php` returns the OpenAPI YAML.
+- `http://localhost:8200/docs/` loads Swagger UI.
 
 Validate the contract file locally:
 

--- a/docs/ja/development/endpoint-scaffold.md
+++ b/docs/ja/development/endpoint-scaffold.md
@@ -106,7 +106,7 @@ docker compose run --rm app composer check
 Docker 経由で提供されるエンドポイントには、ローカルスモークチェックを実行します:
 
 ```bash
-curl -i http://localhost:8080/examples/ping
+curl -i http://localhost:8200/examples/ping
 ```
 
 ## MCP との関係

--- a/docs/ja/development/setup.md
+++ b/docs/ja/development/setup.md
@@ -52,7 +52,7 @@ docker compose up -d app
 動作確認:
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 期待されるレスポンス:
@@ -65,12 +65,12 @@ curl -i http://localhost:8080/health
 
 | URL | 説明 |
 |---|---|
-| `http://localhost:8080/` | フレームワーク情報 |
-| `http://localhost:8080/health` | ヘルスチェック |
-| `http://localhost:8080/examples/ping` | Ping サンプル |
-| `http://localhost:8080/examples/notes/{id}` | Note 取得（DB 必要） |
-| `http://localhost:8080/openapi.php` | OpenAPI JSON |
-| `http://localhost:8080/docs/` | Swagger UI |
+| `http://localhost:8200/` | フレームワーク情報 |
+| `http://localhost:8200/health` | ヘルスチェック |
+| `http://localhost:8200/examples/ping` | Ping サンプル |
+| `http://localhost:8200/examples/notes/{id}` | Note 取得（DB 必要） |
+| `http://localhost:8200/openapi.php` | OpenAPI JSON |
+| `http://localhost:8200/docs/` | Swagger UI |
 
 ## 5. サーバーの停止
 
@@ -99,7 +99,7 @@ SQLite と MySQL の比較については `docs/development/docker.md` を参照
 3. 保護されたエンドポイントを呼び出す:
 
 ```bash
-curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
+curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8200/machine/health
 ```
 
 マシンクライアントのスモークワークフロー全体は `docs/development/machine-client-smoke.md` を参照してください。
@@ -128,7 +128,7 @@ MCP クライアントの設定については `docs/integrations/local-mcp-serv
 1. アプリを起動する: `docker compose up -d app`
 2. リクエストを送信する:
    ```bash
-   curl -i http://localhost:8080/health
+   curl -i http://localhost:8200/health
    # レスポンスヘッダーの X-Request-Id を確認する
    ```
 3. 構造化ログの出力を確認する:
@@ -139,7 +139,7 @@ MCP クライアントの設定については `docs/integrations/local-mcp-serv
 
 独自の ID を指定することもできます:
 ```bash
-curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
+curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8200/health
 # 同じ ID がレスポンスヘッダーと docker compose logs の両方に現れる
 ```
 
@@ -148,11 +148,11 @@ curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
 **クリーンなクローン後に `composer check` が失敗する**
 先に `docker compose run --rm app composer install` を実行してください。`vendor/` ディレクトリはリポジトリにコミットされていません。
 
-**ポート 8080 がすでに使用中**
+**ポート 8200 がすでに使用中**
 使用中のプロセスを停止するか、`compose.yaml` のポートマッピングを変更します:
 ```yaml
 ports:
-  - "8081:80"   # 8081 を代わりに使用する
+  - "8201:80"   # 8201 を代わりに使用する
 ```
 
 **マイグレーション実行時に MySQL 接続が拒否される**

--- a/docs/ja/howto/add-mcp-tools.md
+++ b/docs/ja/howto/add-mcp-tools.md
@@ -181,7 +181,7 @@ $authMiddleware = $secret !== null
 ## 6. MCP サーバーを起動する
 
 ```bash
-NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_API_BASE_URL=http://localhost:8200 \
 NENE2_LOCAL_JWT_SECRET=your-local-secret \
 php vendor/hideyukimori/nene2/tools/local-mcp-server.php
 ```

--- a/docs/ja/howto/budget-tracking.md
+++ b/docs/ja/howto/budget-tracking.md
@@ -179,8 +179,8 @@ ORDER BY total DESC
 **攻撃**: 資格情報なしですべてのアカウントを一覧表示する。
 
 ```bash
-curl -s http://localhost:8080/accounts
-curl -s http://localhost:8080/accounts/1/transactions
+curl -s http://localhost:8200/accounts
+curl -s http://localhost:8200/accounts/1/transactions
 ```
 
 **観測結果**: 両エンドポイントとも認証なしでデータを返します。任意の呼び出し元がすべてのアカウントとその残高を列挙できます。
@@ -311,7 +311,7 @@ curl -X POST /accounts/1/transactions \
 **攻撃**: 別のユーザーのアカウントに属するトランザクションを読み取る。
 
 ```bash
-curl -s http://localhost:8080/accounts/2/transactions
+curl -s http://localhost:8200/accounts/2/transactions
 ```
 
 **観測結果**: エンドポイントは所有権チェックなしにアカウント 2 のすべてのトランザクションを返します。認証がないため、任意の呼び出し元が任意のアカウントを読み取れます。

--- a/docs/ja/howto/content-approval-workflow.md
+++ b/docs/ja/howto/content-approval-workflow.md
@@ -159,8 +159,8 @@ if ($raw !== '') {
 **Attack**: 認証情報なしで投稿を承認または却下する。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/reject
 ```
 
 **Observed**: どちらも `200 OK` で成功する。任意の呼び出し元が任意の投稿を
@@ -177,7 +177,7 @@ curl -X POST http://localhost:8080/posts/1/reject
 **Attack**: まだ `draft` ステータスの投稿を承認しようとする。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve
 # 投稿 1 は draft
 ```
 
@@ -193,9 +193,9 @@ curl -X POST http://localhost:8080/posts/1/approve
 **Attack**: 投稿を 2 度承認する。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/approve  # 2 回目の approve
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve  # 2 回目の approve
 ```
 
 **Observed**: 3 回目のリクエスト: `Approved` からの `canTransitionTo(Approved)` は `false`
@@ -329,9 +329,9 @@ POST /posts/1.5/approve
 **Attack**: 空ボディまたは `reason` フィールドなしで却下する。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject -d '{}'
-curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject -d '{}'
+curl -X POST http://localhost:8200/posts/1/reject -d '{"reason": ""}'
 ```
 
 **Observed**: 3 ケースすべてで `reject_reason` は `null` になる。理由なしの却下は
@@ -347,9 +347,9 @@ curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
 **Attack**: すでに却下された投稿を再度却下しようとする。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject  # 2 回目の reject
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject  # 2 回目の reject
 ```
 
 **Observed**: `Rejected` からの `canTransitionTo(Rejected)` は `false` を返す

--- a/docs/ja/howto/multilingual-content.md
+++ b/docs/ja/howto/multilingual-content.md
@@ -188,7 +188,7 @@ CREATE TABLE IF NOT EXISTS article_translations (
 **攻撃**: 認証情報なしでアーティクルを作成または変更する。
 
 ```bash
-curl -s -X POST http://localhost:8080/articles \
+curl -s -X POST http://localhost:8200/articles \
   -H 'Content-Type: application/json' \
   -d '{"default_locale":"en","published":true}'
 ```
@@ -238,7 +238,7 @@ PUT /articles/1/translations/en" OR "1"="1
 
 ```bash
 # 攻撃者はアーティクル ID 1 が他のユーザーによって作成されたことを知っている
-curl -s -X PUT http://localhost:8080/articles/1/translations/fr \
+curl -s -X PUT http://localhost:8200/articles/1/translations/fr \
   -H 'Content-Type: application/json' \
   -d '{"title":"Hacked","body":"Attacker content"}'
 ```
@@ -327,7 +327,7 @@ PUT /articles/1/translations/fra       → 3 文字の ISO 639-2 コード
 **攻撃**: 存在しないアーティクル ID を対象にする。
 
 ```bash
-curl -s -X PUT http://localhost:8080/articles/99999/translations/en \
+curl -s -X PUT http://localhost:8200/articles/99999/translations/en \
   -H 'Content-Type: application/json' \
   -d '{"title":"Ghost","body":"Body"}'
 ```

--- a/docs/ja/howto/quota-management.md
+++ b/docs/ja/howto/quota-management.md
@@ -188,7 +188,7 @@ if ($limitCount < 1) {
 **Attack**: 認証情報なしで任意のユーザーのクォータポリシーを作成または代理消費する。
 
 ```bash
-curl -s -X PUT http://localhost:8080/quotas/user-123/api-calls \
+curl -s -X PUT http://localhost:8200/quotas/user-123/api-calls \
   -H 'Content-Type: application/json' \
   -d '{"window":"daily","limit_count":10}'
 ```
@@ -249,7 +249,7 @@ POST /quotas/user-1/" OR "1"="1/consume
 **Attack**: ポリシーが設定されていないユーザー/リソースに `POST .../consume` を呼び出す。
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/user-ghost/api-calls/consume
+curl -s -X POST http://localhost:8200/quotas/user-ghost/api-calls/consume
 ```
 
 **Observed**: `findPolicy()` が `null` を返す → Problem Details レスポンスで `404 Not Found`。
@@ -330,7 +330,7 @@ POST /quotas/user-1/; DROP TABLE quota_usage;--/consume
 **Attack**: 別のユーザーのクォータカウンターをリセットしてスロットリングを回避する。
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/target-user/api-calls/reset
+curl -s -X POST http://localhost:8200/quotas/target-user/api-calls/reset
 ```
 
 **Observed**: `200 OK` — 所有権チェックなし。任意の呼び出し元が任意のユーザーのクォータ使用量をリセットし、即座にアクセスを再有効化できます。

--- a/docs/ja/howto/state-machine-audit-log.md
+++ b/docs/ja/howto/state-machine-audit-log.md
@@ -182,7 +182,7 @@ CREATE TABLE IF NOT EXISTS order_transitions (
 **攻撃**: 認証情報なしでオーダーを作成し、トランジションを適用する。
 
 ```bash
-curl -s -X POST http://localhost:8080/orders/1/transitions \
+curl -s -X POST http://localhost:8200/orders/1/transitions \
   -H 'Content-Type: application/json' \
   -d '{"status":"approved"}'
 ```

--- a/docs/ja/howto/webhook-delivery-api.md
+++ b/docs/ja/howto/webhook-delivery-api.md
@@ -225,7 +225,7 @@ POST /deliveries/9999/retry
 
 ### ATK-02 — 内部/プライベート URL への Webhook 登録（SSRF） ⚠️ EXPOSED
 
-**Attack**: 攻撃者が `url: "http://169.254.169.254/latest/meta-data"`（AWS メタデータエンドポイント）または `http://localhost:8080/admin` を登録する。イベントがディスパッチされると、サーバーが内部 URL を取得する。
+**Attack**: 攻撃者が `url: "http://169.254.169.254/latest/meta-data"`（AWS メタデータエンドポイント）または `http://localhost:8200/admin` を登録する。イベントがディスパッチされると、サーバーが内部 URL を取得する。
 **Result**: EXPOSED — webhooklog FT は登録 URL に URL バリデーションや SSRF ブロックを実装していない。本番環境では、登録前に URL がパブリック IP（ループバック、プライベート RFC1918、リンクローカル、メタデータサービスでない）に解決されることを検証してください。SSRF ブロックパターンについては `docs/howto/url-shortener-ssrf-prevention.md` を参照してください。
 
 ---

--- a/docs/ja/integrations/local-mcp-client-configuration.md
+++ b/docs/ja/integrations/local-mcp-client-configuration.md
@@ -16,7 +16,7 @@ docker compose up -d app
 API が到達可能か確認します:
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 MCP サーバーは stdio プロセスです。HTTP サーバーではなく、MCP クライアントによって起動される必要があります。

--- a/docs/ja/integrations/local-mcp-server.md
+++ b/docs/ja/integrations/local-mcp-server.md
@@ -23,10 +23,10 @@ NENE2 にはローカル専用の stdio MCP サーバーが含まれています
 docker compose run --rm app php tools/local-mcp-server.php
 ```
 
-デフォルトでは `http://localhost:8080` のローカル API を呼び出します。必要に応じてリポジトリ外でベース URL を上書きします:
+デフォルトでは `http://localhost:8200` のローカル API を呼び出します。必要に応じてリポジトリ外でベース URL を上書きします:
 
 ```bash
-docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8080 app php tools/local-mcp-server.php
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8200 app php tools/local-mcp-server.php
 ```
 
 Compose の `app` サービスに対して Docker 内でサーバーを実行する場合は、サービス名を API ベース URL として使用します:
@@ -76,7 +76,7 @@ Write ツール（`createExampleNote`・`updateExampleNoteById`・`deleteExample
 ローカル MCP サーバーで許可される操作:
 
 - コミットされた MCP カタログを読み取る
-- `http://localhost:8080/` と他の文書化されたローカル API ルートを呼び出す
+- `http://localhost:8200/` と他の文書化されたローカル API ルートを呼び出す
 - HTTP レスポンスの `X-Request-Id` メタデータを返す
 - `docs/integrations/local-ai-commands.md` の文書化された検証コマンドを実行する
 - コミットされたプロジェクトドキュメントを読み取ってプロジェクト構造に関する質問に答える
@@ -90,7 +90,7 @@ Write ツール（`createExampleNote`・`updateExampleNoteById`・`deleteExample
 許可される例:
 
 ```text
-NENE2_LOCAL_API_BASE_URL=http://localhost:8080
+NENE2_LOCAL_API_BASE_URL=http://localhost:8200
 NENE2_LOCAL_MCP_API_KEY=<リポジトリ外で設定する>
 ```
 

--- a/docs/pt-br/development/endpoint-scaffold.md
+++ b/docs/pt-br/development/endpoint-scaffold.md
@@ -92,7 +92,7 @@ docker compose run --rm app composer check
 Para endpoints servidos via Docker, execute um smoke check local:
 
 ```bash
-curl -i http://localhost:8080/examples/ping
+curl -i http://localhost:8200/examples/ping
 ```
 
 ## Relação com MCP

--- a/docs/pt-br/development/setup.md
+++ b/docs/pt-br/development/setup.md
@@ -52,7 +52,7 @@ docker compose up -d app
 Verificar se está rodando:
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 Resposta esperada:
@@ -65,12 +65,12 @@ Outros endpoints locais úteis:
 
 | URL | Descrição |
 |---|---|
-| `http://localhost:8080/` | Informações do framework |
-| `http://localhost:8080/health` | Verificação de saúde |
-| `http://localhost:8080/examples/ping` | Exemplo ping |
-| `http://localhost:8080/examples/notes/{id}` | Nota por ID (requer DB) |
-| `http://localhost:8080/openapi.php` | JSON OpenAPI bruto |
-| `http://localhost:8080/docs/` | Interface Swagger |
+| `http://localhost:8200/` | Informações do framework |
+| `http://localhost:8200/health` | Verificação de saúde |
+| `http://localhost:8200/examples/ping` | Exemplo ping |
+| `http://localhost:8200/examples/notes/{id}` | Nota por ID (requer DB) |
+| `http://localhost:8200/openapi.php` | JSON OpenAPI bruto |
+| `http://localhost:8200/docs/` | Interface Swagger |
 
 ## 5. Parar o Servidor
 
@@ -97,7 +97,7 @@ O endpoint `/machine/health` requer uma chave de API. Para testá-lo localmente:
 3. Chame o endpoint protegido:
 
 ```bash
-curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
+curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8200/machine/health
 ```
 
 ## Opcional: Configuração do Frontend
@@ -120,7 +120,7 @@ Cada request gera um `X-Request-Id` que é ecoado no header de resposta e anexad
 1. Inicie o app: `docker compose up -d app`
 2. Envie um request:
    ```bash
-   curl -i http://localhost:8080/health
+   curl -i http://localhost:8200/health
    # Procure por X-Request-Id nos headers de resposta
    ```
 3. Observe a saída de log estruturada:
@@ -131,7 +131,7 @@ Cada request gera um `X-Request-Id` que é ecoado no header de resposta e anexad
 
 Você também pode fornecer seu próprio ID:
 ```bash
-curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
+curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8200/health
 ```
 
 ## Solução de Problemas
@@ -139,11 +139,11 @@ curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
 **`composer check` falha em um clone limpo**
 Execute `docker compose run --rm app composer install` primeiro. O diretório `vendor/` não está versionado.
 
-**Porta 8080 já em uso**
+**Porta 8200 já em uso**
 Pare o que está usando, ou altere o mapeamento de porta no `compose.yaml`:
 ```yaml
 ports:
-  - "8081:80"   # usar 8081 em vez disso
+  - "8201:80"   # usar 8201 em vez disso
 ```
 
 **Conexão MySQL recusada durante migrações**

--- a/docs/pt-br/howto/add-mcp-tools.md
+++ b/docs/pt-br/howto/add-mcp-tools.md
@@ -182,7 +182,7 @@ $authMiddleware = $secret !== null
 ## 6. Iniciar o servidor MCP
 
 ```bash
-NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_API_BASE_URL=http://localhost:8200 \
 NENE2_LOCAL_JWT_SECRET=your-local-secret \
 php vendor/hideyukimori/nene2/tools/local-mcp-server.php
 ```

--- a/docs/pt-br/howto/budget-tracking.md
+++ b/docs/pt-br/howto/budget-tracking.md
@@ -192,8 +192,8 @@ ORDER BY total DESC
 **Ataque**: Listar todas as contas sem credenciais.
 
 ```bash
-curl -s http://localhost:8080/accounts
-curl -s http://localhost:8080/accounts/1/transactions
+curl -s http://localhost:8200/accounts
+curl -s http://localhost:8200/accounts/1/transactions
 ```
 
 **Observado**: Ambos os endpoints retornam dados sem autenticação. Qualquer chamador pode
@@ -345,7 +345,7 @@ e (2) envolvendo o ler-então-atualizar em uma transação DB.
 **Ataque**: Ler transações pertencentes à conta de um usuário diferente.
 
 ```bash
-curl -s http://localhost:8080/accounts/2/transactions
+curl -s http://localhost:8200/accounts/2/transactions
 ```
 
 **Observado**: O endpoint retorna todas as transações da conta 2 sem nenhuma

--- a/docs/pt-br/howto/content-approval-workflow.md
+++ b/docs/pt-br/howto/content-approval-workflow.md
@@ -160,8 +160,8 @@ na coluna nullable `reject_reason`.
 **Ataque**: Aprovar ou rejeitar um post sem nenhuma credencial.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/reject
 ```
 
 **Observado**: Ambos têm sucesso com `200 OK`. Qualquer chamador pode empurrar qualquer post
@@ -178,7 +178,7 @@ esteja autenticado.
 **Ataque**: Tentar aprovar um post que ainda está no status `draft`.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve
 # post 1 está em draft
 ```
 
@@ -194,9 +194,9 @@ curl -X POST http://localhost:8080/posts/1/approve
 **Ataque**: Aprovar um post uma segunda vez.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/approve  # segunda aprovação
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve  # segunda aprovação
 ```
 
 **Observado**: Terceira requisição: `canTransitionTo(Approved)` de `Approved` → `false`
@@ -328,9 +328,9 @@ vazios quanto valores com apenas espaços.
 **Ataque**: Rejeitar com corpo vazio ou sem campo `reason`.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject -d '{}'
-curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject -d '{}'
+curl -X POST http://localhost:8200/posts/1/reject -d '{"reason": ""}'
 ```
 
 **Observado**: Todos os três casos produzem `null` para `reject_reason`. A rejeição sem
@@ -346,9 +346,9 @@ que exijam motivo de rejeição obrigatório, adicione `if ($reason === null) �
 **Ataque**: Tentar rejeitar um post que já está rejeitado.
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject  # segunda rejeição
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject  # segunda rejeição
 ```
 
 **Observado**: `canTransitionTo(Rejected)` de `Rejected` → `false` → `409 Conflict`.

--- a/docs/pt-br/howto/multilingual-content.md
+++ b/docs/pt-br/howto/multilingual-content.md
@@ -200,7 +200,7 @@ Escolhas principais de design:
 **Ataque**: Criar ou modificar artigos sem nenhuma credencial.
 
 ```bash
-curl -s -X POST http://localhost:8080/articles \
+curl -s -X POST http://localhost:8200/articles \
   -H 'Content-Type: application/json' \
   -d '{"default_locale":"en","published":true}'
 ```
@@ -255,7 +255,7 @@ PUT /articles/1/translations/en" OR "1"="1
 
 ```bash
 # O atacante sabe que o artigo ID 1 foi criado por outro usuário
-curl -s -X PUT http://localhost:8080/articles/1/translations/fr \
+curl -s -X PUT http://localhost:8200/articles/1/translations/fr \
   -H 'Content-Type: application/json' \
   -d '{"title":"Hacked","body":"Attacker content"}'
 ```
@@ -351,7 +351,7 @@ PUT /articles/1/translations/fra       → código ISO 639-2 de três letras
 **Ataque**: Alvejar um ID de artigo que não existe.
 
 ```bash
-curl -s -X PUT http://localhost:8080/articles/99999/translations/en \
+curl -s -X PUT http://localhost:8200/articles/99999/translations/en \
   -H 'Content-Type: application/json' \
   -d '{"title":"Ghost","body":"Body"}'
 ```

--- a/docs/pt-br/howto/note-management-ownership.md
+++ b/docs/pt-br/howto/note-management-ownership.md
@@ -124,10 +124,10 @@ string livre (o valor de `X-Auth-User`); sem chave estrangeira para uma tabela d
 **Ataque**: Personificar outro usuário enviando seu ID de usuário no header.
 
 ```bash
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: alice'
 
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: bob'
 ```
 
@@ -162,7 +162,7 @@ de chegarem à camada de aplicação.
 **Ataque**: Adivinhar ou enumerar IDs de notas pertencentes a outro usuário.
 
 ```bash
-curl -s http://localhost:8080/notes/1 -H 'X-Auth-User: bob'
+curl -s http://localhost:8200/notes/1 -H 'X-Auth-User: bob'
 # Nota 1 foi criada por alice
 ```
 
@@ -209,7 +209,7 @@ dispara → `422 Unprocessable Entity`.
 **Ataque**: Enviar uma requisição sem o header `X-Auth-User`.
 
 ```bash
-curl -s http://localhost:8080/notes
+curl -s http://localhost:8200/notes
 ```
 
 **Observado**: `getHeaderLine('X-Auth-User')` retorna `""`. Após `trim()` ainda é
@@ -226,7 +226,7 @@ com uma resposta Problem Details estruturada.
 
 ```bash
 # Assumindo que 'admin' é um usuário especial
-curl -s -X POST http://localhost:8080/notes \
+curl -s -X POST http://localhost:8200/notes \
   -H 'X-Auth-User: admin' \
   -H 'Content-Type: application/json' \
   -d '{"title":"Admin note"}'
@@ -298,8 +298,8 @@ truncados silenciosamente. Adicione guarda `ctype_digit()` para validação estr
 **Ataque**: DELETE em um ID de nota que não existe ou pertence a outro usuário.
 
 ```bash
-curl -s -X DELETE http://localhost:8080/notes/99999 -H 'X-Auth-User: alice'
-curl -s -X DELETE http://localhost:8080/notes/1    -H 'X-Auth-User: eve'
+curl -s -X DELETE http://localhost:8200/notes/99999 -H 'X-Auth-User: alice'
+curl -s -X DELETE http://localhost:8200/notes/1    -H 'X-Auth-User: eve'
 # (nota 1 pertence a alice)
 ```
 

--- a/docs/pt-br/howto/quota-management.md
+++ b/docs/pt-br/howto/quota-management.md
@@ -199,7 +199,7 @@ pelo menos 1 — valores zero e negativos são rejeitados.
 **Ataque**: Criar uma política de cota ou consumir em nome de qualquer usuário sem credenciais.
 
 ```bash
-curl -s -X PUT http://localhost:8080/quotas/user-123/api-calls \
+curl -s -X PUT http://localhost:8200/quotas/user-123/api-calls \
   -H 'Content-Type: application/json' \
   -d '{"window":"daily","limit_count":10}'
 ```
@@ -264,7 +264,7 @@ para `window`.
 **Ataque**: Chamar `POST .../consume` para um usuário/recurso sem política configurada.
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/user-ghost/api-calls/consume
+curl -s -X POST http://localhost:8200/quotas/user-ghost/api-calls/consume
 ```
 
 **Observado**: `findPolicy()` retorna `null` → `404 Not Found` com uma resposta Problem Details.
@@ -355,7 +355,7 @@ recurso devem ser restritos a valores conhecidos.
 **Ataque**: Resetar o contador de cota de um usuário diferente para contornar seu throttling.
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/target-user/api-calls/reset
+curl -s -X POST http://localhost:8200/quotas/target-user/api-calls/reset
 ```
 
 **Observado**: `200 OK` — sem verificação de propriedade. Qualquer chamador pode resetar o uso

--- a/docs/pt-br/howto/state-machine-audit-log.md
+++ b/docs/pt-br/howto/state-machine-audit-log.md
@@ -182,7 +182,7 @@ A lista é ordenada por `id ASC` para que o histórico seja cronológico.
 **Ataque**: Criar pedidos e aplicar transições sem credenciais.
 
 ```bash
-curl -s -X POST http://localhost:8080/orders/1/transitions \
+curl -s -X POST http://localhost:8200/orders/1/transitions \
   -H 'Content-Type: application/json' \
   -d '{"status":"approved"}'
 ```

--- a/docs/pt-br/howto/webhook-delivery-api.md
+++ b/docs/pt-br/howto/webhook-delivery-api.md
@@ -225,7 +225,7 @@ POST /deliveries/9999/retry
 
 ### ATK-02 — Registrar Webhook com URL Interna/Privada (SSRF) ⚠️ EXPOSED
 
-**Ataque**: Atacante registra `url: "http://169.254.169.254/latest/meta-data"` (endpoint de metadados AWS) ou `http://localhost:8080/admin`. Quando um evento é despachado, o servidor busca a URL interna.
+**Ataque**: Atacante registra `url: "http://169.254.169.254/latest/meta-data"` (endpoint de metadados AWS) ou `http://localhost:8200/admin`. Quando um evento é despachado, o servidor busca a URL interna.
 **Resultado**: EXPOSED — O FT webhooklog não implementa validação de URL ou bloqueio de SSRF em URLs registradas. Em produção, valide que a URL resolve para um IP público (não loopback, RFC1918 privado, link-local ou serviços de metadados) antes de registrar. Veja `docs/howto/url-shortener-ssrf-prevention.md` para o padrão de bloqueio de SSRF.
 
 ---

--- a/docs/pt-br/integrations/local-mcp-client-configuration.md
+++ b/docs/pt-br/integrations/local-mcp-client-configuration.md
@@ -16,7 +16,7 @@ docker compose up -d app
 Verifique se a API está acessível:
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 O servidor MCP é um processo stdio. Não é um servidor HTTP — precisa ser iniciado pelo cliente MCP.

--- a/docs/pt-br/integrations/local-mcp-server.md
+++ b/docs/pt-br/integrations/local-mcp-server.md
@@ -23,10 +23,10 @@ O NENE2 inclui um servidor MCP stdio apenas local:
 docker compose run --rm app php tools/local-mcp-server.php
 ```
 
-Por padrão, chama a API local em `http://localhost:8080`. Substitua a URL base fora do repositório se necessário:
+Por padrão, chama a API local em `http://localhost:8200`. Substitua a URL base fora do repositório se necessário:
 
 ```bash
-docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8080 app php tools/local-mcp-server.php
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8200 app php tools/local-mcp-server.php
 ```
 
 Ao executar o servidor no Docker contra o serviço Compose `app`:
@@ -68,7 +68,7 @@ Ferramentas de Escrita (`createExampleNote`, `updateExampleNoteById`, `deleteExa
 ## Operações Permitidas para Ferramentas Locais
 
 - Ler o catálogo MCP versionado
-- Chamar `http://localhost:8080/` e outras rotas de API locais documentadas
+- Chamar `http://localhost:8200/` e outras rotas de API locais documentadas
 - Retornar metadados `X-Request-Id` de respostas HTTP
 - Executar comandos de validação documentados de `docs/integrations/local-ai-commands.md`
 

--- a/docs/zh/development/endpoint-scaffold.md
+++ b/docs/zh/development/endpoint-scaffold.md
@@ -92,7 +92,7 @@ docker compose run --rm app composer check
 对通过 Docker 提供的端点，运行本地冒烟检查：
 
 ```bash
-curl -i http://localhost:8080/examples/ping
+curl -i http://localhost:8200/examples/ping
 ```
 
 ## 与 MCP 的关系

--- a/docs/zh/development/setup.md
+++ b/docs/zh/development/setup.md
@@ -52,7 +52,7 @@ docker compose up -d app
 验证运行状态：
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 预期响应：
@@ -65,12 +65,12 @@ curl -i http://localhost:8080/health
 
 | URL | 描述 |
 |---|---|
-| `http://localhost:8080/` | 框架信息 |
-| `http://localhost:8080/health` | 健康检查 |
-| `http://localhost:8080/examples/ping` | Ping 示例 |
-| `http://localhost:8080/examples/notes/{id}` | 按 ID 获取笔记（需要数据库） |
-| `http://localhost:8080/openapi.php` | 原始 OpenAPI JSON |
-| `http://localhost:8080/docs/` | Swagger UI |
+| `http://localhost:8200/` | 框架信息 |
+| `http://localhost:8200/health` | 健康检查 |
+| `http://localhost:8200/examples/ping` | Ping 示例 |
+| `http://localhost:8200/examples/notes/{id}` | 按 ID 获取笔记（需要数据库） |
+| `http://localhost:8200/openapi.php` | 原始 OpenAPI JSON |
+| `http://localhost:8200/docs/` | Swagger UI |
 
 ## 5. 停止服务器
 
@@ -97,7 +97,7 @@ docker compose run --rm app composer test:database:mysql
 3. 调用受保护的端点：
 
 ```bash
-curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8080/machine/health
+curl -i -H 'X-NENE2-API-Key: local-dev-key' http://localhost:8200/machine/health
 ```
 
 ## 可选：前端设置
@@ -120,7 +120,7 @@ docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/loc
 1. 启动 app：`docker compose up -d app`
 2. 发送请求：
    ```bash
-   curl -i http://localhost:8080/health
+   curl -i http://localhost:8200/health
    # 在响应头中查找 X-Request-Id
    ```
 3. 查看结构化日志输出：
@@ -131,7 +131,7 @@ docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://app app php tools/loc
 
 您也可以提供自己的 ID：
 ```bash
-curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
+curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8200/health
 ```
 
 ## 故障排除
@@ -139,11 +139,11 @@ curl -i -H 'X-Request-Id: my-trace-id' http://localhost:8080/health
 **全新克隆时 `composer check` 失败**
 先运行 `docker compose run --rm app composer install`。`vendor/` 目录未被提交。
 
-**端口 8080 已被占用**
+**端口 8200 已被占用**
 停止占用它的进程，或修改 `compose.yaml` 中的端口映射：
 ```yaml
 ports:
-  - "8081:80"   # 使用 8081 代替
+  - "8201:80"   # 使用 8201 代替
 ```
 
 **迁移时 MySQL 连接被拒绝**

--- a/docs/zh/howto/add-mcp-tools.md
+++ b/docs/zh/howto/add-mcp-tools.md
@@ -71,7 +71,7 @@ composer mcp
 ## 6. 启动 MCP 服务器
 
 ```bash
-NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+NENE2_LOCAL_API_BASE_URL=http://localhost:8200 \
 NENE2_LOCAL_JWT_SECRET=your-local-secret \
 php vendor/hideyukimori/nene2/tools/local-mcp-server.php
 ```

--- a/docs/zh/howto/budget-tracking.md
+++ b/docs/zh/howto/budget-tracking.md
@@ -179,8 +179,8 @@ ORDER BY total DESC
 **攻击**：不提供任何凭据列出所有账户。
 
 ```bash
-curl -s http://localhost:8080/accounts
-curl -s http://localhost:8080/accounts/1/transactions
+curl -s http://localhost:8200/accounts
+curl -s http://localhost:8200/accounts/1/transactions
 ```
 
 **观察结果**：两个端点不需要任何认证就返回数据。任何调用者都可以枚举所有账户及其余额。
@@ -311,7 +311,7 @@ curl -X POST /accounts/1/transactions \
 **攻击**：读取属于不同用户账户的交易。
 
 ```bash
-curl -s http://localhost:8080/accounts/2/transactions
+curl -s http://localhost:8200/accounts/2/transactions
 ```
 
 **观察结果**：端点返回账户 2 的所有交易，没有任何所有权检查。由于没有认证，任何调用者都可以读取任何账户。

--- a/docs/zh/howto/content-approval-workflow.md
+++ b/docs/zh/howto/content-approval-workflow.md
@@ -146,8 +146,8 @@ if ($raw !== '') {
 **攻击**：不提供任何凭据批准或拒绝帖子。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/reject
 ```
 
 **观察结果**：两者都以 `200 OK` 成功。任何调用者都可以推动任何帖子通过任何允许的转换。
@@ -161,7 +161,7 @@ curl -X POST http://localhost:8080/posts/1/reject
 **攻击**：尝试批准仍处于 `draft` 状态的帖子。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve
 # 帖子 1 处于 draft 状态
 ```
 
@@ -176,9 +176,9 @@ curl -X POST http://localhost:8080/posts/1/approve
 **攻击**：对帖子进行第二次批准。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/approve
-curl -X POST http://localhost:8080/posts/1/approve  # 第二次批准
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/approve
+curl -X POST http://localhost:8200/posts/1/approve  # 第二次批准
 ```
 
 **观察结果**：第三个请求：从 `Approved` 调用 `canTransitionTo(Approved)` → `false` → `409 Conflict`。帖子保持 `Approved` 状态。
@@ -296,9 +296,9 @@ POST /posts/1.5/approve
 **攻击**：使用空请求体或无 `reason` 字段拒绝。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject -d '{}'
-curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject -d '{}'
+curl -X POST http://localhost:8200/posts/1/reject -d '{"reason": ""}'
 ```
 
 **观察结果**：三种情况都产生 `null` 作为 `reject_reason`。不提供原因的拒绝是被接受的——该列可为 null。
@@ -312,9 +312,9 @@ curl -X POST http://localhost:8080/posts/1/reject -d '{"reason": ""}'
 **攻击**：尝试拒绝已经被拒绝的帖子。
 
 ```bash
-curl -X POST http://localhost:8080/posts/1/submit
-curl -X POST http://localhost:8080/posts/1/reject
-curl -X POST http://localhost:8080/posts/1/reject  # 第二次拒绝
+curl -X POST http://localhost:8200/posts/1/submit
+curl -X POST http://localhost:8200/posts/1/reject
+curl -X POST http://localhost:8200/posts/1/reject  # 第二次拒绝
 ```
 
 **观察结果**：从 `Rejected` 调用 `canTransitionTo(Rejected)` → `false` → `409 Conflict`。

--- a/docs/zh/howto/multilingual-content.md
+++ b/docs/zh/howto/multilingual-content.md
@@ -188,7 +188,7 @@ CREATE TABLE IF NOT EXISTS article_translations (
 **攻击**：无需任何凭据创建或修改文章。
 
 ```bash
-curl -s -X POST http://localhost:8080/articles \
+curl -s -X POST http://localhost:8200/articles \
   -H 'Content-Type: application/json' \
   -d '{"default_locale":"en","published":true}'
 ```
@@ -238,7 +238,7 @@ PUT /articles/1/translations/en" OR "1"="1
 
 ```bash
 # 攻击者知道文章 ID 1 是由另一个用户创建的
-curl -s -X PUT http://localhost:8080/articles/1/translations/fr \
+curl -s -X PUT http://localhost:8200/articles/1/translations/fr \
   -H 'Content-Type: application/json' \
   -d '{"title":"Hacked","body":"Attacker content"}'
 ```
@@ -327,7 +327,7 @@ PUT /articles/1/translations/fra       → 三字母 ISO 639-2 代码
 **攻击**：针对不存在的文章 ID。
 
 ```bash
-curl -s -X PUT http://localhost:8080/articles/99999/translations/en \
+curl -s -X PUT http://localhost:8200/articles/99999/translations/en \
   -H 'Content-Type: application/json' \
   -d '{"title":"Ghost","body":"Body"}'
 ```

--- a/docs/zh/howto/note-management-ownership.md
+++ b/docs/zh/howto/note-management-ownership.md
@@ -114,10 +114,10 @@ CREATE INDEX IF NOT EXISTS idx_notes_owner ON notes (owner_id);
 **攻击**：通过在请求头中发送他人的用户 ID 来冒充其身份。
 
 ```bash
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: alice'
 
-curl -s -X GET http://localhost:8080/notes \
+curl -s -X GET http://localhost:8200/notes \
   -H 'X-Auth-User: bob'
 ```
 
@@ -146,7 +146,7 @@ X-Auth-User: alice\r\nX-Injected: evil
 **攻击**：猜测或枚举属于另一个用户的笔记 ID。
 
 ```bash
-curl -s http://localhost:8080/notes/1 -H 'X-Auth-User: bob'
+curl -s http://localhost:8200/notes/1 -H 'X-Auth-User: bob'
 # 笔记 1 由 alice 创建
 ```
 
@@ -190,7 +190,7 @@ curl -s http://localhost:8080/notes/1 -H 'X-Auth-User: bob'
 **攻击**：发送不带 `X-Auth-User` 请求头的请求。
 
 ```bash
-curl -s http://localhost:8080/notes
+curl -s http://localhost:8200/notes
 ```
 
 **观察结果**：`getHeaderLine('X-Auth-User')` 返回 `""`。`trim()` 之后仍然是 `""`。`$userId !== ''` 失败 → `resolveAuthUser()` 返回 `null` → `401 Unauthorized`，带结构化 Problem Details 响应。
@@ -205,7 +205,7 @@ curl -s http://localhost:8080/notes
 
 ```bash
 # 假设 'admin' 是特殊用户
-curl -s -X POST http://localhost:8080/notes \
+curl -s -X POST http://localhost:8200/notes \
   -H 'X-Auth-User: admin' \
   -H 'Content-Type: application/json' \
   -d '{"title":"Admin note"}'
@@ -268,8 +268,8 @@ GET /notes/1.5
 **攻击**：DELETE 一个不存在或属于另一个用户的笔记 ID。
 
 ```bash
-curl -s -X DELETE http://localhost:8080/notes/99999 -H 'X-Auth-User: alice'
-curl -s -X DELETE http://localhost:8080/notes/1    -H 'X-Auth-User: eve'
+curl -s -X DELETE http://localhost:8200/notes/99999 -H 'X-Auth-User: alice'
+curl -s -X DELETE http://localhost:8200/notes/1    -H 'X-Auth-User: eve'
 # （笔记 1 属于 alice）
 ```
 

--- a/docs/zh/howto/quota-management.md
+++ b/docs/zh/howto/quota-management.md
@@ -188,7 +188,7 @@ if ($limitCount < 1) {
 **攻击**：无凭证即为任意用户创建配额策略或消耗配额。
 
 ```bash
-curl -s -X PUT http://localhost:8080/quotas/user-123/api-calls \
+curl -s -X PUT http://localhost:8200/quotas/user-123/api-calls \
   -H 'Content-Type: application/json' \
   -d '{"window":"daily","limit_count":10}'
 ```
@@ -249,7 +249,7 @@ POST /quotas/user-1/" OR "1"="1/consume
 **攻击**：对没有配置策略的用户/资源调用 `POST .../consume`。
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/user-ghost/api-calls/consume
+curl -s -X POST http://localhost:8200/quotas/user-ghost/api-calls/consume
 ```
 
 **结果**：`findPolicy()` 返回 `null` → `404 Not Found`，带有 Problem Details 响应。
@@ -330,7 +330,7 @@ POST /quotas/user-1/; DROP TABLE quota_usage;--/consume
 **攻击**：重置不同用户的配额计数器以绕过其限流。
 
 ```bash
-curl -s -X POST http://localhost:8080/quotas/target-user/api-calls/reset
+curl -s -X POST http://localhost:8200/quotas/target-user/api-calls/reset
 ```
 
 **结果**：`200 OK`——无所有权检查。任何调用方都可以重置任意用户的配额使用量，立即恢复其访问。

--- a/docs/zh/howto/state-machine-audit-log.md
+++ b/docs/zh/howto/state-machine-audit-log.md
@@ -182,7 +182,7 @@ CREATE TABLE IF NOT EXISTS order_transitions (
 **攻击**：无凭据创建订单并应用转换。
 
 ```bash
-curl -s -X POST http://localhost:8080/orders/1/transitions \
+curl -s -X POST http://localhost:8200/orders/1/transitions \
   -H 'Content-Type: application/json' \
   -d '{"status":"approved"}'
 ```

--- a/docs/zh/howto/webhook-delivery-api.md
+++ b/docs/zh/howto/webhook-delivery-api.md
@@ -225,7 +225,7 @@ POST /deliveries/9999/retry
 
 ### ATK-02 — 注册包含内部/私有 URL 的 Webhook（SSRF）⚠️ EXPOSED
 
-**攻击**：攻击者注册 `url: "http://169.254.169.254/latest/meta-data"`（AWS 元数据端点）或 `http://localhost:8080/admin`。事件分发时，服务器请求内部 URL。
+**攻击**：攻击者注册 `url: "http://169.254.169.254/latest/meta-data"`（AWS 元数据端点）或 `http://localhost:8200/admin`。事件分发时，服务器请求内部 URL。
 **结果**：EXPOSED — webhooklog FT 对已注册 URL 没有实现 URL 验证或 SSRF 阻断。在生产环境中，注册前应验证 URL 解析到公开 IP（非回环、私有 RFC1918、链路本地或元数据服务）。SSRF 阻断模式参见 `docs/howto/url-shortener-ssrf-prevention.md`。
 
 ---

--- a/docs/zh/integrations/local-mcp-client-configuration.md
+++ b/docs/zh/integrations/local-mcp-client-configuration.md
@@ -16,7 +16,7 @@ docker compose up -d app
 验证 API 是否可访问：
 
 ```bash
-curl -i http://localhost:8080/health
+curl -i http://localhost:8200/health
 ```
 
 MCP 服务器是 stdio 进程。它不是 HTTP 服务器——需要由 MCP 客户端启动。

--- a/docs/zh/integrations/local-mcp-server.md
+++ b/docs/zh/integrations/local-mcp-server.md
@@ -23,10 +23,10 @@ NENE2 包含一个仅限本地的 stdio MCP 服务器：
 docker compose run --rm app php tools/local-mcp-server.php
 ```
 
-默认调用 `http://localhost:8080` 上的本地 API。必要时在仓库外覆盖基础 URL：
+默认调用 `http://localhost:8200` 上的本地 API。必要时在仓库外覆盖基础 URL：
 
 ```bash
-docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8080 app php tools/local-mcp-server.php
+docker compose run --rm -e NENE2_LOCAL_API_BASE_URL=http://localhost:8200 app php tools/local-mcp-server.php
 ```
 
 在 Docker 中针对 Compose `app` 服务运行服务器时：
@@ -68,7 +68,7 @@ Write 工具（`createExampleNote`、`updateExampleNoteById`、`deleteExampleNot
 ## 本地工具允许的操作
 
 - 读取已提交的 MCP 目录
-- 调用 `http://localhost:8080/` 和其他文档化的本地 API 路由
+- 调用 `http://localhost:8200/` 和其他文档化的本地 API 路由
 - 从 HTTP 响应中返回 `X-Request-Id` 元数据
 - 执行 `docs/integrations/local-ai-commands.md` 中文档化的验证命令
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,8 +9,8 @@ NENE2 lets you ship a JSON API with OpenAPI contract, optional React frontend, a
 The authoritative machine-readable API specification is available at:
 
 - **Raw YAML**: `https://raw.githubusercontent.com/hideyukiMORI/NENE2/main/docs/openapi/openapi.yaml`
-- **Live Swagger UI** (local): `http://localhost:8080/docs/` (after `docker compose up -d app`)
-- **Live spec endpoint** (local): `http://localhost:8080/openapi.php`
+- **Live Swagger UI** (local): `http://localhost:8200/docs/` (after `docker compose up -d app`)
+- **Live spec endpoint** (local): `http://localhost:8200/openapi.php`
 
 The spec covers all shipped JSON endpoints including health, examples (Note/Tag CRUD), and machine-client endpoints. RFC 9457 Problem Details error schemas are included for every operation.
 
@@ -25,7 +25,7 @@ The spec covers all shipped JSON endpoints including health, examples (Note/Tag 
 
 ## How-to guides
 
-256 task-focused guides. Full index: [docs/howto/README.md](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/README.md)
+260 task-focused guides. Full index: [docs/howto/README.md](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/README.md)
 
 ### Getting Started
 

--- a/tests/Mcp/LocalMcpServerTest.php
+++ b/tests/Mcp/LocalMcpServerTest.php
@@ -83,7 +83,7 @@ final class LocalMcpServerTest extends TestCase
             ],
         ]);
 
-        self::assertSame('http://localhost:8080', $client->baseUrl);
+        self::assertSame('http://localhost:8200', $client->baseUrl);
         self::assertSame('/health', $client->path);
         self::assertSame('get', $client->lastMethod);
         self::assertSame(false, $response['result']['isError'] ?? null);
@@ -264,7 +264,7 @@ final class LocalMcpServerTest extends TestCase
         return new LocalMcpServer(
             new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json'),
             $client ?? new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(200, [], '{}')),
-            'http://localhost:8080',
+            'http://localhost:8200',
         );
     }
 }

--- a/tools/issue-jwt.php
+++ b/tools/issue-jwt.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  *
  * Example:
  *   TOKEN=$(php tools/issue-jwt.php --sub ft6-user)
- *   curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/examples/protected
+ *   curl -H "Authorization: Bearer $TOKEN" http://localhost:8200/examples/protected
  */
 
 require dirname(__DIR__) . '/vendor/autoload.php';

--- a/tools/local-mcp-server.php
+++ b/tools/local-mcp-server.php
@@ -14,7 +14,7 @@ $root = dirname(__DIR__);
 $apiBaseUrl = getenv('NENE2_LOCAL_API_BASE_URL');
 
 if (!is_string($apiBaseUrl) || $apiBaseUrl === '') {
-    $apiBaseUrl = 'http://localhost:8080';
+    $apiBaseUrl = 'http://localhost:8200';
 }
 
 $bearerToken = null;


### PR DESCRIPTION
## 目的
ドキュメント鮮度チェックで見つかった2系統の不整合を解消する。

### 1. ローカルポート 8080 → 8200
正本は全て 8200（`compose.yaml` の `8200:80`、CLAUDE.md、#1361 で修正済みの openapi）。しかし**コード既定値**（`tools/local-mcp-server.php` の `NENE2_LOCAL_API_BASE_URL` フォールバック）と多数の docs が `8080` のまま残っており、これが docs 全体の 8080 の発生源だった。発生源のコード・テスト・全言語 docs を 8200 に統一。

### 2. ガイド数 256/100 → 260
README / llms.txt が「256 task-focused guides」、`docs/README.md` が「100 guides」。実数は **260 本**。

## 変更内訳（81 ファイル / 310 置換）
- code/test 3: `tools/local-mcp-server.php`・`tools/issue-jwt.php`・`tests/Mcp/LocalMcpServerTest.php`
- 英語 docs 18 / 翻訳 docs 58 / ルート 2（README.md・llms.txt）

## 意図的に 8080 を維持（文脈で除外）
- `tutorial/first-api.md`（`php -S localhost:8080` 自己完結）
- `development/client-project-start.md`（consumer プロジェクトの自前ポート）
- `howto/deploy-production.md`（本番デプロイ例・loopback バインド）
- `release-v0.1.*-prep.md` / `milestones/*`（点時記録・履歴）
- `howto/url-shortener-ssrf.md`（SSRF 攻撃標的の例。NENE2 ポートではない）

## 検証
`composer check` 相当 + howto 索引 drift すべてローカル通過:
- phpunit **456 tests / 1092 assertions**（MCP テスト含む）
- PHPStan L8 クリーン / php-cs-fixer クリーン
- openapi / mcp valid / howto frontmatter / howto:index drift なし
- `git diff --check` クリーン

## Self-review
docs-policy

Closes #1393

🤖 Generated with [Claude Code](https://claude.com/claude-code)