### PR TITLE
fix(config): ConfigLoader のカスタム defaults を canonical へ merge する

### DIFF
--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -10,29 +10,48 @@ use Dotenv\Dotenv;
 final readonly class ConfigLoader
 {
     /**
-     * @param array<string, string> $defaults
+     * Canonical framework configuration defaults.
+     *
+     * Every key {@see load()} reads is present here, so the loader can treat each
+     * `$values[...]` access as a guaranteed string. Custom values passed to the
+     * constructor are layered *over* this base rather than replacing it (see
+     * {@see __construct()}), so a partial map can never drop a key and trigger a
+     * `TypeError` deep inside parsing.
+     *
+     * @var array<string, string>
+     */
+    private const DEFAULTS = [
+        'APP_ENV' => 'local',
+        'APP_DEBUG' => 'false',
+        'APP_NAME' => 'NENE2',
+        'NENE2_MACHINE_API_KEY' => '',
+        'NENE2_LOCAL_JWT_SECRET' => '',
+        'NENE2_ALLOW_DEV_SECRET' => '',
+        'PROBLEM_DETAILS_BASE_URL' => 'https://nene2.dev/problems/',
+        'DATABASE_URL' => '',
+        'DB_ENV' => 'local',
+        'DB_ADAPTER' => 'mysql',
+        'DB_HOST' => '127.0.0.1',
+        'DB_PORT' => '3306',
+        'DB_NAME' => 'nene2',
+        'DB_USER' => 'nene2',
+        'DB_PASSWORD' => '',
+        'DB_CHARSET' => 'utf8mb4',
+    ];
+
+    /** @var array<string, string> */
+    private array $defaults;
+
+    /**
+     * @param array<string, string> $defaults Values layered over {@see self::DEFAULTS};
+     *        any unspecified key falls back to the canonical default, so a partial map
+     *        is safe (it never omits a key that {@see load()} requires).
      */
     public function __construct(
         private string $projectRoot,
-        private array $defaults = [
-            'APP_ENV' => 'local',
-            'APP_DEBUG' => 'false',
-            'APP_NAME' => 'NENE2',
-            'NENE2_MACHINE_API_KEY' => '',
-            'NENE2_LOCAL_JWT_SECRET' => '',
-            'NENE2_ALLOW_DEV_SECRET' => '',
-            'PROBLEM_DETAILS_BASE_URL' => 'https://nene2.dev/problems/',
-            'DATABASE_URL' => '',
-            'DB_ENV' => 'local',
-            'DB_ADAPTER' => 'mysql',
-            'DB_HOST' => '127.0.0.1',
-            'DB_PORT' => '3306',
-            'DB_NAME' => 'nene2',
-            'DB_USER' => 'nene2',
-            'DB_PASSWORD' => '',
-            'DB_CHARSET' => 'utf8mb4',
-        ],
+        array $defaults = [],
     ) {
+        $this->defaults = array_merge(self::DEFAULTS, $defaults);
     }
 
     /**

--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -240,6 +240,23 @@ final class ConfigLoaderTest extends TestCase
         self::assertFalse($config->allowDevSecret);
     }
 
+    public function testPartialConstructorDefaultsLayerOverCanonicalDefaults(): void
+    {
+        // A consumer that preseeds the loader with a partial defaults map (omitting keys
+        // it does not care about, e.g. NENE2_ALLOW_DEV_SECRET) must not trigger a
+        // TypeError: unspecified keys fall back to the canonical defaults, and the
+        // dev-secret opt-in stays opted out.
+        $config = (new ConfigLoader($this->emptyProjectRoot(), [
+            'DB_ADAPTER' => 'sqlite',
+            'DB_NAME' => ':memory:',
+        ]))->load();
+
+        self::assertSame('sqlite', $config->database->adapter);
+        self::assertSame(':memory:', $config->database->name);
+        self::assertFalse($config->allowDevSecret);
+        self::assertSame(AppEnvironment::Local, $config->environment);
+    }
+
     private function emptyProjectRoot(): string
     {
         return sys_get_temp_dir();


### PR DESCRIPTION
## 目的
Closes #1509

`ConfigLoader` に部分的な `$defaults` を渡した consumer（ローダーをプリシードする用途）が、`load()` 内の必須 string アクセスで cryptic `TypeError` を起こす頑健性バグを修正する。実害として nene-suite の `ControlDatabaseConfigResolverTest` が CI レッド化していた（#1490 で canonical へ `NENE2_ALLOW_DEV_SECRET` を追加した際、部分 defaults を渡す consumer が silent 破壊された）。

## 変更点
- canonical 全キーを `private const DEFAULTS` に切り出し。
- コンストラクタの独自 `$defaults` を `array_merge(self::DEFAULTS, $defaults)` で **上書き適用**（従来の丸ごと置換をやめ、`load()` 既存の override idiom に揃える）。未指定キーは canonical へフォールバック。
- 回帰テスト `testPartialConstructorDefaultsLayerOverCanonicalDefaults` を追加。

## 検証結果
- `vendor/bin/phpunit --filter ConfigLoaderTest` → OK (30 tests, 67 assertions)
- `composer analyse`（PHPStan）→ No errors
- `php-cs-fixer`（変更ファイル）→ 0 fixable
- unit testsuite `NENE2` → OK (747 tests, 1792 assertions)
- （Database/MySQL suite は当環境で Docker 不可のため未実行。本変更は config パースのみで DB 非依存）
- 併せて nene-suite の該当テストが本ブランチの NENE2 に対して緑化することを確認。

## 後方互換 / ADR
- `ConfigLoader` は ADR 0009 で `@internal`。no-arg／既定 defaults を使う全 consumer は挙動不変（`array_merge(DEFAULTS, []) === DEFAULTS`）。部分指定のみ改善。opt-out 既定（未設定＝dev secret 不許可）不変。

## 残リスク
- なし（内部クラス・挙動不変・改善のみ）。リリース/タグ判断は統括に委ねる。

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)