### PR TITLE
fix(http): サイズ不明/chunked ボディも計測して上限適用 (#1444)

### DIFF
--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -297,7 +297,7 @@ final readonly class RuntimeApplicationFactory
             new SecurityHeadersMiddleware(),
             new CorsMiddleware($this->responseFactory, $this->allowedOrigins),
             new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers, $this->debug, $logger),
-            new RequestSizeLimitMiddleware($problemDetails, $this->requestMaxBodyBytes),
+            new RequestSizeLimitMiddleware($problemDetails, $this->requestMaxBodyBytes, $this->streamFactory),
             new ApiKeyAuthenticationMiddleware(
                 $problemDetails,
                 $this->machineApiKey,

--- a/src/Middleware/RequestSizeLimitMiddleware.php
+++ b/src/Middleware/RequestSizeLimitMiddleware.php
@@ -7,6 +7,8 @@ namespace Nene2\Middleware;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
@@ -17,9 +19,17 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class RequestSizeLimitMiddleware implements MiddlewareInterface
 {
+    /**
+     * @param StreamFactoryInterface|null $streamFactory Used to re-expose an unknown-size body to
+     *                                                    downstream handlers after it is measured.
+     *                                                    Provide it (the framework wiring does) so that
+     *                                                    chunked / streamed bodies stay readable; without
+     *                                                    it the body is only rewound when seekable.
+     */
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
         private int $maxBodyBytes = 1_048_576,
+        private ?StreamFactoryInterface $streamFactory = null,
     ) {
     }
 
@@ -27,19 +37,82 @@ final readonly class RequestSizeLimitMiddleware implements MiddlewareInterface
     {
         $contentLength = $request->getHeaderLine('Content-Length');
 
-        if ($contentLength !== '' && $this->isOversized($contentLength)) {
+        if ($contentLength !== '') {
+            if ($this->isOversized($contentLength)) {
+                return $this->tooLarge($request);
+            }
+
+            return $handler->handle($request);
+        }
+
+        // No Content-Length header. Trust the stream size when it is known; otherwise
+        // (chunked or otherwise unknown-size streamed body) measure the body while
+        // reading, so it cannot bypass the limit unmeasured. A spoofed/absent length
+        // no longer skips enforcement.
+        $body = $request->getBody();
+        $size = $body->getSize();
+
+        if ($size !== null) {
+            if ($size > $this->maxBodyBytes) {
+                return $this->tooLarge($request);
+            }
+
+            return $handler->handle($request);
+        }
+
+        $buffered = $this->readCapped($body);
+
+        if (strlen($buffered) > $this->maxBodyBytes) {
             return $this->tooLarge($request);
         }
 
-        if ($contentLength === '') {
-            $bodySize = $request->getBody()->getSize();
+        return $handler->handle($this->rewindOrReplaceBody($request, $body, $buffered));
+    }
 
-            if ($bodySize !== null && $bodySize > $this->maxBodyBytes) {
-                return $this->tooLarge($request);
-            }
+    /**
+     * Reads at most `maxBodyBytes + 1` bytes so an overflow is detectable without
+     * buffering an unbounded body into memory.
+     */
+    private function readCapped(StreamInterface $body): string
+    {
+        if ($body->isSeekable()) {
+            $body->rewind();
         }
 
-        return $handler->handle($request);
+        $limit = $this->maxBodyBytes + 1;
+        $buffered = '';
+
+        while (strlen($buffered) < $limit && !$body->eof()) {
+            $chunk = $body->read($limit - strlen($buffered));
+
+            if ($chunk === '') {
+                break;
+            }
+
+            $buffered .= $chunk;
+        }
+
+        return $buffered;
+    }
+
+    /**
+     * Re-exposes an already-read body to downstream handlers: replace it with a fresh
+     * stream when a factory is available, otherwise rewind it in place when seekable.
+     */
+    private function rewindOrReplaceBody(
+        ServerRequestInterface $request,
+        StreamInterface $body,
+        string $buffered,
+    ): ServerRequestInterface {
+        if ($this->streamFactory !== null) {
+            return $request->withBody($this->streamFactory->createStream($buffered));
+        }
+
+        if ($body->isSeekable()) {
+            $body->rewind();
+        }
+
+        return $request;
     }
 
     private function tooLarge(ServerRequestInterface $request): ResponseInterface

--- a/tests/Middleware/RequestSizeLimitMiddlewareTest.php
+++ b/tests/Middleware/RequestSizeLimitMiddlewareTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Middleware;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Middleware\RequestSizeLimitMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Focuses on the unknown-size body path (#1444): a body whose stream reports
+ * `getSize() === null` (chunked / streamed) must still be measured and bounded,
+ * not passed through unchecked.
+ */
+final class RequestSizeLimitMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function rejectsUnknownSizeBodyExceedingLimit(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestSizeLimitMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            10,
+            $factory,
+        );
+
+        // 20-byte body, no Content-Length, stream size unknown (like chunked / php://input).
+        $request = $factory->createServerRequest('POST', 'https://example.test/upload')
+            ->withBody($this->unknownSizeStream(str_repeat('a', 20), seekable: false));
+
+        $response = $middleware->process($request, $this->recordingHandler($factory));
+
+        self::assertSame(413, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function allowsUnknownSizeBodyWithinLimitAndKeepsItReadable(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestSizeLimitMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            100,
+            $factory,
+        );
+
+        $handler = $this->recordingHandler($factory);
+        $request = $factory->createServerRequest('POST', 'https://example.test/upload')
+            ->withBody($this->unknownSizeStream('{"ok":true}', seekable: false));
+
+        $response = $middleware->process($request, $handler);
+
+        self::assertSame(200, $response->getStatusCode());
+        // Downstream must still see the full body after it was measured.
+        self::assertSame('{"ok":true}', $handler->seenBody);
+    }
+
+    #[Test]
+    public function rewindsSeekableUnknownSizeBodyWhenNoFactoryProvided(): void
+    {
+        $factory = new Psr17Factory();
+        // No stream factory — falls back to rewinding a seekable body in place.
+        $middleware = new RequestSizeLimitMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            100,
+        );
+
+        $handler = $this->recordingHandler($factory);
+        $request = $factory->createServerRequest('POST', 'https://example.test/upload')
+            ->withBody($this->unknownSizeStream('payload', seekable: true));
+
+        $response = $middleware->process($request, $handler);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('payload', $handler->seenBody);
+    }
+
+    #[Test]
+    public function exactLimitUnknownSizeBodyIsAllowed(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new RequestSizeLimitMiddleware(
+            new ProblemDetailsResponseFactory($factory, $factory),
+            10,
+            $factory,
+        );
+
+        $request = $factory->createServerRequest('POST', 'https://example.test/upload')
+            ->withBody($this->unknownSizeStream(str_repeat('a', 10), seekable: false));
+
+        $response = $middleware->process($request, $this->recordingHandler($factory));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * @return RequestHandlerInterface&object{seenBody: string}
+     */
+    private function recordingHandler(Psr17Factory $factory): RequestHandlerInterface
+    {
+        return new class ($factory) implements RequestHandlerInterface {
+            public string $seenBody = '';
+
+            public function __construct(private readonly Psr17Factory $factory)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->seenBody = (string) $request->getBody();
+
+                return $this->factory->createResponse(200);
+            }
+        };
+    }
+
+    /**
+     * A read-only stream over an in-memory string that reports an unknown size
+     * (`getSize() === null`), modelling a chunked / streamed request body.
+     */
+    private function unknownSizeStream(string $content, bool $seekable): StreamInterface
+    {
+        return new class ($content, $seekable) implements StreamInterface {
+            private int $offset = 0;
+
+            public function __construct(private string $content, private readonly bool $seekable)
+            {
+            }
+
+            public function __toString(): string
+            {
+                if ($this->seekable) {
+                    $this->offset = 0;
+                }
+
+                return substr($this->content, $this->offset);
+            }
+
+            public function close(): void
+            {
+            }
+
+            public function detach()
+            {
+                return null;
+            }
+
+            public function getSize(): ?int
+            {
+                return null;
+            }
+
+            public function tell(): int
+            {
+                return $this->offset;
+            }
+
+            public function eof(): bool
+            {
+                return $this->offset >= strlen($this->content);
+            }
+
+            public function isSeekable(): bool
+            {
+                return $this->seekable;
+            }
+
+            public function seek(int $offset, int $whence = SEEK_SET): void
+            {
+                if (!$this->seekable) {
+                    throw new \RuntimeException('Stream is not seekable.');
+                }
+
+                $this->offset = $offset;
+            }
+
+            public function rewind(): void
+            {
+                $this->seek(0);
+            }
+
+            public function isWritable(): bool
+            {
+                return false;
+            }
+
+            public function write(string $string): int
+            {
+                throw new \RuntimeException('Stream is not writable.');
+            }
+
+            public function isReadable(): bool
+            {
+                return true;
+            }
+
+            public function read(int $length): string
+            {
+                $chunk = substr($this->content, $this->offset, $length);
+                $this->offset += strlen($chunk);
+
+                return $chunk;
+            }
+
+            public function getContents(): string
+            {
+                $chunk = substr($this->content, $this->offset);
+                $this->offset = strlen($this->content);
+
+                return $chunk;
+            }
+
+            public function getMetadata(?string $key = null): mixed
+            {
+                return $key === null ? [] : null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 目的

セキュリティ監査 #1441 の **M-3（Medium）** を是正。

## 問題

`RequestSizeLimitMiddleware` は `Content-Length` 欠如時に `getBody()->getSize()` へフォールバックしていたが、chunked / `php://input` などの**サイズ不明ストリームは `null`** を返す。ガードが `if ($bodySize !== null && ...)` のため素通りし、**上限未適用**で任意サイズのボディが下流に到達していた（413 DoS 保護のバイパス）。実機 Apache では `post_max_size` 等がバックストップするが、SAPI/プロキシに依存しない防御が必要。

## 変更点

- `Content-Length` があればそれで判定（従来どおり）。無い場合:
  - stream size が既知ならそれで判定、
  - **不明（null）なら本文を `maxBodyBytes + 1` バイトまで読みながら計測**して超過を検出（413）。spoof / 欠如した長さでも計測を回避できない。メモリは `maxBodyBytes + 1` に有界。
- 計測後、後続ハンドラが本文を読めるよう**再供給**: `StreamFactory` があれば読み込んだ内容で本文を差し替え、無ければ seekable なとき `rewind`。`StreamFactory` は**後方互換の任意引数**（framework 配線が `Psr17Factory` を渡す。既存の直接生成は不変）。

## 検証

- `composer check` **全通過**: 537 tests / 1326 assertions・PHPStan level 8・CS・OpenAPI・MCP。
- 追加テスト `RequestSizeLimitMiddlewareTest`（新規・unknown-size ストリームのスタブ使用）:
  - unknown-size 超過 → **413**
  - unknown-size 範囲内 → 200 かつ**下流が本文を全量読める**（差し替え検証）
  - factory 無し・seekable → rewind で下流が読める
  - 境界ちょうど（= 上限）→ 200

Self-review: middleware-security

Closes #1444

🤖 Generated with [Claude Code](https://claude.com/claude-code)