### PR TITLE
feat(http): HSTS を opt-in で追加し Referrer-Policy 既定を強化 (#1447)

### DIFF
--- a/src/Http/RuntimeApplicationFactory.php
+++ b/src/Http/RuntimeApplicationFactory.php
@@ -107,6 +107,9 @@ final readonly class RuntimeApplicationFactory
      *                                id the caller references. The endpoint resolves a profile from this
      *                                map; connection details and credentials are never read from the
      *                                request body. Only consulted when $databaseCandidateInspector is set.
+     * @param bool $enableHsts Emit `Strict-Transport-Security` from the security-headers middleware.
+     *                         Off by default; enable only when the app is served over HTTPS (directly or
+     *                         behind a TLS-terminating proxy). See {@see SecurityHeadersMiddleware}.
      */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
@@ -130,6 +133,7 @@ final readonly class RuntimeApplicationFactory
         private ?string $appVersion = null,
         private ?DatabaseCandidateInspector $databaseCandidateInspector = null,
         private array $databaseCandidateProfiles = [],
+        private bool $enableHsts = false,
     ) {
     }
 
@@ -294,7 +298,7 @@ final readonly class RuntimeApplicationFactory
         $middlewareStack = [
             new RequestIdMiddleware('X-Request-Id', $this->requestIdHolder),
             new RequestLoggingMiddleware($logger),
-            new SecurityHeadersMiddleware(),
+            new SecurityHeadersMiddleware(enableHsts: $this->enableHsts),
             new CorsMiddleware($this->responseFactory, $this->allowedOrigins),
             new ErrorHandlerMiddleware($problemDetails, $this->domainExceptionHandlers, $this->debug, $logger),
             new RequestSizeLimitMiddleware($problemDetails, $this->requestMaxBodyBytes, $this->streamFactory),

--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -13,6 +13,11 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Adds security-related HTTP response headers (e.g. `Content-Security-Policy`, `X-Frame-Options`).
  * Headers are injected before the pipeline processes the request so they appear on error responses too.
  *
+ * `Strict-Transport-Security` (HSTS) is **opt-in** (`$enableHsts`): it must only be sent on
+ * deployments where TLS is terminated at or in front of this application, so it is off by default
+ * to avoid pinning HTTPS on plain-HTTP local/dev setups. Browsers ignore an HSTS header received
+ * over plain HTTP (RFC 6797 §7.2), so enabling it is safe once the app is served over HTTPS.
+ *
  * Part of the public API stability guarantee (see ADR 0009).
  */
 final readonly class SecurityHeadersMiddleware implements MiddlewareInterface
@@ -21,15 +26,25 @@ final readonly class SecurityHeadersMiddleware implements MiddlewareInterface
      * @param array<string, string> $headers Override or extend the default security headers.
      *                                        CSP is set to `default-src 'self'` by default; tighten
      *                                        this for apps that load scripts/styles from external origins.
+     *                                        `Referrer-Policy` defaults to `strict-origin-when-cross-origin`
+     *                                        so full URLs (with path/query) are not sent as `Referer`
+     *                                        on cross-origin navigations.
+     * @param bool   $enableHsts Emit `Strict-Transport-Security`. Enable only when the app is served
+     *                           over HTTPS (directly or behind a TLS-terminating proxy).
+     * @param string $hstsValue  The HSTS header value used when `$enableHsts` is true. Defaults to one
+     *                           year with `includeSubDomains`. Add `; preload` only after submitting to
+     *                           the preload list.
      */
     public function __construct(
         private array $headers = [
             'Content-Security-Policy' => "default-src 'self'",
             'X-Content-Type-Options' => 'nosniff',
-            'Referrer-Policy' => 'no-referrer-when-downgrade',
+            'Referrer-Policy' => 'strict-origin-when-cross-origin',
             'X-Frame-Options' => 'SAMEORIGIN',
             'Permissions-Policy' => 'camera=(), geolocation=(), microphone=()',
         ],
+        private bool $enableHsts = false,
+        private string $hstsValue = 'max-age=31536000; includeSubDomains',
     ) {
     }
 
@@ -37,7 +52,13 @@ final readonly class SecurityHeadersMiddleware implements MiddlewareInterface
     {
         $response = $handler->handle($request);
 
-        foreach ($this->headers as $name => $value) {
+        $headers = $this->headers;
+
+        if ($this->enableHsts) {
+            $headers['Strict-Transport-Security'] ??= $this->hstsValue;
+        }
+
+        foreach ($headers as $name => $value) {
             if (!$response->hasHeader($name)) {
                 $response = $response->withHeader($name, $value);
             }

--- a/tests/Middleware/BaselineMiddlewareTest.php
+++ b/tests/Middleware/BaselineMiddlewareTest.php
@@ -71,6 +71,57 @@ final class BaselineMiddlewareTest extends TestCase
 
         self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
         self::assertSame('DENY', $response->getHeaderLine('X-Frame-Options'));
+        // Referrer-Policy defaults to the stronger strict-origin-when-cross-origin (#1447).
+        self::assertSame('strict-origin-when-cross-origin', $response->getHeaderLine('Referrer-Policy'));
+        // HSTS is opt-in — absent by default.
+        self::assertFalse($response->hasHeader('Strict-Transport-Security'));
+    }
+
+    public function testHstsIsEmittedWhenEnabled(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new SecurityHeadersMiddleware(enableHsts: true);
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://example.test/'),
+            new class ($factory) implements RequestHandlerInterface {
+                public function __construct(private readonly Psr17Factory $factory)
+                {
+                }
+
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->factory->createResponse(200);
+                }
+            },
+        );
+
+        self::assertSame('max-age=31536000; includeSubDomains', $response->getHeaderLine('Strict-Transport-Security'));
+    }
+
+    public function testHstsValueIsConfigurable(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new SecurityHeadersMiddleware(
+            enableHsts: true,
+            hstsValue: 'max-age=63072000; includeSubDomains; preload',
+        );
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://example.test/'),
+            new class ($factory) implements RequestHandlerInterface {
+                public function __construct(private readonly Psr17Factory $factory)
+                {
+                }
+
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->factory->createResponse(200);
+                }
+            },
+        );
+
+        self::assertSame('max-age=63072000; includeSubDomains; preload', $response->getHeaderLine('Strict-Transport-Security'));
     }
 
     public function testCorsAddsHeadersForAllowedOrigin(): void


