### PR TITLE
chore(release): v1.9.0 (#1522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.9.0] — 2026-07-09
+
+後方互換なマイナーリリース。invoice で実証した「使い捨て org」デモ（`GET /demo/{template}` → 使い捨てテナント provision → 業種データ seed → セッション seat → 302）の製品非依存な骨格を、opt-in モジュール `Nene2\Demo` として framework へ上流化する（2026-07-09 施主決定=デモ方式を invoice 型に全製品統一・ADR 0017）。invoice #608（デモ org 作成時の容量ガード欠如）の根治点となる作成時容量ガード＋per-IP throttle を含む。未配線の製品には dormant で、既存公開 API への変更は `AppConfig` 末尾への既定引数追加のみ。
+
 ### Added
 - 使い捨て org デモモジュール `Nene2\Demo` — invoice で実証した「使い捨て org」デモ（`GET /demo/{template}` → 使い捨てテナント provision → 業種データ seed → セッション seat → 302）の製品非依存な骨格を framework へ上流化する（2026-07-09 施主決定=デモ方式を invoice 型に全製品統一・設計 `_work/handoff-nene2-demo-module-2026-07-09.md`・#1522）。製品固有部は 5 interface に隔離: `DisposableOrgProvisionerInterface`（org+admin 生成・`ProvisionedDemoOrg` が adminUserId を持ち role リテラル再検索を廃止）／`DisposableOrgReaperInterface`（**子テーブル破棄を含む**全破棄・冪等契約 — 消費側の DeleteOrganizationUseCase は子をカスケードしないため framework へは吸い上げない）／`DemoSessionSeaterInterface`（認証受け渡し＋302。cookie/JWT の製品差を完全隔離）／`DemoDataSeederInterface`（**注入された1接続で書く**規約 — SQLite の database is locked を invoice で実踏済み）／`DemoTemplateKeyInterface`（string-backed enum が2メソッドで満たす template キー）。framework 具象: `StartDisposableDemoHandler`（ゲート→throttle/容量→slug 採番衝突リトライ→provision→seed→seat のオーケストレータ・失敗は RFC 9457 Problem Details）／`DisposableDemoSweeper`（TTL＋あふれ判定→Reaper 委譲・`SweepReport` 返却。入力は `DemoOrgRecord` 注入で orgs スキーマ知識を持たない）／`CountingDemoCapacityGuard`（**作成時の容量上限＋per-IP throttle** — sweep だけでは定常状態しか抑えられない invoice #608 の根治点。demo org 数は callable 注入・throttle は既存 `RateLimitStorageInterface` 流用）／`DemoRouteRegistrar`。例外は `SlugConflictException`（リトライ可）／`DemoCapacityExceededException`（503）／`DemoThrottledException`（429+Retry-After）に分離。設定は `DemoConfig`（typed・既定は invoice 実測値 TTL 3h／上限 200 org／slug 5 試行）を `ConfigLoader` が `DEMO_*` から組み立て `AppConfig::$demo` で提供 — 従来 invoice が getenv 直読み・undocumented だった `DEMO_MODE`/`DEMO_TTL_HOURS`/`DEMO_MAX_ORGS` を typed 化し `.env.example`／`docs/development/configuration.md` に文書化（運用穴の根治）。`DEMO_MODE` は `NENE2_ALLOW_DEV_SECRET` と同じ**厳格 opt-in パース**（`1`/`true`/`yes` のみ有効・typo は必ず OFF＝無認証で org を作る経路の fail-close）。howto `add-disposable-demo.md`（consumer が実装する4 interface と配線例・sweeper cron 例）を追加。すべて opt-in・後方互換（`AppConfig` 末尾への既定引数追加のみ）。consumer 移行（invoice→clear→vault）は別 Issue
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.8.2
+  version: 1.9.0
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.8.2';
+    public const string VERSION = '1.9.0';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的

v1.9.0 リリース（v1.8.2 の次の minor・後方互換）。#1523 で main に入った `Nene2\Demo` モジュールを収録する。

Refs #1522

## 変更点

- `FrameworkInfo::VERSION` 1.8.2 → **1.9.0**
- `docs/openapi/openapi.yaml` `info.version` → 1.9.0
- CHANGELOG: `[Unreleased]` → `[1.9.0] — 2026-07-09`（リリースイントロ付き）

## 検証結果

- `composer validate` / `version:check`（1.9.0 で3箇所一致）/ `openapi` / `openapi:docs`（drift なし）: すべて OK
- コード変更なし（バージョン表記のみ）。CI の `composer check` で全体を再検証

Self-review: release-ci

## 残リスク

なし（マージ後に main から v1.9.0 タグ→GitHub Release→Packagist 反映確認を行う）

🤖 Generated with [Claude Code](https://claude.com/claude-code)