### PR TITLE
chore(release): v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-後方互換なマイナー変更。前段 proxy が標準 `Authorization` ヘッダを PHP に渡す前に剥がす共有ホスティング（HETEML 型 Tier A。`.htaccess` の `E=HTTP_AUTHORIZATION` トリックも `CGIPassAuth` も効かない）向けの受け口を、nene-clear #265 の実証実装から framework 標準へ上流化する（ADR 0019・#1557）。フリートの frontend は `@hideyukimori/nene2-client` v1.1.0 が全リクエストに `X-Authorization: Bearer <token>` ミラーを送信済み — BE 側受け口の per-product 手書きコピーを廃し、GuardedJwtSecretResolver（ADR 0013）と同じ `composer update` 配布経路に載せる。
+---
+
+## [1.11.0] — 2026-07-15
+
+後方互換なマイナーリリース。前段 proxy が標準 `Authorization` ヘッダを PHP に渡す前に剥がす共有ホスティング（HETEML 型 Tier A。`.htaccess` の `E=HTTP_AUTHORIZATION` トリックも `CGIPassAuth` も効かない）向けの受け口を、nene-clear #265 の実証実装から framework 標準へ上流化する（ADR 0019・#1557/#1558）。フリートの frontend は `@hideyukimori/nene2-client` v1.1.0 が全リクエストに `X-Authorization: Bearer <token>` ミラーを送信済み — BE 側受け口の per-product 手書きコピーを廃し、GuardedJwtSecretResolver（ADR 0013）と同じ `composer update` 配布経路に載せる。
 
 ### Added
 - `Nene2\Middleware\AuthorizationHeaderFallbackMiddleware`（公開安定 API・ADR 0019・#1557）— `Authorization` が**不在または空のときのみ** `X-Authorization` ミラーの値を `Authorization` へ採用する PSR-15 middleware。標準ヘッダが届く環境ではバイト不変・method/path 非依存。ヘッダ名は `X-Authorization` **固定**（`FALLBACK_HEADER` 定数 — nene2-js クライアントとのフリート配線契約でありノブではない）。手組み front controller 向けに同一変換の静的 `apply()` も公開（nene-clear 原型互換）。ミラー値は verbatim 採用でトークン検証は従来どおり後段 auth middleware の仕事 — 不正ミラーは不正な標準ヘッダと同一の失敗経路

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NENE2 API
-  version: 1.10.0
+  version: 1.11.0
   description: >
     NENE2 API contract. This file is the source of truth for public JSON APIs.
 servers:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,11 +5,11 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 
 ---
 
-## 🚧 現在のレーン — framework hardening（v1.10.0）
+## 🚧 現在のレーン — framework hardening（v1.11.0）
 
 | 項目 | 値 |
 |------|-----|
-| 現在の VERSION | **1.10.0**（`src/FrameworkInfo.php` が正） |
+| 現在の VERSION | **1.11.0**（`src/FrameworkInfo.php` が正） |
 | 主軸 | 共有ホスティング向け opt-in 部品の連続投入（installer → fail-closed auth → audit → export → conformance → demo） |
 | v1.6.0 の成果 | opt-in インストーラ toolkit `Nene2\Install`（payload セキュリティ核 / preflight & config / TenantConfigurationValidator / DatabaseSchemaApplier / release manifest / ReleaseSource / 提示契約 / 無ブランド参照レンダラ・`src/Install/`） |
 | v1.7.0 の成果 | fail-closed な JWT secret 解決 `GuardedJwtSecretResolver`（ADR 0013）＋ Installer 入力型（#1490/#1482） |
@@ -17,12 +17,13 @@ Purpose: keep the current work visible across chats, agents, and local sessions.
 | v1.8.1/1.8.2 の成果 | 準拠リンタ `tools/conformance.php`（ADR 0016）＋消費側 autoload / D1 誤検知の修正 |
 | **v1.9.0 の成果** | **使い捨て org デモモジュール `Nene2\Demo`**（ADR 0017・2026-07-09 施主決定=デモ方式を invoice 型に全製品統一）。5 interface（provisioner/reaper/seater/seeder/template key）＋具象（`StartDisposableDemoHandler`/`DisposableDemoSweeper`/`CountingDemoCapacityGuard`=invoice #608 根治点/`DemoRouteRegistrar`）＋`DEMO_*` typed 化（`AppConfig::$demo`）＋howto `add-disposable-demo.md`（5ロケール訳）（#1522/#1523/#1524） |
 | **v1.10.0 の成果** | **`Nene2\Demo` ブラウザ向けエラーの HTML negotiation**（ADR 0018・invoice 本番 2026-07-10 実発生の上流化）。`DemoErrorPageRendererInterface`＋既定 `MinimalDemoErrorPageRenderer`（ページ専用 CSP 持ち＝アプリ全体 `default-src 'self'` のインライン CSS ブロック罠を回避）。不変条件（API/成功のバイト不変・status/`Retry-After` 強制コピー・`X-Robots-Tag: noindex`）は handler が強制。`DemoRouteRegistrar` を PSR-15 `RequestHandlerInterface` 受けに拡大（デコレータの一般解）・throttle 既定 10→30回/h（invoice 本番実証）（#1536/#1537） |
