### PR TITLE
docs(release): リリース後にプロフィール README を同期する手順を追加する (#1532)

### DIFF
--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -103,3 +103,4 @@ Release notes should include:
 - Confirm Packagist reflects the new version.
 - Confirm `docs/todo/current.md` does not list the release as incomplete if it is done.
 - Open follow-up Issues for deferred release work.
+- Sync the profile README ([github.com/hideyukiMORI/hideyukiMORI](https://github.com/hideyukiMORI/hideyukiMORI)) with the released version and status: update the relevant rows in At a glance / Runtimes / What shipped recently.


### PR DESCRIPTION
## 目的

プロフィール README（github.com/hideyukiMORI/hideyukiMORI）がリリースから約1ヶ月遅れで陳腐化していた（本日プロフィールリポ PR #7 で同期済み）。リリースチェックリストに同期手順が無いことが原因のため、再発防止として手順を1行追加する。

## 変更点

- `docs/development/release-checklist.md` の After Release 節に、プロフィール README の版数・状況表（At a glance / Runtimes / What shipped recently の該当行）を同期するステップを1行追加（英語・既存文体に合わせた）。

## 検証結果

- ドキュメントのみの変更。`git diff --check` クリーン。Markdown リンク・文体を既存節と目視で整合確認。

Closes #1532

Self-review: docs-policy

## 残リスク

- なし（手順書への1行追加のみ・自動化はしていない）。