### PR TITLE
feat(frontend): gen:feature に mutation archetype（4値 union）を追加する (#1579)

### DIFF
--- a/frontend/gen/templates/entity/mutations.ts.hbs
+++ b/frontend/gen/templates/entity/mutations.ts.hbs
@@ -16,8 +16,7 @@ import { {{camelCase noun}}Keys } from './query-keys';
 // 定義して unknown を置き換える（02 FM-5: submit は values → mapper → mutation）
 export function useCreate{{pascalCase noun}}(): UseMutationResult<
   {{pascalCase noun}},
-  AppError,
-  unknown
+  AppError
 > {
   const queryClient = useQueryClient();
   return useMutation({

--- a/frontend/gen/templates/feature/use-hook.mutation.test.tsx.hbs
+++ b/frontend/gen/templates/feature/use-hook.mutation.test.tsx.hbs
@@ -1,0 +1,96 @@
+// ユニオン遷移テスト（R2⑧ — 状態が型なら、テストは型の遷移表・mutation 4 値）
+// 各フェーズの状態は const に捕捉してから絞り込む（result.current は getter で
+// act/waitFor を跨ぐと narrowing が持続/失効するため）。
+import { act, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { expect, it } from 'vitest';
+
+import { server } from '@tests/msw/server';
+import { renderHookWithProviders } from '@tests/render';
+
+import { use{{pascalCase verbNoun}} } from './use-{{kebabCase verbNoun}}';
+
+it('初期状態は idle で submit を持つ', () => {
+  const { result } = renderHookWithProviders(() => use{{pascalCase verbNoun}}(), {
+    locale: 'ja',
+  });
+
+  const initial = result.current;
+  expect(initial.status).toBe('idle');
+  if (initial.status !== 'idle') throw new Error('unreachable');
+  expect(typeof initial.submit).toBe('function');
+});
+
+it('idle → submitting → success へ遷移する', async () => {
+  const { result } = renderHookWithProviders(() => use{{pascalCase verbNoun}}(), {
+    locale: 'ja',
+  });
+
+  const initial = result.current;
+  if (initial.status !== 'idle') throw new Error('unreachable');
+  act(() => {
+    initial.submit(undefined);
+  });
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('success');
+  });
+  const settled = result.current;
+  if (settled.status !== 'success') throw new Error('unreachable');
+  expect(settled.{{camelCase noun}}.id).toBeDefined();
+});
+
+it('error 状態は retry を持つ（同一 input 再送）', async () => {
+  server.use(
+    http.post('*/api/v1/{{plural (kebabCase noun)}}', () =>
+      HttpResponse.json(
+        {
+          type: 'https://nene2.dev/problems/server-error',
+          title: 'x',
+          status: 500,
+        },
+        { status: 500 },
+      ),
+    ),
+  );
+  const { result } = renderHookWithProviders(() => use{{pascalCase verbNoun}}(), {
+    locale: 'ja',
+  });
+
+  const initial = result.current;
+  if (initial.status !== 'idle') throw new Error('unreachable');
+  act(() => {
+    initial.submit(undefined);
+  });
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('error');
+  });
+  const errored = result.current;
+  if (errored.status !== 'error') throw new Error('unreachable');
+  expect(typeof errored.retry).toBe('function');
+});
+
+it('success → reset → idle へ戻る', async () => {
+  const { result } = renderHookWithProviders(() => use{{pascalCase verbNoun}}(), {
+    locale: 'ja',
+  });
+
+  const initial = result.current;
+  if (initial.status !== 'idle') throw new Error('unreachable');
+  act(() => {
+    initial.submit(undefined);
+  });
+  await waitFor(() => {
+    expect(result.current.status).toBe('success');
+  });
+
+  const settled = result.current;
+  if (settled.status !== 'success') throw new Error('unreachable');
+  act(() => {
+    settled.reset();
+  });
+  await waitFor(() => {
+    expect(result.current.status).toBe('idle');
+  });
+});

--- a/frontend/gen/templates/feature/use-hook.mutation.ts.hbs
+++ b/frontend/gen/templates/feature/use-hook.mutation.ts.hbs
@@ -1,0 +1,38 @@
+// container hook（02 UI-1: 判別ユニオン 4 値固定・mutation archetype —
+// idle / submitting / error(retry=同一 input 再送) / success(reset=idle 復帰)・所属は features）
+// 前提: 消費する entity は --write 生成済み（useCreate<Noun> と POST handler が要る）。
+import { useCallback, useState } from 'react';
+
+import { useCreate{{pascalCase noun}}, type {{pascalCase noun}} } from '@/entities/{{kebabCase noun}}';
+
+export type {{pascalCase verbNoun}}State =
+  | { status: 'idle'; submit: (input: unknown) => void }
+  | { status: 'submitting' }
+  | { status: 'error'; retry: () => void }
+  | { status: 'success'; {{camelCase noun}}: {{pascalCase noun}}; reset: () => void };
+
+export function use{{pascalCase verbNoun}}(): {{pascalCase verbNoun}}State {
+  const mutation = useCreate{{pascalCase noun}}();
+  const [lastInput, setLastInput] = useState<unknown>(undefined);
+
+  const submit = useCallback(
+    (input: unknown) => {
+      setLastInput(input);
+      mutation.mutate(input);
+    },
+    [mutation],
+  );
+  const retry = useCallback(() => {
+    mutation.mutate(lastInput);
+  }, [mutation, lastInput]);
+  const reset = useCallback(() => {
+    mutation.reset();
+  }, [mutation]);
+
+  if (mutation.isPending) return { status: 'submitting' };
+  if (mutation.isError) return { status: 'error', retry };
+  if (mutation.isSuccess) {
+    return { status: 'success', {{camelCase noun}}: mutation.data, reset };
+  }
+  return { status: 'idle', submit };
+}

--- a/frontend/gen/templates/feature/view.mutation.tsx.hbs
+++ b/frontend/gen/templates/feature/view.mutation.tsx.hbs
@@ -1,0 +1,60 @@
+// 網羅 switch の View（02 UI-3: default 節 MUST NOT・mutation archetype —
+// idle=フォーム / submitting=進捗 / error=retry / success=結果+reset）
+import { useTranslation } from '@/shared/i18n';
+import { ErrorState } from '@/shared/ui/error-state';
+import { LoadingState } from '@/shared/ui/loading-state';
+
+import { use{{pascalCase verbNoun}} } from '../model/use-{{kebabCase verbNoun}}';
+
+export function {{pascalCase verbNoun}}() {
+  const { t } = useTranslation();
+  const state = use{{pascalCase verbNoun}}();
+  switch (state.status) {
+    case 'idle':
+      return (
+        <form
+          className="flex flex-col gap-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            // TODO: values → mapper → submit（02 FM-5: submit は values → mapper → mutation）
+            state.submit(undefined);
+          }}
+        >
+          {/* TODO: フォーム項目に置き換える */}
+          <button
+            type="submit"
+            className="rounded-md border border-border bg-surface-raised px-4 py-2 text-sm text-text-primary"
+          >
+            {t('common.actions.submit')}
+          </button>
+        </form>
+      );
+    case 'submitting':
+      return <LoadingState label={t('common.state.submitting')} />;
+    case 'error':
+      return (
+        <ErrorState
+          message={t('error.unknown')}
+          retryLabel={t('common.actions.retry')}
+          onRetry={state.retry}
+        />
+      );
+    case 'success':
+      return (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-text-primary">
+            {t('{{camelCase noun}}.create.success')}
+          </p>
+          {/* TODO: 作成結果の表示に置き換える */}
+          <p className="text-sm text-text-primary">{state.{{camelCase noun}}.id}</p>
+          <button
+            type="button"
+            className="rounded-md border border-border px-4 py-2 text-sm text-text-primary"
+            onClick={state.reset}
+          >
+            {t('common.actions.reset')}
+          </button>
+        </div>
+      );
+  }
+}

