### PR TITLE
feat(install): インストーラ toolkit — TenantConfigurationValidator を追加する (#1468)

### DIFF
--- a/src/Install/TenantConfiguration.php
+++ b/src/Install/TenantConfiguration.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * A validated, normalised tenant resolution configuration produced by
+ * {@see TenantConfigurationValidator}.
+ *
+ * `$mode` is one of the product's allowed resolution modes (e.g. `single`, `path`,
+ * `subdomain`, `custom_domain`); the installer writes this verbatim to wherever the
+ * product reads it (invoice reads `.env`'s `TENANT_RESOLUTION`). `$baseDomain` is set
+ * only for modes that need one and is `''` otherwise.
+ */
+final readonly class TenantConfiguration
+{
+    public function __construct(
+        public string $mode,
+        public string $baseDomain,
+    ) {
+    }
+}

--- a/src/Install/TenantConfigurationResult.php
+++ b/src/Install/TenantConfigurationResult.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * The outcome of validating a proposed tenant configuration.
+ *
+ * Modelled as a result (not an exception) because invalid input is a normal part of
+ * an install wizard's flow — the installer re-prompts. On success `$configuration`
+ * holds the normalised values; on failure `$errors` carries machine-readable reason
+ * codes the product's template maps to user-facing messages.
+ */
+final readonly class TenantConfigurationResult
+{
+    /**
+     * @param list<string> $errors Reason codes, e.g. `['unknown_mode']`, `['base_domain_required']`,
+     *                             `['base_domain_invalid']`. Empty when valid.
+     */
+    public function __construct(
+        public bool $valid,
+        public ?TenantConfiguration $configuration,
+        public array $errors,
+    ) {
+    }
+
+    public static function ok(TenantConfiguration $configuration): self
+    {
+        return new self(true, $configuration, []);
+    }
+
+    /**
+     * @param list<string> $errors
+     */
+    public static function invalid(array $errors): self
+    {
+        return new self(false, null, $errors);
+    }
+}

--- a/src/Install/TenantConfigurationValidator.php
+++ b/src/Install/TenantConfigurationValidator.php
@@ -11,9 +11,12 @@ namespace Nene2\Install;
  * Generic by construction: the set of allowed modes — and which of them need a base
  * domain — is supplied by the caller, so the toolkit bakes in no product vocabulary.
  * This is deliberate: the value written here must match the value the product later
- * reads (invoice reads `.env`'s `TENANT_RESOLUTION`), so letting the product declare
- * its own modes keeps installer and runtime in lock-step. {@see standard()} offers the
- * common NeNe set for convenience.
+ * reads, so letting the product declare its own modes keeps installer and runtime in
+ * lock-step. There is intentionally no shared default set, because the vocabularies are
+ * NOT interchangeable — invoice accepts `single/path/subdomain/custom_domain` (from
+ * `.env`'s `TENANT_RESOLUTION`), whereas records accepts only `single/subdomain/path`
+ * (custom domains are folded into `subdomain`). A product template declares its exact
+ * runtime vocabulary in a line or two.
  *
  * A mode that needs a base domain (typically `subdomain`) requires a non-empty domain
  * matching `^[A-Za-z0-9.-]+$`; any other mode has its base domain normalised to `''`.
@@ -32,18 +35,6 @@ final readonly class TenantConfigurationValidator
         private array $allowedModes,
         private array $modesRequiringBaseDomain = [],
     ) {
-    }
-
-    /**
-     * The common NeNe resolution vocabulary: `single` / `path` / `subdomain` / `custom_domain`,
-     * where only `subdomain` needs a base domain.
-     */
-    public static function standard(): self
-    {
-        return new self(
-            ['single', 'path', 'subdomain', 'custom_domain'],
-            ['subdomain'],
-        );
     }
 
     /**

--- a/src/Install/TenantConfigurationValidator.php
+++ b/src/Install/TenantConfigurationValidator.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * Validates and normalises the tenant resolution mode an installer collected before it
+ * is written to the product's configuration.
+ *
+ * Generic by construction: the set of allowed modes — and which of them need a base
+ * domain — is supplied by the caller, so the toolkit bakes in no product vocabulary.
+ * This is deliberate: the value written here must match the value the product later
+ * reads (invoice reads `.env`'s `TENANT_RESOLUTION`), so letting the product declare
+ * its own modes keeps installer and runtime in lock-step. {@see standard()} offers the
+ * common NeNe set for convenience.
+ *
+ * A mode that needs a base domain (typically `subdomain`) requires a non-empty domain
+ * matching `^[A-Za-z0-9.-]+$`; any other mode has its base domain normalised to `''`.
+ * Part of the opt-in installer toolkit.
+ */
+final readonly class TenantConfigurationValidator
+{
+    private const BASE_DOMAIN_PATTERN = '/^[A-Za-z0-9.-]+$/';
+
+    /**
+     * @param list<string> $allowedModes             Modes the product accepts, e.g.
+     *                                                `['single', 'path', 'subdomain', 'custom_domain']`.
+     * @param list<string> $modesRequiringBaseDomain Subset of `$allowedModes` that need a base domain.
+     */
+    public function __construct(
+        private array $allowedModes,
+        private array $modesRequiringBaseDomain = [],
+    ) {
+    }
+
+    /**
+     * The common NeNe resolution vocabulary: `single` / `path` / `subdomain` / `custom_domain`,
+     * where only `subdomain` needs a base domain.
+     */
+    public static function standard(): self
+    {
+        return new self(
+            ['single', 'path', 'subdomain', 'custom_domain'],
+            ['subdomain'],
+        );
+    }
+
+    /**
+     * Validate a proposed mode and (optional) base domain, returning a normalised result.
+     */
+    public function validate(string $mode, ?string $baseDomain = null): TenantConfigurationResult
+    {
+        if (!in_array($mode, $this->allowedModes, true)) {
+            return TenantConfigurationResult::invalid(['unknown_mode']);
+        }
+
+        $trimmed = trim($baseDomain ?? '');
+
+        if (!in_array($mode, $this->modesRequiringBaseDomain, true)) {
+            // Base domain is meaningless for this mode — normalise it away.
+            return TenantConfigurationResult::ok(new TenantConfiguration($mode, ''));
+        }
+
+        if ($trimmed === '') {
+            return TenantConfigurationResult::invalid(['base_domain_required']);
+        }
+
+        if (preg_match(self::BASE_DOMAIN_PATTERN, $trimmed) !== 1) {
+            return TenantConfigurationResult::invalid(['base_domain_invalid']);
+        }
+
+        return TenantConfigurationResult::ok(new TenantConfiguration($mode, $trimmed));
+    }
+}

--- a/tests/Install/TenantConfigurationValidatorTest.php
+++ b/tests/Install/TenantConfigurationValidatorTest.php
@@ -12,7 +12,7 @@ final class TenantConfigurationValidatorTest extends TestCase
 {
     public function testSingleModeNormalisesBaseDomainAway(): void
     {
-        $result = TenantConfigurationValidator::standard()->validate('single');
+        $result = $this->invoiceValidator()->validate('single');
 
         self::assertTrue($result->valid);
         self::assertNotNull($result->configuration);
@@ -25,7 +25,7 @@ final class TenantConfigurationValidatorTest extends TestCase
     public function testModesThatDoNotNeedABaseDomainDiscardIt(string $mode): void
     {
         // Even if a base domain is supplied, a mode that does not need one drops it.
-        $result = TenantConfigurationValidator::standard()->validate($mode, 'example.com');
+        $result = $this->invoiceValidator()->validate($mode, 'example.com');
 
         self::assertTrue($result->valid);
         self::assertNotNull($result->configuration);
@@ -45,7 +45,7 @@ final class TenantConfigurationValidatorTest extends TestCase
 
     public function testSubdomainWithAValidBaseDomainIsAcceptedAndTrimmed(): void
     {
-        $result = TenantConfigurationValidator::standard()->validate('subdomain', '  records.example.com  ');
+        $result = $this->invoiceValidator()->validate('subdomain', '  records.example.com  ');
 
         self::assertTrue($result->valid);
         self::assertNotNull($result->configuration);
@@ -56,7 +56,7 @@ final class TenantConfigurationValidatorTest extends TestCase
     #[DataProvider('blankBaseDomains')]
     public function testSubdomainRequiresANonEmptyBaseDomain(?string $baseDomain): void
     {
-        $result = TenantConfigurationValidator::standard()->validate('subdomain', $baseDomain);
+        $result = $this->invoiceValidator()->validate('subdomain', $baseDomain);
 
         self::assertFalse($result->valid);
         self::assertNull($result->configuration);
@@ -76,7 +76,7 @@ final class TenantConfigurationValidatorTest extends TestCase
     #[DataProvider('malformedBaseDomains')]
     public function testSubdomainRejectsAMalformedBaseDomain(string $baseDomain): void
     {
-        $result = TenantConfigurationValidator::standard()->validate('subdomain', $baseDomain);
+        $result = $this->invoiceValidator()->validate('subdomain', $baseDomain);
 
         self::assertFalse($result->valid);
         self::assertSame(['base_domain_invalid'], $result->errors);
@@ -97,10 +97,22 @@ final class TenantConfigurationValidatorTest extends TestCase
 
     public function testUnknownModeIsRejected(): void
     {
-        $result = TenantConfigurationValidator::standard()->validate('galaxy');
+        $result = $this->invoiceValidator()->validate('galaxy');
 
         self::assertFalse($result->valid);
         self::assertSame(['unknown_mode'], $result->errors);
+    }
+
+    /**
+     * The invoice runtime vocabulary. There is no shared default factory — each product
+     * declares its own set — so tests construct the one they exercise explicitly.
+     */
+    private function invoiceValidator(): TenantConfigurationValidator
+    {
+        return new TenantConfigurationValidator(
+            ['single', 'path', 'subdomain', 'custom_domain'],
+            ['subdomain'],
+        );
     }
 
     public function testHonoursAnInjectedModeVocabulary(): void

--- a/tests/Install/TenantConfigurationValidatorTest.php
+++ b/tests/Install/TenantConfigurationValidatorTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\TenantConfigurationValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class TenantConfigurationValidatorTest extends TestCase
+{
+    public function testSingleModeNormalisesBaseDomainAway(): void
+    {
+        $result = TenantConfigurationValidator::standard()->validate('single');
+
+        self::assertTrue($result->valid);
+        self::assertNotNull($result->configuration);
+        self::assertSame('single', $result->configuration->mode);
+        self::assertSame('', $result->configuration->baseDomain);
+        self::assertSame([], $result->errors);
+    }
+
+    #[DataProvider('modesThatIgnoreBaseDomain')]
+    public function testModesThatDoNotNeedABaseDomainDiscardIt(string $mode): void
+    {
+        // Even if a base domain is supplied, a mode that does not need one drops it.
+        $result = TenantConfigurationValidator::standard()->validate($mode, 'example.com');
+
+        self::assertTrue($result->valid);
+        self::assertNotNull($result->configuration);
+        self::assertSame($mode, $result->configuration->mode);
+        self::assertSame('', $result->configuration->baseDomain);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function modesThatIgnoreBaseDomain(): iterable
+    {
+        yield 'single' => ['single'];
+        yield 'path' => ['path'];
+        yield 'custom_domain' => ['custom_domain'];
+    }
+
+    public function testSubdomainWithAValidBaseDomainIsAcceptedAndTrimmed(): void
+    {
+        $result = TenantConfigurationValidator::standard()->validate('subdomain', '  records.example.com  ');
+
+        self::assertTrue($result->valid);
+        self::assertNotNull($result->configuration);
+        self::assertSame('subdomain', $result->configuration->mode);
+        self::assertSame('records.example.com', $result->configuration->baseDomain);
+    }
+
+    #[DataProvider('blankBaseDomains')]
+    public function testSubdomainRequiresANonEmptyBaseDomain(?string $baseDomain): void
+    {
+        $result = TenantConfigurationValidator::standard()->validate('subdomain', $baseDomain);
+
+        self::assertFalse($result->valid);
+        self::assertNull($result->configuration);
+        self::assertSame(['base_domain_required'], $result->errors);
+    }
+
+    /**
+     * @return iterable<string, array{?string}>
+     */
+    public static function blankBaseDomains(): iterable
+    {
+        yield 'null' => [null];
+        yield 'empty' => [''];
+        yield 'whitespace' => ['   '];
+    }
+
+    #[DataProvider('malformedBaseDomains')]
+    public function testSubdomainRejectsAMalformedBaseDomain(string $baseDomain): void
+    {
+        $result = TenantConfigurationValidator::standard()->validate('subdomain', $baseDomain);
+
+        self::assertFalse($result->valid);
+        self::assertSame(['base_domain_invalid'], $result->errors);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function malformedBaseDomains(): iterable
+    {
+        yield 'space' => ['bad domain.com'];
+        yield 'underscore' => ['bad_domain.com'];
+        yield 'quote' => ['x".com'];
+        yield 'dollar' => ['x$.com'];
+        yield 'newline' => ["x.com\nEVIL=1"];
+        yield 'slash' => ['x.com/path'];
+    }
+
+    public function testUnknownModeIsRejected(): void
+    {
+        $result = TenantConfigurationValidator::standard()->validate('galaxy');
+
+        self::assertFalse($result->valid);
+        self::assertSame(['unknown_mode'], $result->errors);
+    }
+
+    public function testHonoursAnInjectedModeVocabulary(): void
+    {
+        $validator = new TenantConfigurationValidator(['a', 'b'], ['b']);
+
+        self::assertTrue($validator->validate('a')->valid);
+        self::assertTrue($validator->validate('b', 'host.example')->valid);
+
+        // 'subdomain' is standard but not in this product's vocabulary.
+        self::assertSame(['unknown_mode'], $validator->validate('subdomain', 'host.example')->errors);
+
+        // 'b' needs a base domain here, unlike the standard set.
+        self::assertSame(['base_domain_required'], $validator->validate('b')->errors);
+    }
+}


### PR DESCRIPTION
## 目的

共有ホスティング向け opt-in インストーラ toolkit（`Nene2\Install`）**後続スライス B の tenant 部分**。S1（payload 核 #1465・preflight & config #1467）マージ済に続く。設計: `_work/discussion-log/2026-07-02.md` 議題2。

## 変更点

- `src/Install/TenantConfigurationValidator.php`（＋ `TenantConfiguration` / `TenantConfigurationResult`）— インストーラが受け取ったテナント解決モードを検証・正規化する。
  - **許可モード集合・base domain を要するモードは呼び出し側が注入**＝toolkit に製品語彙を焼かない。
  - subdomain 等は base domain 必須＋ドメイン形式 `^[A-Za-z0-9.-]+$`、それ以外は base domain を `''` へ正規化。
  - 結果は typed（`valid` / 正規化済 `TenantConfiguration` / reason code `unknown_mode`・`base_domain_required`・`base_domain_invalid`）で返す（wizard 再入力向けに throw しない）。
  - 共通 NeNe 語彙の便宜 factory `standard()`（`single/path/subdomain/custom_domain`・subdomain のみ base 必須）。
- `tests/Install/TenantConfigurationValidatorTest.php` — 16 tests（各モード正規化／subdomain 必須・形式／unknown_mode／注入語彙）。

## 関所（fable リナ 申し送り）への対応

installer が書く値は製品が実際に読む値と**文字列一致**必須。**最初の consumer=invoice は `.env TENANT_RESOLUTION` を読む**（`nene-invoice/src/Http/RuntimeServiceProvider.php:239`・登録値 `single/path/subdomain/custom_domain`）。validator を許可集合注入型にしたので、製品が自身の語彙を渡す＝自動的に一致する。invoice の実ルール（`public_html/install.php:540-564`）とも整合。

## 検証

- `composer check` 全 green: PHPUnit **632 tests** / PHPStan L8 no errors / php-cs-fixer clean / OpenAPI valid / MCP valid / version 1.5.333。

## チェックリスト

- 名称: 引継ぎ検証（フル composer check）
- [x] Issue-driven（#1468）
- [x] 追加のみ・既存不変
- [x] generic + opt-in（製品語彙を注入・UI 文言なし）

## 別Issue（後続）

- B2: `DatabaseSchemaApplier`（phinx Manager API programmatic 起動）
- C: `ReleaseSource` interface / `InstallerTemplate`＋UI → S2(invoice consumer)・S3(records)

Closes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