+| **v1.11.0 の成果** | **X-Authorization フォールバック受け口 `Nene2\Middleware\AuthorizationHeaderFallbackMiddleware`**（ADR 0019・nene-clear #265 本番実証の上流化）。前段 proxy が標準 `Authorization` を剥がす共有ホスティング（HETEML 型 Tier A）向けに、`Authorization` 不在/空のときのみ `X-Authorization: Bearer` ミラーを採用（method/path 非依存・標準ヘッダ環境ではバイト不変）。`RuntimeApplicationFactory` に **opt-in** フラグ `enableAuthorizationHeaderFallback`（既定 `false`）。FE 側は nene2-js v1.1.0 が全リクエストで両ヘッダ送出済み — BE 受け口有効化で初めてミラーが E2E で効く。（#1557/#1558） |
 | 第1 consumer | NeNe Invoice（#562。demo モジュールの consumer 化も invoice が先頭 — 指揮リナの別指示書待ち） |
 | 進行中ブランチ | なし |
 
 ### 未処理 Issue
 
-なし（2026-07-10 時点で open Issue ゼロ。#1536 は PR #1537 で完了）。
+なし（2026-07-14 時点で open Issue ゼロ。#1557 は PR #1558 で完了）。
 
 ※ #1421 は 2026-07-06 完了。#1514 は v1.8.2 修正で 07-09 クローズ。#1526/#1527（ローカル限定テスト失敗）は 07-09 修正済み（#1529/#1530）。
 

--- a/src/FrameworkInfo.php
+++ b/src/FrameworkInfo.php
@@ -11,7 +11,7 @@ namespace Nene2;
  */
 final readonly class FrameworkInfo
 {
-    public const string VERSION = '1.10.0';
+    public const string VERSION = '1.11.0';
 
     public function name(): string
     {


### PR DESCRIPTION
## 目的

#1558（X-Authorization フォールバック受け口・opt-in・ADR 0019、2026-07-14 マージ済み）を含む次リリースの **version bump**。`[Unreleased]` を確定版へ切り出し、版定数を同期する。フリートの FE は全リポ transport 化済みで両ヘッダ（`Authorization` ＋ `X-Authorization` ミラー）を送出中——本リリースで BE 受け口が配布経路（`composer update`）に載り、パイロット製品で opt-in 有効化すると初めてミラーが E2E で効く。

## 版

**v1.10.0 → v1.11.0（minor）**。#1558 は公開安定 API への加算（新 middleware ＋ `RuntimeApplicationFactory` コンストラクタ末尾への既定引数）で後方互換 → SemVer minor。

## 変更点（NENE2 の版 bump 別コミット慣行に従う・doc/版定数のみ・コード不変）

- `src/FrameworkInfo.php` — `VERSION` `1.10.0` → `1.11.0`
- `docs/openapi/openapi.yaml` — `info.version` `1.10.0` → `1.11.0`
- `CHANGELOG.md` — `[Unreleased]`（ADR 0019 の Added エントリ）を `## [1.11.0] — 2026-07-15` へ確定切り出し、空の `[Unreleased]` を新設
- `docs/todo/current.md` — 現在の VERSION・レーン見出しを 1.11.0 に前方同期、v1.11.0 成果行を追加

`frontend/` ディレクトリには一切触れていない（別リナがスターター作業中）。変更は上記 4 ファイルのみ（v1.10.0 リリース #1538 と同一の面）。

## 検証結果（実測・worktree で `composer install` 後）

- `php tools/validate-version.php` → `Version consistency OK: 1.11.0`（FrameworkInfo / openapi / CHANGELOG 最新版見出しの三者一致）
- `tests/Middleware/AuthorizationHeaderFallbackMiddlewareTest.php` → **OK (8 tests, 23 assertions)**
- #1558 本体の `composer check` 全緑（863 tests / 2120 assertions）はマージ済みコミットで実証済み。本 PR はコード不変のため CI が全面再検証する。

## マージ後の残作業（統合リナが実施）

- `git tag v1.11.0` を打って push（NENE2 のタグ形式 `vX.Y.Z`）
- **Packagist** の `hideyukimori/nene2` が新タグを取り込んだことを確認（webhook 連携）
- パイロット 2 リポ（nene-profile / nene-field）の Draft PR を `composer require hideyukimori/nene2:^1.11` 相当へ update-branch して完成させる

🤖 Generated with [Claude Code](https://claude.com/claude-code)