### PR TITLE
test(database): MySQL 統合テストに skip ガードを追加 (#1405)

### DIFF
--- a/tests/Database/MySql/PdoMySqlConnectionTest.php
+++ b/tests/Database/MySql/PdoMySqlConnectionTest.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace Nene2\Tests\Database\MySql;
 
-use Nene2\Config\DatabaseConfig;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Database\PdoDatabaseTransactionManager;
-use PDO;
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 final class PdoMySqlConnectionTest extends TestCase
 {
+    use RequiresMySql;
+
     public function testConnectsExecutesQueriesAndRollsBackTransactions(): void
     {
         $tableName = 'nene2_mysql_verification_' . bin2hex(random_bytes(4));
@@ -55,43 +54,5 @@ final class PdoMySqlConnectionTest extends TestCase
         } finally {
             $executor->execute(sprintf('DROP TABLE IF EXISTS %s', $tableName));
         }
-    }
-
-    private function connection(): PDO
-    {
-        $lastError = null;
-
-        for ($attempt = 0; $attempt < 20; $attempt++) {
-            try {
-                return (new PdoConnectionFactory($this->config()))->create();
-            } catch (Throwable $exception) {
-                $lastError = $exception;
-                usleep(250_000);
-            }
-        }
-
-        self::fail('MySQL connection could not be created: ' . $lastError->getMessage());
-    }
-
-    private function config(): DatabaseConfig
-    {
-        return new DatabaseConfig(
-            null,
-            'test',
-            'mysql',
-            $this->env('DB_HOST', 'mysql'),
-            (int) $this->env('DB_PORT', '3306'),
-            $this->env('DB_NAME', 'nene2'),
-            $this->env('DB_USER', 'nene2'),
-            $this->env('DB_PASSWORD', 'nene2'),
-            $this->env('DB_CHARSET', 'utf8mb4'),
-        );
-    }
-
-    private function env(string $key, string $default): string
-    {
-        $value = $_SERVER[$key] ?? $_ENV[$key] ?? getenv($key);
-
-        return is_string($value) && $value !== '' ? $value : $default;
     }
 }

--- a/tests/Database/MySql/PdoNoteRepositoryMySqlTest.php
+++ b/tests/Database/MySql/PdoNoteRepositoryMySqlTest.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace Nene2\Tests\Database\MySql;
 
-use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Example\Note\Note;
 use Nene2\Example\Note\PdoNoteRepository;
-use PDO;
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 final class PdoNoteRepositoryMySqlTest extends TestCase
 {
+    use RequiresMySql;
+
     private PdoDatabaseQueryExecutor $executor;
 
     protected function setUp(): void
@@ -75,43 +74,5 @@ final class PdoNoteRepositoryMySqlTest extends TestCase
         $repository = new PdoNoteRepository($this->executor);
 
         self::assertNull($repository->findById(99999));
-    }
-
-    private function connection(): PDO
-    {
-        $lastError = null;
-
-        for ($attempt = 0; $attempt < 20; $attempt++) {
-            try {
-                return (new PdoConnectionFactory($this->config()))->create();
-            } catch (Throwable $exception) {
-                $lastError = $exception;
-                usleep(250_000);
-            }
-        }
-
-        self::fail('MySQL connection could not be created: ' . $lastError->getMessage());
-    }
-
-    private function config(): DatabaseConfig
-    {
-        return new DatabaseConfig(
-            null,
-            'test',
-            'mysql',
-            $this->env('DB_HOST', 'mysql'),
-            (int) $this->env('DB_PORT', '3306'),
-            $this->env('DB_NAME', 'nene2'),
-            $this->env('DB_USER', 'nene2'),
-            $this->env('DB_PASSWORD', 'nene2'),
-            $this->env('DB_CHARSET', 'utf8mb4'),
-        );
-    }
-
-    private function env(string $key, string $default): string
-    {
-        $value = $_SERVER[$key] ?? $_ENV[$key] ?? getenv($key);
-
-        return is_string($value) && $value !== '' ? $value : $default;
     }
 }

--- a/tests/Database/MySql/PdoTagRepositoryMySqlTest.php
+++ b/tests/Database/MySql/PdoTagRepositoryMySqlTest.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace Nene2\Tests\Database\MySql;
 
-use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Example\Tag\PdoTagRepository;
 use Nene2\Example\Tag\Tag;
-use PDO;
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 final class PdoTagRepositoryMySqlTest extends TestCase
 {
+    use RequiresMySql;
+
     private PdoDatabaseQueryExecutor $executor;
 
     protected function setUp(): void
@@ -100,43 +99,5 @@ final class PdoTagRepositoryMySqlTest extends TestCase
         $repository = new PdoTagRepository($this->executor);
 
         self::assertNull($repository->findById(99999));
-    }
-
-    private function connection(): PDO
-    {
-        $lastError = null;
-
-        for ($attempt = 0; $attempt < 20; $attempt++) {
-            try {
-                return (new PdoConnectionFactory($this->config()))->create();
-            } catch (Throwable $exception) {
-                $lastError = $exception;
-                usleep(250_000);
-            }
-        }
-
-        self::fail('MySQL connection could not be created: ' . $lastError->getMessage());
-    }
-
-    private function config(): DatabaseConfig
-    {
-        return new DatabaseConfig(
-            null,
-            'test',
-            'mysql',
-            $this->env('DB_HOST', 'mysql'),
-            (int) $this->env('DB_PORT', '3306'),
-            $this->env('DB_NAME', 'nene2'),
-            $this->env('DB_USER', 'nene2'),
-            $this->env('DB_PASSWORD', 'nene2'),
-            $this->env('DB_CHARSET', 'utf8mb4'),
-        );
-    }
-
-    private function env(string $key, string $default): string
-    {
-        $value = $_SERVER[$key] ?? $_ENV[$key] ?? getenv($key);
-
-        return is_string($value) && $value !== '' ? $value : $default;
     }
 }

