### PR TITLE
fix(conformance): 消費側 autoload fatal と D1 guarded-literal 誤検知を修正する (#1514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- 準拠リンタ `tools/conformance.php` の**消費側 CI を必ず赤にする autoload バグ**を修正（ADR 0016）。スクリプトは `require dirname(__DIR__) . '/vendor/autoload.php'`（＝ NENE2 自身の vendor）を読んでいたが、消費者は NENE2 を依存として取り込むため `vendor/hideyukimori/nene2/vendor/` を持たず、`../NENE2` を `git clone --depth=1` するだけで `composer install` しない実 CI で **fatal（exit 255）**になっていた（ローカルが緑だったのは symlink 先がフル dev チェックアウトだったため）。姉妹バリデータ `tools/validate-mcp-tools.php`（8製品で CI 実績あり）と同じく `--root`/`getcwd()` で解決した**消費側 `$projectRoot/vendor/autoload.php`** を require する方式へ揃えた。消費側フラット vendor には `Nene2\` PSR-4（`Nene2\Conformance\*` 含む）が登録済みで解決可能。NENE2 自己実行（`--root=.`）でも projectRoot が NENE2 root になり従来どおり動作する。フラット消費側 vendor を模した一時ツリーで nested スクリプトを走らせ fatal 解消を実証する回帰テストを追加（`ConformanceRulesTest::testConformanceCliLoadsConsumerAutoloaderNotFrameworkVendor`）。
+- D1（`JwtDefaultSecretRule`）の**フリート全体の誤検知**を修正（ADR 0016・設計 04 の「+ GuardedJwtSecretResolver 不使用」条件の欠落分）。2026-07-05 の JWT 移行で全11製品が採る正準 fail-close パターン — 製品注入の dev fallback リテラル（例 `const DEFAULT_DEV_SECRET = '<slug>-dev-secret'`）を `GuardedJwtSecretResolver::fromConfig($config, self::DEFAULT_DEV_SECRET)` の第2引数に渡す — を guard 文脈を見ずに裸の secret として検出していた。**同一ファイルで `GuardedJwtSecretResolver::fromConfig()` の第2引数として渡るリテラル**（直接、またはそれを初期化する定数経由）を D1 から免除する。免除は狭く、真の裸 secret（`getenv('X') ?: 'acme-dev-secret'`）は resolver に渡らないため同一ファイルに resolver 使用があっても検出のまま。回帰テスト（定数経由の免除・直接リテラルの免除・同一ファイル併存時に裸 secret を検出のまま）を追加。
+
 ---
 
 ## [1.8.1] — 2026-07-07

--- a/docs/adr/0016-conformance-linter.md
+++ b/docs/adr/0016-conformance-linter.md
@@ -43,7 +43,14 @@ comments and docblocks never trip a rule):
   `T_CONSTANT_ENCAPSED_STRING` values matching a development-secret shape
   (`*-dev-secret`, `changeme`, `secret-key`, ...), excluding whitespace-bearing
   prose, upper snake-case env-variable *names* (`NENE2_ALLOW_DEV_SECRET`), and
