### PR TITLE
docs(daily): 2026-06-27 日報を追加 (#1424)

### DIFF
--- a/docs/daily/2026-06-27.md
+++ b/docs/daily/2026-06-27.md
@@ -1,0 +1,94 @@
+# 日報 — 2026-06-27
+
+## 作業時間帯
+
+2026-06-27。リポジトリ全体の状態把握から始め、1 件の大きな機能 Issue（#1419 candidate-database preflight）を**設計フェーズで A/B/C に分割 → レビュー指摘を受け入れ条件へ落とす → 整合した単位で実装・マージ → リリース**まで通した一日。新機能の実装が中心だが、「いきなり作らず、まず分割と受け入れ条件で設計を固め、レビューの穴を潰してから着手する」という順序を軸にした。
+
+---
+
+## 本日の成果
+
+### 1. リポジトリ全体の状態把握
+
+セッション開始時に全体像を確認。バージョン **1.5.330**（`FrameworkInfo` / `openapi.yaml` / `CHANGELOG` 一致）、main は未追跡記事 1 件を除きクリーン、open Issue は #1419 / #1413、open PR 0。
+
+- **検出した気づき 2 点**: (a) `docs/articles/dev-mcp-should-not-touch-your-database.md` が #1413 のドラフトとして main に未追跡で直置き（後に Cursor 担当の可能性ありと判明 → 放置）、(b) FT ループ引き継ぎ `docs/todo/current.md` が 6/17 付けで陳腐化（FT352/1.5.329 表記、実態は machine 系へ移行・1.5.330）。
+
+### 2. #1419 の設計レビューと A/B/C 分割（#1419 / #1420 / #1421）
+
+#1419（候補 DB の read-only プリフライト診断）を精読し、忖度なしでレビュー。**問題設定（なぜアプリが判定主体か）は秀逸だが、1 Issue に 3 機能が同居し over-scoped** と評価。
+
+- **指摘した設計の穴 2 点**:
+  - (a) identity マーカー前提だと、本機能の主目的である「マーカー導入前から存在する正当な既存 DB」が `foreign` 判定 → **一番効かせたいシナリオが一番 fail-closed** する。
+  - (b) "read-only" の**保証機構**が未定義（規約頼みでは弱い）。
+- **投機性の指摘**: HMAC 署名トークンは「apply はスコープ外」と矛盾 — 消費者なき署名トークンになる。
+- **分割**: A（#1419 を再定義: read-only 診断 + verdict / MVP）/ B（#1420: app identity / tenant 照合）/ C（#1421: fingerprint + 署名トークン）。各々に受け入れ条件・依存リンク・スコープ境界を明記。
+- **レビュー反映**: ユーザー承認コメント（マルチテナント環境では A+B 揃って初めて意味を持つ）を、A の `recommendation` ガード（multi-tenant 構成で tenant 未評価なら無条件 `safe` を出さず `tenant_unevaluated` → `needs_review`）として受け入れ条件に追記し、#1419 に返信。
+
+### 3. A（#1419 / PR #1422）: candidate database preflight エンドポイント
+
+`POST /machine/database/preflight`（machine 認証必須）を実装。Part 1/3。
+
+| 観点 | 実装 |
+|------|------|
+| 入力 | 候補プロファイル **ID のみ**。DSN/ホスト/認証情報はボディから読まず設定から解決（**SSRF 封じ・creds を wire に載せない**） |
+| read-only 機構 | SQLite `PRAGMA query_only` / MySQL・PostgreSQL `START TRANSACTION READ ONLY`、`connect_timeout=3` 再利用。**テストで書き込み拒否を実証** |
+| verdict | reason code のみ（生 DB 名/ホスト/行データを返さない）。`reachable` / `schema_recognized` / `migration_state` / `populated` / `recommendation` / `reason_codes` |
+| framework の形 | `DatabaseCandidateInspector` interface + 無設定で動く `DefaultDatabaseCandidateInspector`（台帳 `phinx_log` ベース）+ VO/enum。台帳知識は default 実装のみ、core は DB 非依存 |
+| 配線 | `RuntimeApplicationFactory` は inspector を渡したときのみルート登録 → null なら従来どおり後方互換 |
+
+- OpenAPI 操作 `machineDatabasePreflight` + スキーマ、MCP ツール（`safety: read`）、ユニット/HTTP テスト追加。`composer check` → **475 tests** 通過。VERSION 1.5.331。
+
+### 4. B（#1420 / PR #1423）: app identity / tenant 照合
+
+A の verdict に identity / tenant 評価を追加。Part 2/3。**設計の穴 (a) を三値設計で解消**。
+
+- `ApplicationIdentity`（VO）+ `ApplicationIdentityMarker::stamp()`（`nene2_app_identity` を冪等書き込み、機能内で唯一の書き込みパス、アプリ自身の DB に対して実行）。
+- `DefaultDatabaseCandidateInspector` に `applicationIdentity` を追加 → `app_identity`（**`match` / `mismatch` / `absent`**）と、マルチテナント identity では `tenant`（`match` / `mismatch`）を read-only 評価。
+- **fail-closed 回避（#1420 の核心）**: マーカー不在は `refuse` にせず `absent` + `identity_unverified` を返し、マイグレーション由来の recommendation を維持。`mismatch`（別アプリ）のみ自動 `refuse`。`tenant: mismatch` も自動 `refuse`。回帰テスト `testAbsentIdentityMarkerDoesNotFailClosed` で固定。
+- マーカーテーブルは framework 内部扱いとし `populated` / `foreign` 判定から除外（マーカーのみ DB は `foreign` でなく `fresh`）。
+- identity 未設定時は A 挙動を維持（後方互換）。`docs/development/machine-database-preflight.md` に **backfill 手順**を記載。`composer check` → **484 tests** 通過。VERSION 1.5.332。
+
+### 5. C（#1421）の defer 判断
+
+#1421 への Suite 由来コメント（apply 設計メモ）を読み、C の検証モデルが変わることを把握。
+
+- **apply は「アプリが自分の接続先を切り替えるランタイム endpoint」にできない**（cf. `NOT_PLANNED` で取り下げ済みの #1416「稼働中アプリは自分を再デプロイできない」）。
+- apply は **deployer の責務**（設定書き換え → アプリ再起動）。アプリの役割は **boot 時のセルフチェック**（migrate/serve 前に token + fingerprint を再検証、失敗なら起動中断）。
+- よって C の再検証 API は HTTP ハンドラでなく **boot guard** として設計するのが筋。時間窓は deploy 1 回分（短め）。
+- **結論**: A+B で read-only の価値は確定。C は apply Issue が立って #1421 から参照されるまで **defer**（受け入れ条件どおり「消費者なき署名トークンを単独 merge しない」）。
+
+### 6. リリース v1.5.331 / v1.5.332
+
+未タグだった A/B の 2 版を、リポジトリの「実体ある framework 変更は 1 版＝1 リリース」パターン（直近 v1.5.327〜330）に倣ってリリース。
+
+- `docs/development/release-checklist.md` のプリコンディション確認（main 同期・`composer validate` OK・`composer check` 通過・`git diff --check` クリーン）。
+- annotated タグを各コミットに打って push → **タグごとに GitHub Release を作成**（Packagist webhook はリリース作成で発火）。英語・house style のリリースノート。v1.5.332 を Latest に設定。
+
+---
+
+## 数値
+
+- マージ PR: **2 件**（#1422 = A / #1423 = B）
+- Issue 整理: #1419 を **A/B/C の 3 分割**（#1420 / #1421 新規作成）、#1419 / #1420 クローズ
+- リリース: **v1.5.331 / v1.5.332**（GitHub Release 作成・Packagist 連動）
+- 新規 `src/` クラス: **8 件**（`Nene2\Database\Preflight\` — MigrationState / PreflightRecommendation / CandidateProfile / PreflightVerdict / DatabaseCandidateInspector / DefaultDatabaseCandidateInspector / ApplicationIdentity / ApplicationIdentityMarker）
+- 新規ドキュメント: `docs/development/machine-database-preflight.md`（backfill 手順含む）
+- テスト: **475（A）→ 484（B）**、PHPStan level 8 クリーン継続
+- VERSION: **1.5.330 → 1.5.332**
+
+---
+
+## 残課題（次回以降）
+
+| 優先 | 内容 |
+|------|------|
+| P1 | **C（#1421）**: apply（deployer 再起動 + boot 再検証）Issue が立って #1421 から参照されてから着手。鍵導出・時間窓・clock skew はそのフローに合わせて確定 |
+| P2 | `docs/todo/current.md`（FT ループ引き継ぎ）の陳腐化。実態（1.5.332・machine 系へ移行）へ更新する余地。FT ループ自体は「全 FT カバー達成」済みで停止中 |
+| P3 | #1413 のDEV記事ドラフト（未追跡）。Cursor 担当の可能性ありで本日は放置。担当が確定したら正式フロー or 削除を判断 |
+
+---
+
+## 所感
+
+1 本の大きな機能 Issue を、いきなり実装せず**設計フェーズで A/B/C に割り、受け入れ条件を書いてから着手**したのが今日の効いた判断。レビューで挙げた 2 つの穴 —「既存 DB が identity マーカー不在で fail-closed する」「read-only の保証機構が未定義」— が、そのまま受け入れ条件 → コードの分岐（`absent` を `refuse` にしない三値設計、`query_only` / READ ONLY txn）になり、レビューが装飾でなく設計の骨になった。ユーザーの「A+B 揃って初めて意味を持つ」という指摘も、口頭の合意で終わらせず `tenant_unevaluated` ガードとして verdict に焼き込めた。C は「作れるが作らない」を選べたのが良い — apply の消費者が居ない署名トークンは、当初 #1419 で自分が指摘した投機的サーフェスそのものなので、Suite 側の boot 再検証モデルが固まるまで寝かせるのが筋。終わってみれば 2 機能 + 2 リリース、main クリーン、open は #1421（意図的に defer）と #1413（他担当）のみ。分割 → 順次出荷 → リリースの一連が綺麗に閉じた。


### PR DESCRIPTION
## 目的
2026-06-27 の作業日報を追加する。

## 変更点
`docs/daily/2026-06-27.md` を新規作成。本日の作業（#1419 の A/B/C 分割、A=#1422 / B=#1423 実装、C=#1421 defer 判断、v1.5.331/v1.5.332 リリース）を記録。

## 検証
- docs のみ（`git diff --check` クリーン）。

Closes #1424

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)