### PR TITLE
docs(daily): 2026-06-17 日報を追加 (#1395)

### DIFF
--- a/docs/daily/2026-06-17.md
+++ b/docs/daily/2026-06-17.md
@@ -1,0 +1,71 @@
+# 日報 — 2026-06-17
+
+## 作業時間帯
+
+2026-06-17。リポジトリのハウスキーピング（引き継ぎ同期・依存更新・ブランチ整理）から、品質指標の実改善、ドキュメント鮮度・整合性の回復まで。新機能ではなく「散らかりを見つけて根本から直し、再発しない形にする」整備中心の一日。
+
+---
+
+## 本日の成果
+
+### 1. リポジトリ整備（引き継ぎ・依存・ブランチ）
+
+| 区分 | 内容 | PR / Issue |
+|------|------|-----------|
+| 引き継ぎ同期 | `docs/todo/current.md` が実態より遅れていた（最終 FT349/v1.5.323 表記 → 実態 FT352/v1.5.329）。引き継ぎ表・直近 FT 履歴・次の ATK(356)/VULN(357) サイクルを実態に同期 | #1380 / #1381 |
+| Dependabot（第1陣） | オープン 9件を処理。CI 緑の 8件をマージ、lock 競合は rebase で順次解消 | #1367/1369/1371/1374/1375/1377/1378/1379 |
+| ブランチ整理 | main にマージ済みのリモートブランチを削除（fr/ja/zh 翻訳3本。他は既にリモート削除済みで古い追跡参照が残っていただけ → `fetch --prune` で解消） | — |
+| Dependabot（第2陣） | 当日新規生成の5件（phpunit/php-cs-fixer/eslint/prettier/react-refresh）を全件マージ | #1386–#1390 |
+
+### 2. #1376 react/react-dom 不整合の修正と再発防止
+
+Dependabot #1376 が `react` を 19.2.7 に上げる一方 `react-dom` を 19.2.6 に据え置き、vitest が "Incompatible React versions" で6スイート失敗していた。単独マージ不可と判断し、root を断つ形で対応。
+
+- **#1382 / #1383**: `react` / `react-dom` を `^19.2.7` に揃え、`@types/react` を `^19.2.17` に更新。`npm run check`（70 tests）通過を確認し #1376 を置換（クローズ）。
+- **#1384 / #1385**: `.github/dependabot.yml` の `/frontend` に `groups`（react / react-dom / @types/react / @types/react-dom）を追加。今後は React 関連が常に1 PR でまとまり、同種の不整合が構造的に再発しない。
+
+### 3. リポジトリ評価 → 指摘点の実改善
+
+リポジトリを横断評価（総合 **A+ / 9.5**）。strict_types 100%・PHPStan L8 クリーン・テスト LOC が実装超過・技術的負債マーカー 0 など高完成度を確認。唯一の減点理由だった「assertion 密度」を、薄かった契約テストの格上げで実際に解消。
+
+- **#1391 / #1392**: `OpenApiProblemDetailsTest` を生 YAML の substring 一致 → `symfony/yaml` による**構造検証**へ格上げ。ProblemDetails の RFC 9457 形状、ValidationProblemDetails の allOf 継承と errors 配列、ValidationError の field/message/code 必須、共有 Problem レスポンスの media type/スキーマ参照、**422 を返す全オペレーションが共有 ValidationFailed を再利用**（inline 化防止）を検証。
+  - 当該ファイル: **2 tests / 6 asserts → 13 tests / 72 asserts**
+
+### 4. ドキュメント鮮度・整合性の回復
+
+鮮度チェックで2系統の不整合を検出し、発生源まで遡って修正（#1393 / #1394、81ファイル / 310置換）。
+
+- **ローカルポート 8080 → 8200**: 正本は全て 8200（`compose.yaml` の `8200:80`、CLAUDE.md、#1361 で修正済みの openapi）。なのに**コード既定値**（`tools/local-mcp-server.php` のフォールバック）と多数 docs が 8080 のまま＝これが docs 全体の発生源。コード/テスト3件 + 全言語 docs を 8200 に統一。`setup.md` のポート競合節（8080/8081）も 8200/8201 に。
+- **ガイド数 256/100 → 260**: README / llms.txt の「256」、`docs/README.md` の「100」を実数 260 に。
+- **文脈で意図的に保持した 8080**: `first-api.md`（php -S）/ `client-project-start.md`（consumer 自前ポート）/ `deploy-production.md`（本番例）/ `release-v0.1.*-prep`・`milestones/*`（履歴）/ `url-shortener-ssrf.md`（SSRF 攻撃標的の例）。起動方法（docker compose か php -S か）を機械判定して切り分け。
+
+### 5. 運用確認・後始末
+
+- **main 保護の確認**: クラシックなブランチ保護は OFF だが、Ruleset `main protection`（active）が PR 必須 / required status checks（Composer・npm）/ non-fast-forward / deletion 禁止を強制。直 push 不可を確認。
+- **/doctor 指摘の設定修正**: `.claude/settings.json` の `permissions.allow` にあった無効ルール `mcp__*`（allow ではワイルドカード不可）を削除。
+- **#1372 クローズ**: EXP-003 DEV 記事は別リポジトリ管理に移行のためクローズ。
+
+---
+
+## 数値
+
+- 本体テスト: **445 → 456 tests** / **1030 → 1092 assertions**（PHPStan level 8 クリーン継続）
+- マージ PR: **18 件**（Dependabot 13 + 整備系 5）
+- 新規 Issue: 5 件（#1380/1382/1384/1391/1393、いずれもクローズ済み）/ クローズ Issue: #1372・#1376
+- 変更規模（鮮度回復）: 81 ファイル / 310 置換
+
+---
+
+## 残課題（次回以降）
+
+| 優先 | 内容 |
+|------|------|
+| P1 | assertion 密度は契約テスト1本を格上げ済み。UseCase 単体テスト（`Example/Note/*` 等）にも永続化ラウンドトリップ／エッジ検証を足す余地あり |
+| P2 | リリース粒度のインフレ（docs-only 変更でも patch が進む）。docs と core release の分離 or FT バッチのまとめリリースを検討 |
+| P3 | Dependabot グルーピングは React のみ。他の関連群（testing-library 系・eslint 系）も束ねると PR 数を減らせる |
+
+---
+
+## 所感
+
+派手さはないが整備が綺麗に決まった一日。特に #1376 は「CI が赤いまま放置された PR」を表面的にマージするのではなく、`react-dom` 取り残しという root を断ち、dependabot グルーピングで再発まで止められた。評価で自分が付けた減点（assertion 密度）をその場で実改善に落とし込めたのも気持ちよく、ドキュメントの 8080→8200 は「発生源がコード既定値」と突き止めて全言語＋テストまで一貫させられた。盲目的 sed で consumer 手順や SSRF 攻撃例の 8080 を壊さず、文脈判定で切り分けられた点も含め、終わってみればオープン Issue 0 / PR 0 / main クリーンで区切りは上々。


### PR DESCRIPTION
## 目的
本日（2026-06-17）の作業日報を追加する。

## 内容
- リポジトリ整備（current.md 同期 / Dependabot 13件処理 / マージ済みブランチ整理）
- #1376 react-dom 不整合の修正（#1382/#1383）と再発防止グルーピング（#1384/#1385）
- リポジトリ評価（A+ / 9.5）→ Problem Details 契約テスト格上げ（#1391/#1392, 2→13 tests）
- ドキュメント鮮度・整合性回復（#1393/#1394, ポート 8080→8200・ガイド数 256→260, 81ファイル）
- main 保護 ruleset の確認・#1372 クローズ

## Self-review
docs-policy

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)