### PR TITLE
refactor(conformance): R3 を既定集から分離し opt-in fleet 層にする (#1593)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "howto:index": "php tools/build-howto-index.php",
     "howto:frontmatter": "php tools/validate-howto-frontmatter.php",
     "mcp": "php tools/validate-mcp-tools.php",
-    "conformance": "php tools/conformance.php",
+    "conformance": "php tools/conformance.php --fleet",
     "version:check": "php tools/validate-version.php",
     "migrations:status": "phinx status -c phinx.php",
     "migrations:migrate": "phinx migrate -c phinx.php",

--- a/docs/adr/0016-conformance-linter.md
+++ b/docs/adr/0016-conformance-linter.md
@@ -106,6 +106,31 @@ own `AGENTS.md`/`CLAUDE.md` port section. **R3** (`warn`) word-bounded-scans
 markdown link target). The fleet is already clean, so R3 is a regression guard,
 not a fix for an active violation — hence `warn`, not `error`.
 
+**2026-07-18 addendum — default (generic) vs opt-in fleet rules.** NENE2 is a
+general-purpose framework that external projects adopt, but R3 encodes a
+NeNe-fleet-internal assumption (the private `nene-origin` governance repo). A
+consumer with no relation to the fleet should not inherit it. So the rule set is
+split: `ConformanceRunner::withDefaultRules()` now ships only the framework-
+generic rules (D1–D4, R1, R2), and a new `withFleetRules()` factory adds the
+NeNe-fleet governance layer (currently just R3) on top. Future fleet-only rules
+join the fleet layer, not the generic default. `tools/conformance.php` selects
+the set with a `--fleet` flag (absent = generic default). NENE2 checks itself
+with the fleet layer (`composer conformance` runs `--fleet`), so its own R3
+coverage and CI exercise of the flag are unchanged.
+
+**How a NeNe product opts into the fleet rules.** Point the vendored linter at
+the fleet set by adding `--fleet` to the `conformance` script in `composer.json`:
+
+```jsonc
+"scripts": {
+  "conformance": "php vendor/hideyukimori/nene2/tools/conformance.php --root=. --fleet"
+}
+```
+
+Products outside the fleet leave the flag off and keep the generic default.
+Rolling `--fleet` out to each fleet product's `composer.json` is a separate wave;
+this ADR change delivers the mechanism on the NENE2 side only.
+
 ## Consequences
 
 - D1 permanently locks in the ADR 0013 fix: a re-introduced default secret fails
@@ -120,9 +145,12 @@ not a fix for an active violation — hence `warn`, not `error`.
 - Fan-out to the other products (report-only baseline capture, then CI gating of
   new drift) is a separate wave, as is the deferred PHPStan type-aware pack and
   the `warn`-tier rules, which follow each upstream interface as it freezes.
-- R1/R2/R3 apply to NENE2's own `README.md` too: no static status badge, a
+- R1/R2 (generic default) and R3 (fleet layer, via `composer conformance`'s
+  `--fleet`) all apply to NENE2's own `README.md`: no static status badge, a
   `## License` section already present, and no `nene-origin` reference, so all
-  three are green with zero new baseline entries.
+  three are green with zero new baseline entries. R3 is `warn` and the baseline
+  carries no R3 ignore entry, so moving it out of the generic default set changes
+  no existing pass/fail outcome for any repo.
 
 ## Related
 
@@ -134,5 +162,6 @@ not a fix for an active violation — hence `warn`, not `error`.
   `GuardedJwtSecretResolver` guarded-literal exemption above.
 - R-series addendum (README/docs conformance, 2026-07-14): Issue `#1551`, PR `#1552`.
 - R3 addendum (private `nene-origin` link, warn, 2026-07-14): Issue `#1555`, PR `#1556`.
+- Default/fleet rule split (R3 → opt-in `--fleet`, audit M-1, 2026-07-18): Issue `#1593`.
 - Supersedes: none
 - Superseded by: none

