### PR TITLE
feat(auth): fail-closed な JWT secret 解決を framework 既定として追加する (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- fail-closed な JWT secret 解決の framework 既定 — `Nene2\Auth\GuardedJwtSecretResolver`（`final readonly`・公開安定 API）と `Nene2\Auth\JwtSecretException`（`RuntimeException` 継承・公開安定 API）。bearer トークンの HMAC secret は全 operator/service トークンを署名するため、推測可能な値は完全な認証バイパスになる。resolver は **ハイブリッド dev 鍵許可モデル**で解決する: 設定済み secret が非空なら全環境で採用（空文字＝未設定扱い）／`AppEnvironment::Production` は常に拒否（opt-in があっても dev 鍵を絶対使わない＝ハード fail）／local・test で明示 opt-in（`NENE2_ALLOW_DEV_SECRET` を strict に `1`/`true`/`yes`）かつ製品注入の dev 鍵があれば dev 鍵を採用／それ以外は例外。dev 鍵は framework が持たず製品が注入（`?string $devSecret`・null＝dev 経路無効）し、製品ごとの dev 鍵分離を保つ。`GuardedJwtSecretResolver::fromConfig(AppConfig, ?string): string` で `NENE2_LOCAL_JWT_SECRET` 経路を1行化。ADR 0013。**製品の自前ガード撤去は別 PR**（今回はコア追加のみ）（#1490）
+- `AppConfig::$allowDevSecret`（型付き bool・既定 `false`）— `NENE2_ALLOW_DEV_SECRET` の strict 真偽（`1`/`true`/`yes` のみ真・typo は opted-out）を `ConfigLoader` が読み取り公開する。raw env 読取は `ConfigLoader` 内のみの規約を守り、resolver は env を直読みしない。コンストラクタ末尾に既定付きで追加＝**後方互換**（#1490）
 - `Nene2\Install` のインストーラフィールドに入力型を追加 — `InstallerInputType`（`text` / `password`）と `InstallerField`（name + type、`InstallerField::text()` / `password()` ファクトリ）。`InstallerRenderer` が型に応じた `<input type="...">` を出力し、**password は送信値をページに反映しない**（平文の再表示を防ぐ）（#1482）
 
 ### Changed

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -55,10 +55,10 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\Routing` | `Router` (methods: `get`, `post`, `put`, `patch`, `delete`, `handle`, `param`), `PARAMETERS_ATTRIBUTE`, `RouteNotFoundException`, `MethodNotAllowedException` |
 | `Nene2\Http` | `RuntimeApplicationFactory` (constructor params and `create()`), `JsonResponseFactory`, `ResponseEmitter`, `HealthCheckInterface`, `HealthStatus`, `JsonRequestBodyParser`, `JsonBodyParseException`, `PaginationQuery`, `PaginationQueryParser`, `QueryStringParser`, `ConditionalGetHelper`, `ConditionalWriteHelper` |
 | `Nene2\DependencyInjection` | `ContainerBuilder` (`set`, `value`, `addProvider`, `build`), `ServiceProviderInterface` |
-| `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
+| `Nene2\Config` | `AppConfig` (incl. `$problemDetailsBaseUrl`, `$allowDevSecret`), `DatabaseConfig`, `AppEnvironment`, `ConfigException` |
 | `Nene2\Database` | All `*Interface` types (`DatabaseConnectionFactoryInterface`, `DatabaseQueryExecutorInterface`, `DatabaseTransactionManagerInterface`), `DatabaseConnectionException`, `DatabaseConstraintException` |
 | `Nene2\Error` | `DomainExceptionHandlerInterface`, `ProblemDetailsResponseFactory` |
-| `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware`, `LocalBearerTokenVerifier`, `CompositeAuthMiddleware`, `TotpAuthenticator`, `RecoveryCodes` |
+| `Nene2\Auth` | `TokenVerifierInterface`, `TokenIssuerInterface`, `TokenVerificationException`, `BearerTokenMiddleware`, `LocalBearerTokenVerifier`, `CompositeAuthMiddleware`, `TotpAuthenticator`, `RecoveryCodes`, `GuardedJwtSecretResolver` (constructor, `resolve()`, `fromConfig()`), `JwtSecretException` — see ADR 0013 |
 | `Nene2\Middleware` | All shipped middleware classes, `RateLimitStorageInterface`, `ThrottleMiddleware` |
 | `Nene2\Validation` | `ValidationException`, `ValidationError` |
 | `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |

--- a/docs/adr/0013-guarded-jwt-secret-resolution.md
+++ b/docs/adr/0013-guarded-jwt-secret-resolution.md
@@ -1,0 +1,116 @@
+# ADR 0013: Guarded JWT Secret Resolution
+
+## Status
+
+accepted
+
+## Context
+
+The HMAC secret used by `LocalBearerTokenVerifier` signs and verifies every operator
+and service bearer token. A predictable value is therefore a full authentication
+bypass: an attacker who knows the secret can forge a superadmin token. The historical
+failure mode was a **silent fallback** to a public, guessable development constant when
+the secret was unset — safe locally, catastrophic if it ever shipped to production.
+
+Every downstream product (nene-suite, nene-invoice, nene-field, and ~9 others) had, by
+mid-2026, grown its own copy of a "resolve the JWT secret, fail closed in production"
+guard. Two shapes emerged:
+
+- **Product shape** (e.g. `nene-invoice`): reject only when `APP_ENV === production` and
+  the secret is unset; fall back to a per-product development constant otherwise.
+- **Best shape** (`nene-suite`): fall back to the development secret **only** behind an
+  explicit `NENE_SUITE_ALLOW_DEV_SECRET` opt-in; otherwise throw in every environment.
+
+Duplicating this security-critical logic per product is a P0 maintenance and
+consistency risk: a bug fixed in one copy is not fixed in the others, and the weaker
+(production-only) shape silently permits the dev secret in any non-production `APP_ENV`
+without an operator opt-in. NENE2 is the correct home for the canonical guard.
+
+### Requirements
+
+- A single, framework-default public API that all products can converge on.
+- Fail closed: a misconfiguration must throw, never sign with a guessable secret.
+- Preserve the existing per-product development-secret **separation** — each product
+  uses its own dev secret so a token minted in one product's dev environment is not
+  accepted by another. The framework must not own or share a dev secret.
+- Respect the NENE2 rule that raw environment access lives only inside `ConfigLoader`;
+  application code (including the resolver) receives typed config.
+
+## Decision
+
+Add `Nene2\Auth\GuardedJwtSecretResolver` (`final readonly`) and
+`Nene2\Auth\JwtSecretException` (`extends RuntimeException`) as **public, stable** API
+(added to the ADR 0009 surface). The resolver applies a **hybrid development-secret
+allowance model**:
+
+1. If the configured secret is **non-empty**, it is used in **every** environment
+   (an empty string is treated as "unset").
+2. Otherwise, in `AppEnvironment::Production`, resolution **always throws** — the
+   development-secret opt-in is intentionally ignored, so production can never sign
+   with a development secret (hard fail).
+3. Otherwise (`local` / `test`), when the operator has **explicitly opted in**
+   (`NENE2_ALLOW_DEV_SECRET`, parsed strictly as `1` / `true` / `yes`) **and** the
+   product injected a non-empty development secret, that development secret is used.
+4. Otherwise resolution throws `JwtSecretException`.
+
+**The development secret is injected by the product**, not owned by the framework:
+`GuardedJwtSecretResolver` takes `?string $devSecret`, where `null` (or empty) disables
+the development path entirely. This preserves the existing per-product dev-secret
+separation.
+
+**The opt-in flows through typed config.** `ConfigLoader` reads `NENE2_ALLOW_DEV_SECRET`
+and parses it with a strict truthy check (only `1` / `true` / `yes`; never throws — any
+other value, including a typo, means "opted out"). The parsed boolean is exposed as the
+new `AppConfig::$allowDevSecret` field. The resolver is pure — it never reads the
+environment. A `GuardedJwtSecretResolver::fromConfig(AppConfig $config, ?string $devSecret): string`
+convenience method covers the common `NENE2_LOCAL_JWT_SECRET` path in one call.
+
+The env-name constructor parameters (`secretEnvName`, `optInEnvName`) exist only to
+build actionable exception messages, so a product reading the secret under a custom key
+(e.g. a serve command's `NENE_SERVE_JWT_SECRET`) can surface the correct variable name.
+
+This PR adds the framework surface only. **Migrating products to remove their own
+guards is deliberately out of scope and will be a follow-up PR per product.**
+
+### Rejected alternatives
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| **`APP_ENV`-only gate (product shape)**: allow the dev secret in any non-production environment without an opt-in | Silently permits the guessable dev secret whenever `APP_ENV` is not exactly `production` (e.g. an unset or mistyped `APP_ENV`). An explicit opt-in is a second, intentional barrier. |
+| **Opt-in only, no hard production block**: honour `NENE2_ALLOW_DEV_SECRET` even in production | An operator who sets the opt-in for local work and later promotes the same env file to production would sign production tokens with a public secret. Production must fail closed unconditionally. |
+| **Framework owns a shared dev secret constant** | Breaks the existing per-product separation — a dev token from product A would verify against product B. Products inject their own secret. |
+| **Resolver reads `getenv()` directly** | Violates the NENE2 boundary rule (raw env only in `ConfigLoader`) and makes the resolver impure and hard to test. The opt-in flows through `AppConfig`. |
+
+The hybrid model is the intersection of the two production shapes: it keeps the
+best-shape opt-in **and** adds an unconditional production block, which neither existing
+shape had on its own.
+
+## Consequences
+
+**Benefits**
+
+- One audited, tested implementation of a full-auth-bypass-class guard, replacing
+  ~11 divergent copies.
+- Production can never sign with a development secret, regardless of opt-in state.
+- The per-product dev-secret separation is preserved (product-injected secret).
+- The opt-in is typed (`AppConfig::$allowDevSecret`), keeping raw env access in
+  `ConfigLoader` only.
+
+**Costs / follow-up**
+
+- `AppConfig` gains a constructor parameter. It is appended with a default (`false`),
+  so existing positional and named construction is unaffected (non-breaking).
+- Products must migrate to the shared resolver in follow-up PRs (one per product) and
+  delete their own guards. Until then, both coexist with identical behaviour.
+- `GuardedJwtSecretResolver` and `JwtSecretException` join the ADR 0009 stability
+  surface and cannot break without a major version bump.
+
+## Related
+
+- Issue: `#1490`
+- See also: ADR 0008 (JWT authentication), ADR 0009 (public API scope — updated),
+  `CHANGELOG.md`, `docs/reference/environment-variables.md`
+- Reference implementations: `nene-suite/src/Http/JwtSecretResolver.php` (opt-in shape),
+  `nene-invoice/src/Auth/AuthServiceProvider.php` (product shape)
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -18,6 +18,7 @@ Architecture decisions are recorded here as lightweight ADRs. Each record captur
 | [0010](0010-rate-limiting.md) | Rate limiting design |
 | [0011](0011-security-review-policy.md) | Security review policy — adversarial review and HTTP security invariants |
 | [0012](0012-sanctioned-test-database-wiring.md) | Sanctioned test database wiring via `Nene2\Testing` |
+| [0013](0013-guarded-jwt-secret-resolution.md) | Guarded JWT secret resolution — fail-closed framework default |
 
 ## Template
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -17,7 +17,8 @@ Set them in `.env` (loaded by phpdotenv) or export them before starting the serv
 | Variable | Type | Default | Description |
 |---|---|---|---|
 | `NENE2_MACHINE_API_KEY` | string | *(empty — disabled)* | API key expected in the `X-NENE2-API-Key` request header for machine client endpoints. Leave empty to disable the machine key path entirely. |
-| `NENE2_LOCAL_JWT_SECRET` | string | *(empty — disabled)* | HMAC-HS256 secret used by `LocalBearerTokenVerifier`. Enables Bearer JWT validation for `GET /examples/protected` and gates write tools in the local MCP server. Leave empty to disable JWT auth and allow read-only MCP access only. |
+| `NENE2_LOCAL_JWT_SECRET` | string | *(empty — disabled)* | HMAC-HS256 secret used by `LocalBearerTokenVerifier`. Enables Bearer JWT validation for `GET /examples/protected` and gates write tools in the local MCP server. Leave empty to disable JWT auth and allow read-only MCP access only. When resolved through `Nene2\Auth\GuardedJwtSecretResolver`, an empty value fails closed unless the development-secret opt-in below is set (never in production). |
+| `NENE2_ALLOW_DEV_SECRET` | boolean (strict) | `false` | Development-secret opt-in consumed by `Nene2\Auth\GuardedJwtSecretResolver` (exposed as `AppConfig::$allowDevSecret`). Accepts **only** `1`, `true`, or `yes` (case-insensitive, trimmed); any other value — including a typo — means opted out. When `NENE2_LOCAL_JWT_SECRET` is unset in a `local`/`test` environment, this permits the product-injected development secret. **Ignored in production** — production always fails closed. See [ADR 0013](../adr/0013-guarded-jwt-secret-resolution.md). |
 
 ## Local MCP server
 

--- a/src/Auth/GuardedJwtSecretResolver.php
+++ b/src/Auth/GuardedJwtSecretResolver.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
+
+/**
+ * Resolves the HMAC secret used to sign and verify local bearer tokens, failing closed.
+ *
+ * The same secret authenticates every operator and service token, so a predictable
+ * value is a full authentication bypass (a forged superadmin token). Rather than let
+ * each product reimplement the guard, this is the framework default. It applies a
+ * hybrid development-secret policy:
+ *
+ * 1. A non-empty configured secret is always used, in every environment. An empty
+ *    string is treated as "unset" and rejected.
+ * 2. Otherwise, in {@see AppEnvironment::Production} resolution always throws — the
+ *    development-secret opt-in is intentionally ignored, so production can never sign
+ *    tokens with a development secret (hard fail).
+ * 3. Otherwise (local / test), when the operator has explicitly opted in
+ *    (`$allowDevSecret`) and the product injected a non-empty development secret,
+ *    that development secret is used.
+ * 4. Otherwise resolution throws.
+ *
+ * The framework does not own a development secret: the product injects it
+ * (`?string $devSecret`, `null` disables the development path entirely). This keeps
+ * each product on its own development secret so tokens from one product's development
+ * environment are not accepted by another.
+ *
+ * The env-name parameters are used only to build actionable exception messages; they
+ * let a product that reads the secret under a custom key (e.g. the serve command's
+ * `NENE_SERVE_JWT_SECRET`) surface the correct variable name.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final readonly class GuardedJwtSecretResolver
+{
+    /**
+     * @param string $configuredSecret The operator-configured secret; empty string means "unset".
+     * @param AppEnvironment $environment The runtime environment; production always rejects the dev path.
+     * @param bool $allowDevSecret Whether the operator opted in to the development secret (local/test only).
+     * @param string|null $devSecret The product-injected development secret, or null to disable the dev path.
+     * @param string $secretEnvName Name of the secret env var, used in exception messages.
+     * @param string $optInEnvName Name of the opt-in env var, used in exception messages.
+     */
+    public function __construct(
+        private string $configuredSecret,
+        private AppEnvironment $environment,
+        private bool $allowDevSecret,
+        private ?string $devSecret,
+        private string $secretEnvName = 'NENE2_LOCAL_JWT_SECRET',
+        private string $optInEnvName = 'NENE2_ALLOW_DEV_SECRET',
+    ) {
+    }
+
+    /**
+     * Resolve the JWT secret or fail closed.
+     *
+     * @throws JwtSecretException when no secret can be resolved safely.
+     */
+    public function resolve(): string
+    {
+        if ($this->configuredSecret !== '') {
+            return $this->configuredSecret;
+        }
+
+        // Production never signs with a development secret, even behind the opt-in.
+        if ($this->environment === AppEnvironment::Production) {
+            $this->failClosed();
+        }
+
+        if ($this->allowDevSecret && $this->devSecret !== null && $this->devSecret !== '') {
+            return $this->devSecret;
+        }
+
+        $this->failClosed();
+    }
+
+    /**
+     * Convenience resolver for the common `NENE2_LOCAL_JWT_SECRET` path: reads the
+     * configured secret, environment, and opt-in from typed config, and takes the
+     * product-injected development secret (`null` to disable the dev path).
+     *
+     * @throws JwtSecretException when no secret can be resolved safely.
+     */
+    public static function fromConfig(AppConfig $config, ?string $devSecret): string
+    {
+        return (new self(
+            $config->localJwtSecret ?? '',
+            $config->environment,
+            $config->allowDevSecret,
+            $devSecret,
+        ))->resolve();
+    }
+
+    /**
+     * @throws JwtSecretException
+     */
+    private function failClosed(): never
+    {
+        $base = sprintf(
+            '%s is not configured. Set it to a random 32+ byte secret '
+            . '(generate one with: php -r "echo bin2hex(random_bytes(32));").',
+            $this->secretEnvName,
+        );
+
+        if ($this->environment === AppEnvironment::Production) {
+            throw new JwtSecretException($base . sprintf(
+                ' The development-secret opt-in (%s) is intentionally ignored in production.',
+                $this->optInEnvName,
+            ));
+        }
+
+        throw new JwtSecretException($base . sprintf(
+            ' Alternatively, set %s=1 to permit an injected development secret '
+            . '(local / development only — never in production).',
+            $this->optInEnvName,
+        ));
+    }
+}

