### PR TITLE
feat(conformance): README 静的statusバッジ禁止(R1/error)＋License節必須(R2/warn)

### DIFF
--- a/docs/adr/0016-conformance-linter.md
+++ b/docs/adr/0016-conformance-linter.md
@@ -81,6 +81,21 @@ Gradual adoption and false-positive relief use three mechanisms:
   configuration error) so exceptions stay auditable.
 - **Inline `// conformance:ignore <rule> <reason>`** for one-off local exceptions.
 
+**2026-07-14 addendum — R-series (README/docs conformance).** Design doc 04's
+D5–D12 range is reserved for backend-only drift (getenv, Installer/Pagination
+reinvention, ...), so README/docs drift — a distinct axis, first raised by
+workspace issue `_work/issues.md#44` ("README統一の後続") and the
+`nene-status-badges-unreliable` observation that static maturity badges drift
+from reality — gets its own **R1/R2** sequence instead of continuing D-numbering.
+Both scan `README.md` only (no findings when it is absent, matching the
+tolerant convention `ProjectFiles` already uses for source-scanning rules):
+**R1** (`error`) flags a static shields.io `status-`/`phase-`-prefixed badge
+(`.../badge/status-...`) — deliberately narrower than a generic badge scan so it
+never trips on CI/License/PHP-version/Packagist badges, which are dynamic or
+effectively invariant; maturity belongs in a `## Status` section instead.
+**R2** (`warn`) flags a missing `## License` section — a license badge alone is
+a thin, easy-to-leave-stale pointer, so a heading is recommended, not required.
+
 ## Consequences
 
 - D1 permanently locks in the ADR 0013 fix: a re-introduced default secret fails
@@ -95,6 +110,9 @@ Gradual adoption and false-positive relief use three mechanisms:
 - Fan-out to the other products (report-only baseline capture, then CI gating of
   new drift) is a separate wave, as is the deferred PHPStan type-aware pack and
   the `warn`-tier rules, which follow each upstream interface as it freezes.
+- R1/R2 apply to NENE2's own `README.md` too: no static status badge and a
+  `## License` section already present, so both are green with zero new
+  baseline entries.
 
 ## Related
 
@@ -104,5 +122,6 @@ Gradual adoption and false-positive relief use three mechanisms:
   (the CLI must require the resolved consumer `vendor/autoload.php`, matching
   `tools/validate-mcp-tools.php`, not NENE2's own nested vendor) and the D1
   `GuardedJwtSecretResolver` guarded-literal exemption above.
+- R-series addendum (README/docs conformance, 2026-07-14): Issue `#1551`, PR `#1552`.
 - Supersedes: none
 - Superseded by: none

--- a/src/Conformance/ConformanceRunner.php
+++ b/src/Conformance/ConformanceRunner.php
@@ -8,6 +8,8 @@ use Nene2\Conformance\Rule\CheckSelfRegistrationRule;
 use Nene2\Conformance\Rule\DependencyBranchPinRule;
 use Nene2\Conformance\Rule\JwtDefaultSecretRule;
 use Nene2\Conformance\Rule\RawClockRule;
+use Nene2\Conformance\Rule\ReadmeLicenseSectionRule;
+use Nene2\Conformance\Rule\ReadmeStaticStatusBadgeRule;
 
 /**
  * Orchestrates the conformance rules over a project tree and applies the three
@@ -34,7 +36,12 @@ final class ConformanceRunner
     }
 
     /**
-     * The current `error`-tier rule set (design doc 04, layer error: D1–D4).
+     * The current default rule set: the `error`-tier D1–D4 rules (design doc 04,
+     * layer error) plus the R1/R2 README/docs-conformance rules (R1 `error`, R2
+     * `warn` — see ADR 0016's R-series addendum). R-series ids are a separate
+     * sequence from D1–D4 because design doc 04 reserves D5–D12 for backend-only
+     * drift (getenv, Installer/Pagination reinvention, ...); README/docs drift is
+     * a distinct axis, not a continuation of that reserved range.
      */
     public static function withDefaultRules(): self
     {
@@ -43,6 +50,8 @@ final class ConformanceRunner
             new DependencyBranchPinRule(),
             new CheckSelfRegistrationRule(),
             new RawClockRule(),
+            new ReadmeStaticStatusBadgeRule(),
+            new ReadmeLicenseSectionRule(),
         ]);
     }
 