--- a/src/Conformance/ConformanceRunner.php
+++ b/src/Conformance/ConformanceRunner.php
@@ -37,25 +37,65 @@ final class ConformanceRunner
     }
 
     /**
-     * The current default rule set: the `error`-tier D1–D4 rules (design doc 04,
-     * layer error) plus the R1–R3 README/docs-conformance rules (R1 `error`,
-     * R2/R3 `warn` — see ADR 0016's R-series addendum). R-series ids are a
-     * separate sequence from D1–D4 because design doc 04 reserves D5–D12 for
-     * backend-only drift (getenv, Installer/Pagination reinvention, ...);
+     * The default, framework-generic rule set: the `error`-tier D1–D4 rules
+     * (design doc 04, layer error) plus the R1/R2 README/docs-conformance rules
+     * (R1 `error`, R2 `warn` — see ADR 0016's R-series addendum). R-series ids
+     * are a separate sequence from D1–D4 because design doc 04 reserves D5–D12
+     * for backend-only drift (getenv, Installer/Pagination reinvention, ...);
      * README/docs drift is a distinct axis, not a continuation of that reserved
      * range.
+     *
+     * Every rule here is framework-generic — it makes sense for any external
+     * consumer of NENE2, with no assumption about the NeNe product fleet. Fleet-
+     * specific governance (currently R3) lives in {@see withFleetRules()} so a
+     * generic consumer never inherits NeNe-internal rules (audit M-1).
      */
     public static function withDefaultRules(): self
     {
-        return new self([
+        return new self(self::genericRules());
+    }
+
+    /**
+     * The generic rules plus the NeNe-fleet-specific governance layer (currently
+     * R3 — the private `nene-origin` link guard). Repositories that belong to the
+     * NeNe fleet opt into this set — via this factory, or the `--fleet` flag on
+     * `tools/conformance.php` — while the default set stays framework-generic.
+     *
+     * Future fleet-only rules join {@see fleetRules()} rather than the generic
+     * default, keeping the "default = generic, fleet governance = opt-in" split
+     * (ADR 0016 opt-in addendum).
+     */
+    public static function withFleetRules(): self
+    {
+        return new self([...self::genericRules(), ...self::fleetRules()]);
+    }
+
+    /**
+     * @return list<RuleInterface>
+     */
+    private static function genericRules(): array
+    {
+        return [
             new JwtDefaultSecretRule(),
             new DependencyBranchPinRule(),
             new CheckSelfRegistrationRule(),
             new RawClockRule(),
             new ReadmeStaticStatusBadgeRule(),
             new ReadmeLicenseSectionRule(),
+        ];
+    }
+
+    /**
+     * The NeNe-fleet-specific governance rules (opt-in — not shipped in the
+     * generic default set).
+     *
+     * @return list<RuleInterface>
+     */
+    private static function fleetRules(): array
+    {
+        return [
             new ReadmePrivateOriginLinkRule(),
-        ]);
+        ];
     }
 
     /**

--- a/tests/Conformance/ConformanceRulesTest.php
+++ b/tests/Conformance/ConformanceRulesTest.php
@@ -500,6 +500,31 @@ final class ConformanceRulesTest extends TestCase
         self::assertSame([], (new ReadmePrivateOriginLinkRule())->check($this->root));
     }
 
+    // --- Rule set composition (default generic vs opt-in fleet) --------------
+
+    public function testDefaultRuleSetIsGenericAndExcludesFleetR3(): void
+    {
+        $ids = array_map(
+            static fn ($rule): string => $rule->id(),
+            ConformanceRunner::withDefaultRules()->rules(),
+        );
+
+        // The framework-generic rules ship by default...
+        self::assertSame(['D1', 'D2', 'D3', 'D4', 'R1', 'R2'], $ids);
+        // ...but the NeNe-fleet-specific R3 is opt-in, not default (audit M-1).
+        self::assertNotContains('R3', $ids);
+    }
+
+    public function testFleetRuleSetAddsR3OnTopOfTheGenericDefault(): void
+    {
+        $ids = array_map(
+            static fn ($rule): string => $rule->id(),
+            ConformanceRunner::withFleetRules()->rules(),
+        );
+
+        self::assertSame(['D1', 'D2', 'D3', 'D4', 'R1', 'R2', 'R3'], $ids);
+    }
+
     // --- Baseline / allowlist / inline ignore -------------------------------
 
     public function testAllowlistRequiresReason(): void

--- a/tools/conformance.php
+++ b/tools/conformance.php
@@ -13,7 +13,12 @@ declare(strict_types=1);
  * to composer.json and "@conformance" to scripts.check.
  *
  * Usage:
- *   php tools/conformance.php [--root=PATH] [--format=text|json] [--write-baseline]
+ *   php tools/conformance.php [--root=PATH] [--format=text|json] [--write-baseline] [--fleet]
+ *
+ * `--fleet` opts into the NeNe-fleet-specific governance rules (currently R3, the
+ * private `nene-origin` link guard) on top of the framework-generic default set.
+ * External consumers omit it; NeNe fleet repos add it to their `@conformance`
+ * script. See ADR 0016 (opt-in addendum).
  *
  * Exit codes: 0 = no active errors, 1 = active error findings, 2 = usage/config error.
  */
