### PR TITLE
feat(install): インストーラ toolkit — release manifest 契約（ReleaseDescriptor / ReleaseManifestParser）を追加する (#1472)

### DIFF
--- a/src/Install/ReleaseDescriptor.php
+++ b/src/Install/ReleaseDescriptor.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * A validated release version manifest — the payload of NeNe Origin's profiled-TUF
+ * "targets" object, parsed by {@see ReleaseManifestParser}.
+ *
+ * The property names are camelCase, but they map one-to-one onto the manifest's
+ * snake_case keys (`artifact_url`, `artifact_sha256`, `min_php`, `min_supported_version`,
+ * `requires`); the toolkit never invents its own key names, so the same descriptor is
+ * produced whether the JSON came from GitHub today or Origin later. `minPhp` and
+ * `minSupportedVersion` are exposed so an installer can gate with
+ * {@see ServerRequirementChecker} BEFORE downloading a large artifact.
+ */
+final readonly class ReleaseDescriptor
+{
+    /**
+     * @param string               $releasedAt         `latest.released_at` (RFC 3339 date-time).
+     * @param string               $artifactUrl        `latest.artifact_url`.
+     * @param string               $artifactSha256     `latest.artifact_sha256` (64 lowercase hex).
+     * @param string               $minSupportedVersion Security floor; below it a client must upgrade.
+     * @param list<string>         $channels           Advertised channels (`stable` / `beta` / `dev`).
+     * @param string|null          $changelogUrl       `latest.changelog_url`, if present.
+     * @param string|null          $minPhp             `latest.min_php` (e.g. `"8.2"`), if present.
+     * @param array<string, string> $requires          `latest.requires`: sibling product slug => version range.
+     */
+    public function __construct(
+        public int $specVersion,
+        public int $schemaVersion,
+        public string $product,
+        public string $channel,
+        public string $version,
+        public string $releasedAt,
+        public string $artifactUrl,
+        public string $artifactSha256,
+        public string $minSupportedVersion,
+        public array $channels,
+        public ?string $changelogUrl,
+        public ?string $minPhp,
+        public array $requires,
+    ) {
+    }
+}

--- a/src/Install/ReleaseManifestParser.php
+++ b/src/Install/ReleaseManifestParser.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+use JsonException;
+
+/**
+ * Parses and validates a release version manifest (NeNe Origin's profiled-TUF "targets"
+ * object) into a {@see ReleaseDescriptor}.
+ *
+ * The field names and constraints mirror `origin/docs/spec/targets.schema.json` exactly —
+ * snake_case keys, the `stable|beta|dev` channel enum, the semver and 64-hex-sha256
+ * patterns — so a manifest served from GitHub today and from Origin later parse
+ * identically. Unknown schema majors are rejected outright (the spec mandates "clients
+ * reject unknown majors"). Unknown *additional* keys within a known major are tolerated,
+ * so a future additive change does not break older installers.
+ *
+ * Pure and I/O-free: it neither fetches nor trusts the network. Transport, TLS policy and
+ * download live in a {@see ReleaseSource}; signature/hash verification and extraction stay
+ * in {@see PayloadInstaller}. Part of the opt-in installer toolkit.
+ */
+final readonly class ReleaseManifestParser
+{
+    /** The manifest schema major this client understands; any other major is rejected. */
+    public const SUPPORTED_SCHEMA_VERSION = 1;
+
+    /** @var list<string> */
+    private const CHANNELS = ['stable', 'beta', 'dev'];
+
+    private const SEMVER_PATTERN = '/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/';
+    private const SHA256_PATTERN = '/^[a-f0-9]{64}$/';
+    private const PRODUCT_PATTERN = '/^[a-z][a-z0-9-]*$/';
+    private const MIN_PHP_PATTERN = '/^[0-9]+\.[0-9]+$/';
+
+    public function parse(string $json): ReleaseManifestResult
+    {
+        try {
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ReleaseManifestResult::invalid(['invalid_json']);
+        }
+
+        // A JSON object decodes to a non-list array; a list or empty array is not a manifest.
+        if (!is_array($decoded) || array_is_list($decoded)) {
+            return ReleaseManifestResult::invalid(['not_an_object']);
+        }
+
+        return $this->validate($decoded);
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    private function validate(array $data): ReleaseManifestResult
+    {
+        // Reject unknown schema majors before trusting any other field.
+        $schemaVersion = $data['schema_version'] ?? null;
+
+        if (!is_int($schemaVersion)) {
+            return ReleaseManifestResult::invalid(['schema_version_missing']);
+        }
+
+        if ($schemaVersion !== self::SUPPORTED_SCHEMA_VERSION) {
+            return ReleaseManifestResult::invalid(['schema_version_unsupported']);
+        }
+
+        /** @var list<string> $errors */
+        $errors = [];
+
+        $specVersion = $data['spec_version'] ?? null;
+
+        if ($specVersion === null) {
+            $errors[] = 'spec_version_missing';
+            $specVersion = 0;
+        } elseif (!is_int($specVersion) || $specVersion < 1) {
+            $errors[] = 'spec_version_invalid';
+            $specVersion = 0;
+        }
+
+        $product = $this->stringField($data, 'product', 'product', $errors);
+
+        if ($product !== null && preg_match(self::PRODUCT_PATTERN, $product) !== 1) {
+            $errors[] = 'product_invalid';
+        }
+
+        $channel = $this->stringField($data, 'channel', 'channel', $errors);
+
+        if ($channel !== null && !in_array($channel, self::CHANNELS, true)) {
+            $errors[] = 'channel_invalid';
+        }
+
+        $minSupported = $this->stringField($data, 'min_supported_version', 'min_supported_version', $errors);
+
+        if ($minSupported !== null && preg_match(self::SEMVER_PATTERN, $minSupported) !== 1) {
+            $errors[] = 'min_supported_version_invalid';
+        }
+
+        $channels = $this->channelsField($data, $errors);
+
+        $latest = $data['latest'] ?? null;
+        $version = null;
+        $releasedAt = null;
+        $artifactUrl = null;
+        $artifactSha256 = null;
+        $changelogUrl = null;
+        $minPhp = null;
+        $requires = [];
+
+        if (!is_array($latest) || array_is_list($latest)) {
+            $errors[] = 'latest_missing';
+        } else {
+            $version = $this->stringField($latest, 'version', 'latest_version', $errors);
+
+            if ($version !== null && preg_match(self::SEMVER_PATTERN, $version) !== 1) {
+                $errors[] = 'latest_version_invalid';
+            }
+
+            $releasedAt = $this->stringField($latest, 'released_at', 'released_at', $errors);
+            $artifactUrl = $this->stringField($latest, 'artifact_url', 'artifact_url', $errors);
+            $artifactSha256 = $this->stringField($latest, 'artifact_sha256', 'artifact_sha256', $errors);
+
+            if ($artifactSha256 !== null && preg_match(self::SHA256_PATTERN, $artifactSha256) !== 1) {
+                $errors[] = 'artifact_sha256_invalid';
+            }
+
+            $changelogUrl = $this->optionalStringField($latest, 'changelog_url', 'changelog_url_invalid', $errors);
+
+            $minPhp = $this->optionalStringField($latest, 'min_php', 'min_php_invalid', $errors);
+
+            if ($minPhp !== null && preg_match(self::MIN_PHP_PATTERN, $minPhp) !== 1) {
+                $errors[] = 'min_php_invalid';
+                $minPhp = null;
+            }
+
+            $requires = $this->requiresField($latest['requires'] ?? null, $errors);
+        }
+
+        if (
+            $errors !== []
+            || $product === null
+            || $channel === null
+            || $minSupported === null
+            || $version === null
+            || $releasedAt === null
+            || $artifactUrl === null
+            || $artifactSha256 === null
+        ) {
+            return ReleaseManifestResult::invalid($errors === [] ? ['not_an_object'] : $errors);
+        }
+
+        return ReleaseManifestResult::ok(new ReleaseDescriptor(
+            specVersion: $specVersion,
+            schemaVersion: $schemaVersion,
+            product: $product,
+            channel: $channel,
+            version: $version,
+            releasedAt: $releasedAt,
+            artifactUrl: $artifactUrl,
+            artifactSha256: $artifactSha256,
+            minSupportedVersion: $minSupported,
+            channels: $channels,
+            changelogUrl: $changelogUrl,
+            minPhp: $minPhp,
+            requires: $requires,
+        ));
+    }
+
+    /**
+     * A required string field: records `<code>_missing` / `<code>_invalid` and returns null on failure.
+     *
+     * @param array<array-key, mixed> $data
+     * @param list<string>            $errors
+     */
+    private function stringField(array $data, string $key, string $code, array &$errors): ?string
+    {
+        $value = $data[$key] ?? null;
+
+        if ($value === null) {
+            $errors[] = $code . '_missing';
+
+            return null;
+        }
+
+        if (!is_string($value) || $value === '') {
+            $errors[] = $code . '_invalid';
+
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * An optional string field: null when absent, records `$invalidCode` when present but not a string.
+     *
+     * @param array<array-key, mixed> $data
+     * @param list<string>            $errors
+     */
+    private function optionalStringField(array $data, string $key, string $invalidCode, array &$errors): ?string
+    {
+        $value = $data[$key] ?? null;
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value) || $value === '') {
+            $errors[] = $invalidCode;
+
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     * @param list<string>            $errors
+     *
+     * @return list<string>
+     */
+    private function channelsField(array $data, array &$errors): array
+    {
+        $value = $data['channels'] ?? null;
+
+        if ($value === null) {
+            $errors[] = 'channels_missing';
+
+            return [];
+        }
+
+        if (!is_array($value) || !array_is_list($value) || $value === []) {
+            $errors[] = 'channels_invalid';
+
+            return [];
+        }
+
+        $channels = [];
+
+        foreach ($value as $item) {
+            if (!is_string($item) || !in_array($item, self::CHANNELS, true)) {
+                $errors[] = 'channels_invalid';
+
+                return [];
+            }
+
+            $channels[] = $item;
+        }
+
+        return $channels;
+    }
+
+    /**
+     * @param list<string> $errors
+     *
+     * @return array<string, string>
+     */
+    private function requiresField(mixed $value, array &$errors): array
+    {
+        if ($value === null || $value === []) {
+            return [];
+        }
+
+        if (!is_array($value) || array_is_list($value)) {
+            $errors[] = 'requires_invalid';
+
+            return [];
+        }
+
+        $requires = [];
+
+        foreach ($value as $key => $range) {
+            if (!is_string($key) || !is_string($range)) {
+                $errors[] = 'requires_invalid';
+
+                return [];
+            }
+
+            $requires[$key] = $range;
+        }
+
+        return $requires;
+    }
+}

--- a/src/Install/ReleaseManifestResult.php
+++ b/src/Install/ReleaseManifestResult.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * The outcome of parsing a release manifest: either a validated {@see ReleaseDescriptor}
+ * or a list of machine-readable reason codes. Modelled as a result (not an exception) so
+ * callers and tests can inspect exactly why a manifest was rejected.
+ */
+final readonly class ReleaseManifestResult
+{
+    /**
+     * @param list<string> $errors Reason codes, e.g. `['schema_version_unsupported']`,
+     *                             `['artifact_sha256_invalid', 'channel_invalid']`. Empty when valid.
+     */
+    public function __construct(
+        public bool $valid,
+        public ?ReleaseDescriptor $descriptor,
+        public array $errors,
+    ) {
+    }
+
+    public static function ok(ReleaseDescriptor $descriptor): self
+    {
+        return new self(true, $descriptor, []);
+    }
+
+    /**
+     * @param list<string> $errors
+     */
+    public static function invalid(array $errors): self
+    {
+        return new self(false, null, $errors);
+    }
+}

--- a/tests/Install/ReleaseManifestParserTest.php
+++ b/tests/Install/ReleaseManifestParserTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\ReleaseManifestParser;
+use Nene2\Install\ReleaseManifestResult;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ReleaseManifestParserTest extends TestCase
+{
+    public function testParsesAValidManifest(): void
+    {
+        $result = $this->parse($this->validManifest());
+
+        self::assertTrue($result->valid, implode(',', $result->errors));
+        self::assertSame([], $result->errors);
+        self::assertNotNull($result->descriptor);
+
+        $descriptor = $result->descriptor;
+        self::assertSame(1, $descriptor->specVersion);
+        self::assertSame(1, $descriptor->schemaVersion);
+        self::assertSame('nene-invoice', $descriptor->product);
+        self::assertSame('stable', $descriptor->channel);
+        self::assertSame('1.4.0', $descriptor->version);
+        self::assertSame('2026-06-19T00:00:00Z', $descriptor->releasedAt);
+        self::assertSame('https://cdn.nene-origin.dev/nene-invoice/nene-invoice-1.4.0.zip', $descriptor->artifactUrl);
+        self::assertSame('3b1f2c9d8e7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c', $descriptor->artifactSha256);
+        self::assertSame('1.2.0', $descriptor->minSupportedVersion);
+        self::assertSame(['stable', 'beta'], $descriptor->channels);
+        self::assertSame('https://cdn.nene-origin.dev/nene-invoice/changelog/1.4.0', $descriptor->changelogUrl);
+        self::assertSame('8.2', $descriptor->minPhp);
+        self::assertSame(['nene-invoice' => '>=1.3.0'], $descriptor->requires);
+    }
+
+    public function testToleratesUnknownAdditionalKeysWithinAKnownMajor(): void
+    {
+        $manifest = $this->validManifest();
+        $manifest['future_top_level'] = 'ignored';
+        $latest = $manifest['latest'];
+        self::assertIsArray($latest);
+        $latest['future_nested'] = 'ignored';
+        $manifest['latest'] = $latest;
+
+        $result = $this->parse($manifest);
+
+        self::assertTrue($result->valid, implode(',', $result->errors));
+    }
+
+    public function testOptionalLatestFieldsMayBeAbsent(): void
+    {
+        $manifest = $this->validManifest();
+        $latest = $manifest['latest'];
+        self::assertIsArray($latest);
+        unset($latest['changelog_url'], $latest['min_php'], $latest['requires']);
+        $manifest['latest'] = $latest;
+
+        $result = $this->parse($manifest);
+
+        self::assertTrue($result->valid, implode(',', $result->errors));
+        self::assertNotNull($result->descriptor);
+        self::assertNull($result->descriptor->changelogUrl);
+        self::assertNull($result->descriptor->minPhp);
+        self::assertSame([], $result->descriptor->requires);
+    }
+
+    #[DataProvider('nonObjectJson')]
+    public function testRejectsNonObjectJson(string $json, string $expected): void
+    {
+        $result = (new ReleaseManifestParser())->parse($json);
+
+        self::assertFalse($result->valid);
+        self::assertSame([$expected], $result->errors);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function nonObjectJson(): iterable
+    {
+        yield 'broken json' => ['{not valid', 'invalid_json'];
+        yield 'json array' => ['[1, 2, 3]', 'not_an_object'];
+        yield 'empty object' => ['{}', 'not_an_object'];
+        yield 'scalar' => ['42', 'not_an_object'];
+    }
+
+    #[DataProvider('unknownSchemaMajors')]
+    public function testRejectsUnknownSchemaMajor(mixed $schemaVersion, string $expected): void
+    {
+        $manifest = $this->validManifest();
+        if ($schemaVersion === '__unset__') {
+            unset($manifest['schema_version']);
+        } else {
+            $manifest['schema_version'] = $schemaVersion;
+        }
+
+        $result = $this->parse($manifest);
+
+        self::assertFalse($result->valid);
+        self::assertSame([$expected], $result->errors);
+    }
+
+    /**
+     * @return iterable<string, array{mixed, string}>
+     */
+    public static function unknownSchemaMajors(): iterable
+    {
+        yield 'future major' => [2, 'schema_version_unsupported'];
+        yield 'zero' => [0, 'schema_version_unsupported'];
+        yield 'missing' => ['__unset__', 'schema_version_missing'];
+        yield 'not an int' => ['1', 'schema_version_missing'];
+    }
+
+    #[DataProvider('missingTopFields')]
+    public function testReportsMissingRequiredTopLevelFields(string $key, string $expected): void
+    {
+        $manifest = $this->validManifest();
+        unset($manifest[$key]);
+
+        $result = $this->parse($manifest);
+
+        self::assertFalse($result->valid);
+        self::assertContains($expected, $result->errors);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function missingTopFields(): iterable
+    {
+        yield 'spec_version' => ['spec_version', 'spec_version_missing'];
+        yield 'product' => ['product', 'product_missing'];
+        yield 'channel' => ['channel', 'channel_missing'];
+        yield 'min_supported_version' => ['min_supported_version', 'min_supported_version_missing'];
+        yield 'channels' => ['channels', 'channels_missing'];
+        yield 'latest' => ['latest', 'latest_missing'];
+    }
+
+    #[DataProvider('missingLatestFields')]
+    public function testReportsMissingRequiredLatestFields(string $key, string $expected): void
+    {
+        $manifest = $this->validManifest();
+        $latest = $manifest['latest'];
+        self::assertIsArray($latest);
+        unset($latest[$key]);
+        $manifest['latest'] = $latest;
+
+        $result = $this->parse($manifest);
+
+        self::assertFalse($result->valid);
+        self::assertContains($expected, $result->errors);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function missingLatestFields(): iterable
+    {
+        yield 'version' => ['version', 'latest_version_missing'];
+        yield 'released_at' => ['released_at', 'released_at_missing'];
+        yield 'artifact_url' => ['artifact_url', 'artifact_url_missing'];
+        yield 'artifact_sha256' => ['artifact_sha256', 'artifact_sha256_missing'];
+    }
+
+    #[DataProvider('malformedTopValues')]
+    public function testRejectsMalformedTopLevelValues(string $key, mixed $value, string $expected): void
+    {
+        $manifest = $this->validManifest();
+        $manifest[$key] = $value;
+
+        $result = $this->parse($manifest);
+
+        self::assertFalse($result->valid);
+        self::assertContains($expected, $result->errors);
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed, string}>
+     */
+    public static function malformedTopValues(): iterable
+    {
+        yield 'product with spaces' => ['product', 'Bad Product', 'product_invalid'];
+        yield 'product uppercase' => ['product', 'NeneInvoice', 'product_invalid'];
+        yield 'unknown channel' => ['channel', 'nightly', 'channel_invalid'];
+        yield 'non-semver floor' => ['min_supported_version', '1.2', 'min_supported_version_invalid'];
+        yield 'channels not a list' => ['channels', ['stable' => true], 'channels_invalid'];
+        yield 'channels with bad entry' => ['channels', ['stable', 'nightly'], 'channels_invalid'];
+        yield 'empty channels' => ['channels', [], 'channels_invalid'];
+    }
+
+    #[DataProvider('malformedLatestValues')]
+    public function testRejectsMalformedLatestValues(string $key, mixed $value, string $expected): void
+    {
+        $manifest = $this->validManifest();
+        $latest = $manifest['latest'];
+        self::assertIsArray($latest);
+        $latest[$key] = $value;
+        $manifest['latest'] = $latest;
+
+        $result = $this->parse($manifest);
+
+        self::assertFalse($result->valid);
+        self::assertContains($expected, $result->errors);
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed, string}>
+     */
+    public static function malformedLatestValues(): iterable
+    {
+        yield 'non-semver version' => ['version', '1.4', 'latest_version_invalid'];
+        yield 'uppercase sha256' => ['artifact_sha256', str_repeat('A', 64), 'artifact_sha256_invalid'];
+        yield 'short sha256' => ['artifact_sha256', 'abc123', 'artifact_sha256_invalid'];
+        yield 'bad min_php' => ['min_php', '8', 'min_php_invalid'];
+        yield 'requires as list' => ['requires', ['a', 'b'], 'requires_invalid'];
+        yield 'requires with non-string value' => ['requires', ['nene-x' => 123], 'requires_invalid'];
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * @param array<string, mixed> $manifest
+     */
+    private function parse(array $manifest): ReleaseManifestResult
+    {
+        $json = json_encode($manifest, JSON_THROW_ON_ERROR);
+
+        return (new ReleaseManifestParser())->parse($json);
+    }
+
+    /**
+     * A valid manifest mirroring origin/docs/spec/examples/targets.example.json.
+     *
+     * @return array<string, mixed>
+     */
+    private function validManifest(): array
+    {
+        return [
+            'spec_version' => 1,
+            'schema_version' => 1,
+            'product' => 'nene-invoice',
+            'channel' => 'stable',
+            'latest' => [
+                'version' => '1.4.0',
+                'released_at' => '2026-06-19T00:00:00Z',
+                'artifact_url' => 'https://cdn.nene-origin.dev/nene-invoice/nene-invoice-1.4.0.zip',
+                'artifact_sha256' => '3b1f2c9d8e7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c',
+                'changelog_url' => 'https://cdn.nene-origin.dev/nene-invoice/changelog/1.4.0',
+                'min_php' => '8.2',
+                'requires' => ['nene-invoice' => '>=1.3.0'],
+            ],
+            'min_supported_version' => '1.2.0',
+            'channels' => ['stable', 'beta'],
+            'provenance' => [
+                'source_commit' => '3b1f2c9d8e7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c',
+                'builder_role_id' => 'origin-release-builder',
+                'built_at' => '2026-06-19T00:00:00Z',
+                'reproducible' => true,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## 目的

共有ホスティング向け opt-in インストーラ toolkit（`Nene2\Install`）**スライス C の wire 契約層（C-1a）**。S1＋B は merged。受入条件は handoff「C 事前関所」、正本 `nene-origin/docs/spec/targets.schema.json`。C-1 のうち最大の関所（**schema とフィールド名逐語一致**）を、純粋・完全テスト可能な形で先に切り出す。

## 変更点

- `src/Install/ReleaseDescriptor.php` — 検証済み版マニフェストの値オブジェクト。**parse キーは snake_case そのまま**（`artifact_url`/`artifact_sha256`/`min_php`/`min_supported_version`/`requires`）＝独自キー名を発明しない。`minPhp`/`minSupportedVersion` を公開＝installer が **download 前に** `ServerRequirementChecker` で gate 可能（受入条件6の descriptor 部）。
- `src/Install/ReleaseManifestParser.php`（＋ `ReleaseManifestResult`）— JSON → 検証 → 結果（valid / descriptor / reason codes）。
  - **`schema_version` の未知 major は reject**（spec 明記「clients reject unknown majors」）。
  - `artifact_sha256`=`^[a-f0-9]{64}$`／`channel`=enum(`stable`/`beta`/`dev`)／semver・`product`・`min_php` 形式／必須欠落は typed reason code。
  - **未知の追加キーは寛容**（同一 major への追加変更に前方互換）。
  - 純粋・I/O 無し。transport/TLS/download は C-1b、hash/署名検証と展開は既存 `PayloadInstaller`（＝検証→展開順序＝ゲート3 を崩さない）。
- `tests/Install/ReleaseManifestParserTest.php` — 34 tests。`targets.example.json` 相当の正常系・追加キー寛容・各必須欠落（top/latest）・未知 schema major reject・不正 sha256/channel/semver/min_php・requires 形式・optional 省略。

## 関所（fable リナ 受入条件）への対応
- **wire 契約＝schema と逐語一致**（受入1）✅／**schema_version 未知 major reject・sha256・channel・必須欠落 typed code**（受入2）✅／**min_php・min_supported_version を descriptor で公開**（受入6 の descriptor 部）✅。
- transport の既定値焼き込み無し（受入4）・https/download（受入5）・両実装同一 descriptor（受入3）は **C-1b** で対応。

## 検証
- `composer check` 全 green: PHPUnit **671 tests** / PHPStan L8 no errors / php-cs-fixer clean / OpenAPI valid / MCP valid / version 1.5.333。

## チェックリスト
- 名称: 引継ぎ検証（フル composer check）
- [x] Issue-driven（#1472）
- [x] 追加のみ・既存不変
- [x] generic + opt-in（純粋・製品前提なし）

## 別Issue（後続）
- C-1b: `ReleaseSource` interface＋`HttpReleaseSource`（https 限定・temp download・base URL/product slug は caller 注入）。
- C-2: `InstallerTemplate`＋無ブランド既定ウィザード UI。

Closes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
