### PR TITLE
feat(machine): preflight に app identity / tenant 照合を追加 (#1420 / B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.332] — 2026-06-27
+
+### Added
+- `Nene2\Database\Preflight\ApplicationIdentity` / `ApplicationIdentityMarker` — アプリ識別マーカーの value object と書き込みパス（#1420 / B）。`stamp()` は `nene2_app_identity` テーブルを作成し単一行を冪等に書き込む。init/マイグレーション時、および既存 DB の backfill（採用時の一度きり）に使う。
+- `Nene2\Database\Preflight\DefaultDatabaseCandidateInspector` — `applicationIdentity`（`?ApplicationIdentity`）と `identityTable`（既定 `nene2_app_identity`）コンストラクタ引数を追加。設定すると verdict の `app_identity`（`match` / `mismatch` / `absent`）と、マルチテナント identity では `tenant`（`match` / `mismatch`）を read-only で評価する。
+- **既存 DB の fail-closed 回避**（#1420 の核心）: identity マーカー不在は `refuse` にせず `app_identity: absent` + `identity_unverified` を返し、マイグレーション由来の recommendation（`safe` / `needs_migration`）を維持する。`mismatch`（別アプリのマーカー）のみ自動 `refuse`。`tenant: mismatch` も自動 `refuse`。
+- 識別マーカーテーブルは framework 内部テーブルとして扱い、`populated` / `foreign` 判定から除外する（マーカーのみの DB は `foreign` でなく `fresh`）。
+- `docs/development/machine-database-preflight.md` — エンドポイント・identity マーカー・**既存 DB の backfill 手順**を記載。
+- `docs/openapi/openapi.yaml` — `MachineDatabasePreflightResponse` の `app_identity` / `tenant` に enum を追加。
+
+### Notes
+- `applicationIdentity` 未設定時は A スコープの挙動を維持（`app_identity: not_evaluated` / `tenant: not_applicable` + 旧マルチテナントガード `tenant_unevaluated`）。後方互換。
+
+---
+
 ## [1.5.331] — 2026-06-27
 
 ### Added

--- a/docs/development/machine-database-preflight.md
+++ b/docs/development/machine-database-preflight.md
@@ -1,0 +1,84 @@
+# Machine database preflight
+
+`POST /machine/database/preflight` lets an application inspect a *candidate* database read-only and
+answer one question: **"is this candidate database legitimate for me?"** Use it before pointing an
+application at an existing database — environment clones, restores/migrations, moving between DB
+servers.
+
+The endpoint is auth-gated (`X-NENE2-API-Key`), strictly read-only, and resolves the candidate from
+the application's own configuration by id. DSN, host, and credentials are never accepted in the
+request body. See the OpenAPI operation `machineDatabasePreflight` for the request/response contract.
+
+## The verdict
+
+The response carries reason codes only — never raw database names, hosts, or row data:
+
+| Field | Meaning |
+|---|---|
+| `reachable` | A read-only connection could be opened. |
+| `schema_recognized` | The candidate carries this framework's migration ledger (`phinx_log`). |
+| `migration_state` | `fresh` \| `compatible` \| `ahead` \| `foreign` \| `partial`. |
+| `populated` | The candidate holds application tables or migration history. |
+| `recommendation` | `safe` \| `needs_migration` \| `needs_review` \| `refuse` (+ `reason_codes`). |
+| `app_identity` | `not_evaluated` \| `match` \| `mismatch` \| `absent`. |
+| `tenant` | `not_applicable` \| `match` \| `mismatch`. |
+
+`ahead`, `foreign`, an `app_identity: mismatch`, and a `tenant: mismatch` all refuse automatically.
+
+## Application identity
+
+The migration ledger tells you a database belongs to *some* application built on this framework. It
+does not tell you the database is **this** application's — another app using the same framework and
+the same migrations would look identical. The application identity marker closes that gap.
+
+`ApplicationIdentity` carries a stable `applicationId` (your database lineage) and an optional
+`tenantId` (null for single-tenant applications). Stamp it into your own database with
+`ApplicationIdentityMarker`:
+
+```php
+use Nene2\Database\Preflight\ApplicationIdentity;
+use Nene2\Database\Preflight\ApplicationIdentityMarker;
+
+$marker = new ApplicationIdentityMarker($yourDatabaseConnectionFactory);
+$marker->stamp(new ApplicationIdentity('orders-prod'));            // single-tenant
+$marker->stamp(new ApplicationIdentity('orders-prod', 'acme'));    // multi-tenant
+```
+
+`stamp()` is idempotent — it creates the `nene2_app_identity` table if needed and replaces the single
+marker row. Run it at initialization / migration time so every database your application owns is
+stamped going forward.
+
+Wire your identity into the inspector so the verdict evaluates it:
+
+```php
+use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
+
+$inspector = new DefaultDatabaseCandidateInspector(
+    applicationMigrationVersions: $yourKnownVersions,
+    applicationIdentity: new ApplicationIdentity('orders-prod'),
+);
+```
+
+## Backfilling an existing database
+
+The most important case — restoring or adopting a database that predates the identity marker — would
+fail closed if a missing marker were treated as "foreign". It is not. **An absent marker never
+refuses**: the verdict reports `app_identity: absent` with the `identity_unverified` reason code and
+keeps the migration-based recommendation (so a compatible candidate stays `safe`/`needs_migration`).
+
+To adopt such a database, confirm the verdict is otherwise acceptable, then stamp it once:
+
+```php
+// One-off backfill against the existing database you are adopting.
+$marker = new ApplicationIdentityMarker($candidateConnectionFactory);
+$marker->stamp(new ApplicationIdentity('orders-prod'));
+```
+
+After backfilling, subsequent preflights report `app_identity: match`. Only a marker that names a
+*different* application produces `mismatch` (and refuses).
+
+## Scope
+
+Identity and tenant matching are the marker comparison only — richer tenant resolution belongs in an
+application-specific `DatabaseCandidateInspector`. Applying a database switch, hot-swapping live
+connections, and running migrations are out of scope for this endpoint; it is read-only diagnosis.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.331
+  version: 1.5.332
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:
@@ -1016,14 +1016,25 @@ components:
             - compatible
         app_identity:
           type: string
+          enum:
+            - not_evaluated
+            - match
+            - mismatch
+            - absent
           description: >-
-            Application-identity match state. Always "not_evaluated" in scope A (#1419); identity-marker
-            matching is enabled by #1420.
-          example: not_evaluated
+            Application-identity match state against the candidate's identity marker. `not_evaluated`
+            when the application did not configure its identity; `absent` when the candidate carries no
+            marker (does not refuse); `mismatch` when the marker belongs to a different application (refuses).
+          example: match
         tenant:
           type: string
+          enum:
+            - not_applicable
+            - match
+            - mismatch
           description: >-
-            Tenant match state. Always "not_applicable" in scope A (#1419); tenant matching is enabled by #1420.
+            Tenant match state. `not_applicable` for single-tenant applications or when identity could
+            not be evaluated; `mismatch` when the candidate belongs to a different tenant (refuses).
           example: not_applicable
     ExamplePingResponse:
       type: object

--- a/src/Database/Preflight/ApplicationIdentity.php
+++ b/src/Database/Preflight/ApplicationIdentity.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database\Preflight;
+
+use InvalidArgumentException;
+
+/**
+ * The stable identity an application stamps into its own database and expects to find again when it
+ * preflights a candidate.
+ *
+ * The {@see $applicationId} answers "is this database mine?" (vs another application that merely uses
+ * the same framework and ledger). The optional {@see $tenantId} answers "is this the database for the
+ * tenant I am configured to serve?" — leave it null for single-tenant applications.
+ *
+ * Written by {@see ApplicationIdentityMarker} and compared read-only by
+ * {@see DefaultDatabaseCandidateInspector}. Part of the public API stability guarantee (ADR 0009).
+ */
+final readonly class ApplicationIdentity
+{
+    /**
+     * @param string $applicationId Stable identifier of this application's database lineage. Must be non-empty.
+     * @param string|null $tenantId Tenant/owner identity the application is configured to serve.
+     *        Null for single-tenant applications (tenant matching is then `not_applicable`).
+     */
+    public function __construct(
+        public string $applicationId,
+        public ?string $tenantId = null,
+    ) {
+        if ($this->applicationId === '') {
+            throw new InvalidArgumentException('Application id must not be empty.');
+        }
+
+        if ($this->tenantId === '') {
+            throw new InvalidArgumentException('Tenant id must be null or a non-empty string.');
+        }
+    }
+}

--- a/src/Database/Preflight/ApplicationIdentityMarker.php
+++ b/src/Database/Preflight/ApplicationIdentityMarker.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Database\Preflight;
+
+use InvalidArgumentException;
+use Nene2\Database\DatabaseConnectionException;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use PDO;
+use Throwable;
+
+/**
+ * Writes the application's {@see ApplicationIdentity} marker into its own database.
+ *
+ * Call {@see stamp()} once at initialization / migration time, and once against any pre-existing
+ * database you are adopting (the backfill path — see docs/development/machine-database-preflight.md).
+ * The marker is what {@see DefaultDatabaseCandidateInspector} reads read-only to answer
+ * `app_identity` and `tenant` during preflight.
+ *
+ * This is the only write path in the preflight feature; it runs against the application's own
+ * database, never against a candidate. Idempotent: stamping replaces the single marker row.
+ *
+ * Part of the public API stability guarantee (ADR 0009).
+ */
+final readonly class ApplicationIdentityMarker
+{
+    public function __construct(
+        private DatabaseConnectionFactoryInterface $connectionFactory,
+        private string $table = 'nene2_app_identity',
+    ) {
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $this->table) !== 1) {
+            throw new InvalidArgumentException('Identity table name must be a bare SQL identifier.');
+        }
+    }
+
+    /**
+     * Create the marker table if needed and stamp $identity as the single marker row, replacing any
+     * existing one. Wraps the write in a transaction so a partial stamp cannot be observed.
+     */
+    public function stamp(ApplicationIdentity $identity): void
+    {
+        $pdo = $this->connectionFactory->create();
+        $driver = (string) $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $this->ensureTable($pdo, $driver);
+
+        $pdo->beginTransaction();
+
+        try {
+            $pdo->exec(sprintf('DELETE FROM %s', $this->table));
+
+            $statement = $pdo->prepare(
+                sprintf('INSERT INTO %s (application_id, tenant_id) VALUES (:application_id, :tenant_id)', $this->table),
+            );
+            $statement->execute([
+                ':application_id' => $identity->applicationId,
+                ':tenant_id' => $identity->tenantId,
+            ]);
+
+            $pdo->commit();
+        } catch (Throwable $exception) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+
+            throw new DatabaseConnectionException('Failed to stamp application identity marker.', previous: $exception);
+        }
+    }
+
+    private function ensureTable(PDO $pdo, string $driver): void
+    {
+        $sql = match ($driver) {
+            'sqlite' => sprintf(
+                'CREATE TABLE IF NOT EXISTS %s (application_id TEXT NOT NULL, tenant_id TEXT NULL)',
+                $this->table,
+            ),
+            'mysql' => sprintf(
+                'CREATE TABLE IF NOT EXISTS %s (application_id VARCHAR(190) NOT NULL, tenant_id VARCHAR(190) NULL)',
+                $this->table,
+            ),
+            'pgsql' => sprintf(
+                'CREATE TABLE IF NOT EXISTS %s (application_id VARCHAR(190) NOT NULL, tenant_id VARCHAR(190))',
+                $this->table,
+            ),
+            default => throw new InvalidArgumentException(sprintf('Unsupported driver "%s".', $driver)),
+        };
+
+        $pdo->exec($sql);
+    }
+}

