### PR TITLE
feat(mcp): LocalMcpToolCatalog に subset フィルタ hook withFilter() を追加する (#1570)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `Nene2\Mcp\LocalMcpToolCatalog::withFilter(callable): self`（公開安定 API・後方互換・#1570）— カタログ（`docs/mcp/tools.json`）の一部だけを公開したい consumer のための immutable な絞り込みフック。述語は検証済みの各ツール（`McpTool` 形状）を受け取り `true` で残す。返り値は絞り込み済みの新カタログで、`tools()` と `find()` の**両方**が述語を尊重するため、フィルタ済みカタログをそのまま `LocalMcpServer` に渡すだけで subset を提供できる（例: 既定 read-only＋admin ツールは明示 opt-in）。フィルタ済みツールは list から隠れるだけでなく `tools/call` からも到達不能。フィルタは合成（chain で単調に絞り込み・全述語が pass）し、元カタログは不変。これにより consumer は「フィルタ済み一時カタログをディスクへ書いて指す」temp-file 回避策（NeNe Invoice ADR 0021）を再実装せずに済む。
+
 ---
 
 ## [1.11.0] — 2026-07-15

--- a/src/Mcp/LocalMcpToolCatalog.php
+++ b/src/Mcp/LocalMcpToolCatalog.php
@@ -20,9 +20,36 @@ final class LocalMcpToolCatalog
     /** @var list<McpTool>|null */
     private ?array $cachedTools = null;
 
+    /** @var list<\Closure(McpTool): bool> */
+    private array $filters = [];
+
     public function __construct(
         private readonly string $catalogPath,
     ) {
+    }
+
+    /**
+     * Returns a copy of this catalog that exposes only the tools matching $filter.
+     *
+     * The predicate receives each fully validated tool (see the McpTool shape) and
+     * returns true to keep it. Both {@see tools()} and {@see find()} on the returned
+     * catalog honour the filter, so a consumer can hand the narrowed catalog straight
+     * to {@see LocalMcpServer} to serve a subset (for example, read-only by default with
+     * admin tools behind an explicit opt-in) without writing a filtered catalog to a
+     * temporary file.
+     *
+     * Filters compose: chaining withFilter() narrows further — every predicate must pass.
+     * The original catalog is left unchanged.
+     *
+     * @param callable(McpTool): bool $filter
+     */
+    public function withFilter(callable $filter): self
+    {
+        $new = clone $this;
+        $new->filters = [...$this->filters, $filter(...)];
+        $new->cachedTools = null;
+
+        return $new;
     }
 
     /**
@@ -58,7 +85,13 @@ final class LocalMcpToolCatalog
 
         $validTools = array_values(array_filter($tools, static fn (mixed $t) => is_array($t)));
 
-        return $this->cachedTools = array_map($this->tool(...), $validTools);
+        $normalized = array_map($this->tool(...), $validTools);
+
+        foreach ($this->filters as $filter) {
+            $normalized = array_values(array_filter($normalized, $filter));
+        }
+
+        return $this->cachedTools = $normalized;
     }
 
     /**

--- a/tests/Mcp/LocalMcpServerTest.php
+++ b/tests/Mcp/LocalMcpServerTest.php
@@ -80,6 +80,34 @@ final class LocalMcpServerTest extends TestCase
         self::assertContains('deleteExampleNoteById', $names);
     }
 
+    public function testServerServesOnlyTheFilteredSubsetAndFilteredOutToolsAreUncallable(): void
+    {
+        $catalog = (new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json'))
+            ->withFilter(static fn (array $tool): bool => $tool['safety'] === 'read');
+
+        $server = new LocalMcpServer(
+            $catalog,
+            new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(200, [], '{}')),
+            'http://localhost:8200',
+            new NullLogger(),
+        );
+
+        $list = $server->handle(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'tools/list']);
+        $names = array_column($list['result']['tools'] ?? [], 'name');
+        self::assertContains('getHealth', $names);
+        self::assertNotContains('createExampleNote', $names);
+
+        // A filtered-out tool is genuinely unreachable, not merely hidden from the list.
+        $call = $server->handle([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'method' => 'tools/call',
+            'params' => ['name' => 'createExampleNote', 'arguments' => []],
+        ]);
+        self::assertSame(-32603, $call['error']['code'] ?? null);
+        self::assertStringContainsString('was not found', $call['error']['message'] ?? '');
+    }
+
     public function testToolsCallInvokesLocalHttpApiAndReturnsRequestId(): void
     {
         $client = new RecordingLocalMcpHttpClient(new LocalMcpHttpResponse(

--- a/tests/Mcp/LocalMcpToolCatalogTest.php
+++ b/tests/Mcp/LocalMcpToolCatalogTest.php
@@ -67,6 +67,69 @@ final class LocalMcpToolCatalogTest extends TestCase
     }
 
     // -----------------------------------------------------------------------
+    // withFilter() — serve a subset without a temp catalog file
+    // -----------------------------------------------------------------------
+
+    public function testWithFilterNarrowsToolsToMatchingSubset(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+
+        $readOnly = $catalog->withFilter(static fn (array $tool): bool => $tool['safety'] === 'read');
+
+        $names = array_column($readOnly->tools(), 'name');
+
+        self::assertContains('getHealth', $names);
+        self::assertNotContains('createExampleNote', $names);
+        self::assertNotContains('deleteExampleNoteById', $names);
+        self::assertSame(['read'], array_values(array_unique(array_column($readOnly->tools(), 'safety'))));
+    }
+
+    public function testWithFilterAlsoAppliesToFind(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+
+        $readOnly = $catalog->withFilter(static fn (array $tool): bool => $tool['safety'] === 'read');
+
+        self::assertNotNull($readOnly->find('getHealth'));
+        self::assertNull($readOnly->find('createExampleNote'));
+    }
+
+    public function testWithFilterLeavesTheOriginalCatalogUnchanged(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+
+        $catalog->withFilter(static fn (array $tool): bool => $tool['safety'] === 'read');
+
+        // The original still exposes write tools — withFilter returns a copy.
+        self::assertNotNull($catalog->find('createExampleNote'));
+    }
+
+    public function testWithFilterComposesByNarrowingFurther(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+
+        $narrowed = $catalog
+            ->withFilter(static fn (array $tool): bool => $tool['safety'] === 'read')
+            ->withFilter(static fn (array $tool): bool => $tool['name'] === 'getHealth');
+
+        self::assertSame(['getHealth'], array_column($narrowed->tools(), 'name'));
+    }
+
+    public function testWithFilterCompositionCannotWidenBackAnEarlierFilter(): void
+    {
+        $catalog = new LocalMcpToolCatalog(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+
+        // First keep only getHealth (a read tool), then ask for write tools:
+        // composition ANDs the predicates, so the result is empty rather than
+        // re-exposing write tools the first filter removed.
+        $narrowed = $catalog
+            ->withFilter(static fn (array $tool): bool => $tool['name'] === 'getHealth')
+            ->withFilter(static fn (array $tool): bool => $tool['safety'] === 'write');
+
+        self::assertSame([], $narrowed->tools());
+    }
+
+    // -----------------------------------------------------------------------
     // File / parse errors
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## 目的

`Nene2\Mcp\LocalMcpToolCatalog` はカタログ**ファイルパス**を読んで `tools` 配列を丸ごと公開するだけで、**subset** を出す hook が無い。committed な `docs/mcp/tools.json` より狭い集合（例: 既定 read-only ＋ admin ツールは opt-in）を公開したい consumer は、**フィルタ済み一時カタログをディスクへ書いて指す** temp-file 回避策を各自再実装するしかなかった（NeNe Invoice ADR 0021）。フリート全体で local MCP server パターンが横展開されるにつれ再発明が増えるため、first-class な hook を追加する。

## 変更点

`LocalMcpToolCatalog::withFilter(callable(McpTool): bool): self` を追加（公開安定 API・後方互換）。

- **immutable な wither**: フィルタ済みの**新カタログ**を返し、元カタログは不変。
- `tools()` と `find()` の**両方**が述語を尊重 → フィルタ済みカタログをそのまま `LocalMcpServer` に渡すだけで subset を提供できる。
- フィルタ済みツールは list から隠れるだけでなく **`tools/call` からも到達不能**（server は `find()` 経由で解決するため）。
- 複数適用時は **AND 合成**（chain で単調に絞り込み・widen 不可）。

## 設計判断（Issue の3案から）

Issue は shape を framework の裁量とし、案1〜3を提示。**案1系の immutable wither** を採用:

| 案 | 評価 |
|---|---|
| 1. `tools(?callable)` 引数のみ | ❌ 不十分 — `LocalMcpServer` は `tools()` **と** `find()` の両方を内部で呼ぶため、引数だけでは server 経由の subset にならない。→ wither 化で解決 |
| 2. `fromTools(array)` 名前付きコンストラクタ | consumer が2インスタンスを juggle する |
| **1'（採用）**. `withFilter(): self` | ✅ 具象型ハンドル・コンストラクタ非破壊のまま用途を完全充足する最小変更 |
| 3. `ToolCatalogInterface` 抽出 | 最も柔軟だが公開コンストラクタに触れ ADR 0009 の安定性に影響・変更が大きい |

invoice の実フィルタ `fn($t)=>$t['safety']==='read'`（正規化済み `McpTool` への述語）ともシグネチャが一致。

## 検証結果

`docker compose run --rm app composer check` **全緑**:
- **869 tests** / **PHPStan level 8** clean / PHP CS Fixer 0 / OpenAPI valid / MCP catalog valid / conformance OK / version consistency OK

追加 UT（両レベル）:
- catalog 単体: narrow・`find()` への波及・**不変性**（元カタログ不変）・**合成**（chain で更に絞り込み）・**widen 不可**（合成は AND）
- server 経由: subset のみ `tools/list`・**除外ツールは `tools/call` で到達不能**（-32603 "was not found"）

## スコープ・ドキュメント

- howto `add-mcp-tools.md`（＝ツール追加手順）とは主題が異なるため本PRでは触れない（5ロケール翻訳・索引再生成のスコープ混入回避）。discoverability は充実した docblock ＋ CHANGELOG で担保。必要なら consumer 向け howto は follow-up。

## 残リスク

- なし（追加のみ・後方互換・既存挙動はフィルタ未設定時にバイト不変）。

Closes #1570

Self-review: backend-api

指揮: 統合リナ work order（2026-07-17 Order 2）