### PR TITLE
feat(audit): 監査ログ基盤 Nene2\Audit\* を framework に追加する (#1494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- 監査ログ基盤 `Nene2\Audit` — 複数製品（invoice/payout/profile/vault/clear）が同型に自作していた監査ログを framework の 1 モジュールに集約する（ADR 0014）。**公開安定 API**: `AuditEvent`（`final readonly` VO・種別 `action` は製品所有の free string で framework は enum を同梱しない・scalar id は `string|int|null` で auto-increment と ULID の両対応・`before`/`after`/`metadata`/`occurredAt` 受け皿付き）／`AuditQuery`（共通フィルタ VO・sort 列と方向をコンストラクタで**ホワイトリスト検証**し不正 sort を境界で拒否）／`AuditPayloadMode`（`BeforeAfter`＝canonical・`SinglePayload`＝過渡）／`AuditTableConfig`（既存テーブルへ**再 migration せず**向けるカラム/モード/id 型の写像・`canonical()` が収斂先）／契約 `AuditRecorderInterface`・`AuditRecorderFactoryInterface`（監査行を業務ミューテーションと同一 TX に束ねる `forExecutor()`＝invoice/payout の良形を既定化）・`AuditEventRepositoryInterface`（**append-only**: append/query/count・更新削除の経路なし）。既定実装 `AuditRecorder`（`occurredAt`↔`ClockInterface`／`organizationId`↔`RequestScopedHolder` を補完し、profile の repo 内 `date()` ドリフト・非原子を構造的に解消）・`AuditRecorderFactory`・`PdoAuditEventRepository`（生パラメタ化 SQL・`JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE`）と参照配線 `AuditServiceProvider` は**安定保証外**（`src/Example/` 同様 copy-and-adapt）。canonical 参照スキーマ `database/migrations/*_create_audit_events_table` ＋ `database/schema/audit_events.sql`（before/after・`metadata_json`・`occurred_at`・BIGINT autoinc 既定／ULID は config 対応）も安定保証外の参照。**製品の自作撤去・移行は別 PR**（今回はコア追加のみ・一覧 route/CSV export/actor_email join は製品の read 層に据え置き）（#1494）
+
 ---
 
 ## [1.7.0] — 2026-07-05

--- a/database/migrations/20260705000000_create_audit_events_table.php
+++ b/database/migrations/20260705000000_create_audit_events_table.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Canonical reference audit table for the `Nene2\Audit` module (ADR 0014).
+ *
+ * This is the convergence target new products should adopt as-is, and existing
+ * products should migrate toward. Like `src/Example/` and the notes/tags tables,
+ * it is a **reference** shape — outside the public API stability guarantee (ADR
+ * 0009): a consumer copies and adapts it rather than depending on it verbatim.
+ *
+ * Canonical choices:
+ * - before/after snapshot columns plus a `metadata_json` receptacle;
+ * - `occurred_at` timestamp (filled from the injected clock by `AuditRecorder`);
+ * - `id` as a DB-generated auto-increment BIGINT.
+ *
+ * ULID string ids are supported by the module instead — construct
+ * `AuditTableConfig` with `idIsAutoIncrement: false` and change `id` here to a
+ * `CHAR(26)` primary key.
+ *
+ * Append-only: application code must never UPDATE or DELETE these rows.
+ */
+final class CreateAuditEventsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('audit_events', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'biginteger', ['identity' => true, 'signed' => false, 'null' => false])
+            ->addColumn('action', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('entity_type', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('entity_id', 'string', ['limit' => 64, 'null' => true, 'default' => null])
+            ->addColumn('actor_id', 'string', ['limit' => 64, 'null' => true, 'default' => null])
+            ->addColumn('organization_id', 'string', ['limit' => 64, 'null' => true, 'default' => null])
+            ->addColumn('before_json', 'text', ['null' => true, 'default' => null])
+            ->addColumn('after_json', 'text', ['null' => true, 'default' => null])
+            ->addColumn('metadata_json', 'text', ['null' => true, 'default' => null])
+            ->addColumn('occurred_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'])
+            ->addIndex(['entity_type', 'entity_id'])
+            ->addIndex(['action'])
+            ->addIndex(['occurred_at'])
+            ->create();
+    }
+}

--- a/database/schema/audit_events.sql
+++ b/database/schema/audit_events.sql
@@ -1,0 +1,23 @@
+-- Canonical audit_events table schema for the Nene2\Audit module (ADR 0014).
+-- Reference shape (outside the public API stability guarantee, ADR 0009):
+-- copy and adapt. Production DDL is applied via database/migrations/ (Phinx);
+-- keep this snapshot in sync. This SQLite dialect variant is what the
+-- Nene2\Audit repository tests create.
+--
+-- Append-only: never UPDATE or DELETE these rows.
+CREATE TABLE IF NOT EXISTS audit_events (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    action          VARCHAR(64) NOT NULL,
+    entity_type     VARCHAR(64) NOT NULL,
+    entity_id       VARCHAR(64) NULL DEFAULT NULL,
+    actor_id        VARCHAR(64) NULL DEFAULT NULL,
+    organization_id VARCHAR(64) NULL DEFAULT NULL,
+    before_json     TEXT NULL DEFAULT NULL,
+    after_json      TEXT NULL DEFAULT NULL,
+    metadata_json   TEXT NULL DEFAULT NULL,
+    occurred_at     DATETIME NOT NULL
+);
+CREATE INDEX idx_audit_events_organization_id ON audit_events (organization_id);
+CREATE INDEX idx_audit_events_entity ON audit_events (entity_type, entity_id);
+CREATE INDEX idx_audit_events_action ON audit_events (action);
+CREATE INDEX idx_audit_events_occurred_at ON audit_events (occurred_at);

--- a/docs/adr/0009-v1.0-public-api-scope.md
+++ b/docs/adr/0009-v1.0-public-api-scope.md
@@ -64,6 +64,7 @@ The following namespaces and their public members are covered by the v1.0 stabil
 | `Nene2\View` | `NativePhpViewRenderer`, `HtmlResponseFactory`, `HtmlEscaper`, `TemplateNotFoundException` |
 | `Nene2\Mcp` | `LocalMcpServer`, `LocalMcpToolCatalog`, `LocalMcpHttpClientInterface`, `LocalMcpHttpResponse`, `LocalMcpException` |
 | `Nene2\Testing` | `DatabaseTestKit` (constructor, public readonly properties `connectionFactory` / `queryExecutor` / `transactionManager`, factories `sqlite` / `fromConfig`) — see ADR 0012 |
+| `Nene2\Audit` | `AuditEvent`, `AuditQuery`, `AuditPayloadMode`, `AuditTableConfig` (VOs/enum/config — stable), and the contracts `AuditRecorderInterface`, `AuditRecorderFactoryInterface`, `AuditEventRepositoryInterface` — see ADR 0014. **Not** stable: the concrete `AuditRecorder`, `AuditRecorderFactory`, `PdoAuditEventRepository`, and `AuditServiceProvider` (see decision 5) |
 
 ### 4. Stable request attributes set by authentication middleware
 
@@ -82,6 +83,8 @@ backward-incompatible way within the v1.x line.
 ### 5. Explicitly outside the stability guarantee
 
 - `Nene2\Example\*` — reference implementation (see decision 2)
+- `Nene2\Audit\AuditRecorder` / `AuditRecorderFactory` / `PdoAuditEventRepository` — default implementations; the `*Interface` types, VOs, and `AuditTableConfig` are the stable boundary (ADR 0014)
+- `Nene2\Audit\AuditServiceProvider` — reference wiring (copy and adapt, like `src/Example/`)
 - `Nene2\Log\*` — internal logging plumbing; PSR-3 (`LoggerInterface`) is the stable boundary
 - `Nene2\Http\RuntimeServiceProvider` — internal wiring; application code should not reference it directly
 - `Nene2\Config\ConfigLoader` — internal; applications receive `AppConfig` / `DatabaseConfig` DTOs

