### PR TITLE
feat(mcp): 状態変更ツールの監査ログと destructive 確認ゲートを追加 (#1446)

### DIFF
--- a/src/Mcp/LocalMcpServer.php
+++ b/src/Mcp/LocalMcpServer.php
@@ -5,12 +5,21 @@ declare(strict_types=1);
 namespace Nene2\Mcp;
 
 use Nene2\FrameworkInfo;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * JSON-RPC 2.0 / MCP server that exposes framework API operations as tools.
  *
  * Run via `tools/local-mcp-server.php`. Reads its tool catalog from
  * `docs/mcp/tools.json` and proxies tool calls through {@see LocalMcpHttpClientInterface}.
+ *
+ * Non-`read` (state-changing) tools go through additional guards, aligned with the MCP
+ * write-tool policy: bearer authentication is required, `destructive` tools require an
+ * explicit confirmation flag, and every state-changing call is audited via `$logger`
+ * (tool, safety level, operation, and the downstream API request id — never the
+ * arguments or any secret). Authorization of the underlying operation is enforced at
+ * the HTTP/JWT boundary the call is proxied through.
  *
  * Part of the public API stability guarantee (see ADR 0009).
  *
@@ -22,6 +31,7 @@ final readonly class LocalMcpServer
         private LocalMcpToolCatalog $catalog,
         private LocalMcpHttpClientInterface $httpClient,
         private string $apiBaseUrl,
+        private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
@@ -134,7 +144,9 @@ final readonly class LocalMcpServer
             throw new LocalMcpException(sprintf('MCP tool "%s" was not found.', $name));
         }
 
