### PR TITLE
test(frontend): mutation archetype の committed exemplar（submit-note）で恒久 CI ゲート化 (#1581)

### DIFF
--- a/frontend/src/entities/note/handlers.ts
+++ b/frontend/src/entities/note/handlers.ts
@@ -16,8 +16,11 @@ export const noteListDtoFixture: NoteListDto = {
   offset: 0,
 };
 
-// 初期エンドポイントは queries.ts の 2 hook（detail / list）に対応する GET 2 本
+// GET 2 本（detail / list）＋ create（useCreateNote に対応する POST 1 本）
 export const noteHandlers = [
   http.get('*/api/examples/notes/:id', () => HttpResponse.json(noteDtoFixture)),
   http.get('*/api/examples/notes', () => HttpResponse.json(noteListDtoFixture)),
+  http.post('*/api/examples/notes', () =>
+    HttpResponse.json(noteDtoFixture, { status: 201 }),
+  ),
 ];

--- a/frontend/src/entities/note/index.ts
+++ b/frontend/src/entities/note/index.ts
@@ -2,4 +2,5 @@
 export { noteSchema } from './model';
 export type { Note, NoteId, NoteList, NoteListParams } from './model';
 export { useNote, useNoteList } from './queries';
+export { useCreateNote } from './mutations';
 export { noteKeys } from './query-keys';

--- a/frontend/src/entities/note/mutations.ts
+++ b/frontend/src/entities/note/mutations.ts
@@ -1,0 +1,32 @@
+// mutation hooks（02 ST-5 — invalidation は key ファクトリ経由のみ）。
+// exemplar 由来: これは `gen:entity note --write` の生テンプレ出力に対し、
+// 差分は **endpoint のみ**（note は実 API `/api/examples/notes` に fleshed。
+// 生テンプレは `/api/v1/notes`）。input の型付けは **consumer TODO のまま** `unknown` を
+// 維持する（生 mutation feature テンプレの `submit(input: unknown)` と対称）。
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+
+import { apiClient, type AppError } from '@/shared/api/client';
+
+import type { NoteDto } from './api-types';
+import { mapNoteDtoToModel } from './mapper';
+import type { Note } from './model';
+import { noteKeys } from './query-keys';
+
+// TODO: CreateNoteInput 型（model.ts）と mapCreateNoteInputToDto（mapper.ts）を
+// 定義して unknown を置き換える（02 FM-5: submit は values → mapper → mutation）
+export function useCreateNote(): UseMutationResult<Note, AppError> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: unknown) => {
+      const dto = await apiClient.post<NoteDto>('/api/examples/notes', input);
+      return mapNoteDtoToModel(dto);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+    },
+  });
+}

--- a/frontend/src/features/submit-note/index.ts
+++ b/frontend/src/features/submit-note/index.ts
@@ -1,0 +1,3 @@
+export { SubmitNote } from './ui/SubmitNote';
+export { useSubmitNote } from './model/use-submit-note';
+export type { SubmitNoteState } from './model/use-submit-note';

