### PR TITLE
docs(readme): 運営元 AYANE への英語1行逆リンクを追加 (#1572)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,3 +274,7 @@ NENE2 is designed to be AI-readable and usable as a tool by AI agents.
 ## License
 
 NENE2 is released under the MIT License.
+
+## Maintainer
+
+NENE2 is built and maintained by [彩音インターナショナル株式会社 (AYANE International Inc.)](https://ayane.co.jp), the company behind the NeNe product family.


### PR DESCRIPTION
## 目的

運営元 AYANE への逆リンクを README に1行加え、AYANE 公式サイト（launch 2026-07-19）→リポの本番結線に対する **entity の双方向結線**を作る。訪問者（AYANE から流入する非エンジニアの意思決定者を含む）が「本当にその会社が運営しているか」を README 上で結線できるようにする。records リナの read-only 監査所見（統合リナ裁定フロー経由）に基づく。

## 変更点

- README 末尾（`## License` 直後）に `## Maintainer` 節を1つ追加（+4行のみ）:
  > NENE2 is built and maintained by [彩音インターナショナル株式会社 (AYANE International Inc.)](https://ayane.co.jp), the company behind the NeNe product family.
- 既存の強み（実数証拠棚 140+/740+/262/125+・Packagist/MIT badges・記事リンク）は**一切不変**。

## 施主裁定に沿った判断（2026-07-17・統合リナ経由）

- **README は English by default を維持**。当初 records 案の「badges 直下に日本語1段落」は**不採用**（README は AYANE 流入者にとって「実在の証拠」であり全編英語が国際水準シグナルとして機能する／日本語の受け皿は AYANE サイト側が担う）。日本語 prose は入れていない。社名の漢字表記のみ identity として英語文中に併記。
- 言語ポリシー `docs/development/language-policy.md`（README = English by default）と整合。

## URL 選定の根拠（恒久ドメイン）

- 会社 identity リンクは正準恒久ドメイン **`https://ayane.co.jp`** を採用（hub 実測 `200`・稼働中）。旧会社サイトが現役の恒久ドメインで、新サイトへの DNS 切替後は ayane.co.jp 側が新サイトに入れ替わる見込み。**どの時点でも 404 にならず、将来の張り替えが不要**。
- もう一方の `https://ayane.nene-records.com` は新サイトの移送中ホスト（切替までの家）で、DNS 切替の文脈で役割が入れ替わりうるため、README には恒久ドメインのみを残す。
- （経緯: URL の当初認識に関係者間で齟齬があったが、施主 hide 確認・hub 実測・records の台帳表現の擦り合わせで、**恒久ドメイン ayane.co.jp を採用**で確定。）

## 検証

- README のみ・+4行。コード変更・設定変更なし（backend/frontend の CI 対象に影響なし）。
- CI 全緑: Composer Check `pass` / Playwright Smoke `pass` / npm Check `pass`。
- `git diff` で差分が Maintainer 節の追加のみ・既存節が無改変であることを確認。
- Markdown リンク構文 `[label](url)` の妥当性を目視確認。
- 依頼元 records の diff レビュー: **LGTM**（entity 双方向結線の狙いを満たすと確認）。

Closes #1572

Self-review: docs-policy

## 残リスク

- 将来 AYANE のドメイン方針が変わる場合は records から連絡を受け次第、別 Issue で逆リンクを差し替える（恒久ドメイン採用のためリスクは小）。