--- a/tests/Database/MySql/RequiresMySql.php
+++ b/tests/Database/MySql/RequiresMySql.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Database\MySql;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use PDO;
+use Throwable;
+
+/**
+ * Shared MySQL wiring for the DatabaseMySQL integration suite.
+ *
+ * These tests require a running MySQL instance (`docker compose up -d mysql`).
+ * When the database cannot be reached the test is skipped instead of failed, so
+ * the suite degrades gracefully on machines without MySQL provisioned. The first
+ * unreachable attempt is cached so the remaining tests skip immediately rather
+ * than each re-running the connection retry budget.
+ */
+trait RequiresMySql
+{
+    private const string SKIP_MESSAGE =
+        'MySQL is not reachable — skipping integration test. Start it with `docker compose up -d mysql`.';
+
+    private static ?bool $mySqlReachable = null;
+
+    private function connection(): PDO
+    {
+        if (self::$mySqlReachable === false) {
+            self::markTestSkipped(self::SKIP_MESSAGE);
+        }
+
+        $lastError = null;
+
+        for ($attempt = 0; $attempt < 20; $attempt++) {
+            try {
+                $connection = (new PdoConnectionFactory($this->config()))->create();
+                self::$mySqlReachable = true;
+
+                return $connection;
+            } catch (Throwable $exception) {
+                $lastError = $exception;
+                usleep(250_000);
+            }
+        }
+
+        self::$mySqlReachable = false;
+        self::markTestSkipped(self::SKIP_MESSAGE . ' Last error: ' . $lastError->getMessage());
+    }
+
+    private function config(): DatabaseConfig
+    {
+        return new DatabaseConfig(
+            null,
+            'test',
+            'mysql',
+            $this->env('DB_HOST', 'mysql'),
+            (int) $this->env('DB_PORT', '3306'),
+            $this->env('DB_NAME', 'nene2'),
+            $this->env('DB_USER', 'nene2'),
+            $this->env('DB_PASSWORD', 'nene2'),
+            $this->env('DB_CHARSET', 'utf8mb4'),
+        );
+    }
+
+    private function env(string $key, string $default): string
+    {
+        $value = $_SERVER[$key] ?? $_ENV[$key] ?? getenv($key);
+
+        return is_string($value) && $value !== '' ? $value : $default;
+    }
+}


### PR DESCRIPTION
## 目的

`tests/Database/MySql/`（DatabaseMySQL スイート、デフォルト `composer test` 対象外の opt-in 統合テスト）に skip ガードが無く、MySQL 未起動で実行すると接続を 20 回リトライ後 `self::fail()` していた。setUp が毎メソッド走るため **計 13 回（1+5+7）× 5 秒 ≒ 65 秒ハング後に FAIL**。CLAUDE.md の FT ルール「MySQL 未設定なら自動 skip」と乖離していた。

## 変更点

| ファイル | 変更 |
|---|---|
| `RequiresMySql.php`（新規 trait）| 3 ファイルに完全重複していた `connection()/config()/env()`（各 ~36 行）を集約。到達不能時は `markTestSkipped()`、判定を `private static` でキャッシュ |
| `PdoMySqlConnectionTest` / `PdoNoteRepositoryMySqlTest` / `PdoTagRepositoryMySqlTest` | ヘルパー削除 → `use RequiresMySql;`、不要 import 整理 |

正味 **重複 123 行削除 + trait 73 行**（−44 行）。

## 設計判断

- `compose.yaml` が app コンテナに `DB_HOST=mysql` を常設するため「env 未設定なら skip」は使えない。よって**接続試行 → 到達不能なら skip**。
- 20 回リトライは MySQL 起動レース吸収のため維持（`docker compose run` は mysql healthcheck を待たない）。
- 到達不能を `static` キャッシュし、初回失敗後の setUp は即スキップ（最悪 13×5 秒 → クラス毎 1 回の探索のみ）。

## 検証（ローカル PHP 8.4.22）

- `php-cs-fixer`（cs）✅ / `phpstan` level 8（analyse）✅
- DatabaseMySQL を MySQL 無しで実行 → **13 件全 skip・exit 0**（fail/error ゼロ）。skip メッセージ: `MySQL is not reachable — skipping integration test. Start it with \`docker compose up -d mysql\`.`
- デフォルト `test`（NENE2,Database）→ **456 件 / 1092 assertions 全通過**（影響なし）

## Self-review

database

Closes #1405