### PR TITLE
chore(release): v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.8.1] — 2026-07-07
+
+ランタイム後方互換なパッチリリース。`@internal` な `ConfigLoader` の部分 defaults 頑健化（fix）と、フリート横断で再発するドリフトを機械検出する開発者向け準拠リンタ `tools/conformance.php`（ADR 0016）を収録する。いずれもランタイム公開 API は不変で、後者は `tools/` 開発者ツール（ADR 0009 §5 でライブラリ API 対象外）＝製品の実行時サーフェスは変わらない。
+
 ### Added
 - 準拠リンタ `tools/conformance.php` — フリート横断で再発するドリフトを既存の `tools/validate-*.php` 配管（`php vendor/hideyukimori/nene2/tools/conformance.php --root=.`）に1本足して機械検出する（ADR 0016・設計 `_work/reports/2026-07-06/upstream-design/04-conformance-linter.md`）。**偽陽性の低い error 適格の4ルールのみ**を token/manifest 解析で実装（生 grep ではなくトークン走査なので comment/docblock では発火しない）: **D1** ハードコード JWT/既定 secret リテラル禁止（`src/` の文字列リテラルを走査し `*-dev-secret`/`changeme`/`secret-key` 等の dev-secret 形のみ検出。空白入りの散文・upper snake の env 変数**名**〔`NENE2_ALLOW_DEV_SECRET`〕・配列キー位置は除外＝`GuardedJwtSecretResolver`〔ADR 0013〕を強制）／**D2** 依存の feature ブランチ固定禁止（`composer.json` require と `composer.lock` の version を解析し `dev-feat/...` 型の branch pin を検出。mainline `dev-main`/`@dev` は設計上 warn 層で対象外）／**D3** `composer check` への conformance 自己組込（`scripts.check` に `@conformance` 必須＝リンタが自己強制）／**D4** 生 `time()`/`microtime()`・単一引数 `date()`/`gmdate()`・`new DateTime[Immutable]('now')` 禁止（`ClockInterface` 実装クラスと明示タイムスタンプ付き `date()`〔表示整形〕は除外＝`Nene2\Http\ClockInterface` 注入を強制）。設計で warn/info とされた再発明系・dead 依存・「不在の証明」系は record #16 の教訓（transitive/runtime 使用の静的見落とし）を制度化して**ゲートに含めない**。段階採用装置として per-repo `conformance.baseline.json`（phpstan baseline 同型・`rule+file+message` 一致で行ズレ耐性・`--write-baseline` 生成の `ignore` スナップショット＋**理由必須の `allow` allowlist**〔理由欠落は設定エラーで実行拒否〕）とインライン `// conformance:ignore <rule> <reason>` を提供。NENE2 自身に `composer check` 経由で report-only 適用し緑（framework の3つの time プリミティブ〔`ThrottleMiddleware`/`InMemoryRateLimitStorage`/`TotpAuthenticator`〕は理由付き `allow`・D1 検出器自身のパターン literal はインライン ignore・他に検出なし）。他製品への fan-out・PHPStan 型 aware 版・warn 層ルールは別 Wave（#1511）
+
+### Fixed
+- `ConfigLoader` に部分的な `$defaults` を渡してローダーをプリシードする consumer が、`load()` 内の必須 string アクセスで cryptic な `TypeError` を起こしていた問題を修正。canonical な全キーを `self::DEFAULTS` 定数へ切り出し、独自 `$defaults` は `array_merge(self::DEFAULTS, $defaults)` で上書き適用する（`load()` 既存の override idiom と同型）。これにより部分指定でも全キーが常に存在し、未指定キーは canonical 既定へフォールバックする。`NENE2_ALLOW_DEV_SECRET` を欠いた defaults でも opt-out 既定（未設定＝dev secret 不許可）を保つ。`ConfigLoader` は ADR 0009 §5 で `@internal`・no-arg／既定 defaults 利用の全 consumer は挙動不変のため**後方互換**。回帰テストを追加（#1510）
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.8.0
+  version: 1.8.1
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.8.0';
+    public const string VERSION = '1.8.1';
 
     public function name(): string
     {


### PR DESCRIPTION
## Release v1.8.1

v1.8.0 tag 以降の main に載った2件を発行するリリース PR。

### 収録
- **#1510** fix(config): `ConfigLoader` の部分 defaults 頑健化 — `array_merge(self::DEFAULTS, $defaults)` で canonical 全キーへ merge。`@internal`（ADR 0009 §5）・no-arg / 既定 defaults 利用の全 consumer は挙動不変で後方互換。回帰テスト追加。
- **#1512** feat(conformance): 準拠リンタ `tools/conformance.php`（D1-D4 error ルール・ADR 0016）— `tools/` 開発者ツール（ADR 0009 §5 でライブラリ API 対象外）。ランタイム公開 API 不変。

### semver: patch (v1.8.1)
- ConfigLoader は ADR 0009 §5 で `@internal` に列挙された非公開クラスへの fix。
- conformance は `tools/` 配下の開発者ツール（ADR 0009 §5「`tools/` scripts — developer tooling, not part of the library API」）＋ `src/Conformance/*` は ADR 0009 §3 の安定サーフェスに未追加。
- いずれもランタイム後方互換で製品の実行時サーフェスを広げないため、release-checklist の「small fixes」に該当しパッチが妥当（minor は runtime framework surface を広げる 1.6/1.7/1.8 系に対応）。

### この PR の内容
- CHANGELOG `[Unreleased]` → `[1.8.1] — 2026-07-07` 昇格（新しい空 `[Unreleased]` を残す）。#1510 の `### Fixed` エントリを追記（元 PR で CHANGELOG 未記載だったため補完）。
- `FrameworkInfo::VERSION` 1.8.0 → 1.8.1
- `docs/openapi/openapi.yaml` info.version 1.8.0 → 1.8.1

### 検証
`composer check` 緑（789 tests / PHPStan 0 errors / cs-fixer 0 / OpenAPI valid / MCP valid / **Conformance OK** / **Version consistency OK: 1.8.1**）、`composer validate` OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)