### PR TITLE
fix(docs): 記事 frontmatter の YAML 不正を修正し VitePress ビルドを修復 (#1439)

### DIFF
--- a/docs/articles/dev-building-self-hosted-business-tools-for-japan.md
+++ b/docs/articles/dev-building-self-hosted-business-tools-for-japan.md
@@ -1,7 +1,7 @@
 ---
 title: I am building self-hosted business tools for small teams in Japan
 published: true
-description: A look at the NeNe OSS series: API-first, self-hosted business tools built on NENE2 for teams operating in Japan.
+description: "A look at the NeNe OSS series: API-first, self-hosted business tools built on NENE2 for teams operating in Japan."
 tags: opensource, php, api, ai
 ---
 


### PR DESCRIPTION
## 目的

Issue #1439 — `main` で Docs（VitePress → Pages deploy）ワークフローが失敗している状態を解消する。

## 原因

`docs/articles/dev-building-self-hosted-business-tools-for-japan.md`（#1437 で追加）の frontmatter `description:` が**引用符なし**かつ「`NeNe OSS series: API-first`」と**コロン+空白**を含み、YAML パーサがネストマッピングと誤認して失敗していた。

```
[vitepress] incomplete explicit mapping pair ... line 4, column 43
```

Docs ワークフローは `push: main` 限定で PR では走らないため、#1437 の PR CI（Composer/npm Check）では検知できなかった。

## 変更点

- `description:` の値をダブルクオートで囲む（1行・最小修正）。

## 検証

- `python yaml.safe_load` で3記事すべて正常パースを確認。
- **ローカル `npm run docs:build` が成功**（`build complete in 390.62s`）。
- 兄弟記事（コロンを含まない）は従来どおり通る。

## 後続（この PR には含めない）

- frontmatter の YAML 検証を CI か pre-commit に追加すれば、PR 段階で同種の破損を検知できる（別 Issue 候補）。

Self-review: docs-policy

Closes #1439

🤖 Generated with [Claude Code](https://claude.com/claude-code)