--- a/src/Auth/JwtSecretException.php
+++ b/src/Auth/JwtSecretException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Auth;
+
+use RuntimeException;
+
+/**
+ * Thrown by {@see GuardedJwtSecretResolver} when a JWT signing/verification secret
+ * cannot be resolved safely, so a misconfigured deployment fails closed rather than
+ * signing tokens with a public, guessable development secret.
+ *
+ * The message names the environment variable to set, a generation command, and — in
+ * non-production environments only — the opt-in that permits an injected development
+ * secret.
+ *
+ * Part of the public API stability guarantee (see ADR 0009).
+ */
+final class JwtSecretException extends RuntimeException
+{
+}

--- a/src/Config/AppConfig.php
+++ b/src/Config/AppConfig.php
@@ -10,6 +10,9 @@ namespace Nene2\Config;
  * Inject this value object wherever application-level settings are needed; never call
  * `getenv()` or `$_ENV` directly outside `ConfigLoader`.
  *
+ * `$allowDevSecret` reflects the `NENE2_ALLOW_DEV_SECRET` opt-in (strictly `1`/`true`/`yes`)
+ * consumed by {@see \Nene2\Auth\GuardedJwtSecretResolver}; it is ignored in production.
+ *
  * Part of the public API stability guarantee (see ADR 0009).
  */
 final readonly class AppConfig
