### PR TITLE
fix(security): エラーログ衛生と入力長/型の検証を修正 (#1445, #1450)

### DIFF
--- a/src/Error/ErrorHandlerMiddleware.php
+++ b/src/Error/ErrorHandlerMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Nene2\Error;
 
 use Nene2\Http\JsonBodyParseException;
+use Nene2\Middleware\RequestIdMiddleware;
 use Nene2\Routing\MethodNotAllowedException;
 use Nene2\Routing\RouteNotFoundException;
 use Nene2\Validation\ValidationException;
@@ -81,10 +82,27 @@ final readonly class ErrorHandlerMiddleware implements MiddlewareInterface
                 }
             }
 
-            $this->logger->error($exception->getMessage(), [
-                'exception' => $exception,
-                'request_id' => $request->getHeaderLine('X-Request-Id'),
-            ]);
+            $requestId = $request->getAttribute(RequestIdMiddleware::ATTRIBUTE);
+
+            // Never log the raw exception message or the full exception object at
+            // ERROR level: driver exceptions (e.g. PDOException) embed SQL text,
+            // table/column names, and DSN/host fragments, which the logging policy
+            // forbids. The message stays static and only class + location are kept.
+            // Full detail (message + trace) is attached only in debug for local
+            // diagnosis; production should route full context to an error-tracking
+            // adapter, not the default logger. The request id comes from the
+            // sanitized RequestIdMiddleware attribute, never the raw client header.
+            $context = [
+                'exception_class' => $exception::class,
+                'exception_at' => $exception->getFile() . ':' . $exception->getLine(),
+                'request_id' => is_string($requestId) ? $requestId : '',
+            ];
+
+            if ($this->debug) {
+                $context['exception'] = $exception;
+            }
+
+            $this->logger->error('Unhandled exception while processing request.', $context);
 
             return $this->problemDetails->create(
                 $request,

--- a/src/Example/Note/CreateNoteHandler.php
+++ b/src/Example/Note/CreateNoteHandler.php
@@ -13,6 +13,12 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class CreateNoteHandler
 {
+    /** Matches the `notes.title` VARCHAR(255) column (character count). */
+    private const int TITLE_MAX_LENGTH = 255;
+
+    /** Matches the `notes.body` TEXT column (byte length). */
+    private const int BODY_MAX_BYTES = 65535;
+
     public function __construct(
         private CreateNoteUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -25,15 +31,29 @@ final readonly class CreateNoteHandler
 
         $errors = [];
 
-        $title = trim((string) ($body['title'] ?? ''));
-        $noteBody = trim((string) ($body['body'] ?? ''));
+        $titleRaw = $body['title'] ?? '';
+        $bodyRaw = $body['body'] ?? '';
 
-        if ($title === '') {
+        $title = is_string($titleRaw) ? trim($titleRaw) : '';
+        $noteBody = is_string($bodyRaw) ? trim($bodyRaw) : '';
+
+        // Reject non-strings and over-length input with 422 rather than letting
+        // an oversized value reach the database and surface as a 500 (title is a
+        // VARCHAR(255) character column; body is a TEXT byte column).
+        if (!is_string($titleRaw)) {
+            $errors[] = new ValidationError('title', 'Title must be a string.', 'invalid');
+        } elseif ($title === '') {
             $errors[] = new ValidationError('title', 'Title is required.', 'required');
+        } elseif (mb_strlen($title) > self::TITLE_MAX_LENGTH) {
+            $errors[] = new ValidationError('title', 'Title must not exceed 255 characters.', 'max_length');
         }
 
-        if ($noteBody === '') {
+        if (!is_string($bodyRaw)) {
+            $errors[] = new ValidationError('body', 'Body must be a string.', 'invalid');
+        } elseif ($noteBody === '') {
             $errors[] = new ValidationError('body', 'Body is required.', 'required');
+        } elseif (strlen($noteBody) > self::BODY_MAX_BYTES) {
+            $errors[] = new ValidationError('body', 'Body must not exceed 65535 bytes.', 'max_length');
         }
 
         if ($errors !== []) {

--- a/src/Example/Note/UpdateNoteHandler.php
+++ b/src/Example/Note/UpdateNoteHandler.php
@@ -14,6 +14,12 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class UpdateNoteHandler
 {
+    /** Matches the `notes.title` VARCHAR(255) column (character count). */
+    private const int TITLE_MAX_LENGTH = 255;
+
+    /** Matches the `notes.body` TEXT column (byte length). */
+    private const int BODY_MAX_BYTES = 65535;
+
     public function __construct(
         private UpdateNoteUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -33,15 +39,29 @@ final readonly class UpdateNoteHandler
 
         $errors = [];
 
-        $title = trim((string) ($body['title'] ?? ''));
-        $noteBody = trim((string) ($body['body'] ?? ''));
+        $titleRaw = $body['title'] ?? '';
+        $bodyRaw = $body['body'] ?? '';
 
-        if ($title === '') {
+        $title = is_string($titleRaw) ? trim($titleRaw) : '';
+        $noteBody = is_string($bodyRaw) ? trim($bodyRaw) : '';
+
+        // Reject non-strings and over-length input with 422 rather than letting
+        // an oversized value reach the database and surface as a 500 (title is a
+        // VARCHAR(255) character column; body is a TEXT byte column).
+        if (!is_string($titleRaw)) {
+            $errors[] = new ValidationError('title', 'Title must be a string.', 'invalid');
+        } elseif ($title === '') {
             $errors[] = new ValidationError('title', 'Title is required.', 'required');
+        } elseif (mb_strlen($title) > self::TITLE_MAX_LENGTH) {
+            $errors[] = new ValidationError('title', 'Title must not exceed 255 characters.', 'max_length');
         }
 
-        if ($noteBody === '') {
+        if (!is_string($bodyRaw)) {
+            $errors[] = new ValidationError('body', 'Body must be a string.', 'invalid');
+        } elseif ($noteBody === '') {
             $errors[] = new ValidationError('body', 'Body is required.', 'required');
+        } elseif (strlen($noteBody) > self::BODY_MAX_BYTES) {
+            $errors[] = new ValidationError('body', 'Body must not exceed 65535 bytes.', 'max_length');
         }
 
         if ($errors !== []) {

--- a/src/Example/Tag/CreateTagHandler.php
+++ b/src/Example/Tag/CreateTagHandler.php
@@ -13,6 +13,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class CreateTagHandler
 {
+    /** Matches the `tags.name` VARCHAR(255) column (character count). */
+    private const int NAME_MAX_LENGTH = 255;
+
     public function __construct(
         private CreateTagUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -23,10 +26,21 @@ final readonly class CreateTagHandler
     {
         $body = JsonRequestBodyParser::parse($request);
 
-        $name = trim((string) ($body['name'] ?? ''));
+        $nameRaw = $body['name'] ?? '';
+        $name = is_string($nameRaw) ? trim($nameRaw) : '';
+
+        // Reject non-strings and over-length input with 422 rather than letting an
+        // oversized value reach the VARCHAR(255) column and surface as a 500.
+        if (!is_string($nameRaw)) {
+            throw new ValidationException([new ValidationError('name', 'Name must be a string.', 'invalid')]);
+        }
 
         if ($name === '') {
             throw new ValidationException([new ValidationError('name', 'Name is required.', 'required')]);
+        }
+
+        if (mb_strlen($name) > self::NAME_MAX_LENGTH) {
+            throw new ValidationException([new ValidationError('name', 'Name must not exceed 255 characters.', 'max_length')]);
         }
 
         $output = $this->useCase->execute(new CreateTagInput(name: $name));

--- a/src/Example/Tag/UpdateTagHandler.php
+++ b/src/Example/Tag/UpdateTagHandler.php
@@ -14,6 +14,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class UpdateTagHandler
 {
+    /** Matches the `tags.name` VARCHAR(255) column (character count). */
+    private const int NAME_MAX_LENGTH = 255;
+
     public function __construct(
         private UpdateTagUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -31,10 +34,21 @@ final readonly class UpdateTagHandler
 
         $body = JsonRequestBodyParser::parse($request);
 
-        $name = trim((string) ($body['name'] ?? ''));
+        $nameRaw = $body['name'] ?? '';
+        $name = is_string($nameRaw) ? trim($nameRaw) : '';
+
+        // Reject non-strings and over-length input with 422 rather than letting an
+        // oversized value reach the VARCHAR(255) column and surface as a 500.
+        if (!is_string($nameRaw)) {
+            throw new ValidationException([new ValidationError('name', 'Name must be a string.', 'invalid')]);
+        }
 
         if ($name === '') {
             throw new ValidationException([new ValidationError('name', 'Name is required.', 'required')]);
+        }
+
+        if (mb_strlen($name) > self::NAME_MAX_LENGTH) {
+            throw new ValidationException([new ValidationError('name', 'Name must not exceed 255 characters.', 'max_length')]);
         }
 
         $output = $this->useCase->execute(new UpdateTagInput(id: $id, name: $name));

--- a/tests/Error/ErrorHandlerMiddlewareTest.php
+++ b/tests/Error/ErrorHandlerMiddlewareTest.php
@@ -7,6 +7,7 @@ namespace Nene2\Tests\Error;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ErrorHandlerMiddleware;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Middleware\RequestIdMiddleware;
 use Nene2\Routing\MethodNotAllowedException;
 use Nene2\Routing\RouteNotFoundException;
 use Nene2\Validation\ValidationError;
@@ -243,24 +244,31 @@ final class ErrorHandlerMiddlewareTest extends TestCase
         };
 
         $middleware = new ErrorHandlerMiddleware($this->problemDetails, [], debug: false, logger: $spyLogger);
+        // The sanitized request id arrives via the RequestIdMiddleware attribute,
+        // not the raw client header.
         $request = $this->factory->createServerRequest('GET', 'https://example.test/crash')
-            ->withHeader('X-Request-Id', 'req-test-123');
+            ->withAttribute(RequestIdMiddleware::ATTRIBUTE, 'req-test-123');
 
         $middleware->process(
             $request,
             new class () implements RequestHandlerInterface {
                 public function handle(ServerRequestInterface $request): ResponseInterface
                 {
-                    throw new RuntimeException('db connection refused');
+                    throw new RuntimeException("SQLSTATE[HY000] [1045] Access denied for user 'nene2'@'db-host'");
                 }
             },
         );
 
         self::assertCount(1, $spyLogger->records);
         self::assertSame('error', $spyLogger->records[0]['level']);
-        self::assertSame('db connection refused', $spyLogger->records[0]['message']);
+        // Log message is static — the raw (secret-bearing) exception message must not leak.
+        self::assertSame('Unhandled exception while processing request.', $spyLogger->records[0]['message']);
+        self::assertStringNotContainsString('Access denied', $spyLogger->records[0]['message']);
         self::assertSame('req-test-123', $spyLogger->records[0]['context']['request_id']);
-        self::assertInstanceOf(RuntimeException::class, $spyLogger->records[0]['context']['exception']);
+        // In non-debug mode only the class + location are kept; the full exception
+        // object (which serializes the SQL/DSN-bearing message) is not logged.
+        self::assertSame(RuntimeException::class, $spyLogger->records[0]['context']['exception_class']);
+        self::assertArrayNotHasKey('exception', $spyLogger->records[0]['context']);
     }
 
     public function testUnhandledExceptionIsLoggedEvenInDebugMode(): void
@@ -290,6 +298,8 @@ final class ErrorHandlerMiddlewareTest extends TestCase
 
         self::assertCount(1, $spyLogger->records);
         self::assertSame('error', $spyLogger->records[0]['level']);
+        // In debug mode the full exception object is attached for local diagnosis.
+        self::assertInstanceOf(RuntimeException::class, $spyLogger->records[0]['context']['exception']);
     }
 
     public function testDomainHandledExceptionIsNotLogged(): void

--- a/tests/Example/Note/NoteHttpTest.php
+++ b/tests/Example/Note/NoteHttpTest.php
@@ -140,6 +140,52 @@ final class NoteHttpTest extends TestCase
         self::assertContains('body', $fields);
     }
 
+    public function testPostNoteReturns422WhenTitleExceedsMaxLength(): void
+    {
+        // Regression (#1450): an over-length title must be rejected with 422,
+        // not reach the VARCHAR(255) column and surface as a 500.
+        $body = $this->factory->createStream(
+            json_encode(['title' => str_repeat('a', 256), 'body' => 'Content'], JSON_THROW_ON_ERROR),
+        );
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/examples/notes')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        $codes = array_column($payload['errors'], 'code');
+        self::assertContains('max_length', $codes);
+    }
+
+    public function testPostNoteReturns422WhenBodyExceedsMaxBytes(): void
+    {
+        // Regression (#1450): an over-length body must be rejected with 422.
+        $body = $this->factory->createStream(
+            json_encode(['title' => 'ok', 'body' => str_repeat('a', 65_536)], JSON_THROW_ON_ERROR),
+        );
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/examples/notes')->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testPostNoteReturns422WhenTitleIsNotAString(): void
+    {
+        // Regression (#1450): a non-string title must be rejected, not coerced to "Array".
+        $body = $this->factory->createStream(
+            json_encode(['title' => ['x'], 'body' => 'Content'], JSON_THROW_ON_ERROR),
+        );
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/examples/notes')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        $codes = array_column($payload['errors'], 'code');
+        self::assertContains('invalid', $codes);
+    }
+
     public function testDeleteNoteReturns204(): void
     {
         $id = $this->repository->save(new Note(title: 'To delete', body: 'Body'));

--- a/tests/Example/Tag/TagHttpTest.php
+++ b/tests/Example/Tag/TagHttpTest.php
@@ -128,6 +128,27 @@ final class TagHttpTest extends TestCase
         self::assertNotEmpty($payload['errors']);
     }
 
+    public function testCreateTagReturns422WhenNameExceedsMaxLength(): void
+    {
+        // Regression (#1450): an over-length name must be rejected with 422,
+        // not reach the VARCHAR(255) column and surface as a 500.
+        $response = $this->request('POST', '/examples/tags', ['name' => str_repeat('a', 256)]);
+        $payload = $this->decode($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertContains('max_length', array_column($payload['errors'], 'code'));
+    }
+
+    public function testCreateTagReturns422WhenNameIsNotAString(): void
+    {
+        // Regression (#1450): a non-string name must be rejected, not coerced to "Array".
+        $response = $this->request('POST', '/examples/tags', ['name' => ['x']]);
+        $payload = $this->decode($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertContains('invalid', array_column($payload['errors'], 'code'));
+    }
+
     public function testUpdateTagReturns200(): void
     {
         $id = $this->repository->save(new Tag(name: 'php'));


### PR DESCRIPTION
## 目的

セキュリティ監査 #1441 とその実機 ATK で確定した Low 2 点を是正。両者は「長い入力 → DB で `1406 Data too long` → 500 → 例外全体をサーバログへ漏洩」という**同一連鎖**なので、施主の指示によりセットで対応し連鎖を断つ。

## #1445 — ErrorHandlerMiddleware のログ衛生

- **L-1**: ログの `request_id` を、生の `X-Request-Id` ヘッダではなく **sanitize 済みの `RequestIdMiddleware::ATTRIBUTE`** から取得（`RequestLoggingMiddleware` と同じ規約）。相関 ID の空文字/不整合を解消。
- **L-2**: 未処理例外を `$exception->getMessage()` や例外オブジェクトごとログするのをやめ、**静的メッセージ ＋ `exception_class` ＋ `file:line`** のみに。`PDOException` 等が埋め込む **SQL 文・テーブル/列名・DSN/host** がログに残らない（ロギング方針準拠）。full detail（message＋trace）は **debug 時のみ**添付。

## #1450 — example Note/Tag の入力検証（Create/Update 4 ハンドラ）

- **最大長検証**を追加し、超過は **500 ではなく 422 validation-failed** に:
  - `title`/`name` … VARCHAR(255) に整合し **`mb_strlen` ≤ 255**（文字数。日本語で過度に厳しくならない）
  - `body` … TEXT に整合し **`strlen` ≤ 65535**（byte）
- **非 string の型を拒否**: `(string)` 強制で `array→"Array"` 保存になっていた型ジャグリングを、`'invalid'` コードの 422 で拒否（監査 B の INFO）。

## 検証

- `docker compose run --rm app composer check` **全通過**: 527 tests / 1313 assertions・PHPStan level 8 No errors・CS 0・OpenAPI valid・MCP valid。
- 追加テスト: `ErrorHandlerMiddlewareTest`（静的ログメッセージ・raw メッセージ非漏洩・非 debug で例外オブジェクト無し・debug で添付）、`NoteHttpTest`/`TagHttpTest`（over-length→422 `max_length`／非 string→422 `invalid`／過大 body→422）。ATK で 500 を誘発したシナリオがそのまま 422 になることを再現。

## スコープ / 補足

- `#1450` は example アプリ層（ADR 0009 stability 保証外）だが、ユーザーが写経する検証パターンなので修正価値あり。
- 監査の残 EXPOSED（#1443 HEAD / #1444 サイズ / #1446 MCP / #1447 HSTS）は本 PR 対象外（別 Issue で継続）。

Self-review: middleware-security, backend-api

Closes #1445
Closes #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)