--- a/src/Conformance/Rule/ReadmeLicenseSectionRule.php
+++ b/src/Conformance/Rule/ReadmeLicenseSectionRule.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Conformance\Rule;
+
+use Nene2\Conformance\Finding;
+use Nene2\Conformance\RuleInterface;
+use Nene2\Conformance\Severity;
+
+/**
+ * R2 — README should carry a `## License` section, not just a badge.
+ *
+ * A `License: MIT` badge is a compact pointer, but it is easy to leave dangling
+ * (wrong link, stale SPDX id) and it carries no room for the actual grant text
+ * or an exception. A `## License` (or deeper, `### License`) heading gives the
+ * license a stable home next to the rest of the README's prose, where a reader
+ * — human or AI — expects to find it and where drift is easy to spot on review.
+ *
+ * This is a `warn`, not an `error`: a badge alone is a real (if thin) signal,
+ * not an outright violation, so it is surfaced without failing CI.
+ *
+ * A repository with no `README.md` produces no findings — same convention as
+ * {@see ReadmeStaticStatusBadgeRule} and {@see \Nene2\Conformance\ProjectFiles}'s
+ * source-scanning rules.
+ */
+final class ReadmeLicenseSectionRule implements RuleInterface
+{
+    private const README_FILE = 'README.md';
+
+    private const LICENSE_HEADING_PATTERN = '/^#{2,}\s*License\b/mi';
+
+    public function id(): string
+    {
+        return 'R2';
+    }
+
+    public function description(): string
+    {
+        return 'README should have a `## License` section (badge alone is not enough).';
+    }
+
+    public function check(string $root): array
+    {
+        $path = $root . '/' . self::README_FILE;
+
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $raw = @file_get_contents($path);
+
+        if ($raw === false) {
+            return [];
+        }
+
+        if (preg_match(self::LICENSE_HEADING_PATTERN, $raw) === 1) {
+            return [];
+        }
+
+        return [
+            new Finding(
+                $this->id(),
+                Severity::Warn,
+                self::README_FILE,
+                0,
+                'README has no `## License` section (badge alone is not enough).',
+            ),
+        ];
+    }
+}

