### PR TITLE
feat(health): /machine/health にアプリ版と framework 版を追加 (#1414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.330] — 2026-06-25
+
+### Added
+- `Nene2\Http\RuntimeApplicationFactory` — `appVersion` コンストラクタ引数（`?string`、既定 `null`）を追加。設定すると `GET /machine/health` のレスポンスに消費側アプリ自身の semver を `version` フィールドとして返す。`null` の場合は `version` を省略するため後方互換。アプリ版（`version`）はフレームワーク版とは別物で、フレームワーク版は常に `framework_version`（= `FrameworkInfo::VERSION`）として返す。suite / orchestrator が公開 `/health` に版情報を晒さずに各アプリの installed version を追跡できるよう、認証済みの machine エンドポイントに載せた（#1414）
+- `docs/openapi/openapi.yaml` — `MachineHealthResponse` に `version`（任意）と `framework_version`（必須）を追記。`withAppVersion` example を追加
+
+### Changed
+- `docs/development/machine-client-smoke.md` — `/machine/health` のレスポンス例を新フィールド（`framework_version` / 任意の `version`）に合わせて更新
+
+---
+
 ## [1.5.329] — 2026-05-31
 
 ### Fixed

--- a/docs/development/machine-client-smoke.md
+++ b/docs/development/machine-client-smoke.md
@@ -24,9 +24,15 @@ The expected success response includes:
 {
   "status": "ok",
   "service": "NENE2",
+  "framework_version": "1.5.330",
   "credential_type": "api_key"
 }
 ```
+
+`framework_version` always reports the running NENE2 framework version. When the application
+injects its own version (`RuntimeApplicationFactory`'s `appVersion`), the response also includes a
+top-level `version` field with the application's own semver; it is omitted otherwise. Consumers must
+treat a missing `version` as "unknown".
 
 ## Start With a Local Key
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.329
+  version: 1.5.330
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:
@@ -110,6 +110,15 @@ paths:
                   value:
                     status: ok
                     service: NENE2
+                    framework_version: 1.5.330
+                    credential_type: api_key
+                withAppVersion:
+                  summary: When the application injects its own version
+                  value:
+                    status: ok
+                    service: NENE2
+                    version: 1.4.2
+                    framework_version: 1.5.330
                     credential_type: api_key
         '401':
           $ref: '#/components/responses/Unauthorized'
@@ -851,6 +860,7 @@ components:
       required:
         - status
         - service
+        - framework_version
         - credential_type
       properties:
         status:
@@ -861,6 +871,17 @@ components:
         service:
           type: string
           example: NENE2
+        version:
+          type: string
+          description: >-
+            The consuming application's own semantic version. Present only when the application
+            injects it via RuntimeApplicationFactory's `appVersion`; omitted otherwise. Distinct
+            from `framework_version`. Consumers must treat a missing value as "unknown".
+          example: 1.4.2
+        framework_version:
+          type: string
+          description: The NENE2 framework version the application runs on (FrameworkInfo::VERSION).
+          example: 1.5.330
         credential_type:
           type: string
           enum:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.329';
+    public const string VERSION = '1.5.330';
 
     public function name(): string
     {

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -81,6 +81,16 @@ final readonly class RuntimeApplicationFactory
      *                                       (env `PROBLEM_DETAILS_BASE_URL`) so framework and domain
      *                                       errors share the same `type` namespace. Defaults to
      *                                       `https://nene2.dev/problems/` for backward compatibility.
+     * @param string|null $appVersion The consuming application's own semantic version (e.g. `'1.4.2'`),
+     *                                surfaced on `GET /machine/health` as the `version` field. Each app
+     *                                injects its own value from wherever it tracks its release (its
+     *                                `composer.json`, a `VERSION` constant, or an environment variable);
+     *                                leave it null to omit the field entirely. This is the *application*
+     *                                version and is intentionally distinct from the *framework* version
+     *                                ({@see FrameworkInfo::VERSION}), which is always reported separately
+     *                                as `framework_version`. Surfacing it on the auth-gated machine
+     *                                endpoint lets a suite/orchestrator track each app's installed
+     *                                version without exposing it on the public `GET /health`.
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
@@ -101,6 +111,7 @@ final readonly class RuntimeApplicationFactory
         private array $machineApiKeyProtectedMethods = [],
         private int $requestMaxBodyBytes = 1_048_576,
         private string $problemDetailsBaseUrl = 'https://nene2.dev/problems/',
+        private ?string $appVersion = null,
     ) {
     }
 
@@ -127,6 +138,7 @@ final readonly class RuntimeApplicationFactory
             $this->problemDetailsBaseUrl,
         );
         $framework = new FrameworkInfo();
