### PR TITLE
feat(install): インストーラ toolkit — ReleaseSource / HttpReleaseSource（取得+temp download）を追加する (#1474)

### DIFF
--- a/src/Install/CurlHttpTransport.php
+++ b/src/Install/CurlHttpTransport.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+use CurlHandle;
+use RuntimeException;
+
+/**
+ * The default {@see HttpTransport}: a cURL client locked down for fetching releases.
+ *
+ * Every request — and every redirect it follows — is confined to https, TLS is verified,
+ * and both a connect and total timeout are enforced. `getString()` caps the in-memory body
+ * so a hostile server cannot exhaust memory; `download()` streams to disk and aborts the
+ * moment the transfer would exceed the caller's ceiling. Errors are reported without
+ * leaking internal details beyond the failing URL.
+ *
+ * Network I/O by nature, so it is exercised through {@see HttpReleaseSource} with a fake
+ * transport rather than in unit tests. Part of the opt-in installer toolkit.
+ */
+final readonly class CurlHttpTransport implements HttpTransport
+{
+    private const MANIFEST_MAX_BYTES = 5 * 1024 * 1024;
+
+    public function __construct()
+    {
+        if (!function_exists('curl_init')) {
+            throw new RuntimeException('The PHP cURL extension is required to download releases.');
+        }
+    }
+
+    public function getString(string $url, int $timeoutSeconds): string
+    {
+        $handle = $this->handle($url, $timeoutSeconds);
+
+        $body = '';
+        $limit = self::MANIFEST_MAX_BYTES;
+
+        curl_setopt($handle, CURLOPT_WRITEFUNCTION, static function (CurlHandle $handle, string $chunk) use (&$body, $limit): int {
+            $body .= $chunk;
+
+            // Returning fewer bytes than received tells cURL to abort the transfer.
+            return strlen($body) > $limit ? 0 : strlen($chunk);
+        });
+
+        $ok = curl_exec($handle);
+        $error = curl_error($handle);
+        curl_close($handle);
+
+        if ($ok === false) {
+            throw new RuntimeException($this->failure('fetch the release manifest', $url, $error));
+        }
+
+        return $body;
+    }
+
+    public function download(string $url, string $destinationPath, int $timeoutSeconds, int $maxBytes): void
+    {
+        $file = @fopen($destinationPath, 'wb');
+
+        if ($file === false) {
+            throw new RuntimeException('Could not open the download destination for writing.');
+        }
+
+        $handle = $this->handle($url, $timeoutSeconds);
+        curl_setopt($handle, CURLOPT_FILE, $file);
+        curl_setopt($handle, CURLOPT_NOPROGRESS, false);
+        curl_setopt($handle, CURLOPT_XFERINFOFUNCTION, static function (CurlHandle $handle, int $dlTotal, int $dlNow) use ($maxBytes): int {
+            // Non-zero aborts: refuse as soon as either the advertised or received size overruns.
+            return ($dlTotal > $maxBytes || $dlNow > $maxBytes) ? 1 : 0;
+        });
+
+        $ok = curl_exec($handle);
+        $error = curl_error($handle);
+        curl_close($handle);
+        fclose($file);
+
+        if ($ok === false) {
+            @unlink($destinationPath);
+
+            throw new RuntimeException($this->failure('download the release', $url, $error));
+        }
+
+        $size = filesize($destinationPath);
+
+        if ($size === false || $size > $maxBytes) {
+            @unlink($destinationPath);
+
+            throw new RuntimeException('The release download exceeded the allowed size.');
+        }
+    }
+
+    private function handle(string $url, int $timeoutSeconds): CurlHandle
+    {
+        $handle = curl_init($url);
+
+        if ($handle === false) {
+            throw new RuntimeException('Could not initialise the HTTP client.');
+        }
+
+        curl_setopt($handle, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($handle, CURLOPT_MAXREDIRS, 5);
+        // Confine the request and any redirect it follows to https only.
+        curl_setopt($handle, CURLOPT_PROTOCOLS_STR, 'https');
+        curl_setopt($handle, CURLOPT_REDIR_PROTOCOLS_STR, 'https');
+        curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, max(1, $timeoutSeconds));
+        curl_setopt($handle, CURLOPT_TIMEOUT, max(1, $timeoutSeconds));
+        curl_setopt($handle, CURLOPT_FAILONERROR, true);
+
+        return $handle;
+    }
+
+    private function failure(string $action, string $url, string $error): string
+    {
+        $suffix = $error === '' ? '' : ' (' . $error . ')';
+
+        return sprintf('Failed to %s from %s%s', $action, $url, $suffix);
+    }
+}

--- a/src/Install/CurlHttpTransport.php
+++ b/src/Install/CurlHttpTransport.php
@@ -82,6 +82,7 @@ final readonly class CurlHttpTransport implements HttpTransport
             throw new RuntimeException($this->failure('download the release', $url, $error));
         }
 
