### PR TITLE
fix(config): 開発用ポート参照を 8080 から 8200 へ統一 (#1397)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,5 +19,5 @@ npm run check --prefix frontend
 
 The starter calls the NENE2 `/health` endpoint through `src/api/health.ts`.
 
-During local development, Vite proxies `/api/*` to the Docker backend at `http://localhost:8080`.
+During local development, Vite proxies `/api/*` to the Docker backend at `http://localhost:8200`.
 Set `VITE_NENE2_API_BASE_URL` when an application needs a different API base URL.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: 'http://localhost:8200',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -4,7 +4,7 @@
 # This MCP server runs alongside a local NENE2 application.
 # Prerequisites:
 #   1. Clone this repository and run: docker compose up -d app
-#   2. The app will be available at http://localhost:8080
+#   2. The app will be available at http://localhost:8200
 #   3. Set NENE2_LOCAL_JWT_SECRET in .env to enable write tools and Bearer auth.
 
 startCommand:
@@ -18,7 +18,7 @@ startCommand:
           Base URL of the running NENE2 application.
           Use "http://app" when the app is running via "docker compose up -d app"
           (the MCP server container shares the same Docker network).
-          Use "http://host.docker.internal:8080" if the app is running directly on the host.
+          Use "http://host.docker.internal:8200" if the app is running directly on the host.
         default: http://app
       jwtSecret:
         type: string


### PR DESCRIPTION
## 目的

`#1393`/`#1394` でドキュメント全体のローカルポートを **8080 → 8200**（ポートレジストリ: NENE2 = HTTP 8200 / MySQL 3316）に統一した際、設定ファイル側に追従漏れがあった 3 箇所を修正する。

## 変更点

| ファイル | 変更 | 影響 |
|---|---|---|
| `frontend/vite.config.ts` | dev proxy `/api` のターゲット 8080→8200 | `npm run dev` の API 呼び出しが 8200 稼働中の NENE2 に届くようになる（実害の修正）|
| `frontend/README.md` | 上記 proxy 先（Docker backend）の説明を 8200 に追従 | ドキュメントと設定の整合 |
| `smithery.yaml` | 起動手順コメント＋`host.docker.internal` 例を 8200 に | Smithery 利用者が誤ポートで host 直結するのを防止 |

## 検証

- `npm run check --prefix frontend` — ✅ type-check / ESLint / Prettier / Vitest 70 テスト全通過
- `smithery.yaml` — ✅ YAML パース確認
- 残存 `8080` の最終確認 — `git grep 8080` の残りは **#1393 で意図的に保持された文脈**のみ（tutorial の `php -S` 例 / consumer 自前ポート手順 / 本番 nginx・caddy リバースプロキシ例 / `url-shortener-ssrf.md` の SSRF 攻撃標的例 / CHANGELOG・日報・milestones の履歴）

## スコープ外

- `compose.override.yaml`（8085/3307）は `.gitignore:1` で **git 追跡対象外のローカル専用上書きファイル**。各開発者のローカルポート選択でありリポジトリのドリフトではないため変更しない。

## Self-review

frontend, docs-policy

Closes #1397