### PR TITLE
fix(frontend): gen:feature --mutation の verbNoun 命名衝突を fail-fast する (#1583)

### DIFF
--- a/frontend/plopfile.mjs
+++ b/frontend/plopfile.mjs
@@ -141,12 +141,28 @@ export default function (plop) {
       ),
       kebabInput('noun', '消費する entity 名（kebab-case 単数形。例: order）'),
     ],
-    actions: () => {
+    actions: (data) => {
       const dir = `${DEST}/src/features/{{kebabCase verbNoun}}`;
       // archetype は flag で選ぶ（決定性・LLM 自動化前提 — 対話プロンプトにしない）。
       // query（既定）= 3値 loading/error/success。mutation = 4値 idle/submitting/error/success。
       // mutation は消費 entity を --write 生成（useCreate<Noun> と POST handler）していることが前提。
       const isMutation = process.argv.includes('--mutation');
+
+      // fail-fast: mutation feature hook use{VerbNoun} が entity の useCreate{Noun}（ST-5 固定命名）と
+      // 衝突すると、生成 hook が自身を呼ぶ自己再帰になる。verb=create かつ noun 一致で発火する
+      // （create-note × note = 最も自然な命名）。決定性文化として黙って壊れるより喋って止まる。
+      if (isMutation && data) {
+        const pascalCase = plop.getHelper('pascalCase');
+        const verbPascal = pascalCase(data.verbNoun);
+        const nounPascal = pascalCase(data.noun);
+        if (verbPascal === `Create${nounPascal}`) {
+          throw new Error(
+            `feature hook "use${verbPascal}" が entity の "useCreate${nounPascal}"（ST-5 固定命名）と衝突します。` +
+              ` create 以外の verb を使ってください（例: submit-${data.noun} / register-${data.noun} / add-${data.noun}）。`,
+          );
+        }
+      }
+
       const suffix = isMutation ? '.mutation' : '';
       const actions = [
         {

--- a/frontend/tests/gen.test.ts
+++ b/frontend/tests/gen.test.ts
@@ -6,6 +6,7 @@
 import { execFileSync } from 'node:child_process';
 import {
   cpSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -188,4 +189,34 @@ it('gen:feature --mutation は決定的で mutation archetype（4値 union）を
   expect(snapA.get('src/shared/i18n/messages/ja.ts')).toContain(
     "'payment.create.success'",
   );
+}, 120_000);
+
+it('gen:feature --mutation は verbNoun が Create<Noun> と衝突するとき fail-fast する', () => {
+  const dir = seedDir();
+
+  let threw = false;
+  let output = '';
+  try {
+    // create-note × note → feature use{CreateNote} と entity useCreate{Note} が同名衝突
+    runGen(dir, 'feature', ['create-note', 'note', '--mutation']);
+  } catch (error) {
+    threw = true;
+    const e = error as { stdout?: Buffer; stderr?: Buffer };
+    output = `${e.stdout?.toString() ?? ''}${e.stderr?.toString() ?? ''}`;
+  }
+
+  expect(threw).toBe(true);
+  // 代替 verb を提案するメッセージ
+  expect(output).toContain('useCreateNote');
+  expect(output).toContain('submit-note');
+  // 衝突時はファイルを書かない（fail-fast）
+  expect(existsSync(path.join(dir, 'src/features/create-note'))).toBe(false);
+
+  // 対照: 非衝突 verb（submit-note）は従来どおり生成できる
+  runGen(dir, 'feature', ['submit-note', 'note', '--mutation']);
+  expect(
+    existsSync(
+      path.join(dir, 'src/features/submit-note/model/use-submit-note.ts'),
+    ),
+  ).toBe(true);
 }, 120_000);


### PR DESCRIPTION
## 目的（#1581 exemplar 制作で発見した footgun）

`gen:feature <verb-noun> <noun> --mutation` は container hook を `use{PascalCase(verbNoun)}` として生成し、内部で entity の `useCreate{PascalCase(noun)}`（ST-5 固定命名）を呼ぶ。**verbNoun が `create-<noun>`（verb=create かつ noun 一致）のとき両者が同名 `useCreate{Noun}` に衝突** → 生成 hook が自身を呼ぶ自己再帰（`Maximum call stack size exceeded`）＋ `Import declaration conflicts` で壊れる。

「新しい `<noun>` を作る feature」を `create-<noun>` と名付けるのは mutation feature で**最も自然な命名**であり踏みやすい。

## 変更点（hub 裁定・fail-fast）

`frontend/plopfile.mjs` の feature generator に衝突ガードを追加:

- mutation かつ `pascalCase(verbNoun) === "Create" + pascalCase(noun)` を検出したら**エラー停止**。
- 代替 verb を提案するメッセージ: `feature hook "useCreateNote" が entity の "useCreateNote"（ST-5 固定命名）と衝突します。create 以外の verb を使ってください（例: submit-note / register-note / add-note）。`
- entity 側 `useCreate{Noun}` は会議 **ST-5 の固定命名につき動かさない**。
- 決定性・自動化文化として「黙って壊れるより喋って止まる」（hub）。

## 検証結果

決定性テストに衝突ケースを追加:
- 衝突 verb（`create-note note --mutation`）→ **fail-fast**（非ゼロ終了・`src/features/create-note` 未生成・提案メッセージに `useCreateNote` と `submit-note` を含む）。
- 非衝突 verb（`submit-note note --mutation`）→ 従来どおり生成。

`npm run check` **全緑**（type-check / eslint `--max-warnings 0` / test **33** / format）。既存 gen 出力は非破壊（ガードは mutation×衝突時のみ発火）。

## 残リスク

- なし（生成ロジックへの追加ガードのみ・既存の非衝突 gen は不変）。

Closes #1583

Self-review: frontend

指揮: 統合リナ work order（footgun 別 Issue・2026-07-18・手番 NENE2）