### PR TITLE
docs(daily): 2026-07-17 日報を追加 (#1574)

### DIFF
--- a/docs/daily/2026-07-17.md
+++ b/docs/daily/2026-07-17.md
@@ -1,0 +1,34 @@
+# 2026-07-17
+
+統合リナ指揮下で launch 07-19 前の外向き整備を中心に対応。README に運営元 AYANE への逆リンクを追加（PR #1573 マージ）、NENE2 の Social preview カードを新設（Issue #1571）、board 旧項目 (C)「CLAUDE.md スリム化」は着手前調査で既済みと判明し close。いずれも独断で進めず、規約衝突・事実齟齬・stale 前提を着手前に検出して裁定へ上げる流れで処理した。
+
+---
+
+## README → 運営元 AYANE 逆リンク（PR #1573 / Issue #1572・Close）
+
+- README 末尾に `## Maintainer` 節を追加（+4行）: `NENE2 is built and maintained by [彩音インターナショナル株式会社 (AYANE International Inc.)](https://ayane.co.jp), the company behind the NeNe product family.` 〔実測: `git diff` +4行・既存節は無改変〕
+- CI 全緑〔実測: Composer Check / Playwright Smoke / npm Check 各 pass〕。依頼元 records の diff レビュー LGTM〔伝聞〕。施主目視でマージ済み〔伝聞: hub が main 反映を実測〕。
+- 判断ポイント: records 原案の「README 冒頭に日本語1段落」は言語ポリシー（`docs/development/language-policy.md`＝README は English by default）に触れるため独断せず裁定へ → 施主裁定で「英語維持・逆リンクのみ」。URL は本番の恒久ドメイン `ayane.co.jp`〔hub 実測 200・伝聞〕を採用し、ステージング `ayane.nene-records.com` は貼らず。
+- 残タスク: なし。
+
+## NENE2 Social preview カード（Issue #1571・Close）
+
+- AYANE ENGINEERED トークン（生成 #F6F3EC / 墨 #14120F / 朱 #D64525・Zen Kaku + IBM Plex Mono・工モチーフ不使用）で 1280×640（2x）カードを新設。施主がアップロード。
+- og:image がカスタム画像へ切替＋配信バイトが成果物 PNG と sha1 一致で検証〔伝聞: hub 実測 sha1 `bc7f52d4…`〕。
+- 成果物・再現用 source.html は `_work/assets/`（リポ未所属素材）。
+
+## board (C) CLAUDE.md スリム化 — 調査のみ・stale で close
+
+- 発注前提「763行→目安150-200」に対し、実ファイルは現 **161 行**〔実測: `wc -l`〕。
+- commit `b064790`（#1487/#1488）で **776 行削除**・FT/DX 機構を `docs/todo/ft-loop-workflow.md` へ分離済み＝(C) の作業実体そのもの〔実測: `git log --stat`〕。
+- AGENTS.md（33 行）との二重管理は、英語簡潔版 vs 日本語ハンドブックの意図的多層化で有害な重複なし〔実測: 内容確認〕。
+- 裁定: (C) を done で close・微トリムは不採用〔伝聞: hub 裁定。`_work/done.txt` に `x 2026-07-17 (C)`〕。再作業なし＝二重作業回避。
+
+## 横断（別ログ・申し送り）
+
+- 主力4商品（invoice / clear / deal / vault）の Social preview カード量産も本セッションで実施したが、複数リポにまたがる横断作業のため記録の正は `_work/`（成果物 `_work/assets/nene-*-social-preview.png` ＋ 手順書 `social-preview-upload-guide.md`）。規約 §3 に従い本日報の対象外。
+- `docs/daily/README.md` 索引（規約 §4）は未作成。フリート日報移行 §7 の小 PR で別途対応。
+
+## 📊 本日の数字
+
+- NENE2 リポ: PR 1件マージ（#1573）/ Issue 2件 Close（#1571・#1572）/ board (C) close。〔実測〕

--- a/docs/daily/2026-07-17.md
+++ b/docs/daily/2026-07-17.md
@@ -2,6 +2,8 @@
 
 統合リナ指揮下で launch 07-19 前の外向き整備を中心に対応。README に運営元 AYANE への逆リンクを追加（PR #1573 マージ）、NENE2 の Social preview カードを新設（Issue #1571）、board 旧項目 (C)「CLAUDE.md スリム化」は着手前調査で既済みと判明し close。いずれも独断で進めず、規約衝突・事実齟齬・stale 前提を着手前に検出して裁定へ上げる流れで処理した。
 
+夕方以降は hub の work order で framework hardening を2本: W0.starter 依存の npm 実在版化（PR #1577）と MCP subset フィルタ hook `withFilter()` 追加（PR #1578）。どちらも事実を自分で実測してから着手し、実 install / `composer check` 全緑で検証、レビュー承認後に self-merge。
+
 ---
 
 ## README → 運営元 AYANE 逆リンク（PR #1573 / Issue #1572・Close）
@@ -24,6 +26,24 @@
 - AGENTS.md（33 行）との二重管理は、英語簡潔版 vs 日本語ハンドブックの意図的多層化で有害な重複なし〔実測: 内容確認〕。
 - 裁定: (C) を done で close・微トリムは不採用〔伝聞: hub 裁定。`_work/done.txt` に `x 2026-07-17 (C)`〕。再作業なし＝二重作業回避。
 
+## W0.starter 依存を npm 実在版へ同期（Issue #1576 / PR #1577・Merge）
+
+- W0.starter は `@hideyukimori/nene2-standards` 1.0.x の lint false-positive（fleet-tooling#19/#20 で修正）で lockfile bump 保留中だった。標準側 **1.1.0 が publish 済み**で解消〔実測: `npm view` で version 1.1.0・shasum `080230a1…` を自分で再計測し hub 申告と一致確認〕。
+- `frontend/package.json` を実在版へ同期: standards `^1.0.0`→`^1.1.0`・client `^1.1.0`→`^1.2.0`・tokens `^1.0.0`→`^1.0.1`〔実測: `git diff`＝3行のみ・他行無改変〕。未 publish の tokens 1.0.2 は書かない（施主裁定 07-16）・i18n 0.1.0 の runtime 置換は W0b 別PR に分離。
+- **検証は実 install**（`rm -rf node_modules && npm ci` で実タルボール取得・mount/link で lock 版ずれを隠さない＝issues.md #59 の教訓）〔実測: node_modules 実体=real dir・1.1.0/1.2.0/1.0.1〕。`npm run check`（lint 0件＝FP 解消の実証・test 27）・build・Playwright smoke 緑。CI 3本 SUCCESS〔実測〕。
+- ついで確認: starter テンプレの `hooks/` 残渣ゼロ・plopfile は A1 既定 `model/` 出力〔実測: grep〕。
+- hub がレビュー（diff hunk 全読・CI 実測）のうえ APPROVE→ squash merge・main 同期〔実測: SHA `34f14f7`〕。
+- 判断ポイント: hub の「1.1.0 published」申告を鵜呑みにせず自分で `npm view` 再計測してから記述（`meta.from` 未認証チャネル方針）。merge は自走せずレビュー承認を待って実行。
+
+## MCP subset フィルタ hook `withFilter()`（Issue #1570 / PR #1578・Merge）
+
+- `LocalMcpToolCatalog` は catalog 全体しか公開できず、subset を出したい consumer が「フィルタ済み一時カタログをディスクへ書いて指す」temp-file 回避策（NeNe Invoice ADR 0021）を各自再実装していた問題を解消。
+- **immutable wither `withFilter(callable(McpTool): bool): self`** を追加。`tools()` と `find()` の両方が述語を尊重するため、フィルタ済みカタログをそのまま `LocalMcpServer` に渡すだけで subset を提供できる。フィルタ済みツールは list から隠れるだけでなく **`tools/call` からも到達不能**・複数適用は AND 合成（widen 不可）・未使用時バイト不変〔実測〕。
+- 設計判断（Issue は shape を framework 裁量とし3案提示）: **案1系 wither を採用**。素の `tools(?callable)` は server が `tools()`/`find()` 両方を呼ぶため subset にならず不十分・案3 interface 抽出は公開コンストラクタに触れ ADR 0009 安定性に影響する一方、wither は具象型ハンドルとコンストラクタ非破壊のまま用途を完全充足する最小変更。
+- 検証: `composer check` 全緑〔実測: 869 tests / PHPStan level 8 / CS / OpenAPI / MCP catalog / conformance / version〕。UT は catalog 単体（narrow・find 波及・不変性・合成・widen 不可）＋ server 経由（subset のみ list・除外ツール呼び出し不可 -32603）の両レベル。CI 3本 SUCCESS〔実測〕。
+- ドキュメント: consumer 向け howto は今回不要（docblock＋CHANGELOG で足りる）・follow-up は invoice が ADR 0021 を実置換する PR が自然な場〔hub と合意〕。
+- hub がレビュー（diff 185行全読・clone 時 `cachedTools=null` リセットの罠回避まで確認）のうえ APPROVE→ squash merge・main 同期〔実測: SHA `765f526`〕。
+
 ## 横断（別ログ・申し送り）
 
 - 主力4商品（invoice / clear / deal / vault）の Social preview カード量産も本セッションで実施したが、複数リポにまたがる横断作業のため記録の正は `_work/`（成果物 `_work/assets/nene-*-social-preview.png` ＋ 手順書 `social-preview-upload-guide.md`）。規約 §3 に従い本日報の対象外。
@@ -31,4 +51,5 @@
 
 ## 📊 本日の数字
 
-- NENE2 リポ: PR 1件マージ（#1573）/ Issue 2件 Close（#1571・#1572）/ board (C) close。〔実測〕
+- NENE2 リポ: PR 3件マージ（#1573・#1577・#1578）/ Issue 4件 Close（#1571・#1572・#1576・#1570）/ board (C) close。〔実測〕
+- framework hardening: W0.starter 依存の実在版化（starter の初期状態を npm 実在版で閉じ、issues.md #59 系の再発芽を starter 段階で遮断）＋ MCP subset フィルタ hook 追加（consumer の temp-file 再発明を解消）。いずれも最小差分・後方互換〔実測〕。


### PR DESCRIPTION
## 目的

2026-07-17 の NENE2 リポ内作業の日報を追加。フリート共通の日報規約正本（`_work/daily-report-convention.md`・hub APPROVE 2026-07-17）に準拠。

## 変更点

- `docs/daily/2026-07-17.md` を新規追加（# 見出し・リード段落・トピック＋PR/Issue 番号・数字は実測/伝聞を書き分け・frontmatter なし）。
- 内容: README→AYANE 逆リンク（#1573）/ NENE2 Social preview（#1571）/ board (C) CLAUDE.md スリム化の stale 判定と close。

## 検証

- ドキュメント追加のみ・コード変更なし。
- 既存 docs/daily 群と同形式（# YYYY-MM-DD・リード・トピック）であることを確認。
- 規約 §3 の線引きに従い、横断（複数リポ）作業は本日報の対象外（正は `_work/`）とした。

Closes #1574

Self-review: docs-policy

## 残リスク

- `docs/daily/README.md` 索引（規約 §4）は未作成。フリート日報移行 §7 の別 PR で対応予定（本 PR のスコープ外）。