### PR TITLE
fix(conformance): renderText に Warn/Info を表示

### DIFF
--- a/tools/conformance.php
+++ b/tools/conformance.php
@@ -22,6 +22,7 @@ use Nene2\Conformance\Baseline;
 use Nene2\Conformance\ConformanceRunner;
 use Nene2\Conformance\Finding;
 use Nene2\Conformance\RunResult;
+use Nene2\Conformance\Severity;
 
 // When run via `composer conformance` or directly, getcwd() is the project root.
 // --root=<path> overrides this for explicit invocation from another directory.
@@ -101,30 +102,55 @@ exit($result->exitCode());
 
 function renderText(RunResult $result): string
 {
+    // Pass/fail is decided solely by error-tier findings (see RunResult::exitCode());
+    // Warn/Info are surfaced here for visibility but never affect the exit code.
     $errors = $result->errors();
+    $warnings = findingsOfSeverity($result, Severity::Warn);
+    $infos = findingsOfSeverity($result, Severity::Info);
 
-    if ($errors === []) {
+    if ($errors === [] && $warnings === [] && $infos === []) {
         return sprintf(
-            "Conformance OK — no error findings (%d suppressed by baseline/ignore).\n",
+            "Conformance OK — no findings (%d suppressed by baseline/ignore).\n",
             $result->suppressed,
         );
     }
 
     $lines = [sprintf(
-        "Conformance: %d error finding(s), %d suppressed by baseline/ignore.\n",
+        "Conformance: %d error(s), %d warning(s), %d info(s), %d suppressed by baseline/ignore.\n",
         count($errors),
+        count($warnings),
+        count($infos),
         $result->suppressed,
     )];
 
-    foreach ($errors as $finding) {
-        $location = $finding->line > 0 ? "{$finding->file}:{$finding->line}" : $finding->file;
-        $lines[] = sprintf("  [%s] %s\n        %s\n", $finding->ruleId, $location, $finding->message);
+    foreach ([
+        ['ERROR', $errors],
+        ['WARN', $warnings],
+        ['INFO', $infos],
+    ] as [$label, $findings]) {
+        foreach ($findings as $finding) {
+            $location = $finding->line > 0 ? "{$finding->file}:{$finding->line}" : $finding->file;
+            $lines[] = sprintf("  [%s][%s] %s\n        %s\n", $label, $finding->ruleId, $location, $finding->message);
+        }
     }
 
-    $lines[] = "\nBaseline existing drift with: php tools/conformance.php --write-baseline\n";
-    $lines[] = "Allowlist a false positive in conformance.baseline.json (\"allow\": with a required \"reason\").\n";
+    if ($errors !== []) {
+        $lines[] = "\nBaseline existing drift with: php tools/conformance.php --write-baseline\n";
+        $lines[] = "Allowlist a false positive in conformance.baseline.json (\"allow\": with a required \"reason\").\n";
+    }
 
     return implode('', $lines);
+}
+
+/**
+ * @return list<Finding>
+ */
+function findingsOfSeverity(RunResult $result, Severity $severity): array
+{
+    return array_values(array_filter(
+        $result->findings,
+        static fn (Finding $f): bool => $f->severity === $severity,
+    ));
 }
 
 function renderJson(RunResult $result): string


### PR DESCRIPTION
## 目的

直前 PR #1552 で R2（`ReadmeLicenseSectionRule`、`Severity::Warn`）を追加したが、
`tools/conformance.php` の `renderText()` が `RunResult::errors()`（Error tier のみ）
しか列挙しないため、R2 の警告は通常の `composer conformance`（text 出力）では見えず
`--format=json` でしか確認できなかった。この非対称を解消する。

内部追跡: `_work/issues.md` #46（このリポの GitHub issue 番号とは別体系・混同注意）。

## 変更点

- `renderText()` を拡張し、Error に加えて Warn / Info の finding も
  `[ERROR]` / `[WARN]` / `[INFO]` の severity ラベル付きでグルーピング表示。
- サマリ行を `Conformance: N error(s), M warning(s), K info(s), L suppressed by baseline/ignore.` の内訳表示に変更。
- 全件ゼロ（Error/Warn/Info すべて空）の場合のみ `Conformance OK — no findings (...)` を返す（従来は Error のみで判定していた分岐）。
- Error が 0 件のときは baseline/allowlist の案内文（`--write-baseline` 等）を出さないよう調整（Warn/Info だけの出力にエラー対処の案内を混ぜない）。
- **pass/fail 判定（`RunResult::exitCode()`）は Error 件数のみで決める現行挙動を変更していない** — Warn/Info があっても Error 0 件なら exit 0 のまま。
- `renderJson()` は元々全 finding を出力していたため変更なし。

## 検証

- `docker compose run --rm app composer check`（test 851件/analyse/cs/openapi/mcp/conformance/version:check）全緑。
- `docker compose run --rm app composer conformance`: `Conformance OK — no findings (4 suppressed by baseline/ignore).`（NENE2 自身は README に `## License` 節ありのため R2 は発火せず、既存 D4 allowlist 3件+運用上の1件が suppressed のまま）。
- 手動フィクスチャで動作確認: README から `## License` 節を除いた一時ディレクトリに対し `--root=<fixture> --format=text` を実行し、
  ```
  Conformance: 0 error(s), 1 warning(s), 0 info(s), 0 suppressed by baseline/ignore.
    [WARN][R2] README.md
          README has no `## License` section (badge alone is not enough).
  ```
  が表示され、かつ exit code は 0 のままであることを確認（`--format=json` の出力とも整合）。
- 既存の CLI サブプロセステスト（`ConformanceRulesTest`、D1 flat-consumer autoload smoke test、`--format=json` のみ検証）は変更なしで green。text 出力専用の既存テストは無かったため、上記の手動フィクスチャ確認に留めた（依頼のスコープ通り）。

## Closes

Closes #1553

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)