### PR TITLE
chore(release): v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.10.0] — 2026-07-10
+
+後方互換なマイナーリリース。`GET /demo/{template}`（営業プロスペクトがブラウザで踏む唯一の公開動線）の 4xx/5xx を、`Accept: text/html` のとき差し替え可能なレンダラ経由の HTML ページへ置換する既定サポートを `Nene2\Demo` に追加する（ADR 0018・2026-07-10 invoice 本番で裸 JSON が施主ブラウザに露出した実発生の上流化）。あわせて `DemoRouteRegistrar` を PSR-15 `RequestHandlerInterface` 受けに拡大（デコレータの一般解）、per-IP throttle 既定を invoice 本番実証の 30回/h へ引き上げる。API クライアントと成功応答はバイト不変。
+
 ### Added
 - `Nene2\Demo` にブラウザ向けエラーの HTML negotiation を既定サポート（ADR 0018・#1536）。`GET /demo/{template}` は営業プロスペクトが**ブラウザで踏む**唯一の公開動線だが、429/503/404 が RFC 9457 Problem Details（JSON）で返り非技術者には「壊れた」と映っていた（2026-07-10 invoice 本番で実発生 → 製品側ラップ nene-invoice#613/#615 で対処済み・その上流化）。`StartDisposableDemoHandler` は `Accept` に `text/html` を含むリクエストへの 4xx/5xx を、注入された `DemoErrorPageRendererInterface`（新設・公開安定 API）の HTML ページへ置換する。framework は locale 非依存（英語・無ブランド・最小）の既定実装 `MinimalDemoErrorPageRenderer` を同梱（クラス名とコンストラクタのみ安定保証・マークアップと文言は presentation で契約外）— 製品はレンダラ差し替えで文言・言語・ブランドを上書きする。**transport 不変条件はレンダラによらず handler が強制**: 元のエラー status と `Retry-After`（429）をページへ強制コピーし `X-Robots-Tag: noindex` を付与。`Accept` に `text/html` を含まない API クライアントと成功応答は**バイト不変**（単体テストで固定）。レンダラ interface は意図的に status と retry 秒数しか受け取らず、リクエスト入力がページに混入し得ない構造（XSS 面）。既定実装は**ページ専用 CSP を自ら持つ**（`default-src 'none'; style-src 'unsafe-inline'` 他施錠 — 消費製品のアプリ全体 `default-src 'self'` がインライン CSS をブロックする罠の根治。`SecurityHeadersMiddleware` は不在ヘッダのみ付与するため生き残る）。カスタムレンダラ向けの CSP の罠と参照ヘッダは howto `add-disposable-demo.md`（＋5ロケール訳）に明記
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.9.0
+  version: 1.10.0
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,29 +5,31 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ---
 
-## 🚧 現在のレーン — framework hardening（v1.9.0）
+## 🚧 現在のレーン — framework hardening（v1.10.0）
 
 | 項目 | 値 |
 |------|-----|
-| 現在の VERSION | **1.9.0**（`src/FrameworkInfo.php` が正） |
+| 現在の VERSION | **1.10.0**（`src/FrameworkInfo.php` が正） |
 | 主軸 | 共有ホスティング向け opt-in 部品の連続投入（installer → fail-closed auth → audit → export → conformance → demo） |
 | v1.6.0 の成果 | opt-in インストーラ toolkit `Nene2\Install`（payload セキュリティ核 / preflight & config / TenantConfigurationValidator / DatabaseSchemaApplier / release manifest / ReleaseSource / 提示契約 / 無ブランド参照レンダラ・`src/Install/`） |
 | v1.7.0 の成果 | fail-closed な JWT secret 解決 `GuardedJwtSecretResolver`（ADR 0013）＋ Installer 入力型（#1490/#1482） |
 | v1.8.0 の成果 | 監査ログ基盤 `Nene2\Audit`（ADR 0014）＋ CSV 出力 `Nene2\Export\CsvWriter`（ADR 0015）＋ `LocalBearerTokenVerifier` の Clock 注入 |
 | v1.8.1/1.8.2 の成果 | 準拠リンタ `tools/conformance.php`（ADR 0016）＋消費側 autoload / D1 誤検知の修正 |
 | **v1.9.0 の成果** | **使い捨て org デモモジュール `Nene2\Demo`**（ADR 0017・2026-07-09 施主決定=デモ方式を invoice 型に全製品統一）。5 interface（provisioner/reaper/seater/seeder/template key）＋具象（`StartDisposableDemoHandler`/`DisposableDemoSweeper`/`CountingDemoCapacityGuard`=invoice #608 根治点/`DemoRouteRegistrar`）＋`DEMO_*` typed 化（`AppConfig::$demo`）＋howto `add-disposable-demo.md`（5ロケール訳）（#1522/#1523/#1524） |