--- a/src/Database/Preflight/DefaultDatabaseCandidateInspector.php
+++ b/src/Database/Preflight/DefaultDatabaseCandidateInspector.php
@@ -9,11 +9,13 @@ use PDO;
 use Throwable;
 
 /**
- * Default {@see DatabaseCandidateInspector}: classifies a candidate from its migration ledger and
- * the application's own known migration versions, with no application-specific configuration.
+ * Default {@see DatabaseCandidateInspector}: classifies a candidate from its migration ledger, the
+ * application's own known migration versions, and (when configured) the application identity marker.
  *
- * Knowledge of the concrete ledger table name (`phinx_log` by default, ADR 0004) lives only here —
- * the {@see DatabaseCandidateInspector} interface and the framework core stay database-agnostic.
+ * Knowledge of the concrete ledger table name (`phinx_log` by default, ADR 0004) and the identity
+ * marker table lives only here — the {@see DatabaseCandidateInspector} interface and the framework
+ * core stay database-agnostic. Tenant matching is intentionally limited to the marker comparison;
+ * richer tenant resolution belongs in an application-specific inspector via the interface.
  *
  * Read-only is enforced as a mechanism, not a convention: the candidate connection is put into a
  * read-only mode immediately after opening (SQLite `PRAGMA query_only`, MySQL/PostgreSQL
@@ -29,13 +31,25 @@ final readonly class DefaultDatabaseCandidateInspector implements DatabaseCandid
      *        `partial`. When empty, the inspector cannot verify versions and downgrades an otherwise
      *        safe verdict to `needs_review` with the `migration_versions_unknown` reason code.
      * @param string $ledgerTable The migration ledger table name. Defaults to Phinx's `phinx_log`.
+     * @param ApplicationIdentity|null $applicationIdentity The inspecting application's own identity.
+     *        When provided, the inspector reads the candidate's identity marker and reports
+     *        `app_identity` (`match` / `mismatch` / `absent`) and, for multi-tenant identities,
+     *        `tenant` (`match` / `mismatch`). When null, both stay at their A-scope placeholders
+     *        (`not_evaluated` / `not_applicable`) and the legacy multi-tenant guard applies.
+     * @param string $identityTable The identity marker table name written by {@see ApplicationIdentityMarker}.
      */
     public function __construct(
         private array $applicationMigrationVersions = [],
         private string $ledgerTable = 'phinx_log',
+        private ?ApplicationIdentity $applicationIdentity = null,
+        private string $identityTable = 'nene2_app_identity',
     ) {
         if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $this->ledgerTable) !== 1) {
             throw new InvalidArgumentException('Ledger table name must be a bare SQL identifier.');
+        }
+
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $this->identityTable) !== 1) {
+            throw new InvalidArgumentException('Identity table name must be a bare SQL identifier.');
         }
     }
 