--- a/docs/adr/0014-audit-log-framework-module.md
+++ b/docs/adr/0014-audit-log-framework-module.md
@@ -1,0 +1,182 @@
+# ADR 0014: Audit Log Framework Module (`Nene2\Audit`)
+
+## Status
+
+accepted
+
+## Context
+
+Every NeNe product that records who changed what needs an audit trail. By
+mid-2026 at least five products had grown their own, near-identical copy:
+`nene-invoice`, `nene-payout`, `nene-profile`, `nene-vault`, and `nene-clear`
+each ship an `AuditRecorder` + `PdoAudit*Repository` + record value object
+(`_work/reports/2026-07-05/nene-backend-audit.md` §4-1). The shapes converged on
+the same idea but diverged in quality:
+
+- **Good shape** (`nene-invoice`, `nene-payout`): a `ClockInterface`-injected
+  recorder writing before/after snapshots, plus a `recorderFactory` that binds
+  the recorder to the transaction's executor so the audit row and the business
+  mutation commit atomically. `nene-payout` additionally uses ULID string ids.
+- **Weak shape** (`nene-profile`): the repository calls `date()` itself (time
+  drift, untestable) and appends outside the mutation's transaction (an audit row
+  can survive a rolled-back change, or vice versa).
+- **Divergent record shape**: `nene-clear` stores a single JSON `payload` column
+  in an `audit_events` table instead of separate before/after columns; `nene-vault`
+  carries a `metadata` receptacle and an action-string enum.
+
+Duplicating a compliance-relevant subsystem five ways is a maintenance and
+correctness risk: a fix in one copy is not a fix in the others, and the weak
+shape is a silent integrity bug. NENE2 is the right home for one canonical,
+tested implementation.
+
+This is not only a de-duplication play. Products that do **not** yet have an
+audit trail (and new products still to come) should be able to adopt auditing as
+a first-class framework feature rather than re-deriving it — so the module is
+designed as a standard adoption path, not merely a lowest-common-denominator of
+the existing five.
+
+### Requirements
+
+- One record value object and one recorder/repository contract all products can
+  converge on.
+- Atomicity: the audit row must commit in the **same** transaction as the
+  mutation it describes (promote the invoice/payout good form to the default).
+- Deterministic time: the timestamp comes from the injected clock, never a
+  repository-local `date()` (fix the profile anti-pattern structurally).
+- Support both auto-increment `BIGINT` ids and ULID string ids without forking
+  the type.
+- Let an existing product point the module at its **current** table (different
+  name, columns, id type, single-payload vs before/after) **without a
+  re-migration**, so adoption is one step and schema migration is a later step.
+- Respect NENE2 boundaries: raw SQL through `DatabaseQueryExecutorInterface`,
+  parameterised queries, `JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE`.
+
+## Decision
+
+Add a `Nene2\Audit` module (see the ADR 0009 surface update) with this split
+between stable contract and swappable implementation:
+
+**Stable surface** (no breaking change without a major bump):
+
+- `AuditEvent` (`final readonly` VO) — `action`, `entityType`, `entityId`,
+  `actorId`, `organizationId`, `before`, `after`, `metadata`, `occurredAt`, `id`.
+  Scalar ids are `string|int|null` (int **or** ULID).
+- `AuditRecorderInterface::record(AuditEvent): void`.
+- `AuditRecorderFactoryInterface::forExecutor(DatabaseQueryExecutorInterface): AuditRecorderInterface`
+  — the transaction-atomic seam.
+- `AuditEventRepositoryInterface` — **append-only**: `append` / `query` / `count`.
+  No update or delete path exists on the contract; the trail is immutable.
+- `AuditQuery` (`final readonly` VO) — common filters plus a sort column/direction
+  validated against a **closed whitelist in the constructor**, so an invalid or
+  injected sort fails at the boundary and never reaches SQL interpolation.
+- `AuditPayloadMode` (enum) — `BeforeAfter` (canonical) / `SinglePayload` (transition).
+- `AuditTableConfig` — maps an `AuditEvent` onto a concrete table (name, column
+  map, id type, payload mode).
+
+**Outside the stability guarantee** (implementation detail — depend on the
+interfaces): `AuditRecorder`, `AuditRecorderFactory`, `PdoAuditEventRepository`,
+and `AuditServiceProvider` (a copy-and-adapt reference wiring, analogous to
+`src/Example/`).
+
+**Reference schema** (also outside the guarantee, like the notes/tags example):
+`database/migrations/20260705000000_create_audit_events_table.php` and
+`database/schema/audit_events.sql` — before/after columns, `metadata_json`,
+`occurred_at`, and an auto-increment `BIGINT` id.
+
+### The action vocabulary is owned by the product, not the framework
+
+`action` is a **free string**. NENE2 ships **no** action enum. Every product owns
+its own vocabulary (e.g. `invoice.issued`, `document.uploaded`) and registers it
+in its own terminology registry; the framework only guarantees the string is
+stored and queried verbatim. Baking an enum into the framework would either
+constrain products or bloat with every product's terms.
+
+### The default recorder fixes time and tenant structurally
+
+`AuditRecorder` fills `occurredAt` from the injected `ClockInterface` when the
+caller left it null, and fills `organizationId` from an optional
+`RequestScopedHolder` when absent. This removes both the profile `date()` drift
+and the "forgot to pass the tenant" class of bug. `AuditRecorderFactory.forExecutor()`
+builds a recorder whose repository writes through the transaction's executor, so
+audit and mutation are one atomic unit.
+
+### Canonical is the convergence target; transition configs are temporary
+
+`AuditTableConfig::canonical()` is the shape new products should adopt as-is. The
+non-canonical knobs — `SinglePayload` mode, custom column names, `idIsAutoIncrement:
+false` — exist so an existing product (notably `nene-clear`'s single-`payload`
+`audit_events`) can adopt the module **without re-migrating first**. They are an
+adoption ramp, **not** a permanent home: the stated end state is that every
+product — including clear — converges on the canonical before/after schema via a
+schema migration, not that config compatibility is maintained indefinitely.
+
+### Schema ownership is the union of the existing shapes (A ∪ B)
+
+The canonical table is the **union** of what the good-form products need (A:
+before/after, actor/org/action/entity, ULID-or-int id) and what the divergent
+ones carry (B: a `metadata` receptacle, an `occurred_at` name, single-payload
+folding). Rather than pick one product's table, the canonical shape carries every
+field any product legitimately needs, and `SinglePayload` mode lets a product
+whose physical table is narrower still round-trip through the same VO.
+
+### Standard adoption path for new products
+
+A product with no audit trail adopts by: (1) applying the reference migration (or
+its own equivalent), (2) registering `AuditTableConfig::canonical()`, (3) wiring
+`AuditRecorderFactoryInterface` (copy `AuditServiceProvider`), and (4) calling
+`forExecutor($exec)->record(new AuditEvent(...))` inside each mutating use case's
+`transactional()`. No per-product recorder/repository code is written.
+
+### Scope (v1)
+
+record + repository + query only. **List routes, CSV export, and actor-email
+joins are intentionally not upstreamed** — they are product-specific read
+concerns and stay in each product's read layer. Migrating the five existing
+products off their hand-rolled code is a **separate PR per product**; this PR adds
+the framework surface only.
+
+### Rejected alternatives
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| **Ship an `AuditAction` enum in the framework** | Action vocabularies are product-owned and unbounded; a framework enum would either constrain products or accrete every product's terms. Free string + per-product registry keeps ownership correct. |
+| **Canonical-only, no `AuditTableConfig`/`SinglePayload`** | Forces every existing product to re-migrate before it can delete its duplicate code. The config seam makes adoption a one-step change and defers the migration. |
+| **Keep config compatibility forever (no convergence)** | Leaves the fleet permanently forked across two table shapes. Canonical is declared the convergence target so transition configs are a ramp, not a fork. |
+| **Upstream list routes / CSV export / actor-email join too** | These differ per product (envelope shape, columns, join tables) and belong to the read layer. Upstreaming them would import product-specific decisions into the framework. |
+| **Recorder owns the transaction** | The mutation's use case owns the transaction; the recorder must join it, not open its own. `forExecutor()` binds to the caller's executor instead. |
+
+## Consequences
+
+**Benefits**
+
+- One tested, atomic, clock-driven audit implementation replaces five divergent
+  copies; the profile drift/non-atomicity bug cannot recur under the default.
+- New products adopt auditing as a first-class feature with no bespoke code.
+- Existing products can adopt without a re-migration (config seam) and converge on
+  the canonical schema later.
+- The append-only contract and whitelisted sort make the compliance and
+  injection properties structural, not per-product discipline.
+
+**Costs / follow-up**
+
+- Five products must migrate to the module and delete their own audit code — one
+  follow-up PR each (out of scope here).
+- `nene-clear` additionally needs a schema migration to reach canonical (its
+  `SinglePayload` config is a transition state, not the end state).
+- The reference migration/schema and `AuditServiceProvider` are reference code
+  (outside the stability guarantee); consumers copy and adapt them.
+
+## Related
+
+- Issue: `#1494`
+- See also: ADR 0009 (public API scope — updated with the `Nene2\Audit` row),
+  ADR 0012 (sanctioned test DB wiring, used by the module's tests), `CHANGELOG.md`
+- Audit source: `_work/reports/2026-07-05/nene-backend-audit.md` §4-1
+- Reference implementations: `nene-invoice/src/Audit/` and `nene-payout/src/Audit/`
+  (good form — clock injection, before/after, transaction-atomic recorder factory,
+  ULID ids); `nene-profile/src/Audit/PdoAuditLogRepository.php` (the `date()` /
+  non-atomic anti-pattern this module fixes); `nene-vault/src/Audit/AuditAction.php`
+  (product-owned action enum); `nene-clear/src/Audit/AuditEvent.php` (single-payload
+  variant that `SinglePayload` mode accommodates)
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -19,6 +19,7 @@ Architecture decisions are recorded here as lightweight ADRs. Each record captur
 | [0011](0011-security-review-policy.md) | Security review policy — adversarial review and HTTP security invariants |
 | [0012](0012-sanctioned-test-database-wiring.md) | Sanctioned test database wiring via `Nene2\Testing` |
 | [0013](0013-guarded-jwt-secret-resolution.md) | Guarded JWT secret resolution — fail-closed framework default |
+| [0014](0014-audit-log-framework-module.md) | Audit log framework module (`Nene2\Audit`) |
 
 ## Template
 

--- a/src/Audit/AuditEvent.php
+++ b/src/Audit/AuditEvent.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+/**
+ * One recorded mutating operation in the audit trail.
+ *
+ * This is the framework-canonical audit record shape (ADR 0014). It is a
+ * transport value object: use cases construct it and hand it to an
+ * {@see AuditRecorderInterface}; repositories map it to and from storage.
+ *
+ * Design notes:
+ *
+ * - **`action` is a free string owned by the product.** NENE2 ships no action
+ *   enum — every product defines its own vocabulary (e.g. `invoice.issued`,
+ *   `document.uploaded`) and registers it in its own terminology registry. The
+ *   framework only guarantees that the string is stored and queryable verbatim.
+ * - **Scalar ids are `string|int|null`** so both auto-increment `BIGINT` ids and
+ *   ULID string ids are supported without a second type. `null` means "not set"
+ *   (e.g. no actor for a system event, or an unresolved `entityId`).
+ * - **`before` / `after`** are sanitized snapshots (no secrets). `before` is
+ *   null for creates; `after` is null for deletes.
+ * - **`metadata`** is the receptacle for cross-cutting context (`source`,
+ *   `request_id`, `ip`, …). Products decide the keys; the framework stores it as
+ *   JSON.
+ * - **`occurredAt`** is an optional caller-supplied instant. When null, the
+ *   default {@see AuditRecorder} fills it from the injected {@see \Nene2\Http\ClockInterface}
+ *   so timestamps are deterministic in tests and never drift from every other "now".
+ *
+ * Part of the public API stability guarantee (see ADR 0009 and ADR 0014).
+ */
+final readonly class AuditEvent
+{
+    /**
+     * @param array<string, mixed>|null $before   sanitized snapshot before the change (null for create)
+     * @param array<string, mixed>|null $after    sanitized snapshot after the change (null for delete)
+     * @param array<string, mixed>|null $metadata cross-cutting context (source / request_id / ip / …)
+     */
+    public function __construct(
+        public string $action,
+        public string $entityType,
+        public string|int|null $entityId = null,
+        public string|int|null $actorId = null,
+        public string|int|null $organizationId = null,
+        public ?array $before = null,
+        public ?array $after = null,
+        public ?array $metadata = null,
+        public ?string $occurredAt = null,
+        public string|int|null $id = null,
+    ) {
+    }
+
+    /**
+     * Returns a copy of this event with the timestamp and organization filled in.
+     *
+     * Used by {@see AuditRecorder} to complete an event before appending it,
+     * without mutating the caller's value object.
+     *
+     * @param array<string, mixed>|null $metadata
+     */
+    public function completed(
+        string $occurredAt,
+        string|int|null $organizationId,
+        ?array $metadata = null,
+    ): self {
+        return new self(
+            action: $this->action,
+            entityType: $this->entityType,
+            entityId: $this->entityId,
+            actorId: $this->actorId,
+            organizationId: $organizationId,
+            before: $this->before,
+            after: $this->after,
+            metadata: $metadata ?? $this->metadata,
+            occurredAt: $occurredAt,
+            id: $this->id,
+        );
+    }
+}

--- a/src/Audit/AuditEventRepositoryInterface.php
+++ b/src/Audit/AuditEventRepositoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+/**
+ * Append-only persistence for {@see AuditEvent} records (ADR 0014).
+ *
+ * The audit trail is immutable: this interface exposes {@see append()} but no
+ * update or delete. Reads go through {@see query()} / {@see count()} with a
+ * common {@see AuditQuery} filter. Product-specific read concerns (actor email
+ * joins, CSV export, list routes) live in the product's own read layer and are
+ * intentionally **not** part of this interface.
+ *
+ * Part of the public API stability guarantee (see ADR 0009 and ADR 0014).
+ */
+interface AuditEventRepositoryInterface
+{
+    /**
+     * Appends one audit event. Never updates or deletes existing rows.
+     */
+    public function append(AuditEvent $event): void;
+
+    /**
+     * @return list<AuditEvent>
+     */
+    public function query(AuditQuery $query, int $limit, int $offset): array;
+
+    public function count(AuditQuery $query): int;
+}

--- a/src/Audit/AuditPayloadMode.php
+++ b/src/Audit/AuditPayloadMode.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+/**
+ * How an audit table stores the mutation payload (ADR 0014).
+ *
+ * The **canonical** model is {@see BeforeAfter}: separate `before` / `after`
+ * snapshot columns plus an optional `metadata` column. {@see SinglePayload} is a
+ * transition accommodation for products (e.g. NeNe Clear) whose existing table
+ * has one JSON `payload` column — the repository folds `before` / `after` /
+ * `metadata` into a single object on write and unfolds them on read, so those
+ * products can adopt {@see AuditEvent} **without re-migrating** first.
+ *
+ * `SinglePayload` exists to smooth adoption, not as a permanent shape: the
+ * convergence target for every product is the canonical before/after schema.
+ *
+ * Part of the public API stability guarantee (see ADR 0009 and ADR 0014).
+ */
+enum AuditPayloadMode
+{
+    /** Separate `before_json` / `after_json` (+ optional `metadata_json`) columns. Canonical. */
+    case BeforeAfter;
+
+    /** One JSON column holding `{before, after, metadata}`. Transition only. */
+    case SinglePayload;
+}

--- a/src/Audit/AuditQuery.php
+++ b/src/Audit/AuditQuery.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+use InvalidArgumentException;
+
+/**
+ * Read-side filter for the audit trail (ADR 0014).
+ *
+ * Every filter field is optional; `null` does not constrain. The sort column and
+ * direction are validated against a fixed whitelist **in the constructor**, so an
+ * invalid sort fails fast at the boundary and can never reach SQL string
+ * interpolation — the columns and directions the repository splices into
+ * `ORDER BY` are guaranteed to come from this closed set, not from user input.
+ *
+ * `sortColumn` is a **logical** field name (see {@see SORT_COLUMNS}); the
+ * repository translates it to the physical column via {@see AuditTableConfig},
+ * so the whitelist is storage-independent.
+ *
+ * Part of the public API stability guarantee (see ADR 0009 and ADR 0014).
+ */
+final readonly class AuditQuery
+{
+    /** Logical sort fields accepted by {@see $sortColumn}. */
+    public const SORT_COLUMNS = ['occurred_at', 'id', 'action', 'entity_type'];
+
+    /** Sort directions accepted by {@see $sortDirection} (normalised to upper case). */
+    public const SORT_DIRECTIONS = ['ASC', 'DESC'];
+
+    public string $sortColumn;
+
+    public string $sortDirection;
+
+    public function __construct(
+        public string|int|null $organizationId = null,
+        public ?string $entityType = null,
+        public string|int|null $entityId = null,
+        public ?string $action = null,
+        public string|int|null $actorId = null,
+        public ?string $occurredFrom = null,
+        public ?string $occurredTo = null,
+        string $sortColumn = 'occurred_at',
+        string $sortDirection = 'DESC',
+    ) {
+        if (!in_array($sortColumn, self::SORT_COLUMNS, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid audit sort column "%s". Allowed: %s.',
+                $sortColumn,
+                implode(', ', self::SORT_COLUMNS),
+            ));
+        }
+
+        $direction = strtoupper($sortDirection);
+
+        if (!in_array($direction, self::SORT_DIRECTIONS, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid audit sort direction "%s". Allowed: %s.',
+                $sortDirection,
+                implode(', ', self::SORT_DIRECTIONS),
+            ));
+        }
+
+        $this->sortColumn = $sortColumn;
+        $this->sortDirection = $direction;
+    }
+}

