### PR TITLE
fix(frontend): 脆弱な js-yaml を overrides で ^4.3.0 に固定する (#1614)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6831,9 +6831,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,5 +60,8 @@
     "typescript": "^5.9.3",
     "vite": "^8.1.3",
     "vitest": "^4.1.9"
+  },
+  "overrides": {
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
## 目的

frontend 依存ツリーに残存する脆弱な `js-yaml` 4.2.0（GHSA-52cp-r559-cp3m・high）を排除する。フリート事前承認パターン（overrides で `^4.3.0` 固定）の予防適用。

## 変更点

- `frontend/package.json` に `overrides.js-yaml = ^4.3.0` を追加。
- `frontend/package-lock.json` を同期（js-yaml 4.2.0 → 4.3.0 のみの最小差分）。

## 検証結果

- `npm audit --audit-level=high` → **found 0 vulnerabilities（rc=0）** を実測（before: js-yaml high + @redocly/openapi-core 依存の 2 high）。
- lock 差分 = js-yaml の version/resolved/integrity のみ（3 insertions / 3 deletions）。
- `npm install --package-lock-only --dry-run` = up to date（package.json ⇔ lock 整合・npm ci 安全）。
- js-yaml 解決版 = 4.3.0（lock 実測）。

## 方針メモ

- `npm audit fix` は platform binary 混入の懸念からフリート方針で不採用。overrides 固定を採用。
- NENE2 は starter＝基準艦のため、audit gate 未設置でも latent 脆弱版を残さない（判例11：予防的自力適用は歓迎）。
- frontend CI への npm audit gate 新設は本 PR スコープ外（完全クローズ C6 レーン）。

Closes #1614

Self-review: frontend
残リスク: なし（依存1行・app コード非改変・CI 全緑を merge 条件とする）