### PR TITLE
feat(auth): 再利用可能な TOTP プリミティブとリカバリコードを追加 (#1427)

### DIFF
--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -58,7 +58,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException`, `DatabaseConstraintException` |
 | `Nene2\Error` | `DomainExceptionHandlerInterface`, `ProblemDetailsResponseFactory` |
-| `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware`, `LocalBearerTokenVerifier`, `CompositeAuthMiddleware` |
+| `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware`, `LocalBearerTokenVerifier`, `CompositeAuthMiddleware`, `TotpAuthenticator`, `RecoveryCodes` |
 | `Nene2\Middleware` | All shipped middleware classes, `RateLimitStorageInterface`, `ThrottleMiddleware` |
 | `Nene2\Validation` | `ValidationException`, `ValidationError` |
 | `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |

--- a/docs/howto/totp-authentication.md
+++ b/docs/howto/totp-authentication.md
@@ -55,6 +55,43 @@ CREATE TABLE used_totp_steps (
 
 ---
 
+## フレームワーク組み込みプリミティブ（推奨）
+
+v1.5 以降、危険な暗号部分は framework が提供する `Nene2\Auth\TotpAuthenticator` と
+`Nene2\Auth\RecoveryCodes` をそのまま使える（ADR 0009 の安定 public API）。
+RFC 6238 の計算・Base32・定数時間比較を各アプリで再実装する必要はない。
+`SecureTokenHelper` と同じく「危険な暗号は framework の1実装、enroll/challenge の
+HTTP フロー・enforce ポリシー・シークレットの at-rest 暗号化・リプレイ防止の永続化は
+アプリの責務」という分担。
+
+```php
+use Nene2\Auth\TotpAuthenticator;
+use Nene2\Auth\RecoveryCodes;
+
+$totp = new TotpAuthenticator();          // digits=6 / period=30 / sha1 / window=1
+
+// 登録: シークレット生成 → QR 用 otpauth URI
+$secret = $totp->generateSecret();
+$uri    = $totp->provisioningUri($secret, 'alice@example.com', 'NENE2');
+
+// 検証: 一致した time_step が返る（null なら無効）。リプレイ防止は step を永続化して判定。
+$step = $totp->verify($secret, $submittedCode);
+if ($step === null || $repo->isStepUsed($userId, $step)) {
+    // 無効 or リプレイ
+} else {
+    $repo->markStepUsed($userId, $step);  // 使用済み step を記録（1回限り）
+}
+
+// リカバリコード: 生成して一度だけ表示、hash のみ保存、redeem 時に verify → consume
+$codes = RecoveryCodes::generate();       // 例: ["3f9ac-1b0e7", ...]
+$repo->storeRecoveryHash($userId, RecoveryCodes::hash($codes[0]));
+```
+
+次節以降は、このプリミティブが内部で行っている計算とセキュリティ設計の解説。
+自前実装や理解のための参考として残す。
+
+---
+
 ## RFC 6238 TOTP の実装
 
 ```php

--- a/src/Auth/RecoveryCodes.php
+++ b/src/Auth/RecoveryCodes.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+/**
+ * Generation, hashing, and constant-time verification of one-time recovery codes.
+ *
+ * Recovery (backup) codes let a user regain access when their TOTP device is
+ * unavailable. The safe pattern is always the same and mirrors
+ * `SecureTokenHelper`:
+ *
+ * 1. Generate a batch of high-entropy codes and show them to the user **once**.
+ * 2. Store only the hash of each code — never the raw value.
+ * 3. On use, verify with a timing-safe comparison and then **consume** the code
+ *    (delete or flag its hash) so it cannot be reused.
+ *
+ * This helper owns steps 1–2 and the comparison in step 3. Persisting the
+ * hashes and enforcing single use (the "consume" action, plus rate limiting)
+ * stay with the application, following the same framework/app split as
+ * {@see TotpAuthenticator}.
+ *
+ * Codes are normalized before hashing and comparison, so formatting and case
+ * entered by the user (e.g. `ABCDE-12345` vs `abcde12345`) do not matter.
+ *
+ * ```php
+ * // Enrollment: generate and display once, persist the hashes.
+ * $codes = RecoveryCodes::generate();            // e.g. ["3f9ac-1b0e7", ...]
+ * foreach ($codes as $code) {
+ *     $repo->storeRecoveryHash($userId, RecoveryCodes::hash($code));
+ * }
+ * // → show $codes to the user now; they are unrecoverable afterwards.
+ *
+ * // Redemption: verify against each stored hash, then consume the match.
+ * foreach ($repo->recoveryHashes($userId) as $stored) {
+ *     if (RecoveryCodes::verify($submitted, $stored->hash)) {
+ *         $repo->consumeRecoveryHash($stored->id); // single use
+ *         // authenticated
+ *     }
+ * }
+ * ```
+ *
+ * Security notes:
+ * - `generate()` uses `random_bytes()` — a CSPRNG suitable for security tokens.
+ * - `hash()` uses SHA-256; a database breach exposes only hashes.
+ * - `verify()` uses `hash_equals()` for constant-time comparison.
+ * - Codes are single-use secrets — the application must consume a code on
+ *   success and rate-limit redemption attempts.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class RecoveryCodes
+{
+    /**
+     * Generates a batch of formatted recovery codes.
+     *
+     * Each code is `$bytes` random bytes rendered as hex and grouped into
+     * five-character blocks joined by hyphens for readability. The default of
+     * 5 bytes gives 40 bits of entropy per code; increase `$bytes` for a wider
+     * margin when redemption is not strongly rate-limited.
+     *
+     * ```php
+     * $codes = RecoveryCodes::generate();       // 10 codes like "3f9ac-1b0e7"
+     * $codes = RecoveryCodes::generate(8, 8);   // 8 codes, 64-bit each
+     * ```
+     *
+     * @param int $count Number of codes to generate. Must be at least 1.
+     * @param int $bytes Random bytes per code. Must be at least 1.
+     *
+     * @return list<string>
+     *
+     * @throws \InvalidArgumentException When `$count` or `$bytes` is less than 1.
+     */
+    public static function generate(int $count = 10, int $bytes = 5): array
+    {
+        if ($count < 1) {
+            throw new \InvalidArgumentException('Recovery code count must be at least 1.');
+        }
+
+        if ($bytes < 1) {
+            throw new \InvalidArgumentException('Recovery code byte length must be at least 1.');
+        }
+
+        $codes = [];
+        for ($i = 0; $i < $count; $i++) {
+            $codes[] = implode('-', str_split(bin2hex(random_bytes($bytes)), 5));
+        }
+
+        return $codes;
+    }
+
+    /**
+     * Returns the SHA-256 hash of a recovery code as a lowercase hex string.
+     *
+     * The code is normalized first, so the stored hash is independent of
+     * formatting and case. Store this value, never the raw code.
+     */
+    public static function hash(string $code): string
+    {
+        return hash('sha256', self::normalize($code));
+    }
+
+    /**
+     * Verifies a submitted recovery code against a stored SHA-256 hash.
+     *
+     * Normalizes the input, then compares with `hash_equals()` in constant time.
+     * Always returns `false` for empty inputs. A `true` result means the caller
+     * should now **consume** the matching stored hash to enforce single use.
+     */
+    public static function verify(string $code, string $storedHash): bool
+    {
+        if ($code === '' || $storedHash === '') {
+            return false;
+        }
+
+        return hash_equals($storedHash, self::hash($code));
+    }
+
+    /**
+     * Normalizes a recovery code by removing non-alphanumeric characters and
+     * lowercasing, so hashing and comparison ignore separators and case.
+     */
+    public static function normalize(string $code): string
+    {
+        return strtolower((string) preg_replace('/[^A-Za-z0-9]/', '', $code));
+    }
+}

--- a/src/Auth/TotpAuthenticator.php
+++ b/src/Auth/TotpAuthenticator.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+/**
+ * RFC 6238 Time-based One-Time Password (TOTP) primitive.
+ *
+ * This class provides the security-critical parts of TOTP two-factor
+ * authentication so that each application does not re-implement the RFC 6238
+ * algorithm, Base32 secret handling, or the constant-time code comparison. It
+ * is generic and application-independent, following the same split as
+ * {@see LocalBearerTokenVerifier} and `SecureTokenHelper`: the framework owns
+ * the dangerous cryptography, the application owns the HTTP flow and policy.
+ *
+ * What this class does:
+ * - generate a Base32 shared secret ({@see generateSecret()});
+ * - build an `otpauth://` provisioning URI for authenticator apps
+ *   ({@see provisioningUri()});
+ * - compute a code for a specific time step ({@see computeCode()});
+ * - verify a submitted code within a tolerance window, in constant time,
+ *   returning the matched time step for replay tracking ({@see verify()}).
+ *
+ * What the application still owns (intentionally out of scope):
+ * - the enroll / challenge HTTP endpoints and any UI;
+ * - the enforcement policy (who must use TOTP, when it is required);
+ * - secret storage and at-rest encryption in the data layer;
+ * - replay prevention — persist the matched time step returned by
+ *   {@see verify()} and reject a step that was already consumed;
+ * - brute-force lockout.
+ *
+ * ```php
+ * $totp = new TotpAuthenticator();
+ *
+ * // Enrollment: generate a secret and show it to the user.
+ * $secret = $totp->generateSecret();
+ * $uri    = $totp->provisioningUri($secret, 'alice@example.com', 'NENE2');
+ * // → render $uri as a QR code; persist $secret for the user (encrypted).
+ *
+ * // Verification (login / enable): validate a 6-digit code.
+ * $matchedStep = $totp->verify($secret, $submittedCode);
+ * if ($matchedStep === null) {
+ *     // invalid or expired code
+ * } elseif ($repo->isStepUsed($userId, $matchedStep)) {
+ *     // replay: this code was already used
+ * } else {
+ *     $repo->markStepUsed($userId, $matchedStep);
+ *     // authenticated
+ * }
+ * ```
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final readonly class TotpAuthenticator
+{
+    /** RFC 4648 Base32 alphabet (no padding). */
+    private const string BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+    private int $digits;
+    private int $period;
+    private string $algorithm;
+    private int $window;
+
+    /**
+     * @param int    $digits    Number of code digits (6, 7, or 8). Authenticator apps use 6.
+     * @param int    $period    Time step length in seconds (RFC 6238 default: 30).
+     * @param string $algorithm HMAC hash algorithm: `sha1` (default, widest app support),
+     *                          `sha256`, or `sha512`.
+     * @param int    $window    Number of adjacent time steps accepted on each side of the
+     *                          current step to tolerate clock skew (default: 1 → ±`$period` s).
+     *                          Keep small; a wider window weakens security.
+     *
+     * @throws \InvalidArgumentException When any configuration value is out of range.
+     */
+    public function __construct(int $digits = 6, int $period = 30, string $algorithm = 'sha1', int $window = 1)
+    {
+        if ($digits < 6 || $digits > 8) {
+            throw new \InvalidArgumentException('TOTP digit count must be between 6 and 8.');
+        }
+
+        if ($period < 1) {
+            throw new \InvalidArgumentException('TOTP period must be at least 1 second.');
+        }
+
+        if ($window < 0) {
+            throw new \InvalidArgumentException('TOTP verification window must not be negative.');
+        }
+
+        $normalizedAlgorithm = strtolower($algorithm);
+
+        if (!in_array($normalizedAlgorithm, ['sha1', 'sha256', 'sha512'], true)) {
+            throw new \InvalidArgumentException('TOTP algorithm must be one of sha1, sha256, or sha512.');
+        }
+
+        $this->digits = $digits;
+        $this->period = $period;
+        $this->algorithm = $normalizedAlgorithm;
+        $this->window = $window;
+    }
+
+    /**
+     * Generates a new Base32-encoded shared secret using a CSPRNG.
+     *
+     * The default of 20 bytes is the RFC 6238 recommended secret size for SHA-1
+     * (160 bits) and encodes to 32 Base32 characters with no padding.
+     *
+     * ```php
+     * $secret = $totp->generateSecret(); // e.g. "JBSWY3DPEHPK3PXP..." (32 chars)
+     * ```
+     *
+     * @param int $bytes Number of random bytes. Must be at least 1.
+     *
+     * @throws \InvalidArgumentException When `$bytes` is less than 1.
+     */
+    public function generateSecret(int $bytes = 20): string
+    {
+        if ($bytes < 1) {
+            throw new \InvalidArgumentException('Secret byte length must be at least 1.');
+        }
+
+        return $this->base32Encode(random_bytes($bytes));
+    }
+
+    /**
+     * Builds an `otpauth://totp/` provisioning URI for authenticator apps.
+     *
+     * Render the returned URI as a QR code. The parameters (algorithm, digits,
+     * period) reflect this authenticator's configuration so the app computes
+     * matching codes.
+     *
+     * ```php
+     * $uri = $totp->provisioningUri($secret, 'alice@example.com', 'NENE2');
+     * // otpauth://totp/NENE2:alice%40example.com?secret=...&issuer=NENE2&algorithm=SHA1&digits=6&period=30
+     * ```
+     */
+    public function provisioningUri(string $secret, string $accountName, string $issuer): string
+    {
+        $label = rawurlencode($issuer) . ':' . rawurlencode($accountName);
+
+        $query = http_build_query([
+            'secret' => $secret,
+            'issuer' => $issuer,
+            'algorithm' => strtoupper($this->algorithm),
+            'digits' => $this->digits,
+            'period' => $this->period,
+        ], '', '&', PHP_QUERY_RFC3986);
+
+        return 'otpauth://totp/' . $label . '?' . $query;
+    }
+
+    /**
+     * Returns the current time step for a given (or the current) Unix timestamp.
+     *
+     * Pass `$now` in tests to make code generation deterministic.
+     */
+    public function currentTimeStep(?int $now = null): int
+    {
+        return intdiv($now ?? time(), $this->period);
+    }
+
+    /**
+     * Computes the TOTP code for a specific time step.
+     *
+     * Useful for tests and for the enable flow, where the caller needs a code
+     * for the current or an adjacent step. See {@see currentTimeStep()}.
+     *
+     * ```php
+     * $code = $totp->computeCode($secret, $totp->currentTimeStep());
+     * ```
+     */
+    public function computeCode(string $secret, int $timeStep): string
+    {
+        $key = $this->base32Decode($secret);
+        $counter = pack('J', $timeStep); // 8-byte big-endian counter (RFC 4226 §5.3)
+        $hash = hash_hmac($this->algorithm, $counter, $key, true);
+
+        // Dynamic truncation (RFC 4226 §5.4): low 4 bits of the last byte give the offset.
+        $offset = ord($hash[strlen($hash) - 1]) & 0x0F;
+        $binary = ((ord($hash[$offset]) & 0x7F) << 24)
+            | ((ord($hash[$offset + 1]) & 0xFF) << 16)
+            | ((ord($hash[$offset + 2]) & 0xFF) << 8)
+            | (ord($hash[$offset + 3]) & 0xFF);
+
+        $otp = $binary % (int) (10 ** $this->digits);
+
+        return str_pad((string) $otp, $this->digits, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Verifies a submitted code against the secret within the tolerance window.
+     *
+     * Returns the matched time step on success, or `null` when the code is
+     * invalid, malformed, or outside the window. Comparison uses `hash_equals()`
+     * for constant-time behavior, preventing timing-oracle attacks.
+     *
+     * The returned step is the caller's replay key: persist it and reject a
+     * step that was already consumed (a single code stays valid for one period).
+     *
+     * ```php
+     * $step = $totp->verify($secret, $code);
+     * if ($step === null || $repo->isStepUsed($userId, $step)) {
+     *     return $unauthorized;
+     * }
+     * $repo->markStepUsed($userId, $step);
+     * ```
+     *
+     * @param int|null $now Optional Unix timestamp for deterministic tests.
+     */
+    public function verify(string $secret, string $code, ?int $now = null): ?int
+    {
+        $code = trim($code);
+
+        if ($secret === '' || strlen($code) !== $this->digits || !ctype_digit($code)) {
+            return null;
+        }
+
+        $currentStep = $this->currentTimeStep($now);
+
+        for ($offset = -$this->window; $offset <= $this->window; $offset++) {
+            $step = $currentStep + $offset;
+
+            if (hash_equals($this->computeCode($secret, $step), $code)) {
+                return $step;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Encodes raw bytes to an unpadded RFC 4648 Base32 string.
+     */
+    private function base32Encode(string $binary): string
+    {
+        if ($binary === '') {
+            return '';
+        }
+
+        $bits = '';
+        foreach (str_split($binary) as $char) {
+            $bits .= str_pad(decbin(ord($char)), 8, '0', STR_PAD_LEFT);
+        }
+
+        $encoded = '';
+        foreach (str_split($bits, 5) as $chunk) {
+            $chunk = str_pad($chunk, 5, '0', STR_PAD_RIGHT);
+            $encoded .= self::BASE32_ALPHABET[(int) bindec($chunk)];
+        }
+
+        return $encoded;
+    }
+
+    /**
+     * Decodes an RFC 4648 Base32 string to raw bytes.
+     *
+     * Case-insensitive; ignores whitespace, padding, and any non-alphabet
+     * characters. Trailing bits that do not form a full byte are discarded.
+     */
+    private function base32Decode(string $base32): string
+    {
+        $base32 = strtoupper((string) preg_replace('/[^A-Za-z2-7]/', '', $base32));
+
+        if ($base32 === '') {
+            return '';
+        }
+
+        $bits = '';
+        foreach (str_split($base32) as $char) {
+            $index = strpos(self::BASE32_ALPHABET, $char);
+            if ($index === false) {
+                continue;
+            }
+            $bits .= str_pad(decbin($index), 5, '0', STR_PAD_LEFT);
+        }
+
+        $bytes = '';
+        foreach (str_split($bits, 8) as $chunk) {
+            if (strlen($chunk) === 8) {
+                $bytes .= chr((int) bindec($chunk));
+            }
+        }
+
+        return $bytes;
+    }
+}

--- a/tests/Auth/RecoveryCodesTest.php
+++ b/tests/Auth/RecoveryCodesTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Auth;
+
+use Nene2\Auth\RecoveryCodes;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RecoveryCodesTest extends TestCase
+{
+    // ------------------------------------------------------------------ generate
+
+    #[Test]
+    public function generateReturnsRequestedCount(): void
+    {
+        self::assertCount(10, RecoveryCodes::generate());
+        self::assertCount(3, RecoveryCodes::generate(3));
+    }
+
+    #[Test]
+    public function generateReturnsFormattedCodes(): void
+    {
+        foreach (RecoveryCodes::generate() as $code) {
+            // default 5 bytes → 10 hex chars grouped as "xxxxx-xxxxx"
+            self::assertMatchesRegularExpression('/^[0-9a-f]{5}-[0-9a-f]{5}$/', $code);
+        }
+    }
+
+    #[Test]
+    public function generateReturnsUniqueCodes(): void
+    {
+        $codes = RecoveryCodes::generate();
+
+        self::assertSame($codes, array_values(array_unique($codes)));
+    }
+
+    #[Test]
+    public function generateRespectsCustomByteLength(): void
+    {
+        foreach (RecoveryCodes::generate(2, 8) as $code) {
+            // 8 bytes → 16 hex chars grouped by 5 → "xxxxx-xxxxx-xxxxx-x"
+            self::assertSame(16, strlen(str_replace('-', '', $code)));
+        }
+    }
+
+    #[Test]
+    public function generateRejectsNonPositiveCount(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        RecoveryCodes::generate(0);
+    }
+
+    #[Test]
+    public function generateRejectsNonPositiveByteLength(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        RecoveryCodes::generate(10, 0);
+    }
+
+    // ------------------------------------------------------------------ hash / verify
+
+    #[Test]
+    public function hashReturnsSha256HexString(): void
+    {
+        $hash = RecoveryCodes::hash('abcde-12345');
+
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
+    }
+
+    #[Test]
+    public function verifyAcceptsMatchingCode(): void
+    {
+        $code = RecoveryCodes::generate()[0];
+
+        self::assertTrue(RecoveryCodes::verify($code, RecoveryCodes::hash($code)));
+    }
+
+    #[Test]
+    public function verifyRejectsWrongCode(): void
+    {
+        $hash = RecoveryCodes::hash('abcde-12345');
+
+        self::assertFalse(RecoveryCodes::verify('fffff-00000', $hash));
+    }
+
+    #[Test]
+    public function verifyIgnoresFormattingAndCase(): void
+    {
+        $hash = RecoveryCodes::hash('abcde-12345');
+
+        self::assertTrue(RecoveryCodes::verify('ABCDE12345', $hash));
+        self::assertTrue(RecoveryCodes::verify('  abcde-12345  ', $hash));
+        self::assertTrue(RecoveryCodes::verify('ab cd e1 23 45', $hash));
+    }
+
+    #[Test]
+    public function verifyRejectsEmptyInputs(): void
+    {
+        self::assertFalse(RecoveryCodes::verify('', RecoveryCodes::hash('abcde-12345')));
+        self::assertFalse(RecoveryCodes::verify('abcde-12345', ''));
+    }
+
+    // ------------------------------------------------------------------ normalize
+
+    #[Test]
+    public function normalizeStripsSeparatorsAndLowercases(): void
+    {
+        self::assertSame('abcde12345', RecoveryCodes::normalize('ABCDE-12345'));
+        self::assertSame('abcde12345', RecoveryCodes::normalize('  ab cd-e1 2345 '));
+    }
+}

--- a/tests/Auth/TotpAuthenticatorTest.php
+++ b/tests/Auth/TotpAuthenticatorTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Auth;
+
+use Nene2\Auth\TotpAuthenticator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TotpAuthenticatorTest extends TestCase
+{
+    // ------------------------------------------------------------------ construction
+
+    #[Test]
+    public function rejectsDigitsBelowSix(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TotpAuthenticator(digits: 5);
+    }
+
+    #[Test]
+    public function rejectsDigitsAboveEight(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TotpAuthenticator(digits: 9);
+    }
+
+    #[Test]
+    public function rejectsNonPositivePeriod(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TotpAuthenticator(period: 0);
+    }
+
+    #[Test]
+    public function rejectsNegativeWindow(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TotpAuthenticator(window: -1);
+    }
+
+    #[Test]
+    public function rejectsUnknownAlgorithm(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TotpAuthenticator(algorithm: 'md5');
+    }
+
+    // ------------------------------------------------------------------ generateSecret
+
+    #[Test]
+    public function generateSecretReturnsBase32String(): void
+    {
+        $secret = (new TotpAuthenticator())->generateSecret();
+
+        self::assertMatchesRegularExpression('/^[A-Z2-7]+$/', $secret);
+    }
+
+    #[Test]
+    public function generateSecretDefaultIs32Chars(): void
+    {
+        // 20 bytes → 160 bits → 32 Base32 chars (no padding)
+        self::assertSame(32, strlen((new TotpAuthenticator())->generateSecret()));
+    }
+
+    #[Test]
+    public function generateSecretIsUnique(): void
+    {
+        $totp = new TotpAuthenticator();
+
+        self::assertNotSame($totp->generateSecret(), $totp->generateSecret());
+    }
+
+    #[Test]
+    public function generateSecretRejectsZeroBytes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new TotpAuthenticator())->generateSecret(0);
+    }
+
+    // ------------------------------------------------------------------ computeCode (RFC 6238 vectors)
+
+    /**
+     * RFC 6238 Appendix B reference: the ASCII secret "12345678901234567890"
+     * with SHA-1 and 8 digits yields known codes at fixed timestamps.
+     * "12345678901234567890" Base32-encodes to "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ".
+     */
+    #[Test]
+    public function computeCodeMatchesRfc6238ReferenceVector(): void
+    {
+        $totp = new TotpAuthenticator(digits: 8);
+        $secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+        // T=59 → time step 1, expected code 94287082 (RFC 6238 Appendix B table).
+        $step = $totp->currentTimeStep(59);
+
+        self::assertSame(1, $step);
+        self::assertSame('94287082', $totp->computeCode($secret, $step));
+    }
+
+    #[Test]
+    public function computeCodeMatchesSecondRfc6238Vector(): void
+    {
+        $totp = new TotpAuthenticator(digits: 8);
+        $secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+        // T=1111111109 → expected code 07081804 (RFC 6238 Appendix B).
+        self::assertSame('07081804', $totp->computeCode($secret, $totp->currentTimeStep(1111111109)));
+    }
+
+    #[Test]
+    public function computeCodeHasConfiguredDigitLength(): void
+    {
+        $totp = new TotpAuthenticator();
+        $secret = $totp->generateSecret();
+
+        self::assertSame(6, strlen($totp->computeCode($secret, 42)));
+    }
+
+    #[Test]
+    public function computeCodeIsDeterministicForSameStep(): void
+    {
+        $totp = new TotpAuthenticator();
+        $secret = $totp->generateSecret();
+
+        self::assertSame(
+            $totp->computeCode($secret, 100),
+            $totp->computeCode($secret, 100),
+        );
+    }
+
+    // ------------------------------------------------------------------ currentTimeStep
+
+    #[Test]
+    public function currentTimeStepDividesByPeriod(): void
+    {
+        $totp = new TotpAuthenticator(period: 30);
+
+        self::assertSame(3, $totp->currentTimeStep(90));
+        self::assertSame(3, $totp->currentTimeStep(119));
+        self::assertSame(4, $totp->currentTimeStep(120));
+    }
+
+    // ------------------------------------------------------------------ verify
+
+    #[Test]
+    public function verifyAcceptsCurrentCodeAndReturnsStep(): void
+    {
+        $totp = new TotpAuthenticator();
+        $secret = $totp->generateSecret();
+        $now = 1_700_000_000;
+        $step = $totp->currentTimeStep($now);
+        $code = $totp->computeCode($secret, $step);
+
+        self::assertSame($step, $totp->verify($secret, $code, $now));
+    }
+
+    #[Test]
+    public function verifyAcceptsPreviousStepWithinWindow(): void
+    {
+        $totp = new TotpAuthenticator(window: 1);
+        $secret = $totp->generateSecret();
+        $now = 1_700_000_000;
+        $previousStep = $totp->currentTimeStep($now) - 1;
+        $code = $totp->computeCode($secret, $previousStep);
+
+        self::assertSame($previousStep, $totp->verify($secret, $code, $now));
+    }
+
+    #[Test]
+    public function verifyRejectsCodeOutsideWindow(): void
+    {
+        $totp = new TotpAuthenticator(window: 1);
+        $secret = $totp->generateSecret();
+        $now = 1_700_000_000;
+        // Two steps ahead is outside a window of 1.
+        $code = $totp->computeCode($secret, $totp->currentTimeStep($now) + 2);
+
+        self::assertNull($totp->verify($secret, $code, $now));
+    }
+
+    #[Test]
+    public function verifyWithZeroWindowRejectsAdjacentStep(): void
+    {
+        $totp = new TotpAuthenticator(window: 0);
+        $secret = $totp->generateSecret();
+        $now = 1_700_000_000;
+        $code = $totp->computeCode($secret, $totp->currentTimeStep($now) - 1);
+
+        self::assertNull($totp->verify($secret, $code, $now));
+    }
+
+    #[Test]
+    public function verifyRejectsWrongCode(): void
+    {
+        $totp = new TotpAuthenticator();
+        $secret = $totp->generateSecret();
+
+        self::assertNull($totp->verify($secret, '000000', 1_700_000_000));
+    }
+
+    #[Test]
+    public function verifyRejectsMalformedCode(): void
+    {
+        $totp = new TotpAuthenticator();
+        $secret = $totp->generateSecret();
+
+        self::assertNull($totp->verify($secret, 'abcdef', 1_700_000_000));
+        self::assertNull($totp->verify($secret, '12345', 1_700_000_000));  // too short
+        self::assertNull($totp->verify($secret, '1234567', 1_700_000_000)); // too long
+    }
+
+    #[Test]
+    public function verifyRejectsEmptyInputs(): void
+    {
+        $totp = new TotpAuthenticator();
+
+        self::assertNull($totp->verify('', '123456', 1_700_000_000));
+        self::assertNull($totp->verify($totp->generateSecret(), '', 1_700_000_000));
+    }
+
+    #[Test]
+    public function verifyTrimsSurroundingWhitespace(): void
+    {
+        $totp = new TotpAuthenticator();
+        $secret = $totp->generateSecret();
+        $now = 1_700_000_000;
+        $code = $totp->computeCode($secret, $totp->currentTimeStep($now));
+
+        self::assertSame($totp->currentTimeStep($now), $totp->verify($secret, "  {$code}  ", $now));
+    }
+
+    // ------------------------------------------------------------------ provisioningUri
+
+    #[Test]
+    public function provisioningUriHasExpectedShape(): void
+    {
+        $totp = new TotpAuthenticator();
+        $uri = $totp->provisioningUri('JBSWY3DPEHPK3PXP', 'alice@example.com', 'NENE2');
+
+        self::assertStringStartsWith('otpauth://totp/NENE2:alice%40example.com?', $uri);
+        self::assertStringContainsString('secret=JBSWY3DPEHPK3PXP', $uri);
+        self::assertStringContainsString('issuer=NENE2', $uri);
+        self::assertStringContainsString('algorithm=SHA1', $uri);
+        self::assertStringContainsString('digits=6', $uri);
+        self::assertStringContainsString('period=30', $uri);
+    }
+
+    #[Test]
+    public function provisioningUriReflectsCustomConfiguration(): void
+    {
+        $totp = new TotpAuthenticator(digits: 8, period: 60, algorithm: 'sha256');
+        $uri = $totp->provisioningUri('JBSWY3DPEHPK3PXP', 'bob', 'Acme');
+
+        self::assertStringContainsString('algorithm=SHA256', $uri);
+        self::assertStringContainsString('digits=8', $uri);
+        self::assertStringContainsString('period=60', $uri);
+    }
+}


### PR DESCRIPTION
## 目的

Issue #1427 — `totp-authentication` howto のレシピはあるが**再利用可能なコードが無く**、各アプリが TOTP の検証・シークレット管理・リカバリコードを自前実装している。セキュリティクリティカルな暗号部分の重複実装は脆弱性混入リスク。これをフレームワークの安定 public API へ昇格する。

## 変更点

- **`src/Auth/TotpAuthenticator.php`**（新規・`final readonly`）: RFC 6238 TOTP プリミティブ。
  - `generateSecret()` — Base32 シークレット生成（CSPRNG、既定 20 byte = 32 文字）
  - `provisioningUri()` — 認証アプリ用 `otpauth://` URI
  - `computeCode()` / `currentTimeStep()` — 時間ステップ計算（テスト・enable フロー用に `now` 注入可）
  - `verify()` — 許容ウィンドウ内で **`hash_equals()` 定数時間比較**、一致した time_step を返す（リプレイ防止の鍵）
  - `digits` / `period` / `algorithm`（sha1/256/512）/ `window` を設定可能
- **`src/Auth/RecoveryCodes.php`**（新規）: リカバリコードの生成・SHA-256 ハッシュ化・定数時間検証。書式/大小を正規化するので入力ゆれに強い。
- **framework/app 分担**: 危険な暗号のみ framework の1実装。enroll/challenge の HTTP フロー・enforce ポリシー・at-rest 暗号化・リプレイ防止の永続化は**アプリ責務**（`SecureTokenHelper` / `LocalBearerTokenVerifier` と同じ流儀。Issue のスコープ通り）。
- **ADR 0009** の安定 public API 表（`Nene2\Auth` 行）に 2 クラスを追記。
- **`docs/howto/totp-authentication.md`** 先頭に組み込みプリミティブの利用例を追記（以降の自前実装解説は理解・参考用として残置）。

## 検証

- 新規 36 tests（`TotpAuthenticatorTest` は **RFC 6238 Appendix B 参照ベクトル**〔T=59→94287082、T=1111111109→07081804〕で計算を固定 + `RecoveryCodesTest`）。
- `docker compose run --rm app composer check` **全通過**: 520 tests / 1278 assertions・PHPStan level 8 No errors・CS 0・OpenAPI valid・MCP valid・version consistency OK。
- `composer howto:index` ドリフトなし・`howto:frontmatter --require-all` 260/260 pass。

## Self-review

backend-api

## 残リスク / 後続

- howto の追記は primary（ja）のみ。他 5 ロケール訳は既知のドリフト運用に従い別途。
- enroll/verify の **HTTP エンドポイント**や enforce ポリシーは意図的にスコープ外（アプリ責務）。

Closes #1427

🤖 Generated with [Claude Code](https://claude.com/claude-code)