### PR TITLE
feat(install): InstallerStep に入力型を追加し参照レンダラで反映する (#1482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `Nene2\Install` のインストーラフィールドに入力型を追加 — `InstallerInputType`（`text` / `password`）と `InstallerField`（name + type、`InstallerField::text()` / `password()` ファクトリ）。`InstallerRenderer` が型に応じた `<input type="...">` を出力し、**password は送信値をページに反映しない**（平文の再表示を防ぐ）（#1482）
+
+### Changed
+- `InstallerStep::$inputs` が `list<string>` から正規化済み `list<InstallerField>` になった。**後方互換**: bare な文字列名は従来どおり text フィールドへ昇格するため、`new InstallerStep('database', ['db_name'])` は変わらず動作する。`$step->inputs` を直接読む場合のみ要素が `InstallerField` になる（新モジュール `Nene2\Install` は 1.6.0 で導入されたばかりで、唯一の consumer の採用と協調済み）（#1482）
+
 ---
 
 ## [1.6.0] — 2026-07-04

--- a/src/Install/InstallerField.php
+++ b/src/Install/InstallerField.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * A single input an {@see InstallerStep} collects: the field name plus its
+ * {@see InstallerInputType}. Carries no wording — labels come from the product's
+ * {@see InstallerMessages}, like the rest of the neutral toolkit.
+ *
+ * A bare field name (string) passed to a step is promoted to a `Text` field, so existing
+ * callers keep working and only fields that need it declare a different type.
+ */
+final readonly class InstallerField
+{
+    public function __construct(
+        public string $name,
+        public InstallerInputType $type = InstallerInputType::Text,
+    ) {
+    }
+
+    public static function text(string $name): self
+    {
+        return new self($name, InstallerInputType::Text);
+    }
+
+    public static function password(string $name): self
+    {
+        return new self($name, InstallerInputType::Password);
+    }
+}

--- a/src/Install/InstallerInputType.php
+++ b/src/Install/InstallerInputType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Install;
+
+/**
+ * The input type of an {@see InstallerField}, backing the HTML `type` attribute the neutral
+ * {@see InstallerRenderer} emits. Kept to the minimum a wizard needs: free text and secrets.
+ *
+ * The backing values are safe literal attribute values (`text` / `password`) chosen by the
+ * product, never operator input, so the renderer can emit them without escaping. Additional
+ * cases (e.g. a future `select`) can be added without breaking the default-`Text` contract.
+ */
+enum InstallerInputType: string
+{
+    case Text = 'text';
+    case Password = 'password';
+
+    /**
+     * Whether a submitted value for this type may be reflected back into the rendered form.
+     * Secrets are never echoed, so an operator's password can't leak into page source.
+     */
+    public function reflectsValue(): bool
+    {
+        return $this !== self::Password;
+    }
+}

--- a/src/Install/InstallerRenderer.php
+++ b/src/Install/InstallerRenderer.php
@@ -54,11 +54,19 @@ final readonly class InstallerRenderer
 
         $html .= '<form method="post">';
 
-        foreach ($step->inputs as $input) {
-            $name = Html::escape($input);
-            $value = Html::escape($values[$input] ?? '');
+        foreach ($step->inputs as $field) {
+            $name = Html::escape($field->name);
+            // The type comes from a product-controlled enum, never operator input,
+            // so its literal value is safe to place in the attribute unescaped.
+            $type = $field->type->value;
+
+            // Secrets are never reflected: a submitted password must not reappear in page source.
+            $valueAttr = $field->type->reflectsValue()
+                ? ' value="' . Html::escape($values[$field->name] ?? '') . '"'
+                : '';
+
             $html .= '<label class="installer-field">' . $name
-                . '<input type="text" name="' . $name . '" value="' . $value . '"></label>';
+                . '<input type="' . $type . '" name="' . $name . '"' . $valueAttr . '></label>';
         }
 
         $html .= '</form></section>';

--- a/src/Install/InstallerStep.php
+++ b/src/Install/InstallerStep.php
@@ -5,19 +5,33 @@ declare(strict_types=1);
 namespace Nene2\Install;
 
 /**
- * One step of an installer wizard: a machine identifier and the names of the inputs it
+ * One step of an installer wizard: a machine identifier and the {@see InstallerField}s it
  * collects. It carries no wording — the display text comes from {@see InstallerMessages}
  * so a product owns branding and locale. Ordered into an {@see InstallerFlow}.
  */
 final readonly class InstallerStep
 {
     /**
-     * @param string       $id     Machine identifier, e.g. `requirements`, `database`, `administrator`.
-     * @param list<string> $inputs Names of the fields this step collects (empty for display-only steps).
+     * The fields this step collects, in order (empty for display-only steps). Bare string
+     * names are normalised to {@see InstallerField}s of type {@see InstallerInputType::Text}.
+     *
+     * @var list<InstallerField>
+     */
+    public array $inputs;
+
+    /**
+     * @param string                      $id     Machine identifier, e.g. `requirements`, `database`, `administrator`.
+     * @param list<string|InstallerField> $inputs Fields collected. A plain name is treated as a text field;
+     *                                            pass an {@see InstallerField} to set a type (e.g. password).
      */
     public function __construct(
         public string $id,
-        public array $inputs = [],
+        array $inputs = [],
     ) {
+        $this->inputs = array_map(
+            static fn (string|InstallerField $input): InstallerField
+                => $input instanceof InstallerField ? $input : new InstallerField($input),
+            $inputs,
+        );
     }
 }

--- a/tests/Install/InstallerFlowTest.php
+++ b/tests/Install/InstallerFlowTest.php
@@ -23,7 +23,10 @@ final class InstallerFlowTest extends TestCase
         self::assertFalse($flow->has('nope'));
 
         self::assertSame('database', $flow->step('database')->id);
-        self::assertSame(['db_name', 'db_user'], $flow->step('database')->inputs);
+        self::assertSame(
+            ['db_name', 'db_user'],
+            array_map(static fn ($field): string => $field->name, $flow->step('database')->inputs),
+        );
 
         self::assertSame('database', $flow->next('requirements')?->id);
         self::assertSame('complete', $flow->next('database')?->id);

--- a/tests/Install/InstallerRendererTest.php
+++ b/tests/Install/InstallerRendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Nene2\Tests\Install;
 
 use Nene2\Install\DefaultInstallerMessages;
+use Nene2\Install\InstallerField;
 use Nene2\Install\InstallerFlow;
 use Nene2\Install\InstallerMessages;
 use Nene2\Install\InstallerRenderer;
@@ -51,6 +52,33 @@ final class InstallerRendererTest extends TestCase
 
         self::assertStringNotContainsString('<script>', $html);
         self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testRendersDeclaredInputTypes(): void
+    {
+        $html = (new InstallerRenderer())->render($this->template($this->openGuard()), 'database');
+
+        // A bare field name defaults to a text input.
+        self::assertStringContainsString('type="text" name="db_name"', $html);
+        // A declared password field renders as a password input.
+        self::assertStringContainsString('type="password" name="db_password"', $html);
+    }
+
+    public function testNeverReflectsASubmittedPasswordValue(): void
+    {
+        $html = (new InstallerRenderer())->render(
+            $this->template($this->openGuard()),
+            'database',
+            [],
+            ['db_name' => 'shop', 'db_password' => 'hunter2'],
+        );
+
+        // The secret must never appear in the page source...
+        self::assertStringNotContainsString('hunter2', $html);
+        // ...and the password input must carry no value attribute at all.
+        self::assertStringContainsString('type="password" name="db_password">', $html);
+        // A non-secret field still reflects its submitted value.
+        self::assertStringContainsString('value="shop"', $html);
     }
 
     public function testRendersErrorCodesThroughTheMessageCatalogue(): void
@@ -100,7 +128,8 @@ final class InstallerRendererTest extends TestCase
             public function flow(): InstallerFlow
             {
                 return new InstallerFlow([
-                    new InstallerStep('database', ['db_name', 'db_user']),
+                    // Bare names default to text fields; the password field declares its type.
+                    new InstallerStep('database', ['db_name', 'db_user', InstallerField::password('db_password')]),
                     new InstallerStep('complete'),
                 ]);
             }

--- a/tests/Install/InstallerStepTest.php
+++ b/tests/Install/InstallerStepTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Install;
+
+use Nene2\Install\InstallerField;
+use Nene2\Install\InstallerInputType;
+use Nene2\Install\InstallerStep;
+use PHPUnit\Framework\TestCase;
+
+final class InstallerStepTest extends TestCase
+{
+    public function testBareNamesBecomeTextFields(): void
+    {
+        $step = new InstallerStep('database', ['db_name', 'db_user']);
+
+        self::assertSame(['db_name', 'db_user'], array_map(static fn (InstallerField $f): string => $f->name, $step->inputs));
+        self::assertSame(
+            [InstallerInputType::Text, InstallerInputType::Text],
+            array_map(static fn (InstallerField $f): InstallerInputType => $f->type, $step->inputs),
+        );
+    }
+
+    public function testDeclaredFieldsKeepTheirType(): void
+    {
+        $step = new InstallerStep('database', ['db_name', InstallerField::password('db_password')]);
+
+        self::assertSame('db_name', $step->inputs[0]->name);
+        self::assertSame(InstallerInputType::Text, $step->inputs[0]->type);
+        self::assertSame('db_password', $step->inputs[1]->name);
+        self::assertSame(InstallerInputType::Password, $step->inputs[1]->type);
+    }
+
+    public function testDisplayOnlyStepHasNoInputs(): void
+    {
+        self::assertSame([], (new InstallerStep('complete'))->inputs);
+    }
+
+    public function testInputTypeControlsWhetherAValueIsReflected(): void
+    {
+        self::assertTrue(InstallerInputType::Text->reflectsValue());
+        self::assertFalse(InstallerInputType::Password->reflectsValue());
+    }
+
+    public function testFieldFactoriesProduceTheRightType(): void
+    {
+        self::assertSame(InstallerInputType::Text, InstallerField::text('a')->type);
+        self::assertSame(InstallerInputType::Password, InstallerField::password('b')->type);
+    }
+}


### PR DESCRIPTION
## 目的
`Nene2\Install` の無ブランド参照 UI が全フィールドを `type="text"` で描画するため、DB/管理者パスワードが平文表示になる。第2 consumer（NeNe Records Tier A インストーラ・records #707）の参照 UI 採用に向けた関所承認済み改善。

## 変更点
- **追加**: `InstallerInputType`（`text` / `password`）＋ `InstallerField`（name + type、`::text()` / `::password()` ファクトリ）
- **レンダラ**: 型に応じた `<input type>` を出力。**password は送信値をページに反映しない**（平文の再表示防止）。既存のエスケープ・reason-code only 規律は維持
- **後方互換**: `InstallerStep` に渡す bare な文字列名は従来どおり text フィールドへ昇格（`new InstallerStep('database', ['db_name'])` は不変）

## 破壊的変更の注意（新モジュールにつき minor 扱い）
- `InstallerStep::$inputs` の要素が `string` → `InstallerField` に変化。直接読む場合のみ影響。`Nene2\Install` は 1.6.0 で導入されたばかりで唯一の consumer の採用と協調済みのため `!` は付けない（CHANGELOG に明記）。

## 検証
- `tests/Install/` 163 tests / 403 assertions green（新規 `InstallerStepTest` ＋ renderer の型・password 非反映テスト含む）
- PHPStan level 8: No errors（src/Install・tests/Install）
- php-cs-fixer: クリーン
- `git diff --check`: クリーン

Closes #1482
Self-review: backend-api, view-rendering