@@ -22,6 +25,7 @@ final readonly class AppConfig
         public ?string $machineApiKey,
         public ?string $localJwtSecret = null,
         public string $problemDetailsBaseUrl = 'https://nene2.dev/problems/',
+        public bool $allowDevSecret = false,
     ) {
         if ($this->name === '') {
             throw new ConfigException('APP_NAME must not be empty.');

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -20,6 +20,7 @@ final readonly class ConfigLoader
             'APP_NAME' => 'NENE2',
             'NENE2_MACHINE_API_KEY' => '',
             'NENE2_LOCAL_JWT_SECRET' => '',
+            'NENE2_ALLOW_DEV_SECRET' => '',
             'PROBLEM_DETAILS_BASE_URL' => 'https://nene2.dev/problems/',
             'DATABASE_URL' => '',
             'DB_ENV' => 'local',
@@ -65,6 +66,7 @@ final readonly class ConfigLoader
             $this->optionalString($values['NENE2_MACHINE_API_KEY']),
             $this->optionalString($values['NENE2_LOCAL_JWT_SECRET']),
             trim($values['PROBLEM_DETAILS_BASE_URL']),
+            $this->parseDevSecretOptIn($values['NENE2_ALLOW_DEV_SECRET']),
         );
     }
 
@@ -103,6 +105,20 @@ final readonly class ConfigLoader
             '0', 'false', 'no', 'off' => false,
             default => throw new ConfigException(sprintf('%s must be a boolean value.', $key)),
         };
