### PR TITLE
fix(http): HEAD を GET と同一に認証・本文抑制し protectedMethods 回避を封鎖 (#1443)

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -27,4 +27,4 @@ $response = $application->handle($request);
 
 $emitter = $container->get(ResponseEmitter::class);
 assert($emitter instanceof ResponseEmitter);
-$emitter->emit($response);
+$emitter->emit($response, $request->getMethod());

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -14,7 +14,14 @@ use Psr\Http\Message\ResponseInterface;
  */
 final class ResponseEmitter
 {
-    public function emit(ResponseInterface $response): void
+    /**
+     * @param string|null $requestMethod The request's HTTP method. When it is `HEAD`,
+     *                                    the message body is suppressed per RFC 7231 §4.3.2
+     *                                    while the headers (including Content-Length) are
+     *                                    still emitted. Pass `$request->getMethod()` from the
+     *                                    front controller; omit for non-HEAD-aware callers.
+     */
+    public function emit(ResponseInterface $response, ?string $requestMethod = null): void
     {
         if (!headers_sent()) {
             http_response_code($response->getStatusCode());
@@ -24,6 +31,13 @@ final class ResponseEmitter
                     header(sprintf('%s: %s', $name, $value), false);
                 }
             }
+        }
+
+        // RFC 7231 §4.3.2: a response to a HEAD request carries the same headers as the
+        // equivalent GET but must not include a message body. The router serves HEAD via
+        // the GET handler, so the body is present here and must be dropped on emit.
+        if ($requestMethod !== null && strtoupper($requestMethod) === 'HEAD') {
+            return;
         }
 
         echo (string) $response->getBody();

--- a/src/Middleware/ApiKeyAuthenticationMiddleware.php
+++ b/src/Middleware/ApiKeyAuthenticationMiddleware.php
@@ -27,8 +27,10 @@ use Psr\Http\Server\RequestHandlerInterface;
  * In all modes, `OPTIONS` requests are always skipped (CORS preflight).
  *
  * Method filtering (`$protectedMethods`): when non-empty, only requests whose HTTP method appears
- * in the list are protected. Use this to allow safe methods (GET, HEAD) while requiring an API
- * key only for state-changing operations (POST, PUT, PATCH, DELETE).
+ * in the list are protected. Use this to require an API key only for state-changing operations
+ * (POST, PUT, PATCH, DELETE) while leaving reads open. `HEAD` is normalized to `GET` before the
+ * check — because the router serves HEAD via the GET handler, listing `GET` also protects `HEAD`
+ * (and listing only `HEAD` has no effect). OPTIONS is always excluded.
  *
  * Part of the public API stability guarantee (see ADR 0009).
  */
@@ -40,8 +42,9 @@ final readonly class ApiKeyAuthenticationMiddleware implements MiddlewareInterfa
      * @param list<string> $protectedPathPrefixes  Path prefixes to protect (e.g. `/admin/` matches `/admin/users/42`).
      *                                             Combined with $protectedPaths in union mode.
      * @param list<string> $protectedMethods       HTTP methods to protect (uppercase). When non-empty, only requests
-     *                                             whose method appears here are protected. Useful to allow GET while
-     *                                             requiring an API key for POST/PUT/DELETE. OPTIONS is always excluded.
+     *                                             whose method appears here are protected. Useful to require an API key
+     *                                             for POST/PUT/DELETE while leaving reads open. HEAD is normalized to GET
+     *                                             (listing GET also protects HEAD); OPTIONS is always excluded.
      * @param list<string> $excludedPaths          Exact paths that are always public, checked before any protect mode.
      *                                             Combine with the "protect all" default to make specific paths public:
      *                                             `excludedPaths: ['/', '/health', '/examples/ping']`.
@@ -84,7 +87,13 @@ final readonly class ApiKeyAuthenticationMiddleware implements MiddlewareInterfa
             return false;
         }
 