### PR DESCRIPTION
## 目的

セキュリティ監査 #1441 の **L-4（Low）** を是正。

## 変更点

- **HSTS opt-in**: `SecurityHeadersMiddleware` に `Strict-Transport-Security` を追加。`$enableHsts`（既定 `false`）で有効化、`$hstsValue`（既定 `max-age=31536000; includeSubDomains`）で値を設定。
  - 既定 off の理由: HTTP のローカル/開発を HTTPS にピン留めしないため。ブラウザは HTTP 上の HSTS を無視する（RFC 6797 §7.2）ので、HTTPS 配信（自身 or TLS 終端プロキシ後段）で有効化するのが安全。
- **Referrer-Policy 強化**: 既定を `no-referrer-when-downgrade` → **`strict-origin-when-cross-origin`**（パス/クエリを含む full URL を cross-origin 遷移で `Referer` に送らない）。
- `RuntimeApplicationFactory` に `$enableHsts` を追加し middleware へ配線（**コンストラクタ末尾に追加で後方互換**）。

## 検証

- `composer check` **全通過**: 539 tests / 1330 assertions・PHPStan level 8・CS・OpenAPI・MCP。
- 追加テスト: 既定で HSTS 無し＋Referrer-Policy 新既定／`enableHsts:true` で HSTS 出力／`hstsValue` 設定可。

Self-review: middleware-security

Closes #1447

🤖 Generated with [Claude Code](https://claude.com/claude-code)