+        $appVersion = $this->appVersion;
 
         $router = (new Router())
             ->get(
@@ -176,11 +188,21 @@ final readonly class RuntimeApplicationFactory
             )
             ->get(
                 '/machine/health',
-                static fn (ServerRequestInterface $request) => $jsonResponses->create([
-                    'status' => 'ok',
-                    'service' => $framework->name(),
-                    'credential_type' => $request->getAttribute('nene2.auth.credential_type'),
-                ]),
+                function (ServerRequestInterface $request) use ($jsonResponses, $framework, $appVersion) {
+                    $payload = [
+                        'status' => 'ok',
+                        'service' => $framework->name(),
+                    ];
+
+                    if ($appVersion !== null) {
+                        $payload['version'] = $appVersion;
+                    }
+
+                    $payload['framework_version'] = FrameworkInfo::VERSION;
+                    $payload['credential_type'] = $request->getAttribute('nene2.auth.credential_type');
+
+                    return $jsonResponses->create($payload);
+                },
             )
             ->get(
                 '/examples/ping',

--- a/tests/HttpRuntimeTest.php
+++ b/tests/HttpRuntimeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Tests;
 
+use Nene2\FrameworkInfo;
 use Nene2\Http\HealthCheckInterface;
 use Nene2\Http\HealthStatus;
 use Nene2\Http\JsonResponseFactory;
@@ -144,6 +145,31 @@ final class HttpRuntimeTest extends TestCase
         self::assertSame('ok', $payload['status']);
         self::assertSame('NENE2', $payload['service']);
         self::assertSame('api_key', $payload['credential_type']);
+        // framework_version is always reported; the application version is omitted unless injected.
+        self::assertSame(FrameworkInfo::VERSION, $payload['framework_version']);
+        self::assertArrayNotHasKey('version', $payload);
+    }
+
+    public function testMachineHealthIncludesAppVersionWhenInjected(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            machineApiKey: 'test-key',
+            appVersion: '2.3.4',
+        ))->create();
+
+        $response = $application->handle(
+            $factory
+                ->createServerRequest('GET', 'https://example.test/machine/health')
+                ->withHeader('X-NENE2-API-Key', 'test-key'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('2.3.4', $payload['version']);
+        self::assertSame(FrameworkInfo::VERSION, $payload['framework_version']);
     }
 
     public function testExamplePingEndpointRunsThroughRuntime(): void

--- a/tests/OpenApi/RuntimeContractTest.php
+++ b/tests/OpenApi/RuntimeContractTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Tests\OpenApi;
 
+use Nene2\FrameworkInfo;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -90,6 +91,14 @@ final class RuntimeContractTest extends TestCase
 
                 if (!is_array($example) || !is_string($schemaRef)) {
                     continue;
+                }
+
+                // framework_version is reported dynamically from FrameworkInfo::VERSION and changes on
+                // every release. Normalize the documented example to the running version so the strict
+                // example-vs-response contract assertion verifies the field is present and equals the
+                // framework version, without breaking on each version bump.
+                if (array_key_exists('framework_version', $example)) {
+                    $example['framework_version'] = FrameworkInfo::VERSION;
                 }
 
                 yield sprintf('%s %s', strtoupper($method), $path) => [


### PR DESCRIPTION
## 目的

`GET /machine/health` に、稼働中アプリの **installed version** を載せる。NeNe Suite の update-aggregation が各アプリの版を追跡し「更新あり/最新」を判定できるようにする。Issue #1414 で消費側（Suite）と契約合意済み。

## 変更点

- `Nene2\Http\RuntimeApplicationFactory` に optional `?string $appVersion = null` を追加。
  - 設定時のみ `/machine/health` に **`version`**（アプリ自身の semver）を返す。未注入なら省略（additive / 後方互換）。
  - **`framework_version`**（= `FrameworkInfo::VERSION`）は常に返す。アプリ版とフレームワーク版を明確に分離。
- 露出面は **認証済みの `/machine/health` のみ**。公開 `/health` には版情報を出さない（開示懸念を回避）。
- OpenAPI `MachineHealthResponse` に `version`(任意) / `framework_version`(必須) を追記、`withAppVersion` example を追加。
- `RuntimeContractTest` は `framework_version` を実行時の `FrameworkInfo::VERSION` に正規化 → バンプ毎の example drift を防止しつつ「machine/health は常に現行版を返す」ことを検証。
- バージョン **1.5.330** へバンプ。CHANGELOG / machine-client-smoke.md 更新。

## 確定した契約

```jsonc
GET /machine/health        // 既存 auth-gated
{
  "status": "ok",
  "service": "NENE2",
  "version": "1.4.2",            // アプリ semver（注入時のみ）
  "framework_version": "1.5.330", // = FrameworkInfo::VERSION（常時）
  "credential_type": "api_key"
}
```

## 検証

- `composer check` 全項目グリーン: 457 tests / 1102 assertions、PHPStan level 8 エラー 0、CS Fixer 0、OpenAPI valid、MCP valid、**Version consistency OK: 1.5.330**
- 追加テスト: `testMachineHealthIncludesAppVersionWhenInjected`、既存 `testMachineHealthAcceptsConfiguredApiKey` に `framework_version` / `version` 省略の検証を追加

## Self-review

backend-api, openapi-contract, middleware-security

## 後続

- Suite repo 側で client seam（`SiblingHealthClientInterface`）を machine-health + 認証へ差し替える follow-up（別 repo）。

Closes #1414