### PR TITLE
docs: roadmap Phase 75 の FT スコープを実態へ更新（FT349→FT352）(#1403)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -815,7 +815,7 @@ same gotchas.
 
 ## Phase 75: v2.0 Design and Framework Evolution
 
-Goal: review the friction and gaps accumulated across FT96–FT349 and decide
+Goal: review the friction and gaps accumulated across FT96–FT352 and decide
 what moves into the framework core vs. remains as howto-only patterns.
 
 - Collect top-friction patterns from field trial reports


### PR DESCRIPTION
## 目的

`docs/roadmap.md` Phase 75（v2.0 Design、未完了の現在進行フェーズ）の Goal が friction レビュー対象を **FT96–FT349** と記載していたが、FT ループは **FT352** まで到達済み。現在スコープの記述を実態に同期する。

## 変更点

- L818: `FT96–FT349` → `FT96–FT352`（1行のみ）

## 対象外（意図的に据え置き）

**Phase 73（✅完了）の「256 howto guides, 6 locales 完全同期」** は変更しない。これは完了フェーズの達成時点スナップショット（#1302 が当時 256 件でサイドバー生成）であり:

- Phase 71/72 が「100 howto guides」を据え置くのと同じ歴史記録の慣習。
- 直近の鮮度回復 #1393 も README/llms.txt は 256→260 に直したが roadmap の完了フェーズは意図的に未変更。
- 260 に書き換えると過去 PR（#1302）の実績を誤記することになる。

## 検証

- `git diff --check` 空白エラーなし / roadmap 内に `FT349` 残存なし

## Self-review

docs-policy

Closes #1403