+| **v1.10.0 の成果** | **`Nene2\Demo` ブラウザ向けエラーの HTML negotiation**（ADR 0018・invoice 本番 2026-07-10 実発生の上流化）。`DemoErrorPageRendererInterface`＋既定 `MinimalDemoErrorPageRenderer`（ページ専用 CSP 持ち＝アプリ全体 `default-src 'self'` のインライン CSS ブロック罠を回避）。不変条件（API/成功のバイト不変・status/`Retry-After` 強制コピー・`X-Robots-Tag: noindex`）は handler が強制。`DemoRouteRegistrar` を PSR-15 `RequestHandlerInterface` 受けに拡大（デコレータの一般解）・throttle 既定 10→30回/h（invoice 本番実証）（#1536/#1537） |
 | 第1 consumer | NeNe Invoice（#562。demo モジュールの consumer 化も invoice が先頭 — 指揮リナの別指示書待ち） |
 | 進行中ブランチ | なし |
 
 ### 未処理 Issue
 
-なし（2026-07-09 時点で open Issue ゼロ）。
+なし（2026-07-10 時点で open Issue ゼロ。#1536 は PR #1537 で完了）。
 
 ※ #1421 は 2026-07-06 完了。#1514 は v1.8.2 修正で 07-09 クローズ。#1526/#1527（ローカル限定テスト失敗）は 07-09 修正済み（#1529/#1530）。
 
 ### 引き継ぎメモ（2026-07-09・Nene2\Demo リリース）
 
 - 次工程は **invoice/clear/vault の consumer 化**（NENE2 スコープ外・指揮リナが別指示書を発行）。invoice consumer 化では `TENANT_RESOLUTION=path` 前提と path 二重合成（workspace issues #38）を実機回帰で必ず踏むこと。
+- v1.10.0（ADR 0018）取り込み後、invoice は `DemoBrowserErrorPage` を `DemoErrorPageRendererInterface` 実装へ載せ替えて自前 registrar を廃止できる（NENE2 スコープ外・別発注）。clear/deal/vault は framework 既定でブラウザ向けエラーページが最初から効く。
 - ローカル Docker の `composer test` は**完全緑**（832 tests）。かつて存在した環境起因失敗2種は根治済み — ① compose の `DB_NAME` env 干渉 → テストを env 非依存化（#1526/#1530） ② ext-zip 欠如 → Dockerfile に追加（#1527/#1529・**要 `docker compose build app`**）。
 
 > 設計方針: すべて opt-in・generic。wire しなければ dormant、製品固有の前提（UI/ブランド/語彙/パス）を core に焼かない。詳細は CHANGELOG `[1.6.0]` / `[1.7.0]` / `[Unreleased]`。

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.9.0';
+    public const string VERSION = '1.10.0';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的

v1.10.0 リリース準備（#1536 / PR #1537 の収録）。`FrameworkInfo::VERSION` / openapi `info.version` / CHANGELOG（Unreleased → `[1.10.0] — 2026-07-10`）/ `docs/todo/current.md` を 1.10.0 に同期する。

Refs #1536

## 変更点

- `src/FrameworkInfo.php`: `VERSION` 1.9.0 → 1.10.0
- `docs/openapi/openapi.yaml`: `info.version` 1.10.0
- `CHANGELOG.md`: Unreleased の Added/Changed を `[1.10.0] — 2026-07-10` 見出しへ移動＋リリース要約
- `docs/todo/current.md`: レーン表を v1.10.0 に更新・引き継ぎメモに invoice 載せ替え（別発注）を追記

## 検証結果

- `docker compose run --rm app composer validate` OK
- `docker compose run --rm app composer check` 全緑（845 tests / PHPStan / cs / openapi / mcp / conformance）
- `git diff --check` clean

Self-review: release-ci

## 残リスク

なし（バージョン同期のみ・ランタイム変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)