@@ -55,10 +69,11 @@ final readonly class DefaultDatabaseCandidateInspector implements DatabaseCandid
             $tables = $this->listTables($pdo, $driver);
             $schemaRecognized = in_array($this->ledgerTable, $tables, true);
             $candidateVersions = $schemaRecognized ? $this->ledgerVersions($pdo) : [];
-            $nonLedgerTables = array_values(array_filter($tables, fn (string $t): bool => $t !== $this->ledgerTable));
-            $populated = $nonLedgerTables !== [] || $candidateVersions !== [];
+            $appTables = $this->applicationTables($tables);
+            $populated = $appTables !== [] || $candidateVersions !== [];
+            $marker = $this->applicationIdentity !== null ? $this->readIdentityMarker($pdo, $tables) : null;
 
-            return $this->classify($profile, $schemaRecognized, $populated, $tables, $candidateVersions);
+            return $this->classify($profile, $schemaRecognized, $populated, $appTables, $candidateVersions, $marker);
         } catch (Throwable) {
             return new PreflightVerdict(
                 reachable: true,
@@ -80,30 +95,30 @@ final readonly class DefaultDatabaseCandidateInspector implements DatabaseCandid
     }
 
     /**
-     * @param list<string> $tables
+     * @param list<string> $appTables
      * @param list<string> $candidateVersions
+     * @param array{application_id: string, tenant_id: string|null}|null $marker
      */
     private function classify(
         CandidateProfile $profile,
         bool $schemaRecognized,
         bool $populated,
-        array $tables,
+        array $appTables,
         array $candidateVersions,
+        ?array $marker,
     ): PreflightVerdict {
         [$state, $recommendation, $reasonCodes] = $this->classifyState(
             $schemaRecognized,
-            $tables,
+            $appTables,
             $candidateVersions,
         );
 
-        // Multi-tenant guard (#1419 / A): never emit an unconditional `safe` for a multi-tenant
-        // application while tenant identity is unevaluated — a candidate that merely matches the
-        // migration state could still belong to a different tenant. Downgrade to needs_review so the
-        // promise "A alone is single-tenant safe only" holds at the verdict level. Resolved by #1420.
-        if ($profile->multiTenant && $recommendation === PreflightRecommendation::Safe) {
-            $recommendation = PreflightRecommendation::NeedsReview;
-            $reasonCodes[] = 'tenant_unevaluated';
-        }
+        [$appIdentity, $tenant, $recommendation, $reasonCodes] = $this->applyIdentity(
+            $profile,
+            $recommendation,
+            $reasonCodes,
+            $marker,
+        );
 
         return new PreflightVerdict(
             reachable: true,
@@ -112,37 +127,33 @@ final readonly class DefaultDatabaseCandidateInspector implements DatabaseCandid
             populated: $populated,
             recommendation: $recommendation,
             reasonCodes: $reasonCodes,
+            appIdentity: $appIdentity,
+            tenant: $tenant,
         );
     }
 
     /**
-     * @param list<string> $tables
+     * @param list<string> $appTables
      * @param list<string> $candidateVersions
      * @return array{0: MigrationState, 1: PreflightRecommendation, 2: list<string>}
      */
-    private function classifyState(bool $schemaRecognized, array $tables, array $candidateVersions): array
+    private function classifyState(bool $schemaRecognized, array $appTables, array $candidateVersions): array
     {
-        if ($tables === []) {
-            return [MigrationState::Fresh, PreflightRecommendation::NeedsMigration, ['needs_migration']];
-        }
-
         if (!$schemaRecognized) {
+            if ($appTables === []) {
+                return [MigrationState::Fresh, PreflightRecommendation::NeedsMigration, ['needs_migration']];
+            }
+
             return [MigrationState::Foreign, PreflightRecommendation::Refuse, ['foreign_schema']];
         }
 
-        $nonLedgerTables = array_values(array_filter($tables, fn (string $t): bool => $t !== $this->ledgerTable));
-
         // Ledger present but nothing applied and no application tables — an initialized-but-empty
         // database is fresh, not partial.
-        if ($candidateVersions === [] && $nonLedgerTables === []) {
+        if ($candidateVersions === [] && $appTables === []) {
             return [MigrationState::Fresh, PreflightRecommendation::NeedsMigration, ['needs_migration']];
         }
 
         if ($this->applicationMigrationVersions === []) {
-            if ($candidateVersions === []) {
-                return [MigrationState::Fresh, PreflightRecommendation::NeedsMigration, ['needs_migration']];
-            }
-
             return [
                 MigrationState::Compatible,
                 PreflightRecommendation::NeedsReview,
@@ -165,6 +176,61 @@ final readonly class DefaultDatabaseCandidateInspector implements DatabaseCandid
         return [MigrationState::Compatible, PreflightRecommendation::Safe, ['compatible']];
     }
 
+    /**
+     * Evaluate the application identity / tenant marker and adjust the recommendation.
+     *
+     * @param list<string> $reasonCodes
+     * @param array{application_id: string, tenant_id: string|null}|null $marker
+     * @return array{0: string, 1: string, 2: PreflightRecommendation, 3: list<string>}
+     */
+    private function applyIdentity(
+        CandidateProfile $profile,
+        PreflightRecommendation $recommendation,
+        array $reasonCodes,
+        ?array $marker,
+    ): array {
+        // Identity not configured: preserve A-scope behaviour, including the legacy multi-tenant guard
+        // that withholds an unconditional `safe` until tenant identity can be evaluated.
+        if ($this->applicationIdentity === null) {
+            if ($profile->multiTenant && $recommendation === PreflightRecommendation::Safe) {
+                $reasonCodes[] = 'tenant_unevaluated';
+
+                return ['not_evaluated', 'not_applicable', PreflightRecommendation::NeedsReview, $reasonCodes];
+            }
+
+            return ['not_evaluated', 'not_applicable', $recommendation, $reasonCodes];
+        }
+
+        // Marker absent must NOT fail closed (#1420): a legitimate pre-existing database that predates
+        // the identity marker would otherwise be refused. Keep the migration-based recommendation and
+        // flag it as unverified instead.
+        if ($marker === null) {
+            $reasonCodes[] = 'identity_unverified';
+
+            return ['absent', 'not_applicable', $recommendation, $reasonCodes];
+        }
+
+        // A marker that belongs to a different application is the one identity signal that refuses.
+        if ($marker['application_id'] !== $this->applicationIdentity->applicationId) {
+            $reasonCodes[] = 'identity_mismatch';
+
+            return ['mismatch', 'not_applicable', PreflightRecommendation::Refuse, $reasonCodes];
+        }
+
+        // Application identity matches. Single-tenant applications stop here.
+        if ($this->applicationIdentity->tenantId === null) {
+            return ['match', 'not_applicable', $recommendation, $reasonCodes];
+        }
+
+        if (($marker['tenant_id'] ?? null) === $this->applicationIdentity->tenantId) {
+            return ['match', 'match', $recommendation, $reasonCodes];
+        }
+
+        $reasonCodes[] = 'tenant_mismatch';
+
+        return ['match', 'mismatch', PreflightRecommendation::Refuse, $reasonCodes];
+    }
+
     private function enforceReadOnly(PDO $pdo, string $driver): void
     {
         match ($driver) {
@@ -174,6 +240,19 @@ final readonly class DefaultDatabaseCandidateInspector implements DatabaseCandid
             // without an explicit guard. A SELECT-only credential remains the recommended backstop.
             default => null,
         };
+    }
+
+    /**
+     * Application tables are everything except the framework-internal ledger and identity marker.
+     *
+     * @param list<string> $tables
+     * @return list<string>
+     */
+    private function applicationTables(array $tables): array
+    {
+        $internal = [$this->ledgerTable, $this->identityTable];
+
+        return array_values(array_filter($tables, fn (string $t): bool => !in_array($t, $internal, true)));
     }
 
     /**
@@ -226,5 +305,36 @@ final readonly class DefaultDatabaseCandidateInspector implements DatabaseCandid
         }
 
         return $versions;
+    }
+
+    /**
+     * @param list<string> $tables
+     * @return array{application_id: string, tenant_id: string|null}|null
+     */
+    private function readIdentityMarker(PDO $pdo, array $tables): ?array
+    {
+        if (!in_array($this->identityTable, $tables, true)) {
+            return null;
+        }
+
+        // $this->identityTable is validated as a bare identifier in the constructor.
+        $statement = $pdo->query(sprintf('SELECT application_id, tenant_id FROM %s LIMIT 1', $this->identityTable));
+
+        if ($statement === false) {
+            return null;
+        }
+
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row) || !isset($row['application_id']) || !is_scalar($row['application_id'])) {
+            return null;
+        }
+
+        $tenant = $row['tenant_id'] ?? null;
+
+        return [
+            'application_id' => (string) $row['application_id'],
+            'tenant_id' => is_scalar($tenant) ? (string) $tenant : null,
+        ];
     }
 }

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.331';
+    public const string VERSION = '1.5.332';
 
     public function name(): string
     {

--- a/tests/Database/Preflight/ApplicationIdentityMarkerTest.php
+++ b/tests/Database/Preflight/ApplicationIdentityMarkerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Database\Preflight;
+
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\Preflight\ApplicationIdentity;
+use Nene2\Database\Preflight\ApplicationIdentityMarker;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ApplicationIdentityMarkerTest extends TestCase
+{
+    public function testStampCreatesMarkerTableAndRow(): void
+    {
+        $pdo = $this->sqlite();
+
+        (new ApplicationIdentityMarker($this->factory($pdo)))->stamp(new ApplicationIdentity('app-A'));
+
+        $row = $this->fetchRow($pdo, 'SELECT application_id, tenant_id FROM nene2_app_identity');
+
+        self::assertIsArray($row);
+        self::assertSame('app-A', $row['application_id']);
+        self::assertNull($row['tenant_id']);
+    }
+
+    public function testStampStoresTenant(): void
+    {
+        $pdo = $this->sqlite();
+
+        (new ApplicationIdentityMarker($this->factory($pdo)))->stamp(new ApplicationIdentity('app-A', 'tenant-1'));
+
+        $row = $this->fetchRow($pdo, 'SELECT application_id, tenant_id FROM nene2_app_identity');
+
+        self::assertIsArray($row);
+        self::assertSame('tenant-1', $row['tenant_id']);
+    }
+
+    public function testStampIsIdempotentAndKeepsASingleRow(): void
+    {
+        $pdo = $this->sqlite();
+        $marker = new ApplicationIdentityMarker($this->factory($pdo));
+
+        $marker->stamp(new ApplicationIdentity('app-A'));
+        $marker->stamp(new ApplicationIdentity('app-A', 'tenant-9'));
+
+        $statement = $pdo->query('SELECT COUNT(*) FROM nene2_app_identity');
+        self::assertNotFalse($statement);
+        $count = $statement->fetchColumn();
+        $row = $this->fetchRow($pdo, 'SELECT application_id, tenant_id FROM nene2_app_identity');
+
+        self::assertSame('1', (string) $count);
+        self::assertIsArray($row);
+        self::assertSame('tenant-9', $row['tenant_id']);
+    }
+
+    private function fetchRow(PDO $pdo, string $sql): mixed
+    {
+        $statement = $pdo->query($sql);
+        self::assertNotFalse($statement);
+
+        return $statement->fetch(PDO::FETCH_ASSOC);
+    }
+
+    private function sqlite(): PDO
+    {
+        return new PDO('sqlite::memory:', null, null, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]);
+    }
+
+    private function factory(PDO $pdo): DatabaseConnectionFactoryInterface
+    {
+        return new class ($pdo) implements DatabaseConnectionFactoryInterface {
+            public function __construct(private PDO $pdo)
+            {
+            }
+
+            public function create(): PDO
+            {
+                return $this->pdo;
+            }
+        };
+    }
+}

--- a/tests/Database/Preflight/DefaultDatabaseCandidateInspectorTest.php
+++ b/tests/Database/Preflight/DefaultDatabaseCandidateInspectorTest.php
@@ -6,6 +6,7 @@ namespace Nene2\Tests\Database\Preflight;
 
 use Nene2\Database\DatabaseConnectionException;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\Preflight\ApplicationIdentity;
 use Nene2\Database\Preflight\CandidateProfile;
 use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
 use Nene2\Database\Preflight\MigrationState;
@@ -139,6 +140,98 @@ final class DefaultDatabaseCandidateInspectorTest extends TestCase
         self::assertSame(['foreign_schema'], $verdict->reasonCodes);
     }
 