--- a/src/Audit/AuditRecorder.php
+++ b/src/Audit/AuditRecorder.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+
+/**
+ * Default {@see AuditRecorderInterface} (ADR 0014).
+ *
+ * Completes an {@see AuditEvent} before appending it:
+ *
+ * - `occurredAt` is filled from the injected {@see ClockInterface} when the caller
+ *   left it null — the audit timestamp is a UTC instant from the same clock as
+ *   every other "now", so it is deterministic in tests and cannot drift. This is
+ *   the structural fix for the anti-pattern of a repository calling `date()`
+ *   itself (nene-profile's `PdoAuditLogRepository`).
+ * - `organizationId` is filled from an optional request-scoped tenant holder when
+ *   the caller left it null, so a use case that already knows the tenant need not
+ *   thread it through, and one that does not gets it from the request context.
+ *
+ * Concrete implementation detail — **outside** the public API stability guarantee
+ * (ADR 0009). Depend on {@see AuditRecorderInterface}; construct this (or obtain
+ * it from {@see AuditRecorderFactory}) at the composition root.
+ *
+ * @see AuditRecorderFactory for the transaction-atomic recorder factory.
+ */
+final readonly class AuditRecorder implements AuditRecorderInterface
+{
+    /**
+     * @param RequestScopedHolder<string|int>|null $organizationHolder tenant id for events that omit it
+     */
+    public function __construct(
+        private AuditEventRepositoryInterface $repository,
+        private ClockInterface $clock,
+        private ?RequestScopedHolder $organizationHolder = null,
+    ) {
+    }
+
+    public function record(AuditEvent $event): void
+    {
+        $occurredAt = $event->occurredAt ?? $this->clock->now()->format('Y-m-d H:i:s');
+
+        $organizationId = $event->organizationId;
+
+        if ($organizationId === null && $this->organizationHolder !== null && $this->organizationHolder->isSet()) {
+            $organizationId = $this->organizationHolder->get();
+        }
+
+        $this->repository->append($event->completed($occurredAt, $organizationId));
+    }
+}