--- a/frontend/src/features/submit-note/model/use-submit-note.test.tsx
+++ b/frontend/src/features/submit-note/model/use-submit-note.test.tsx
@@ -1,0 +1,97 @@
+// ユニオン遷移テスト（R2⑧ — 状態が型なら、テストは型の遷移表・mutation 4 値）
+// 各フェーズの状態は const に捕捉してから絞り込む（result.current は getter で
+// act/waitFor を跨ぐと narrowing が持続/失効するため）。
+import { act, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { expect, it } from 'vitest';
+
+import { server } from '@tests/msw/server';
+import { renderHookWithProviders } from '@tests/render';
+
+import { useSubmitNote } from './use-submit-note';
+
+it('初期状態は idle で submit を持つ', () => {
+  const { result } = renderHookWithProviders(() => useSubmitNote(), {
+    locale: 'ja',
+  });
+
+  const initial = result.current;
+  expect(initial.status).toBe('idle');
+  if (initial.status !== 'idle') throw new Error('unreachable');
+  expect(typeof initial.submit).toBe('function');
+});
+
+it('idle → submitting → success へ遷移する', async () => {
+  const { result } = renderHookWithProviders(() => useSubmitNote(), {
+    locale: 'ja',
+  });
+
+  const initial = result.current;
+  if (initial.status !== 'idle') throw new Error('unreachable');
+  act(() => {
+    initial.submit(undefined);
+  });
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('success');
+  });
+  const settled = result.current;
+  if (settled.status !== 'success') throw new Error('unreachable');
+  // exemplar 由来: 生テンプレの id 存在チェックを、実 API fixture のドメイン値で固定
+  expect(settled.note.title).toBe('Example Note');
+});
+
+it('error 状態は retry を持つ（同一 input 再送）', async () => {
+  server.use(
+    http.post('*/api/examples/notes', () =>
+      HttpResponse.json(
+        {
+          type: 'https://nene2.dev/problems/server-error',
+          title: 'x',
+          status: 500,
+        },
+        { status: 500 },
+      ),
+    ),
+  );
+  const { result } = renderHookWithProviders(() => useSubmitNote(), {
+    locale: 'ja',
+  });
+
+  const initial = result.current;
+  if (initial.status !== 'idle') throw new Error('unreachable');
+  act(() => {
+    initial.submit(undefined);
+  });
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('error');
+  });
+  const errored = result.current;
+  if (errored.status !== 'error') throw new Error('unreachable');
+  expect(typeof errored.retry).toBe('function');
+});
+
+it('success → reset → idle へ戻る', async () => {
+  const { result } = renderHookWithProviders(() => useSubmitNote(), {
+    locale: 'ja',
+  });
+
+  const initial = result.current;
+  if (initial.status !== 'idle') throw new Error('unreachable');
+  act(() => {
+    initial.submit(undefined);
+  });
+  await waitFor(() => {
+    expect(result.current.status).toBe('success');
+  });
+
+  const settled = result.current;
+  if (settled.status !== 'success') throw new Error('unreachable');
+  act(() => {
+    settled.reset();
+  });
+  await waitFor(() => {
+    expect(result.current.status).toBe('idle');
+  });
+});

--- a/frontend/src/features/submit-note/model/use-submit-note.ts
+++ b/frontend/src/features/submit-note/model/use-submit-note.ts
@@ -1,0 +1,38 @@
+// container hook（02 UI-1: 判別ユニオン 4 値固定・mutation archetype —
+// idle / submitting / error(retry=同一 input 再送) / success(reset=idle 復帰)・所属は features）
+// 前提: 消費する entity は --write 生成済み（useCreate<Noun> と POST handler が要る）。
+import { useCallback, useState } from 'react';
+
+import { useCreateNote, type Note } from '@/entities/note';
+
+export type SubmitNoteState =
+  | { status: 'idle'; submit: (input: unknown) => void }
+  | { status: 'submitting' }
+  | { status: 'error'; retry: () => void }
+  | { status: 'success'; note: Note; reset: () => void };
+
+export function useSubmitNote(): SubmitNoteState {
+  const mutation = useCreateNote();
+  const [lastInput, setLastInput] = useState<unknown>(undefined);
+
+  const submit = useCallback(
+    (input: unknown) => {
+      setLastInput(input);
+      mutation.mutate(input);
+    },
+    [mutation],
+  );
+  const retry = useCallback(() => {
+    mutation.mutate(lastInput);
+  }, [mutation, lastInput]);
+  const reset = useCallback(() => {
+    mutation.reset();
+  }, [mutation]);
+
+  if (mutation.isPending) return { status: 'submitting' };
+  if (mutation.isError) return { status: 'error', retry };
+  if (mutation.isSuccess) {
+    return { status: 'success', note: mutation.data, reset };
+  }
+  return { status: 'idle', submit };
+}

