### PR TITLE
feat(config): APP_ENV 未設定時を production 既定にして secure by default にする (#1599)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# local | test | production. Development must set this to `local` explicitly:
+# if APP_ENV is unset/empty the framework defaults to `production` (secure by
+# default), which fails closed on the development-secret path.
 APP_ENV=local
 APP_DEBUG=false
 APP_NAME=NENE2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `Nene2\Mcp\LocalMcpToolCatalog::withFilter(callable): self`（公開安定 API・後方互換・#1570）— カタログ（`docs/mcp/tools.json`）の一部だけを公開したい consumer のための immutable な絞り込みフック。述語は検証済みの各ツール（`McpTool` 形状）を受け取り `true` で残す。返り値は絞り込み済みの新カタログで、`tools()` と `find()` の**両方**が述語を尊重するため、フィルタ済みカタログをそのまま `LocalMcpServer` に渡すだけで subset を提供できる（例: 既定 read-only＋admin ツールは明示 opt-in）。フィルタ済みツールは list から隠れるだけでなく `tools/call` からも到達不能。フィルタは合成（chain で単調に絞り込み・全述語が pass）し、元カタログは不変。これにより consumer は「フィルタ済み一時カタログをディスクへ書いて指す」temp-file 回避策（NeNe Invoice ADR 0021）を再実装せずに済む。
 
 ### Changed
+- 準拠リンタ `Nene2\Conformance\ConformanceRunner::withDefaultRules()` を**汎用ルールのみ**（D1–D4 / R1 / R2）に変更し、NeNe フリート固有の R3（`ReadmePrivateOriginLinkRule`＝非公開 `nene-origin` 参照ガード）を **opt-in の fleet 層**（`withFleetRules()` ／ `tools/conformance.php --fleet`）へ分離（#1593）。外部 consumer は既定で NeNe 内部前提のルールを継承しない。NeNe 製品は `@conformance` スクリプトに `--fleet` を足すと従来どおり R3 を得る（ADR 0016）。R3 は `warn` で baseline に ignore エントリが無いため、既定集から外しても既存の pass/fail は不変。
 - `APP_ENV` 未設定/空時の既定環境を `local` → **`production`** に変更（secure by default・#1599）。本番で `APP_ENV` を設定し忘れても暗黙の `local` にフォールバックしなくなり、`GuardedJwtSecretResolver`（ADR 0013）の production ハードフェイル段（dev-secret 経路を封鎖）が常に効く。開発は `APP_ENV=local` を明示すること（`.env.example` 参照）— 明示 `local` での dev-secret opt-in（`NENE2_ALLOW_DEV_SECRET`）は不変。**移行**: 本番・ステージングの環境に `APP_ENV` を明示設定する。`APP_ENV` 未設定のまま `local` 挙動を暗黙に頼っていた環境のみ影響。
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - `Nene2\Mcp\LocalMcpToolCatalog::withFilter(callable): self`（公開安定 API・後方互換・#1570）— カタログ（`docs/mcp/tools.json`）の一部だけを公開したい consumer のための immutable な絞り込みフック。述語は検証済みの各ツール（`McpTool` 形状）を受け取り `true` で残す。返り値は絞り込み済みの新カタログで、`tools()` と `find()` の**両方**が述語を尊重するため、フィルタ済みカタログをそのまま `LocalMcpServer` に渡すだけで subset を提供できる（例: 既定 read-only＋admin ツールは明示 opt-in）。フィルタ済みツールは list から隠れるだけでなく `tools/call` からも到達不能。フィルタは合成（chain で単調に絞り込み・全述語が pass）し、元カタログは不変。これにより consumer は「フィルタ済み一時カタログをディスクへ書いて指す」temp-file 回避策（NeNe Invoice ADR 0021）を再実装せずに済む。
 
+### Changed
+- `APP_ENV` 未設定/空時の既定環境を `local` → **`production`** に変更（secure by default・#1599）。本番で `APP_ENV` を設定し忘れても暗黙の `local` にフォールバックしなくなり、`GuardedJwtSecretResolver`（ADR 0013）の production ハードフェイル段（dev-secret 経路を封鎖）が常に効く。開発は `APP_ENV=local` を明示すること（`.env.example` 参照）— 明示 `local` での dev-secret opt-in（`NENE2_ALLOW_DEV_SECRET`）は不変。**移行**: 本番・ステージングの環境に `APP_ENV` を明示設定する。`APP_ENV` 未設定のまま `local` 挙動を暗黙に頼っていた環境のみ影響。
+
 ---
 
 ## [1.11.0] — 2026-07-15

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -75,7 +75,10 @@ The first implementation uses `vlucas/phpdotenv` for optional local `.env` loadi
 
 The initial application config includes:
 
-- `APP_ENV`: `local`, `test`, or `production`
+- `APP_ENV`: `local`, `test`, or `production`. **Secure by default**: when unset or
+  empty it resolves to `production` (the most restrictive environment), so a forgotten
+  `APP_ENV` in a deployment never silently enables `local`-tier behaviour such as the
+  development-secret path. Development must set `APP_ENV=local` explicitly.
 - `APP_DEBUG`: boolean value
 - `APP_NAME`: non-empty application name
 - database config values used by Phinx and future database adapters:

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -22,7 +22,13 @@ final readonly class ConfigLoader
      * @var array<string, string>
      */
     private const DEFAULTS = [
-        'APP_ENV' => 'local',
+        // Secure by default (audit M-2): an unset/empty APP_ENV resolves to the most
+        // restrictive environment, `production`, not `local`. A forgotten APP_ENV in a
+        // real deployment must not silently unlock the `local`-tier development-secret
+        // path — in production {@see \Nene2\Auth\GuardedJwtSecretResolver} always fails
+        // closed. Development opts in explicitly with `APP_ENV=local` (see .env.example),
+        // so only the implicit-`local` footgun is removed, not the explicit dev workflow.
+        'APP_ENV' => 'production',
         'APP_DEBUG' => 'false',
         'APP_NAME' => 'NENE2',
         'NENE2_MACHINE_API_KEY' => '',

--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Nene2\Tests\Config;
 
+use Nene2\Auth\GuardedJwtSecretResolver;
+use Nene2\Auth\JwtSecretException;
 use Nene2\Config\AppConfig;
 use Nene2\Config\AppEnvironment;
 use Nene2\Config\ConfigException;
@@ -15,9 +17,15 @@ final class ConfigLoaderTest extends TestCase
 {
     public function testLoadsDefaultAppConfig(): void
     {
-        $config = (new ConfigLoader($this->emptyProjectRoot()))->load();
+        // APP_ENV is cleared so the environment assertion exercises the canonical
+        // default deterministically in every environment (#1526). With nothing set,
+        // that default is production — secure by default (M-2).
+        $config = $this->withoutEnvironmentKeys(
+            ['APP_ENV'],
+            fn (): AppConfig => (new ConfigLoader($this->emptyProjectRoot()))->load(),
+        );
 
-        self::assertSame(AppEnvironment::Local, $config->environment);
+        self::assertSame(AppEnvironment::Production, $config->environment);
         self::assertFalse($config->debug);
         self::assertSame('NENE2', $config->name);
         self::assertNull($config->machineApiKey);
@@ -72,6 +80,56 @@ final class ConfigLoaderTest extends TestCase
         (new ConfigLoader($this->emptyProjectRoot()))->load([
             'APP_ENV' => 'staging',
         ]);
+    }
+
+    // --- APP_ENV secure by default (audit M-2) ------------------------------
+
+    public function testUnsetAppEnvResolvesToProductionAndBlocksDevSecret(): void
+    {
+        // 未設定 → 防御作動: with APP_ENV unset the config resolves to production, so even
+        // an explicit dev-secret opt-in plus an injected secret fails closed — the
+        // forgotten-APP_ENV footgun can no longer silently unlock the dev path.
+        $config = $this->withoutEnvironmentKeys(
+            ['APP_ENV'],
+            fn (): AppConfig => (new ConfigLoader($this->emptyProjectRoot()))->load([
+                'NENE2_ALLOW_DEV_SECRET' => '1',
+            ]),
+        );
+
+        self::assertSame(AppEnvironment::Production, $config->environment);
+
+        $this->expectException(JwtSecretException::class);
+        GuardedJwtSecretResolver::fromConfig($config, 'injected-dev-secret');
+    }
+
+    public function testExplicitLocalAppEnvKeepsDevSecretPath(): void
+    {
+        // 明示 local → 従来どおり: an explicit APP_ENV=local preserves the development
+        // opt-in, so the injected dev secret is still returned.
+        $config = (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'APP_ENV' => 'local',
+            'NENE2_ALLOW_DEV_SECRET' => '1',
+        ]);
+
+        self::assertSame(AppEnvironment::Local, $config->environment);
+        self::assertSame(
+            'injected-dev-secret',
+            GuardedJwtSecretResolver::fromConfig($config, 'injected-dev-secret'),
+        );
+    }
+
+    public function testExplicitProductionAppEnvStaysFailClosed(): void
+    {
+        // production → fail-closed 維持: unchanged behaviour for an explicit production env.
+        $config = (new ConfigLoader($this->emptyProjectRoot()))->load([
+            'APP_ENV' => 'production',
+            'NENE2_ALLOW_DEV_SECRET' => '1',
+        ]);
+
+        self::assertSame(AppEnvironment::Production, $config->environment);
+
+        $this->expectException(JwtSecretException::class);
+        GuardedJwtSecretResolver::fromConfig($config, 'injected-dev-secret');
     }
 
     public function testInvalidBooleanFailsFast(): void
@@ -264,7 +322,8 @@ final class ConfigLoaderTest extends TestCase
         self::assertSame('sqlite', $config->database->adapter);
         self::assertSame(':memory:', $config->database->name);
         self::assertFalse($config->allowDevSecret);
-        self::assertSame(AppEnvironment::Local, $config->environment);
+        // APP_ENV is cleared above, so this exercises the secure-by-default fallback (M-2).
+        self::assertSame(AppEnvironment::Production, $config->environment);
     }
 
     public function testDemoConfigDefaultsAreOffAndInvoiceMeasured(): void


### PR DESCRIPTION
## 目的
汎用性監査 **M-2**。`ConfigLoader` の `APP_ENV` 既定が `local` のため、**本番で `APP_ENV` を書き忘れると暗黙 `local` 扱い**になり、`GuardedJwtSecretResolver`（ADR 0013）の「production は dev-secret を絶対使わない」ハードフェイル段が眠る穴があった。

## 設計（案A採用・Laravel 流）
- `DEFAULTS['APP_ENV']` を `local` → **`production`** に。未設定/空 → Production → JWT 使用時は configured secret 無しで **fail-closed に throw**（loud）。
- **明示 `APP_ENV=local` は従来どおり Local**（dev の明示 opt-in を温存）。「未設定の暗黙 local」だけを潰す。
- `environment` を分岐に使うのは `GuardedJwtSecretResolver` のみ（他は docblock）＝影響範囲は限定的。

## 後方互換（実測）
- `.env.example` は `APP_ENV=local` を明示済み・`compose.yaml` は `APP_ENV` を注入しない → **dev 環境は不変**。
- `NENE2_ALLOW_DEV_SECRET=1` の dev opt-in は不変。
- 全 874 テスト緑＝app-boot 系テストも既定 env flip で壊れないことを実測（環境分岐が resolver に限定される裏取り）。

## テスト（hub 指定の3系統・e2e）
| 系統 | テスト | 結果 |
|---|---|---|
| 未設定 → 防御作動 | `testUnsetAppEnvResolvesToProductionAndBlocksDevSecret`（Production・dev-secret 経路が fail-closed） | ✅ |
| 明示 local → 従来どおり | `testExplicitLocalAppEnvKeepsDevSecretPath`（dev-secret 経路が効く） | ✅ |
| production → 維持 | `testExplicitProductionAppEnvStaysFailClosed` | ✅ |

既定 env を検証する既存2テスト（`testLoadsDefaultAppConfig` / `testPartialConstructorDefaultsLayerOverCanonicalDefaults`）を Production へ更新（`#1526` の env 非依存化手法で決定的に）。

## 検証結果
- `composer test` **874 tests 緑**（+3） / **PHPStan level 8 OK** / **cs 緑**〔ローカル実測 PHP 8.4.22〕。
- docs（`configuration.md`・`.env.example`）と CHANGELOG `[Unreleased]` に secure-by-default と**移行手順**を明記（既存 CHANGELOG 分は非改変＝遡及是正は別レーン）。

## スコープ外
- 各製品の本番 env への `APP_ENV` 明示投入（実機棚卸し）は別レーン（post-launch 台帳・施主 seam）。本 PR は「器を secure by default に」まで。

Closes #1599

Self-review: backend-api, middleware-security, docs-policy
発注: 統合リナ P1（監査 M-2・施主 GO）
※ 製品セキュリティコードにつき hub 事前レビュー依頼・self-merge しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)