### PR TITLE
feat(install): インストーラ toolkit — 提示契約（InstallerMessages / InstallerFlow）を追加する (#1476)

### DIFF
--- a/src/Install/DefaultInstallerMessages.php
+++ b/src/Install/DefaultInstallerMessages.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * The neutral, unbranded {@see InstallerMessages}: plain-English wording for the reason
+ * codes the toolkit itself emits. It names no product, so any installer can use it and a
+ * product can wrap or replace it for translation or branding.
+ *
+ * A default catalogue here is safe (unlike a baked-in tenant vocabulary) because these
+ * codes are produced by shipped toolkit classes — they are universal, not a per-product
+ * assumption. Unknown codes fall back to a generic message so the UI never shows a bare
+ * code or breaks.
+ */
+final readonly class DefaultInstallerMessages implements InstallerMessages
+{
+    /** @var array<string, string> */
+    private const MESSAGES = [
+        // ServerRequirementChecker
+        'php_too_old' => 'The installed PHP version is too old. Switch your hosting to a newer PHP version and retry.',
+        'extension_missing' => 'A required PHP extension is not enabled. Ask your host to enable it, then retry.',
+        'not_writable' => 'A required file or directory is not writable. Adjust its permissions and retry.',
+        // TenantConfigurationValidator
+        'unknown_mode' => 'The selected tenancy mode is not supported by this product.',
+        'base_domain_required' => 'This tenancy mode needs a base domain. Enter one to continue.',
+        'base_domain_invalid' => 'The base domain format is invalid. Use letters, digits, dots and hyphens only.',
+        // ReInstallationGuard
+        'marker_present' => 'This application is already installed. Remove the installer to continue using it.',
+        'database_provisioned' => 'A provisioned database already exists, so installation was refused.',
+    ];
+
+    private const FALLBACK = 'An installation check did not pass. Review the details and try again.';
+
+    public function forReasonCode(string $reasonCode): string
+    {
+        return self::MESSAGES[$reasonCode] ?? self::FALLBACK;
+    }
+}

--- a/src/Install/InstallerFlow.php
+++ b/src/Install/InstallerFlow.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+use RuntimeException;
+
+/**
+ * The ordered sequence of {@see InstallerStep}s a wizard walks through, with the
+ * navigation an orchestrator needs (first/last, next, position "step X of N").
+ *
+ * The steps are supplied by the caller — the toolkit ships no baked-in flow, because the
+ * right steps differ per product (the lesson from dropping a "standard" default
+ * elsewhere). Pure and immutable, so it is trivially testable.
+ */
+final readonly class InstallerFlow
+{
+    /**
+     * @param list<InstallerStep> $steps Non-empty, with unique step ids.
+     *
+     * @throws RuntimeException if the list is empty or contains duplicate ids.
+     */
+    public function __construct(
+        public array $steps,
+    ) {
+        if ($steps === []) {
+            throw new RuntimeException('An installer flow needs at least one step.');
+        }
+
+        $ids = array_map(static fn (InstallerStep $step): string => $step->id, $steps);
+
+        if (count($ids) !== count(array_unique($ids))) {
+            throw new RuntimeException('Installer step ids must be unique.');
+        }
+    }
+
+    public function first(): InstallerStep
+    {
+        return $this->steps[0];
+    }
+
+    public function last(): InstallerStep
+    {
+        return $this->steps[count($this->steps) - 1];
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->indexOf($id) !== null;
+    }
+
+    /**
+     * @throws RuntimeException if no step has that id.
+     */
+    public function step(string $id): InstallerStep
+    {
+        $index = $this->indexOf($id);
+
+        if ($index === null) {
+            throw new RuntimeException(sprintf('Unknown installer step: %s', $id));
+        }
+
+        return $this->steps[$index];
+    }
+
+    /**
+     * The step after $id, or null when $id is the last step (or unknown).
+     */
+    public function next(string $id): ?InstallerStep
+    {
+        $index = $this->indexOf($id);
+
+        if ($index === null) {
+            return null;
+        }
+
+        return $this->steps[$index + 1] ?? null;
+    }
+
+    public function isLast(string $id): bool
+    {
+        $index = $this->indexOf($id);
+
+        return $index !== null && $index === count($this->steps) - 1;
+    }
+
+    /**
+     * 1-based position of the step, for "step X of N" display.
+     *
+     * @throws RuntimeException if no step has that id.
+     */
+    public function position(string $id): int
+    {
+        $index = $this->indexOf($id);
+
+        if ($index === null) {
+            throw new RuntimeException(sprintf('Unknown installer step: %s', $id));
+        }
+
+        return $index + 1;
+    }
+
+    public function count(): int
+    {
+        return count($this->steps);
+    }
+
+    private function indexOf(string $id): ?int
+    {
+        foreach ($this->steps as $index => $step) {
+            if ($step->id === $id) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Install/InstallerMessages.php
+++ b/src/Install/InstallerMessages.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * Turns a toolkit reason code (e.g. `php_too_old`, `base_domain_required`) into a
+ * human-readable message for the installer UI.
+ *
+ * This is the seam that keeps the wizard reason-code-driven: the orchestrator branches
+ * on the machine codes emitted by {@see ServerRequirementChecker},
+ * {@see TenantConfigurationValidator} and {@see ReInstallationGuard}, and asks this for
+ * the wording — never by matching exception message strings. A product swaps in its own
+ * implementation to translate or rebrand. {@see DefaultInstallerMessages} is the neutral,
+ * unbranded default.
+ */
+interface InstallerMessages
+{
+    /**
+     * A display message for the given reason code, or a safe generic fallback for an
+     * unrecognised code (never throws — the UI always has something to show).
+     */
+    public function forReasonCode(string $reasonCode): string;
+}

--- a/src/Install/InstallerStep.php
+++ b/src/Install/InstallerStep.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * One step of an installer wizard: a machine identifier and the names of the inputs it
+ * collects. It carries no wording — the display text comes from {@see InstallerMessages}
+ * so a product owns branding and locale. Ordered into an {@see InstallerFlow}.
+ */
+final readonly class InstallerStep
+{
+    /**
+     * @param string       $id     Machine identifier, e.g. `requirements`, `database`, `administrator`.
+     * @param list<string> $inputs Names of the fields this step collects (empty for display-only steps).
+     */
+    public function __construct(
+        public string $id,
+        public array $inputs = [],
+    ) {
+    }
+}

--- a/tests/Install/DefaultInstallerMessagesTest.php
+++ b/tests/Install/DefaultInstallerMessagesTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\DefaultInstallerMessages;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultInstallerMessagesTest extends TestCase
+{
+    public function testMapsKnownReasonCodesToWording(): void
+    {
+        $messages = new DefaultInstallerMessages();
+
+        self::assertStringContainsString('PHP version', $messages->forReasonCode('php_too_old'));
+        self::assertStringContainsString('base domain', $messages->forReasonCode('base_domain_required'));
+        self::assertStringContainsString('already installed', $messages->forReasonCode('marker_present'));
+    }
+
+    public function testUnknownReasonCodesFallBackToAGenericMessage(): void
+    {
+        $messages = new DefaultInstallerMessages();
+
+        $fallback = $messages->forReasonCode('something_new');
+        self::assertNotSame('', $fallback);
+        self::assertNotSame('something_new', $fallback, 'a raw code must never be shown');
+        // Two different unknown codes get the same generic message.
+        self::assertSame($fallback, $messages->forReasonCode('another_unknown'));
+    }
+
+    #[DataProvider('knownReasonCodes')]
+    public function testEveryKnownMessageIsNonEmptyAndUnbranded(string $code): void
+    {
+        $message = (new DefaultInstallerMessages())->forReasonCode($code);
+
+        self::assertNotSame('', $message);
+        // The default catalogue must name no product; branding belongs to the product template.
+        self::assertSame(false, stripos($message, 'nene'), 'the default messages must be brand-neutral');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function knownReasonCodes(): iterable
+    {
+        yield 'php_too_old' => ['php_too_old'];
+        yield 'extension_missing' => ['extension_missing'];
+        yield 'not_writable' => ['not_writable'];
+        yield 'unknown_mode' => ['unknown_mode'];
+        yield 'base_domain_required' => ['base_domain_required'];
+        yield 'base_domain_invalid' => ['base_domain_invalid'];
+        yield 'marker_present' => ['marker_present'];
+        yield 'database_provisioned' => ['database_provisioned'];
+    }
+}

--- a/tests/Install/InstallerFlowTest.php
+++ b/tests/Install/InstallerFlowTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\InstallerFlow;
+use Nene2\Install\InstallerStep;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class InstallerFlowTest extends TestCase
+{
+    public function testNavigatesAcrossSteps(): void
+    {
+        $flow = $this->flow();
+
+        self::assertSame('requirements', $flow->first()->id);
+        self::assertSame('complete', $flow->last()->id);
+        self::assertSame(3, $flow->count());
+
+        self::assertTrue($flow->has('database'));
+        self::assertFalse($flow->has('nope'));
+
+        self::assertSame('database', $flow->step('database')->id);
+        self::assertSame(['db_name', 'db_user'], $flow->step('database')->inputs);
+
+        self::assertSame('database', $flow->next('requirements')?->id);
+        self::assertSame('complete', $flow->next('database')?->id);
+        self::assertNull($flow->next('complete'), 'the last step has no next');
+        self::assertNull($flow->next('nope'), 'an unknown step has no next');
+
+        self::assertFalse($flow->isLast('requirements'));
+        self::assertTrue($flow->isLast('complete'));
+
+        self::assertSame(1, $flow->position('requirements'));
+        self::assertSame(3, $flow->position('complete'));
+    }
+
+    public function testStepRejectsAnUnknownId(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unknown installer step');
+        $this->flow()->step('nope');
+    }
+
+    public function testPositionRejectsAnUnknownId(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unknown installer step');
+        $this->flow()->position('nope');
+    }
+
+    public function testRejectsAnEmptyFlow(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('at least one step');
+        new InstallerFlow([]);
+    }
+
+    public function testRejectsDuplicateStepIds(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('unique');
+        new InstallerFlow([new InstallerStep('database'), new InstallerStep('database')]);
+    }
+
+    private function flow(): InstallerFlow
+    {
+        return new InstallerFlow([
+            new InstallerStep('requirements'),
+            new InstallerStep('database', ['db_name', 'db_user']),
+            new InstallerStep('complete'),
+        ]);
+    }
+}


### PR DESCRIPTION
## 目的

共有ホスティング向け opt-in インストーラ toolkit（`Nene2\Install`）**スライス C 最終部の提示契約層（C-2a）**。C-1（manifest 契約 #1473・ReleaseSource #1475）merged に続く。受入条件は handoff「C 事前関所」C-2。純粋・完全テスト可能な部分を先に切り出す（HTML 参照レンダラは C-2b）。

## 変更点

- `src/Install/InstallerMessages.php`（interface）＋ `src/Install/DefaultInstallerMessages.php` — **toolkit の reason code → 無ブランド表示文字列**（`php_too_old` / `extension_missing` / `not_writable` / `unknown_mode` / `base_domain_required` / `base_domain_invalid` / `marker_present` / `database_provisioned`）＋未知コードの安全な fallback（生コードを絶対に出さない）。**reason code は toolkit 自身が発行＝普遍**なので default カタログは製品前提ではない（`standard()` の轍を踏まない）。製品はロケール/ブランドで差し替え。→ **受入2（reason code で分岐・例外 message 文字列で分岐しない）**の土台。
- `src/Install/InstallerStep.php`（VO: id＋収集入力名）＋ `src/Install/InstallerFlow.php`（汎用ステップ機械: first/last/next/isLast/position/count・id 重複/空を reject）。**フローの中身は製品が渡す＝baked default なし**。→ **受入1 の「ステップ列」**の機械。

## 設計判断（リナへ）
- **baked default flow は作らない**（`standard()` の教訓）。`InstallerFlow` は製品がステップを渡す汎用機械のみ。reason-code カタログだけは「toolkit が発行するコード＝普遍」ゆえ default を持つ（製品前提ではない）。
- **C-2b で**: 無ブランド参照レンダラ（HTML・全出力 escape＝受入3 XSS）＋ `InstallerTemplate` interface（flow/messages/guard を束ね毎ステップ入口で `ReInstallationGuard` 評価＝受入1 の既定リファレンスUI・受入3 の guard）。CSRF 相当は S2 で invoice 現行と突合。

## 検証
- `composer check` 全 green: PHPUnit **694 tests** / PHPStan L8 no errors / php-cs-fixer clean / OpenAPI valid / MCP valid / version 1.5.333。

## チェックリスト
- 名称: 引継ぎ検証（フル composer check）
- [x] Issue-driven（#1476）
- [x] 追加のみ・既存不変
- [x] generic + opt-in（baked flow なし・製品前提なし）

Closes #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