+    public function testIdentityMatchIsSafe(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101']);
+        $this->seedMarker($pdo, 'app-A');
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101'], applicationIdentity: new ApplicationIdentity('app-A')))
+            ->inspect($this->profile($pdo));
+
+        self::assertSame('match', $verdict->appIdentity);
+        self::assertSame('not_applicable', $verdict->tenant);
+        self::assertSame(PreflightRecommendation::Safe, $verdict->recommendation);
+        self::assertSame(['compatible'], $verdict->reasonCodes);
+    }
+
+    public function testIdentityMismatchIsRefused(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101']);
+        $this->seedMarker($pdo, 'app-OTHER');
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101'], applicationIdentity: new ApplicationIdentity('app-A')))
+            ->inspect($this->profile($pdo));
+
+        self::assertSame('mismatch', $verdict->appIdentity);
+        self::assertSame(PreflightRecommendation::Refuse, $verdict->recommendation);
+        self::assertSame(['compatible', 'identity_mismatch'], $verdict->reasonCodes);
+    }
+
+    public function testAbsentIdentityMarkerDoesNotFailClosed(): void
+    {
+        // The core #1420 guard: a legitimate pre-existing database without an identity marker must not
+        // be refused as foreign — it stays at its migration-based recommendation, flagged unverified.
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101']);
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101'], applicationIdentity: new ApplicationIdentity('app-A')))
+            ->inspect($this->profile($pdo));
+
+        self::assertSame('absent', $verdict->appIdentity);
+        self::assertSame(PreflightRecommendation::Safe, $verdict->recommendation);
+        self::assertSame(['compatible', 'identity_unverified'], $verdict->reasonCodes);
+    }
+
+    public function testTenantMatchIsSafe(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101']);
+        $this->seedMarker($pdo, 'app-A', 'tenant-1');
+
+        $verdict = (new DefaultDatabaseCandidateInspector(
+            ['20260101'],
+            applicationIdentity: new ApplicationIdentity('app-A', 'tenant-1'),
+        ))->inspect($this->profile($pdo));
+
+        self::assertSame('match', $verdict->appIdentity);
+        self::assertSame('match', $verdict->tenant);
+        self::assertSame(PreflightRecommendation::Safe, $verdict->recommendation);
+    }
+
+    public function testTenantMismatchIsRefused(): void
+    {
+        $pdo = $this->sqlite();
+        $this->seedLedger($pdo, ['20260101']);
+        $this->seedMarker($pdo, 'app-A', 'tenant-2');
+
+        $verdict = (new DefaultDatabaseCandidateInspector(
+            ['20260101'],
+            applicationIdentity: new ApplicationIdentity('app-A', 'tenant-1'),
+        ))->inspect($this->profile($pdo));
+
+        self::assertSame('match', $verdict->appIdentity);
+        self::assertSame('mismatch', $verdict->tenant);
+        self::assertSame(PreflightRecommendation::Refuse, $verdict->recommendation);
+        self::assertSame(['compatible', 'tenant_mismatch'], $verdict->reasonCodes);
+    }
+
+    public function testIdentityMarkerTableIsNotTreatedAsApplicationSchema(): void
+    {
+        // A database holding only the framework's identity marker (no ledger, no app tables) is fresh,
+        // not foreign — the marker table must be excluded from the "populated / foreign" decision.
+        $pdo = $this->sqlite();
+        $this->seedMarker($pdo, 'app-A');
+
+        $verdict = (new DefaultDatabaseCandidateInspector(['20260101'], applicationIdentity: new ApplicationIdentity('app-A')))
+            ->inspect($this->profile($pdo));
+
+        self::assertSame(MigrationState::Fresh, $verdict->migrationState);
+        self::assertFalse($verdict->populated);
+        self::assertSame('match', $verdict->appIdentity);
+    }
+
     public function testUnreachableCandidateIsRefused(): void
     {
         $factory = new class () implements DatabaseConnectionFactoryInterface {
@@ -193,6 +286,13 @@ final class DefaultDatabaseCandidateInspectorTest extends TestCase
             $statement = $pdo->prepare('INSERT INTO phinx_log (version, migration_name) VALUES (:v, :n)');
             $statement->execute([':v' => $version, ':n' => 'Migration' . $version]);
         }
+    }
+
+    private function seedMarker(PDO $pdo, string $applicationId, ?string $tenantId = null): void
+    {
+        $pdo->exec('CREATE TABLE nene2_app_identity (application_id TEXT NOT NULL, tenant_id TEXT NULL)');
+        $statement = $pdo->prepare('INSERT INTO nene2_app_identity (application_id, tenant_id) VALUES (:a, :t)');
+        $statement->execute([':a' => $applicationId, ':t' => $tenantId]);
     }
 
     private function profile(PDO $pdo, bool $multiTenant = false): CandidateProfile