+        clearstatcache(true, $destinationPath);
         $size = filesize($destinationPath);
 
         if ($size === false || $size > $maxBytes) {
@@ -101,9 +102,20 @@ final readonly class CurlHttpTransport implements HttpTransport
 
         curl_setopt($handle, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($handle, CURLOPT_MAXREDIRS, 5);
-        // Confine the request and any redirect it follows to https only.
-        curl_setopt($handle, CURLOPT_PROTOCOLS_STR, 'https');
-        curl_setopt($handle, CURLOPT_REDIR_PROTOCOLS_STR, 'https');
+
+        // Confine the request AND every redirect to https. Use the legacy bitmask, not the
+        // CURLOPT_*_STR variants: those need libcurl 7.85+, and on the older libcurl still
+        // common on shared hosting curl_setopt() would merely return false and silently leave
+        // the protocol restriction off. So we also check the return value and fail closed.
+        $restricted = curl_setopt($handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS)
+            && curl_setopt($handle, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTPS);
+
+        if (!$restricted) {
+            curl_close($handle);
+
+            throw new RuntimeException('Could not restrict the HTTP client to https; refusing to fetch a release.');
+        }
+
         curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, max(1, $timeoutSeconds));

--- a/src/Install/HttpReleaseSource.php
+++ b/src/Install/HttpReleaseSource.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+use RuntimeException;
+
+/**
+ * An {@see ReleaseSource} that reads the manifest and artifact over HTTP(S).
+ *
+ * The manifest lives at `{baseUrl}/{product}/{channel}/latest.json`. The base URL,
+ * product slug and channel are all injected — the toolkit bakes in no default origin or
+ * product (the lesson from dropping `TenantConfigurationValidator::standard()`), so a
+ * product wires its own coordinates.
+ *
+ * Security: both the manifest URL and the artifact URL must be https (the transport also
+ * confines redirects to https) and within a sane length; the fetched manifest must be for
+ * the product and channel that were requested. Download goes straight to a caller-owned
+ * temp path — verification and extraction stay in {@see PayloadInstaller}.
+ */
+final readonly class HttpReleaseSource implements ReleaseSource
+{
+    private const MAX_URL_LENGTH = 2048;
+
+    public function __construct(
+        private HttpTransport $transport,
+        private ReleaseManifestParser $parser,
+        private string $baseUrl,
+        private string $product,
+        private string $channel,
+        private int $timeoutSeconds = 30,
+    ) {
+    }
+
+    public function fetchDescriptor(): ReleaseDescriptor
+    {
+        $url = $this->manifestUrl();
+        $this->assertHttps($url, 'The release manifest URL must be https.');
+
+        $result = $this->parser->parse($this->transport->getString($url, $this->timeoutSeconds));
+
+        if (!$result->valid || $result->descriptor === null) {
+            throw new RuntimeException('The release manifest is invalid: ' . implode(', ', $result->errors));
+        }
+
+        $descriptor = $result->descriptor;
+
+        if ($descriptor->product !== $this->product) {
+            throw new RuntimeException('The release manifest is for a different product than requested.');
+        }
+
+        if ($descriptor->channel !== $this->channel) {
+            throw new RuntimeException('The release manifest is for a different channel than requested.');
+        }
+
+        return $descriptor;
+    }
+
+    public function downloadArtifact(ReleaseDescriptor $descriptor, string $destinationPath, int $maxBytes): void
+    {
+        $this->assertHttps($descriptor->artifactUrl, 'The release artifact URL must be https.');
+
+        $this->transport->download($descriptor->artifactUrl, $destinationPath, $this->timeoutSeconds, $maxBytes);
+    }
+
+    private function manifestUrl(): string
+    {
+        // product and channel are constrained slugs, but encode defensively so a stray value
+        // can never climb out of the path.
+        return rtrim($this->baseUrl, '/')
+            . '/' . rawurlencode($this->product)
+            . '/' . rawurlencode($this->channel)
+            . '/latest.json';
+    }
+
+    private function assertHttps(string $url, string $message): void
+    {
+        if (strlen($url) > self::MAX_URL_LENGTH) {
+            throw new RuntimeException('The release URL is unreasonably long; refusing to fetch it.');
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        if (!is_string($scheme) || strtolower($scheme) !== 'https') {
+            throw new RuntimeException($message);
+        }
+    }
+}

--- a/src/Install/HttpTransport.php
+++ b/src/Install/HttpTransport.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+use RuntimeException;
+
+/**
+ * The minimal HTTP surface a {@see ReleaseSource} needs: fetch a small text resource
+ * (the manifest) and download a binary artifact to disk with a size ceiling.
+ *
+ * Extracting it behind an interface keeps {@see HttpReleaseSource} unit-testable with a
+ * fake, and lets a product swap in its own client. The default {@see CurlHttpTransport}
+ * restricts every request — including redirects — to https. Part of the opt-in installer
+ * toolkit.
+ */
+interface HttpTransport
+{
+    /**
+     * GET a small text resource and return its body.
+     *
+     * @throws RuntimeException on a transport error, a non-2xx status, or a body larger than the
+     *         implementation's in-memory ceiling.
+     */
+    public function getString(string $url, int $timeoutSeconds): string;
+
+    /**
+     * Download a resource to $destinationPath, aborting if it would exceed $maxBytes.
+     * Implementations must not extract or otherwise interpret the bytes.
+     *
+     * @throws RuntimeException on a transport error, a non-2xx status, or when the body exceeds $maxBytes.
+     */
+    public function download(string $url, string $destinationPath, int $timeoutSeconds, int $maxBytes): void;
+}

--- a/src/Install/ReleaseSource.php
+++ b/src/Install/ReleaseSource.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+use RuntimeException;
+
+/**
+ * A pluggable source of product releases: it resolves the current version manifest and
+ * downloads the release artifact to a temporary file.
+ *
+ * Its responsibility ends at download. Integrity (SHA-256), signatures, zip-slip and
+ * extraction remain with {@see PayloadInstaller} so the verify-before-extract order is
+ * never bypassed. Fetching the descriptor first lets an installer gate on
+ * {@see ReleaseDescriptor::$minPhp} / `$minSupportedVersion` with a
+ * {@see ServerRequirementChecker} BEFORE downloading a large artifact.
+ *
+ * A GitHub-backed implementation serves today; an Origin-backed one arrives later. Both
+ * return the same {@see ReleaseDescriptor}, so switching sources is configuration only.
+ */
+interface ReleaseSource
+{
+    /**
+     * Resolve and validate the current release manifest.
+     *
+     * @throws RuntimeException if the manifest cannot be fetched or fails validation.
+     */
+    public function fetchDescriptor(): ReleaseDescriptor;
+
+    /**
+     * Download the release artifact to $destinationPath (a caller-owned temp path).
+     * Performs no verification or extraction.
+     *
+     * @param int $maxBytes Hard ceiling on the download size.
+     *
+     * @throws RuntimeException on an insecure URL, transport failure, or size overrun.
+     */
+    public function downloadArtifact(ReleaseDescriptor $descriptor, string $destinationPath, int $maxBytes): void;
+}

--- a/tests/Install/HttpReleaseSourceTest.php
+++ b/tests/Install/HttpReleaseSourceTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\HttpReleaseSource;
+use Nene2\Install\HttpTransport;
+use Nene2\Install\ReleaseDescriptor;
+use Nene2\Install\ReleaseManifestParser;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class HttpReleaseSourceTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->cleanup = [];
+    }
+
+    public function testFetchDescriptorBuildsTheManifestUrlAndReturnsTheDescriptor(): void
+    {
+        $transport = new class () implements HttpTransport {
+            public string $lastGetUrl = '';
+            public string $body = '';
+
+            public function getString(string $url, int $timeoutSeconds): string
+            {
+                $this->lastGetUrl = $url;
+
+                return $this->body;
+            }
+
+            public function download(string $url, string $destinationPath, int $timeoutSeconds, int $maxBytes): void
+            {
+            }
+        };
+        $transport->body = $this->manifestJson('nene-invoice', 'stable');
+
+        $source = new HttpReleaseSource(
+            $transport,
+            new ReleaseManifestParser(),
+            'https://cdn.example.com/',
+            'nene-invoice',
+            'stable',
+        );
+
+        $descriptor = $source->fetchDescriptor();
+
+        self::assertSame('https://cdn.example.com/nene-invoice/stable/latest.json', $transport->lastGetUrl);
+        self::assertSame('1.4.0', $descriptor->version);
+        self::assertSame('nene-invoice', $descriptor->product);
+    }
+
+    public function testFetchDescriptorRejectsANonHttpsBaseUrl(): void
+    {
+        $source = new HttpReleaseSource(
+            $this->silentTransport(),
+            new ReleaseManifestParser(),
+            'http://cdn.example.com',
+            'nene-invoice',
+            'stable',
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('manifest URL must be https');
+        $source->fetchDescriptor();
+    }
+
+    public function testFetchDescriptorRejectsAnInvalidManifest(): void
+    {
+        $transport = $this->transportReturning('{}');
+        $source = new HttpReleaseSource($transport, new ReleaseManifestParser(), 'https://cdn.example.com', 'nene-invoice', 'stable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('manifest is invalid');
+        $source->fetchDescriptor();
+    }
+
+    public function testFetchDescriptorRejectsAProductMismatch(): void
+    {
+        $transport = $this->transportReturning($this->manifestJson('nene-clear', 'stable'));
+        $source = new HttpReleaseSource($transport, new ReleaseManifestParser(), 'https://cdn.example.com', 'nene-invoice', 'stable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('different product');
+        $source->fetchDescriptor();
+    }
+
+    public function testFetchDescriptorRejectsAChannelMismatch(): void
+    {
+        $transport = $this->transportReturning($this->manifestJson('nene-invoice', 'beta'));
+        $source = new HttpReleaseSource($transport, new ReleaseManifestParser(), 'https://cdn.example.com', 'nene-invoice', 'stable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('different channel');
+        $source->fetchDescriptor();
+    }
+
+    public function testDownloadArtifactRejectsANonHttpsArtifactUrl(): void
+    {
+        $source = new HttpReleaseSource($this->silentTransport(), new ReleaseManifestParser(), 'https://cdn.example.com', 'nene-invoice', 'stable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('artifact URL must be https');
+        $source->downloadArtifact($this->descriptor('http://cdn.example.com/a.zip'), $this->tempPath(), 1000);
+    }
+
+    public function testDownloadArtifactRejectsAnOverlongUrl(): void
+    {
+        $source = new HttpReleaseSource($this->silentTransport(), new ReleaseManifestParser(), 'https://cdn.example.com', 'nene-invoice', 'stable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('unreasonably long');
+        $source->downloadArtifact($this->descriptor('https://cdn.example.com/' . str_repeat('a', 2100)), $this->tempPath(), 1000);
+    }
+
+    public function testDownloadArtifactPassesThroughToTheTransport(): void
+    {
+        $transport = new class () implements HttpTransport {
+            public string $lastDownloadUrl = '';
+            public string $lastDestination = '';
+            public int $lastMaxBytes = 0;
+
+            public function getString(string $url, int $timeoutSeconds): string
+            {
+                return '';
+            }
+
+            public function download(string $url, string $destinationPath, int $timeoutSeconds, int $maxBytes): void
+            {
+                $this->lastDownloadUrl = $url;
+                $this->lastDestination = $destinationPath;
+                $this->lastMaxBytes = $maxBytes;
+                file_put_contents($destinationPath, 'ZIP');
+            }
+        };
+
+        $source = new HttpReleaseSource($transport, new ReleaseManifestParser(), 'https://cdn.example.com', 'nene-invoice', 'stable');
+        $dest = $this->tempPath();
+        $url = 'https://cdn.example.com/nene-invoice/nene-invoice-1.4.0.zip';
+
+        $source->downloadArtifact($this->descriptor($url), $dest, 50_000_000);
+
+        self::assertSame($url, $transport->lastDownloadUrl);
+        self::assertSame($dest, $transport->lastDestination);
+        self::assertSame(50_000_000, $transport->lastMaxBytes);
+        self::assertFileExists($dest);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private function silentTransport(): HttpTransport
+    {
+        return new class () implements HttpTransport {
+            public function getString(string $url, int $timeoutSeconds): string
+            {
+                return '';
+            }
+
+            public function download(string $url, string $destinationPath, int $timeoutSeconds, int $maxBytes): void
+            {
+            }
+        };
+    }
+
+    private function transportReturning(string $body): HttpTransport
+    {
+        return new class ($body) implements HttpTransport {
+            public function __construct(private string $body)
+            {
+            }
+
+            public function getString(string $url, int $timeoutSeconds): string
+            {
+                return $this->body;
+            }
+
+            public function download(string $url, string $destinationPath, int $timeoutSeconds, int $maxBytes): void
+            {
+            }
+        };
+    }
+
+    private function descriptor(string $artifactUrl): ReleaseDescriptor
+    {
+        return new ReleaseDescriptor(
+            specVersion: 1,
+            schemaVersion: 1,
+            product: 'nene-invoice',
+            channel: 'stable',
+            version: '1.4.0',
+            releasedAt: '2026-06-19T00:00:00Z',
+            artifactUrl: $artifactUrl,
+            artifactSha256: str_repeat('a', 64),
+            minSupportedVersion: '1.2.0',
+            channels: ['stable'],
+            changelogUrl: null,
+            minPhp: null,
+            requires: [],
+        );
+    }
+
+    private function manifestJson(string $product, string $channel): string
+    {
+        return json_encode([
+            'spec_version' => 1,
+            'schema_version' => 1,
+            'product' => $product,
+            'channel' => $channel,
+            'latest' => [
+                'version' => '1.4.0',
+                'released_at' => '2026-06-19T00:00:00Z',
+                'artifact_url' => 'https://cdn.example.com/' . $product . '/' . $product . '-1.4.0.zip',
+                'artifact_sha256' => str_repeat('a', 64),
+            ],
+            'min_supported_version' => '1.2.0',
+            'channels' => [$channel],
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    private function tempPath(): string
+    {
+        $path = sys_get_temp_dir() . '/nene2-relsrc-' . bin2hex(random_bytes(6)) . '.zip';
+        $this->cleanup[] = $path;
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## 目的

共有ホスティング向け opt-in インストーラ toolkit（`Nene2\Install`）**スライス C の transport/source 層（C-1b）**。C-1a（`ReleaseDescriptor`/`ReleaseManifestParser` #1473 merged）に続く。受入条件は handoff「C 事前関所」C-1 の 3/4/5/6。

## 変更点

- `src/Install/ReleaseSource.php`（interface）— `fetchDescriptor(): ReleaseDescriptor` ／ `downloadArtifact(ReleaseDescriptor, string $destinationPath, int $maxBytes): void`。責務は取得+DLまで（**検証/展開は `PayloadInstaller`**）。
- `src/Install/HttpTransport.php`（interface）＋ `src/Install/CurlHttpTransport.php`（既定）— https 限定 protocol＋redirect・TLS 検証・connect/total timeout・`getString` は in-memory 上限・`download` は `maxBytes` 超過で abort＋事後 filesize 検査。エラーは URL 以外の内部情報を出さない。network ゆえ単体対象外（`HttpReleaseSource` を fake transport で検証）。
- `src/Install/HttpReleaseSource.php`（`implements ReleaseSource`）— `${baseUrl}/{product}/{channel}/latest.json` を取得→parser→descriptor。**base URL・product・channel は caller 注入**（既定を core に焼かない）。descriptor の product/channel 一致検証。
- `tests/Install/HttpReleaseSourceTest.php` — 8 tests（URL 構築・https reject〈manifest/artifact〉・parser 統合・product/channel 不一致・URL 長 2048 超過・download passthrough）。

## 関所（fable リナ 受入条件）への対応
- **受入3**（両実装同一 descriptor）: source は parser の descriptor を返す＝GitHub/Origin で形は一つ。取得先 `${baseUrl}/{product}/{channel}/latest.json`。
- **受入4**（既定を焼かない）: base URL・product・channel すべて ctor 注入。NENE2 に origin/slug の既定なし。
- **受入5**（セキュリティ）: **manifest/artifact とも https 以外 reject**（`CurlHttpTransport` は redirect 先も https 限定）／URL 長 2048 上限／download は **temp 保存のみ・展開しない**／timeout・maxBytes は caller 指定／エラーに URL 以外の内部情報を出さない。**C-1a レビューで昇格した「artifact_url の https 強制は C-1b が担う」を実装**（`downloadArtifact` 冒頭で `assertHttps`）。
- **受入6**（download 前 gate）: `fetchDescriptor` が先に descriptor(min_php/min_supported_version)を返す＝installer は download 前に `ServerRequirementChecker` で gate 可能。

## 検証
- `composer check` 全 green: PHPUnit **679 tests** / PHPStan L8 no errors / php-cs-fixer clean / OpenAPI valid / MCP valid / version 1.5.333。

## チェックリスト
- 名称: 引継ぎ検証（フル composer check）
- [x] Issue-driven（#1474）
- [x] 追加のみ・既存不変
- [x] generic + opt-in（base URL/product/channel 注入・製品前提なし）

## 別Issue（後続）
- C-2: `InstallerTemplate`＋無ブランド既定ウィザード UI。

Closes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
