### PR TITLE
docs: 運用ログ移設に伴う生きた導線の dead-link を private ミラーへ sweep する (#1603)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,13 +11,13 @@ NENE2 is built through small, Issue-driven changes. This document is the shared 
 | Commit messages | `docs/development/commit-conventions.md` |
 | AI tools | `docs/integrations/ai-tools.md` |
 | Roadmap | `docs/roadmap.md` |
-| Current work | `docs/todo/current.md` |
+| Current work | `nene-origin/internal-docs/nene2/todo/current.md` |
 
 ## Collaboration Policy
 
 - Start work from a GitHub Issue.
 - Use one branch and one PR per focused work unit.
-- Keep `docs/milestones/`, `docs/roadmap.md`, and `docs/todo/current.md` updated when the direction changes.
+- Keep `docs/milestones/`, `docs/roadmap.md`, and `nene-origin/internal-docs/nene2/todo/current.md` updated when the direction changes.
 - Explain intent, impact, verification, and remaining risk in PRs.
 - Prefer documentation that helps the next developer or AI agent decide what to do without rereading chat history.
 

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -75,7 +75,7 @@ Other documents explain how the project currently works:
 
 - `docs/development/`: current policies and implementation guidance
 - `docs/roadmap.md`: phase direction
-- `docs/todo/current.md`: current task board
+- `nene-origin/internal-docs/nene2/todo/current.md`: current task board
 - GitHub Issues: work units and discussion
 - PRs: concrete changes and verification
 

--- a/docs/development/client-project-start.md
+++ b/docs/development/client-project-start.md
@@ -290,7 +290,7 @@ Before handing off a client-style project, confirm:
 - MCP tools, if any, call documented API boundaries only.
 - `docker compose run --rm app composer check` passes.
 - Frontend checks pass when the React starter is part of the handoff.
-- Deferred work is visible in `docs/todo/current.md` or a project-specific tracker.
+- Deferred work is visible in `nene-origin/internal-docs/nene2/todo/current.md` or a project-specific tracker.
 
 ## Useful Next Documents
 

--- a/docs/development/endpoint-scaffold.md
+++ b/docs/development/endpoint-scaffold.md
@@ -24,7 +24,7 @@ An endpoint is complete only when its behavior is visible in all relevant places
 5. **When a new entity introduces a new database table**: add a Phinx migration in `database/migrations/` and a schema snapshot in `database/schema/`. Run `composer migrations:migrate` before HTTP smoke tests.
 6. Run the focused tests first, then `docker compose run --rm app composer check`.
 7. Run a local HTTP smoke check when the endpoint is reachable through Docker.
-8. Update `docs/todo/current.md`, milestone docs, or MCP catalog only when the endpoint affects current work.
+8. Update `nene-origin/internal-docs/nene2/todo/current.md`, milestone docs, or MCP catalog only when the endpoint affects current work.
 
 ## Runtime Route
 

--- a/docs/development/howto-frontmatter.md
+++ b/docs/development/howto-frontmatter.md
@@ -4,7 +4,7 @@ Every guide in `docs/howto/` carries a small YAML frontmatter block so that
 category and tag indexes can be regenerated from data instead of hand-curated
 lists. The schema is intentionally minimal — rich schemas do not get filled in.
 
-See `docs/todo/howto-curation-strategy.md` for the rollout plan (Phase B).
+See `nene-origin/internal-docs/nene2/todo/howto-curation-strategy.md` for the rollout plan (Phase B).
 
 ## Fields
 
@@ -26,7 +26,7 @@ ft: FT102
 | `tags` | yes | list of strings | 1–6 lowercase kebab-case tags (`[a-z0-9-]+`). |
 | `difficulty` | yes | enum | `beginner` \| `intermediate` \| `advanced`. |
 | `related` | no | list of slugs | Other howto file names without `.md`; each must exist. |
-| `ft` | no | string | Field-trial id, `FT` followed by digits (cross-references `docs/ft-registry.md`). |
+| `ft` | no | string | Field-trial id, `FT` followed by digits (cross-references `nene-origin/internal-docs/nene2/field-trials/ft-registry.md`). |
 
 Unknown keys are rejected to keep the schema tight.
 

--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -12,7 +12,7 @@ Preparation notes for the `v0.1.1` checkpoint candidate live in `docs/developmen
 - `main` is up to date with `origin/main`.
 - The working tree is clean.
 - Relevant Issues and PRs are merged or explicitly deferred.
-- `docs/todo/current.md` reflects the actual project state.
+- `nene-origin/internal-docs/nene2/todo/current.md` reflects the actual project state.
 - Public behavior changes are documented in source-of-truth docs and OpenAPI when applicable.
 
 ## Verification
@@ -101,6 +101,6 @@ Release notes should include:
 
 - Confirm the GitHub Release points to the expected tag.
 - Confirm Packagist reflects the new version.
-- Confirm `docs/todo/current.md` does not list the release as incomplete if it is done.
+- Confirm `nene-origin/internal-docs/nene2/todo/current.md` does not list the release as incomplete if it is done.
 - Open follow-up Issues for deferred release work.
 - Sync the profile README ([github.com/hideyukiMORI/hideyukiMORI](https://github.com/hideyukiMORI/hideyukiMORI)) with the released version and status: update the relevant rows in At a glance / Runtimes / What shipped recently.

--- a/docs/development/release-ci.md
+++ b/docs/development/release-ci.md
@@ -177,7 +177,7 @@ Before tagging a release, use `docs/development/release-checklist.md`. At minimu
 - Required CI checks are passing.
 - Local `composer check` passes when practical.
 - Documentation for changed public behavior is updated.
-- `docs/todo/current.md` does not claim an incomplete release task is done.
+- `nene-origin/internal-docs/nene2/todo/current.md` does not claim an incomplete release task is done.
 - Release notes are prepared.
 - The tag follows `vX.Y.Z`.
 

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -8,7 +8,7 @@ NENE2 is designed to be easy for AI agents to inspect, change, and verify withou
 - LLM-assisted delivery direction: `docs/integrations/llm-delivery-starter.md`
 - Workflow: `docs/workflow.md`
 - Coding rules: `docs/development/coding-standards.md`
-- Current state: `docs/todo/current.md`
+- Current state: `nene-origin/internal-docs/nene2/todo/current.md`
 - Local milestones: `docs/milestones/`
 - Agent entry point: `AGENTS.md`
 - Cursor summaries: `.cursor/rules/`

--- a/docs/integrations/llm-field-trial.md
+++ b/docs/integrations/llm-field-trial.md
@@ -4,7 +4,7 @@
 > step at the `v0.1.1` delivery-starter checkpoint. The first field trial has since been
 > run and the loop grew to FT352; on 2026-07-04 the field-trial loop was demoted (no fixed
 > deadline) in favour of the installer toolkit and business lanes. For current work see
-> `docs/todo/current.md`; for the loop mechanics see `docs/todo/ft-loop-workflow.md`.
+> `nene-origin/internal-docs/nene2/todo/current.md`; for the loop mechanics see `nene-origin/internal-docs/nene2/todo/ft-loop-workflow.md`.
 
 This document records the next practical step after the `v0.1.1` delivery-starter checkpoint.
 

--- a/docs/integrations/local-ai-commands.md
+++ b/docs/integrations/local-ai-commands.md
@@ -61,4 +61,4 @@ Before a command becomes part of AI or MCP automation:
 - define whether it is read-only, write, admin, or destructive
 - verify it locally
 - add it to CI only after its configuration is committed
-- update `docs/todo/current.md` or the related Issue when it changes current workflow
+- update `nene-origin/internal-docs/nene2/todo/current.md` or the related Issue when it changes current workflow

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -10,13 +10,13 @@ Source policies:
 - `docs/development/language-policy.md`
 - `docs/development/package-selection.md`
 - `docs/development/self-review.md`
-- `docs/todo/current.md`
+- `nene-origin/internal-docs/nene2/todo/current.md`
 - `docs/roadmap.md`
 
 ## Checklist
 
 - [ ] The source-of-truth policy doc was updated instead of only adding a summary elsewhere.
-- [ ] Related `docs/roadmap.md` or `docs/todo/current.md` state was updated when project state changed.
+- [ ] Related `docs/roadmap.md` or `nene-origin/internal-docs/nene2/todo/current.md` state was updated when project state changed.
 - [ ] New major architecture, dependency, public contract, or release decisions considered whether an ADR is needed.
 - [ ] Concrete package selections were recorded in an ADR when applicable.
 - [ ] Public source-of-truth docs, API contracts, and OpenAPI text are in English unless policy allows otherwise.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -5,7 +5,7 @@ NENE2 uses GitHub Issues for work tracking and local Markdown files for project 
 ## Standard Flow
 
 1. Create or reuse a focused GitHub Issue.
-2. Confirm related local context in `docs/roadmap.md`, `docs/milestones/`, and `docs/todo/current.md`.
+2. Confirm related local context in `docs/roadmap.md`, `docs/milestones/`, and `nene-origin/internal-docs/nene2/todo/current.md`.
 3. Create a branch from `main` named like `type/issue-number-summary`.
 4. Implement the smallest useful change.
 5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
@@ -45,7 +45,7 @@ Public release work should happen from `main` tags after required checks pass. D
 
 - `docs/roadmap.md`: long-lived direction and phases
 - `docs/milestones/`: medium-sized goals and acceptance criteria
-- `docs/todo/current.md`: current task board and handoff notes
+- `nene-origin/internal-docs/nene2/todo/current.md`: current task board and handoff notes
 - `docs/adr/`: major architecture decisions that should remain traceable
 
 Do not leave important decisions only in chat. If it changes how the project should be built, record it in `docs/`.


### PR DESCRIPTION
## 目的
P3 Phase 2 の **③ dead-link sweep**（②削除 #1602 merged の後段・裁定(1)）。運用ログの private 移設で公開 docs 内の `docs/todo/current.md` 等が dead link 化した（`ignoreDeadLinks:true` で build は維持）分を、**生きた導線だけ** private ミラーへ repoint する。

## 変更点（英語の生きた docs・12ファイル・path-for-path repoint）
`docs/todo/{current,ft-loop-workflow,howto-curation-strategy}.md`・`docs/ft-registry.md` → `nene-origin/internal-docs/nene2/...`:
CONTRIBUTING / workflow / review・docs-policy / development・adr / release-checklist / release-ci / endpoint-scaffold / howto-frontmatter / integrations・ai-tools / local-ai-commands / llm-field-trial / client-project-start。

## 意図的に残置（裁定(1)A）
- **歴史スナップショット**: `docs/milestones/*`（13）・`release-v0.1.1/0.1.2-prep`・`release-v0.1.x-policy`・`adr/0012`（過去の記録・書き換えない）。
- **locale 翻訳**: `de/fr/ja/pt-br/zh` の `client-project-start`・`endpoint-scaffold`（10ファイル）＝低トラフィック。要望あれば follow-up で sweep。

## 検証
- 対象12ファイルに `docs/todo/`・`docs/ft-registry` 残存**なし**〔実測 grep〕。ドキュメントのみ・path 置換のみ（文構造・コードスパン維持）。

Closes #1603

Self-review: docs-policy
発注: 統合リナ P3 Phase 2 ③（裁定(1)・2026-07-18）
🤖 Generated with [Claude Code](https://claude.com/claude-code)