### PR TITLE
feat(machine): 候補DBの read-only プリフライト診断エンドポイント (#1419 / A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.331] — 2026-06-27
+
+### Added
+- `Nene2\Database\Preflight` — 候補データベースを **read-only で自己診断**する framework 機能の MVP（#1419 / A）。`DatabaseCandidateInspector` インターフェース、無設定で動く `DefaultDatabaseCandidateInspector`（マイグレーション台帳 `phinx_log` ベース）、`CandidateProfile` / `PreflightVerdict` value object、`MigrationState` / `PreflightRecommendation` enum を追加。
+- `Nene2\Http\RuntimeApplicationFactory` — `databaseCandidateInspector`（`?DatabaseCandidateInspector`、既定 `null`）と `databaseCandidateProfiles`（`array<string, CandidateProfile>`、既定 `[]`）コンストラクタ引数を追加。inspector を渡したときのみ `POST /machine/database/preflight` を登録する。`null` のままなら framework コアは従来どおり DB 非依存で、エンドポイントは生えない（後方互換）。エンドポイントは machine API キーで自動保護される（allowlist モード時）。
+- エンドポイントは候補プロファイル **ID のみ**を受け取り、接続情報・認証情報はアプリ自身の設定から解決する（DSN/creds を wire に載せない・SSRF 封じ）。verdict は reason code のみで生の DB 名/ホスト/データを含まない。read-only はトランザクション機構で保証（SQLite `PRAGMA query_only`、MySQL/PostgreSQL `START TRANSACTION READ ONLY`）。
+- マルチテナント構成のガード（#1419）: tenant 未評価（B / #1420 未導入）の間は無条件 `safe` を返さず、`reason_codes` に `tenant_unevaluated` を付けて `needs_review` に倒す。`app_identity` は `not_evaluated`、`tenant` は `not_applicable`（いずれも #1420 で有効化）。
+- `docs/openapi/openapi.yaml` — `machineDatabasePreflight` 操作、`MachineDatabasePreflightRequest` / `MachineDatabasePreflightResponse` スキーマを追加。
+- `docs/mcp/tools.json` — `machineDatabasePreflight` ツール（`safety: read`）を追加。
+
+---
+
 ## [1.5.330] — 2026-06-25
 
 ### Added

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -341,6 +341,29 @@
         }
       },
       "responseSchemaRef": null
+    },
+    {
+      "name": "machineDatabasePreflight",
+      "title": "Machine Database Preflight",
+      "description": "Run a read-only self-diagnosis on a candidate database (resolved from the application's own configuration by id) and return a structured verdict. The candidate connection and credentials are never passed through this tool. Auth-gated machine endpoint.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "machineDatabasePreflight",
+        "method": "POST",
+        "path": "/machine/database/preflight"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["candidate"],
+        "properties": {
+          "candidate": {
+            "type": "string"
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/MachineDatabasePreflightResponse"
     }
   ]
 }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.330
+  version: 1.5.331
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:
@@ -124,6 +124,64 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '413':
           $ref: '#/components/responses/PayloadTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /machine/database/preflight:
