### PR TITLE
feat(conformance): README の private nene-origin 参照検出(R3/warn) (#1555)

### DIFF
--- a/docs/adr/0016-conformance-linter.md
+++ b/docs/adr/0016-conformance-linter.md
@@ -96,6 +96,16 @@ effectively invariant; maturity belongs in a `## Status` section instead.
 **R2** (`warn`) flags a missing `## License` section — a license badge alone is
 a thin, easy-to-leave-stale pointer, so a heading is recommended, not required.
 
+**2026-07-14 addendum — R3 (private `nene-origin` link, warn).** Workspace
+issue `_work/issues.md#44①` found that a public product README can link/path
+into the private `nene-origin` repo (e.g. its port registry
+`nene-origin/docs/development/local-ports.md`), which 404s for external readers
+who have no access to it; the correct home for that content is the product's
+own `AGENTS.md`/`CLAUDE.md` port section. **R3** (`warn`) word-bounded-scans
+`README.md` for the repo slug `nene-origin` (path, `github.com/...` URL, or
+markdown link target). The fleet is already clean, so R3 is a regression guard,
+not a fix for an active violation — hence `warn`, not `error`.
+
 ## Consequences
 
 - D1 permanently locks in the ADR 0013 fix: a re-introduced default secret fails
@@ -110,9 +120,9 @@ a thin, easy-to-leave-stale pointer, so a heading is recommended, not required.
 - Fan-out to the other products (report-only baseline capture, then CI gating of
   new drift) is a separate wave, as is the deferred PHPStan type-aware pack and
   the `warn`-tier rules, which follow each upstream interface as it freezes.
-- R1/R2 apply to NENE2's own `README.md` too: no static status badge and a
-  `## License` section already present, so both are green with zero new
-  baseline entries.
+- R1/R2/R3 apply to NENE2's own `README.md` too: no static status badge, a
+  `## License` section already present, and no `nene-origin` reference, so all
+  three are green with zero new baseline entries.
 
 ## Related
 
@@ -123,5 +133,6 @@ a thin, easy-to-leave-stale pointer, so a heading is recommended, not required.
   `tools/validate-mcp-tools.php`, not NENE2's own nested vendor) and the D1
   `GuardedJwtSecretResolver` guarded-literal exemption above.
 - R-series addendum (README/docs conformance, 2026-07-14): Issue `#1551`, PR `#1552`.
+- R3 addendum (private `nene-origin` link, warn, 2026-07-14): Issue `#1555`, PR TBD.
 - Supersedes: none
 - Superseded by: none

--- a/docs/adr/0016-conformance-linter.md
+++ b/docs/adr/0016-conformance-linter.md
@@ -133,6 +133,6 @@ not a fix for an active violation — hence `warn`, not `error`.
   `tools/validate-mcp-tools.php`, not NENE2's own nested vendor) and the D1
   `GuardedJwtSecretResolver` guarded-literal exemption above.
 - R-series addendum (README/docs conformance, 2026-07-14): Issue `#1551`, PR `#1552`.
-- R3 addendum (private `nene-origin` link, warn, 2026-07-14): Issue `#1555`, PR TBD.
+- R3 addendum (private `nene-origin` link, warn, 2026-07-14): Issue `#1555`, PR `#1556`.
 - Supersedes: none
 - Superseded by: none

--- a/src/Conformance/ConformanceRunner.php
+++ b/src/Conformance/ConformanceRunner.php
@@ -9,6 +9,7 @@ use Nene2\Conformance\Rule\DependencyBranchPinRule;
 use Nene2\Conformance\Rule\JwtDefaultSecretRule;
 use Nene2\Conformance\Rule\RawClockRule;
 use Nene2\Conformance\Rule\ReadmeLicenseSectionRule;
+use Nene2\Conformance\Rule\ReadmePrivateOriginLinkRule;
 use Nene2\Conformance\Rule\ReadmeStaticStatusBadgeRule;
 
 /**
@@ -37,11 +38,12 @@ final class ConformanceRunner
 
     /**
      * The current default rule set: the `error`-tier D1–D4 rules (design doc 04,
-     * layer error) plus the R1/R2 README/docs-conformance rules (R1 `error`, R2
-     * `warn` — see ADR 0016's R-series addendum). R-series ids are a separate
-     * sequence from D1–D4 because design doc 04 reserves D5–D12 for backend-only
-     * drift (getenv, Installer/Pagination reinvention, ...); README/docs drift is
-     * a distinct axis, not a continuation of that reserved range.
+     * layer error) plus the R1–R3 README/docs-conformance rules (R1 `error`,
+     * R2/R3 `warn` — see ADR 0016's R-series addendum). R-series ids are a
+     * separate sequence from D1–D4 because design doc 04 reserves D5–D12 for
+     * backend-only drift (getenv, Installer/Pagination reinvention, ...);
+     * README/docs drift is a distinct axis, not a continuation of that reserved
+     * range.
      */
     public static function withDefaultRules(): self
     {
@@ -52,6 +54,7 @@ final class ConformanceRunner
             new RawClockRule(),
             new ReadmeStaticStatusBadgeRule(),
             new ReadmeLicenseSectionRule(),
+            new ReadmePrivateOriginLinkRule(),
         ]);
     }
 

