### PR TITLE
chore(release): v1.6.0 (#1480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.6.0] — 2026-07-04
+
+共有ホスティング向け **opt-in インストーラ toolkit `Nene2\Install`** を追加するマイナーリリース。製品ごとに巨大な install.php を複製せず、危険な核（zip 安全性・SHA-256/署名・.env 原子書込・DB migration・再インストール阻止・リリース取得）をフレームワークに一箇所だけ置き、各製品が再利用する（第1 consumer = NeNe Invoice #562）。すべて opt-in・generic — wire しなければ dormant、製品固有の前提（UI/ブランド/語彙/パス）は core に焼かない。
+
+### Added
+- `Nene2\Install` payload セキュリティ核 — `PayloadInstaller`（検証は必ず展開前・使い捨て staging→原子 swap）/ `ZipEntrySafety`（zip-slip・絶対パス・許可トップレベル検査）/ `PayloadSignatureVerifier`（SHA-256＋署名フック）（#1464）
+- preflight & config — `ServerRequirementChecker`（+`ServerRequirements`/`RequirementCheck`/`SystemProbe`/`LiveSystemProbe`・診断のみ FS 非変更）/ `EnvironmentWriter`（.env 原子書込・phpdotenv 文法エスケープ・`generateSecret()`）/ `ReInstallationGuard`（+`ProvisioningProbe`・marker 短絡＋DB probe の二層）（#1466）
+- `TenantConfigurationValidator`（+`TenantConfiguration`/`TenantConfigurationResult`）— テナント解決モード検証。共有 default なし・語彙と base domain 必須集合は製品が注入し、reason code で返す（#1468）
+- `DatabaseSchemaApplier` — phinx Manager API による programmatic migration 適用（CLI 不可の共有ホスティング向け）。⚠️ 利用する consumer は `robmorgan/phinx` を **`require`**（not require-dev）に置くこと — `--no-dev` 本番 vendor でクラス不在のまま CI/dev だけ緑になる（#1470）
+- release manifest 契約 — `ReleaseDescriptor` / `ReleaseManifestParser`（+`ReleaseManifestResult`）。origin `targets.schema.json` 逐語 parse・unknown schema major は reject（#1472）
+- リリース取得 — `ReleaseSource` / `HttpReleaseSource` / `HttpTransport` / `CurlHttpTransport`（https 限定・artifact の temp download。検証/展開は PayloadInstaller の責務）（#1474）
+- ウィザード提示契約 — `InstallerMessages` / `DefaultInstallerMessages`（無ブランド英文既定・reason code→文言）/ `InstallerStep` / `InstallerFlow`（baked flow なし・製品がステップを渡す）（#1476）
+- 無ブランド参照 UI — `InstallerTemplate` / `InstallerRenderer` / `Html`（毎ステップ guard 評価・全 escape・error は reason-code のみ）（#1478）
+
+---
+
 ## [1.5.333] — 2026-07-02
 
 セキュリティ強化リリース。横断セキュリティ監査（コード5系統＋捨てコンテナ実機 ATK）で検出した全 EXPOSED を是正し、修正後の再テストで 0 EXPOSED を確認・文書化した。加えて再利用可能な TOTP プリミティブを追加。

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.5.333
+  version: 1.6.0
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.5.333';
+    public const string VERSION = '1.6.0';
 
     public function name(): string
     {


### PR DESCRIPTION
Closes #1480

## 概要

共有ホスティング向け opt-in インストーラ toolkit `Nene2\Install`（#1464〜#1478・29 部品・全 merged）を含む **v1.6.0** リリース。第1 consumer = NeNe Invoice S2（invoice #562・関所レビュー全合格済み）。施主 GO 取得済み（2026-07-04）。

## 変更

- `FrameworkInfo::VERSION` / `docs/openapi/openapi.yaml` info.version / CHANGELOG → 1.6.0
- CHANGELOG に Install toolkit 8 スライスの [1.6.0] セクション（DatabaseSchemaApplier の phinx 梱包警告つき）

## 検証

- `composer check` 全緑（699 tests / phpstan / cs / openapi / mcp / **Version consistency OK: 1.6.0**）

Self-review: release-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)