### PR TITLE
feat(install): インストーラ toolkit — preflight & config 基本部品を追加する (#1466)

### DIFF
--- a/src/Install/EnvironmentWriter.php
+++ b/src/Install/EnvironmentWriter.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+use RuntimeException;
+
+/**
+ * Writes a product's `.env` atomically during installation.
+ *
+ * The caller supplies an ordered map of `KEY => value`, so the toolkit carries no
+ * product-specific keys — app name, tenancy defaults and the like belong to each
+ * product's installer template. Values are serialised to be read back verbatim by
+ * vlucas/phpdotenv (the loader NENE2 uses): a value is written bare when it is safe,
+ * otherwise double-quoted with `\\`, `"` and `$` escaped, so passwords containing
+ * quotes, spaces, `#` or `$` survive a round-trip. Line breaks and null bytes are
+ * refused outright to prevent injecting extra `.env` lines.
+ *
+ * The write is atomic — a sibling temp file is written, `chmod`ed to 0640, then
+ * renamed over the target — so an interrupted install never leaves a half-written
+ * `.env`. Part of the opt-in installer toolkit.
+ */
+final readonly class EnvironmentWriter
+{
+    /**
+     * Serialise and atomically write the given values to `$path`.
+     *
+     * @param array<string, string> $values Ordered map of environment key => value.
+     *
+     * @throws RuntimeException on an invalid key, an unserialisable value, or a write failure.
+     */
+    public function write(string $path, array $values): void
+    {
+        $content = $this->serialize($values);
+
+        $dir = dirname($path);
+
+        if (!is_dir($dir)) {
+            throw new RuntimeException(sprintf('The .env directory does not exist: %s', $dir));
+        }
+
+        $tmp = $path . '.tmp.' . bin2hex(random_bytes(6));
+
+        if (@file_put_contents($tmp, $content) === false) {
+            throw new RuntimeException('Could not write the .env file; check the directory permissions.');
+        }
+
+        @chmod($tmp, 0640);
+
+        if (!@rename($tmp, $path)) {
+            @unlink($tmp);
+
+            throw new RuntimeException('Could not save the .env file; check the directory permissions.');
+        }
+    }
+
+    /**
+     * Serialise the values to `.env` text (one `KEY=value` line each, trailing newline).
+     *
+     * @param array<string, string> $values
+     *
+     * @throws RuntimeException on an invalid key or unserialisable value.
+     */
+    public function serialize(array $values): string
+    {
+        $lines = [];
+
+        foreach ($values as $key => $value) {
+            $lines[] = $this->line($key, $value);
+        }
+
+        return $lines === [] ? '' : implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * Generate a cryptographically secure secret as lowercase hex (e.g. a JWT signing key).
+     * Kept here as a convenience so installers never invent their own weak secret; the value
+     * is returned, never logged, and the caller places it in the value map.
+     *
+     * @throws RuntimeException if fewer than one byte is requested.
+     */
+    public static function generateSecret(int $bytes = 32): string
+    {
+        if ($bytes < 1) {
+            throw new RuntimeException('A secret needs at least one byte.');
+        }
+
+        return bin2hex(random_bytes($bytes));
+    }
+
+    private function line(string $key, string $value): string
+    {
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $key) !== 1) {
+            throw new RuntimeException(sprintf('Invalid environment key: %s', $key));
+        }
+
+        if (preg_match('/[\r\n\0]/', $value) === 1) {
+            throw new RuntimeException(
+                sprintf('The value for %s contains a line break or null byte and cannot be written to .env.', $key),
+            );
+        }
+
+        // Bare when the value is drawn entirely from a set phpdotenv reads back unchanged;
+        // otherwise double-quote and escape the three characters that are special inside quotes.
+        if ($value !== '' && preg_match('~^[A-Za-z0-9_./:@%+-]+$~', $value) === 1) {
+            return $key . '=' . $value;
+        }
+
+        $escaped = str_replace(['\\', '"', '$'], ['\\\\', '\\"', '\\$'], $value);
+
+        return $key . '="' . $escaped . '"';
+    }
+}

--- a/src/Install/EnvironmentWriter.php
+++ b/src/Install/EnvironmentWriter.php
@@ -19,7 +19,8 @@ use RuntimeException;
  *
  * The write is atomic — a sibling temp file is written, `chmod`ed to 0640, then
  * renamed over the target — so an interrupted install never leaves a half-written
