### PR TITLE
docs(daily): 2026-07-02 日報を追加 (#1462)

### DIFF
--- a/docs/daily/2026-07-02.md
+++ b/docs/daily/2026-07-02.md
@@ -1,0 +1,108 @@
+# 日報 — 2026-07-02
+
+## 作業時間帯
+
+2026-07-01 夜からの連続セッション（日付をまたいで 07-02 まで）。リポジトリ全体の状態把握から始め、小さな整合修正 → 溜まっていた依存 PR の一掃 → 機能追加（TOTP プリミティブ）→ **横断セキュリティ監査 → 検出した全 EXPOSED の修正 → 捨てコンテナでの実機 ATK 再テスト＆文書化 → リリース v1.5.333** まで通した一日。中心テーマは「自分のフレームワークを敵対的に壊しにいって、出た穴を全部塞ぎ、塞げたことを実機で再確認して文書に残し、版として締める」こと。
+
+---
+
+## 本日の成果
+
+### 1. リポジトリ状態把握と記事 / README 整合（#1436 / PR #1437）
+
+セッション開始時に全体像を確認。作業中の記事ブランチ（DEV ポートフォリオ記事）と、**README の実態ずれ**を検出。
+
+- howto 件数が README で `262` になっていたが実数は **260**（索引2ファイルの数え込み誤り）→ 修正。
+- Reference Implementations の例数 `93` は陳腐化 → GitHub API で `NENE2-examples` の実ディレクトリ数を数え（126 − `tools` = **125**）正確な値へ補正。
+- 記事本文＋README リンクを整えて #1436 をマージ。
+
+### 2. Dependabot 8 件の一掃（#1428〜#1435）
+
+全 8 件が MERGEABLE / CLEAN / CI 緑であることを確認してから処理。composer/actions の 3 件（独立）を先にマージ、frontend 5 件は `frontend/package-lock.json` を共有するため **1 件マージ→rebase 連鎖**を見ながら順次処理（#1434 で一度 lock 競合 → `@dependabot rebase` → 8.62.1 で解消）。
+
+### 3. TOTP プリミティブの昇格（#1427 / PR #1438）
+
+`totp-authentication` howto にレシピはあるが再利用可能コードが無く、各アプリが暗号部分を自前実装していた点を是正。
+
+- **`Nene2\Auth\TotpAuthenticator`** — RFC 6238（Base32 シークレット生成 / `otpauth://` URI / 定数時間 `hash_equals` 検証 / window 設定可、一致 time_step を返しリプレイ防止に使える）。
+- **`Nene2\Auth\RecoveryCodes`** — 生成・SHA-256・定数時間検証（書式/大小を正規化）。
+- ADR 0009 の安定 API 表に 2 クラス追記、howto 先頭に利用例。`TotpAuthenticatorTest` は **RFC 6238 Appendix B 参照ベクトル**で計算を固定。`composer check` 通過。
+
+### 4. CI 修復（#1439 / PR #1440）
+
+「CI 通ってる？」の確認から、**main の Docs（VitePress→Pages）ワークフローが連続失敗**していることを発見。原因は #1437 で自分がマージした記事 frontmatter の `description:` に未引用のコロン（`series: API-first`）が入り YAML パーサが壊れていたこと（Docs は push:main 限定で PR では走らず検知できなかった）。値をダブルクオートで囲んで解消。ローカル VitePress ビルド成功を確認。
+
+### 5. 横断セキュリティ監査（#1441）
+
+`src/`（約 8.3k SLOC）を **5 系統の並行サブエージェント**（認証/暗号・注入/DB・ミドルウェア/HTTP・情報漏洩/ログ/XSS・MCP/machine/config）＋ 依存/CI/シークレットスキャンで監査。
+
+- **Critical / High: ゼロ。** 中核（パラメタライズド SQL・厳格 JWT・定数時間認証・CORS allowlist・Problem Details・SSRF 封じ）は堅牢と確認。
+- **EXPOSED: Medium 3 / Low 4**。個別 Issue 化（#1442〜#1448）。監査レポートを #1441 に投稿。
+
+### 6. 捨てコンテナでの実機 ATK
+
+稼働アプリ（Docker: Apache+mod_php+MySQL）へ攻撃者マインドで 29 カテゴリ・約 60 リクエストを投入。**フレームワークは壊せず**（RCE / 注入 / 認証・JWT バイパス / CRLF / mass assignment / パストラバーサルすべて BLOCKED、`restarts=0`）。
+
+- **live で確定**: #1445（巨大 title で `1406` を誘発 → サーバログに `PDOException` の SQL・列名・ファイルパス、かつ `context.request_id` 空）。
+- **新規発見**: #1450（title/body の長さ・型が未検証で DB 到達 → **500**。422 で弾くべき）。
+
+### 7. 全 EXPOSED の修正（#1442〜#1448 / #1450）
+
+| Issue | Sev | 内容 | PR |
+|------|-----|------|-----|
+| #1442 | Med | RecoveryCodes 40→**80bit**（自分の #1427 regression） | #1449 |
+| #1443 | Med | HEAD が protectedMethods 認証を回避（HEAD→GET 正規化＋HEAD 本文抑制） | #1452 |
+| #1444 | Med | サイズ不明/chunked ボディの制限回避（読みながら計測） | #1453 |
+| #1445 | Low | エラーログ衛生（生 X-Request-Id / 例外全体） | #1451 |
+| #1450 | Low | 入力長・型未検証で 500 → 422 | #1451 |
+| #1446 | Low | MCP 状態変更ツールの監査＋destructive 確認 | #1458 |
+| #1447 | Low | HSTS opt-in ＋ Referrer-Policy 強化 | #1457 |
+| #1448 | deps | npm undici(high) 等（0 vulns へ） | #1456 |
+
+`#1446` の per-call scope 照合は `LocalMcpHttpClientInterface` の破壊的変更が要るため **Low の範囲を超えると判断**し、proportionate に監査ログ＋確認ゲートに絞った（実認可は HTTP/JWT 境界が担う既存設計）。監査 #1441 は全 EXPOSED 消化でクローズ。
+
+### 8. Zenn 設計メモの引き継ぎ（#1454 / PR #1455）
+
+施主が書き始めた 352 行のドラフトを引き継ぎ、**事実誤り 1 点のみ修正**（howto 本数 262→260）して仕上げ。frontmatter YAML 検証＋ローカル VitePress ビルド成功を確認してマージ（本文は施主の文章を尊重）。
+
+### 9. 再セキュリティテスト＆文書化（#1459 / PR #1460）
+
+修正後コードへ**捨てコンテナ実機 ATK を再投入**。回帰＋新規スイープとも **0 EXPOSED**。100k 入力→**422**（was 500）、日本語 200 字→201、5MB chunked→**413**（framework が捕捉）、`Referrer-Policy: strict-origin-when-cross-origin`、**サーバログ漏洩 0 行・ERROR 0 件**、`restarts=0`。結果を恒久ドキュメント `docs/security/2026-07-02-post-fix-assessment.md`＋索引 `docs/security/README.md` に残した。
+
+### 10. リリース v1.5.333（#1461）
+
+`release-checklist.md` 準拠。バージョン整合 3 箇所（`FrameworkInfo` / `openapi.yaml` / `CHANGELOG`）を **1.5.333** に bump、CHANGELOG に v1.5.332 以降の全変更を記載、`composer validate` + `check`（543 tests）通過 → PR マージ → main にタグ `v1.5.333` → **GitHub Release 作成**（Packagist webhook 連動）。
+
+---
+
+## 数値
+
+- マージ PR: **約 21 件**（記事1・Dependabot 8・TOTP1・CI修復1・セキュリティ修正6・Zenn1・監査文書1・リリース1 ほか）
+- Issue: **13 件作成**（#1439 / #1441〜#1448 / #1450 / #1459 / #1462）、**13 件クローズ**（#1436 / #1427 / #1439 / #1441〜#1448 / #1450 / #1454 / #1459）
+- セキュリティ: 監査で **Critical/High ゼロ**・**Medium 3 / Low 4 + 入力検証 1 を全修正**。実機 ATK 二巡（初回で穴発見、修正後で 0 EXPOSED）
+- 新規 `src/` クラス: **2 件**（`TotpAuthenticator` / `RecoveryCodes`）
+- 新規ドキュメント: `docs/security/`（評価レポート＋索引）、DEV 記事（#1436）、Zenn 設計メモ（#1454）
+- テスト: 約 **520 → 543**、PHPStan level 8 クリーン継続
+- リリース: **v1.5.333**（GitHub Release・Packagist 連動）
+- VERSION: **1.5.332 → 1.5.333**
+
+---
+
+## 残課題（次回以降）
+
+| 優先 | 内容 |
+|------|------|
+| P1 | **C（#1421）**: preflight 署名トークン。apply（deployer 再起動 + boot 再検証）Issue が立って #1421 から参照されるまで defer（唯一の open Issue） |
+| P2 | 監査の **INFO 系 hardening**（MCP の per-call scope 認可、`machineDatabasePreflight` の readOnlyHint 表記、in-memory rate limiter の非アトミック、front controller の bootstrap catch、docs 依存 esbuild/vite）。重大度低・必要時に個別対応 |
+| P3 | `docs/todo/current.md`（FT ループ引き継ぎ）の陳腐化（まだ 1.5.329 表記）。実態へ更新する余地 |
+| P4 | Docs(VitePress) ワークフローは push:main 限定で PR で走らない → docs frontmatter/ビルド破損はマージ後まで検知できない。frontmatter 検証を CI/pre-commit に足す余地 |
+
+---
+
+## 所感
+
+「敵対的に自分のコードを壊しにいく」ことの費用対効果が高かった一日。捨てコンテナでの実機 ATK は、**自分がその日に足したばかりの `RecoveryCodes`（40bit エントロピー）と、入力長未検証で 500 になる穴**を捕まえた — 静的レビュー（5 系統エージェント）だけでも Medium を挙げられたが、実際に走らせて壊しにいくと「サーバログに SQL/DSN が出る」「長い文字列を投げるだけで 500 を量産できる」という**連鎖**が生々しく見え、修正の優先度が明確になった。
+
+修正フェーズでは #1446 で「やり過ぎない」を選べたのが良い。per-call scope 照合は正論だが、安定 interface の破壊的変更まで踏み込むのは Low の対価として重すぎる。監査ログ＋destructive 確認に絞り、実認可は既存の HTTP/JWT 境界に委ねると PR に明記した — 「指摘を全部実装する」より「重大度に見合う範囲で確実に効かせる」方が筋が通る。
+
+そして締め方。修正して終わりにせず、**同じ攻撃を修正後コードへ再投入して 0 EXPOSED を実機で確認 → それを恒久ドキュメントに残す → 版として切る**まで一周させた。ATK レポートが Issue コメントで消えず `docs/security/` に定着し、CHANGELOG と GitHub Release に「セキュリティ強化リリース」として刻まれた。終わってみれば main クリーン・CI 全緑・監査クローズ・リリース済み、open は意図的 defer の #1421 のみ。監査 → 修正 → 再検証 → 文書化 → 出荷の一連が綺麗に閉じた。


### PR DESCRIPTION
## 目的

Issue #1462 — 2026-07-02（前夜 07-01 からの連続セッション）の作業日報を追加。

## 内容

`docs/daily/2026-07-02.md`。テーマ: **セキュリティ監査 → 全 EXPOSED 修正 → 捨てコンテナ実機 ATK 再テスト＆文書化 → リリース v1.5.333**。既存日報（〜2026-06-27）と同一構成（作業時間帯 / 本日の成果 / 数値 / 残課題 / 所感）。

Self-review: docs-policy

Closes #1462