-        if ($tool['safety'] !== 'read' && !$this->httpClient->hasAuthentication()) {
+        $safety = $tool['safety'];
+
+        if ($safety !== 'read' && !$this->httpClient->hasAuthentication()) {
             throw new LocalMcpException(
                 sprintf(
                     'Write tool "%s" requires bearer authentication. Set NENE2_LOCAL_JWT_SECRET in the MCP server environment.',
@@ -143,11 +155,52 @@ final readonly class LocalMcpServer
             );
         }
 
+        // Destructive tools require an explicit confirmation so an agent cannot delete or
+        // purge data by inference. The flag is consumed here and never forwarded to the API.
+        if ($safety === 'destructive') {
+            if (($arguments['confirm'] ?? null) !== true) {
+                throw new LocalMcpException(
+                    sprintf('Destructive tool "%s" requires an explicit "confirm": true argument.', $name),
+                );
+            }
+
+            unset($arguments['confirm']);
+        }
+
         if ($tool['source']['type'] !== 'openapi') {
             throw new LocalMcpException(sprintf('MCP tool "%s" does not map to a local OpenAPI operation.', $name));
         }
 
-        return $this->httpToolResult($tool, $arguments);
+        $result = $this->httpToolResult($tool, $arguments);
+
+        if ($safety !== 'read') {
+            $this->auditSensitiveCall($tool, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Emits a structured audit record for a state-changing tool call. Records the tool,
+     * safety level, operation, and the downstream API request id for correlation — never
+     * the request arguments or any secret, per the logging policy.
+     *
+     * @param McpTool $tool
+     * @param array<string, mixed> $result
+     */
+    private function auditSensitiveCall(array $tool, array $result): void
+    {
+        $structured = $result['structuredContent'] ?? null;
+
+        $this->logger->info('MCP state-changing tool invoked.', [
+            'tool' => $tool['name'],
+            'safety' => $tool['safety'],
+            'operation_id' => $tool['source']['operationId'],
+            'method' => $tool['source']['method'],
+            'status_code' => is_array($structured) ? ($structured['statusCode'] ?? null) : null,
+            'request_id' => is_array($structured) ? ($structured['requestId'] ?? null) : null,
+            'is_error' => $result['isError'] ?? null,
+        ]);
     }
 
     /**

--- a/tests/Mcp/LocalMcpServerTest.php
+++ b/tests/Mcp/LocalMcpServerTest.php
@@ -9,9 +9,25 @@ use Nene2\Mcp\LocalMcpHttpResponse;
 use Nene2\Mcp\LocalMcpServer;
 use Nene2\Mcp\LocalMcpToolCatalog;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Stringable;
 
 final class LocalMcpServerTest extends TestCase
 {
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            @unlink($file);
+        }
+
+        $this->tempFiles = [];
+    }
+
     public function testInitializeReturnsServerCapabilities(): void
     {
         $server = $this->server();
@@ -259,12 +275,138 @@ final class LocalMcpServerTest extends TestCase
         ]));
     }
 
-    private function server(?RecordingLocalMcpHttpClient $client = null): LocalMcpServer
+    private function server(?RecordingLocalMcpHttpClient $client = null, ?LoggerInterface $logger = null): LocalMcpServer
     {
         return new LocalMcpServer(
             new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json'),
             $client ?? new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(200, [], '{}')),
             'http://localhost:8200',
+            $logger ?? new NullLogger(),
+        );
+    }
+
+    /**
+     * @return AbstractLogger&object{records: list<array{level: string, message: string, context: array<string, mixed>}>}
+     */
+    private function spyLogger(): AbstractLogger
+    {
+        return new class () extends AbstractLogger {
+            /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            public function log(mixed $level, string|Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+    }
+
+    // --- audit logging (#1446) ---
+
+    public function testStateChangingToolCallIsAudited(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(
+            201,
+            ['x-request-id' => 'req-audit-1'],
+            '{"id":1,"title":"n","body":"b"}',
+        ));
+        $logger = $this->spyLogger();
+        $server = $this->server($client, $logger);
+
+        $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 20,
+            'method' => 'tools/call',
+            'params' => ['name' => 'createExampleNote', 'arguments' => ['title' => 'n', 'body' => 'b']],
+        ]);
+
+        self::assertCount(1, $logger->records);
+        $record = $logger->records[0];
+        self::assertSame('info', $record['level']);
+        self::assertSame('createExampleNote', $record['context']['tool']);
+        self::assertSame('write', $record['context']['safety']);
+        self::assertSame('req-audit-1', $record['context']['request_id']);
+        self::assertSame(201, $record['context']['status_code']);
+        // The audit record must not carry the request arguments (no secret/PII leakage).
+        self::assertArrayNotHasKey('arguments', $record['context']);
+    }
+
+    public function testReadToolCallIsNotAudited(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(200, [], '{"items":[]}'));
+        $logger = $this->spyLogger();
+        $server = $this->server($client, $logger);
+
+        $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 21,
+            'method' => 'tools/call',
+            'params' => ['name' => 'listExampleNotes', 'arguments' => []],
+        ]);
+
+        self::assertSame([], $logger->records);
+    }
+
+    // --- destructive confirmation gate (#1446) ---
+
+    public function testDestructiveToolRequiresConfirmation(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(204, [], ''));
+        $server = $this->destructiveServer($client);
+
+        $response = $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 22,
+            'method' => 'tools/call',
+            'params' => ['name' => 'purgeEverything', 'arguments' => []],
+        ]);
+
+        self::assertNull($client->lastMethod, 'The API must not be called without confirmation.');
+        self::assertArrayHasKey('error', $response ?? []);
+        self::assertStringContainsString('confirm', (string) ($response['error']['message'] ?? ''));
+    }
+
+    public function testDestructiveToolProceedsWithConfirmationAndDoesNotForwardFlag(): void
+    {
+        $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(204, [], ''));
+        $logger = $this->spyLogger();
+        $server = $this->destructiveServer($client, $logger);
+
+        $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 23,
+            'method' => 'tools/call',
+            'params' => ['name' => 'purgeEverything', 'arguments' => ['confirm' => true]],
+        ]);
+
+        self::assertSame('delete', $client->lastMethod);
+        self::assertCount(1, $logger->records);
+        self::assertSame('destructive', $logger->records[0]['context']['safety']);
+    }
+
+    private function destructiveServer(RecordingLocalMcpHttpClient $client, ?LoggerInterface $logger = null): LocalMcpServer
+    {
+        $path = tempnam(sys_get_temp_dir(), 'mcp-cat-');
+        self::assertIsString($path);
+        $this->tempFiles[] = $path;
+
+        file_put_contents($path, (string) json_encode([
+            'tools' => [[
+                'name' => 'purgeEverything',
+                'title' => 'Purge Everything',
+                'description' => 'Deletes all records.',
+                'safety' => 'destructive',
+                'source' => ['type' => 'openapi', 'operationId' => 'purgeAll', 'method' => 'DELETE', 'path' => '/purge'],
+                'inputSchema' => ['type' => 'object'],
+                'responseSchemaRef' => null,
+            ]],
+        ], JSON_THROW_ON_ERROR));
+
+        return new LocalMcpServer(
+            new LocalMcpToolCatalog($path),
+            $client,
+            'http://localhost:8200',
+            $logger ?? new NullLogger(),
         );
     }
 }

