### PR TITLE
docs(daily): 2026-07-09 日報を追加 (#1534)

### DIFF
--- a/docs/daily/2026-07-09.md
+++ b/docs/daily/2026-07-09.md
@@ -1,0 +1,86 @@
+# 日報 — 2026-07-09
+
+## 作業時間帯
+
+2026-07-09 昼〜夕方の連続セッション。指揮リナの指示書（`_work/handoff-nene2-demo-module-2026-07-09-work-order.md`）を受けて **`Nene2\Demo` モジュールの裏取り → 実装 → v1.9.0 リリース（Packagist 反映まで）** を一気通貫。その後、統合リナからの返しを受けて **「CI 緑なのにローカル `composer test` が完全緑にならない」環境負債 2 件をその場で根治**し、日次の締めまで行った。期日 07-17 の仕事を当日で完了。
+
+---
+
+## 本日の成果
+
+### 1. Phase 0: 裏取り — 停止級の齟齬なし（設計正本の1点を適合）
+
+設計正本（invoice の read-only 解剖）を自分の目で検証。invoice `src/Demo/`（StartDemoHandler / DemoDataSeeder / DemoTemplate / Registrar / Provider）と `tools/sweep-demo.php` を読み、正本 §1 の切り分け・§4 リスク6項目に異論なしを確認。
+
+唯一の発見: 正本の **`DemoConfig::fromConfig(AppConfig)` は文字通りには成立しない**（`AppConfig` は固定 typed フィールドで `DEMO_*` を持たない）。停止せず、「raw env アクセスは `ConfigLoader` のみ」という framework 不変条件と `DatabaseConfig` ネスト前例に合わせ、**`ConfigLoader` が `DEMO_*` をパースして `AppConfig::$demo` で提供**する形へ適合し、逸脱として理由つきで報告。統合リナから「正しい判断。設計正本に押し付けず不変条件に合わせたのは良い仕事」と是認された。
+
+### 2. `Nene2\Demo` モジュール実装（#1522 / PR #1523）
+
+invoice で実証した「使い捨て org」デモ（`GET /demo/{template}` → provision → seed → seat → 302）の製品非依存な骨格を framework 化。
+
+- **interface 6本**（consumer 実装側）: `DisposableOrgProvisionerInterface` / `DisposableOrgReaperInterface`（**子テーブル破棄を含む**冪等契約 — DeleteOrganizationUseCase は子をカスケードしない実踏に基づき framework へ吸い上げない）/ `DemoSessionSeaterInterface`（cookie/JWT の認証差を完全隔離）/ `DemoDataSeederInterface`（**注入1接続規約** — SQLite の database is locked 対策）/ `DemoTemplateKeyInterface` / `DemoCapacityGuardInterface`
+- **framework 具象**: `StartDisposableDemoHandler`（ゲート→throttle/容量→slug 衝突リトライ→provision→seed→seat・RFC 9457）/ `DisposableDemoSweeper`（TTL＋あふれ→Reaper 委譲・`SweepReport`）/ `CountingDemoCapacityGuard`（**作成時の容量上限＋per-IP throttle = invoice #608 の根治点**。org 数は callable 注入・throttle は既存 `RateLimitStorageInterface` 流用）/ `DemoConfig`（既定は invoice 実測 3h/200org/5attempts・`DEMO_MODE` は厳格 opt-in パース=fail-close）/ `DemoRouteRegistrar`
+- **正本からの追加型**（理由つき報告済み）: `DemoThrottledException`（429/503 の HTTP 意味論分離）・`DemoOrgRecord`/`SweepReport`（sweeper の入出力を型に・orgs スキーマ知識を framework に入れない）
+- **テスト 30 件新規**: ハンドラは throttle→capacity→provision→seed→seat の**呼び出し順まで**検証。sweeper は TTL 境界（strict <）・あふれ・重複 reap 防止・tiebreak。ガードは IP 別バケット・keyExtractor 注入。Config は厳格パースと fail-fast
+- **ドキュメント**: ADR 0017 新設・ADR 0009 安定サーフェス登録・howto `add-disposable-demo.md`（＋**ja/de/fr/zh/pt-br の5ロケール訳**を並列サブエージェントで同日整備）・`.env.example`/`configuration.md` の DEMO_* 文書化（getenv 直読み・undocumented だった運用穴の根治）
+
+### 3. CI インフラ障害の切り分け
+
+PR #1523 の初回 Composer Check が 15 分後に **cancelled**。ログ・API を掘ると `steps: []`・`runner_id: 0`（**ランナー未割当のまま放置→打ち切り**）で、コード起因ではないと確定。再実行で 1m42s pass。「fail の見た目でも中身を見てから疑う」を実践できた。
+
+### 4. リリース v1.9.0（#1524）→ Packagist 反映確認
+
+release-checklist 準拠。バージョン整合 3 箇所（`FrameworkInfo` / `openapi.yaml` / `CHANGELOG`）を 1.9.0 に bump → PR → タグ → GitHub Release 作成。Packagist は website JSON API のキャッシュが数十分古い値を返し続けたが、**Composer 実体（`repo.packagist.org/p2`）には反映済み・webhook 202 OK** を確認して「落ちていない」と切り分け。`composer show -a hideyukimori/nene2` の versions 先頭に v1.9.0。
+
+### 5. 報告・引き継ぎ
+
+- 指揮リナ宛の正式報告を `_work/handoff-nene2-demo-module-2026-07-09-report.md` に作成（Phase 0 齟齬有無 / 実装一覧 / テスト実出力 / リリース版数・URL / 正本からの変更点と理由 / 申し送り）
+- `docs/todo/current.md` を v1.7.0 時点の陳腐化から v1.9.0 実態へ更新（#1525）
+
+### 6. Issue 台帳の実態同期（統合リナの返し対応）
+
+- **#1514（準拠リンタ横展開ブロッカー）をクローズ** — A（consumer autoload fatal）・B（D1 誤検知）とも v1.8.2 で修正・リリース済みだったため、根拠コメント付きで閉鎖
+- #1421 は 07-06 クローズ済みだったが current.md の未処理表に残骸 → 表をクローズ実態に同期（#1528）
+
+### 7. ローカルテスト環境負債 2 件の根治（#1526→PR #1530 / #1527→PR #1529）
+
+統合リナ指摘「CI 緑でもローカル `composer test` が完全緑にならないのは新しい担当リナが毎回つまずく」を受けて起票 → 施主指示で**即日修正**。
+
+| Issue | 内容 | 修正 |
+|-------|------|------|
+| #1526 | compose の `DB_NAME=nene2` env が `ConfigLoaderTest` の partial-defaults テスト（#1510 回帰）を上書きして落とす | 干渉キーを退避・除去→finally 復元する `withoutEnvironmentKeys()` でテストを env 非依存化（PR #1530） |
+| #1527 | app イメージに ext-zip が無く `PayloadInstallerTest` 8件が `ZipArchive not found` Error | Dockerfile に `libzip-dev`＋`docker-php-ext-install zip`（根治）＋ `#[RequiresPhpExtension('zip')]` で拡張なし環境は Skip（PR #1529） |
+
+結果: **ローカルのフル `docker compose run --rm app composer test` が史上初の完全緑 — OK (832 tests, 2016 assertions)**。他環境では一度 `docker compose build app` が必要（current.md に明記・#1531）。
+
+---
+
+## 数値
+
+- Issue: **4 件作成**（#1522 / #1526 / #1527 / #1534）、**4 件クローズ**（#1522 / #1514 / #1526 / #1527）→ **open Issue 0 件**
+- マージ PR: **7 件**（#1523 実装 / #1524 リリース / #1525・#1528・#1531 current.md 同期 / #1529・#1530 環境根治）
+- リリース: **v1.9.0**（minor・後方互換・GitHub Release・Packagist 反映確認済み）
+- 新規 `src/Demo/`: **17 ファイル**（interface 6・具象 5・VO 3・例外 3）＋ `ConfigLoader`/`AppConfig` 拡張
+- テスト: **802 → 832**（+30、Demo/Config）、PHPStan level 8 クリーン継続、conformance 緑
+- ドキュメント: ADR 0017・ADR 0009 表更新・howto 1本（+5ロケール訳）・`.env.example`/`configuration.md`・CHANGELOG
+- VERSION: **1.8.2 → 1.9.0**
+
+---
+
+## 残課題（次回以降）
+
+| 優先 | 内容 |
+|------|------|
+| P1 | **`Nene2\Demo` の consumer 化（invoice→clear→vault）** — NENE2 スコープ外。指揮リナの別指示書を待って着手。invoice 実機回帰で `TENANT_RESOLUTION=path` 前提と path 二重合成（workspace issues #38）を必ず踏む |
+| P2 | invoice #608 の**最小止血**（正本 §5・due 07-10）— モジュールが当日出たため、止血を飛ばして直接 consumer 化する選択肢あり（指揮判断待ち） |
+| P3 | `Nene2\Audit` への製品側自作監査ログ移行（invoice / payout / profile / vault / clear）— 継続レーン |
+
+---
+
+## 所感
+
+**Phase 0 に時間を使う価値が今日も実証された一日。** 設計正本の `DemoConfig::fromConfig(AppConfig)` が成立しないことは、実装に入ってから気づくと手戻りになるが、裏取りフェーズで AppConfig / ConfigLoader / GuardedJwtSecretResolver を先に読んでいたので、着手前に適合方針（不変条件優先・前例踏襲）を決めて報告に織り込めた。「handoff とリポの規約が食い違ったら、停止級か判定 → 不変条件に適合 → 逸脱を理由つきで報告」という型は統合リナにも是認されたので、今後の標準にする。
+
+もう一つは**環境負債の即日返済**。`DB_NAME` env と ext-zip の2件はどちらも「実害はローカルの紛らわしさだけ」だったが、v1.9.0 リリース検証の過程で main でも再現することを切り分け済みだったので、起票→修正→フル緑の実証まで最短で回れた。「CI 緑・ローカル赤」は誰かが毎回 20 分溶かす種で、832 テスト完全緑の状態を作って current.md に「要イメージ再ビルド」まで書き残せたのは、次の担当リナへの一番実用的な引き継ぎだと思う。
+
+締めてみれば、指示書の全フェーズ完了・open Issue/PR ゼロ・main クリーン・ローカル完全緑・リリース済み。デモ上流化の次バトン（consumer 化）は指揮側にある。


### PR DESCRIPTION
## 目的
2026-07-09 の作業記録（日報）を追加する。

Closes #1534

## 変更点
- `docs/daily/2026-07-09.md` 新規 — Nene2\Demo 実装〜v1.9.0 リリース、Issue 台帳同期、ローカルテスト環境根治（832 tests 完全緑）

## 検証結果
ドキュメントのみ（CI の composer check で再検証）

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)