### PR TITLE
feat(install): インストーラ toolkit — DatabaseSchemaApplier（phinx programmatic 適用）を追加する (#1470)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
     ]
   },
   "suggest": {
-    "symfony/yaml": "Required to run validate-mcp-tools.php from a consumer project (add to your require-dev)"
+    "symfony/yaml": "Required to run validate-mcp-tools.php from a consumer project (add to your require-dev)",
+    "robmorgan/phinx": "Required by Nene2\\Install\\DatabaseSchemaApplier. A consumer that uses it MUST add phinx to its require (NOT require-dev) — it is here only as a dev dependency, so a --no-dev production build would omit it and installs would fatally fail when applying migrations."
   },
   "config": {
     "sort-packages": true

--- a/src/Install/DatabaseSchemaApplier.php
+++ b/src/Install/DatabaseSchemaApplier.php
@@ -23,6 +23,12 @@ use Throwable;
  *
  * Generic and opt-in: the caller supplies the phinx configuration (its own `phinx.php`),
  * so the toolkit bakes in no product paths, connection details, or environment names.
+ *
+ * ⚠️ Packaging: this class hard-depends on `robmorgan/phinx` (and `symfony/console`),
+ * which NENE2 declares only under `require-dev`. A consumer that uses it MUST add phinx
+ * to its own `require` — NOT `require-dev`. Otherwise a `composer install --no-dev`
+ * production build omits phinx and the installer fatals at migrate time, even though CI
+ * and local dev (which have dev dependencies) stay green.
  */
 final readonly class DatabaseSchemaApplier
 {
@@ -63,8 +69,13 @@ final readonly class DatabaseSchemaApplier
         try {
             $manager->migrate($environment ?? $config->getDefaultEnvironment());
         } catch (Throwable $exception) {
+            // Surface whatever phinx printed before it failed — on shared hosting the
+            // installer screen is often the only place an operator can see it.
+            $captured = trim($output->fetch());
+            $detail = $captured === '' ? '' : ' — phinx output: ' . $captured;
+
             throw new RuntimeException(
-                sprintf('Applying database migrations failed: %s', $exception->getMessage()),
+                sprintf('Applying database migrations failed: %s%s', $exception->getMessage(), $detail),
                 0,
                 $exception,
             );

--- a/src/Install/DatabaseSchemaApplier.php
+++ b/src/Install/DatabaseSchemaApplier.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+use Phinx\Config\Config;
+use Phinx\Config\ConfigInterface;
+use Phinx\Migration\Manager;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Throwable;
+
+/**
+ * Applies a product's database schema during installation by running its pending
+ * phinx migrations — programmatically, via phinx's {@see Manager} API.
+ *
+ * Shared hosting has no CLI, so migrations cannot be run with `phinx migrate`; this
+ * drives the same engine in-process instead. Migrations (not a dumped SQL file) are the
+ * source of truth for the schema, so a fresh install and an in-place upgrade converge
+ * on the same state.
+ *
+ * Generic and opt-in: the caller supplies the phinx configuration (its own `phinx.php`),
+ * so the toolkit bakes in no product paths, connection details, or environment names.
+ */
+final readonly class DatabaseSchemaApplier
+{
+    /**
+     * Apply pending migrations using the phinx config loaded from a PHP config file
+     * (typically the product's `phinx.php`).
+     *
+     * @param string      $phinxConfigPath Absolute path to a phinx PHP config file.
+     * @param string|null $environment     Phinx environment; defaults to the config's default.
+     *
+     * @return string The captured migration output.
+     *
+     * @throws RuntimeException if the config file is missing or the migration fails.
+     */
+    public function applyFromPhpConfig(string $phinxConfigPath, ?string $environment = null): string
+    {
+        if (!is_file($phinxConfigPath)) {
+            throw new RuntimeException(sprintf('The phinx config file does not exist: %s', $phinxConfigPath));
+        }
+
+        return $this->apply(Config::fromPhp($phinxConfigPath), $environment);
+    }
+
+    /**
+     * Apply pending migrations for the given phinx configuration.
+     *
+     * @param string|null $environment Phinx environment; defaults to the config's default.
+     *
+     * @return string The captured migration output.
+     *
+     * @throws RuntimeException if the migration fails (the underlying phinx error is chained).
+     */
+    public function apply(ConfigInterface $config, ?string $environment = null): string
+    {
+        $output = new BufferedOutput();
+        $manager = new Manager($config, new ArrayInput([]), $output);
+
+        try {
+            $manager->migrate($environment ?? $config->getDefaultEnvironment());
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                sprintf('Applying database migrations failed: %s', $exception->getMessage()),
+                0,
+                $exception,
+            );
+        }
+
+        return $output->fetch();
+    }
+}

--- a/tests/Install/DatabaseSchemaApplierTest.php
+++ b/tests/Install/DatabaseSchemaApplierTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\DatabaseSchemaApplier;
+use Phinx\Config\Config;
+use Phinx\Migration\Manager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class DatabaseSchemaApplierTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            self::markTestSkipped('pdo_sqlite is required to exercise the migration runner.');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            $this->removePath($path);
+        }
+
+        $this->cleanup = [];
+    }
+
+    public function testAppliesPendingMigrations(): void
+    {
+        [$migrationsDir, $table] = $this->writeCreateTableMigration();
+        $config = $this->sqliteConfig($migrationsDir, $this->makeDir());
+
+        (new DatabaseSchemaApplier())->apply($config, 'test');
+
+        self::assertTrue($this->hasTable($config, $table), 'the migration created its table');
+        self::assertTrue($this->hasTable($config, 'phinxlog'), 'phinx recorded the migration');
+    }
+
+    public function testApplyingIsIdempotent(): void
+    {
+        [$migrationsDir, $table] = $this->writeCreateTableMigration();
+        $config = $this->sqliteConfig($migrationsDir, $this->makeDir());
+        $applier = new DatabaseSchemaApplier();
+
+        $applier->apply($config, 'test');
+        // A second run has nothing pending and must not error or re-create the table.
+        $applier->apply($config, 'test');
+
+        self::assertTrue($this->hasTable($config, $table));
+    }
+
+    public function testWrapsAMigrationFailure(): void
+    {
+        [$migrationsDir] = $this->writeCreateTableMigration();
+        $config = $this->sqliteConfig($migrationsDir, $this->makeDir());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Applying database migrations failed');
+        (new DatabaseSchemaApplier())->apply($config, 'no_such_environment');
+    }
+
+    public function testApplyFromPhpConfigLoadsAndMigrates(): void
+    {
+        [$migrationsDir, $table] = $this->writeCreateTableMigration();
+        $configArray = $this->sqliteConfigArray($migrationsDir, $this->makeDir());
+        $configFile = $this->makeDir() . '/phinx.php';
+        file_put_contents($configFile, "<?php\n\nreturn " . var_export($configArray, true) . ";\n");
+
+        (new DatabaseSchemaApplier())->applyFromPhpConfig($configFile, 'test');
+
+        self::assertTrue($this->hasTable(new Config($configArray), $table));
+    }
+
+    public function testApplyFromPhpConfigRejectsAMissingFile(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('does not exist');
+        (new DatabaseSchemaApplier())->applyFromPhpConfig('/no/such/phinx.php');
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Inspect the migrated database through a fresh phinx manager sharing the config
+     * (a temp-file SQLite, so a second connection sees the committed schema).
+     */
+    private function hasTable(Config $config, string $table): bool
+    {
+        $manager = new Manager($config, new ArrayInput([]), new BufferedOutput());
+
+        return $manager->getEnvironment('test')->getAdapter()->hasTable($table);
+    }
+
+    /**
+     * Write a single valid phinx migration into a fresh temp directory.
+     *
+     * @return array{0: string, 1: string} [migrationsDir, tableName]
+     */
+    private function writeCreateTableMigration(): array
+    {
+        $dir = $this->makeDir();
+        $suffix = $this->randomLetters(8);
+        $table = 'widget_' . $suffix;
+        $class = 'CreateWidget' . ucfirst($suffix);
+
+        $migration = <<<PHP
+        <?php
+
+        declare(strict_types=1);
+
+        use Phinx\\Migration\\AbstractMigration;
+
+        final class {$class} extends AbstractMigration
+        {
+            public function change(): void
+            {
+                \$this->table('{$table}')
+                    ->addColumn('name', 'string', ['null' => false])
+                    ->create();
+            }
+        }
+        PHP;
+
+        file_put_contents($dir . '/20260101000001_create_widget_' . $suffix . '.php', $migration);
+
+        return [$dir, $table];
+    }
+
+    /**
+     * @return array{paths: array{migrations: string}, environments: array<string, mixed>, version_order: string}
+     */
+    private function sqliteConfigArray(string $migrationsDir, string $dbDir): array
+    {
+        return [
+            'paths' => ['migrations' => $migrationsDir],
+            'environments' => [
+                'default_environment' => 'test',
+                'test' => [
+                    'adapter' => 'sqlite',
+                    'name' => $dbDir . '/schema',
+                ],
+            ],
+            'version_order' => 'creation',
+        ];
+    }
+
+    private function sqliteConfig(string $migrationsDir, string $dbDir): Config
+    {
+        return new Config($this->sqliteConfigArray($migrationsDir, $dbDir));
+    }
+
+    private function makeDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/nene2-schema-' . bin2hex(random_bytes(6));
+        self::assertTrue(mkdir($dir, 0777, true));
+        $this->cleanup[] = $dir;
+
+        return $dir;
+    }
+
+    private function randomLetters(int $count): string
+    {
+        $bytes = random_bytes(max(1, $count));
+        $letters = '';
+
+        for ($i = 0; $i < $count; $i++) {
+            $letters .= chr(97 + (ord($bytes[$i]) % 26));
+        }
+
+        return $letters;
+    }
+
+    private function removePath(string $path): void
+    {
+        if (is_dir($path)) {
+            $items = scandir($path);
+
+            if ($items !== false) {
+                foreach ($items as $item) {
+                    if ($item !== '.' && $item !== '..') {
+                        $this->removePath($path . '/' . $item);
+                    }
+                }
+            }
+
+            @rmdir($path);
+
+            return;
+        }
+
+        if (is_file($path)) {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## 目的

共有ホスティング向け opt-in インストーラ toolkit（`Nene2\Install`）**後続スライス B の DB スキーマ適用**。S1（#1465/#1467）＋B1 tenant（#1469 merged）に続く。設計: `_work/discussion-log/2026-07-02.md` 議題2。

## 変更点

- `src/Install/DatabaseSchemaApplier.php` — Web インストーラから **phinx マイグレーションを programmatic に適用**する。
  - 共有ホスティングは CLI 不可のため phinx を **Manager API 経由**で in-process 起動（`new Manager($config, new ArrayInput([]), new BufferedOutput())` → `migrate($env ?? $config->getDefaultEnvironment())`）。phinx 例外は `RuntimeException` に chain-wrap。
  - `apply(ConfigInterface $config, ?string $environment)` ／ `applyFromPhpConfig(string $phinxConfigPath, ?string $environment)`（製品の `phinx.php` を `Config::fromPhp`）。
  - phinx 設定は**呼び出し側が渡す**＝toolkit に製品前提を焼かない。migration が schema の正（生 SQL dump 実行は不採用）。
- `tests/Install/DatabaseSchemaApplierTest.php` — 5 tests。fixture migration を**実行時に temp dir へ生成**し、**一時ファイル SQLite** に適用→同一 config の別 Manager から `getEnvironment()->getAdapter()->hasTable()` で検証（適用／idempotency／不正 environment の wrap／`fromPhp`／欠損 config）。実 migration・committed fixture class を使わず adapter 差異と autoload/phpstan 汚染を回避（class 名は毎回ユニーク）。

## 関所（fable リナ 申し送り）への対応
- phinx は **Manager API 経由**（CLI 前提を持ち込まない）＝申し送りどおり。
- schema dump は SQLite 構文ゆえ migration が正、を踏襲。

## 検証
- `composer check` 全 green: PHPUnit **637 tests** / PHPStan L8 no errors / php-cs-fixer clean / OpenAPI valid / MCP valid / version 1.5.333。

## チェックリスト
- 名称: 引継ぎ検証（フル composer check）
- [x] Issue-driven（#1470）
- [x] 追加のみ・既存不変
- [x] generic + opt-in（phinx 設定を注入）

## 後続（C）
- `ReleaseSource` interface（GitHub 今／Origin 後・origin `targets.schema.json` とフィールド名一致）
- `InstallerTemplate`＋既定ウィザード UI → S2(invoice consumer)・S3(records)

Closes #1470

🤖 Generated with [Claude Code](https://claude.com/claude-code)