--- a/frontend/plopfile.mjs
+++ b/frontend/plopfile.mjs
@@ -10,6 +10,7 @@
  *   npm run gen:entity  <noun>            例: npm run gen:entity order
  *   npm run gen:entity  <noun> y          （--write 相当: mutations.ts を追加生成）
  *   npm run gen:feature <verb-noun> <noun> 例: npm run gen:feature view-orders order
+ *   npm run gen:feature <verb-noun> <noun> --mutation  （mutation archetype = 4値 union）
  *   npm run gen:page    <name>            例: npm run gen:page dashboard
  */
 import { readFileSync } from 'node:fs';
@@ -132,7 +133,7 @@ export default function (plop) {
 
   plop.setGenerator('feature', {
     description:
-      'feature 4ファイル（ui＋container hook＋遷移テスト＋barrel — 05 §6.2）',
+      'feature 4ファイル（ui＋container hook＋遷移テスト＋barrel — 05 §6.2）。--mutation で mutation archetype（4値 union）',
     prompts: [
       kebabInput(
         'verbNoun',
@@ -142,23 +143,28 @@ export default function (plop) {
     ],
     actions: () => {
       const dir = `${DEST}/src/features/{{kebabCase verbNoun}}`;
-      return [
+      // archetype は flag で選ぶ（決定性・LLM 自動化前提 — 対話プロンプトにしない）。
+      // query（既定）= 3値 loading/error/success。mutation = 4値 idle/submitting/error/success。
+      // mutation は消費 entity を --write 生成（useCreate<Noun> と POST handler）していることが前提。
+      const isMutation = process.argv.includes('--mutation');
+      const suffix = isMutation ? '.mutation' : '';
+      const actions = [
         {
           type: 'add',
           path: `${dir}/model/use-{{kebabCase verbNoun}}.ts`,
-          templateFile: 'gen/templates/feature/use-hook.ts.hbs',
+          templateFile: `gen/templates/feature/use-hook${suffix}.ts.hbs`,
           transform: formatTs,
         },
         {
           type: 'add',
           path: `${dir}/model/use-{{kebabCase verbNoun}}.test.tsx`,
-          templateFile: 'gen/templates/feature/use-hook.test.tsx.hbs',
+          templateFile: `gen/templates/feature/use-hook${suffix}.test.tsx.hbs`,
           transform: formatTs,
         },
         {
           type: 'add',
           path: `${dir}/ui/{{pascalCase verbNoun}}.tsx`,
-          templateFile: 'gen/templates/feature/view.tsx.hbs',
+          templateFile: `gen/templates/feature/view${suffix}.tsx.hbs`,
           transform: formatTs,
         },
         {
@@ -167,13 +173,27 @@ export default function (plop) {
           templateFile: 'gen/templates/feature/index.ts.hbs',
           transform: formatTs,
         },
-        addMessage(
-          'ja.ts',
-          '{{camelCase noun}}.list.empty',
-          'まだデータがありません。',
-        ),
-        addMessage('en.ts', '{{camelCase noun}}.list.empty', 'No items yet.'),
       ];
+      if (isMutation) {
+        actions.push(
+          addMessage(
+            'ja.ts',
+            '{{camelCase noun}}.create.success',
+            '作成しました。',
+          ),
+          addMessage('en.ts', '{{camelCase noun}}.create.success', 'Created.'),
+        );
+      } else {
+        actions.push(
+          addMessage(
+            'ja.ts',
+            '{{camelCase noun}}.list.empty',
+            'まだデータがありません。',
+          ),
+          addMessage('en.ts', '{{camelCase noun}}.list.empty', 'No items yet.'),
+        );
+      }
+      return actions;
     },
   });
 

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -5,8 +5,11 @@ import type { MessageKey } from './ja';
 
 export const en = {
   'app.name': 'NENE2 Starter',
+  'common.actions.reset': 'Reset',
   'common.actions.retry': 'Retry',
+  'common.actions.submit': 'Submit',
   'common.state.loading': 'Loading…',
+  'common.state.submitting': 'Submitting…',
   'error.conflict': 'A conflict occurred. Please check the latest state.',
   'error.forbidden': 'You do not have permission to perform this action.',
   'error.notFound': 'The requested resource was not found.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -5,8 +5,11 @@
  */
 export const ja = {
   'app.name': 'NENE2 Starter',
+  'common.actions.reset': 'リセット',
   'common.actions.retry': '再試行',
+  'common.actions.submit': '送信',
   'common.state.loading': '読み込み中…',
+  'common.state.submitting': '送信中…',
   'error.conflict': '競合が発生しました。最新の状態を確認してください。',
   'error.forbidden': 'この操作を行う権限がありません。',
   'error.notFound': '対象が見つかりません。',

--- a/frontend/tests/gen.test.ts
+++ b/frontend/tests/gen.test.ts
@@ -139,3 +139,53 @@ it('gen 3種は決定的（同入力 → 同出力）で、期待ファイル集
   );
   expect(snapA.get('tests/msw/server.ts')).toContain('...orderHandlers,');
 }, 120_000);
+
+it('gen:feature --mutation は決定的で mutation archetype（4値 union）を生成する', () => {
+  const gen = (dest: string): void => {
+    // mutation feature は消費 entity を --write 生成（useCreate<Noun> と POST handler）している前提。
+    runGen(dest, 'entity', ['payment', 'y']);
+    runGen(dest, 'feature', ['submit-payment', 'payment', '--mutation']);
+  };
+  const a = seedDir();
+  const b = seedDir();
+  gen(a);
+  gen(b);
+
+  const snapA = snapshot(a);
+  const snapB = snapshot(b);
+
+  // 決定性: ファイル集合＋内容の完全一致
+  expect([...snapA.keys()].sort()).toEqual([...snapB.keys()].sort());
+  for (const [file, content] of snapA) {
+    expect(snapB.get(file), file).toBe(content);
+  }
+
+  // 期待出力: feature 4 ファイル
+  for (const file of [
+    'model/use-submit-payment.ts',
+    'model/use-submit-payment.test.tsx',
+    'ui/SubmitPayment.tsx',
+    'index.ts',
+  ]) {
+    expect(snapA.has(`src/features/submit-payment/${file}`), file).toBe(true);
+  }
+
+  // mutation archetype の核: 4値 union・error(retry)・success(reset)
+  const hook =
+    snapA.get('src/features/submit-payment/model/use-submit-payment.ts') ?? '';
+  expect(hook).toContain("status: 'idle'");
+  expect(hook).toContain("status: 'submitting'");
+  expect(hook).toContain("status: 'error'");
+  expect(hook).toContain("status: 'success'");
+  expect(hook).toContain('retry:');
+  expect(hook).toContain('reset:');
+
+  // --write 前提: entity mutation hook と POST handler が揃っていること
+  expect(snapA.has('src/entities/payment/mutations.ts')).toBe(true);
+  expect(snapA.get('src/entities/payment/handlers.ts')).toContain('http.post(');
+
+  // per-feature 成功メッセージが追記される（list.empty ではない）
+  expect(snapA.get('src/shared/i18n/messages/ja.ts')).toContain(
+    "'payment.create.success'",
+  );
+}, 120_000);


### PR DESCRIPTION
## 目的（会議未確定台帳 U-8）

`gen:feature` は read/query archetype 1種（3値 `loading | error(retry) | success`・empty は success 導出＝UI-4）のみを生成し、**フォーム/ミューテーション feature の canonical union が未定**だった。各リポが `idle` 等を発明しかけている（実測: payout は list を4値 `loading|empty|error|success` に拡張・form/mutation は react-query 生 boolean を View で直消費＝union 不在）。hub 裁定に基づき mutation archetype を正本化して発明の芽を止める。

## 変更点

`gen:feature <verb-noun> <noun> --mutation` を追加:

- **4値 union** `idle | submitting | error(retry) | success(reset)`（`gen/templates/feature/*.mutation.*.hbs` 3種）
  - `idle`: 未送信・編集可（query が持てない状態＝3値で表せない理由）
  - `error.retry`: 同一 input 再 mutate（error+retry MUST を query と同契約で統一）
  - `success.reset`: idle 復帰（反復送信 UX・**hub Q2 採用**）
- flag は `process.argv` 検出（決定性・LLM 自動化前提 — 対話プロンプト不採用・**hub Q3**）。既定 query（後方互換・`suffix .mutation` で分岐）。
- View は網羅 switch（default 節 MUST NOT）。遷移テストテンプレ4本（idle 初期 / idle→submitting→success / error→retry / success→reset→idle）。
- 共通 i18n キー `common.actions.submit`/`reset`・`common.state.submitting` を権威カタログ（ja/en）へ追加。
- mutation は消費 entity を `--write` 生成（`useCreate<Noun>` と POST handler）している前提。
- 決定性テストに mutation archetype ケースを追加（query・既存 entity(--n) 出力は非破壊）。

### 併せて修正した latent defect（素振り発見）

entity `mutations.ts` テンプレの `UseMutationResult<Noun, AppError, unknown>` の第3型引数 `unknown` は既定値で **`@typescript-eslint/no-unnecessary-type-arguments` に触れ、`gen:entity <noun> --write` 出力が lint 落ちしていた**（未 commit のため CI 未検出）。mutation archetype は entity --write 出力に依存するため除去（TVariables 既定=unknown で挙動不変）。

## 設計判断（hub と合意）

- **Q1** query は3値据置（UI-4「empty は success 導出・第4値発明 MUST NOT」は DECIDED）。payout の empty 明示 arm 6本は U-10 で hub が是正。
- **Q2** `success` 腕に `reset` 同梱（省くと製品が reset を再発明＝U-8 の目的に反する）。
- **Q3** flag 形（`--mutation`）・対話プロンプト不採用（決定性・自動化）。

## 検証結果（実 gen 素振り＋ CI 同条件）

`gen:entity payment y` ＋ `gen:feature submit-payment payment --mutation` の**生成物**を実測:
- **type-check clean**（`result.current` の narrowing 失効を各フェーズ const 捕捉で回避）
- **eslint `--max-warnings 0` clean**（entity --write 出力含む）
- **生成 mutation テスト 4/4 passed**（実 msw 200/500 で遷移実測）
- prettier clean

frontend 全体: `npm run check` **28 tests** 緑・決定性テスト（query/mutation 2 archetype）緑。

## 残リスク

- なし（追加＋既定 query 非破壊）。生成物の型/lint/runtime を実 gen で検証済み。committed exemplar（view-notes 相当の mutation 版）による恒久 CI ゲート化は follow-up 候補（hub 判断）。

Closes #1579

Self-review: frontend

指揮: 統合リナ work order（U-8・2026-07-18）