--- a/src/Conformance/Rule/ReadmeStaticStatusBadgeRule.php
+++ b/src/Conformance/Rule/ReadmeStaticStatusBadgeRule.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Conformance\Rule;
+
+use Nene2\Conformance\Finding;
+use Nene2\Conformance\RuleInterface;
+use Nene2\Conformance\Severity;
+
+/**
+ * R1 — static README status/phase badge instead of a `## Status` section.
+ *
+ * A shields.io badge of the shape `.../badge/status-...` (e.g.
+ * `status-Phase%201-blue`, `status-Early-orange`) hand-encodes a maturity claim
+ * into an image URL. Unlike CI/License/PHP-version/Packagist badges — which are
+ * either dynamic (recomputed by shields.io from a live source) or effectively
+ * invariant (a license rarely changes) — a status/phase badge is a static string
+ * a human must remember to edit, and the fleet's own experience is that it goes
+ * stale (see `nene-status-badges-unreliable`): the badge keeps saying "Phase 0"
+ * long after the code has moved on. A `## Status` section (prose or a table) is
+ * cheap to keep honest by comparison, since it sits next to the content that
+ * makes it true or false.
+ *
+ * Detection is a plain text scan for the literal `shields.io/badge/status-`
+ * (case-insensitive) rather than a generic badge/token scan, so it is
+ * deliberately narrow: it never trips on the CI, License, PHP version or
+ * Packagist badges NENE2 itself ships, only on a `status-`/`phase-`-prefixed
+ * badge slug.
+ *
+ * A repository with no `README.md` produces no findings — same convention as
+ * {@see \Nene2\Conformance\ProjectFiles}'s source-scanning rules.
+ */
+final class ReadmeStaticStatusBadgeRule implements RuleInterface
+{
+    private const README_FILE = 'README.md';
+
+    /** Matches the fixed shields.io URL segment a static status/phase badge uses. */
+    private const BADGE_PATTERN = '/shields\.io\/badge\/status-[^)\]\s]*/i';
+
+    public function id(): string
+    {
+        return 'R1';
+    }
+
+    public function description(): string
+    {
+        return 'No static README status/phase badge (shields.io/badge/status-...); use a `## Status` section instead.';
+    }
+
+    public function check(string $root): array
+    {
+        $path = $root . '/' . self::README_FILE;
+
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $raw = @file_get_contents($path);
+
+        if ($raw === false) {
+            return [];
+        }
+
+        $findings = [];
+
+        foreach (explode("\n", $raw) as $index => $line) {
+            if (preg_match_all(self::BADGE_PATTERN, $line, $matches) === 0) {
+                continue;
+            }
+
+            foreach ($matches[0] as $badge) {
+                $findings[] = new Finding(
+                    $this->id(),
+                    Severity::Error,
+                    self::README_FILE,
+                    $index + 1,
+                    sprintf(
+                        'Static status/phase badge in README (`%s`). Maturity belongs in a `## Status` '
+                        . 'section (table), not a brittle badge that goes stale.',
+                        $badge,
+                    ),
+                );
+            }
+        }
+
+        return $findings;
+    }
+}

--- a/tests/Conformance/ConformanceRulesTest.php
+++ b/tests/Conformance/ConformanceRulesTest.php
@@ -11,6 +11,8 @@ use Nene2\Conformance\Rule\CheckSelfRegistrationRule;
 use Nene2\Conformance\Rule\DependencyBranchPinRule;
 use Nene2\Conformance\Rule\JwtDefaultSecretRule;
 use Nene2\Conformance\Rule\RawClockRule;
+use Nene2\Conformance\Rule\ReadmeLicenseSectionRule;
+use Nene2\Conformance\Rule\ReadmeStaticStatusBadgeRule;
 use Nene2\Conformance\Severity;
 use PHPUnit\Framework\TestCase;
 
@@ -369,6 +371,84 @@ final class ConformanceRulesTest extends TestCase
             PHP);
 
         self::assertCount(1, (new RawClockRule())->check($this->root));
