### PR TITLE
build(docker): app イメージに ext-zip を追加する (#1527)

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -5,8 +5,8 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends unzip \
-    && docker-php-ext-install pdo_mysql \
+    && apt-get install -y --no-install-recommends unzip libzip-dev \
+    && docker-php-ext-install pdo_mysql zip \
     && rm -rf /var/lib/apt/lists/* \
     && a2enmod rewrite headers \
     && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene2.conf \

--- a/tests/Install/PayloadInstallerTest.php
+++ b/tests/Install/PayloadInstallerTest.php
@@ -6,10 +6,13 @@ namespace Nene2\Tests\Install;
 
 use Nene2\Install\PayloadInstaller;
 use Nene2\Install\PayloadSignatureVerifier;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use ZipArchive;
 
+// Skip (instead of Error) on environments without ext-zip; the app image ships it (#1527).
+#[RequiresPhpExtension('zip')]
 final class PayloadInstallerTest extends TestCase
 {
     /** @var list<string> */


### PR DESCRIPTION
## 目的
ローカル Docker で `PayloadInstallerTest` 8件が `Class "ZipArchive" not found` の Error になる問題の根治（CI は setup-php 既定拡張で緑だがローカルが完全緑にならない）。

Closes #1527

## 変更点
- `docker/php/Dockerfile`: `libzip-dev` を導入し `docker-php-ext-install` に `zip` を追加
- `tests/Install/PayloadInstallerTest.php`: クラスに `#[RequiresPhpExtension('zip')]` を付与（拡張なし環境では Error ではなく Skip）

## 検証結果
- イメージ再ビルド後 `php -m | grep zip` → `zip`
- `vendor/bin/phpunit tests/Install/PayloadInstallerTest.php` → **OK (8 tests, 34 assertions)**（従来は 8 Errors）
- `composer analyse`（PHPStan L8）/ `composer cs` → 緑

Self-review: release-ci（Docker/検証系）

## 残リスク
なし（イメージ肥大は libzip のみで軽微）

🤖 Generated with [Claude Code](https://claude.com/claude-code)