### PR TITLE
fix(auth): RecoveryCodes の既定エントロピーを 80bit へ引き上げ (#1442)

### DIFF
--- a/docs/howto/totp-authentication.md
+++ b/docs/howto/totp-authentication.md
@@ -83,7 +83,7 @@ if ($step === null || $repo->isStepUsed($userId, $step)) {
 }
 
 // リカバリコード: 生成して一度だけ表示、hash のみ保存、redeem 時に verify → consume
-$codes = RecoveryCodes::generate();       // 例: ["3f9ac-1b0e7", ...]
+$codes = RecoveryCodes::generate();       // 例: ["3f9ac-1b0e7-8d2f4-0a6c1", ...]（既定 80bit）
 $repo->storeRecoveryHash($userId, RecoveryCodes::hash($codes[0]));
 ```
 

--- a/src/Auth/RecoveryCodes.php
+++ b/src/Auth/RecoveryCodes.php
@@ -26,7 +26,7 @@ namespace Nene2\Auth;
  *
  * ```php
  * // Enrollment: generate and display once, persist the hashes.
- * $codes = RecoveryCodes::generate();            // e.g. ["3f9ac-1b0e7", ...]
+ * $codes = RecoveryCodes::generate();            // e.g. ["3f9ac-1b0e7-8d2f4-0a6c1", ...]
  * foreach ($codes as $code) {
  *     $repo->storeRecoveryHash($userId, RecoveryCodes::hash($code));
  * }
@@ -43,7 +43,13 @@ namespace Nene2\Auth;
  *
  * Security notes:
  * - `generate()` uses `random_bytes()` — a CSPRNG suitable for security tokens.
- * - `hash()` uses SHA-256; a database breach exposes only hashes.
+ * - `hash()` uses SHA-256 without a salt. This is safe *only* because each code
+ *   carries high entropy (80 bits by default): a database breach exposes hashes
+ *   whose 2^80 preimage space is infeasible to brute-force offline, even
+ *   unsalted and even shared across users. Do not lower `$bytes` below ~10
+ *   (80 bits) — a low-entropy code space (e.g. 40 bits) is GPU-crackable from
+ *   the stolen hashes, which would let one offline pass recover every user's
+ *   codes.
  * - `verify()` uses `hash_equals()` for constant-time comparison.
  * - Codes are single-use secrets — the application must consume a code on
  *   success and rate-limit redemption attempts.
@@ -57,22 +63,24 @@ final class RecoveryCodes
      *
      * Each code is `$bytes` random bytes rendered as hex and grouped into
      * five-character blocks joined by hyphens for readability. The default of
-     * 5 bytes gives 40 bits of entropy per code; increase `$bytes` for a wider
-     * margin when redemption is not strongly rate-limited.
+     * 10 bytes gives 80 bits of entropy per code, which keeps the stored
+     * unsalted SHA-256 hashes infeasible to brute-force offline after a breach.
+     * Do not lower `$bytes` below 10 unless codes are hashed with a slow,
+     * salted KDF instead; raise it for an even wider margin.
      *
      * ```php
-     * $codes = RecoveryCodes::generate();       // 10 codes like "3f9ac-1b0e7"
-     * $codes = RecoveryCodes::generate(8, 8);   // 8 codes, 64-bit each
+     * $codes = RecoveryCodes::generate();       // 10 codes like "3f9ac-1b0e7-8d2f4-0a6c1"
+     * $codes = RecoveryCodes::generate(8, 16);  // 8 codes, 128-bit each
      * ```
      *
      * @param int $count Number of codes to generate. Must be at least 1.
-     * @param int $bytes Random bytes per code. Must be at least 1.
+     * @param int $bytes Random bytes per code. Must be at least 1 (≥10 recommended for 80-bit entropy).
      *
      * @return list<string>
      *
      * @throws \InvalidArgumentException When `$count` or `$bytes` is less than 1.
      */
-    public static function generate(int $count = 10, int $bytes = 5): array
+    public static function generate(int $count = 10, int $bytes = 10): array
     {
         if ($count < 1) {
             throw new \InvalidArgumentException('Recovery code count must be at least 1.');
@@ -105,16 +113,20 @@ final class RecoveryCodes
      * Verifies a submitted recovery code against a stored SHA-256 hash.
      *
      * Normalizes the input, then compares with `hash_equals()` in constant time.
-     * Always returns `false` for empty inputs. A `true` result means the caller
-     * should now **consume** the matching stored hash to enforce single use.
+     * Always returns `false` when the normalized code or the stored hash is
+     * empty (so all-separator input like `"-----"` cannot match). A `true`
+     * result means the caller should now **consume** the matching stored hash
+     * to enforce single use.
      */
     public static function verify(string $code, string $storedHash): bool
     {
-        if ($code === '' || $storedHash === '') {
+        $normalized = self::normalize($code);
+
+        if ($normalized === '' || $storedHash === '') {
             return false;
         }
 
-        return hash_equals($storedHash, self::hash($code));
+        return hash_equals($storedHash, hash('sha256', $normalized));
     }
 
     /**

--- a/tests/Auth/RecoveryCodesTest.php
+++ b/tests/Auth/RecoveryCodesTest.php
@@ -23,8 +23,18 @@ final class RecoveryCodesTest extends TestCase
     public function generateReturnsFormattedCodes(): void
     {
         foreach (RecoveryCodes::generate() as $code) {
-            // default 5 bytes → 10 hex chars grouped as "xxxxx-xxxxx"
-            self::assertMatchesRegularExpression('/^[0-9a-f]{5}-[0-9a-f]{5}$/', $code);
+            // default 10 bytes → 20 hex chars grouped as "xxxxx-xxxxx-xxxxx-xxxxx"
+            self::assertMatchesRegularExpression('/^[0-9a-f]{5}-[0-9a-f]{5}-[0-9a-f]{5}-[0-9a-f]{5}$/', $code);
+        }
+    }
+
+    #[Test]
+    public function generateDefaultHasAtLeast80BitsOfEntropy(): void
+    {
+        // Regression guard (#1442): default must be >= 10 bytes (80 bits) so the
+        // unsalted stored hashes are not offline-brute-forceable after a breach.
+        foreach (RecoveryCodes::generate() as $code) {
+            self::assertGreaterThanOrEqual(20, strlen(str_replace('-', '', $code)));
         }
     }
 
@@ -102,6 +112,13 @@ final class RecoveryCodesTest extends TestCase
     {
         self::assertFalse(RecoveryCodes::verify('', RecoveryCodes::hash('abcde-12345')));
         self::assertFalse(RecoveryCodes::verify('abcde-12345', ''));
+    }
+
+    #[Test]
+    public function verifyRejectsAllSeparatorInputThatNormalizesToEmpty(): void
+    {
+        // "-----" normalizes to "" and must not match a hash of the empty string.
+        self::assertFalse(RecoveryCodes::verify('-----', hash('sha256', '')));
     }
 
     // ------------------------------------------------------------------ normalize


### PR DESCRIPTION
## 目的

セキュリティ監査 #1441 の **M-1（Medium）** を是正する。#1427 で追加した `RecoveryCodes` の自作コードの欠陥。

## 問題

`RecoveryCodes::generate()` の既定 `$bytes = 5`（**40bit**）を無塩 SHA-256 で保存していた。DB を読めた攻撃者は GPU で単一コードを数秒〜数分でオフライン総当たりでき、無塩・全ユーザー共有ハッシュ空間のため **1回の総当たり/レインボーで全ユーザーの未使用リカバリコードを回収**→2FA バイパスが可能だった。docblock の「a database breach exposes only hashes」保証が破綻していた。（`SecureTokenHelper` は 256bit なので無塩でも安全＝対照的）

## 変更点

- `generate()` の既定 `$bytes` を **5 → 10（80bit）**。2^80 のオフライン総当たりは無塩でも非現実的。コード形式は `"xxxxx-xxxxx-xxxxx-xxxxx"`（20 hex）に。
- docblock にオフライン/DB 漏洩の観点と `$bytes` 下限（≥10 推奨）を明記。
- `verify()` の空ガードを raw ではなく**正規化後の値**で判定（`"-----"` 等が空文字ハッシュに一致しないよう厳格化・監査 INFO A#9）。
- 回帰ガードテスト追加: 既定 ≥80bit / all-separator 入力の拒否。
- `totp-authentication.md` の例コメントを新形式へ更新。

## 検証

- `docker compose run --rm app composer check` **全通過**: 522 tests / 1299 assertions・PHPStan level 8 No errors・CS 0・OpenAPI valid・MCP valid。
- `RecoveryCodesTest` 14 tests（新規 2 件含む）。

## 補足

- 破壊的変更ではない（`generate()` のシグネチャ・戻り型は不変、既定値のみ変更）。既存の保存済みハッシュは引き続き検証可能。

Self-review: backend-api

Closes #1442

🤖 Generated with [Claude Code](https://claude.com/claude-code)