--- a/tools/local-mcp-server.php
+++ b/tools/local-mcp-server.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Mcp\LocalMcpException;
 use Nene2\Mcp\LocalMcpServer;
@@ -25,10 +29,17 @@ if (is_string($jwtSecret) && $jwtSecret !== '') {
     $bearerToken = $v->issue(['sub' => 'mcp-server', 'scope' => 'read:system write:example', 'iat' => time(), 'exp' => time() + 86400]);
 }
 
+// Audit log for state-changing tool calls goes to STDERR (STDOUT carries the JSON-RPC
+// protocol and must not be polluted).
+$auditHandler = new StreamHandler('php://stderr', Level::Info);
+$auditHandler->setFormatter(new JsonFormatter());
+$auditLogger = new Logger('mcp-audit', [$auditHandler]);
+
 $server = new LocalMcpServer(
     new LocalMcpToolCatalog($root . '/docs/mcp/tools.json'),
     new NativeLocalMcpHttpClient($bearerToken),
     $apiBaseUrl,
+    $auditLogger,
 );
 
 while (($line = fgets(STDIN)) !== false) {


### PR DESCRIPTION
## 目的

セキュリティ監査 #1441 の **L-3（Low）** を是正。MCP の write/admin/destructive ツールが**トークンの存在のみ**で通り、per-call の監査・確認が無かった（CLAUDE.md §7「write/admin/destructive には認証・認可・監査・request id・確認動作が必要」との乖離）。

## 変更点

- **監査ログ**: `LocalMcpServer` に PSR-3 logger（任意・既定 `NullLogger`）を注入し、**非 read ツール呼び出しごとに構造化監査ログ**を出力（`tool` / `safety` / `operation_id` / `method` / `status_code` / API `request_id` / `is_error`）。**引数やシークレットは記録しない**（ロギング方針準拠）。
- **destructive 確認ゲート**: `destructive` ツールは明示的な `"confirm": true` 引数を要求し、無ければ API を呼ばず拒否（推論による削除・全消去を防止）。`confirm` フラグは API へ転送しない。
- **配線**: `tools/local-mcp-server.php` が監査ログを **STDERR（Info）** へ出力する Monolog logger を注入（STDOUT は JSON-RPC 用なので汚さない）。

## スコープ判断

- **per-call の scope 照合は見送り**: トークン scope の公開には `LocalMcpHttpClientInterface` の破壊的変更、加えてカタログ schema へ scope フィールド追加が必要で、本 Low の範囲を超える。実際の認可は proxy 先の **HTTP/JWT 境界**が担う（既存設計）。将来 scope ベース認可を足す場合の土台は本 PR の監査で整う。

## 検証

- `composer check` **全通過**: 541 tests / 1342 assertions・PHPStan level 8・CS・OpenAPI・**MCP catalog valid**。
- 追加テスト: write 呼び出しで監査ログ出力（引数は非記録）／read は非監査／destructive は confirm 必須・confirm 非転送。

Self-review: middleware-security

Closes #1446

🤖 Generated with [Claude Code](https://claude.com/claude-code)