+    post:
+      tags:
+        - System
+      summary: Candidate database preflight (read-only self-diagnosis)
+      description: >-
+        Inspects a candidate database read-only and returns a structured verdict answering
+        "is this candidate database legitimate for me?". The candidate is resolved from the
+        application's own configuration by id; connection details and credentials are never
+        accepted in the request body (SSRF protection, no credentials on the wire). The verdict
+        carries reason codes only — never raw database names, hosts, or row data. Auth-gated for
+        machine clients. Scope A (issue #1419): single-tenant; app_identity and tenant are
+        placeholders enabled by #1420.
+      operationId: machineDatabasePreflight
+      security:
+        - ApiKeyAuth:
+            - read:database
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MachineDatabasePreflightRequest'
+            examples:
+              candidate:
+                summary: Reference a candidate profile by id
+                value:
+                  candidate: restore-2026-06
+      responses:
+        '200':
+          description: Structured read-only verdict for the candidate database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MachineDatabasePreflightResponse'
+              examples:
+                ok:
+                  summary: A compatible candidate, safe to use
+                  value:
+                    reachable: true
+                    schema_recognized: true
+                    migration_state: compatible
+                    populated: true
+                    recommendation: safe
+                    reason_codes:
+                      - compatible
+                    app_identity: not_evaluated
+                    tenant: not_applicable
+        '400':
+          $ref: '#/components/responses/InvalidJson'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /examples/protected:
@@ -887,6 +945,86 @@ components:
           enum:
             - api_key
           example: api_key
+    MachineDatabasePreflightRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - candidate
+      properties:
+        candidate:
+          type: string
+          description: >-
+            The id of a candidate profile configured on the application. The application resolves the
+            connection from its own configuration; DSN, host, and credentials are never read from the body.
+          example: restore-2026-06
+    MachineDatabasePreflightResponse:
+      type: object
+      required:
+        - reachable
+        - schema_recognized
+        - migration_state
+        - populated
+        - recommendation
+        - reason_codes
+        - app_identity
+        - tenant
+      properties:
+        reachable:
+          type: boolean
+          description: Whether a read-only connection to the candidate could be opened.
+          example: true
+        schema_recognized:
+          type:
+            - boolean
+            - 'null'
+          description: Whether the candidate carries this framework's migration ledger. Null when unreachable.
+          example: true
+        migration_state:
+          type:
+            - string
+            - 'null'
+          enum:
+            - fresh
+            - compatible
+            - ahead
+            - foreign
+            - partial
+            - null
+          description: Migration state of the candidate relative to the application. Null when unreachable.
+          example: compatible
+        populated:
+          type:
+            - boolean
+            - 'null'
+          description: Whether the candidate holds application tables or migration history. Null when unreachable.
+          example: true
+        recommendation:
+          type: string
+          enum:
+            - safe
+            - needs_migration
+            - needs_review
+            - refuse
+          description: The actionable recommendation. A diagnosis, not an authorization.
+          example: safe
+        reason_codes:
+          type: array
+          items:
+            type: string
+          description: Machine-readable codes explaining the recommendation. Never raw database names, hosts, or data.
+          example:
+            - compatible
+        app_identity:
+          type: string
+          description: >-
+            Application-identity match state. Always "not_evaluated" in scope A (#1419); identity-marker
+            matching is enabled by #1420.
+          example: not_evaluated
+        tenant:
+          type: string
+          description: >-
+            Tenant match state. Always "not_applicable" in scope A (#1419); tenant matching is enabled by #1420.
+          example: not_applicable
     ExamplePingResponse:
       type: object
       required:

--- a/src/Database/Preflight/CandidateProfile.php
+++ b/src/Database/Preflight/CandidateProfile.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database\Preflight;
+
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+
+/**
+ * A named candidate database the application may be pointed at, resolved entirely from the
+ * application's own configuration.
+ *
+ * The caller of `POST /machine/database/preflight` supplies only the {@see $id}; the application
+ * resolves the matching profile (and its read-only connection factory) from its own environment
+ * (e.g. an env allowlist such as `*_DB_CANDIDATE_*`). Connection details and credentials are never
+ * accepted from the request body — this prevents the caller from pointing the application at an
+ * arbitrary host (SSRF) and keeps credentials off the wire.
+ *
+ * Part of the public API stability guarantee (ADR 0009).
+ */
+final readonly class CandidateProfile
+{
+    /**
+     * @param non-empty-string $id Stable identifier the caller references (e.g. `"restore-2026-06"`).
+     * @param DatabaseConnectionFactoryInterface $connectionFactory Builds a connection to the candidate
+     *        using the application's own credentials. A least-privilege (SELECT-only) credential is
+     *        recommended; the inspector additionally enforces a read-only transaction.
+     * @param bool $multiTenant Whether the application is deployed in a multi-tenant configuration.
+     *        When true, a verdict that would otherwise be `safe` is downgraded to `needs_review`
+     *        until tenant identity can be evaluated (see issue #1420). Single-tenant applications
+     *        leave this false and are unaffected.
+     */
+    public function __construct(
+        public string $id,
+        public DatabaseConnectionFactoryInterface $connectionFactory,
+        public bool $multiTenant = false,
+    ) {
+    }
+}

--- a/src/Database/Preflight/DatabaseCandidateInspector.php
+++ b/src/Database/Preflight/DatabaseCandidateInspector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database\Preflight;
+
+/**
+ * Inspects a candidate database read-only and returns a structured {@see PreflightVerdict}.
+ *
+ * This is the extension point behind `POST /machine/database/preflight`. Most applications use the
+ * shipped {@see DefaultDatabaseCandidateInspector}; implement this interface to add application
+ * specific checks (custom identity markers, domain invariants) while reusing the endpoint and the
+ * verdict contract.
+ *
+ * Implementations MUST NOT issue any DDL or DML against the candidate — this is a diagnosis, not a
+ * migration. Part of the public API stability guarantee (ADR 0009).
+ */
+interface DatabaseCandidateInspector
+{
+    /**
+     * Open a read-only connection to the candidate described by $profile, inspect it, and return a
+     * verdict. Connection failures are reported as an unreachable verdict rather than thrown
+     * (see {@see PreflightVerdict::unreachable()}).
+     */
+    public function inspect(CandidateProfile $profile): PreflightVerdict;
+}

--- a/src/Database/Preflight/DefaultDatabaseCandidateInspector.php
+++ b/src/Database/Preflight/DefaultDatabaseCandidateInspector.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database\Preflight;
+
+use InvalidArgumentException;
+use PDO;
+use Throwable;
+
+/**
+ * Default {@see DatabaseCandidateInspector}: classifies a candidate from its migration ledger and
+ * the application's own known migration versions, with no application-specific configuration.
+ *
+ * Knowledge of the concrete ledger table name (`phinx_log` by default, ADR 0004) lives only here —
+ * the {@see DatabaseCandidateInspector} interface and the framework core stay database-agnostic.
+ *
+ * Read-only is enforced as a mechanism, not a convention: the candidate connection is put into a
+ * read-only mode immediately after opening (SQLite `PRAGMA query_only`, MySQL/PostgreSQL
+ * `START TRANSACTION READ ONLY`). A SELECT-only credential is still recommended as defence in depth.
+ *
+ * Part of the public API stability guarantee (ADR 0009).
+ */
+final readonly class DefaultDatabaseCandidateInspector implements DatabaseCandidateInspector
+{
+    /**
+     * @param list<string> $applicationMigrationVersions The migration versions the application knows
+     *        about (e.g. Phinx version ids as strings). Used to distinguish `compatible` / `ahead` /
+     *        `partial`. When empty, the inspector cannot verify versions and downgrades an otherwise
+     *        safe verdict to `needs_review` with the `migration_versions_unknown` reason code.
+     * @param string $ledgerTable The migration ledger table name. Defaults to Phinx's `phinx_log`.
+     */
+    public function __construct(
+        private array $applicationMigrationVersions = [],
+        private string $ledgerTable = 'phinx_log',
+    ) {
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $this->ledgerTable) !== 1) {
+            throw new InvalidArgumentException('Ledger table name must be a bare SQL identifier.');
+        }
+    }
+
+    public function inspect(CandidateProfile $profile): PreflightVerdict
+    {
+        try {
+            $pdo = $profile->connectionFactory->create();
+        } catch (Throwable) {
+            return PreflightVerdict::unreachable();
+        }
+
+        $driver = (string) $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        try {
+            $this->enforceReadOnly($pdo, $driver);
+
+            $tables = $this->listTables($pdo, $driver);
+            $schemaRecognized = in_array($this->ledgerTable, $tables, true);
+            $candidateVersions = $schemaRecognized ? $this->ledgerVersions($pdo) : [];
+            $nonLedgerTables = array_values(array_filter($tables, fn (string $t): bool => $t !== $this->ledgerTable));
+            $populated = $nonLedgerTables !== [] || $candidateVersions !== [];
+
+            return $this->classify($profile, $schemaRecognized, $populated, $tables, $candidateVersions);
+        } catch (Throwable) {
+            return new PreflightVerdict(
+                reachable: true,
+                schemaRecognized: null,
+                migrationState: null,
+                populated: null,
+                recommendation: PreflightRecommendation::Refuse,
+                reasonCodes: ['inspection_failed'],
+            );
+        } finally {
+            if ($driver === 'mysql' || $driver === 'pgsql') {
+                try {
+                    $pdo->exec('ROLLBACK');
+                } catch (Throwable) {
+                    // Best effort: the candidate connection is discarded immediately after.
+                }
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $tables
+     * @param list<string> $candidateVersions
+     */
+    private function classify(
+        CandidateProfile $profile,
+        bool $schemaRecognized,
+        bool $populated,
+        array $tables,
+        array $candidateVersions,
+    ): PreflightVerdict {
+        [$state, $recommendation, $reasonCodes] = $this->classifyState(
+            $schemaRecognized,
+            $tables,
+            $candidateVersions,
+        );
+
+        // Multi-tenant guard (#1419 / A): never emit an unconditional `safe` for a multi-tenant
+        // application while tenant identity is unevaluated — a candidate that merely matches the
+        // migration state could still belong to a different tenant. Downgrade to needs_review so the
+        // promise "A alone is single-tenant safe only" holds at the verdict level. Resolved by #1420.
+        if ($profile->multiTenant && $recommendation === PreflightRecommendation::Safe) {
+            $recommendation = PreflightRecommendation::NeedsReview;
+            $reasonCodes[] = 'tenant_unevaluated';
+        }
+
+        return new PreflightVerdict(
+            reachable: true,
+            schemaRecognized: $schemaRecognized,
+            migrationState: $state,
+            populated: $populated,
+            recommendation: $recommendation,
+            reasonCodes: $reasonCodes,
+        );
+    }
+
+    /**
+     * @param list<string> $tables
+     * @param list<string> $candidateVersions
+     * @return array{0: MigrationState, 1: PreflightRecommendation, 2: list<string>}
+     */
+    private function classifyState(bool $schemaRecognized, array $tables, array $candidateVersions): array
+    {
+        if ($tables === []) {
+            return [MigrationState::Fresh, PreflightRecommendation::NeedsMigration, ['needs_migration']];
+        }
+
+        if (!$schemaRecognized) {
+            return [MigrationState::Foreign, PreflightRecommendation::Refuse, ['foreign_schema']];
+        }
+
+        $nonLedgerTables = array_values(array_filter($tables, fn (string $t): bool => $t !== $this->ledgerTable));
+
+        // Ledger present but nothing applied and no application tables — an initialized-but-empty
+        // database is fresh, not partial.
+        if ($candidateVersions === [] && $nonLedgerTables === []) {
+            return [MigrationState::Fresh, PreflightRecommendation::NeedsMigration, ['needs_migration']];
+        }
+
+        if ($this->applicationMigrationVersions === []) {
+            if ($candidateVersions === []) {
+                return [MigrationState::Fresh, PreflightRecommendation::NeedsMigration, ['needs_migration']];
+            }
+
+            return [
+                MigrationState::Compatible,
+                PreflightRecommendation::NeedsReview,
+                ['compatible', 'migration_versions_unknown'],
+            ];
+        }
+
+        $extra = array_diff($candidateVersions, $this->applicationMigrationVersions);
+
+        if ($extra !== []) {
+            return [MigrationState::Ahead, PreflightRecommendation::Refuse, ['migrations_ahead']];
+        }
+
+        $missing = array_diff($this->applicationMigrationVersions, $candidateVersions);
+
+        if ($missing !== []) {
+            return [MigrationState::Partial, PreflightRecommendation::NeedsMigration, ['partial_migrations']];
+        }
+
+        return [MigrationState::Compatible, PreflightRecommendation::Safe, ['compatible']];
+    }
+
+    private function enforceReadOnly(PDO $pdo, string $driver): void
+    {
+        match ($driver) {
+            'sqlite' => $pdo->exec('PRAGMA query_only = ON'),
+            'mysql', 'pgsql' => $pdo->exec('START TRANSACTION READ ONLY'),
+            // Unknown driver: the inspector issues only SELECTs, so behaviour stays read-only even
+            // without an explicit guard. A SELECT-only credential remains the recommended backstop.
+            default => null,
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listTables(PDO $pdo, string $driver): array
+    {
+        $sql = match ($driver) {
+            'sqlite' => "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+            'mysql' => 'SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE()',
+            'pgsql' => "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname NOT IN ('pg_catalog', 'information_schema')",
+            default => throw new InvalidArgumentException(sprintf('Unsupported driver "%s".', $driver)),
+        };
+
+        $statement = $pdo->query($sql);
+
+        if ($statement === false) {
+            return [];
+        }
+
+        $names = [];
+
+        foreach ($statement->fetchAll(PDO::FETCH_COLUMN) as $name) {
+            if (is_string($name)) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function ledgerVersions(PDO $pdo): array
+    {
+        // $this->ledgerTable is validated as a bare identifier in the constructor.
+        $statement = $pdo->query(sprintf('SELECT version FROM %s', $this->ledgerTable));
+
+        if ($statement === false) {
+            return [];
+        }
+
+        $versions = [];
+
+        foreach ($statement->fetchAll(PDO::FETCH_COLUMN) as $version) {
+            if (is_scalar($version)) {
+                $versions[] = (string) $version;
+            }
+        }
+
+        return $versions;
+    }
+}

--- a/src/Database/Preflight/MigrationState.php
+++ b/src/Database/Preflight/MigrationState.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database\Preflight;
+
+/**
+ * Classification of a candidate database's migration state relative to the inspecting application.
+ *
+ * Computed by {@see DatabaseCandidateInspector} from the candidate's migration ledger and the
+ * application's own known migration versions. Part of the public API stability guarantee (ADR 0009).
+ */
+enum MigrationState: string
+{
+    /** The candidate is empty — no application tables and no recognized migration ledger. */
+    case Fresh = 'fresh';
+
+    /** The candidate's applied migrations exactly match what the application expects. */
+    case Compatible = 'compatible';
+
+    /** The candidate has applied migrations the application does not know about (candidate is ahead). */
+    case Ahead = 'ahead';
+
+    /** The candidate holds schema/data but no recognized migration ledger — it is not this framework's. */
+    case Foreign = 'foreign';
+
+    /** The candidate's ledger is recognized but some expected migrations are missing (interrupted/incomplete). */
+    case Partial = 'partial';
+}

--- a/src/Database/Preflight/PreflightRecommendation.php
+++ b/src/Database/Preflight/PreflightRecommendation.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database\Preflight;
+
+/**
+ * The actionable recommendation a {@see PreflightVerdict} carries for the caller.
+ *
+ * This is a diagnosis, not an authorization: the application reports what it found about the
+ * candidate; the caller (operator, deployment tool, CI) decides what to do. Part of the public
+ * API stability guarantee (ADR 0009).
+ */
+enum PreflightRecommendation: string
+{
+    /** The candidate is compatible and safe to point the application at as-is. */
+    case Safe = 'safe';
+
+    /** The candidate is recognized but requires migration before use (fresh or partial). */
+    case NeedsMigration = 'needs_migration';
+
+    /**
+     * The candidate cannot be auto-classified as safe and requires human review — e.g. a
+     * multi-tenant application whose tenant identity could not be evaluated in this scope.
+     */
+    case NeedsReview = 'needs_review';
+
+    /** The candidate must not be used (unreachable, foreign schema, or ahead of the application). */
+    case Refuse = 'refuse';
+}

--- a/src/Database/Preflight/PreflightVerdict.php
+++ b/src/Database/Preflight/PreflightVerdict.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database\Preflight;
+
+/**
+ * The structured, read-only diagnosis a {@see DatabaseCandidateInspector} returns for a candidate
+ * database.
+ *
+ * Carries reason codes only — never raw database names, hosts, or row data — so the verdict is safe
+ * to return over the auth-gated machine endpoint and to log. Part of the public API stability
+ * guarantee (ADR 0009).
+ */
+final readonly class PreflightVerdict
+{
+    /**
+     * @param list<string> $reasonCodes Machine-readable codes explaining the recommendation
+     *        (e.g. `['compatible']`, `['foreign_schema']`, `['compatible', 'tenant_unevaluated']`).
+     * @param string $appIdentity Application-identity match state. Always `'not_evaluated'` in this
+     *        scope (issue #1419 / A); identity-marker matching arrives in #1420 (B).
+     * @param string $tenant Tenant match state. Always `'not_applicable'` in this scope; tenant
+     *        matching arrives in #1420 (B).
+     */
+    public function __construct(
+        public bool $reachable,
+        public ?bool $schemaRecognized,
+        public ?MigrationState $migrationState,
+        public ?bool $populated,
+        public PreflightRecommendation $recommendation,
+        public array $reasonCodes,
+        public string $appIdentity = 'not_evaluated',
+        public string $tenant = 'not_applicable',
+    ) {
+    }
+
+    /**
+     * Build the verdict for a candidate that could not be reached (connection refused, timed out,
+     * or otherwise failed to open). Everything beyond reachability is unknown, so the recommendation
+     * is always {@see PreflightRecommendation::Refuse}.
+     *
+     * @param list<string> $reasonCodes
+     */
+    public static function unreachable(array $reasonCodes = ['unreachable']): self
+    {
+        return new self(
+            reachable: false,
+            schemaRecognized: null,
+            migrationState: null,
+            populated: null,
+            recommendation: PreflightRecommendation::Refuse,
+            reasonCodes: $reasonCodes,
+        );
+    }
+
+    /**
+     * @return array{
+     *     reachable: bool,
+     *     schema_recognized: bool|null,
+     *     migration_state: string|null,
+     *     populated: bool|null,
+     *     recommendation: string,
+     *     reason_codes: list<string>,
+     *     app_identity: string,
+     *     tenant: string
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'reachable' => $this->reachable,
+            'schema_recognized' => $this->schemaRecognized,
+            'migration_state' => $this->migrationState?->value,
+            'populated' => $this->populated,
+            'recommendation' => $this->recommendation->value,
+            'reason_codes' => $this->reasonCodes,
+            'app_identity' => $this->appIdentity,
+            'tenant' => $this->tenant,
+        ];
+    }
+}

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.330';
+    public const string VERSION = '1.5.331';
 
     public function name(): string
     {

--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Nene2\Http;
 
+use Nene2\Database\Preflight\CandidateProfile;
+use Nene2\Database\Preflight\DatabaseCandidateInspector;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ErrorHandlerMiddleware;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -18,6 +20,8 @@ use Nene2\Middleware\RequestSizeLimitMiddleware;
 use Nene2\Middleware\SecurityHeadersMiddleware;
 use Nene2\Middleware\ThrottleMiddleware;
 use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -92,6 +96,17 @@ final readonly class RuntimeApplicationFactory
      *                                endpoint keeps the application version readable by machine clients
      *                                (monitoring, operators, deployment tooling) without exposing it on
      *                                the public `GET /health`.
+     * @param DatabaseCandidateInspector|null $databaseCandidateInspector When provided, registers the
+     *                                auth-gated `POST /machine/database/preflight` endpoint, which
+     *                                inspects a candidate database read-only and returns a structured
+     *                                verdict (see issue #1419). Leave null to omit the endpoint entirely
+     *                                — the framework core stays database-agnostic for applications that
+     *                                do not opt in. The path is automatically added to the machine API
+     *                                key protected paths when an allowlist is in effect.
+     * @param array<string, CandidateProfile> $databaseCandidateProfiles Candidate profiles keyed by the
+     *                                id the caller references. The endpoint resolves a profile from this
+     *                                map; connection details and credentials are never read from the
+     *                                request body. Only consulted when $databaseCandidateInspector is set.
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
@@ -113,6 +128,8 @@ final readonly class RuntimeApplicationFactory
         private int $requestMaxBodyBytes = 1_048_576,
         private string $problemDetailsBaseUrl = 'https://nene2.dev/problems/',
         private ?string $appVersion = null,
+        private ?DatabaseCandidateInspector $databaseCandidateInspector = null,
+        private array $databaseCandidateProfiles = [],
     ) {
     }
 
@@ -224,8 +241,54 @@ final readonly class RuntimeApplicationFactory
             );
         }
 
+        if ($this->databaseCandidateInspector !== null) {
+            $inspector = $this->databaseCandidateInspector;
+            $profiles = $this->databaseCandidateProfiles;
+
+            $router->post(
+                '/machine/database/preflight',
+                static function (ServerRequestInterface $request) use ($jsonResponses, $inspector, $profiles) {
+                    $body = JsonRequestBodyParser::parse($request);
+                    $candidateId = $body['candidate'] ?? null;
+
+                    // Connection details / credentials in the body are intentionally ignored — only the
+                    // candidate id is read, and the profile (and its connection) is resolved from the
+                    // application's own configuration. This blocks SSRF and keeps credentials off the wire.
+                    if (!is_string($candidateId) || $candidateId === '') {
+                        throw new ValidationException([
+                            new ValidationError('candidate', 'A candidate profile id is required.', 'required'),
+                        ]);
+                    }
+
+                    $profile = $profiles[$candidateId] ?? null;
+
+                    if (!$profile instanceof CandidateProfile) {
+                        throw new ValidationException([
+                            new ValidationError('candidate', 'Unknown candidate profile.', 'unknown_candidate'),
+                        ]);
+                    }
+
+                    return $jsonResponses->create($inspector->inspect($profile)->toArray());
+                },
+            );
+        }
+
         foreach ($this->routeRegistrars as $registrar) {
             $registrar($router);
+        }
+
+        // Auto-protect the preflight endpoint with the machine API key. Only append when an allowlist
+        // is already in effect — appending to "protect all" mode (both lists empty) would silently
+        // switch it to allowlist mode and un-protect every other path.
+        $machineProtectedPaths = $this->machineApiKeyProtectedPaths;
+        $allowlistMode = $this->machineApiKeyProtectedPaths !== [] || $this->machineApiKeyProtectedPathPrefixes !== [];
+
+        if (
+            $this->databaseCandidateInspector !== null
+            && $allowlistMode
+            && !in_array('/machine/database/preflight', $machineProtectedPaths, true)
+        ) {
+            $machineProtectedPaths[] = '/machine/database/preflight';
         }
 
         $middlewareStack = [
@@ -238,7 +301,7 @@ final readonly class RuntimeApplicationFactory
             new ApiKeyAuthenticationMiddleware(
                 $problemDetails,
                 $this->machineApiKey,
-                $this->machineApiKeyProtectedPaths,
+                $machineProtectedPaths,
                 excludedPaths:          $this->machineApiKeyExcludedPaths,
                 protectedPathPrefixes:  $this->machineApiKeyProtectedPathPrefixes,
                 protectedMethods:       $this->machineApiKeyProtectedMethods,

--- a/tests/Database/Preflight/DefaultDatabaseCandidateInspectorTest.php
+++ b/tests/Database/Preflight/DefaultDatabaseCandidateInspectorTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Database\Preflight;
+
+use Nene2\Database\DatabaseConnectionException;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\Preflight\CandidateProfile;
+use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
+use Nene2\Database\Preflight\MigrationState;
+use Nene2\Database\Preflight\PreflightRecommendation;
+use PDO;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultDatabaseCandidateInspectorTest extends TestCase
+{
+    public function testCompatibleCandidateIsSafe(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101', '20260102']);
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101', '20260102']))
+            ->inspect($this->profile($pdo));
+
+        self::assertTrue($verdict->reachable);
+        self::assertTrue($verdict->schemaRecognized);
+        self::assertSame(MigrationState::Compatible, $verdict->migrationState);
+        self::assertTrue($verdict->populated);
+        self::assertSame(PreflightRecommendation::Safe, $verdict->recommendation);
+        self::assertSame(['compatible'], $verdict->reasonCodes);
+        self::assertSame('not_evaluated', $verdict->appIdentity);
+        self::assertSame('not_applicable', $verdict->tenant);
+    }
+
+    public function testAheadCandidateIsRefused(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101', '20260102', '20260103']);
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101', '20260102']))
+            ->inspect($this->profile($pdo));
+
+        self::assertSame(MigrationState::Ahead, $verdict->migrationState);
+        self::assertSame(PreflightRecommendation::Refuse, $verdict->recommendation);
+        self::assertSame(['migrations_ahead'], $verdict->reasonCodes);
+    }
+
+    public function testPartialCandidateNeedsMigration(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101']);
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101', '20260102']))
+            ->inspect($this->profile($pdo));
+
+        self::assertSame(MigrationState::Partial, $verdict->migrationState);
+        self::assertSame(PreflightRecommendation::NeedsMigration, $verdict->recommendation);
+        self::assertSame(['partial_migrations'], $verdict->reasonCodes);
+    }
+
+    public function testForeignSchemaIsRefused(): void
+    {
+        $pdo = $this->sqlite();
+        $pdo->exec('CREATE TABLE customers (id INTEGER PRIMARY KEY)');
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101']))
+            ->inspect($this->profile($pdo));
+
+        self::assertFalse($verdict->schemaRecognized);
+        self::assertTrue($verdict->populated);
+        self::assertSame(MigrationState::Foreign, $verdict->migrationState);
+        self::assertSame(PreflightRecommendation::Refuse, $verdict->recommendation);
+        self::assertSame(['foreign_schema'], $verdict->reasonCodes);
+    }
+
+    public function testFreshEmptyCandidateNeedsMigration(): void
+    {
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101']))
+            ->inspect($this->profile($this->sqlite()));
+
+        self::assertFalse($verdict->schemaRecognized);
+        self::assertFalse($verdict->populated);
+        self::assertSame(MigrationState::Fresh, $verdict->migrationState);
+        self::assertSame(PreflightRecommendation::NeedsMigration, $verdict->recommendation);
+        self::assertSame(['needs_migration'], $verdict->reasonCodes);
+    }
+
+    public function testInitializedButEmptyLedgerIsFresh(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, []);
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101', '20260102']))
+            ->inspect($this->profile($pdo));
+
+        self::assertTrue($verdict->schemaRecognized);
+        self::assertFalse($verdict->populated);
+        self::assertSame(MigrationState::Fresh, $verdict->migrationState);
+        self::assertSame(PreflightRecommendation::NeedsMigration, $verdict->recommendation);
+    }
+
+    public function testUnknownApplicationVersionsDowngradesToNeedsReview(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101']);
+
+        $verdict = (new DefaultDatabaseCandidateInspector([]))
+            ->inspect($this->profile($pdo));
+
+        self::assertSame(MigrationState::Compatible, $verdict->migrationState);
+        self::assertSame(PreflightRecommendation::NeedsReview, $verdict->recommendation);
+        self::assertSame(['compatible', 'migration_versions_unknown'], $verdict->reasonCodes);
+    }
+
+    public function testMultiTenantSafeIsDowngradedToNeedsReview(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101']);
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101']))
+            ->inspect($this->profile($pdo, multiTenant: true));
+
+        self::assertSame(MigrationState::Compatible, $verdict->migrationState);
+        self::assertSame(PreflightRecommendation::NeedsReview, $verdict->recommendation);
+        self::assertSame(['compatible', 'tenant_unevaluated'], $verdict->reasonCodes);
+    }
+
+    public function testMultiTenantGuardDoesNotAffectRefuse(): void
+    {
+        $pdo = $this->sqlite();
+        $pdo->exec('CREATE TABLE customers (id INTEGER PRIMARY KEY)');
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101']))
+            ->inspect($this->profile($pdo, multiTenant: true));
+
+        self::assertSame(PreflightRecommendation::Refuse, $verdict->recommendation);
+        self::assertSame(['foreign_schema'], $verdict->reasonCodes);
+    }
+
+    public function testUnreachableCandidateIsRefused(): void
+    {
+        $factory = new class () implements DatabaseConnectionFactoryInterface {
+            public function create(): PDO
+            {
+                throw new DatabaseConnectionException('Candidate is down.');
+            }
+        };
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101']))
+            ->inspect(new CandidateProfile('restore', $factory));
+
+        self::assertFalse($verdict->reachable);
+        self::assertNull($verdict->schemaRecognized);
+        self::assertNull($verdict->migrationState);
+        self::assertNull($verdict->populated);
+        self::assertSame(PreflightRecommendation::Refuse, $verdict->recommendation);
+        self::assertSame(['unreachable'], $verdict->reasonCodes);
+    }
+
+    public function testCandidateConnectionIsLeftReadOnly(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101']);
+
+        (new DefaultDatabaseCandidateInspector(['20260101']))->inspect($this->profile($pdo));
+
+        $statement = $pdo->query('PRAGMA query_only');
+        self::assertNotFalse($statement);
+        self::assertSame('1', (string) $statement->fetchColumn());
+
+        $this->expectException(PDOException::class);
+        $pdo->exec('CREATE TABLE injected (id INTEGER)');
+    }
+
+    private function sqlite(): PDO
+    {
+        return new PDO('sqlite::memory:', null, null, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]);
+    }
+
+    /**
+     * @param list<string> $versions
+     */
+    private function seedLedger(PDO $pdo, array $versions): void
+    {
+        $pdo->exec('CREATE TABLE phinx_log (version BIGINT PRIMARY KEY, migration_name VARCHAR(100))');
+
+        foreach ($versions as $version) {
+            $statement = $pdo->prepare('INSERT INTO phinx_log (version, migration_name) VALUES (:v, :n)');
+            $statement->execute([':v' => $version, ':n' => 'Migration' . $version]);
+        }
+    }
+
+    private function profile(PDO $pdo, bool $multiTenant = false): CandidateProfile
+    {
+        $factory = new class ($pdo) implements DatabaseConnectionFactoryInterface {
+            public function __construct(private PDO $pdo)
+            {
+            }
+
+            public function create(): PDO
+            {
+                return $this->pdo;
+            }
+        };
+
+        return new CandidateProfile('restore', $factory, $multiTenant);
+    }
+}

--- a/tests/Http/MachineDatabasePreflightHttpTest.php
+++ b/tests/Http/MachineDatabasePreflightHttpTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\Preflight\CandidateProfile;
+use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class MachineDatabasePreflightHttpTest extends TestCase
+{
+    private const VERDICT_KEYS = [
+        'reachable',
+        'schema_recognized',
+        'migration_state',
+        'populated',
+        'recommendation',
+        'reason_codes',
+        'app_identity',
+        'tenant',
+    ];
+
+    public function testRequiresApiKey(): void
+    {
+        $response = $this->application()->handle(
+            $this->postRequest(['candidate' => 'restore']),
+        );
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('application/problem+json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertSame('https://nene2.dev/problems/unauthorized', $this->decodeJson($response)['type']);
+    }
+
+    public function testReturnsVerdictForKnownCandidate(): void
+    {
+        $response = $this->application()->handle(
+            $this->postRequest(['candidate' => 'restore'])->withHeader('X-NENE2-API-Key', 'test-key'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
+
+        self::assertSame(self::VERDICT_KEYS, array_keys($payload));
+        self::assertTrue($payload['reachable']);
+        self::assertTrue($payload['schema_recognized']);
+        self::assertSame('compatible', $payload['migration_state']);
+        self::assertTrue($payload['populated']);
+        self::assertSame('safe', $payload['recommendation']);
+        self::assertSame(['compatible'], $payload['reason_codes']);
+        self::assertSame('not_evaluated', $payload['app_identity']);
+        self::assertSame('not_applicable', $payload['tenant']);
+    }
+
+    public function testUnknownCandidateIsValidationError(): void
+    {
+        $response = $this->application()->handle(
+            $this->postRequest(['candidate' => 'ghost'])->withHeader('X-NENE2-API-Key', 'test-key'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertSame('https://nene2.dev/problems/validation-failed', $payload['type']);
+        self::assertSame('candidate', $payload['errors'][0]['field']);
+        self::assertSame('unknown_candidate', $payload['errors'][0]['code']);
+    }
+
+    public function testMissingCandidateFieldIsValidationError(): void
+    {
+        // A JSON object without the candidate field — distinct from a malformed body (400).
+        $response = $this->application()->handle(
+            $this->postRequest(['unused' => 'value'])->withHeader('X-NENE2-API-Key', 'test-key'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertSame('candidate', $payload['errors'][0]['field']);
+        self::assertSame('required', $payload['errors'][0]['code']);
+    }
+
+    public function testInvalidJsonBodyIsBadRequest(): void
+    {
+        $request = $this->postRequest([])
+            ->withHeader('X-NENE2-API-Key', 'test-key')
+            ->withBody((new Psr17Factory())->createStream('not json at all'));
+
+        $response = $this->application()->handle($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('https://nene2.dev/problems/invalid-json', $this->decodeJson($response)['type']);
+    }
+
+    public function testConnectionDetailsInBodyAreIgnored(): void
+    {
+        // A caller cannot point the application at an arbitrary host: extra body fields (host, dsn,
+        // credentials) are ignored — only the candidate id is read and resolved from configuration.
+        $response = $this->application()->handle(
+            $this->postRequest([
+                'candidate' => 'restore',
+                'host' => 'attacker.example.com',
+                'dsn' => 'mysql:host=attacker.example.com;dbname=loot',
+                'password' => 'steal-me',
+            ])->withHeader('X-NENE2-API-Key', 'test-key'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(self::VERDICT_KEYS, array_keys($payload));
+        self::assertSame('safe', $payload['recommendation']);
+    }
+
+    public function testEndpointIsAbsentWithoutInspector(): void
+    {
+        $factory = new Psr17Factory();
+        $application = (new RuntimeApplicationFactory($factory, $factory, machineApiKey: 'test-key'))->create();
+
+        $response = $application->handle(
+            $this->postRequest(['candidate' => 'restore'])->withHeader('X-NENE2-API-Key', 'test-key'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    private function application(): \Psr\Http\Server\RequestHandlerInterface
+    {
+        $factory = new Psr17Factory();
+        $pdo = new PDO('sqlite::memory:', null, null, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]);
+        $pdo->exec('CREATE TABLE phinx_log (version BIGINT PRIMARY KEY, migration_name VARCHAR(100))');
+        $pdo->exec("INSERT INTO phinx_log (version, migration_name) VALUES (20260101, 'Init')");
+
+        $connectionFactory = new class ($pdo) implements DatabaseConnectionFactoryInterface {
+            public function __construct(private PDO $pdo)
+            {
+            }
+
+            public function create(): PDO
+            {
+                return $this->pdo;
+            }
+        };
+
+        return (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            machineApiKey: 'test-key',
+            databaseCandidateInspector: new DefaultDatabaseCandidateInspector(['20260101']),
+            databaseCandidateProfiles: ['restore' => new CandidateProfile('restore', $connectionFactory)],
+        ))->create();
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function postRequest(array $body): ServerRequestInterface
+    {
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('POST', 'https://example.test/machine/database/preflight');
+
+        return $request->withBody(
+            $factory->createStream(json_encode($body, JSON_THROW_ON_ERROR)),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/OpenApi/RuntimeContractTest.php
+++ b/tests/OpenApi/RuntimeContractTest.php
@@ -74,6 +74,12 @@ final class RuntimeContractTest extends TestCase
                     continue;
                 }
 
+                // The preflight endpoint requires an opt-in DatabaseCandidateInspector and a candidate
+                // body; it is covered by MachineDatabasePreflightHttpTest with a SQLite-backed candidate.
+                if ($path === '/machine/database/preflight') {
+                    continue;
+                }
+
                 $successResponse = $operation['responses']['200'] ?? null;
 
                 if (!is_array($successResponse)) {


### PR DESCRIPTION
## 目的

`#1419` を A/B/C に分割した **Part 1/3（A: MVP）**。アプリが候補データベースを **read-only で自己診断**し、「**この候補 DB は自分にとって正当か**」に構造化 verdict で答える `POST /machine/database/preflight` を追加する。`/machine/health`（#1414）と同じ machine 認証の隣に置く。

## 変更点

### 新規エンドポイント
- `POST /machine/database/preflight`（machine API キー必須）。
- 入力は **候補プロファイル ID のみ**（`{"candidate": "<id>"}`）。DSN・ホスト・認証情報はボディから受け取らず、アプリ自身の設定から解決する → **SSRF 封じ・creds を wire に載せない**。
- `RuntimeApplicationFactory` は `databaseCandidateInspector` を渡したときのみルートを登録。`null` のままなら従来どおりエンドポイントは生えず、framework コアは DB 非依存（後方互換）。allowlist モード時はパスを machine 保護に自動追加。

### verdict（reason code のみ・生データなし）
`reachable` / `schema_recognized` / `migration_state`（`fresh`|`compatible`|`ahead`|`foreign`|`partial`）/ `populated` / `recommendation`（`safe`|`needs_migration`|`needs_review`|`refuse`）+ `reason_codes` / `app_identity` / `tenant`。

### 設計フェーズで合意した 2 つのガードを機構化
- **read-only の保証**: 接続直後に read-only 化 — SQLite `PRAGMA query_only`、MySQL/PostgreSQL `START TRANSACTION READ ONLY`。`connect_timeout=3`（既存 `PdoConnectionFactory` / FIND-05）を再利用。テストで「inspect 後に書き込みが弾かれる」ことを証明。
- **マルチテナント・ガード**（#1419 コメント反映）: multi-tenant 構成かつ tenant 未評価（#1420 未導入）の間は無条件 `safe` を返さず、`tenant_unevaluated` を付けて `needs_review` に倒す。「A 単独は単一テナント安全のみ」を verdict レベルで担保。

### framework の形
`DatabaseCandidateInspector` interface + 無設定で動く `DefaultDatabaseCandidateInspector`（台帳 `phinx_log` ベース）+ value object / enum。台帳名の知識は **default 実装のみ**に置き、interface / core は DB 非依存（ADR 0004 / 0009）。

### ドキュメント・契約
- OpenAPI: `machineDatabasePreflight` 操作 + `MachineDatabasePreflightRequest` / `MachineDatabasePreflightResponse` スキーマ。
- MCP: `machineDatabasePreflight` ツール（`safety: read`）。
- CHANGELOG / FrameworkInfo / openapi `info.version` を **1.5.331** にバンプ。

## 検証結果

```
composer check
  → PHPUnit: OK (475 tests, 1182 assertions)
  → PHPStan level 8: No errors
  → PHP CS Fixer: clean
  → OpenAPI contract is valid.
  → MCP tool catalog is valid.
```

新規テスト:
- `tests/Database/Preflight/DefaultDatabaseCandidateInspectorTest.php` — 全 migration_state 分類・recommendation・マルチテナントガード・**read-only 強制**・unreachable（SQLite）。
- `tests/Http/MachineDatabasePreflightHttpTest.php` — 401 未認証 / 200 verdict / 422 unknown_candidate / 422 required / 400 invalid-json / **ボディ内 creds 無視** / inspector 無し時 404（後方互換）。

## 関連 Issue

Part 1/3。`Closes #1419`。後続: #1420（B: app identity / tenant 照合）、#1421（C: fingerprint + 署名トークン）。

## Self-review

backend-api, openapi-contract, middleware-security, database

## 残りのリスク・後続作業

- `migration_state` の `compatible`/`ahead`/`partial` は `DefaultDatabaseCandidateInspector` にアプリの既知マイグレーション版を渡して算出する。未指定時は `needs_review` + `migration_versions_unknown` に保守的に倒す。
- MySQL/PostgreSQL の introspection SQL は実装済みだが、結合テストは SQLite 中心（既存方針どおり FT MySQL は別途）。
- `app_identity` / `tenant` は本スコープでは placeholder。**既存 DB が identity マーカー不在で fail-closed しない**三値設計は #1420 で実装する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