+    }
+
+    /**
+     * Parse the development-secret opt-in strictly.
+     *
+     * Unlike {@see parseBoolean}, this never throws and accepts only `1`, `true`, or
+     * `yes` (case-insensitive, trimmed) as truthy. Any other value — including empty,
+     * `0`, `false`, `off`, or an arbitrary string — is treated as opted out, so a
+     * typo never silently permits the development secret. Consumed by
+     * {@see \Nene2\Auth\GuardedJwtSecretResolver} via {@see AppConfig::$allowDevSecret}.
+     */
+    private function parseDevSecretOptIn(string $value): bool
+    {
+        return in_array(strtolower(trim($value)), ['1', 'true', 'yes'], true);
     }
 
     private function optionalString(string $value): ?string

--- a/tests/Auth/GuardedJwtSecretResolverTest.php
+++ b/tests/Auth/GuardedJwtSecretResolverTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Auth;
+
+use Nene2\Auth\GuardedJwtSecretResolver;
+use Nene2\Auth\JwtSecretException;
+use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
+use Nene2\Config\DatabaseConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class GuardedJwtSecretResolverTest extends TestCase
+{
+    private const CONFIGURED = 'a-real-random-secret';
+    private const DEV = 'product-dev-secret';
+
+    /**
+     * A non-empty configured secret is always used, in every environment.
+     *
+     * @return list<array{AppEnvironment}>
+     */
+    public static function allEnvironments(): array
+    {
+        return [
+            [AppEnvironment::Local],
+            [AppEnvironment::Test],
+            [AppEnvironment::Production],
+        ];
+    }
+
+    #[DataProvider('allEnvironments')]
+    public function testConfiguredSecretIsUsedInEveryEnvironment(AppEnvironment $environment): void
+    {
+        $resolver = new GuardedJwtSecretResolver(self::CONFIGURED, $environment, false, self::DEV);
+
+        self::assertSame(self::CONFIGURED, $resolver->resolve());
+    }
+
+    public function testConfiguredSecretWinsEvenWhenOptInAndDevSecretPresent(): void
+    {
+        $resolver = new GuardedJwtSecretResolver(self::CONFIGURED, AppEnvironment::Local, true, self::DEV);
+
+        self::assertSame(self::CONFIGURED, $resolver->resolve());
+    }
+
+    /**
+     * The core of the hybrid model: production rejects even with the opt-in and a dev secret.
+     */
+    public function testProductionRejectsEvenWithOptInAndDevSecret(): void
+    {
+        $resolver = new GuardedJwtSecretResolver('', AppEnvironment::Production, true, self::DEV);
+
+        $this->expectException(JwtSecretException::class);
+        $this->expectExceptionMessageMatches('/NENE2_LOCAL_JWT_SECRET/');
+
+        $resolver->resolve();
+    }
+
+    public function testProductionMessageDoesNotSuggestOptIn(): void
+    {
+        $resolver = new GuardedJwtSecretResolver('', AppEnvironment::Production, true, self::DEV);
+
+        $this->expectException(JwtSecretException::class);
+        $this->expectExceptionMessageMatches('/intentionally ignored in production/');
+
+        $resolver->resolve();
+    }
+
+    /**
+     * @return list<array{AppEnvironment}>
+     */
+    public static function nonProductionEnvironments(): array
+    {
+        return [
+            [AppEnvironment::Local],
+            [AppEnvironment::Test],
+        ];
+    }
+
+    #[DataProvider('nonProductionEnvironments')]
+    public function testDevSecretUsedWhenUnsetAndOptInAndInjected(AppEnvironment $environment): void
+    {
+        $resolver = new GuardedJwtSecretResolver('', $environment, true, self::DEV);
+
+        self::assertSame(self::DEV, $resolver->resolve());
+    }
+
+    public function testThrowsWhenUnsetAndNoOptIn(): void
+    {
+        $resolver = new GuardedJwtSecretResolver('', AppEnvironment::Local, false, self::DEV);
+
+        $this->expectException(JwtSecretException::class);
+        $this->expectExceptionMessageMatches('/NENE2_LOCAL_JWT_SECRET.*NENE2_ALLOW_DEV_SECRET/s');
+
+        $resolver->resolve();
+    }
+
+    public function testThrowsWhenOptInButDevSecretIsNull(): void
+    {
+        $resolver = new GuardedJwtSecretResolver('', AppEnvironment::Local, true, null);
+
+        $this->expectException(JwtSecretException::class);
+
+        $resolver->resolve();
+    }
+
+    public function testThrowsWhenOptInButDevSecretIsEmpty(): void
+    {
+        $resolver = new GuardedJwtSecretResolver('', AppEnvironment::Local, true, '');
+
+        $this->expectException(JwtSecretException::class);
+
+        $resolver->resolve();
+    }
+
+    public function testEmptyConfiguredSecretIsTreatedAsUnset(): void
+    {
+        // Empty configured secret + no opt-in path => fail closed rather than sign with '' .
+        $resolver = new GuardedJwtSecretResolver('', AppEnvironment::Local, false, null);
+
+        $this->expectException(JwtSecretException::class);
+
+        $resolver->resolve();
+    }
+
+    public function testCustomEnvNamesAppearInMessage(): void
+    {
+        $resolver = new GuardedJwtSecretResolver(
+            '',
+            AppEnvironment::Local,
+            false,
+            self::DEV,
+            'NENE_SERVE_JWT_SECRET',
+            'NENE_SERVE_ALLOW_DEV_SECRET',
+        );
+
+        $this->expectException(JwtSecretException::class);
+        $this->expectExceptionMessageMatches('/NENE_SERVE_JWT_SECRET.*NENE_SERVE_ALLOW_DEV_SECRET/s');
+
+        $resolver->resolve();
+    }
+
+    public function testFromConfigResolvesConfiguredSecret(): void
+    {
+        $config = $this->config(localJwtSecret: self::CONFIGURED, allowDevSecret: false);
+
+        self::assertSame(self::CONFIGURED, GuardedJwtSecretResolver::fromConfig($config, self::DEV));
+    }
+
+    public function testFromConfigUsesDevSecretWithOptIn(): void
+    {
+        $config = $this->config(localJwtSecret: null, allowDevSecret: true, environment: AppEnvironment::Local);
+
+        self::assertSame(self::DEV, GuardedJwtSecretResolver::fromConfig($config, self::DEV));
+    }
+
+    public function testFromConfigRejectsProductionWithOptIn(): void
+    {
+        $config = $this->config(localJwtSecret: null, allowDevSecret: true, environment: AppEnvironment::Production);
+
+        $this->expectException(JwtSecretException::class);
+
+        GuardedJwtSecretResolver::fromConfig($config, self::DEV);
+    }
+
+    public function testFromConfigRejectsWhenDevSecretNullAndNoConfiguredSecret(): void
+    {
+        $config = $this->config(localJwtSecret: null, allowDevSecret: true, environment: AppEnvironment::Local);
+
+        $this->expectException(JwtSecretException::class);
+
+        GuardedJwtSecretResolver::fromConfig($config, null);
+    }
+
+    private function config(
+        ?string $localJwtSecret,
+        bool $allowDevSecret,
+        AppEnvironment $environment = AppEnvironment::Local,
+    ): AppConfig {
+        return new AppConfig(
+            $environment,
+            false,
+            'NENE2 Test',
+            new DatabaseConfig(null, 'test', 'sqlite', '', 0, ':memory:', '', '', ''),
+            null,
+            $localJwtSecret,
+            'https://nene2.dev/problems/',
+            $allowDevSecret,
+        );
+    }
+}