-  array-key positions.
+  array-key positions. A literal fed to the fail-closed
+  `GuardedJwtSecretResolver::fromConfig()` as its second argument (the
+  product-injected dev secret) — directly, or via the constant it initialises in
+  the same file — is exempt, since the resolver refuses it in production (this is
+  the design's "+ `GuardedJwtSecretResolver` unused" condition, and the canonical
+  2026-07-05 fleet fail-close shape). The exemption is narrow: a naked fallback
+  (`getenv('X') ?: 'acme-dev-secret'`) never reaches the resolver and stays
+  flagged even alongside resolver use in the same file.
 - **D2** — Composer dependency pinned to a feature branch. Parse `composer.json`
   requires and `composer.lock` package versions; flag `dev-feat/...`-style
   feature-branch pins (mainline `dev-main` / `@dev` are the design's `warn`
@@ -90,5 +97,9 @@ Gradual adoption and false-positive relief use three mechanisms:
 
 - Issue: `#1511`
 - PR: `#1512`
+- Fan-out fixes (fleet CI pilot, 2026-07-07): `#1514` — consumer autoload path
+  (the CLI must require the resolved consumer `vendor/autoload.php`, matching
+  `tools/validate-mcp-tools.php`, not NENE2's own nested vendor) and the D1
+  `GuardedJwtSecretResolver` guarded-literal exemption above.
 - Supersedes: none
 - Superseded by: none

--- a/src/Conformance/Rule/JwtDefaultSecretRule.php
+++ b/src/Conformance/Rule/JwtDefaultSecretRule.php
@@ -24,6 +24,18 @@ use Nene2\Conformance\Severity;
  * `<slug>-secret`, etc. Env-variable **names** such as `NENE2_LOCAL_JWT_SECRET`
  * (upper snake case) are intentionally excluded, keeping false positives near
  * zero.
+ *
+ * Guarded-literal exemption (design 04 "+ GuardedJwtSecretResolver 不使用"):
+ * the canonical fail-close pattern injects a product development secret **into**
+ * {@see \Nene2\Auth\GuardedJwtSecretResolver::fromConfig()} as its second
+ * argument, e.g. `GuardedJwtSecretResolver::fromConfig($config,
+ * self::DEFAULT_DEV_SECRET)` with `const DEFAULT_DEV_SECRET = '<slug>-dev-secret'`.
+ * Such a literal is *not* a naked default secret — the resolver refuses it in
+ * production (ADR 0013) — so a literal that is passed (directly, or via the
+ * constant it initialises) as `fromConfig()`'s second argument in the same file
+ * is exempt. The exemption is narrow on purpose: a truly naked secret
+ * (`getenv('X') ?: 'acme-dev-secret'`) is never fed to the resolver, so it stays
+ * flagged even in a file that also uses `GuardedJwtSecretResolver` elsewhere.
  */
 final class JwtDefaultSecretRule implements RuleInterface
 {
@@ -91,6 +103,7 @@ final class JwtDefaultSecretRule implements RuleInterface
 
         $hits = [];
         $count = count($tokens);
+        [$guardedLiteralIndices, $guardedConstNames] = $this->guardedDevSecrets($tokens, $count);
 
         for ($i = 0; $i < $count; $i++) {
             $token = $tokens[$i];
@@ -122,12 +135,174 @@ final class JwtDefaultSecretRule implements RuleInterface
                 continue;
             }
 
-            if (preg_match(self::SECRET_PATTERN, $value) === 1) {
-                $hits[] = [$token[2], $value];
+            if (preg_match(self::SECRET_PATTERN, $value) !== 1) {
+                continue;
             }
+
+            // Guarded-literal exemption: the literal is handed to the fail-closed
+            // GuardedJwtSecretResolver (ADR 0013), so it is not a naked default.
+            // Either the literal is itself `fromConfig()`'s second argument, or it
+            // initialises the constant that is passed there in the same file.
+            if (isset($guardedLiteralIndices[$i])) {
+                continue;
+            }
+
+            if ($this->isToken($prev, '=')
+                && $this->isGuardedConstAssignment($tokens[$i - 2] ?? null, $guardedConstNames)
+            ) {
+                continue;
+            }
+
+            $hits[] = [$token[2], $value];
         }
 
         return $hits;
+    }
+
+    /**
+     * Collects the development-secret literals that feed
+     * `GuardedJwtSecretResolver::fromConfig(..., <literal|CONST>)` in this file.
+     *
+     * The resolver's second parameter is the product-injected development secret,
+     * which the resolver refuses in production — so those literals are not naked
+     * defaults and must not trip D1. Returns two lookups: token indices of literals
+     * passed directly, and the names of constants passed there (whose initialiser
+     * literal is then exempt).
+     *
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     * @return array{0: array<int, true>, 1: array<string, true>}
+     */
+    private function guardedDevSecrets(array $tokens, int $count): array
+    {
+        $literalIndices = [];
+        $constNames = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            if (!$this->isGuardedResolverName($tokens[$i])) {
+                continue;
+            }
+
+            $colon = $tokens[$i + 1] ?? null;
+            $method = $tokens[$i + 2] ?? null;
+            $paren = $tokens[$i + 3] ?? null;
+
+            if (!is_array($colon) || $colon[0] !== T_DOUBLE_COLON) {
+                continue;
+            }
+
+            if (!is_array($method) || $method[0] !== T_STRING || $method[1] !== 'fromConfig') {
+                continue;
+            }
+
+            if (!$this->isToken($paren, '(')) {
+                continue;
+            }
+
+            $secondArg = $this->secondArgumentTokens($tokens, $count, $i + 3);
+
+            if ($secondArg === null || $secondArg === []) {
+                continue;
+            }
+
+            if (count($secondArg) === 1) {
+                [$index, $only] = $secondArg[0];
+
+                if (is_array($only) && $only[0] === T_CONSTANT_ENCAPSED_STRING) {
+                    $literalIndices[$index] = true;
+                    continue;
+                }
+            }
+
+            // `self::DEFAULT_DEV_SECRET`, `Foo::DEFAULT_DEV_SECRET`, or a bare
+            // `DEFAULT_DEV_SECRET`: the trailing identifier is the constant name.
+            $last = $secondArg[count($secondArg) - 1][1];
+
+            if (is_array($last) && $last[0] === T_STRING) {
+                $constNames[$last[1]] = true;
+            }
+        }
+
+        return [$literalIndices, $constNames];
+    }
+
+    /**
+     * Top-level tokens of the second argument of the call whose `(` is at
+     * `$openParenIndex`, or null when there is no second argument. Commas nested
+     * inside `()`/`[]`/`{}` do not separate arguments.
+     *
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     * @return list<array{0: int, 1: array{0: int, 1: string, 2: int}|string}>|null
+     */
+    private function secondArgumentTokens(array $tokens, int $count, int $openParenIndex): ?array
+    {
+        $depth = 0;
+        $argIndex = 0;
+        $current = [];
+
+        for ($j = $openParenIndex + 1; $j < $count; $j++) {
+            $token = $tokens[$j];
+
+            if (is_string($token)) {
+                if ($token === '(' || $token === '[' || $token === '{') {
+                    $depth++;
+                    $current[] = [$j, $token];
+                    continue;
+                }
+
+                if ($token === ')' || $token === ']' || $token === '}') {
+                    if ($depth === 0) {
+                        return $argIndex === 1 ? $current : null;
+                    }
+
+                    $depth--;
+                    $current[] = [$j, $token];
+                    continue;
+                }
+
+                if ($token === ',' && $depth === 0) {
+                    if ($argIndex === 1) {
+                        return $current;
+                    }
+
+                    $argIndex++;
+                    $current = [];
+                    continue;
+                }
+            }
+
+            $current[] = [$j, $token];
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether the token is a reference to `GuardedJwtSecretResolver`, imported or
+     * written as a (fully) qualified name.
+     *
+     * @param array{0: int, 1: string, 2: int}|string|null $token
+     */
+    private function isGuardedResolverName(array|string|null $token): bool
+    {
+        if (!is_array($token) || !in_array($token[0], [T_STRING, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED], true)) {
+            return false;
+        }
+
+        $position = strrpos($token[1], '\\');
+        $base = $position === false ? $token[1] : substr($token[1], $position + 1);
+
+        return $base === 'GuardedJwtSecretResolver';
+    }
+
+    /**
+     * Whether the token is a constant identifier that names a guarded dev secret.
+     *
+     * @param array{0: int, 1: string, 2: int}|string|null $token
+     * @param array<string, true> $constNames
+     */
+    private function isGuardedConstAssignment(array|string|null $token, array $constNames): bool
+    {
+        return is_array($token) && $token[0] === T_STRING && isset($constNames[$token[1]]);
     }
 
     /**

--- a/tests/Conformance/ConformanceRulesTest.php
+++ b/tests/Conformance/ConformanceRulesTest.php
@@ -63,6 +63,116 @@ final class ConformanceRulesTest extends TestCase
         self::assertSame([], (new JwtDefaultSecretRule())->check($this->root));
     }
 
+    public function testD1ExemptsDevSecretConstantFedToGuardedResolver(): void
+    {
+        // Canonical 2026-07-05 fail-close pattern (all 11 migrated products): the
+        // dev-secret literal only feeds GuardedJwtSecretResolver::fromConfig() via
+        // the constant it initialises, so the resolver (ADR 0013) guards it.
+        $this->writeSrc('Auth/AuthServiceProvider.php', <<<'PHP'
+            <?php
+            namespace App\Auth;
+            use Nene2\Auth\GuardedJwtSecretResolver;
+            final class AuthServiceProvider {
+                private const DEFAULT_DEV_SECRET = 'nene-invoice-dev-secret';
+                public function verifier(object $config): string {
+                    return GuardedJwtSecretResolver::fromConfig($config, self::DEFAULT_DEV_SECRET);
+                }
+            }
+            PHP);
+
+        self::assertSame([], (new JwtDefaultSecretRule())->check($this->root));
+    }
+
+    public function testD1ExemptsLiteralPassedDirectlyToGuardedResolver(): void
+    {
+        $this->writeSrc('Auth/Direct.php', <<<'PHP'
+            <?php
+            namespace App\Auth;
+            use Nene2\Auth\GuardedJwtSecretResolver;
+            final class Direct {
+                public function verifier(object $config): string {
+                    return GuardedJwtSecretResolver::fromConfig($config, 'acme-dev-secret');
+                }
+            }
+            PHP);
+
+        self::assertSame([], (new JwtDefaultSecretRule())->check($this->root));
+    }
+
+    public function testD1StillFlagsNakedSecretDespiteGuardedResolverInSameFile(): void
+    {
+        // Over-exemption guard: the guarded constant is exempt, but a truly naked
+        // fallback in the *same* file — never fed to the resolver — stays flagged.
+        $this->writeSrc('Auth/Mixed.php', <<<'PHP'
+            <?php
+            namespace App\Auth;
+            use Nene2\Auth\GuardedJwtSecretResolver;
+            final class Mixed {
+                private const DEFAULT_DEV_SECRET = 'guarded-dev-secret';
+                public function ok(object $config): string {
+                    return GuardedJwtSecretResolver::fromConfig($config, self::DEFAULT_DEV_SECRET);
+                }
+                public function leak(): string {
+                    return getenv('JWT_SECRET') ?: 'naked-dev-secret';
+                }
+            }
+            PHP);
+
+        $findings = (new JwtDefaultSecretRule())->check($this->root);
+        self::assertCount(1, $findings);
+        self::assertSame('D1', $findings[0]->ruleId);
+        self::assertStringContainsString('naked-dev-secret', $findings[0]->message);
+    }
+
+    public function testConformanceCliLoadsConsumerAutoloaderNotFrameworkVendor(): void
+    {
+        // Regression for the fan-out blocker: the CLI must require the *consumer's*
+        // vendor/autoload.php (resolved from --root), not `dirname(__DIR__)/vendor`
+        // (NENE2's own vendor). Simulate a flat consumer install where the script
+        // lives at vendor/hideyukimori/nene2/tools/ (so dirname(__DIR__) has NO
+        // vendor/) while the consumer root carries the flat autoloader.
+        $frameworkRoot = dirname(__DIR__, 2);
+        $frameworkAutoload = $frameworkRoot . '/vendor/autoload.php';
+
+        if (!is_file($frameworkAutoload)) {
+            self::markTestSkipped('framework vendor autoloader unavailable');
+        }
+
+        $nestedTools = $this->root . '/vendor/hideyukimori/nene2/tools';
+        mkdir($nestedTools, 0o777, true);
+        copy($frameworkRoot . '/tools/conformance.php', $nestedTools . '/conformance.php');
+
+        // Flat consumer autoloader shim standing in for Composer's, which registers
+        // the Nene2\ PSR-4 prefix (incl. Nene2\Conformance\*).
+        $this->write('vendor/autoload.php', sprintf(
+            "<?php require %s;\n",
+            var_export($frameworkAutoload, true),
+        ));
+        $this->write('composer.json', json_encode([
+            'scripts' => ['check' => ['@conformance']],
+        ], JSON_THROW_ON_ERROR));
+
+        $command = sprintf(
+            '%s %s --root=%s --format=json 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($nestedTools . '/conformance.php'),
+            escapeshellarg($this->root),
+        );
+
+        $output = [];
+        $code = 0;
+        exec($command, $output, $code);
+        $stdout = implode("\n", $output);
+
+        self::assertNotSame(255, $code, 'CLI fatally errored (autoload) on a flat consumer vendor: ' . $stdout);
+        self::assertJson($stdout);
+
+        $decoded = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('ok', $decoded);
+        self::assertTrue($decoded['ok']);
+    }
+
     // --- D2 -----------------------------------------------------------------
 
     public function testD2FlagsFeatureBranchPinInComposerJson(): void

--- a/tools/conformance.php
+++ b/tools/conformance.php
@@ -53,7 +53,15 @@ if (!in_array($format, ['text', 'json'], true)) {
     exit(2);
 }
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+// Load the *consumer's* autoloader (the resolved project root), matching the
+// sibling validators (`tools/validate-mcp-tools.php`). Consumers take NENE2 as a
+// dependency and have a flat `vendor/` that registers `Nene2\` (incl.
+// `Nene2\Conformance\*`) but not a nested `vendor/hideyukimori/nene2/vendor/`.
+// Requiring `dirname(__DIR__) . '/vendor/autoload.php'` (NENE2's own vendor) was a
+// fatal in consumer CI, which clones NENE2 without running `composer install`
+// inside it. When NENE2 runs the linter on itself (`--root=.`), $projectRoot is
+// the NENE2 root and this resolves to NENE2's own vendor.
+require $projectRoot . '/vendor/autoload.php';
 
 $root = rtrim(str_replace('\\', '/', $projectRoot), '/');
 $baselinePath = $root . '/' . ConformanceRunner::BASELINE_FILENAME;


### PR DESCRIPTION
## 目的

準拠リンタ `tools/conformance.php`（ADR 0016・v1.8.1 出荷済み）の**横展開ブロッカー2件**を修正する。2製品 pilot（nene-invoice / nene-clear）が実 CI で炙り出したもの。`Closes #1514`。

## 変更点

### A. 消費側 autoload fatal（全消費者の CI を赤にする）
`tools/conformance.php` は `require dirname(__DIR__) . '/vendor/autoload.php'`（＝ **NENE2 自身の vendor**）で autoload を読んでいた。消費者は NENE2 を依存として取り込むため `vendor/hideyukimori/nene2/vendor/` を持たず、`../NENE2` を `git clone --depth=1` するだけで `composer install` しない CI で **fatal（exit 255）**。

- **修正**: 姉妹バリデータ `tools/validate-mcp-tools.php`（8製品で CI 実績あり）と同じく `--root`/`getcwd()` で解決した**消費側 `$projectRoot/vendor/autoload.php`** を require する（`before`: `require dirname(__DIR__) . '/vendor/autoload.php'` → `after`: `require $projectRoot . '/vendor/autoload.php'`）。消費側フラット vendor には `Nene2\` PSR-4（`Nene2\Conformance\*` 含む）が登録済みで解決可能。
- NENE2 自己実行（`--root=.`）でも projectRoot=NENE2 root で従来どおり動作する。

### B. D1 の GuardedJwtSecretResolver 誤検知（fail-close 済み全11製品が踏む）
`JwtDefaultSecretRule`（D1）が、`GuardedJwtSecretResolver::fromConfig($config, self::DEFAULT_DEV_SECRET)` の第2引数に渡す fail-close 済み dev fallback リテラル（2026-07-05 JWT 移行の正準パターン）を guard 文脈を見ずに誤検知していた。設計 04 の「+ GuardedJwtSecretResolver 不使用」条件の欠落分。

- **修正**: 同一ファイルで `GuardedJwtSecretResolver::fromConfig()` の第2引数として渡るリテラル（直接、またはそれを初期化する定数経由）を D1 から免除する。トークン走査で第2引数を特定し、直接リテラル or それを初期化する定数の宣言を免除。
- **過剰免除しない根拠**: 免除は「resolver の第2引数として実際に渡る」ものに限る。裸の `getenv('X') ?: 'acme-dev-secret'` は resolver に渡らないため、同一ファイルに resolver 使用があっても**検出のまま**（回帰テストで担保）。

## 検証結果

- `composer check` 緑（`Conformance OK` 含む・test 793 / analyse / cs / openapi / mcp すべて OK）。
- 追加回帰テスト（`ConformanceRulesTest`）:
  - `testConformanceCliLoadsConsumerAutoloaderNotFrameworkVendor` — フラット消費側 vendor（nested tools・root にフラット autoloader shim）を模した一時ツリーで nested スクリプトを実行し、fatal（exit 255）せず有効な JSON を返すことを実証。
  - `testD1ExemptsDevSecretConstantFedToGuardedResolver` / `testD1ExemptsLiteralPassedDirectlyToGuardedResolver` — 定数経由・直接リテラルの免除。
  - `testD1StillFlagsNakedSecretDespiteGuardedResolverInSameFile` — 併存時に裸 secret を検出継続（過剰免除しない）。
- 実 `nene-invoice/src` に D1 を直接適用し **0 findings**（従来は `DEFAULT_DEV_SECRET` リテラルが FP）を確認。
- 一時ツリーで old code=exit 255（fatal）/ new code=exit 0 を対比実証。

## セルフレビュー

- `release-ci`, `docs-policy`

## 残リスク

- 免除は `fromConfig()` の第2引数に限定（`new GuardedJwtSecretResolver(...)` 直呼びは対象外）。全11製品が `fromConfig` 経路のため現状は十分。将来コンストラクタ直呼びの製品が出たら追随する。
- リリース/タグは打たない（統括が v1.8.2 で判断）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)