--- a/frontend/src/features/submit-note/ui/SubmitNote.tsx
+++ b/frontend/src/features/submit-note/ui/SubmitNote.tsx
@@ -1,0 +1,60 @@
+// 網羅 switch の View（02 UI-3: default 節 MUST NOT・mutation archetype —
+// idle=フォーム / submitting=進捗 / error=retry / success=結果+reset）
+import { useTranslation } from '@/shared/i18n';
+import { ErrorState } from '@/shared/ui/error-state';
+import { LoadingState } from '@/shared/ui/loading-state';
+
+import { useSubmitNote } from '../model/use-submit-note';
+
+export function SubmitNote() {
+  const { t } = useTranslation();
+  const state = useSubmitNote();
+  switch (state.status) {
+    case 'idle':
+      return (
+        <form
+          className="flex flex-col gap-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            // TODO: values → mapper → submit（02 FM-5: submit は values → mapper → mutation）
+            state.submit(undefined);
+          }}
+        >
+          {/* TODO: フォーム項目に置き換える */}
+          <button
+            type="submit"
+            className="rounded-md border border-border bg-surface-raised px-4 py-2 text-sm text-text-primary"
+          >
+            {t('common.actions.submit')}
+          </button>
+        </form>
+      );
+    case 'submitting':
+      return <LoadingState label={t('common.state.submitting')} />;
+    case 'error':
+      return (
+        <ErrorState
+          message={t('error.unknown')}
+          retryLabel={t('common.actions.retry')}
+          onRetry={state.retry}
+        />
+      );
+    case 'success':
+      return (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-text-primary">
+            {t('note.create.success')}
+          </p>
+          {/* TODO: 作成結果の表示に置き換える */}
+          <p className="text-sm text-text-primary">{state.note.id}</p>
+          <button
+            type="button"
+            className="rounded-md border border-border px-4 py-2 text-sm text-text-primary"
+            onClick={state.reset}
+          >
+            {t('common.actions.reset')}
+          </button>
+        </div>
+      );
+  }
+}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -24,5 +24,6 @@ export const en = {
   'home.title': 'NENE2 Frontend Starter',
   'note.list.empty': 'No notes yet.',
   'note.list.title': 'Notes',
+  'note.create.success': 'Created.',
   // [nene2-gen:messages] — generator がこの行の上にキーを追記する
 } satisfies Record<MessageKey, string>;

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -26,6 +26,7 @@ export const ja = {
   'home.title': 'NENE2 フロントエンドスターター',
   'note.list.empty': 'ノートはまだありません。',
   'note.list.title': 'ノート一覧',
+  'note.create.success': '作成しました。',
   // [nene2-gen:messages] — generator がこの行の上にキーを追記する
 } as const;
 


### PR DESCRIPTION
## 目的（U-8 follow-up・hub 裁定 (C)）

#1579 で追加した `gen:feature --mutation`（4値 union）の生成物は素振り検証のみで恒久 CI ゲートが無かった。query archetype の `view-notes` exemplar と対称に、mutation archetype の committed exemplar を追加し **CI が type-check / lint / test を恒久的に守る**。

## 変更点（view-notes の確立済み型の延長）

- **feature `submit-note`（生 gen 出力を commit）**: endpoint を持たない hook（`use-submit-note.ts`）/ view（`SubmitNote.tsx`）は生テンプレと byte 一致。test のみ POST endpoint を実 API `/api/examples/notes` へ置換＋ドメイン assertion（`note.title === 'Example Note'`）— view-notes と同じ調整。
- **note entity に create 側を fleshed 追加**: `mutations.ts`（`useCreateNote` → POST `/api/examples/notes`）・`index.ts` 公開・`handlers.ts` に POST 201。
  - **中間形（実 endpoint × unknown input）に由来コメント明記**（hub 条件）: 生テンプレとの差分は endpoint のみ・input 型付けは consumer TODO のまま。
- i18n `note.create.success`（gen が権威カタログへ追記）。
- **page/route 配線は不要**: 未配線でも lint（`--max-warnings 0`）が通る＝最小スコープで恒久ゲート成立。

## exemplar 命名の判断 ＋ 発見した footgun

verbNoun=`create-note` は entity の `useCreateNote` と**同名衝突**（feature hook `use{VerbNoun}` = `useCreateNote` ⇔ entity `useCreate{Noun}` = `useCreateNote` → 自己再帰で stack overflow・import 衝突）。exemplar は `submit-note`（`useSubmitNote` / `useCreateNote` で非衝突）を採用。

> ⚠️ **mutation archetype の潜在 footgun**: `gen:feature create-<noun> <noun> --mutation`（verb=create かつ noun 一致）は生成コードが自己再帰で壊れる。別途上流（#1579 系）へ報告し、命名ガード or entity hook 命名の見直しを別 Issue で検討予定。本 PR のスコープ外。

## 検証結果

- `npm run check` **全緑**: type-check / eslint `--max-warnings 0` / lint:css / check:themes / format / test **32**（うち submit-note 遷移テスト4本: idle 初期 / idle→submitting→success / error→retry / success→reset→idle）。
- 決定性テストは非破壊（テンプレ不変）。

## 残リスク

- なし（追加のみ・note entity は create 側の additive 拡張で既存 query/test 非破壊）。

Closes #1581

Self-review: frontend

指揮: 統合リナ work order（U-8 follow-up・2026-07-18・裁定 (C)）