--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -7,6 +7,7 @@ namespace Nene2\Tests\Config;
 use Nene2\Config\AppEnvironment;
 use Nene2\Config\ConfigException;
 use Nene2\Config\ConfigLoader;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigLoaderTest extends TestCase
@@ -194,6 +195,49 @@ final class ConfigLoaderTest extends TestCase
             'DB_ADAPTER' => 'mysql',
             'DB_PORT' => '65536',
         ]);
+    }
+
+    public function testAllowDevSecretDefaultsToFalse(): void
+    {
+        $config = (new ConfigLoader($this->emptyProjectRoot()))->load();
+
+        self::assertFalse($config->allowDevSecret);
+    }
+
+    /**
+     * @return list<array{string}>
+     */
+    public static function truthyDevSecretOptInValues(): array
+    {
+        return [['1'], ['true'], ['yes'], ['YES'], ['  true  ']];
+    }
+
+    #[DataProvider('truthyDevSecretOptInValues')]
+    public function testAllowDevSecretIsTrueForStrictTruthyValues(string $value): void
+    {
+        $config = (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'NENE2_ALLOW_DEV_SECRET' => $value,
+        ]);
+
+        self::assertTrue($config->allowDevSecret);
+    }
+
+    /**
+     * @return list<array{string}>
+     */
+    public static function nonTruthyDevSecretOptInValues(): array
+    {
+        return [['0'], ['false'], ['no'], ['off'], ['on'], ['2'], ['maybe'], ['']];
+    }
+
+    #[DataProvider('nonTruthyDevSecretOptInValues')]
+    public function testAllowDevSecretIsFalseForNonStrictTruthyValues(string $value): void
+    {
+        $config = (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'NENE2_ALLOW_DEV_SECRET' => $value,
+        ]);
+
+        self::assertFalse($config->allowDevSecret);
     }
 
     private function emptyProjectRoot(): string


