### PR TITLE
docs(i18n): 運用ログ移設の dead-link sweep を locale 翻訳へ波及する (#1605)

### DIFF
--- a/docs/de/development/client-project-start.md
+++ b/docs/de/development/client-project-start.md
@@ -217,7 +217,7 @@ Vor der Übergabe eines Client-artigen Projekts bestätigen:
 - Geschützte Routen dokumentieren erforderliche Anmeldedaten ohne Secret-Werte preiszugeben.
 - MCP-Tools, falls vorhanden, rufen nur dokumentierte API-Grenzen auf.
 - `docker compose run --rm app composer check` besteht.
-- Zurückgestellte Arbeit ist in `docs/todo/current.md` sichtbar.
+- Zurückgestellte Arbeit ist in `nene-origin/internal-docs/nene2/todo/current.md` sichtbar.
 
 ## Nützliche Folgedokumente
 

--- a/docs/de/development/endpoint-scaffold.md
+++ b/docs/de/development/endpoint-scaffold.md
@@ -23,7 +23,7 @@ Ein Endpunkt ist erst vollständig, wenn sein Verhalten an allen relevanten Stel
 4. Tests nahe am Verhalten hinzufügen oder aktualisieren.
 5. Zuerst fokussierte Tests ausführen, dann `docker compose run --rm app composer check`.
 6. Wenn der Endpunkt über Docker erreichbar ist, einen lokalen HTTP-Smoke-Check ausführen.
-7. `docs/todo/current.md`, Milestone-Dokumente und MCP-Katalog nur aktualisieren, wenn die aktuelle Arbeit betroffen ist.
+7. `nene-origin/internal-docs/nene2/todo/current.md`, Milestone-Dokumente und MCP-Katalog nur aktualisieren, wenn die aktuelle Arbeit betroffen ist.
 
 ## Laufzeitroute
 

--- a/docs/fr/development/client-project-start.md
+++ b/docs/fr/development/client-project-start.md
@@ -217,7 +217,7 @@ Avant de transférer un projet style client, confirmez :
 - Les routes protégées documentent les credentials requis sans exposer les valeurs secrètes.
 - Les outils MCP, s'il y en a, appellent uniquement les frontières API documentées.
 - `docker compose run --rm app composer check` passe.
-- Le travail différé est visible dans `docs/todo/current.md`.
+- Le travail différé est visible dans `nene-origin/internal-docs/nene2/todo/current.md`.
 
 ## Prochains documents utiles
 

--- a/docs/fr/development/endpoint-scaffold.md
+++ b/docs/fr/development/endpoint-scaffold.md
@@ -23,7 +23,7 @@ Un endpoint n'est complet que lorsque son comportement est visible dans tous les
 4. Ajouter ou mettre à jour les tests proches du comportement.
 5. Exécuter d'abord les tests ciblés, puis `docker compose run --rm app composer check`.
 6. Si l'endpoint est accessible via Docker, exécuter un smoke check HTTP local.
-7. Mettre à jour `docs/todo/current.md`, les documents de milestone et le catalogue MCP uniquement si le travail actuel est impacté.
+7. Mettre à jour `nene-origin/internal-docs/nene2/todo/current.md`, les documents de milestone et le catalogue MCP uniquement si le travail actuel est impacté.
 
 ## Route runtime
 

--- a/docs/ja/development/client-project-start.md
+++ b/docs/ja/development/client-project-start.md
@@ -284,7 +284,7 @@ docker compose run --rm app composer test:database:mysql
 - MCP ツールがある場合、文書化された API 境界のみを呼び出している。
 - `docker compose run --rm app composer check` が通る。
 - React スターターが引き継ぎの一部の場合、フロントエンドチェックが通る。
-- 延期された作業が `docs/todo/current.md` またはプロジェクト固有のトラッカーに表示されている。
+- 延期された作業が `nene-origin/internal-docs/nene2/todo/current.md` またはプロジェクト固有のトラッカーに表示されている。
 
 ## 次のドキュメント
 

--- a/docs/ja/development/endpoint-scaffold.md
+++ b/docs/ja/development/endpoint-scaffold.md
@@ -23,7 +23,7 @@
 4. 動作に近いテストを追加または更新する。
 5. フォーカスされたテストを最初に実行し、次に `docker compose run --rm app composer check` を実行する。
 6. エンドポイントが Docker 経由で到達可能な場合は、ローカル HTTP スモークチェックを実行する。
-7. エンドポイントが現在の作業に影響する場合にのみ、`docs/todo/current.md`・マイルストーンドキュメント・MCP カタログを更新する。
+7. エンドポイントが現在の作業に影響する場合にのみ、`nene-origin/internal-docs/nene2/todo/current.md`・マイルストーンドキュメント・MCP カタログを更新する。
 
 ## ランタイムルート
 

--- a/docs/pt-br/development/client-project-start.md
+++ b/docs/pt-br/development/client-project-start.md
@@ -217,7 +217,7 @@ Antes de entregar um projeto estilo cliente, confirme:
 - Rotas protegidas documentam credenciais necessárias sem expor valores secretos.
 - Ferramentas MCP, se houver, chamam apenas fronteiras de API documentadas.
 - `docker compose run --rm app composer check` passa.
-- Trabalho adiado é visível em `docs/todo/current.md`.
+- Trabalho adiado é visível em `nene-origin/internal-docs/nene2/todo/current.md`.
 
 ## Próximos Documentos Úteis
 

--- a/docs/pt-br/development/endpoint-scaffold.md
+++ b/docs/pt-br/development/endpoint-scaffold.md
@@ -23,7 +23,7 @@ Um endpoint só está completo quando seu comportamento é visível em todos os 
 4. Adicionar ou atualizar testes próximos ao comportamento.
 5. Executar primeiro testes focados, depois `docker compose run --rm app composer check`.
 6. Se o endpoint for acessível via Docker, executar um smoke check HTTP local.
-7. Atualizar `docs/todo/current.md`, documentos de milestone e catálogo MCP apenas se o trabalho atual for impactado.
+7. Atualizar `nene-origin/internal-docs/nene2/todo/current.md`, documentos de milestone e catálogo MCP apenas se o trabalho atual for impactado.
 
 ## Rota Runtime
 

--- a/docs/zh/development/client-project-start.md
+++ b/docs/zh/development/client-project-start.md
@@ -215,7 +215,7 @@ docker compose run --rm app composer test:database:mysql
 - 受保护路由文档化了所需凭证而不暴露密钥值。
 - MCP 工具（如有）仅调用文档化的 API 边界。
 - `docker compose run --rm app composer check` 通过。
-- 延迟的工作在 `docs/todo/current.md` 中可见。
+- 延迟的工作在 `nene-origin/internal-docs/nene2/todo/current.md` 中可见。
 
 ## 有用的后续文档
 

--- a/docs/zh/development/endpoint-scaffold.md
+++ b/docs/zh/development/endpoint-scaffold.md
@@ -23,7 +23,7 @@
 4. 添加或更新接近行为的测试。
 5. 首先运行专注测试，然后运行 `docker compose run --rm app composer check`。
 6. 如果端点可通过 Docker 访问，运行本地 HTTP 冒烟检查。
-7. 仅在当前工作受影响时更新 `docs/todo/current.md`、里程碑文档和 MCP 目录。
+7. 仅在当前工作受影响时更新 `nene-origin/internal-docs/nene2/todo/current.md`、里程碑文档和 MCP 目录。
 
 ## 运行时路由
 


### PR DESCRIPTION
## 目的
P3 Phase 2 ③（#1604）の follow-up。英語の生きた導線を private ミラーへ repoint した分の **locale 翻訳の非整合**を解消する（hub 裁定=consistency は取る・follow-up 可）。

## 変更点（10ファイル・path-for-path・③と同一機械置換）
`de/fr/ja/pt-br/zh` の `development/client-project-start.md`・`development/endpoint-scaffold.md` の `docs/todo/current.md` → `nene-origin/internal-docs/nene2/todo/current.md`。

## 検証
- locale 配下に `docs/todo/current.md`・`docs/ft-registry` 残存**なし**〔実測 grep〕。ドキュメントのみ・path 置換のみ。

Closes #1605

Self-review: docs-policy
発注: 統合リナ ③ follow-up（裁定(1)・locale consistency）
🤖 Generated with [Claude Code](https://claude.com/claude-code)