--- a/src/Audit/AuditRecorderFactory.php
+++ b/src/Audit/AuditRecorderFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+
+/**
+ * Default {@see AuditRecorderFactoryInterface} (ADR 0014).
+ *
+ * Binds a fresh {@see AuditRecorder} to the executor of the enclosing transaction,
+ * so the audit row is written through the same {@see DatabaseQueryExecutorInterface}
+ * as the business mutation and the two commit or roll back together. This
+ * generalises the invoice/payout `recorderFactory` good form into a framework
+ * default.
+ *
+ * Concrete implementation detail — **outside** the public API stability guarantee
+ * (ADR 0009). Depend on {@see AuditRecorderFactoryInterface}.
+ */
+final readonly class AuditRecorderFactory implements AuditRecorderFactoryInterface
+{
+    /**
+     * @param RequestScopedHolder<string|int>|null $organizationHolder tenant id for events that omit it
+     */
+    public function __construct(
+        private ClockInterface $clock,
+        private AuditTableConfig $tableConfig,
+        private ?RequestScopedHolder $organizationHolder = null,
+    ) {
+    }
+
+    public function forExecutor(DatabaseQueryExecutorInterface $executor): AuditRecorderInterface
+    {
+        return new AuditRecorder(
+            new PdoAuditEventRepository($executor, $this->tableConfig),
+            $this->clock,
+            $this->organizationHolder,
+        );
+    }
+}

--- a/src/Audit/AuditRecorderFactoryInterface.php
+++ b/src/Audit/AuditRecorderFactoryInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Builds an {@see AuditRecorderInterface} bound to a specific query executor.
+ *
+ * A mutating use case runs inside `DatabaseTransactionManagerInterface::transactional()`,
+ * which hands the closure a transaction-scoped {@see DatabaseQueryExecutorInterface}.
+ * Passing that executor here yields a recorder whose repository writes through the
+ * **same** transaction, so the audit row and the business mutation commit (or roll
+ * back) atomically — the invoice/payout good-form pattern, promoted to a framework
+ * default (ADR 0014).
+ *
+ * ```php
+ * return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (...): Entity {
+ *     $repo   = ($this->entityRepoFactory)($exec);
+ *     $entity = $repo->save(...);
+ *     $this->auditFactory->forExecutor($exec)->record(new AuditEvent(...));
+ *     return $entity;
+ * });
+ * ```
+ *
+ * Part of the public API stability guarantee (see ADR 0009 and ADR 0014).
+ */
+interface AuditRecorderFactoryInterface
+{
+    public function forExecutor(DatabaseQueryExecutorInterface $executor): AuditRecorderInterface;
+}

--- a/src/Audit/AuditRecorderInterface.php
+++ b/src/Audit/AuditRecorderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+/**
+ * Records one mutating operation in the audit trail (ADR 0014).
+ *
+ * A use case calls {@see record()} after a successful create / update / delete.
+ * The recorder completes the event (timestamp, organization) and appends it via
+ * an {@see AuditEventRepositoryInterface}.
+ *
+ * To make the audit row commit atomically with the business mutation, obtain a
+ * recorder bound to the transaction's executor from an
+ * {@see AuditRecorderFactoryInterface::forExecutor()} inside
+ * `DatabaseTransactionManagerInterface::transactional()`.
+ *
+ * Part of the public API stability guarantee (see ADR 0009 and ADR 0014).
+ */
+interface AuditRecorderInterface
+{
+    public function record(AuditEvent $event): void;
+}

--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Reference wiring for the audit module — copy and adapt, do not depend on.
+ *
+ * This provider shows the consumption types: given a product-registered
+ * {@see AuditTableConfig} plus the framework's {@see ClockInterface} and
+ * {@see DatabaseQueryExecutorInterface}, it wires the append-only
+ * {@see AuditEventRepositoryInterface}, the transaction-atomic
+ * {@see AuditRecorderFactoryInterface} (for mutating use cases inside
+ * `transactional()`), and a default non-transactional {@see AuditRecorderInterface}
+ * (for read-side or already-in-transaction callers).
+ *
+ * A product that scopes audit reads/writes to a tenant registers its own
+ * `RequestScopedHolder<string|int>` and passes it as the third argument of
+ * {@see AuditRecorder} / {@see AuditRecorderFactory} — omitted here to keep the
+ * sample framework-generic (organizationId then comes only from the event).
+ *
+ * **Reference implementation — outside the public API stability guarantee**
+ * (analogous to `src/Example/`, ADR 0009). Its shape may change without a major
+ * version bump; the stable surface is the interfaces, VOs, and {@see AuditTableConfig}.
+ *
+ * @internal
+ */
+final readonly class AuditServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                AuditEventRepositoryInterface::class,
+                static function (ContainerInterface $container): AuditEventRepositoryInterface {
+                    return new PdoAuditEventRepository(
+                        self::executor($container),
+                        self::tableConfig($container),
+                    );
+                },
+            )
+            ->set(
+                AuditRecorderFactoryInterface::class,
+                static function (ContainerInterface $container): AuditRecorderFactoryInterface {
+                    return new AuditRecorderFactory(
+                        self::clock($container),
+                        self::tableConfig($container),
+                    );
+                },
+            )
+            ->set(
+                AuditRecorderInterface::class,
+                static function (ContainerInterface $container): AuditRecorderInterface {
+                    $repository = $container->get(AuditEventRepositoryInterface::class);
+
+                    if (!$repository instanceof AuditEventRepositoryInterface) {
+                        throw new LogicException('Audit event repository service is invalid.');
+                    }
+
+                    return new AuditRecorder($repository, self::clock($container));
+                },
+            );
+    }
+
+    private static function executor(ContainerInterface $container): DatabaseQueryExecutorInterface
+    {
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+
+        if (!$executor instanceof DatabaseQueryExecutorInterface) {
+            throw new LogicException('Database query executor service is invalid.');
+        }
+
+        return $executor;
+    }
+
+    private static function clock(ContainerInterface $container): ClockInterface
+    {
+        $clock = $container->get(ClockInterface::class);
+
+        if (!$clock instanceof ClockInterface) {
+            throw new LogicException('Clock service is invalid.');
+        }
+
+        return $clock;
+    }
+
+    private static function tableConfig(ContainerInterface $container): AuditTableConfig
+    {
+        $config = $container->get(AuditTableConfig::class);
+
+        if (!$config instanceof AuditTableConfig) {
+            throw new LogicException('Audit table config service is invalid.');
+        }
+
+        return $config;
+    }
+}

--- a/src/Audit/AuditTableConfig.php
+++ b/src/Audit/AuditTableConfig.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+use InvalidArgumentException;
+
+/**
+ * Maps an {@see AuditEvent} onto a concrete audit table (ADR 0014).
+ *
+ * This is the seam that lets an existing product point {@see PdoAuditEventRepository}
+ * at its **current** table — different table name, column names, id type, and
+ * payload shape — **without a re-migration**, so a product can delete its
+ * hand-rolled audit code and adopt the framework module in one step and migrate
+ * its schema later.
+ *
+ * The variation axes it absorbs are:
+ *
+ * - **table name** (`audit_logs` vs `audit_events` vs …);
+ * - **column names** for every field (id / action / entity / actor / organization /
+ *   timestamp / payload / metadata);
+ * - **id type** via {@see $idIsAutoIncrement}: `true` = DB-generated `BIGINT`
+ *   (id omitted from INSERT), `false` = caller-supplied ULID string (id written);
+ * - **payload shape** via {@see AuditPayloadMode}: canonical before/after columns
+ *   vs a single JSON payload column.
+ *
+ * The **canonical** configuration ({@see canonical()}) is the convergence target:
+ * new products should adopt it as-is, and products on a transition config should
+ * migrate toward it. The non-canonical knobs exist to buy time, not to be a
+ * permanent home (施主要件: clear も canonical に収斂).
+ *
+ * Part of the public API stability guarantee (see ADR 0009 and ADR 0014).
+ */
+final readonly class AuditTableConfig
+{
+    /**
+     * @param string      $organizationColumn column holding the tenant id
+     * @param ?string     $metadataColumn     column holding metadata JSON, or null if the table has none
+     * @param ?string     $beforeColumn       before-snapshot column (required for {@see AuditPayloadMode::BeforeAfter})
+     * @param ?string     $afterColumn        after-snapshot column (required for {@see AuditPayloadMode::BeforeAfter})
+     * @param ?string     $payloadColumn      single JSON payload column (required for {@see AuditPayloadMode::SinglePayload})
+     * @param bool        $idIsAutoIncrement  true = DB-generated numeric id (omitted from INSERT); false = caller-supplied id (written)
+     */
+    public function __construct(
+        public string $table,
+        public AuditPayloadMode $mode,
+        public string $idColumn = 'id',
+        public string $actionColumn = 'action',
+        public string $entityTypeColumn = 'entity_type',
+        public string $entityIdColumn = 'entity_id',
+        public string $actorColumn = 'actor_id',
+        public string $organizationColumn = 'organization_id',
+        public string $occurredAtColumn = 'occurred_at',
+        public ?string $metadataColumn = 'metadata_json',
+        public ?string $beforeColumn = 'before_json',
+        public ?string $afterColumn = 'after_json',
+        public ?string $payloadColumn = null,
+        public bool $idIsAutoIncrement = true,
+    ) {
+        if ($mode === AuditPayloadMode::BeforeAfter) {
+            if ($beforeColumn === null || $afterColumn === null) {
+                throw new InvalidArgumentException(
+                    'AuditPayloadMode::BeforeAfter requires both beforeColumn and afterColumn.',
+                );
+            }
+        } elseif ($payloadColumn === null) {
+            throw new InvalidArgumentException(
+                'AuditPayloadMode::SinglePayload requires payloadColumn.',
+            );
+        }
+    }
+
+    /**
+     * The framework-canonical table shape (the convergence target).
+     *
+     * Before/after snapshot columns, a `metadata_json` column, an `occurred_at`
+     * timestamp, and a DB-generated auto-increment `BIGINT` id. Matches the
+     * reference migration `database/migrations/*_create_audit_events_table` and
+     * `database/schema/audit_events.sql`.
+     *
+     * Pass `idIsAutoIncrement: false` on the constructor (not here) if your
+     * canonical table uses ULID ids instead.
+     */
+    public static function canonical(string $table = 'audit_events'): self
+    {
+        return new self(
+            table: $table,
+            mode: AuditPayloadMode::BeforeAfter,
+            idColumn: 'id',
+            actionColumn: 'action',
+            entityTypeColumn: 'entity_type',
+            entityIdColumn: 'entity_id',
+            actorColumn: 'actor_id',
+            organizationColumn: 'organization_id',
+            occurredAtColumn: 'occurred_at',
+            metadataColumn: 'metadata_json',
+            beforeColumn: 'before_json',
+            afterColumn: 'after_json',
+            payloadColumn: null,
+            idIsAutoIncrement: true,
+        );
+    }
+
+    /**
+     * Translates a whitelisted logical sort field ({@see AuditQuery::SORT_COLUMNS})
+     * to this table's physical column name. The input is always one of the closed
+     * set validated by {@see AuditQuery}, so the result is safe to splice into SQL.
+     */
+    public function physicalSortColumn(string $logicalColumn): string
+    {
+        return match ($logicalColumn) {
+            'occurred_at' => $this->occurredAtColumn,
+            'action' => $this->actionColumn,
+            'entity_type' => $this->entityTypeColumn,
+            default => $this->idColumn,
+        };
+    }
+}

