### PR TITLE
docs(health): #1414 の説明文から下流製品名(suite/orchestrator)を除去 (#1417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.5.330] — 2026-06-25
 
 ### Added
-- `Nene2\Http\RuntimeApplicationFactory` — `appVersion` コンストラクタ引数（`?string`、既定 `null`）を追加。設定すると `GET /machine/health` のレスポンスに消費側アプリ自身の semver を `version` フィールドとして返す。`null` の場合は `version` を省略するため後方互換。アプリ版（`version`）はフレームワーク版とは別物で、フレームワーク版は常に `framework_version`（= `FrameworkInfo::VERSION`）として返す。suite / orchestrator が公開 `/health` に版情報を晒さずに各アプリの installed version を追跡できるよう、認証済みの machine エンドポイントに載せた（#1414）
+- `Nene2\Http\RuntimeApplicationFactory` — `appVersion` コンストラクタ引数（`?string`、既定 `null`）を追加。設定すると `GET /machine/health` のレスポンスに消費側アプリ自身の semver を `version` フィールドとして返す。`null` の場合は `version` を省略するため後方互換。アプリ版（`version`）はフレームワーク版とは別物で、フレームワーク版は常に `framework_version`（= `FrameworkInfo::VERSION`）として返す。machine クライアント（監視・運用・デプロイツール等）が公開 `/health` に版情報を晒さずにアプリ版を読めるよう、認証済みの machine エンドポイントに載せた（#1414）
 - `docs/openapi/openapi.yaml` — `MachineHealthResponse` に `version`（任意）と `framework_version`（必須）を追記。`withAppVersion` example を追加
 
 ### Changed

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -89,8 +89,9 @@ final readonly class RuntimeApplicationFactory
      *                                version and is intentionally distinct from the *framework* version
      *                                ({@see FrameworkInfo::VERSION}), which is always reported separately
      *                                as `framework_version`. Surfacing it on the auth-gated machine
-     *                                endpoint lets a suite/orchestrator track each app's installed
-     *                                version without exposing it on the public `GET /health`.
+     *                                endpoint keeps the application version readable by machine clients
+     *                                (monitoring, operators, deployment tooling) without exposing it on
+     *                                the public `GET /health`.
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,


### PR DESCRIPTION
## 目的

NENE2 は特定の下流消費者（suite / orchestrator）を知らないのが健康体。#1414 の **機能・契約は汎用で健全**だが、PHPDoc と CHANGELOG の **説明文で下流製品を名指し**していたため、フレームワーク非結合な汎用表現へ戻す。

## 変更点（説明文のみ・挙動/契約は無変更）

- `src/Http/RuntimeApplicationFactory.php` — `appVersion` PHPDoc の "suite/orchestrator が installed version を追跡" を "machine クライアント（監視・運用・デプロイツール）がアプリ版を読める" へ
- `CHANGELOG.md` — 1.5.330 エントリを同様に汎用化

## 監査結果

漏れは #1414 起因の言い回し 3 箇所のみ（src PHPDoc / CHANGELOG / Release 本文）。OpenAPI 契約・smoke doc・README・llms.txt はクリーン。`src/` の他ヒット（`downstream`/`aggregate`）は PSR-15/DI の汎用語で無関係。コミットメッセージにも consumer 名なし。

Release v1.5.330 本文は別途 `gh release edit` で汎用化する。

## 検証

`composer check` 全緑（test / PHPStan level 8 / CS / OpenAPI / MCP / Version consistency 1.5.330）。

## Self-review

docs-policy, backend-api

Closes #1417