--- a/src/Conformance/Rule/ReadmePrivateOriginLinkRule.php
+++ b/src/Conformance/Rule/ReadmePrivateOriginLinkRule.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Conformance\Rule;
+
+use Nene2\Conformance\Finding;
+use Nene2\Conformance\RuleInterface;
+use Nene2\Conformance\Severity;
+
+/**
+ * R3 — README should not reference the private `nene-origin` repo.
+ *
+ * `nene-origin` is the fleet's private port-registry/governance repo
+ * (`nene-origin/docs/development/local-ports.md` and similar). A public product
+ * README that links or paths into it — a bare `nene-origin/...` path, a
+ * `github.com/hideyukiMORI/nene-origin` URL, or a markdown link whose target
+ * contains the slug — gives an external reader (no access to the private repo)
+ * a dead 404 link. The correct home for that content is the product's own
+ * `AGENTS.md`/`CLAUDE.md` port section, which ships alongside the README and is
+ * readable by everyone who can read the README itself.
+ *
+ * Detection is a plain word-bounded scan for the repo slug `nene-origin`
+ * (case-insensitive) rather than parsing markdown link syntax, so it also
+ * catches the rare prose mention — false positives are minimal because the
+ * slug's only realistic appearance in a README is a link/path reference.
+ *
+ * This is a `warn`, not an `error`: the fleet is already clean (no product
+ * README currently references `nene-origin`), so this rule exists to catch a
+ * *regression*, not an active violation — same warn-first posture as
+ * {@see ReadmeLicenseSectionRule}.
+ *
+ * A repository with no `README.md` produces no findings — same convention as
+ * {@see ReadmeStaticStatusBadgeRule} and {@see ReadmeLicenseSectionRule}.
+ */
+final class ReadmePrivateOriginLinkRule implements RuleInterface
+{
+    private const README_FILE = 'README.md';
+
+    /** Matches the repo slug `nene-origin` as a whole token (word-bounded). */
+    private const ORIGIN_SLUG_PATTERN = '/\bnene-origin\b/i';
+
+    public function id(): string
+    {
+        return 'R3';
+    }
+
+    public function description(): string
+    {
+        return 'README should not link/path into the private `nene-origin` repo (broken link for external readers).';
+    }
+
+    public function check(string $root): array
+    {
+        $path = $root . '/' . self::README_FILE;
+
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $raw = @file_get_contents($path);
+
+        if ($raw === false) {
+            return [];
+        }
+
+        $findings = [];
+
+        foreach (explode("\n", $raw) as $index => $line) {
+            if (preg_match(self::ORIGIN_SLUG_PATTERN, $line) !== 1) {
+                continue;
+            }
+
+            $findings[] = new Finding(
+                $this->id(),
+                Severity::Warn,
+                self::README_FILE,
+                $index + 1,
+                'README references the private `nene-origin` repo (broken link for external readers). '
+                . "Link to this repo's own AGENTS.md/CLAUDE.md port section instead.",
+            );
+        }
+
+        return $findings;
+    }
+}

--- a/tests/Conformance/ConformanceRulesTest.php
+++ b/tests/Conformance/ConformanceRulesTest.php
@@ -12,6 +12,7 @@ use Nene2\Conformance\Rule\DependencyBranchPinRule;
 use Nene2\Conformance\Rule\JwtDefaultSecretRule;
 use Nene2\Conformance\Rule\RawClockRule;
 use Nene2\Conformance\Rule\ReadmeLicenseSectionRule;
+use Nene2\Conformance\Rule\ReadmePrivateOriginLinkRule;
 use Nene2\Conformance\Rule\ReadmeStaticStatusBadgeRule;
 use Nene2\Conformance\Severity;
 use PHPUnit\Framework\TestCase;