--- a/src/Audit/PdoAuditEventRepository.php
+++ b/src/Audit/PdoAuditEventRepository.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Audit;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * {@see AuditEventRepositoryInterface} backed by a {@see DatabaseQueryExecutorInterface}
+ * and steered by an {@see AuditTableConfig} (ADR 0014).
+ *
+ * All SQL is parameterised. The only identifiers spliced into a statement are
+ * column/table names taken from the {@see AuditTableConfig} and a sort column
+ * resolved from {@see AuditQuery}'s closed whitelist — never caller-supplied
+ * strings. JSON is encoded with `JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE`
+ * so multibyte snapshots round-trip and an unencodable payload fails loudly
+ * rather than silently truncating the trail.
+ *
+ * Append-only: there is no update or delete path.
+ *
+ * Concrete implementation detail — **outside** the public API stability guarantee
+ * (ADR 0009). Depend on {@see AuditEventRepositoryInterface}.
+ *
+ * @phpstan-import-type SqlParameter from DatabaseQueryExecutorInterface
+ * @phpstan-import-type SqlParameters from DatabaseQueryExecutorInterface
+ */
+final readonly class PdoAuditEventRepository implements AuditEventRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private AuditTableConfig $config,
+    ) {
+    }
+
+    public function append(AuditEvent $event): void
+    {
+        $columns = [];
+        /** @var SqlParameters $params */
+        $params = [];
+
+        if (!$this->config->idIsAutoIncrement) {
+            $columns[] = $this->config->idColumn;
+            $params[] = $event->id;
+        }
+
+        $columns[] = $this->config->actionColumn;
+        $params[] = $event->action;
+
+        $columns[] = $this->config->entityTypeColumn;
+        $params[] = $event->entityType;
+
+        $columns[] = $this->config->entityIdColumn;
+        $params[] = $event->entityId;
+
+        $columns[] = $this->config->actorColumn;
+        $params[] = $event->actorId;
+
+        $columns[] = $this->config->organizationColumn;
+        $params[] = $event->organizationId;
+
+        $columns[] = $this->config->occurredAtColumn;
+        $params[] = $event->occurredAt;
+
+        if ($this->config->mode === AuditPayloadMode::BeforeAfter) {
+            // beforeColumn / afterColumn are guaranteed non-null by AuditTableConfig.
+            $columns[] = (string) $this->config->beforeColumn;
+            $params[] = self::encode($event->before);
+
+            $columns[] = (string) $this->config->afterColumn;
+            $params[] = self::encode($event->after);
+
+            if ($this->config->metadataColumn !== null) {
+                $columns[] = $this->config->metadataColumn;
+                $params[] = self::encode($event->metadata);
+            }
+        } else {
+            // payloadColumn is guaranteed non-null by AuditTableConfig.
+            $columns[] = (string) $this->config->payloadColumn;
+            $params[] = self::encode(self::foldPayload($event));
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($columns), '?'));
+
+        $this->query->execute(
+            'INSERT INTO ' . $this->config->table . ' (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')',
+            $params,
+        );
+    }
+
+    /**
+     * @return list<AuditEvent>
+     */
+    public function query(AuditQuery $query, int $limit, int $offset): array
+    {
+        [$where, $params] = $this->buildWhere($query);
+
+        $orderColumn = $this->config->physicalSortColumn($query->sortColumn);
+        $params[] = $limit;
+        $params[] = $offset;
+
+        $rows = $this->query->fetchAll(
+            'SELECT ' . $this->selectColumns() . ' FROM ' . $this->config->table
+            . ($where !== '' ? ' WHERE ' . $where : '')
+            . ' ORDER BY ' . $orderColumn . ' ' . $query->sortDirection . ', ' . $this->config->idColumn . ' ' . $query->sortDirection
+            . ' LIMIT ? OFFSET ?',
+            $params,
+        );
+
+        return array_map(fn (array $row): AuditEvent => $this->mapRow($row), $rows);
+    }
+
+    public function count(AuditQuery $query): int
+    {
+        [$where, $params] = $this->buildWhere($query);
+
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM ' . $this->config->table . ($where !== '' ? ' WHERE ' . $where : ''),
+            $params,
+        );
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    /**
+     * @return array{0: string, 1: SqlParameters}
+     */
+    private function buildWhere(AuditQuery $query): array
+    {
+        $clauses = [];
+        /** @var SqlParameters $params */
+        $params = [];
+
+        if ($query->organizationId !== null) {
+            $clauses[] = $this->config->organizationColumn . ' = ?';
+            $params[] = $query->organizationId;
+        }
+
+        if ($query->entityType !== null) {
+            $clauses[] = $this->config->entityTypeColumn . ' = ?';
+            $params[] = $query->entityType;
+        }
+
+        if ($query->entityId !== null) {
+            $clauses[] = $this->config->entityIdColumn . ' = ?';
+            $params[] = $query->entityId;
+        }
+
+        if ($query->action !== null) {
+            $clauses[] = $this->config->actionColumn . ' = ?';
+            $params[] = $query->action;
+        }
+
+        if ($query->actorId !== null) {
+            $clauses[] = $this->config->actorColumn . ' = ?';
+            $params[] = $query->actorId;
+        }
+
+        if ($query->occurredFrom !== null) {
+            $clauses[] = $this->config->occurredAtColumn . ' >= ?';
+            $params[] = $query->occurredFrom;
+        }
+
+        if ($query->occurredTo !== null) {
+            $clauses[] = $this->config->occurredAtColumn . ' <= ?';
+            $params[] = $query->occurredTo;
+        }
+
+        return [implode(' AND ', $clauses), $params];
+    }
+
+    private function selectColumns(): string
+    {
+        $columns = [
+            $this->config->idColumn,
+            $this->config->actionColumn,
+            $this->config->entityTypeColumn,
+            $this->config->entityIdColumn,
+            $this->config->actorColumn,
+            $this->config->organizationColumn,
+            $this->config->occurredAtColumn,
+        ];
+
+        if ($this->config->mode === AuditPayloadMode::BeforeAfter) {
+            $columns[] = (string) $this->config->beforeColumn;
+            $columns[] = (string) $this->config->afterColumn;
+
+            if ($this->config->metadataColumn !== null) {
+                $columns[] = $this->config->metadataColumn;
+            }
+        } else {
+            $columns[] = (string) $this->config->payloadColumn;
+        }
+
+        return implode(', ', $columns);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): AuditEvent
+    {
+        $before = null;
+        $after = null;
+        $metadata = null;
+
+        if ($this->config->mode === AuditPayloadMode::BeforeAfter) {
+            $before = self::decode($row[(string) $this->config->beforeColumn] ?? null);
+            $after = self::decode($row[(string) $this->config->afterColumn] ?? null);
+
+            if ($this->config->metadataColumn !== null) {
+                $metadata = self::decode($row[$this->config->metadataColumn] ?? null);
+            }
+        } else {
+            $folded = self::decode($row[(string) $this->config->payloadColumn] ?? null) ?? [];
+            $before = self::sub($folded, 'before');
+            $after = self::sub($folded, 'after');
+            $metadata = self::sub($folded, 'metadata');
+        }
+
+        $rawId = $row[$this->config->idColumn] ?? null;
+        $id = $rawId === null
+            ? null
+            : ($this->config->idIsAutoIncrement ? (int) $rawId : (string) $rawId);
+
+        return new AuditEvent(
+            action: (string) $row[$this->config->actionColumn],
+            entityType: (string) $row[$this->config->entityTypeColumn],
+            entityId: self::scalar($row[$this->config->entityIdColumn] ?? null),
+            actorId: self::scalar($row[$this->config->actorColumn] ?? null),
+            organizationId: self::scalar($row[$this->config->organizationColumn] ?? null),
+            before: $before,
+            after: $after,
+            metadata: $metadata,
+            occurredAt: (string) $row[$this->config->occurredAtColumn],
+            id: $id,
+        );
+    }
+
+    /**
+     * Folds before / after / metadata into one object for a single-payload table.
+     * Null branches are omitted so the stored JSON stays minimal.
+     *
+     * @return array<string, mixed>
+     */
+    private static function foldPayload(AuditEvent $event): array
+    {
+        $folded = [];
+
+        if ($event->before !== null) {
+            $folded['before'] = $event->before;
+        }
+
+        if ($event->after !== null) {
+            $folded['after'] = $event->after;
+        }
+
+        if ($event->metadata !== null) {
+            $folded['metadata'] = $event->metadata;
+        }
+
+        return $folded;
+    }
+
+    /**
+     * @param array<string, mixed> $folded
+     * @return array<string, mixed>|null
+     */
+    private static function sub(array $folded, string $key): ?array
+    {
+        $value = $folded[$key] ?? null;
+
+        return is_array($value) ? $value : null;
+    }
+
+    private static function scalar(mixed $value): string|int|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        return is_scalar($value) ? (string) $value : null;
+    }
+
+    /**
+     * @param array<string, mixed>|null $value
+     */
+    private static function encode(?array $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function decode(mixed $json): ?array
+    {
+        if (!is_string($json) || $json === '') {
+            return null;
+        }
+
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/tests/Audit/AuditQueryTest.php
+++ b/tests/Audit/AuditQueryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Audit;
+
+use InvalidArgumentException;
+use Nene2\Audit\AuditQuery;
+use PHPUnit\Framework\TestCase;
+
+final class AuditQueryTest extends TestCase
+{
+    public function testDefaultsToOccurredAtDescending(): void
+    {
+        $query = new AuditQuery();
+
+        self::assertSame('occurred_at', $query->sortColumn);
+        self::assertSame('DESC', $query->sortDirection);
+    }
+
+    public function testAcceptsEveryWhitelistedSortColumn(): void
+    {
+        foreach (AuditQuery::SORT_COLUMNS as $column) {
+            $query = new AuditQuery(sortColumn: $column);
+            self::assertSame($column, $query->sortColumn);
+        }
+    }
+
+    public function testNormalisesSortDirectionToUpperCase(): void
+    {
+        self::assertSame('ASC', (new AuditQuery(sortDirection: 'asc'))->sortDirection);
+        self::assertSame('DESC', (new AuditQuery(sortDirection: 'desc'))->sortDirection);
+    }
+
+    public function testRejectsSortColumnOutsideWhitelist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/sort column/');
+
+        // A classic injection attempt must never survive the boundary.
+        new AuditQuery(sortColumn: 'occurred_at; DROP TABLE audit_events');
+    }
+
+    public function testRejectsSortDirectionOutsideWhitelist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/sort direction/');
+
+        new AuditQuery(sortDirection: 'RANDOM()');
+    }
+}