### PR DESCRIPTION
Closes #1490

## 目的

bearer トークンの HMAC secret を解決する fail-closed ガードを NENE2 コアの1つの公開安定 API に集約する（P0 の根治・上流化）。共有 secret は全 operator/service トークンを署名するため、推測可能な値は完全な認証バイパス（superadmin トークン偽造）になる。~11 製品に散らばった重複ガードを一箇所に寄せる。**今回はコア追加のみ・製品の自前ガード撤去は別 PR。**

## 変更点（加算のみ・既存署名不変）

- **`Nene2\Auth\GuardedJwtSecretResolver`**（`final readonly`・公開安定 API）
  - ctor: `string $configuredSecret, AppEnvironment $environment, bool $allowDevSecret, ?string $devSecret, string $secretEnvName = 'NENE2_LOCAL_JWT_SECRET', string $optInEnvName = 'NENE2_ALLOW_DEV_SECRET'`
  - `resolve(): string` — ハイブリッド dev 鍵許可モデル
  - `public static fromConfig(AppConfig $config, ?string $devSecret): string` — `NENE2_LOCAL_JWT_SECRET` 経路の1行化
- **`Nene2\Auth\JwtSecretException`**（`RuntimeException` 継承・公開安定 API）— secret 変数名／生成コマンド／opt-in（本番以外）を案内。**本番のメッセージは opt-in を案内しない**（本番では無視されるため）。
- **opt-in は AppConfig 経由**（raw env 読取は `ConfigLoader` 内のみの規約遵守）:
  - `ConfigLoader` に `NENE2_ALLOW_DEV_SECRET` の strict 真偽パース（`1`/`true`/`yes` のみ・never throws・typo は opted-out）を追加
  - `AppConfig::$allowDevSecret`（型付き bool・既定 `false`・コンストラクタ末尾追加＝**後方互換**）を追加
  - resolver は純粋（env を直読みしない）
