### PR TITLE
feat(install): インストーラ toolkit — 無ブランド参照レンダラ / InstallerTemplate を追加する（C 完成）(#1478)

### DIFF
--- a/src/Install/Html.php
+++ b/src/Install/Html.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * The single point through which the reference installer UI escapes output, so nothing an
+ * operator typed (database names, domains, error context) can inject markup or script.
+ * Quotes and invalid byte sequences are handled too. Part of the opt-in installer toolkit.
+ */
+final class Html
+{
+    public static function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}

--- a/src/Install/InstallerRenderer.php
+++ b/src/Install/InstallerRenderer.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * A neutral, unbranded reference renderer for an installer step.
+ *
+ * It carries no product name, logo, host preset or styling — only structural markup with
+ * class hooks — so a product restyles it or replaces it wholesale. Every value it emits is
+ * escaped ({@see Html}). It evaluates the template's {@see ReInstallationGuard} at the entry
+ * of each step and, if installation is blocked, renders the blocked notice instead of the
+ * form.
+ *
+ * Errors are supplied as reason codes and resolved through {@see InstallerMessages} — there
+ * is deliberately no way to hand it a raw string, so an exception message (which may carry a
+ * URL or other internal detail) can never be echoed to the page. Map failures to a reason
+ * code; unknown codes fall back to a safe generic message.
+ *
+ * CSRF for the wizard POST is intentionally out of scope here and is reconciled with the
+ * product's existing installer during its adoption.
+ */
+final readonly class InstallerRenderer
+{
+    /**
+     * @param list<string>          $errorCodes Reason codes to display (never raw messages).
+     * @param array<string, string> $values     Current values for the step's inputs, keyed by input name.
+     */
+    public function render(InstallerTemplate $template, string $stepId, array $errorCodes = [], array $values = []): string
+    {
+        $blockedReason = $template->guard()->blockedReason();
+
+        if ($blockedReason !== null) {
+            return $this->renderBlocked($template->messages(), $blockedReason);
+        }
+
+        $flow = $template->flow();
+        $step = $flow->step($stepId);
+        $messages = $template->messages();
+
+        $html = '<section class="installer-step" data-step="' . Html::escape($step->id) . '">';
+        $html .= '<p class="installer-progress">Step ' . $flow->position($stepId) . ' of ' . $flow->count() . '</p>';
+
+        if ($errorCodes !== []) {
+            $html .= '<ul class="installer-errors">';
+
+            foreach ($errorCodes as $code) {
+                $html .= '<li>' . Html::escape($messages->forReasonCode($code)) . '</li>';
+            }
+
+            $html .= '</ul>';
+        }
+
+        $html .= '<form method="post">';
+
+        foreach ($step->inputs as $input) {
+            $name = Html::escape($input);
+            $value = Html::escape($values[$input] ?? '');
+            $html .= '<label class="installer-field">' . $name
+                . '<input type="text" name="' . $name . '" value="' . $value . '"></label>';
+        }
+
+        $html .= '</form></section>';
+
+        return $html;
+    }
+
+    private function renderBlocked(InstallerMessages $messages, string $reasonCode): string
+    {
+        return '<section class="installer-blocked"><p>'
+            . Html::escape($messages->forReasonCode($reasonCode))
+            . '</p></section>';
+    }
+}

--- a/src/Install/InstallerTemplate.php
+++ b/src/Install/InstallerTemplate.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * The machine contract for an installer: its step {@see InstallerFlow}, the
+ * {@see InstallerMessages} that turn reason codes into wording, and the
+ * {@see ReInstallationGuard} evaluated at the entry of every step.
+ *
+ * A product implements this to declare its own flow and branding; the toolkit ships no
+ * default template because the right steps differ per product (the lesson from not baking
+ * a default vocabulary elsewhere). The neutral {@see InstallerRenderer} consumes a
+ * template to produce unbranded HTML.
+ */
+interface InstallerTemplate
+{
+    public function flow(): InstallerFlow;
+
+    public function messages(): InstallerMessages;
+
+    public function guard(): ReInstallationGuard;
+}

--- a/tests/Install/InstallerRendererTest.php
+++ b/tests/Install/InstallerRendererTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\DefaultInstallerMessages;
+use Nene2\Install\InstallerFlow;
+use Nene2\Install\InstallerMessages;
+use Nene2\Install\InstallerRenderer;
+use Nene2\Install\InstallerStep;
+use Nene2\Install\InstallerTemplate;
+use Nene2\Install\ReInstallationGuard;
+use PHPUnit\Framework\TestCase;
+
+final class InstallerRendererTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->cleanup = [];
+    }
+
+    public function testRendersTheStepWithProgressAndFields(): void
+    {
+        $html = (new InstallerRenderer())->render($this->template($this->openGuard()), 'database');
+
+        self::assertStringContainsString('data-step="database"', $html);
+        self::assertStringContainsString('Step 1 of 2', $html);
+        self::assertStringContainsString('name="db_name"', $html);
+        self::assertStringContainsString('name="db_user"', $html);
+        self::assertStringContainsString('<form method="post">', $html);
+    }
+
+    public function testEscapesInputValues(): void
+    {
+        $html = (new InstallerRenderer())->render(
+            $this->template($this->openGuard()),
+            'database',
+            [],
+            ['db_name' => '"><script>alert(1)</script>'],
+        );
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testRendersErrorCodesThroughTheMessageCatalogue(): void
+    {
+        $html = (new InstallerRenderer())->render(
+            $this->template($this->openGuard()),
+            'database',
+            ['php_too_old'],
+        );
+
+        self::assertStringContainsString('class="installer-errors"', $html);
+        self::assertStringContainsString('PHP version', $html);
+    }
+
+    public function testUnknownErrorCodeFallsBackAndIsNeverEchoedRaw(): void
+    {
+        $html = (new InstallerRenderer())->render(
+            $this->template($this->openGuard()),
+            'database',
+            ['download_failed_http_500_https://secret.internal/x'],
+        );
+
+        // The raw code (which here stands in for leaky internal detail) must not appear.
+        self::assertStringNotContainsString('secret.internal', $html);
+        self::assertStringContainsString('did not pass', $html);
+    }
+
+    public function testABlockedGuardRendersTheNoticeInsteadOfTheForm(): void
+    {
+        $marker = $this->markerPath();
+        file_put_contents($marker, 'installed');
+
+        $html = (new InstallerRenderer())->render($this->template(new ReInstallationGuard($marker)), 'database');
+
+        self::assertStringContainsString('installer-blocked', $html);
+        self::assertStringContainsString('already installed', $html);
+        self::assertStringNotContainsString('<form', $html, 'a blocked installer must not render the form');
+    }
+
+    private function template(ReInstallationGuard $guard): InstallerTemplate
+    {
+        return new class ($guard) implements InstallerTemplate {
+            public function __construct(private ReInstallationGuard $guard)
+            {
+            }
+
+            public function flow(): InstallerFlow
+            {
+                return new InstallerFlow([
+                    new InstallerStep('database', ['db_name', 'db_user']),
+                    new InstallerStep('complete'),
+                ]);
+            }
+
+            public function messages(): InstallerMessages
+            {
+                return new DefaultInstallerMessages();
+            }
+
+            public function guard(): ReInstallationGuard
+            {
+                return $this->guard;
+            }
+        };
+    }
+
+    private function openGuard(): ReInstallationGuard
+    {
+        // A marker path that does not exist -> not blocked.
+        return new ReInstallationGuard($this->markerPath());
+    }
+
+    private function markerPath(): string
+    {
+        $path = sys_get_temp_dir() . '/nene2-render-' . bin2hex(random_bytes(6)) . '.installed';
+        $this->cleanup[] = $path;
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## 目的

共有ホスティング向け opt-in インストーラ toolkit（`Nene2\Install`）**最後のスライス（C-2b・C 完成）**。C-2a（提示契約 #1477 merged）に続き、無ブランド参照レンダラと template 契約を追加。受入条件は handoff「C 事前関所」C-2（1 の既定リファレンスUI・3 の guard/escape）＋C-2a レビューの「例外→表示」申し送り。

## 変更点

- `src/Install/Html.php` — 全出力 escape の単一窓口（`htmlspecialchars(ENT_QUOTES|ENT_SUBSTITUTE, UTF-8)`）。
- `src/Install/InstallerTemplate.php`（interface）— `flow()`/`messages()`/`guard()` を束ねる機械契約。**baked default template なし**（フローは製品固有＝standard() の教訓）。製品が実装。
- `src/Install/InstallerRenderer.php`（無ブランド参照）—
  - **毎ステップ入口で `guard()->blockedReason()` を評価**し、blocked なら参照ブロック画面（reason-code→messages）を返す（受入3 guard）。
  - 未 block なら "Step X of N"・入力フィールド・error を**全 escape**で描画（受入3 XSS）。製品名/ロゴ/host プリセット/CSS を含めない（**受入1 無ブランド**）。
  - **error は reason-code 経由のみ**＝生文字列を受ける error API を持たない＝**例外 message（URL 等内部情報）を raw echo できない構造**（**C-2a 申し送り a への構造的対応**）。未知コードは C-2a fallback で安全文言。
- `tests/Install/InstallerRendererTest.php` — 5 tests（progress/フィールド描画・値 escape・error コード→カタログ・**未知コードは fallback で生コード非表示**〈内部情報漏洩の代理検証〉・**guard blocked でフォーム非表示＋blocked 文言**）。

**注記**: wizard POST の CSRF は本レンダラ対象外、S2 で invoice 現行と突合（受入3・handoff どおり）。

## 検証
- `composer check` 全 green: PHPUnit **699 tests** / PHPStan L8 no errors / php-cs-fixer clean / OpenAPI valid / MCP valid / version 1.5.333。

## チェックリスト
- 名称: 引継ぎ検証（フル composer check）
- [x] Issue-driven（#1478）
- [x] 追加のみ・既存不変
- [x] generic + opt-in（無ブランド・baked flow なし）

## これで toolkit 完成
S1（payload核/preflight&config）＋B（Tenant/SchemaApplier）＋C（manifest契約/ReleaseSource/提示契約/参照レンダラ）。次は **S2: invoice を consumer 化**（phinx 統一・--no-dev migrate 回帰・既存稼働の回帰確認）。

Closes #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