- * `.env`. Part of the opt-in installer toolkit.
+ * `.env`. If the file cannot be made non-world-readable it fails closed rather than
+ * persist the secret in the clear. Part of the opt-in installer toolkit.
  */
 final readonly class EnvironmentWriter
 {
@@ -47,6 +48,20 @@ final readonly class EnvironmentWriter
         }
 
         @chmod($tmp, 0640);
+
+        // .env carries the DB password and JWT secret. If chmod could not restrict it
+        // (e.g. an unsupported filesystem left it world-readable at the umask default),
+        // fail closed rather than persist a secret the whole host can read.
+        $perms = fileperms($tmp);
+
+        if ($perms !== false && ($perms & 0007) !== 0) {
+            @unlink($tmp);
+
+            throw new RuntimeException(
+                'The .env file could not be restricted to non-world-readable permissions; '
+                . 'refusing to write the database password where any host user could read it.',
+            );
+        }
 
         if (!@rename($tmp, $path)) {
             @unlink($tmp);

--- a/src/Install/LiveSystemProbe.php
+++ b/src/Install/LiveSystemProbe.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * The production {@see SystemProbe}: answers each question straight from the PHP
+ * runtime and filesystem. Injected by default into {@see ServerRequirementChecker}
+ * so callers get real checks without wiring, while tests substitute a fake.
+ */
+final class LiveSystemProbe implements SystemProbe
+{
+    public function phpVersion(): string
+    {
+        return PHP_VERSION;
+    }
+
+    public function extensionLoaded(string $extension): bool
+    {
+        return extension_loaded($extension);
+    }
+
+    public function isWritable(string $path): bool
+    {
+        return is_writable($path);
+    }
+
+    public function exists(string $path): bool
+    {
+        return file_exists($path);
+    }
+}

--- a/src/Install/ProvisioningProbe.php
+++ b/src/Install/ProvisioningProbe.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * Answers whether the target datastore already holds a provisioned installation —
+ * the defence-in-depth check {@see ReInstallationGuard} uses when the on-disk
+ * `.installed` marker is missing (e.g. an ephemeral `var/` wiped it on redeploy).
+ *
+ * Product-specific by nature (which table or row proves provisioning), so the
+ * installer supplies the implementation; the toolkit stays generic. Optional: when
+ * no probe is wired the guard relies on the marker alone.
+ */
+interface ProvisioningProbe
+{
+    /**
+     * Whether the datastore already contains a provisioned installation. Implementations
+     * should return `false` (not throw) when the datastore is simply unreachable or empty,
+     * so a genuinely fresh target is not mistaken for a provisioned one.
+     */
+    public function isProvisioned(): bool;
+}

--- a/src/Install/ReInstallationGuard.php
+++ b/src/Install/ReInstallationGuard.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+use RuntimeException;
+
+/**
+ * Refuses to re-run an installer against an already-provisioned target, so a stray
+ * second visit to `install.php` cannot overwrite `.env` or recreate the admin account.
+ *
+ * Two layers: an on-disk `.installed` marker, and — as defence in depth when the
+ * marker is lost (an ephemeral `var/` wiped on redeploy) — an optional
+ * {@see ProvisioningProbe} that inspects the datastore. The marker is checked first
+ * and short-circuits, so the probe is only consulted when the marker is absent.
+ *
+ * Both the marker path and the probe are injected, keeping the toolkit generic and
+ * unit-testable. Part of the opt-in installer toolkit.
+ */
+final readonly class ReInstallationGuard
+{
+    public function __construct(
+        private string $markerPath,
+        private ?ProvisioningProbe $provisioningProbe = null,
+    ) {
+    }
+
+    /**
+     * Why installation must be refused, or `null` when it may proceed.
+     *
+     * @return 'marker_present'|'database_provisioned'|null
+     */
+    public function blockedReason(): ?string
+    {
+        if (is_file($this->markerPath)) {
+            return 'marker_present';
+        }
+
+        if ($this->provisioningProbe !== null && $this->provisioningProbe->isProvisioned()) {
+            return 'database_provisioned';
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether installation must be refused.
+     */
+    public function isBlocked(): bool
+    {
+        return $this->blockedReason() !== null;
+    }
+
+    /**
+     * Write the `.installed` marker so a later run is refused. Written atomically
+     * (sibling temp file then rename) for consistency with the rest of the install.
+     *
+     * @param string $note Optional non-secret content (e.g. an ISO timestamp) for operators.
+     *
+     * @throws RuntimeException if the marker's directory is missing or the write fails.
+     */
+    public function markInstalled(string $note = ''): void
+    {
+        $dir = dirname($this->markerPath);
+
+        if (!is_dir($dir)) {
+            throw new RuntimeException(sprintf('The installation marker directory does not exist: %s', $dir));
+        }
+
+        $tmp = $this->markerPath . '.tmp.' . bin2hex(random_bytes(6));
+
+        if (@file_put_contents($tmp, $note) === false) {
+            throw new RuntimeException('Could not write the installation marker.');
+        }
+
+        if (!@rename($tmp, $this->markerPath)) {
+            @unlink($tmp);
+
+            throw new RuntimeException('Could not save the installation marker.');
+        }
+    }
+}

--- a/src/Install/RequirementCheck.php
+++ b/src/Install/RequirementCheck.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * The structured result of a single server requirement check.
+ *
+ * Carries machine-readable fields only — a requirement kind, the target that was
+ * checked, whether it is satisfied, and reason codes — so a product's installer
+ * template owns all user-facing wording (labels, fixes, translations). This keeps
+ * the toolkit free of UI and locale assumptions.
+ */
+final readonly class RequirementCheck
+{
+    /**
+     * @param string       $requirement One of {@see ServerRequirementChecker}'s `REQUIREMENT_*` kinds.
+     * @param string       $target      What was required (min PHP version, extension name, or path).
+     * @param bool         $satisfied   Whether the requirement is met.
+     * @param list<string> $reasonCodes Machine-readable codes explaining the outcome, e.g. `['php_too_old']`,
+     *                                   `['extension_missing']`, `['creatable']`.
+     */
+    public function __construct(
+        public string $requirement,
+        public string $target,
+        public bool $satisfied,
+        public array $reasonCodes,
+    ) {
+    }
+}

--- a/src/Install/ServerRequirementChecker.php
+++ b/src/Install/ServerRequirementChecker.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * Diagnoses whether a server meets a product's {@see ServerRequirements} before an
+ * install proceeds — the PHP version, required extensions, writable paths, and files
+ * that must already be present.
+ *
+ * Purely diagnostic: it never mutates the filesystem (a missing writable path is
+ * reported as `creatable` when its parent is writable, rather than being created
+ * here). All runtime facts come from an injected {@see SystemProbe}, so the logic is
+ * fully unit-testable. Results are machine-readable {@see RequirementCheck}s; the
+ * product's installer template maps them to user-facing labels and fixes.
+ *
+ * Part of the opt-in installer toolkit — dormant unless a product's installer calls it.
+ */
+final readonly class ServerRequirementChecker
+{
+    public const REQUIREMENT_PHP = 'php_version';
+    public const REQUIREMENT_EXTENSION = 'extension';
+    public const REQUIREMENT_WRITABLE = 'writable_path';
+    public const REQUIREMENT_FILE = 'required_file';
+
+    public function __construct(
+        private SystemProbe $probe = new LiveSystemProbe(),
+    ) {
+    }
+
+    /**
+     * @return list<RequirementCheck> One check per PHP version, extension, writable path and required file.
+     */
+    public function check(ServerRequirements $requirements): array
+    {
+        $checks = [$this->checkPhpVersion($requirements->minPhpVersion)];
+
+        foreach ($requirements->requiredExtensions as $extension) {
+            $loaded = $this->probe->extensionLoaded($extension);
+            $checks[] = new RequirementCheck(
+                self::REQUIREMENT_EXTENSION,
+                $extension,
+                $loaded,
+                [$loaded ? 'extension_loaded' : 'extension_missing'],
+            );
+        }
+
+        foreach ($requirements->writablePaths as $path) {
+            [$satisfied, $reason] = $this->evaluateWritable($path);
+            $checks[] = new RequirementCheck(self::REQUIREMENT_WRITABLE, $path, $satisfied, [$reason]);
+        }
+
+        foreach ($requirements->requiredFiles as $file) {
+            $present = $this->probe->exists($file);
+            $checks[] = new RequirementCheck(
+                self::REQUIREMENT_FILE,
+                $file,
+                $present,
+                [$present ? 'present' : 'missing'],
+            );
+        }
+
+        return $checks;
+    }
+
+    /**
+     * Convenience: whether every check in the list is satisfied.
+     *
+     * @param list<RequirementCheck> $checks
+     */
+    public static function allSatisfied(array $checks): bool
+    {
+        foreach ($checks as $check) {
+            if (!$check->satisfied) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Convenience: the subset of checks that are not satisfied.
+     *
+     * @param list<RequirementCheck> $checks
+     *
+     * @return list<RequirementCheck>
+     */
+    public static function unmet(array $checks): array
+    {
+        return array_values(array_filter($checks, static fn (RequirementCheck $c): bool => !$c->satisfied));
+    }
+
+    private function checkPhpVersion(string $minVersion): RequirementCheck
+    {
+        $satisfied = version_compare($this->probe->phpVersion(), $minVersion, '>=');
+
+        return new RequirementCheck(
+            self::REQUIREMENT_PHP,
+            $minVersion,
+            $satisfied,
+            [$satisfied ? 'php_ok' : 'php_too_old'],
+        );
+    }
+
+    /**
+     * @return array{0: bool, 1: string} [satisfied, reasonCode] — `writable` when a writable dir/file
+     *         already exists, `creatable` when the path is absent but its parent is writable, otherwise
+     *         `not_writable`.
+     */
+    private function evaluateWritable(string $path): array
+    {
+        if ($this->probe->exists($path)) {
+            return $this->probe->isWritable($path) ? [true, 'writable'] : [false, 'not_writable'];
+        }
+
+        return $this->probe->isWritable(dirname($path)) ? [true, 'creatable'] : [false, 'not_writable'];
+    }
+}

--- a/src/Install/ServerRequirements.php
+++ b/src/Install/ServerRequirements.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * The set of server requirements a product's installer expects, checked by
+ * {@see ServerRequirementChecker}. Supplying this as a value object keeps the
+ * toolkit generic: each product declares its own minimum PHP version, extensions,
+ * writable paths and required files — the framework carries no product assumptions.
+ */
+final readonly class ServerRequirements
+{
+    /**
+     * @param string       $minPhpVersion      Minimum PHP version, e.g. `"8.4.0"` (compared with `version_compare`).
+     * @param list<string> $requiredExtensions PHP extensions that must be loaded, e.g. `['pdo_mysql', 'mbstring']`.
+     * @param list<string> $writablePaths      Paths that must be writable (or creatable), e.g. `['/app/var', '/app']`.
+     * @param list<string> $requiredFiles      Paths that must already exist, e.g. `['/app/vendor/autoload.php']`.
+     */
+    public function __construct(
+        public string $minPhpVersion,
+        public array $requiredExtensions = [],
+        public array $writablePaths = [],
+        public array $requiredFiles = [],
+    ) {
+    }
+}

--- a/src/Install/SystemProbe.php
+++ b/src/Install/SystemProbe.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * Read-only view of the runtime and filesystem facts a {@see ServerRequirementChecker}
+ * needs to diagnose an installation target.
+ *
+ * Extracting these behind an interface keeps the checker pure and unit-testable: tests
+ * supply a synthetic probe, while production uses {@see LiveSystemProbe}. Part of the
+ * opt-in installer toolkit — nothing here runs unless a product's installer calls it.
+ */
+interface SystemProbe
+{
+    /**
+     * The running PHP version, e.g. `PHP_VERSION` (`"8.4.22"`).
+     */
+    public function phpVersion(): string;
+
+    /**
+     * Whether the named PHP extension is loaded, e.g. `extension_loaded('pdo_mysql')`.
+     */
+    public function extensionLoaded(string $extension): bool;
+
+    /**
+     * Whether the path exists and is writable.
+     */
+    public function isWritable(string $path): bool;
+
+    /**
+     * Whether anything exists at the path (file, directory, or otherwise).
+     */
+    public function exists(string $path): bool;
+}

--- a/tests/Install/EnvironmentWriterTest.php
+++ b/tests/Install/EnvironmentWriterTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Dotenv\Dotenv;
+use Nene2\Install\EnvironmentWriter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class EnvironmentWriterTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->cleanup = [];
+    }
+
+    public function testSerializesSafeValuesBare(): void
+    {
+        $env = (new EnvironmentWriter())->serialize([
+            'APP_ENV' => 'production',
+            'DB_PORT' => '3306',
+            'BASE_DOMAIN' => 'records.example.com',
+        ]);
+
+        self::assertSame(
+            "APP_ENV=production\nDB_PORT=3306\nBASE_DOMAIN=records.example.com\n",
+            $env,
+        );
+    }
+
+    public function testSerializesAnEmptyMapAsAnEmptyString(): void
+    {
+        self::assertSame('', (new EnvironmentWriter())->serialize([]));
+    }
+
+    #[DataProvider('awkwardValues')]
+    public function testRoundTripsAwkwardValuesThroughPhpdotenv(string $value): void
+    {
+        $content = (new EnvironmentWriter())->serialize(['DB_PASSWORD' => $value]);
+
+        $parsed = Dotenv::parse($content);
+
+        self::assertSame($value, $parsed['DB_PASSWORD']);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function awkwardValues(): iterable
+    {
+        yield 'plain' => ['simplepass'];
+        yield 'at and digits' => ['p@ssw0rd'];
+        yield 'space' => ['has space'];
+        yield 'hash' => ['has#hash'];
+        yield 'double quote' => ['has"quote'];
+        yield 'apostrophe' => ["has'apostrophe"];
+        yield 'dollar' => ['has$dollar'];
+        yield 'braced var' => ['${HOME}'];
+        yield 'backslash' => ['back\\slash'];
+        yield 'trailing backslash' => ['ends-with\\'];
+        yield 'semicolon' => ['semi;colon'];
+        yield 'equals' => ['a=b=c'];
+        yield 'tab' => ["col1\tcol2"];
+        yield 'everything' => ['mix "a" $b \\c #d = e'];
+        yield 'multibyte' => ['パス春ワード'];
+        yield 'empty' => [''];
+    }
+
+    public function testWritesAtomicallyWithRestrictedPermissions(): void
+    {
+        $path = $this->tempPath();
+
+        (new EnvironmentWriter())->write($path, [
+            'APP_ENV' => 'production',
+            'DB_PASSWORD' => 'p @ss "w" $x',
+        ]);
+
+        self::assertFileExists($path);
+        self::assertSame(0640, fileperms($path) & 0777);
+
+        $content = file_get_contents($path);
+        self::assertNotFalse($content);
+        $parsed = Dotenv::parse($content);
+        self::assertSame('production', $parsed['APP_ENV']);
+        self::assertSame('p @ss "w" $x', $parsed['DB_PASSWORD']);
+    }
+
+    public function testWriteToAMissingDirectoryThrows(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('directory does not exist');
+        (new EnvironmentWriter())->write('/no/such/dir/.env', ['APP_ENV' => 'production']);
+    }
+
+    #[DataProvider('invalidKeys')]
+    public function testRejectsInvalidKeys(string $key): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid environment key');
+        (new EnvironmentWriter())->serialize([$key => 'x']);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidKeys(): iterable
+    {
+        yield 'leading digit' => ['1ABC'];
+        yield 'dash' => ['HAS-DASH'];
+        yield 'space' => ['HAS SPACE'];
+        yield 'dot' => ['HAS.DOT'];
+        yield 'empty' => [''];
+    }
+
+    #[DataProvider('unserialisableValues')]
+    public function testRejectsValuesWithLineBreaksOrNullBytes(string $value): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('line break or null byte');
+        (new EnvironmentWriter())->serialize(['KEY' => $value]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unserialisableValues(): iterable
+    {
+        yield 'newline' => ["line1\nline2"];
+        yield 'carriage return' => ["line1\rline2"];
+        yield 'null byte' => ["a\0b"];
+    }
+
+    public function testGenerateSecretProducesDistinctLowercaseHex(): void
+    {
+        $a = EnvironmentWriter::generateSecret();
+        $b = EnvironmentWriter::generateSecret();
+
+        self::assertSame(64, strlen($a), '32 bytes -> 64 hex chars');
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $a);
+        self::assertNotSame($a, $b);
+        self::assertSame(16, strlen(EnvironmentWriter::generateSecret(8)));
+    }
+
+    public function testGenerateSecretRejectsNonPositiveByteCount(): void
+    {
+        $this->expectException(RuntimeException::class);
+        EnvironmentWriter::generateSecret(0);
+    }
+
+    private function tempPath(): string
+    {
+        $path = sys_get_temp_dir() . '/nene2-env-' . bin2hex(random_bytes(6)) . '.env';
+        $this->cleanup[] = $path;
+
+        return $path;
+    }
+}

--- a/tests/Install/ReInstallationGuardTest.php
+++ b/tests/Install/ReInstallationGuardTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\ProvisioningProbe;
+use Nene2\Install\ReInstallationGuard;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ReInstallationGuardTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->cleanup = [];
+    }
+
+    public function testNotBlockedWhenNoMarkerAndNoProbe(): void
+    {
+        $guard = new ReInstallationGuard($this->markerPath());
+
+        self::assertNull($guard->blockedReason());
+        self::assertFalse($guard->isBlocked());
+    }
+
+    public function testBlockedByAnExistingMarker(): void
+    {
+        $marker = $this->markerPath();
+        file_put_contents($marker, 'installed');
+
+        $guard = new ReInstallationGuard($marker);
+
+        self::assertSame('marker_present', $guard->blockedReason());
+        self::assertTrue($guard->isBlocked());
+    }
+
+    public function testBlockedByTheProbeWhenTheMarkerIsAbsent(): void
+    {
+        $guard = new ReInstallationGuard($this->markerPath(), $this->fixedProbe(true));
+
+        self::assertSame('database_provisioned', $guard->blockedReason());
+    }
+
+    public function testNotBlockedWhenTheProbeReportsNotProvisioned(): void
+    {
+        $guard = new ReInstallationGuard($this->markerPath(), $this->fixedProbe(false));
+
+        self::assertNull($guard->blockedReason());
+    }
+
+    public function testTheMarkerShortCircuitsTheProbe(): void
+    {
+        $marker = $this->markerPath();
+        file_put_contents($marker, 'installed');
+
+        $probe = new class () implements ProvisioningProbe {
+            public int $calls = 0;
+
+            public function isProvisioned(): bool
+            {
+                $this->calls++;
+
+                return true;
+            }
+        };
+        $guard = new ReInstallationGuard($marker, $probe);
+
+        self::assertSame('marker_present', $guard->blockedReason());
+        self::assertSame(0, $probe->calls, 'the probe must not be consulted once the marker is present');
+    }
+
+    public function testMarkInstalledWritesTheMarkerAndThenBlocks(): void
+    {
+        $marker = $this->markerPath();
+        $guard = new ReInstallationGuard($marker);
+
+        self::assertFalse($guard->isBlocked());
+
+        $guard->markInstalled('2026-07-02T00:00:00Z');
+
+        self::assertFileExists($marker);
+        self::assertSame('2026-07-02T00:00:00Z', file_get_contents($marker));
+        self::assertSame('marker_present', $guard->blockedReason());
+    }
+
+    public function testMarkInstalledThrowsWhenTheDirectoryIsMissing(): void
+    {
+        $guard = new ReInstallationGuard('/no/such/dir/.installed');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('directory does not exist');
+        $guard->markInstalled();
+    }
+
+    private function fixedProbe(bool $provisioned): ProvisioningProbe
+    {
+        return new class ($provisioned) implements ProvisioningProbe {
+            public function __construct(private bool $provisioned)
+            {
+            }
+
+            public function isProvisioned(): bool
+            {
+                return $this->provisioned;
+            }
+        };
+    }
+
+    private function markerPath(): string
+    {
+        $path = sys_get_temp_dir() . '/nene2-marker-' . bin2hex(random_bytes(6)) . '.installed';
+        $this->cleanup[] = $path;
+
+        return $path;
+    }
+}

--- a/tests/Install/ServerRequirementCheckerTest.php
+++ b/tests/Install/ServerRequirementCheckerTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\ServerRequirementChecker;
+use Nene2\Install\ServerRequirements;
+use Nene2\Install\SystemProbe;
+use PHPUnit\Framework\TestCase;
+
+final class ServerRequirementCheckerTest extends TestCase
+{
+    public function testReportsPhpVersionSatisfiedAndTooOld(): void
+    {
+        $ok = (new ServerRequirementChecker($this->probe(phpVersion: '8.4.5')))
+            ->check(new ServerRequirements('8.4.0'));
+        self::assertCount(1, $ok);
+        self::assertSame(ServerRequirementChecker::REQUIREMENT_PHP, $ok[0]->requirement);
+        self::assertTrue($ok[0]->satisfied);
+        self::assertSame(['php_ok'], $ok[0]->reasonCodes);
+
+        $tooOld = (new ServerRequirementChecker($this->probe(phpVersion: '8.3.9')))
+            ->check(new ServerRequirements('8.4.0'));
+        self::assertFalse($tooOld[0]->satisfied);
+        self::assertSame(['php_too_old'], $tooOld[0]->reasonCodes);
+    }
+
+    public function testReportsExtensionsLoadedAndMissingPerExtension(): void
+    {
+        $checks = (new ServerRequirementChecker($this->probe(extensions: ['pdo_mysql'])))
+            ->check(new ServerRequirements('8.0.0', requiredExtensions: ['pdo_mysql', 'gd']));
+
+        // [php, pdo_mysql, gd]
+        self::assertSame('pdo_mysql', $checks[1]->target);
+        self::assertTrue($checks[1]->satisfied);
+        self::assertSame(['extension_loaded'], $checks[1]->reasonCodes);
+
+        self::assertSame('gd', $checks[2]->target);
+        self::assertFalse($checks[2]->satisfied);
+        self::assertSame(['extension_missing'], $checks[2]->reasonCodes);
+    }
+
+    public function testWritablePathThatExistsAndIsWritable(): void
+    {
+        $checks = (new ServerRequirementChecker($this->probe(exists: ['/app/var'], writable: ['/app/var'])))
+            ->check(new ServerRequirements('8.0.0', writablePaths: ['/app/var']));
+
+        self::assertTrue($checks[1]->satisfied);
+        self::assertSame(['writable'], $checks[1]->reasonCodes);
+    }
+
+    public function testWritablePathThatExistsButIsNotWritable(): void
+    {
+        $checks = (new ServerRequirementChecker($this->probe(exists: ['/app/var'])))
+            ->check(new ServerRequirements('8.0.0', writablePaths: ['/app/var']));
+
+        self::assertFalse($checks[1]->satisfied);
+        self::assertSame(['not_writable'], $checks[1]->reasonCodes);
+    }
+
+    public function testMissingPathIsCreatableWhenParentIsWritable(): void
+    {
+        $checks = (new ServerRequirementChecker($this->probe(writable: ['/app'])))
+            ->check(new ServerRequirements('8.0.0', writablePaths: ['/app/var']));
+
+        self::assertTrue($checks[1]->satisfied);
+        self::assertSame(['creatable'], $checks[1]->reasonCodes);
+    }
+
+    public function testMissingPathIsNotWritableWhenParentIsNotWritable(): void
+    {
+        $checks = (new ServerRequirementChecker($this->probe()))
+            ->check(new ServerRequirements('8.0.0', writablePaths: ['/app/var']));
+
+        self::assertFalse($checks[1]->satisfied);
+        self::assertSame(['not_writable'], $checks[1]->reasonCodes);
+    }
+
+    public function testReportsRequiredFilePresentAndMissing(): void
+    {
+        $present = (new ServerRequirementChecker($this->probe(exists: ['/app/vendor/autoload.php'])))
+            ->check(new ServerRequirements('8.0.0', requiredFiles: ['/app/vendor/autoload.php']));
+        self::assertTrue($present[1]->satisfied);
+        self::assertSame(['present'], $present[1]->reasonCodes);
+
+        $missing = (new ServerRequirementChecker($this->probe()))
+            ->check(new ServerRequirements('8.0.0', requiredFiles: ['/app/vendor/autoload.php']));
+        self::assertFalse($missing[1]->satisfied);
+        self::assertSame(['missing'], $missing[1]->reasonCodes);
+    }
+
+    public function testAllSatisfiedAndUnmetHelpers(): void
+    {
+        $checks = (new ServerRequirementChecker($this->probe(phpVersion: '8.4.0', extensions: ['json'])))
+            ->check(new ServerRequirements('8.4.0', requiredExtensions: ['json', 'imagick']));
+
+        self::assertFalse(ServerRequirementChecker::allSatisfied($checks));
+
+        $unmet = ServerRequirementChecker::unmet($checks);
+        self::assertCount(1, $unmet);
+        self::assertSame('imagick', $unmet[0]->target);
+
+        $allOk = (new ServerRequirementChecker($this->probe(phpVersion: '8.4.0', extensions: ['json'])))
+            ->check(new ServerRequirements('8.4.0', requiredExtensions: ['json']));
+        self::assertTrue(ServerRequirementChecker::allSatisfied($allOk));
+        self::assertSame([], ServerRequirementChecker::unmet($allOk));
+    }
+
+    public function testDefaultProbeReadsTheLiveRuntime(): void
+    {
+        $checks = (new ServerRequirementChecker())->check(new ServerRequirements(
+            minPhpVersion: '5.6.0',
+            requiredExtensions: ['json', 'nene_missing_extension_xyz'],
+            writablePaths: [sys_get_temp_dir()],
+            requiredFiles: [__FILE__],
+        ));
+
+        self::assertTrue($checks[0]->satisfied, 'live PHP is newer than 5.6');
+        self::assertTrue($checks[1]->satisfied, 'json is always loaded');
+        self::assertFalse($checks[2]->satisfied, 'the fake extension is missing');
+        self::assertTrue($checks[3]->satisfied, 'the temp dir is writable');
+        self::assertTrue($checks[4]->satisfied, 'this test file exists');
+    }
+
+    /**
+     * @param list<string> $extensions Loaded extensions.
+     * @param list<string> $writable   Writable paths.
+     * @param list<string> $exists     Existing paths.
+     */
+    private function probe(
+        string $phpVersion = '8.4.0',
+        array $extensions = [],
+        array $writable = [],
+        array $exists = [],
+    ): SystemProbe {
+        return new class ($phpVersion, $extensions, $writable, $exists) implements SystemProbe {
+            /**
+             * @param list<string> $extensions
+             * @param list<string> $writable
+             * @param list<string> $exists
+             */
+            public function __construct(
+                private string $phpVersion,
+                private array $extensions,
+                private array $writable,
+                private array $exists,
+            ) {
+            }
+
+            public function phpVersion(): string
+            {
+                return $this->phpVersion;
+            }
+
+            public function extensionLoaded(string $extension): bool
+            {
+                return in_array($extension, $this->extensions, true);
+            }
+
+            public function isWritable(string $path): bool
+            {
+                return in_array($path, $this->writable, true);
+            }
+
+            public function exists(string $path): bool
+            {
+                return in_array($path, $this->exists, true);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 目的

共有ホスティング向け opt-in インストーラ toolkit（`Nene2\Install`）の **S1 残りスライス**。payload セキュリティ核（#1464 / PR #1465）に続き、invoice `public_html/install.php` にインラインだった **preflight／プロビジョニングの基本部品**を、generic・opt-in・単体テスト可能な形で NENE2 へ抽出する。設計: `_work/discussion-log/2026-07-02.md` 議題2。

toolkit は machine-readable な typed verdict（reason code）を返し、表示文言・ブランドは各製品の installer template が所有する（framework core に製品前提を焼かない）。

## 変更点

- `src/Install/ServerRequirementChecker.php`（＋ `ServerRequirements` / `RequirementCheck` / `SystemProbe` / `LiveSystemProbe`）— PHP バージョン／必須拡張／書込権限／必須ファイルを判定し typed な結果を返す。**純粋・診断のみ**（FS を変更しない。不在パスは親が書込可なら `creatable`）。ランタイム事実は `SystemProbe` に分離＝完全に単体テスト可能。要件セットは製品が渡す＝generic。
- `src/Install/EnvironmentWriter.php` — `.env` を**原子的に**書き出す（同一 dir に tmp → `chmod 0640` → rename）。値は **vlucas/phpdotenv v5 文法へ安全にシリアライズ**（安全文字は bare／それ以外は二重引用符で `\ " $` を escape）＝クォート・空白・`#`・`$` を含むパスワードも round-trip する。改行・NUL は拒否（`.env` 行注入対策）。JWT secret 生成ヘルパ付き。
- `src/Install/ReInstallationGuard.php`（＋ `ProvisioningProbe`）— `.installed` marker ＋ DB probe による**多層の再インストール阻止**（ephemeral な var/ で marker が消えても DB に既存があれば拒否）。marker を先に見て短絡＝probe は marker 不在時のみ consult。marker 書込も原子的。
- `tests/Install/*` — 46 tests。要件各分岐／phpdotenv round-trip（実パーサ `Dotenv::parse` を oracle に awkward 値検証）／再インストール阻止・短絡・marker 書込。

**追加のみ・invoice/既存不変**（回帰ゼロ）。

## 検証

- `composer check` 全 green: PHPUnit **589 tests** / PHPStan L8 no errors / php-cs-fixer clean / OpenAPI valid / MCP valid / version 1.5.333。

## チェックリスト

- 名称: 引継ぎ検証（フル composer check）
- [x] Issue-driven（#1466）
- [x] 追加のみ・invoice/既存不変
- [x] generic + opt-in（製品固有前提・UI 文言なし）

## 後続スライス（別Issue/PR）

- B. `DatabaseSchemaApplier`（phinx programmatic）/ `TenantConfigurationValidator`
- C. `ReleaseSource` interface（GitHub 今／Origin 後）/ `InstallerTemplate`＋既定ウィザード UI
- → invoice を最初の consumer に refactor（S2）→ records に薄い install.php＋Records config（S3）

Closes #1466

🤖 Generated with [Claude Code](https://claude.com/claude-code)
