### PR TITLE
fix(conformance): D1 guarded 免除にコンストラクタ直接形を追加する (#1517)

### DIFF
--- a/docs/adr/0016-conformance-linter.md
+++ b/docs/adr/0016-conformance-linter.md
@@ -44,13 +44,16 @@ comments and docblocks never trip a rule):
   (`*-dev-secret`, `changeme`, `secret-key`, ...), excluding whitespace-bearing
   prose, upper snake-case env-variable *names* (`NENE2_ALLOW_DEV_SECRET`), and
   array-key positions. A literal fed to the fail-closed
-  `GuardedJwtSecretResolver::fromConfig()` as its second argument (the
-  product-injected dev secret) — directly, or via the constant it initialises in
-  the same file — is exempt, since the resolver refuses it in production (this is
-  the design's "+ `GuardedJwtSecretResolver` unused" condition, and the canonical
-  2026-07-05 fleet fail-close shape). The exemption is narrow: a naked fallback
-  (`getenv('X') ?: 'acme-dev-secret'`) never reaches the resolver and stays
-  flagged even alongside resolver use in the same file.
+  `GuardedJwtSecretResolver`'s dev-secret slot — `fromConfig()`'s second
+  argument, or the constructor's `devSecret` parameter (fourth positional, or
+  the named argument `devSecret:`, the shape products with a custom secret env
+  key use) — directly, or via the constant it initialises in the same file — is
+  exempt, since the resolver refuses it in production (this is the design's
+  "+ `GuardedJwtSecretResolver` unused" condition, and the canonical 2026-07-05
+  fleet fail-close shape). The exemption is narrow: only what actually flows
+  into the resolver is exempt — a naked fallback (`getenv('X') ?:
+  'acme-dev-secret'`) never reaches it and stays flagged even alongside
+  resolver use in the same file.
 - **D2** — Composer dependency pinned to a feature branch. Parse `composer.json`
   requires and `composer.lock` package versions; flag `dev-feat/...`-style
   feature-branch pins (mainline `dev-main` / `@dev` are the design's `warn`

--- a/src/Conformance/Rule/JwtDefaultSecretRule.php
+++ b/src/Conformance/Rule/JwtDefaultSecretRule.php
@@ -27,15 +27,21 @@ use Nene2\Conformance\Severity;
  *
  * Guarded-literal exemption (design 04 "+ GuardedJwtSecretResolver 不使用"):
  * the canonical fail-close pattern injects a product development secret **into**
+ * {@see \Nene2\Auth\GuardedJwtSecretResolver}, either via
  * {@see \Nene2\Auth\GuardedJwtSecretResolver::fromConfig()} as its second
- * argument, e.g. `GuardedJwtSecretResolver::fromConfig($config,
- * self::DEFAULT_DEV_SECRET)` with `const DEFAULT_DEV_SECRET = '<slug>-dev-secret'`.
+ * argument — e.g. `GuardedJwtSecretResolver::fromConfig($config,
+ * self::DEFAULT_DEV_SECRET)` with `const DEFAULT_DEV_SECRET = '<slug>-dev-secret'`
+ * — or by driving the constructor directly when a product uses a custom secret
+ * env key (nene-serve), where the development secret is the `devSecret`
+ * parameter: `new GuardedJwtSecretResolver(..., devSecret:
+ * self::DEFAULT_DEV_SECRET, ...)` (named, or the fourth positional argument).
  * Such a literal is *not* a naked default secret — the resolver refuses it in
  * production (ADR 0013) — so a literal that is passed (directly, or via the
- * constant it initialises) as `fromConfig()`'s second argument in the same file
- * is exempt. The exemption is narrow on purpose: a truly naked secret
- * (`getenv('X') ?: 'acme-dev-secret'`) is never fed to the resolver, so it stays
- * flagged even in a file that also uses `GuardedJwtSecretResolver` elsewhere.
+ * constant it initialises) into the resolver's `devSecret` slot in the same file
+ * is exempt. The exemption is narrow on purpose: it only covers what actually
+ * flows into the resolver — a truly naked secret (`getenv('X') ?:
+ * 'acme-dev-secret'`) is never fed to it, so it stays flagged even in a file
+ * that also uses `GuardedJwtSecretResolver` elsewhere.
  */
 final class JwtDefaultSecretRule implements RuleInterface
 {
@@ -141,8 +147,9 @@ final class JwtDefaultSecretRule implements RuleInterface
 
             // Guarded-literal exemption: the literal is handed to the fail-closed
             // GuardedJwtSecretResolver (ADR 0013), so it is not a naked default.
-            // Either the literal is itself `fromConfig()`'s second argument, or it
-            // initialises the constant that is passed there in the same file.
+            // Either the literal itself fills the resolver's `devSecret` slot
+            // (`fromConfig()` second argument, or the constructor's `devSecret`
+            // parameter), or it initialises the constant passed there in this file.
             if (isset($guardedLiteralIndices[$i])) {
                 continue;
             }
@@ -161,12 +168,15 @@ final class JwtDefaultSecretRule implements RuleInterface
 
     /**
      * Collects the development-secret literals that feed
-     * `GuardedJwtSecretResolver::fromConfig(..., <literal|CONST>)` in this file.
+     * `GuardedJwtSecretResolver`'s `devSecret` slot in this file — either
+     * `GuardedJwtSecretResolver::fromConfig(..., <literal|CONST>)` (second
+     * argument) or `new GuardedJwtSecretResolver(...)` (fourth positional
+     * argument, or the named argument `devSecret:`).
      *
-     * The resolver's second parameter is the product-injected development secret,
-     * which the resolver refuses in production — so those literals are not naked
-     * defaults and must not trip D1. Returns two lookups: token indices of literals
-     * passed directly, and the names of constants passed there (whose initialiser
+     * That parameter is the product-injected development secret, which the
+     * resolver refuses in production — so those literals are not naked defaults
+     * and must not trip D1. Returns two lookups: token indices of literals passed
+     * directly, and the names of constants passed there (whose initialiser
      * literal is then exempt).
      *
      * @param list<array{0: int, 1: string, 2: int}|string> $tokens
@@ -178,34 +188,21 @@ final class JwtDefaultSecretRule implements RuleInterface
         $constNames = [];
 
         for ($i = 0; $i < $count; $i++) {
-            if (!$this->isGuardedResolverName($tokens[$i])) {
+            $call = $this->guardedResolverCallAt($tokens, $i);
+
+            if ($call === null) {
                 continue;
             }
 
-            $colon = $tokens[$i + 1] ?? null;
-            $method = $tokens[$i + 2] ?? null;
-            $paren = $tokens[$i + 3] ?? null;
+            [$openParen, $positionalIndex] = $call;
+            $arg = $this->devSecretArgumentTokens($tokens, $count, $openParen, $positionalIndex);
 
-            if (!is_array($colon) || $colon[0] !== T_DOUBLE_COLON) {
+            if ($arg === null || $arg === []) {
                 continue;
             }
 
-            if (!is_array($method) || $method[0] !== T_STRING || $method[1] !== 'fromConfig') {
-                continue;
-            }
-
-            if (!$this->isToken($paren, '(')) {
-                continue;
-            }
-
-            $secondArg = $this->secondArgumentTokens($tokens, $count, $i + 3);
-
-            if ($secondArg === null || $secondArg === []) {
-                continue;
-            }
-
-            if (count($secondArg) === 1) {
-                [$index, $only] = $secondArg[0];
+            if (count($arg) === 1) {
+                [$index, $only] = $arg[0];
 
                 if (is_array($only) && $only[0] === T_CONSTANT_ENCAPSED_STRING) {
                     $literalIndices[$index] = true;
@@ -215,7 +212,7 @@ final class JwtDefaultSecretRule implements RuleInterface
 
             // `self::DEFAULT_DEV_SECRET`, `Foo::DEFAULT_DEV_SECRET`, or a bare
             // `DEFAULT_DEV_SECRET`: the trailing identifier is the constant name.
-            $last = $secondArg[count($secondArg) - 1][1];
+            $last = $arg[count($arg) - 1][1];
 
             if (is_array($last) && $last[0] === T_STRING) {
                 $constNames[$last[1]] = true;
@@ -226,15 +223,62 @@ final class JwtDefaultSecretRule implements RuleInterface
     }
 
     /**
-     * Top-level tokens of the second argument of the call whose `(` is at
-     * `$openParenIndex`, or null when there is no second argument. Commas nested
-     * inside `()`/`[]`/`{}` do not separate arguments.
+     * Recognises a `GuardedJwtSecretResolver` call carrying a `devSecret` slot at
+     * token `$i`: `GuardedJwtSecretResolver::fromConfig(` (devSecret is the second
+     * argument) or `new GuardedJwtSecretResolver(` (devSecret is the fourth
+     * constructor argument). Returns the open-paren token index and the
+     * zero-based positional index of `devSecret`, or null when `$i` is neither.
+     *
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     * @return array{0: int, 1: int}|null
+     */
+    private function guardedResolverCallAt(array $tokens, int $i): ?array
+    {
+        if (is_array($tokens[$i]) && $tokens[$i][0] === T_NEW
+            && $this->isGuardedResolverName($tokens[$i + 1] ?? null)
+            && $this->isToken($tokens[$i + 2] ?? null, '(')
+        ) {
+            return [$i + 2, 3];
+        }
+
+        if (!$this->isGuardedResolverName($tokens[$i])) {
+            return null;
+        }
+
+        $colon = $tokens[$i + 1] ?? null;
+        $method = $tokens[$i + 2] ?? null;
+
+        if (!is_array($colon) || $colon[0] !== T_DOUBLE_COLON) {
+            return null;
+        }
+
+        if (!is_array($method) || $method[0] !== T_STRING || $method[1] !== 'fromConfig') {
+            return null;
+        }
+
+        if (!$this->isToken($tokens[$i + 3] ?? null, '(')) {
+            return null;
+        }
+
+        return [$i + 3, 1];
+    }
+
+    /**
+     * Top-level tokens of the `devSecret` argument of the call whose `(` is at
+     * `$openParenIndex`: the named argument `devSecret:` when present, otherwise
+     * the unnamed argument at `$positionalIndex` (PHP only allows positional
+     * arguments before named ones). Returns null when the call passes neither.
+     * Commas nested inside `()`/`[]`/`{}` do not separate arguments.
      *
      * @param list<array{0: int, 1: string, 2: int}|string> $tokens
      * @return list<array{0: int, 1: array{0: int, 1: string, 2: int}|string}>|null
      */
-    private function secondArgumentTokens(array $tokens, int $count, int $openParenIndex): ?array
-    {
+    private function devSecretArgumentTokens(
+        array $tokens,
+        int $count,
+        int $openParenIndex,
+        int $positionalIndex,
+    ): ?array {
         $depth = 0;
         $argIndex = 0;
         $current = [];
@@ -251,7 +295,7 @@ final class JwtDefaultSecretRule implements RuleInterface
 
                 if ($token === ')' || $token === ']' || $token === '}') {
                     if ($depth === 0) {
-                        return $argIndex === 1 ? $current : null;
+                        return $this->devSecretFromArgument($current, $argIndex, $positionalIndex);
                     }
 
                     $depth--;
@@ -260,8 +304,10 @@ final class JwtDefaultSecretRule implements RuleInterface
                 }
 
                 if ($token === ',' && $depth === 0) {
-                    if ($argIndex === 1) {
-                        return $current;
+                    $match = $this->devSecretFromArgument($current, $argIndex, $positionalIndex);
+
+                    if ($match !== null) {
+                        return $match;
                     }
 
                     $argIndex++;
@@ -274,6 +320,35 @@ final class JwtDefaultSecretRule implements RuleInterface
         }
 
         return null;
+    }
+
+    /**
+     * The value tokens of one call argument when it fills the `devSecret` slot:
+     * either it is labelled `devSecret:` (label tokens stripped), or it is
+     * unlabelled and sits at `$positionalIndex`. Null otherwise.
+     *
+     * @param list<array{0: int, 1: array{0: int, 1: string, 2: int}|string}> $argument
+     * @return list<array{0: int, 1: array{0: int, 1: string, 2: int}|string}>|null
+     */
+    private function devSecretFromArgument(array $argument, int $argIndex, int $positionalIndex): ?array
+    {
+        $label = null;
+
+        // A named argument starts with `<identifier> :` (T_DOUBLE_COLON is a
+        // distinct token, so `self::CONST` cannot masquerade as a label).
+        if (count($argument) >= 2
+            && is_array($argument[0][1]) && $argument[0][1][0] === T_STRING
+            && $this->isToken($argument[1][1], ':')
+        ) {
+            $label = $argument[0][1][1];
+            $argument = array_slice($argument, 2);
+        }
+
+        if ($label !== null) {
+            return $label === 'devSecret' ? $argument : null;
+        }
+
+        return $argIndex === $positionalIndex ? $argument : null;
     }
 
     /**

--- a/tests/Conformance/ConformanceRulesTest.php
+++ b/tests/Conformance/ConformanceRulesTest.php
@@ -124,6 +124,98 @@ final class ConformanceRulesTest extends TestCase
         self::assertStringContainsString('naked-dev-secret', $findings[0]->message);
     }
 
+    public function testD1ExemptsNamedDevSecretConstructorArgument(): void
+    {
+        // nene-serve's real shape (src/Http/RuntimeServiceProvider.php): a custom
+        // secret env key means the product drives the resolver's constructor
+        // directly with named arguments instead of the fromConfig() convenience
+        // path; the dev-secret constant still only feeds the fail-closed resolver.
+        $this->writeSrc('Http/RuntimeServiceProvider.php', <<<'PHP'
+            <?php
+            namespace App\Http;
+            use Nene2\Auth\GuardedJwtSecretResolver;
+            final class RuntimeServiceProvider {
+                private const string JWT_SECRET_ENV_KEY = 'NENE_SERVE_JWT_SECRET';
+                private const string DEFAULT_DEV_SECRET = 'nene-serve-dev-secret';
+                public function secret(object $config): string {
+                    $configuredSecret = $_SERVER[self::JWT_SECRET_ENV_KEY] ?? '';
+                    return (new GuardedJwtSecretResolver(
+                        configuredSecret: is_string($configuredSecret) ? $configuredSecret : '',
+                        environment: $config->environment,
+                        allowDevSecret: $config->allowDevSecret,
+                        devSecret: self::DEFAULT_DEV_SECRET,
+                        secretEnvName: self::JWT_SECRET_ENV_KEY,
+                    ))->resolve();
+                }
+            }
+            PHP);
+
+        self::assertSame([], (new JwtDefaultSecretRule())->check($this->root));
+    }
+
+    public function testD1ExemptsPositionalDevSecretConstructorArgument(): void
+    {
+        // Fourth positional constructor argument is the devSecret parameter; a
+        // literal passed there is guarded by the resolver just like fromConfig().
+        $this->writeSrc('Auth/PositionalCtor.php', <<<'PHP'
+            <?php
+            namespace App\Auth;
+            use Nene2\Auth\GuardedJwtSecretResolver;
+            final class PositionalCtor {
+                public function secret(object $config): string {
+                    return (new GuardedJwtSecretResolver(
+                        getenv('APP_JWT_SECRET') ?: '',
+                        $config->environment,
+                        $config->allowDevSecret,
+                        'acme-dev-secret',
+                    ))->resolve();
+                }
+            }
+            PHP);
+
+        self::assertSame([], (new JwtDefaultSecretRule())->check($this->root));
+    }
+
+    public function testD1StillFlagsNakedSecretDespiteGuardedConstructorInSameFile(): void
+    {
+        // Over-exemption guard for the constructor form: only the literal feeding
+        // the resolver's devSecret slot is exempt — a naked fallback in the same
+        // file, and a dev-secret-shaped literal in a *different* constructor
+        // argument, both stay flagged.
+        $this->writeSrc('Auth/CtorMixed.php', <<<'PHP'
+            <?php
+            namespace App\Auth;
+            use Nene2\Auth\GuardedJwtSecretResolver;
+            final class CtorMixed {
+                private const string DEFAULT_DEV_SECRET = 'guarded-dev-secret';
+                public function ok(object $config): string {
+                    return (new GuardedJwtSecretResolver(
+                        configuredSecret: '',
+                        environment: $config->environment,
+                        allowDevSecret: $config->allowDevSecret,
+                        devSecret: self::DEFAULT_DEV_SECRET,
+                    ))->resolve();
+                }
+                public function bad(object $config): string {
+                    return (new GuardedJwtSecretResolver(
+                        configuredSecret: 'hardcoded-dev-secret',
+                        environment: $config->environment,
+                        allowDevSecret: $config->allowDevSecret,
+                        devSecret: null,
+                    ))->resolve();
+                }
+                public function leak(): string {
+                    return getenv('JWT_SECRET') ?: 'naked-dev-secret';
+                }
+            }
+            PHP);
+
+        $findings = (new JwtDefaultSecretRule())->check($this->root);
+        self::assertCount(2, $findings);
+        self::assertStringContainsString('hardcoded-dev-secret', $findings[0]->message);
+        self::assertStringContainsString('naked-dev-secret', $findings[1]->message);
+    }
+
     public function testConformanceCliLoadsConsumerAutoloaderNotFrameworkVendor(): void
     {
         // Regression for the fan-out blocker: the CLI must require the *consumer's*


### PR DESCRIPTION
## 目的

準拠リンタ D1（`JwtDefaultSecretRule`）の guarded-literal 免除を、`GuardedJwtSecretResolver::fromConfig()` 第2引数形に加えて**コンストラクタ直接形** `new GuardedJwtSecretResolver(...)` にも拡張する。カスタム secret env キーを使う nene-serve はコンストラクタを named 引数で直接駆動しており（`devSecret: self::DEFAULT_DEV_SECRET`）、D1 が誤検知して serve 側で allowlist 吸収を強いていた（2026-07-07 検品の申し送り）。

Closes #1517

## 変更点

- `src/Conformance/Rule/JwtDefaultSecretRule.php`
  - `guardedResolverCallAt()` を新設: `GuardedJwtSecretResolver::fromConfig(`（devSecret＝第2引数）と `new GuardedJwtSecretResolver(`（devSecret＝第4引数）の両形を認識
  - 引数抽出を `devSecretArgumentTokens()` に一般化: **named 引数 `devSecret:`**（fromConfig 形でも有効）と**位置引数**の両対応。named 引数のラベル判定は arg 先頭の `T_STRING` + `':'` のみ（`T_DOUBLE_COLON` は別トークンなので `self::CONST` と衝突しない）
  - 免除範囲は従来どおり「resolver の devSecret スロットへ実際に流れるリテラル（直接 or 同一ファイル内定数の初期化子）」のみ。`configuredSecret:` 等**他引数**の dev-secret 形リテラルや同一ファイル内の naked fallback は引き続き検出
- `tests/Conformance/ConformanceRulesTest.php`: fixture 3本追加
  - serve の実コード形（named 引数・typed const・ternary 引数・trailing comma 込みで `RuntimeServiceProvider` を再現）
  - 位置引数（第4引数）へのリテラル直渡し
  - over-exemption ガード: コンストラクタ形と同居する naked fallback／`configuredSecret:` へのリテラルが**2件とも**検出されることを固定
- `docs/adr/0016-conformance-linter.md`: D1 免除の記述をコンストラクタ形込みに更新

新しい error ルールの追加は無し。**免除の追加＝検出の緩和のみ**なので、@dev 消費者（main HEAD を clone する製品 CI）を壊さない。

## 検証結果

- `vendor/bin/phpunit --filter ConformanceRulesTest`: OK（22 tests, 39 assertions）
- `composer analyse`（PHPStan）: 0 errors / `composer cs`: 0 issues
- `composer conformance`（自己適用）: OK — no error findings（4 suppressed、従来どおり）
- **serve 実コードのカバー実測**: HEAD のルールをコンテナ内で `nene-serve/src` に read-only 適用し **D1 findings 0** を確認（serve vendor の旧ルールではなく本ブランチのクラスを直接ロードして実行）
- `composer check` のフル実行は、ローカルコンテナ起因の**既存**failure（`ZipArchive` 拡張欠如による `PayloadInstallerTest` エラー8件・env 由来の `ConfigLoaderTest` 1件）が main でも同一に再現するため CI を正とする。本変更のファイルとは無関係

Self-review: backend-api（該当項目のみ・リンタ内部変更）

## serve 側フォローアップ（このPRでは変更しない）

本変更が入った NENE2 を serve が取り込めば、`nene-serve/conformance.baseline.json` の D1 allow エントリ（`src/Http/RuntimeServiceProvider.php`・「fromConfig() 形のみ exempt するため誤検出」理由）は**削除可能**になる。serve 側の作業として別途実施。

## 残リスク

- named 引数ラベルの字句判定は保守的（arg 先頭の `identifier :` のみ）。理論上 `devSecret` という別クラスの named 引数にも反応し得るが、`GuardedJwtSecretResolver` 呼び出し内に限定しているため実質リスクなし
- 別 namespace の同名クラス `GuardedJwtSecretResolver` を免除し得る点は fromConfig 形と同一の既存受容リスク

🤖 Generated with [Claude Code](https://claude.com/claude-code)