### PR TITLE
chore(release): v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.8.2] — 2026-07-07
+
+ランタイム後方互換なパッチリリース。v1.8.1 で追加した準拠リンタ `tools/conformance.php`（ADR 0016）を他製品へ横展開する際のブロッカー2件 — 消費側 CI を必ず赤にする autoload バグと、2026-07-05 の JWT 移行で全11製品が採る fail-close パターンを裸 secret と誤検知する D1 の偽陽性 — を修正する。いずれも `tools/` 開発者ツール（ADR 0009 §5 でライブラリ API 対象外）と安定サーフェス未登録の `src/Conformance/*` に閉じ、ランタイム公開 API は不変＝製品の実行時サーフェスは変わらない。
+
 ### Fixed
 - 準拠リンタ `tools/conformance.php` の**消費側 CI を必ず赤にする autoload バグ**を修正（ADR 0016）。スクリプトは `require dirname(__DIR__) . '/vendor/autoload.php'`（＝ NENE2 自身の vendor）を読んでいたが、消費者は NENE2 を依存として取り込むため `vendor/hideyukimori/nene2/vendor/` を持たず、`../NENE2` を `git clone --depth=1` するだけで `composer install` しない実 CI で **fatal（exit 255）**になっていた（ローカルが緑だったのは symlink 先がフル dev チェックアウトだったため）。姉妹バリデータ `tools/validate-mcp-tools.php`（8製品で CI 実績あり）と同じく `--root`/`getcwd()` で解決した**消費側 `$projectRoot/vendor/autoload.php`** を require する方式へ揃えた。消費側フラット vendor には `Nene2\` PSR-4（`Nene2\Conformance\*` 含む）が登録済みで解決可能。NENE2 自己実行（`--root=.`）でも projectRoot が NENE2 root になり従来どおり動作する。フラット消費側 vendor を模した一時ツリーで nested スクリプトを走らせ fatal 解消を実証する回帰テストを追加（`ConformanceRulesTest::testConformanceCliLoadsConsumerAutoloaderNotFrameworkVendor`）。
 - D1（`JwtDefaultSecretRule`）の**フリート全体の誤検知**を修正（ADR 0016・設計 04 の「+ GuardedJwtSecretResolver 不使用」条件の欠落分）。2026-07-05 の JWT 移行で全11製品が採る正準 fail-close パターン — 製品注入の dev fallback リテラル（例 `const DEFAULT_DEV_SECRET = '<slug>-dev-secret'`）を `GuardedJwtSecretResolver::fromConfig($config, self::DEFAULT_DEV_SECRET)` の第2引数に渡す — を guard 文脈を見ずに裸の secret として検出していた。**同一ファイルで `GuardedJwtSecretResolver::fromConfig()` の第2引数として渡るリテラル**（直接、またはそれを初期化する定数経由）を D1 から免除する。免除は狭く、真の裸 secret（`getenv('X') ?: 'acme-dev-secret'`）は resolver に渡らないため同一ファイルに resolver 使用があっても検出のまま。回帰テスト（定数経由の免除・直接リテラルの免除・同一ファイル併存時に裸 secret を検出のまま）を追加。

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.8.1
+  version: 1.8.2
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.8.1';
+    public const string VERSION = '1.8.2';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的
v1.8.1 tag 以降に main へ載った変更を **v1.8.2** として発行するためのリリース PR。

## 収録差分（v1.8.1..main）
- **#1515** 準拠リンタ `tools/conformance.php` の横展開ブロッカー2件修正:
  - (A) autoload を消費側 vendor（`$projectRoot/vendor/autoload.php`）へ揃え、全消費者 CI 赤の主因（nested `vendor/hideyukimori/nene2/vendor` 不在による fatal / exit 255）を解消。
  - (B) `JwtDefaultSecretRule`（D1）が `GuardedJwtSecretResolver::fromConfig` 第2引数リテラル（フリート正準 fail-close パターン）を裸 secret と誤検知する FP を免除。

## 変更点
- `CHANGELOG.md`: `[Unreleased]` → `[1.8.2] — 2026-07-07` へ昇格（新しい空 `[Unreleased]` を残す）。
- `src/FrameworkInfo.php`: `VERSION` を `1.8.2` に更新。
- `docs/openapi/openapi.yaml`: `info.version` を `1.8.2` に更新。

## semver 根拠
両修正とも **`tools/`（developer tooling・ADR 0009 §5 で stability guarantee 外）** と **`src/Conformance/*`（安定サーフェス未登録）** に閉じ、ランタイム公開 API は不変。したがって **patch `v1.8.2`** が妥当。

## 検証結果
- `composer version:check`: Version consistency OK: 1.8.2（FrameworkInfo::VERSION / openapi.yaml info.version / CHANGELOG 整合）
- `composer validate`: valid
- `composer check`（このブランチ）: OK (793 tests, 1918 assertions) / PHPStan L8 No errors / PHP CS Fixer 0 fixable (304 files) / OpenAPI valid / MCP valid / **Conformance OK — no error findings (4 suppressed by baseline/ignore)**

## 残リスク
None（version 昇格のみ・ランタイム挙動不変）。

Self-review: release-ci

Closes #1515