### PR TITLE
docs(readme): Highlights 生数字を検証済み現在値＋時点併記に更新（陳腐化是正）

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The `v1.x` foundation covers full Note/Tag CRUD, Bearer JWT auth, pagination hel
 
 NENE2 is built in the open, at high velocity, by a solo maintainer using an AI-assisted, Issue-driven workflow:
 
-- **30 releases** (current: `v1.10.0`) and **730+ merged pull requests** since the first commit in May 2026 — every change lands through an Issue → branch → PR → CI pipeline; nothing is committed directly to `main`.
+- **140+ releases** (current: `v1.10.0`) and **740+ merged pull requests** since the first commit in May 2026 (as of 2026-07) — every change lands through an Issue → branch → PR → CI pipeline; nothing is committed directly to `main`.
 - **[262 how-to guides](docs/howto/README.md)** covering authentication, security, database patterns, API design, background jobs, and 100+ product feature recipes.
-- **[125 runnable example apps](https://github.com/hideyukiMORI/NENE2-examples)** — each a self-contained JSON API with tests, built as field trials of the framework itself.
+- **[125+ runnable example apps](https://github.com/hideyukiMORI/NENE2-examples)** — each a self-contained JSON API with tests, built as field trials of the framework itself.
 - **Powers the NeNe product family** — 12+ open-source, self-hosted business tools for small teams (invoicing, records, deal tracking, contact management, and more), all built on this framework and sharing its fail-closed security baseline.
 - **Documented decisions** — ADRs for every architectural choice, an OpenAPI 3.1 contract, six-language documentation, and an MCP server listed on Smithery.
 


### PR DESCRIPTION
## 目的

Closes #1549

README の Project Highlights にある実績数字が、記載後の実績蓄積で陳腐化（過少表示）していたため、検証済みの現在値へ更新する。docs-only PR。

## 変更点

| 項目 | before | after |
|---|---|---|
| releases | 30 releases | 140+ releases |
| merged pull requests | 730+ merged pull requests | 740+ merged pull requests |
| runnable example apps | 125 runnable example apps | 125+ runnable example apps |
| how-to guides | 262 how-to guides | （変更なし・実測一致） |

加えて Highlights の releases/PR 行末に「(as of 2026-07)」の時点併記を1箇所追加（以後リリース毎の更新を不要にする意図）。`current: v1.10.0` は #1548 で対応済みのため変更なし。

## 実測値（2026-07-13時点・裏取り済み）

- releases = 144
- merged PRs = 745
- how-to guides = 262（一致）
- example apps = 127

裏取り方法の詳細は `_work/reports/2026-07-13-readme-unification-audit.md`（統合リナ側の監査レポート、リポジトリ外）を参照。

## 検証結果

README.md の1箇所のみを変更するdocs-only変更。コード・設定・CI挙動への影響なし。`git diff README.md` で意図した3行のみの変更であることを確認済み。

## セルフレビュー

Self-review: docs-policy

## 残リスク

数字は丸めて記載しており、時点併記により将来の軽微な乖離（さらなる実績増加）は許容する運用とする。次回大きく乖離した場合は再度更新Issueを起票する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)