- ADR 0013 新規／ADR 0009 公開安定表に両クラス＋`$allowDevSecret` 追記／ADR index／CHANGELOG／`docs/reference/environment-variables.md` 更新

## ハイブリッド dev 鍵許可モデル（施主承認・ADR 0013）

1. `configuredSecret` 非空 → 全環境で採用（空文字＝未設定扱いで拒否）
2. 該当せず `Production` → **常に拒否**（opt-in があっても dev 鍵を絶対使わない＝ハード fail）
3. local/test で明示 opt-in かつ非空の製品注入 dev 鍵 → dev 鍵を採用
4. それ以外 → `JwtSecretException`

dev 鍵は framework が持たず製品が注入（`?string $devSecret`・null または空＝dev 経路無効）。製品ごとの dev 鍵分離を保つ。

## 検証結果

`composer check` **green**:
- PHPUnit: 737 tests / 1783 assertions OK（新規 `GuardedJwtSecretResolverTest` 18 ケース＋`ConfigLoaderTest` 追加）
- PHPStan **level 8**: 272 files, no errors（抑制・baseline・cast 追加なし）
- php-cs-fixer / OpenAPI / MCP catalog / version: 全 OK

テスト網羅（ハイブリッドの核心）:
- 非空 secret → 全環境（local/test/production）で採用
- **本番×未設定×opt-in×dev鍵 → 拒否**（opt-in があっても拒否＝核心）／本番メッセージは opt-in を案内しない
- local/test×未設定×opt-in×dev鍵 → dev鍵
- local×未設定×opt-in無 → 例外
- local×未設定×opt-in×devSecret=null / '' → 例外
- 空文字 secret → 未設定扱いで拒否
- opt-in strict 綴り（`0`/`false`/`on`/`2`/`maybe`/空 → 偽）
- `fromConfig` 経路・カスタム env 名のメッセージ反映

## 残リスク

- 製品はまだ自前ガードを使用中（別 PR で撤去して寄せる）。両者は同一挙動で共存する。

## Self-review

Self-review: backend-api, docs-policy