### PR TITLE
fix(test): ConfigLoaderTest の partial-defaults テストを env 非依存にする (#1526)

### DIFF
--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene2\Tests\Config;
 
+use Nene2\Config\AppConfig;
 use Nene2\Config\AppEnvironment;
 use Nene2\Config\ConfigException;
 use Nene2\Config\ConfigLoader;
@@ -246,10 +247,19 @@ final class ConfigLoaderTest extends TestCase
         // it does not care about, e.g. NENE2_ALLOW_DEV_SECRET) must not trigger a
         // TypeError: unspecified keys fall back to the canonical defaults, and the
         // dev-secret opt-in stays opted out.
-        $config = (new ConfigLoader($this->emptyProjectRoot(), [
-            'DB_ADAPTER' => 'sqlite',
-            'DB_NAME' => ':memory:',
-        ]))->load();
+        //
+        // load() lets real environment values override constructor defaults by design,
+        // and this repo's compose.yaml injects DB_NAME=nene2 into the app container —
+        // which would shadow the ':memory:' default under test (#1526). Clear the
+        // interfering keys for the duration of the load so this exercises the
+        // constructor-defaults path in every environment.
+        $config = $this->withoutEnvironmentKeys(
+            ['APP_ENV', 'DB_ADAPTER', 'DB_NAME', 'NENE2_ALLOW_DEV_SECRET'],
+            fn (): AppConfig => (new ConfigLoader($this->emptyProjectRoot(), [
+                'DB_ADAPTER' => 'sqlite',
+                'DB_NAME' => ':memory:',
+            ]))->load(),
+        );
 
         self::assertSame('sqlite', $config->database->adapter);
         self::assertSame(':memory:', $config->database->name);
@@ -328,5 +338,43 @@ final class ConfigLoaderTest extends TestCase
     private function emptyProjectRoot(): string
     {
         return sys_get_temp_dir();
+    }
+
+    /**
+     * Runs $callback with the given keys removed from $_SERVER / $_ENV, restoring
+     * the original values afterwards (even when the callback throws).
+     *
+     * @template T
+     *
+     * @param list<string> $keys
+     * @param callable(): T $callback
+     *
+     * @return T
+     */
+    private function withoutEnvironmentKeys(array $keys, callable $callback): mixed
+    {
+        $saved = [];
+
+        foreach ($keys as $key) {
+            $saved[$key] = [
+                array_key_exists($key, $_SERVER) ? $_SERVER[$key] : null,
+                array_key_exists($key, $_ENV) ? $_ENV[$key] : null,
+            ];
+            unset($_SERVER[$key], $_ENV[$key]);
+        }
+
+        try {
+            return $callback();
+        } finally {
+            foreach ($saved as $key => [$serverValue, $envValue]) {
+                if ($serverValue !== null) {
+                    $_SERVER[$key] = $serverValue;
+                }
+
+                if ($envValue !== null) {
+                    $_ENV[$key] = $envValue;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## 目的
compose の `DB_NAME=nene2` env 注入により、CI では緑の `testPartialConstructorDefaultsLayerOverCanonicalDefaults` がローカル Docker で必ず落ちる問題の根治。

Closes #1526

## 変更点
- `tests/Config/ConfigLoaderTest.php`: 干渉する環境変数キー（`APP_ENV`/`DB_ADAPTER`/`DB_NAME`/`NENE2_ALLOW_DEV_SECRET`）を `$_SERVER`/`$_ENV` から退避・除去して `load()` を実行し、finally で復元する `withoutEnvironmentKeys()` ヘルパーを追加
- テストの検証意図（#1510: partial defaults が TypeError を起こさず canonical 既定へフォールバック）は不変。`ConfigLoader` 本体は無変更

## 検証結果
- compose env をそのままにして `vendor/bin/phpunit tests/Config` → **OK (42 tests, 94 assertions)**（従来は当該1件が failure）
- フル `docker compose run --rm app composer test` → **OK (832 tests, 2016 assertions)** — #1529（ext-zip 済みイメージ）と合わせ、ローカルが初めて完全緑
- `composer analyse`（PHPStan L8）/ `composer cs` → 緑

Self-review: backend-api（テスト変更のみ）

## 残リスク
なし（$_SERVER/$_ENV の退避・復元は finally 保証・対象キー限定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)