--- a/tests/Audit/AuditRecorderFactoryTest.php
+++ b/tests/Audit/AuditRecorderFactoryTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Audit;
+
+use DateTimeImmutable;
+use Nene2\Audit\AuditEvent;
+use Nene2\Audit\AuditQuery;
+use Nene2\Audit\AuditRecorderFactory;
+use Nene2\Audit\AuditTableConfig;
+use Nene2\Audit\PdoAuditEventRepository;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Testing\DatabaseTestKit;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class AuditRecorderFactoryTest extends TestCase
+{
+    private string $path = '';
+
+    private DatabaseTestKit $kit;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir() . '/' . uniqid('audit-tx-', true) . '.sqlite';
+        $this->kit = DatabaseTestKit::sqlite($this->path);
+
+        $this->kit->queryExecutor->execute(
+            'CREATE TABLE audit_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                action VARCHAR(64) NOT NULL,
+                entity_type VARCHAR(64) NOT NULL,
+                entity_id VARCHAR(64) NULL,
+                actor_id VARCHAR(64) NULL,
+                organization_id VARCHAR(64) NULL,
+                before_json TEXT NULL,
+                after_json TEXT NULL,
+                metadata_json TEXT NULL,
+                occurred_at DATETIME NOT NULL
+            )',
+        );
+        $this->kit->queryExecutor->execute('CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->path !== '' && is_file($this->path)) {
+            @unlink($this->path);
+        }
+    }
+
+    public function testAuditRowCommitsAtomicallyWithMutation(): void
+    {
+        $factory = new AuditRecorderFactory($this->fixedClock(), AuditTableConfig::canonical());
+
+        $this->kit->transactionManager->transactional(function (DatabaseQueryExecutorInterface $exec) use ($factory): void {
+            $exec->insert('INSERT INTO widgets (name) VALUES (?)', ['gadget']);
+            $factory->forExecutor($exec)->record(new AuditEvent(
+                action: 'widget.created',
+                entityType: 'widget',
+                entityId: 1,
+                organizationId: 1,
+            ));
+        });
+
+        self::assertSame(1, $this->countWidgets());
+        self::assertSame(1, $this->auditRepo()->count(new AuditQuery(organizationId: 1)));
+    }
+
+    public function testAuditRowRollsBackWithMutation(): void
+    {
+        $factory = new AuditRecorderFactory($this->fixedClock(), AuditTableConfig::canonical());
+
+        try {
+            $this->kit->transactionManager->transactional(function (DatabaseQueryExecutorInterface $exec) use ($factory): void {
+                $exec->insert('INSERT INTO widgets (name) VALUES (?)', ['doomed']);
+                $factory->forExecutor($exec)->record(new AuditEvent(
+                    action: 'widget.created',
+                    entityType: 'widget',
+                    entityId: 1,
+                    organizationId: 1,
+                ));
+
+                throw new RuntimeException('business rule violated after the audit write');
+            });
+        } catch (RuntimeException $expected) {
+            self::assertSame('business rule violated after the audit write', $expected->getMessage());
+        }
+
+        // Neither the business row nor its audit row survive — they committed as one unit.
+        self::assertSame(0, $this->countWidgets());
+        self::assertSame(0, $this->auditRepo()->count(new AuditQuery(organizationId: 1)));
+    }
+
+    private function countWidgets(): int
+    {
+        $row = $this->kit->queryExecutor->fetchOne('SELECT COUNT(*) AS cnt FROM widgets');
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    private function auditRepo(): PdoAuditEventRepository
+    {
+        return new PdoAuditEventRepository($this->kit->queryExecutor, AuditTableConfig::canonical());
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class () implements ClockInterface {
+            public function now(): DateTimeImmutable
+            {
+                return new DateTimeImmutable('2026-07-05 12:00:00');
+            }
+        };
+    }
+}