### PR DESCRIPTION
## 目的

`#1419` を A/B/C に分割した **Part 2/3（B）**。A（#1419、merged）の verdict に **app identity / tenant 照合**を有効化する。前回フラグした設計穴②「正当な既存 DB が fail-closed する」を回避する三値設計で実装。

## 変更点

### identity マーカー（書き込みパス）
- `ApplicationIdentity`（value object）: `applicationId`（DB lineage）+ 任意 `tenantId`（null = 単一テナント）。
- `ApplicationIdentityMarker::stamp()`: `nene2_app_identity` テーブルを作成し単一行を冪等に書く（トランザクション内で DELETE→INSERT）。init/マイグレーション時、および既存 DB の **backfill**（採用時の一度きり）に使う。これが preflight 機能で唯一の書き込みパス（候補ではなくアプリ自身の DB に対して実行）。

### inspector の identity / tenant 評価（read-only）
- `DefaultDatabaseCandidateInspector` に `applicationIdentity` / `identityTable`（既定 `nene2_app_identity`）引数を追加。
- `app_identity`: **三値** `match` / `mismatch` / `absent`。
- `tenant`: マルチテナント identity（`tenantId` 非 null）のときのみ `match` / `mismatch` を評価。単一テナントは `not_applicable`。

### 設計穴②の解消 — fail-closed させない
- **マーカー不在は `refuse` にしない**: `app_identity: absent` + `identity_unverified` を返し、マイグレーション由来の recommendation（`safe` / `needs_migration`）を維持する。マーカー導入前から存在する正当な DB（リストア/クローン）が拒否されない。
- `mismatch`（別アプリのマーカー）**のみ**自動 `refuse`。`tenant: mismatch` も自動 `refuse`。
- 識別マーカーテーブルは framework 内部扱いとし、`populated` / `foreign` 判定から除外（マーカーのみの DB は `foreign` でなく `fresh`）。

