### PR TITLE
docs(vitepress): 内部運用ログを公開ビルドから srcExclude する (#1587)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -112,6 +112,13 @@ export default defineConfig({
   cleanUrls: true,
   ignoreDeadLinks: true,
 
+  // Keep internal operational logs out of the published site.
+  // These directories are AI-/maintainer-facing handoff notes, not framework
+  // documentation, and must not be reachable at public URLs. Patterns are
+  // relative to srcDir (./docs). Note: this only affects the built site — the
+  // files remain tracked in git (relocating them is a separate, later change).
+  srcExclude: ['todo/**', 'daily/**', 'field-trials/**'],
+
   head: [['meta', { name: 'theme-color', content: '#3b82f6' }]],
 
   locales: {


### PR DESCRIPTION
## 目的
汎用性監査（`_work/reports/2026-07-18-nene2-general-framework-coupling-audit.md` B-1）の P0 止血。NENE2 は公開・汎用フレームワークだが、VitePress `srcExclude` 未設定のため内部運用ログ（`docs/todo`・`docs/daily`・`docs/field-trials`）が nav に無くても**直 URL で公開サイトに到達可能**だった（例: `/todo/current`＝引き継ぎ板）。

## 変更点
- `.vitepress/config.mts` に `srcExclude: ['todo/**', 'daily/**', 'field-trials/**']` を追加（srcDir=`./docs` 基準）。
- 意図をコメントで明記（公開サイトからのみ除外・git 追跡は残す・移設は別変更）。

## 検証結果（ローカル実測・vitepress 1.6.4 / Node heap 8GB）
| | before | after |
|---|---|---|
| todo html | 6 | **0**（dist に dir 無し） |
| daily html | 11 | **0** |
| field-trials html | 157 | **0** |
| total html | 2022 | **1848** |

差分 **174 = 6 + 11 + 157** と厳密一致。build exit 0。`ignoreDeadLinks` は**既存の `true` のまま変更せず**、除外で生じうるリンク切れは既存挙動どおり無視される（新たな dead-link 警告・失敗なし＝実測）。

## スコープ・残リスク
- これは**サイト面の止血のみ**。**git 上の露出は残る**（既知）。移設（`_work/` か private ミラーへ）は受け皿設計が要るため **P2/P3**・施主裁定は「移す」方向で確定済み。
- 履歴改変・移設・publish は本 PR では**行わない**（work order の縛り）。

Closes #1587

Self-review: docs-policy
発注: 統合リナ work order `_work/handoff-nene2-audit-p0-2026-07-18-work-order.md`（施主 GO 済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)