### PR TITLE
docs(security): 修正後の再セキュリティテスト結果を文書化 (#1459)

### DIFF
--- a/docs/security/2026-07-02-post-fix-assessment.md
+++ b/docs/security/2026-07-02-post-fix-assessment.md
@@ -1,0 +1,123 @@
+# Security Assessment — Post-Remediation Verification (2026-07-02)
+
+Framework version at time of test: **v1.5.332**
+Scope of this report: NENE2 framework core (`src/`) and the shipped example
+application, exercised as a running service.
+
+This assessment re-tests NENE2 after the remediation of every `EXPOSED` finding
+from the previous cross-cutting audit (issue #1441). Its two goals are to
+**verify the fixes hold under live attack** (regression) and to **re-sweep the
+core attack surface**. It complements — it does not replace — the standing
+[security review policy](../adr/0011-security-review-policy.md) and the
+per-change checklist in [`docs/review/middleware-security.md`](../review/middleware-security.md).
+
+## Result
+
+**0 Critical / 0 High / 0 Medium / 0 Low `EXPOSED`.** Every attack category was
+blocked. The application processed the full battery without a single server
+error and without restarting (`restarts=0`), and no SQL, DSN, column name, or
+file path reached the logs.
+
+## Methodology
+
+- **Black-box live attack (ATK):** the framework and example app were booted in
+  a disposable Docker stack (Apache + mod_php 8.4 + MySQL 8.4), migrated, and
+  attacked over HTTP with a cracker mindset — malicious inputs aimed at breaking
+  authentication, injecting SQL, leaking data, and crashing the process. Source
+  was not modified; the container and its volumes were destroyed afterwards.
+- **Regression verification:** each prior `EXPOSED` finding was re-exercised with
+  the exact input that previously triggered it, confirming the new behaviour.
+- **Test-suite corroboration:** findings whose fix is not fully observable in the
+  default HTTP wiring (library primitives, opt-in features, the stdio MCP server)
+  are cross-referenced to the unit tests that lock the behaviour in.
+
+Verdict legend: `BLOCKED` (attack defended) · `SAFE` (no attack surface) ·
+`EXPOSED` (defect).
+
+## Environment
+
+| Item | Value |
+|---|---|
+| Runtime | Docker, Apache + mod_php, PHP 8.4.21 |
+| Database | MySQL 8.4 |
+| App wiring | Example Note/Tag CRUD, machine API key (`/machine/*`), Bearer JWT (`/examples/protected`) |
+| `APP_DEBUG` | `false` (production default) |
+
+## Attack results
+
+| # | Category | Techniques | Result |
+|---|----------|------------|--------|
+| A | SQL injection | path id (`1 OR 1=1`, `;DROP TABLE`), query `limit`/`offset`, time-based `SLEEP`, body & tag stacked queries | 🚫 BLOCKED — id routes require `\d+` (404); list params cast to int; body/tag payloads stored as inert literals; tables intact; `SLEEP(3)` returned in 9 ms |
+| B | API-key auth | none / wrong / prefix / SQLi-in-key / valid | 🚫 BLOCKED — all 401 except the correct key; constant-time `hash_equals` |
+| C | JWT auth | none / `alg:none` / wrong-secret / tampered-sig / expired / valid | 🚫 BLOCKED — all 401 except valid HS256; alg-confusion and signature forgery rejected |
+| D | HEAD / method (#1443) | `HEAD` on machine + bearer routes, `X-HTTP-Method-Override` | 🚫 BLOCKED — HEAD gated like GET (401); method-override ignored (405) |
+| E | Input length / type (#1450) | 100k-char title/body, 256-char title/name, array/number title | 🚫 BLOCKED — all **422** (validation-failed), not 500; 255-char and 200-char Japanese titles accepted (201) |
+| F | Request size / DoS (#1444) | 5 MB body (Content-Length), 5 MB chunked (no Content-Length) | 🚫 BLOCKED — both **413**; the unknown-size/chunked body is now measured and capped by the framework |
+| G | Header injection | CRLF in `X-Request-Id` | 🚫 BLOCKED — no injected header; value sanitized |
+| G | Mass assignment | `id` / `is_admin` in create body | 🚫 BLOCKED — id server-assigned, extra fields ignored |
+| G | CORS | `Origin: https://evil.example` | 🚫 BLOCKED — no `Access-Control-Allow-Origin` reflected |
+| H | Info disclosure | error bodies, response banners | 🚫 BLOCKED — generic Problem Details; `Server: Apache` (no version), no `X-Powered-By` |
+| I | Log hygiene (#1445) | force errors, inspect stderr | 🚫 BLOCKED — **0** lines containing SQL/DSN/column/path; **0** ERROR-level records across the whole battery |
+| — | Stability | full battery + burst | ✅ SAFE — `restarts=0`, `/health` 200 throughout |
+
+## Regression verification of prior findings
+
+Every `EXPOSED` finding from #1441 was confirmed remediated.
+
+| Prior finding | Severity | Fix (PR) | Verification in this test |
+|---------------|----------|----------|---------------------------|
+| #1442 RecoveryCodes 40-bit + unsalted hash | Medium | #1449 | Library primitive — default entropy raised to 80 bits; locked by `RecoveryCodesTest` (default ≥ 20 hex chars) |
+| #1443 HEAD bypasses `protectedMethods` | Medium | #1452 | Live: `HEAD` on protected routes → 401. Method-filter normalization (HEAD→GET) locked by `ApiKeyAuthenticationMiddlewareTest`; HEAD body suppression by `ResponseEmitterTest` |
+| #1444 size limit skipped for unknown-size body | Medium | #1453 | Live: 5 MB chunked (no Content-Length) → **413**. Unknown-size measurement locked by `RequestSizeLimitMiddlewareTest` |
+| #1445 raw `X-Request-Id` + full exception in logs | Low | #1451 | Live: **0** SQL/DSN/path lines and **0** ERROR records during the battery |
+| #1450 unvalidated input length/type → 500 | Low | #1451 | Live: oversized/typed input → **422** everywhere; the 500 → log-leak chain is closed at the source |
+| #1446 MCP write tools lacked audit/confirmation | Low | #1458 | stdio server — state-changing calls now audited; destructive calls require explicit confirmation; locked by `LocalMcpServerTest` |
+| #1447 no HSTS, weak Referrer-Policy | Low | #1457 | Live: `Referrer-Policy: strict-origin-when-cross-origin`. HSTS is opt-in and off in default wiring (correct); emission locked by `BaselineMiddlewareTest` |
+| #1448 `undici` (high) / `brace-expansion` | deps | #1456 | `npm audit`: 0 vulnerabilities |
+
+## Verified-safe core controls
+
+Confirmed intact (evidence in the run above and the audit report on #1441):
+
+- Parameterized SQL end-to-end; no dynamic SQL reaches user input.
+- Constant-time secret comparison (`hash_equals`) for API keys, JWT signatures,
+  TOTP codes, and recovery codes.
+- Strict HS256-only JWT verification with mandatory `exp`.
+- CORS allowlist with no origin reflection and no wildcard-with-credentials.
+- Sanitized, length-capped `X-Request-Id`; no CRLF/header injection.
+- Generic RFC 9457 Problem Details with `APP_DEBUG=false` by default; no stack
+  traces, SQL, or paths in client responses.
+- Suppressed server/version banners.
+
+## Residual notes (non-blocking)
+
+These are `INFO`-level hardening ideas, tracked for future consideration rather
+than as defects:
+
+- **MCP per-call scope authorization** — the MCP layer now audits and confirms
+  state-changing calls (#1446), but does not yet validate a per-tool scope
+  against the token. Real authorization is enforced at the HTTP/JWT boundary the
+  call is proxied through. Adding scope checks would require exposing token
+  scopes on `LocalMcpHttpClientInterface` and extending the tool catalog schema.
+- **`machineDatabasePreflight`** is a side-effecting POST catalogued with
+  `readOnlyHint`; it fails closed at the HTTP layer (API-key gated) but the hint
+  could mislead an LLM client.
+- **`InMemoryRateLimitStorage`** is non-atomic and single-process — documented as
+  dev-only; production deployments must use a shared atomic store.
+- **Front controller** has no bootstrap-level `try/catch`; leak safety before the
+  pipeline depends on `display_errors=Off` (set in the shipped image).
+- **Docs toolchain** (`esbuild`/`vite`/`vitepress`) carries dev-server-only
+  advisories with no upstream fix; not part of the production runtime.
+
+## Conclusion
+
+NENE2 at v1.5.332 withstands the full ATK battery with **zero exposed findings**.
+All previously identified issues are remediated and regression-verified, and the
+core security controls hold. The remaining items are low-severity hardening
+opportunities, not exploitable defects.
+
+---
+
+*Methodology: authorized black-box penetration test of the maintainer's own
+framework in a disposable container, plus unit-test corroboration. Source was
+not modified. ~60 requests across 9 categories.*

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,26 @@
+# Security
+
+Security posture, policy, and assessment records for NENE2.
+
+## Policy and process
+
+- **[ADR 0011 — Security review policy](../adr/0011-security-review-policy.md)** —
+  when and how security review happens.
+- **[Middleware & security self-review checklist](../review/middleware-security.md)** —
+  the per-change checklist for auth, logging, CORS, and headers.
+
+## Assessments
+
+Point-in-time security assessments (black-box penetration tests plus code
+review). Each is a snapshot of the version tested.
+
+| Date | Version | Report | Result |
+|------|---------|--------|--------|
+| 2026-07-02 | v1.5.332 | [Post-remediation verification](2026-07-02-post-fix-assessment.md) | 0 exposed findings; all prior issues regression-verified |
+
+## Reporting a vulnerability
+
+Security issues are tracked as GitHub issues in this repository. For a
+maintainer-run assessment, follow the ATK/verification methodology described in
+the latest report above: exercise the running application in a disposable
+container, never against production data or credentials.


### PR DESCRIPTION
## 目的

Issue #1459 — 前回監査（#1441）の全 EXPOSED 是正後に、**修正後コードへ再度セキュリティテスト**を実施し、結果を**恒久ドキュメント**としてリポジトリに残す。

## 実施内容

捨てコンテナ（Docker: Apache + mod_php 8.4 + MySQL 8.4）で稼働アプリへ能動攻撃（ATK）を再投入し、① 前回 EXPOSED の**回帰検証**、② 主要攻撃面の**新規スイープ**を行った。ソース非改変・終了後コンテナ破棄。

**結果: 0 Critical / High / Medium / Low EXPOSED。全カテゴリ BLOCKED。** `restarts=0`、ログに SQL/DSN/列名/パス漏洩 **0 行**、ERROR ログ **0 件**。

## 追加ファイル

- **`docs/security/2026-07-02-post-fix-assessment.md`** — 方法論・環境・攻撃結果表（SQLi/認証/JWT/HEAD/入力長/サイズ/CRLF/mass-assign/CORS/情報漏洩/ログ衛生）・前回 finding(#1442–1450) の回帰検証表・SAFE 確認済みコア制御・残 INFO・結論。
- **`docs/security/README.md`** — セキュリティ文書の索引（ADR 0011 / middleware-security チェックリスト / 評価レポート一覧）。

## 回帰ハイライト

- #1450: 100k 入力 → **422**（was 500）／日本語 200 字 → 201
- #1444: 5MB chunked（no CL）→ **413**（framework が捕捉）
- #1447: `Referrer-Policy: strict-origin-when-cross-origin`（HSTS は opt-in で既定 off = 正）
- #1445: バッテリー中の ERROR ログ **0 件**・漏洩 **0 行**

## 検証

- 実機 ATK（~60 リクエスト / 9 カテゴリ）。
- HTTP で完全には観測できない項目（#1442 primitive・#1443 method-filter・#1446 MCP・#1447 HSTS）は対応ユニットテストを参照リンク。
- **VitePress ローカルビルド成功**（Docs ワークフローを落とさないことを確認）。

Self-review: docs-policy, middleware-security

Closes #1459

🤖 Generated with [Claude Code](https://claude.com/claude-code)