-        if ($this->protectedMethods !== [] && !in_array($method, $this->protectedMethods, true)) {
+        // The router serves HEAD through the GET handler (RFC 7231 §4.3.2), so HEAD
+        // must be gated exactly like GET. Normalizing here closes the bypass where a
+        // `protectedMethods: ['GET']` config would otherwise let an unauthenticated
+        // HEAD reach — and return the body of — the protected GET handler.
+        $effectiveMethod = $method === 'HEAD' ? 'GET' : $method;
+
+        if ($this->protectedMethods !== [] && !in_array($effectiveMethod, $this->protectedMethods, true)) {
             return false;
         }
 

--- a/tests/Http/ResponseEmitterTest.php
+++ b/tests/Http/ResponseEmitterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Http;
+
+use Nene2\Http\ResponseEmitter;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the body-emission contract. Header emission relies on `header()` /
+ * `http_response_code()`, which are no-ops under the CLI SAPI, so these tests
+ * assert only on the emitted body captured from the output buffer.
+ */
+final class ResponseEmitterTest extends TestCase
+{
+    #[Test]
+    public function emitsBodyForGetRequests(): void
+    {
+        $response = (new Psr17Factory())->createResponse(200)
+            ->withBody((new Psr17Factory())->createStream('{"ok":true}'));
+
+        ob_start();
+        (new ResponseEmitter())->emit($response, 'GET');
+        $output = (string) ob_get_clean();
+
+        self::assertSame('{"ok":true}', $output);
+    }
+
+    #[Test]
+    public function suppressesBodyForHeadRequests(): void
+    {
+        // RFC 7231 §4.3.2: a HEAD response must not include a message body, even
+        // though the router produced one via the GET handler (#1443).
+        $response = (new Psr17Factory())->createResponse(200)
+            ->withBody((new Psr17Factory())->createStream('{"secret":"data"}'));
+
+        ob_start();
+        (new ResponseEmitter())->emit($response, 'HEAD');
+        $output = (string) ob_get_clean();
+
+        self::assertSame('', $output);
+    }
+
+    #[Test]
+    public function headMatchIsCaseInsensitive(): void
+    {
+        $response = (new Psr17Factory())->createResponse(200)
+            ->withBody((new Psr17Factory())->createStream('body'));
+
+        ob_start();
+        (new ResponseEmitter())->emit($response, 'head');
+        $output = (string) ob_get_clean();
+
+        self::assertSame('', $output);
+    }
+
+    #[Test]
+    public function emitsBodyWhenMethodIsOmitted(): void
+    {
+        // Backward-compatible default: callers that do not pass a method still get the body.
+        $response = (new Psr17Factory())->createResponse(200)
+            ->withBody((new Psr17Factory())->createStream('legacy'));
+
+        ob_start();
+        (new ResponseEmitter())->emit($response);
+        $output = (string) ob_get_clean();
+
+        self::assertSame('legacy', $output);
+    }
+}

--- a/tests/Middleware/ApiKeyAuthenticationMiddlewareTest.php
+++ b/tests/Middleware/ApiKeyAuthenticationMiddlewareTest.php
@@ -154,6 +154,31 @@ final class ApiKeyAuthenticationMiddlewareTest extends TestCase
         self::assertSame(401, $mw->process($request, $this->okHandler($factory))->getStatusCode());
     }
 
+    public function testMethodFilterProtectsHeadWhenGetIsProtected(): void
+    {
+        // #1443: the router serves HEAD via the GET handler, so gating GET must also
+        // gate HEAD — otherwise HEAD reaches (and returns the body of) the protected
+        // GET handler unauthenticated.
+        $factory = new Psr17Factory();
+        $mw = $this->make($factory, protectedMethods: ['GET']);
+
+        $getRequest = $factory->createServerRequest('GET', 'https://example.test/tags');
+        self::assertSame(401, $mw->process($getRequest, $this->okHandler($factory))->getStatusCode());
+
+        $headRequest = $factory->createServerRequest('HEAD', 'https://example.test/tags');
+        self::assertSame(401, $mw->process($headRequest, $this->okHandler($factory))->getStatusCode());
+    }
+
+    public function testMethodFilterLeavesHeadOpenWhenGetIsNotProtected(): void
+    {
+        // Symmetry: when reads are open (only writes protected), HEAD passes like GET.
+        $factory = new Psr17Factory();
+        $mw = $this->make($factory, protectedMethods: ['POST', 'PUT', 'DELETE']);
+        $request = $factory->createServerRequest('HEAD', 'https://example.test/tags');
+
+        self::assertSame(200, $mw->process($request, $this->okHandler($factory))->getStatusCode());
+    }
+
     public function testMethodFilterCombinedWithPrefix(): void
     {
         $factory = new Psr17Factory();


### PR DESCRIPTION
## 目的

セキュリティ監査 #1441 の **M-2（Medium）** を是正。

## 問題

Router は `HEAD` を GET ハンドラで処理する（RFC 7231 §4.3.2）が、`ApiKeyAuthenticationMiddleware` は `HEAD` を独立メソッドとして扱っていた。このため運用者が `protectedMethods: ['GET']` で読み取りを保護しても、`HEAD /path` は method フィルタで「非対象」と判定されて**認証をスキップ**し、Router が GET ハンドラを実行して**本文まで返して**いた。

## 変更点

- **`ApiKeyAuthenticationMiddleware::requiresAuthentication()`**: method フィルタ判定の前に `HEAD → GET` を正規化。`GET` を保護すれば `HEAD` も保護される（`HEAD` 単独指定は無効）。→ 認証バイパスを封鎖。
- **`ResponseEmitter::emit()`**: 後方互換な任意引数 `?string $requestMethod` を追加し、`HEAD` のときは**本文を出力しない**（RFC 7231 §4.3.2。ヘッダ＝Content-Length 等は従来どおり emit）。front controller が `$request->getMethod()` を渡す。既存の `emit($response)` 呼び出しは不変。
- 併せて `protectedMethods` の PHPDoc に「HEAD は GET に正規化」を明記。

## 検証

- `composer check` **全通過**: 533 tests / 1320 assertions・PHPStan level 8・CS・OpenAPI・MCP。
- 追加テスト:
  - `ApiKeyAuthenticationMiddlewareTest`: `protectedMethods:['GET']` で GET も HEAD も 401／読み取り開放時は HEAD 通過。
  - `ResponseEmitterTest`（新規）: HEAD→本文なし・GET→本文・大小無視・method 省略時は本文（後方互換）。

## 補足

- `BearerTokenMiddleware` は method フィルタを持たない（パス allowlist のみ）ため非該当。
- 既定構成（`protectedMethods=[]`＝全メソッド保護）は元々影響なし。本 PR は method-filter オプトイン時の footgun を塞ぐ。

Self-review: middleware-security

Closes #1443

🤖 Generated with [Claude Code](https://claude.com/claude-code)