--- a/tests/Audit/AuditRecorderTest.php
+++ b/tests/Audit/AuditRecorderTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Audit;
+
+use DateTimeImmutable;
+use Nene2\Audit\AuditEvent;
+use Nene2\Audit\AuditEventRepositoryInterface;
+use Nene2\Audit\AuditQuery;
+use Nene2\Audit\AuditRecorder;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+use PHPUnit\Framework\TestCase;
+
+final class AuditRecorderTest extends TestCase
+{
+    public function testFillsOccurredAtFromClockWhenAbsent(): void
+    {
+        $repository = self::spyRepository();
+        $recorder = new AuditRecorder($repository, self::clockAt('2026-07-05 09:30:00'));
+
+        $recorder->record(new AuditEvent(action: 'invoice.issued', entityType: 'invoice', entityId: 7));
+
+        self::assertSame('2026-07-05 09:30:00', $repository->last()->occurredAt);
+    }
+
+    public function testKeepsCallerSuppliedOccurredAt(): void
+    {
+        $repository = self::spyRepository();
+        $recorder = new AuditRecorder($repository, self::clockAt('2026-07-05 09:30:00'));
+
+        $recorder->record(new AuditEvent(
+            action: 'invoice.issued',
+            entityType: 'invoice',
+            entityId: 7,
+            occurredAt: '2020-01-01 00:00:00',
+        ));
+
+        self::assertSame('2020-01-01 00:00:00', $repository->last()->occurredAt);
+    }
+
+    public function testFillsOrganizationFromHolderWhenAbsent(): void
+    {
+        $repository = self::spyRepository();
+        /** @var RequestScopedHolder<string|int> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set('org-42');
+
+        $recorder = new AuditRecorder($repository, self::clockAt('2026-07-05 09:30:00'), $holder);
+        $recorder->record(new AuditEvent(action: 'user.created', entityType: 'user', entityId: 'u1'));
+
+        self::assertSame('org-42', $repository->last()->organizationId);
+    }
+
+    public function testKeepsCallerSuppliedOrganizationOverHolder(): void
+    {
+        $repository = self::spyRepository();
+        /** @var RequestScopedHolder<string|int> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set('org-from-holder');
+
+        $recorder = new AuditRecorder($repository, self::clockAt('2026-07-05 09:30:00'), $holder);
+        $recorder->record(new AuditEvent(
+            action: 'user.created',
+            entityType: 'user',
+            entityId: 'u1',
+            organizationId: 'org-explicit',
+        ));
+
+        self::assertSame('org-explicit', $repository->last()->organizationId);
+    }
+
+    public function testLeavesOrganizationNullWhenNoHolderAndNoValue(): void
+    {
+        $repository = self::spyRepository();
+        $recorder = new AuditRecorder($repository, self::clockAt('2026-07-05 09:30:00'));
+
+        $recorder->record(new AuditEvent(action: 'system.ping', entityType: 'system'));
+
+        self::assertNull($repository->last()->organizationId);
+    }
+
+    public function testDoesNotReadHolderThatWasNeverSet(): void
+    {
+        $repository = self::spyRepository();
+        // An unset holder throws on get(); the recorder must guard with isSet().
+        /** @var RequestScopedHolder<string|int> $holder */
+        $holder = new RequestScopedHolder();
+
+        $recorder = new AuditRecorder($repository, self::clockAt('2026-07-05 09:30:00'), $holder);
+        $recorder->record(new AuditEvent(action: 'system.ping', entityType: 'system'));
+
+        self::assertNull($repository->last()->organizationId);
+    }
+
+    private static function clockAt(string $instant): ClockInterface
+    {
+        return new class ($instant) implements ClockInterface {
+            public function __construct(private string $instant)
+            {
+            }
+
+            public function now(): DateTimeImmutable
+            {
+                return new DateTimeImmutable($this->instant);
+            }
+        };
+    }
+
+    private static function spyRepository(): SpyAuditEventRepository
+    {
+        return new SpyAuditEventRepository();
+    }
+}
+
+/**
+ * In-memory {@see AuditEventRepositoryInterface} capturing appended events.
+ */
+final class SpyAuditEventRepository implements AuditEventRepositoryInterface
+{
+    /** @var list<AuditEvent> */
+    private array $events = [];
+
+    public function append(AuditEvent $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    public function query(AuditQuery $query, int $limit, int $offset): array
+    {
+        return $this->events;
+    }
+
+    public function count(AuditQuery $query): int
+    {
+        return count($this->events);
+    }
+
+    public function last(): AuditEvent
+    {
+        return $this->events[count($this->events) - 1];
+    }
+}

--- a/tests/Audit/PdoAuditEventRepositoryTest.php
+++ b/tests/Audit/PdoAuditEventRepositoryTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Audit;
+
+use Nene2\Audit\AuditEvent;
+use Nene2\Audit\AuditPayloadMode;
+use Nene2\Audit\AuditQuery;
+use Nene2\Audit\AuditTableConfig;
+use Nene2\Audit\PdoAuditEventRepository;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class PdoAuditEventRepositoryTest extends TestCase
+{
+    private string $path = '';
+
+    private DatabaseQueryExecutorInterface $executor;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir() . '/' . uniqid('audit-', true) . '.sqlite';
+        $this->executor = DatabaseTestKit::sqlite($this->path)->queryExecutor;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->path !== '' && is_file($this->path)) {
+            @unlink($this->path);
+        }
+    }
+
+    public function testAppendAndQueryRoundTripCanonicalWithUnicode(): void
+    {
+        $this->createCanonicalTable();
+        $repo = new PdoAuditEventRepository($this->executor, AuditTableConfig::canonical());
+
+        $repo->append(new AuditEvent(
+            action: 'invoice.updated',
+            entityType: 'invoice',
+            entityId: 42,
+            actorId: 7,
+            organizationId: 3,
+            before: ['title' => '請求書', 'total' => 1000],
+            after: ['title' => '請求書（改訂）', 'total' => 1200],
+            metadata: ['request_id' => 'req-1', 'source' => 'api'],
+            occurredAt: '2026-07-05 10:00:00',
+        ));
+
+        $events = $repo->query(new AuditQuery(organizationId: 3), 10, 0);
+
+        self::assertCount(1, $events);
+        $event = $events[0];
+        self::assertSame('invoice.updated', $event->action);
+        self::assertSame('invoice', $event->entityType);
+        self::assertSame('42', (string) $event->entityId);
+        self::assertSame('7', (string) $event->actorId);
+        self::assertSame(['title' => '請求書', 'total' => 1000], $event->before);
+        self::assertSame(['title' => '請求書（改訂）', 'total' => 1200], $event->after);
+        self::assertSame(['request_id' => 'req-1', 'source' => 'api'], $event->metadata);
+        self::assertSame('2026-07-05 10:00:00', $event->occurredAt);
+        self::assertIsInt($event->id);
+
+        // Unicode is stored unescaped (JSON_UNESCAPED_UNICODE).
+        $raw = $this->executor->fetchOne('SELECT before_json FROM audit_events LIMIT 1');
+        self::assertNotNull($raw);
+        self::assertIsString($raw['before_json']);
+        self::assertStringContainsString('請求書', $raw['before_json']);
+    }
+
+    public function testAppendUsesAutoIncrementIdWhenConfigured(): void
+    {
+        $this->createCanonicalTable();
+        $repo = new PdoAuditEventRepository($this->executor, AuditTableConfig::canonical());
+
+        $repo->append(new AuditEvent(action: 'a.one', entityType: 't', occurredAt: '2026-07-05 10:00:00'));
+        $repo->append(new AuditEvent(action: 'a.two', entityType: 't', occurredAt: '2026-07-05 10:00:01'));
+
+        $events = $repo->query(new AuditQuery(sortColumn: 'id', sortDirection: 'ASC'), 10, 0);
+
+        self::assertSame([1, 2], array_map(static fn (AuditEvent $e): int|string|null => $e->id, $events));
+    }
+
+    public function testCreateAndDeleteSnapshotsMapToNullBranches(): void
+    {
+        $this->createCanonicalTable();
+        $repo = new PdoAuditEventRepository($this->executor, AuditTableConfig::canonical());
+
+        $repo->append(new AuditEvent(action: 'x.created', entityType: 'x', after: ['v' => 1], occurredAt: '2026-07-05 10:00:00'));
+        $repo->append(new AuditEvent(action: 'x.deleted', entityType: 'x', before: ['v' => 1], occurredAt: '2026-07-05 10:00:01'));
+
+        $events = $repo->query(new AuditQuery(sortColumn: 'id', sortDirection: 'ASC'), 10, 0);
+
+        self::assertNull($events[0]->before);
+        self::assertSame(['v' => 1], $events[0]->after);
+        self::assertSame(['v' => 1], $events[1]->before);
+        self::assertNull($events[1]->after);
+    }
+
+    public function testQueryFiltersAndSortDirection(): void
+    {
+        $this->createCanonicalTable();
+        $repo = new PdoAuditEventRepository($this->executor, AuditTableConfig::canonical());
+
+        $repo->append(new AuditEvent(action: 'a', entityType: 'invoice', entityId: 1, actorId: 5, organizationId: 1, occurredAt: '2026-07-01 00:00:00'));
+        $repo->append(new AuditEvent(action: 'b', entityType: 'payment', entityId: 2, actorId: 6, organizationId: 1, occurredAt: '2026-07-02 00:00:00'));
+        $repo->append(new AuditEvent(action: 'c', entityType: 'invoice', entityId: 3, actorId: 5, organizationId: 2, occurredAt: '2026-07-03 00:00:00'));
+
+        // organization scope
+        self::assertSame(2, $repo->count(new AuditQuery(organizationId: 1)));
+
+        // entityType + actorId filter
+        $filtered = $repo->query(new AuditQuery(organizationId: 1, entityType: 'invoice', actorId: 5), 10, 0);
+        self::assertCount(1, $filtered);
+        self::assertSame('a', $filtered[0]->action);
+
+        // date window
+        $window = $repo->query(new AuditQuery(occurredFrom: '2026-07-02 00:00:00', occurredTo: '2026-07-02 23:59:59'), 10, 0);
+        self::assertCount(1, $window);
+        self::assertSame('b', $window[0]->action);
+
+        // sort ascending vs descending by occurred_at
+        $asc = $repo->query(new AuditQuery(sortColumn: 'occurred_at', sortDirection: 'ASC'), 10, 0);
+        $desc = $repo->query(new AuditQuery(sortColumn: 'occurred_at', sortDirection: 'DESC'), 10, 0);
+        self::assertSame(['a', 'b', 'c'], array_map(static fn (AuditEvent $e): string => $e->action, $asc));
+        self::assertSame(['c', 'b', 'a'], array_map(static fn (AuditEvent $e): string => $e->action, $desc));
+    }
+
+    public function testColumnMapAndSinglePayloadModeSwap(): void
+    {
+        // A product table with different names, a single JSON payload column, no metadata column.
+        $this->executor->execute(
+            'CREATE TABLE clear_audit (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type VARCHAR(64) NOT NULL,
+                entity_type VARCHAR(64) NOT NULL,
+                entity_id VARCHAR(64) NULL,
+                actor_user_id VARCHAR(64) NULL,
+                organization_id VARCHAR(64) NULL,
+                payload_json TEXT NOT NULL,
+                occurred_at DATETIME NOT NULL
+            )',
+        );
+
+        $config = new AuditTableConfig(
+            table: 'clear_audit',
+            mode: AuditPayloadMode::SinglePayload,
+            actionColumn: 'event_type',
+            actorColumn: 'actor_user_id',
+            metadataColumn: null,
+            beforeColumn: null,
+            afterColumn: null,
+            payloadColumn: 'payload_json',
+        );
+        $repo = new PdoAuditEventRepository($this->executor, $config);
+
+        $repo->append(new AuditEvent(
+            action: 'payment.reconciled',
+            entityType: 'payment',
+            entityId: 9,
+            actorId: 4,
+            organizationId: 1,
+            before: ['status' => 'pending'],
+            after: ['status' => 'reconciled'],
+            metadata: ['ip' => '10.0.0.1'],
+            occurredAt: '2026-07-05 12:00:00',
+        ));
+
+        // before / after / metadata are folded into and unfolded from the single column.
+        $events = $repo->query(new AuditQuery(organizationId: 1), 10, 0);
+        self::assertCount(1, $events);
+        self::assertSame('payment.reconciled', $events[0]->action);
+        self::assertSame(['status' => 'pending'], $events[0]->before);
+        self::assertSame(['status' => 'reconciled'], $events[0]->after);
+        self::assertSame(['ip' => '10.0.0.1'], $events[0]->metadata);
+
+        // Physically, one JSON object holds all three sub-parts.
+        $raw = $this->executor->fetchOne('SELECT payload_json FROM clear_audit LIMIT 1');
+        self::assertNotNull($raw);
+        self::assertIsString($raw['payload_json']);
+        $decoded = json_decode($raw['payload_json'], true);
+        self::assertSame(['before', 'after', 'metadata'], array_keys((array) $decoded));
+    }
+
+    public function testUlidStringIdConfigWritesCallerSuppliedId(): void
+    {
+        $this->executor->execute(
+            'CREATE TABLE ulid_audit (
+                id CHAR(26) PRIMARY KEY,
+                action VARCHAR(64) NOT NULL,
+                entity_type VARCHAR(64) NOT NULL,
+                entity_id VARCHAR(64) NULL,
+                actor_id VARCHAR(64) NULL,
+                organization_id VARCHAR(64) NULL,
+                before_json TEXT NULL,
+                after_json TEXT NULL,
+                metadata_json TEXT NULL,
+                occurred_at DATETIME NOT NULL
+            )',
+        );
+
+        $config = new AuditTableConfig(
+            table: 'ulid_audit',
+            mode: AuditPayloadMode::BeforeAfter,
+            idIsAutoIncrement: false,
+        );
+        $repo = new PdoAuditEventRepository($this->executor, $config);
+
+        $repo->append(new AuditEvent(
+            action: 'document.uploaded',
+            entityType: 'document',
+            entityId: '01HXULIDENTITY0000000000000',
+            organizationId: 'org-1',
+            occurredAt: '2026-07-05 12:00:00',
+            id: '01HXAUDITEVENT00000000000000',
+        ));
+
+        $events = $repo->query(new AuditQuery(organizationId: 'org-1'), 10, 0);
+        self::assertCount(1, $events);
+        self::assertSame('01HXAUDITEVENT00000000000000', $events[0]->id);
+    }
+
+    public function testInterfaceIsAppendOnly(): void
+    {
+        // The persistence contract exposes no update/delete — the audit trail is immutable.
+        $methods = array_map(
+            static fn (\ReflectionMethod $m): string => $m->getName(),
+            (new ReflectionClass(\Nene2\Audit\AuditEventRepositoryInterface::class))->getMethods(),
+        );
+
+        sort($methods);
+        self::assertSame(['append', 'count', 'query'], $methods);
+    }
+
+    private function createCanonicalTable(): void
+    {
+        $sql = (string) file_get_contents(dirname(__DIR__, 2) . '/database/schema/audit_events.sql');
+
+        // Drop comment lines so the statement splitter sees only DDL.
+        $lines = array_filter(
+            explode("\n", $sql),
+            static fn (string $line): bool => !str_starts_with(trim($line), '--'),
+        );
+
+        foreach (array_filter(array_map('trim', explode(';', implode("\n", $lines)))) as $statement) {
+            $this->executor->execute($statement);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1494

## 目的

複数製品（invoice / payout / profile / vault / clear）が同型に自作していた監査ログ（`AuditRecorder` + `PdoAudit*Repository` + 記録 VO）を、NENE2 コアの 1 モジュール `Nene2\Audit` に集約する（横断監査 §4-1）。良形（invoice/payout: Clock 注入・before/after・recorderFactory による監査行の TX 原子性・ULID/int 両対応）を既定化し、悪形（profile: repo 内 `date()`・非原子）を構造的に解消する。dedup だけでなく**新規製品が監査を第一級機能として採用する標準経路**を提供する。

**スコープ**: NENE2 コアへの加算のみ。既存署名は不変。製品の自作撤去・移行は別 PR。他 repo 不接触（参照読取のみ）。

## 変更点

### 追加した公開安定 API（`src/Audit/`）
- `AuditEvent`（`final readonly` VO）— `action`（製品所有の free string・framework は enum 非同梱）/ `entityType` / `entityId` / `actorId` / `organizationId` / `before` / `after` / `metadata` / `occurredAt` / `id`。scalar id は `string|int|null`（auto-increment と ULID 両対応）。
- `AuditRecorderInterface::record(AuditEvent): void`
- `AuditRecorderFactoryInterface::forExecutor(DatabaseQueryExecutorInterface): AuditRecorderInterface` — 監査行を業務ミューテーションと同一 TX に束ねる seam。
- `AuditEventRepositoryInterface` — **append-only**（`append` / `query` / `count`・更新削除の経路なし）。
- `AuditQuery`（`final readonly` VO）— 共通フィルタ + sort 列/方向を**コンストラクタでホワイトリスト検証**（不正 sort を境界で拒否）。
- `AuditPayloadMode`（enum）— `BeforeAfter`（canonical）/ `SinglePayload`（過渡）。
- `AuditTableConfig` — 既存テーブルへ**再 migration せず**向けるカラム/モード/id 型の写像。`canonical()` が収斂先。

### 追加した既定実装（安定保証外・`src/Example/` 同様 depend on interface）
- `AuditRecorder` — `occurredAt`↔`ClockInterface`・`organizationId`↔`RequestScopedHolder` を補完（profile の `date()` ドリフト・非原子を構造解消）。
- `AuditRecorderFactory` — `forExecutor()` で TX 原子化（invoice/payout の良形を既定化）。
- `PdoAuditEventRepository` — 生パラメタ化 SQL・`JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE`。
- `AuditServiceProvider` — 参照配線サンプル（copy-and-adapt）。

### canonical 参照スキーマ（安定保証外の参照）
- `database/migrations/20260705000000_create_audit_events_table.php` ＋ `database/schema/audit_events.sql` — before/after・`metadata_json`・`occurred_at`・BIGINT autoinc 既定（ULID は `idIsAutoIncrement: false` で config 対応）。

### ドキュメント
- ADR 0014（上流化決定・種別非同梱の宣言・**canonical 収斂先＋新規採用経路**・スキーマ所有 A∪B・却下代替）。施主 2 点（clear も canonical に収斂／新規製品の標準採用経路）を Decision に明記。
- ADR 0009 安定表に `Nene2\Audit` 行追加（安定＝IF/VO/`AuditTableConfig`、保証外＝具象実装/`PdoAuditEventRepository`/`AuditServiceProvider`）。
- ADR index・CHANGELOG（Unreleased/Added）。

## 検証
- `composer check` green: **PHPUnit 757 tests / 1842 assertions OK**・**PHPStan L8 0 errors**・**CS 0**・OpenAPI valid・MCP valid・version OK。
- 新規テスト `tests/Audit/*`（22 tests）: record→append の occurredAt/org 補完・holder 未設定ガード・`forExecutor` の TX 原子性（commit/rollback とも監査行が業務行と同運命）・`AuditQuery` の sort ホワイトリスト（injection 文字列拒否）・`AuditTableConfig` のカラム/モード差し替え（canonical BeforeAfter・SinglePayload fold/unfold・ULID id config）・JSON unicode 非エスケープ・append-only 契約。

## スコープ外（別 PR）
製品の自作撤去・移行／一覧 route・CSV export・actor_email join（製品差・製品の read 層に据え置き）。

## Self-review
backend-api, database, docs-policy

## 残リスク
- `SinglePayload` は clear 過渡向け。clear の canonical 収斂は schema 移行が必要（別 PR）。
- 参照 migration は Example と同様 consumer が phinx 実行時に生成され得る（notes/tags と同じ扱い・安定保証外）。