@@ -449,6 +450,54 @@ final class ConformanceRulesTest extends TestCase
     public function testR2ProducesNoFindingsWithoutReadme(): void
     {
         self::assertSame([], (new ReadmeLicenseSectionRule())->check($this->root));
+    }
+
+    // --- R3 -----------------------------------------------------------------
+
+    public function testR3FlagsPrivateOriginPathReference(): void
+    {
+        $this->write('README.md', <<<'MD'
+            # Acme
+
+            Port registry: see `nene-origin/docs/development/local-ports.md`.
+            MD);
+
+        $findings = (new ReadmePrivateOriginLinkRule())->check($this->root);
+        self::assertCount(1, $findings);
+        self::assertSame('R3', $findings[0]->ruleId);
+        self::assertSame(Severity::Warn, $findings[0]->severity);
+        self::assertSame('README.md', $findings[0]->file);
+        self::assertSame(3, $findings[0]->line);
+    }
+
+    public function testR3FlagsPrivateOriginGithubUrl(): void
+    {
+        $this->write('README.md', <<<'MD'
+            # Acme
+
+            See [port registry](https://github.com/hideyukiMORI/nene-origin/blob/main/docs/development/local-ports.md).
+            MD);
+
+        $findings = (new ReadmePrivateOriginLinkRule())->check($this->root);
+        self::assertCount(1, $findings);
+        self::assertSame('R3', $findings[0]->ruleId);
+    }
+
+    public function testR3IgnoresUnrelatedReposAndOwnPortSection(): void
+    {
+        $this->write('README.md', <<<'MD'
+            # Acme
+
+            Ports: see this repo's own `AGENTS.md`/`CLAUDE.md` port section.
+            Acme's design originally traces back to an earlier internal prototype.
+            MD);
+
+        self::assertSame([], (new ReadmePrivateOriginLinkRule())->check($this->root));
+    }
+
+    public function testR3ProducesNoFindingsWithoutReadme(): void
+    {
+        self::assertSame([], (new ReadmePrivateOriginLinkRule())->check($this->root));
     }
 
     // --- Baseline / allowlist / inline ignore -------------------------------


### PR DESCRIPTION
## 目的

直前 PR #1552(R1/R2 追加)・#1554(renderText Warn/Info 表示) と同じ流儀で、
public 製品 README が private リポ `nene-origin`（例: ポートレジストリ
`nene-origin/docs/development/local-ports.md`）を参照していないかを検出する
**R3** ルールを追加する。外部読者には 404 になるため、正しくは自リポの
`AGENTS.md`/`CLAUDE.md` の port 節へリンクすべき（`_work/issues.md` #44①由来）。

フリート実測では現在全製品 clean（`nene-origin` への参照なし）なので、この
ルールは**回帰防止**が主目的。

## 変更点

- `src/Conformance/Rule/ReadmePrivateOriginLinkRule.php` を新設。
  - `README.md` を行走査し、repo slug `nene-origin` の word-bounded 出現
    （`nene-origin/...` パス、`github.com/hideyukiMORI/nene-origin` URL、
    markdown リンク先の `nene-origin`）を検出。
  - `README.md` 無し → findings ゼロ（R1/R2 と同じ規約）。
  - Severity: **Warn**（新ルール・warn-first、`#1553`/`#1554` の renderText で可視）。
  - message: 「README references the private `nene-origin` repo (broken link for
    external readers). Link to this repo's own AGENTS.md/CLAUDE.md port section
    instead.」
- `src/Conformance/ConformanceRunner.php::withDefaultRules()` に登録。
- `tests/Conformance/ConformanceRulesTest.php` に fixture テスト4本追加
  （path参照=Warn／GitHub URL参照=Warn／無関係な言及・自前port節への言及=0件／
  README無し=0件）。既存テストは無変更。
- `docs/adr/0016-conformance-linter.md` の R系addendumに R3 を追記
  （Related の PR リンクは本 PR マージ後に更新予定）。

## 検証結果

- `docker compose run --rm app composer check` 全緑
  （855 tests / 2097 assertions OK・PHPStan 0 errors・CS-Fixer 0 差分・
  OpenAPI/MCP valid・**Conformance OK — no findings**）。
- NENE2 自身の `README.md` は R3 で緑（`nene-origin` 参照なし）。baseline 更新不要
  （フリート clean のため新規 baseline entry 発生せず）。

## Self-review

Self-review: docs-policy（README/ADR 文書規約に沿った追記であることを確認）

## 残リスク

- word-boundary 正規表現のため、prose での稀な `nene-origin` 言及も拾う
  （設計方針として許容・FP は極小）。

Closes #1555

🤖 Generated with [Claude Code](https://claude.com/claude-code)