### PR TITLE
docs(readme): README の版表記を v1.10.0 に同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `v1.x` foundation covers full Note/Tag CRUD, Bearer JWT auth, pagination hel
 
 NENE2 is built in the open, at high velocity, by a solo maintainer using an AI-assisted, Issue-driven workflow:
 
-- **30 releases** (current: `v1.8.2`) and **730+ merged pull requests** since the first commit in May 2026 — every change lands through an Issue → branch → PR → CI pipeline; nothing is committed directly to `main`.
+- **30 releases** (current: `v1.10.0`) and **730+ merged pull requests** since the first commit in May 2026 — every change lands through an Issue → branch → PR → CI pipeline; nothing is committed directly to `main`.
 - **[262 how-to guides](docs/howto/README.md)** covering authentication, security, database patterns, API design, background jobs, and 100+ product feature recipes.
 - **[125 runnable example apps](https://github.com/hideyukiMORI/NENE2-examples)** — each a self-contained JSON API with tests, built as field trials of the framework itself.
 - **Powers the NeNe product family** — 12+ open-source, self-hosted business tools for small teams (invoicing, records, deal tracking, contact management, and more), all built on this framework and sharing its fail-closed security baseline.


### PR DESCRIPTION
## 目的

README.md の "current" バージョン表記が `v1.8.2` のまま実版から2版古くなっていた。表記を実版に合わせる。

## 変更点

- README.md 20行目: `current: \`v1.8.2\`` → `current: \`v1.10.0\`` の1点のみ。
- 正: `src/FrameworkInfo.php` の `VERSION = '1.10.0'` / `docs/todo/current.md` / CHANGELOG 最新 `[1.10.0] 2026-07-10`。
- **スコープ外**: 同じ行の「30 releases」「730+ merged pull requests」等の生数字は #1521 で意図的に追加した検証済み実績のため、今回は変更していない（別途 P1 判断）。

## 検証結果

- `git diff README.md` で変更が版表記1トークンのみであることを確認。
- docs-only 変更のため CI 影響なし。

## セルフレビュー

Self-review: docs-policy

Closes #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)