### 後方互換
- `applicationIdentity` 未設定時は A スコープの挙動を維持（`app_identity: not_evaluated` / `tenant: not_applicable` + 旧マルチテナントガード `tenant_unevaluated`）。

### スコープの線引き（core を肥大化させない）
- core は **マーカー照合のみ**。richer なテナント解決は `DatabaseCandidateInspector` 拡張点に委ねる（NENE2 minimal framework 非ゴールを守る）。

## 検証結果

```
composer check
  → PHPUnit: OK (484 tests, 1214 assertions)
  → PHPStan level 8: No errors
  → PHP CS Fixer: clean
  → OpenAPI contract is valid.
  → MCP tool catalog is valid.
```

主な新規テスト:
- **`testAbsentIdentityMarkerDoesNotFailClosed`** — マーカー不在の互換 DB が refuse に落ちない回帰テスト（#1420 の核心）。
- identity match/mismatch、tenant match/mismatch、マーカーのみ DB が fresh 扱い、`ApplicationIdentityMarker` の stamp/冪等性。

## 関連 Issue

Part 2/3。`Closes #1420`。前提: #1419（A, merged）。後続: #1421（C: fingerprint + 署名トークン）。

## Self-review

backend-api, openapi-contract, database, docs-policy

## 残りのリスク・後続作業

- DDL（マーカーテーブル作成）は sqlite/mysql/pgsql 向けに実装。結合テストは SQLite 中心（FT MySQL は別途）。
- backfill は運用手順（`docs/development/machine-database-preflight.md`）。自動化はしていない（意図的）。
- C（#1421）: verdict の fingerprint + HMAC 署名トークンは "apply" Issue と対で着手。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
