### PR TITLE
docs(readme): 検証済みプロジェクト実績の Highlights セクションを追加する (#1519)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ NENE2 is a small, modern PHP framework foundation designed for projects that wan
 
 The `v1.x` foundation covers full Note/Tag CRUD, Bearer JWT auth, pagination helpers, and a six-language VitePress documentation site, with opt-in rate limiting and database health checks as production-ready opt-in features. A maintainer can clone the repository, run a local API, share an OpenAPI contract, expose safe MCP tools through the API boundary, and verify database behavior in Docker Compose.
 
+## Project Highlights
+
+NENE2 is built in the open, at high velocity, by a solo maintainer using an AI-assisted, Issue-driven workflow:
+
+- **30 releases** (current: `v1.8.2`) and **730+ merged pull requests** since the first commit in May 2026 — every change lands through an Issue → branch → PR → CI pipeline; nothing is committed directly to `main`.
+- **[262 how-to guides](docs/howto/README.md)** covering authentication, security, database patterns, API design, background jobs, and 100+ product feature recipes.
+- **[125 runnable example apps](https://github.com/hideyukiMORI/NENE2-examples)** — each a self-contained JSON API with tests, built as field trials of the framework itself.
+- **Powers the NeNe product family** — 12+ open-source, self-hosted business tools for small teams (invoicing, records, deal tracking, contact management, and more), all built on this framework and sharing its fail-closed security baseline.
+- **Documented decisions** — ADRs for every architectural choice, an OpenAPI 3.1 contract, six-language documentation, and an MCP server listed on Smithery.
+
 ## Theme
 
 - **API first**: define behavior through clear HTTP boundaries and OpenAPI contracts.
@@ -197,7 +207,7 @@ NENE2's quality baseline includes PHP-CS-Fixer for backend style checks and npm,
 
 ## How-to guides
 
-260 task-focused guides covering authentication, security, database patterns, API design, background jobs, and 100+ product feature recipes.
+262 task-focused guides covering authentication, security, database patterns, API design, background jobs, and 100+ product feature recipes.
 
 **[Full guide index →](docs/howto/README.md)**
 


### PR DESCRIPTION
## 目的

Claude for OSS プログラム応募（https://claude.com/contact-sales/claude-for-oss）にあたり、審査者が README だけでプロジェクトの規模・実態を裏取りできるようにする。

## 変更点

- intro 直後に英語の **Project Highlights** セクションを追加（30 releases / 730+ merged PRs / 262 howto / 125 examples / NeNe 製品群 / ADR・OpenAPI・6言語ドキュメント）
- How-to guides の本数表記を 260 → 262 に実数同期

## 検証結果

数字はすべて 2026-07-08 に実測:

- releases 30: `gh api repos/hideyukiMORI/NENE2/releases --jq length`
- merged PR 732: `gh api search/issues -f q='repo:hideyukiMORI/NENE2 type:pr is:merged'`
- howto 262: `ls docs/howto/*.md | wc -l`
- v1.8.2: `src/FrameworkInfo.php` VERSION と最新リリースの双方で確認
- examples 125: NENE2-examples README 記載どおり

ドキュメントのみの変更でランタイム影響なし。

## 残リスク

- howto 本数は増えるたびに陳腐化する（Highlights 側は今後 "260+" 的な丸めに変える選択肢あり）

Self-review: docs-policy

Closes #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)