+    }
+
+    // --- R1 -----------------------------------------------------------------
+
+    public function testR1FlagsStaticStatusBadge(): void
+    {
+        $this->write('README.md', <<<'MD'
+            # Acme
+
+            [![status](https://img.shields.io/badge/status-Phase%200-orange)](#status)
+            MD);
+
+        $findings = (new ReadmeStaticStatusBadgeRule())->check($this->root);
+        self::assertCount(1, $findings);
+        self::assertSame('R1', $findings[0]->ruleId);
+        self::assertSame(Severity::Error, $findings[0]->severity);
+        self::assertSame('README.md', $findings[0]->file);
+        self::assertSame(3, $findings[0]->line);
+    }
+
+    public function testR1IgnoresDynamicBadgesAndOtherPrefixes(): void
+    {
+        $this->write('README.md', <<<'MD'
+            # Acme
+
+            [![CI](https://img.shields.io/github/actions/workflow/status/acme/acme/ci.yml)](#)
+            [![PHP](https://img.shields.io/badge/PHP-8.4%2B-8892BF)](https://www.php.net/)
+            [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+            [![Packagist](https://img.shields.io/packagist/v/acme/acme)](https://packagist.org/packages/acme/acme)
+            MD);
+
+        self::assertSame([], (new ReadmeStaticStatusBadgeRule())->check($this->root));
+    }
+
+    public function testR1ProducesNoFindingsWithoutReadme(): void
+    {
+        self::assertSame([], (new ReadmeStaticStatusBadgeRule())->check($this->root));
+    }
+
+    // --- R2 -----------------------------------------------------------------
+
+    public function testR2FlagsMissingLicenseSection(): void
+    {
+        $this->write('README.md', <<<'MD'
+            # Acme
+
+            [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
+            ## Usage
+
+            ...
+            MD);
+
+        $findings = (new ReadmeLicenseSectionRule())->check($this->root);
+        self::assertCount(1, $findings);
+        self::assertSame('R2', $findings[0]->ruleId);
+        self::assertSame(Severity::Warn, $findings[0]->severity);
+        self::assertSame('README.md', $findings[0]->file);
+    }
+
+    public function testR2AcceptsLicenseSection(): void
+    {
+        $this->write('README.md', <<<'MD'
+            # Acme
+
+            [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
+            ## License
+
+            MIT, see [LICENSE](./LICENSE).
+            MD);
+
+        self::assertSame([], (new ReadmeLicenseSectionRule())->check($this->root));
+    }
+
+    public function testR2ProducesNoFindingsWithoutReadme(): void
+    {
+        self::assertSame([], (new ReadmeLicenseSectionRule())->check($this->root));
     }
 
     // --- Baseline / allowlist / inline ignore -------------------------------


### PR DESCRIPTION
## 目的

準拠リンタに README/docs 系ドリフトを検出する新ルールを2本追加する。既存の D1-D4（backend 向け error 4ルール）とは別系列の **R1/R2** として新設する（D5-D12 は上流化設計ドキュメント `_work/reports/2026-07-06/upstream-design/04-conformance-linter.md` で backend 用に予約済みのため）。

背景: workspace `_work/issues.md#44`（README統一の後続）と `nene-status-badges-unreliable`（README のステータスバッジが実態と乖離しやすいという観察）。

## 変更点

- `src/Conformance/Rule/ReadmeStaticStatusBadgeRule.php`（**R1 / Severity::Error**）
  - `$root/README.md` を行走査し、`shields.io/badge/status-...` 形式の静的 status/phase バッジを検出。
  - CI/License/PHP バージョン/Packagist 等の動的・不変バッジは対象外（`badge/status-` プレフィクスのみ厳密一致）。
  - README.md が無ければ findings ゼロ。
- `src/Conformance/Rule/ReadmeLicenseSectionRule.php`（**R2 / Severity::Warn**）
  - `$root/README.md` に `^##+\s*License` 見出しが無ければ Warn（バッジのみでは不足）。
  - README.md が無ければ findings ゼロ。
- `ConformanceRunner::withDefaultRules()` に2本を登録。
- `tests/Conformance/ConformanceRulesTest.php` に fixture ベースの単体テストを追加（バッジ有/無・License 有/無・README 無しの各ケース、計6テスト）。既存テストは無変更で全て通過。
- `docs/adr/0016-conformance-linter.md` に R系追加の addendum を追記（Decision セクション末尾・Consequences・Related）。

## 検証

- `docker compose run --rm app vendor/bin/phpunit --filter Conformance` → 28 tests, 52 assertions, 全緑
- `docker compose run --rm app composer check` → test(851)/analyse(PHPStan L8 0 errors)/cs(0 issues)/openapi/mcp/**conformance**/version:check 全緑
- `docker compose run --rm app composer conformance -- --format=json` → NENE2 自身の README は R1/R2 とも findings ゼロ（静的statusバッジ無し・`## License` 節あり）。`conformance.baseline.json` の更新は不要（新規違反なし）。

## Self-review

- `docs/review/docs-policy.md`
- `docs/review/backend-api.md`（新規クラスのみ・ドメイン変更無し）

## 残リスク

- R2 は `warn` 層のため `composer conformance` のテキスト出力（`renderText`）では表示されず、`--format=json` の `findings` 配列でのみ可視化される（既存の CLI 挙動どおりで本 PR の変更対象外）。fan-out/レポート用途で警告を確認する場合は JSON 出力を使うこと。

Closes #1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