@@ -30,6 +35,7 @@ $cwd = getcwd();
 $projectRoot = $cwd !== false ? $cwd : dirname(__DIR__);
 $format = 'text';
 $writeBaseline = false;
+$useFleetRules = false;
 
 foreach ($argv as $index => $arg) {
     if ($index === 0) {
@@ -43,6 +49,8 @@ foreach ($argv as $index => $arg) {
         $format = substr($arg, 9);
     } elseif ($arg === '--write-baseline') {
         $writeBaseline = true;
+    } elseif ($arg === '--fleet') {
+        $useFleetRules = true;
     } else {
         fwrite(STDERR, "Unknown argument: {$arg}\n");
         exit(2);
@@ -66,7 +74,9 @@ require $projectRoot . '/vendor/autoload.php';
 
 $root = rtrim(str_replace('\\', '/', $projectRoot), '/');
 $baselinePath = $root . '/' . ConformanceRunner::BASELINE_FILENAME;
-$runner = ConformanceRunner::withDefaultRules();
+$runner = $useFleetRules
+    ? ConformanceRunner::withFleetRules()
+    : ConformanceRunner::withDefaultRules();
 $baseline = Baseline::load($baselinePath);
 
 if ($baseline->validationErrors() !== []) {


### PR DESCRIPTION
## 目的
汎用性監査 M-1 の是正。NENE2 は汎用フレームワークだが、既定ルール集 `withDefaultRules()` に NeNe フリート固有ガバナンスの **R3**（`ReadmePrivateOriginLinkRule`＝非公開 `nene-origin` repo 参照ガード）が含まれ、フリートと無関係な外部 consumer が NeNe 内部前提のルールを継承していた。

## 変更点
- `ConformanceRunner::withDefaultRules()` を**汎用ルールのみ**（D1–D4 / R1 / R2）に分離。
- opt-in の **`withFleetRules()`**（汎用 + R3）を追加。将来の fleet 固有ルールは `fleetRules()` に加える（「既定=汎用・fleet ガバナンス=opt-in」の分離原則）。
- `tools/conformance.php` に **`--fleet` フラグ**（付与時のみ fleet 層を使用）。
- NENE2 自身の `composer conformance` を `--fleet` 付きにして現行挙動（自 README への R3・CI での flag 実行）を保持。
- ADR 0016 に分離決定＋**製品 opt-in 手順**（`--fleet` を `@conformance` に足す）を addendum で明文化。

## 検証結果（ローカル・PHP 8.4.22）
- **R3 opt-in の E2E 実証**〔実測〕: `nene-origin` を含む fixture で
  - `--fleet` なし → findings `[R2]`（R3 は出ない）
  - `--fleet` あり → findings `[R2, R3]`（R3 warn・`ok=true`＝exit 不変）
- **baseline 影響ゼロ**〔実測〕: baseline の `ignore` は空・R3 は `warn`（exit code は error のみ）＝既定から外しても既存の pass/fail を一切変えない。`git diff` で baseline 変更なし。
- `composer test` **871 tests 緑**（新規 composition テスト2件込み） / **PHPStan level 8 OK** / **cs 緑**。

## スコープ・残
- **各製品リポへの `--fleet` 実適用は別波**（本 PR は NENE2 側の器のみ・work order どおり）。

Closes #1593

Self-review: backend-api, docs-policy
発注: 統合リナ P1 GO（監査 M-1・施主「フェーズを進めて」）

🤖 Generated with [Claude Code](https://claude.com/claude-code)