### PR TITLE
chore(release): v1.7.0 (#1492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.7.0] — 2026-07-05
+
+fail-closed な JWT secret 解決を framework 既定化するマイナーリリース。bearer トークンの HMAC secret 解決を一箇所（`GuardedJwtSecretResolver`・ハイブリッド dev 鍵モデル・ADR 0013）に集約し、Production では dev 鍵を絶対に採用しない・空 secret は未設定扱いで例外という fail-closed 挙動を framework の既定として提供する。あわせて Installer フィールドに入力型（`InstallerInputType` / `InstallerField`）を追加し、password 入力の平文再表示を防ぐ。いずれも公開 API への加算・後方互換で、製品側の自前ガード撤去は別 PR に分離する。
+
 ### Added
 - fail-closed な JWT secret 解決の framework 既定 — `Nene2\Auth\GuardedJwtSecretResolver`（`final readonly`・公開安定 API）と `Nene2\Auth\JwtSecretException`（`RuntimeException` 継承・公開安定 API）。bearer トークンの HMAC secret は全 operator/service トークンを署名するため、推測可能な値は完全な認証バイパスになる。resolver は **ハイブリッド dev 鍵許可モデル**で解決する: 設定済み secret が非空なら全環境で採用（空文字＝未設定扱い）／`AppEnvironment::Production` は常に拒否（opt-in があっても dev 鍵を絶対使わない＝ハード fail）／local・test で明示 opt-in（`NENE2_ALLOW_DEV_SECRET` を strict に `1`/`true`/`yes`）かつ製品注入の dev 鍵があれば dev 鍵を採用／それ以外は例外。dev 鍵は framework が持たず製品が注入（`?string $devSecret`・null＝dev 経路無効）し、製品ごとの dev 鍵分離を保つ。`GuardedJwtSecretResolver::fromConfig(AppConfig, ?string): string` で `NENE2_LOCAL_JWT_SECRET` 経路を1行化。ADR 0013。**製品の自前ガード撤去は別 PR**（今回はコア追加のみ）（#1490）
 - `AppConfig::$allowDevSecret`（型付き bool・既定 `false`）— `NENE2_ALLOW_DEV_SECRET` の strict 真偽（`1`/`true`/`yes` のみ真・typo は opted-out）を `ConfigLoader` が読み取り公開する。raw env 読取は `ConfigLoader` 内のみの規約を守り、resolver は env を直読みしない。コンストラクタ末尾に既定付きで追加＝**後方互換**（#1490）

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.6.0
+  version: 1.7.0
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.6.0';
+    public const string VERSION = '1.7.0';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的
`[Unreleased]` に積まれた加算的 API 追加を **v1.7.0**（SemVer minor）として確定する。Closes #1492

## 変更点
- `CHANGELOG.md`: `## [Unreleased]` を `## [1.7.0] — 2026-07-05` に確定＋リリース要約（fail-closed な JWT secret 解決を framework 既定化）。新しい空の `## [Unreleased]` を上に残す。
- `src/FrameworkInfo.php`: `VERSION` `1.6.0` → `1.7.0`。
- `docs/openapi/openapi.yaml`: `info.version` `1.6.0` → `1.7.0`。

含まれる変更（いずれも加算・後方互換）:
- #1490 — `Nene2\Auth\GuardedJwtSecretResolver` / `JwtSecretException`（ADR 0013・ハイブリッド dev 鍵モデル・Production は dev 鍵を絶対不採用）＋ `AppConfig::$allowDevSecret`。
- #1482 — Installer 入力型（`InstallerInputType` / `InstallerField`・password 平文再表示防止）。

## 検証結果
- `composer validate`: valid。
- `git diff --check`: clean。
- `composer version:check`: **Version consistency OK: 1.7.0**（FrameworkInfo / openapi / CHANGELOG 整合）。
- `composer analyse` (PHPStan L8): No errors。
- `composer cs`: 0 fixable / 274 files。
- `composer openapi`: valid。 `composer mcp`: valid。
- `composer test`: `PayloadInstallerTest` 8 件が **ローカル docker image の ext-zip 不在**で error（環境限定・本 PR のコード非該当・v1.6.0 で導入済み）。CI 環境では緑を確認する。

## 残リスク
- 製品側の自前ガード撤去は本 PR に含めない（別作業・versioned 3 本はこのリリース後）。

Self-review: release-ci