### PR TITLE
fix(version-check): README の現行版表記を version:check の突合対象に加える (#1623)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `v1.x` foundation covers full Note/Tag CRUD, Bearer JWT auth, pagination hel
 
 NENE2 is built in the open, at high velocity, by a solo maintainer using an AI-assisted, Issue-driven workflow:
 
-- **140+ releases** (current: `v1.10.0`) and **740+ merged pull requests** since the first commit in May 2026 (as of 2026-07) — every change lands through an Issue → branch → PR → CI pipeline; nothing is committed directly to `main`.
+- **140+ releases** (current: `v1.11.0`) and **780+ merged pull requests** since the first commit in May 2026 (as of 2026-07) — every change lands through an Issue → branch → PR → CI pipeline; nothing is committed directly to `main`.
 - **[262 how-to guides](docs/howto/README.md)** covering authentication, security, database patterns, API design, background jobs, and 100+ product feature recipes.
 - **[125+ runnable example apps](https://github.com/hideyukiMORI/NENE2-examples)** — each a self-contained JSON API with tests, built as field trials of the framework itself.
 - **Powers the NeNe product family** — 12+ open-source, self-hosted business tools for small teams (invoicing, records, deal tracking, contact management, and more), all built on this framework and sharing its fail-closed security baseline.

--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -98,6 +98,18 @@ The first validation should verify:
 
 Runtime response validation belongs to later contract test work.
 
+## Version Consistency
+
+`composer version:check` (`tools/validate-version.php`, part of `composer check`) treats `FrameworkInfo::VERSION` as the single source of truth and fails the build when another artifact disagrees with it:
+
+- `docs/openapi/openapi.yaml` — `info.version`
+- `CHANGELOG.md` — the most recent released version heading
+- `README.md` — a version claimed as the current one
+
+The README check looks only at `X.Y.Z` literals on a line that also says "current" or "latest", so historical references ("forked from `v0.1.1`", "available since v1.6.0") are left alone. It exists because that one line is edited by hand and had drifted twice by the time it was machine-checked; a release-checklist step would have been a second thing to remember.
+
+This script is NENE2-internal tooling and is not distributed to consumer projects (see ADR 0009 §5), unlike `tools/conformance.php` and `tools/validate-mcp-tools.php`.
+
 ## Command Shape
 
 The intended split is:

--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -27,6 +27,8 @@ git diff --check
 
 If Docker is unavailable, run the equivalent Composer commands in a PHP `8.4` environment and record the limitation in the release notes.
 
+`composer check` includes `composer version:check`, which fails when `docs/openapi/openapi.yaml`, `CHANGELOG.md`, or `README.md` disagrees with `FrameworkInfo::VERSION`. There is deliberately no manual "remember to update the README" step here — see `docs/development/quality-tools.md`.
+
 ## Version Selection
 
 - Use `vX.Y.Z` tags.

--- a/tests/Tools/ValidateVersionTest.php
+++ b/tests/Tools/ValidateVersionTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene2\Tests\Tools;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers `tools/validate-version.php` (`composer version:check`) — in particular
+ * the README "current version" claim added in #1623.
+ *
+ * The script is exercised as a subprocess against fixture trees via `--root`,
+ * because that is how it fails in practice: a non-zero exit code inside
+ * `composer check`. Asserting on the exit code and the stderr text keeps the
+ * regression honest about the part CI actually observes.
+ */
+final class ValidateVersionTest extends TestCase
+{
+    private const VERSION = '1.11.0';
+
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/nene2-version-' . bin2hex(random_bytes(6));
+        mkdir($this->root, 0o777, true);
+
+        // A consistent baseline tree; each test perturbs only what it is about.
+        $this->write('src/FrameworkInfo.php', sprintf(
+            "<?php\nfinal class FrameworkInfo { public const string VERSION = '%s'; }\n",
+            self::VERSION,
+        ));
+        $this->write('docs/openapi/openapi.yaml', sprintf(
+            "openapi: 3.1.0\ninfo:\n  title: Fixture\n  version: '%s'\n",
+            self::VERSION,
+        ));
+        $this->write('CHANGELOG.md', sprintf(
+            "# Changelog\n\n## [Unreleased]\n\n## [%s] — 2026-07-14\n",
+            self::VERSION,
+        ));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+    }
+
+    public function testPassesWhenReadmeClaimsTheCurrentVersion(): void
+    {
+        $this->write('README.md', sprintf(
+            "# Fixture\n\n- **140+ releases** (current: `v%s`) and 780+ merged pull requests.\n",
+            self::VERSION,
+        ));
+
+        [$code, $output] = $this->runScript();
+
+        self::assertSame(0, $code, $output);
+        self::assertStringContainsString('Version consistency OK', $output);
+    }
+
+    public function testFailsWhenReadmeClaimsAnOlderVersion(): void
+    {
+        // The exact drift #1623 was filed for: the release moved, the README did not.
+        $this->write('README.md', "# Fixture\n\n- **140+ releases** (current: `v1.10.0`) and 740+ merged pull requests.\n");
+
+        [$code, $output] = $this->runScript();
+
+        self::assertSame(1, $code, $output);
+        self::assertStringContainsString('README.md:3', $output);
+        self::assertStringContainsString("claims current version '1.10.0'", $output);
+        self::assertStringContainsString("FrameworkInfo::VERSION is '1.11.0'", $output);
+    }
+
+    public function testIgnoresHistoricalVersionReferencesWithoutACurrentClaim(): void
+    {
+        // README.md:249 in this repository points at the v0.1.1 field-trial fork.
+        // A version literal is only a claim about *now* when the line says so.
+        $this->write('README.md', <<<'MD'
+            # Fixture
+
+            Forked from **`v0.1.1`** with exhibition-shaped read-only APIs.
+            Available since v1.6.0; the installer toolkit landed in v1.6.0 too.
+            MD);
+
+        [$code, $output] = $this->runScript();
+
+        self::assertSame(0, $code, $output);
+    }
+
+    public function testReportsEveryDriftedClaimOnALineAtOnce(): void
+    {
+        $this->write('README.md', "# Fixture\n\nlatest: v1.9.0 (previously v1.8.2)\n");
+
+        [$code, $output] = $this->runScript();
+
+        self::assertSame(1, $code, $output);
+        self::assertStringContainsString("claims current version '1.9.0'", $output);
+        self::assertStringContainsString("claims current version '1.8.2'", $output);
+    }
+
+    public function testPassesWhenTheProjectHasNoReadme(): void
+    {
+        // No README means no claim to contradict — the other checks still apply.
+        [$code, $output] = $this->runScript();
+
+        self::assertSame(0, $code, $output);
+    }
+
+    public function testStillFailsOnChangelogDriftWithACleanReadme(): void
+    {
+        // Guards against the README check shadowing the pre-existing checks.
+        $this->write('README.md', sprintf("# Fixture\n\ncurrent: `v%s`\n", self::VERSION));
+        $this->write('CHANGELOG.md', "# Changelog\n\n## [Unreleased]\n\n## [1.10.0] — 2026-07-10\n");
+
+        [$code, $output] = $this->runScript();
+
+        self::assertSame(1, $code, $output);
+        self::assertStringContainsString('CHANGELOG.md latest released version', $output);
+    }
+
+    public function testRejectsUnknownArguments(): void
+    {
+        [$code, $output] = $this->runScript('--unknown');
+
+        self::assertSame(2, $code, $output);
+        self::assertStringContainsString('Unknown argument', $output);
+    }
+
+    /**
+     * @return array{0: int, 1: string}
+     */
+    private function runScript(string ...$extra): array
+    {
+        $command = sprintf(
+            '%s %s --root=%s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(dirname(__DIR__, 2) . '/tools/validate-version.php'),
+            escapeshellarg($this->root),
+        );
+
+        foreach ($extra as $argument) {
+            $command .= ' ' . escapeshellarg($argument);
+        }
+
+        $output = [];
+        $code = 0;
+        exec($command . ' 2>&1', $output, $code);
+
+        return [$code, implode("\n", $output)];
+    }
+
+    private function write(string $relative, string $contents): void
+    {
+        $path = $this->root . '/' . $relative;
+        $dir = dirname($path);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+
+        file_put_contents($path, $contents);
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $entry) {
+            if ($entry instanceof \SplFileInfo) {
+                $entry->isDir() ? rmdir($entry->getPathname()) : unlink($entry->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/tools/validate-version.php
+++ b/tools/validate-version.php
@@ -6,8 +6,28 @@ declare(strict_types=1);
  * Validates that FrameworkInfo::VERSION is consistent with:
  *   - docs/openapi/openapi.yaml  info.version
  *   - CHANGELOG.md               most recent released version heading
+ *   - README.md                  the "current version" claim (see below)
+ *
+ * The README check exists because that claim is the one version string a human
+ * has to remember to edit, and the repository's own history shows it goes stale:
+ * #1548 synced it to v1.10.0, and the v1.11.0 release (#1569) desynced it again
+ * within a day, unnoticed for two weeks (#1623). Adding a step to the release
+ * checklist would be a second thing to remember, so the claim is machine-checked
+ * here instead — this script already runs inside `composer check` and CI.
+ *
+ * Detection is deliberately narrow: only a `X.Y.Z` literal on a line that also
+ * says "current" or "latest" is treated as a claim about the *current* version.
+ * Historical references ("forked from `v0.1.1`", "available since v1.6.0") carry
+ * no such marker and are left alone.
  *
  * Run via: composer version:check
+ *
+ * Usage: php tools/validate-version.php [--root=PATH]
+ *
+ * `--root` exists so the checks can be exercised against fixture trees in tests;
+ * it defaults to this repository's root, which is what `composer version:check`
+ * relies on. This is NENE2-internal tooling and is not distributed to consumers
+ * (ADR 0009 §5), unlike tools/conformance.php or tools/validate-mcp-tools.php.
  */
 
 use Symfony\Component\Yaml\Yaml;
@@ -15,6 +35,21 @@ use Symfony\Component\Yaml\Yaml;
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $root = dirname(__DIR__);
+
+foreach ($argv as $index => $arg) {
+    if ($index === 0) {
+        continue;
+    }
+
+    if (str_starts_with($arg, '--root=')) {
+        $explicit = substr($arg, 7);
+        $root = realpath($explicit) ?: $explicit;
+    } else {
+        fwrite(STDERR, "Unknown argument: {$arg}\n");
+        exit(2);
+    }
+}
+
 $errors = [];
 
 // --- 1. Read FrameworkInfo::VERSION ---
@@ -69,6 +104,43 @@ if (!preg_match('/^##\s+\[(\d+\.\d+\.\d+)\]/m', $changelog, $cm)) {
             $changelogVersion,
             $frameworkVersion,
         );
+    }
+}
+
+// --- 4. Read the README's "current version" claim ---
+$readmePath = $root . '/README.md';
+
+// A repository without a README simply has no claim to contradict.
+if (is_file($readmePath)) {
+    $readme = file_get_contents($readmePath);
+
+    if ($readme === false) {
+        fwrite(STDERR, "Could not read {$readmePath}\n");
+        exit(1);
+    }
+
+    foreach (explode("\n", $readme) as $index => $line) {
+        // Only lines that present a version as the *present* one are claims.
+        if (preg_match('/\b(?:current|latest)\b/i', $line) !== 1) {
+            continue;
+        }
+
+        if (preg_match_all('/\bv?(\d+\.\d+\.\d+)\b/', $line, $lm) === 0) {
+            continue;
+        }
+
+        foreach ($lm[1] as $claimed) {
+            if ($claimed === $frameworkVersion) {
+                continue;
+            }
+
+            $errors[] = sprintf(
+                "README.md:%d claims current version '%s' but FrameworkInfo::VERSION is '%s'.",
+                $index + 1,
+                $claimed,
+                $frameworkVersion,
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## 目的

README が主張する現行版が `v1.10.0` のまま実際の `v1.11.0` とずれていた（#1623）。同じドリフトは #1548 で一度直しており、v1.11.0 リリース（#1569）で**翌日には再発**して2週間気づかれなかった。README の版表記は「人が手で直す唯一の版文字列」であり、覚えておく手順を増やしても再発する — これを機械検出に倒す。

`Closes #1623`

## 変更点

### 1. `tools/validate-version.php` に README 突合を追加

このスクリプトは既に `FrameworkInfo::VERSION` を正本として `docs/openapi/openapi.yaml` の `info.version` と `CHANGELOG.md` の最新リリース見出しを突合し、`composer check` 経由で CI（`backend.yml`）で走っている。**README だけが突合対象から漏れていた**ので、そこへ足した。

検出は意図的に狭い:

- `current` / `latest` を含む**行**にある `X.Y.Z` リテラルだけを「現行版の主張」とみなす
- 履歴上の言及は反応しない — 本 README の L249（`v0.1.1` からのフォーク）、「available since v1.6.0」の類
- 1行に複数の主張があれば全部まとめて報告する
- `README.md` が無いリポジトリでは突合対象が存在しないので何も報告しない

### 2. `--root=PATH` を追加

フィクスチャツリーに対して検査を回せるようにするため（`tools/conformance.php` と同じ形）。既定は当リポジトリのルートなので `composer version:check` の挙動は不変。

### 3. README を実測値へ更新

- 現行版 `v1.10.0` → `v1.11.0`
- merged PR `740+` → `780+`（実測 789）
- リリース数は実測 144 なので `140+` のまま真

### 4. ドキュメント

- `docs/development/quality-tools.md` に `## Version Consistency` 節を新設（従来 `version:check` はどこにも記載が無かった）
- `docs/development/release-checklist.md` の Verification に「`composer check` が版整合を落とす／手動の README 更新手順は意図的に置かない」旨を追記

## 実装先についての注記（当初案からの変更）

Issue では選択肢として conformance ルール R4 を挙げ、いったんそちらの方針で承認を得たが、以下3点により**既存の `tools/validate-version.php` 拡張へ実装先を訂正**した（指揮に理由を添えて報告・承認済み）:

1. **二重実装の回避** — 版整合の機械検査は既に存在し `composer check` / CI で走っている。R4 は同じ仕事の2つ目の実装になる。
2. **不変条件との適合** — 版の正本 `src/FrameworkInfo.php` は NENE2 固有。conformance 既定集は framework-generic でなければならない（ADR 0016 / 汎用性監査 M-1）ため、R4 として書くには CHANGELOG から版を再導出する別実装が要る。
3. **影響範囲** — conformance 既定集は全消費製品へ配布されるので error 段の新ルールは各消費者の CI を予告なく赤にしうる（v1.8.2 の D1 誤検知の前例）。`tools/validate-version.php` は NENE2 内部ツール（ADR 0009 §5・消費者へ非配布）なので影響が当リポジトリに閉じる。

「忘れられない機械検査を入れる」という当初の意図はそのまま満たしている。他の NeNe 製品へ同種の検査を広げるかは、誤検知率を当リポジトリで観測してから別 Issue で判断する。

## CHANGELOG を更新しない理由

`tools/` の内部ツールとドキュメントのみの変更で、公開ライブラリ API の振る舞いは不変。`CLAUDE.md` の CHANGELOG 記述規約（「利用者に影響する変更だけを書く」）に照らして追記対象外と判断した。

## 検証結果

```
docker compose run --rm app composer install   # bump 済み lock へ vendor を同期
docker compose run --rm app composer check
```

- **test**: `OK (881 tests, 2157 assertions)`（新規 7 tests / 15 assertions を含む）
- **analyse**: PHPStan level 8 `[OK] No errors`（334 files）
- **cs**: PHP-CS-Fixer 3.95.17 `Found 0 of 336 files that can be fixed`
- **openapi**: `OpenAPI contract is valid.`
- **mcp**: `MCP tool catalog is valid.`
- **conformance**: `Conformance OK — no findings (4 suppressed by baseline/ignore)`
- **version:check**: `Version consistency OK: 1.11.0`
- `git diff --check` = クリーン

ドリフトを実際に捕まえることの確認（README 修正前）:

```
Version consistency error: README.md:20 claims current version '1.10.0' but FrameworkInfo::VERSION is '1.11.0'.
Script php tools/validate-version.php handling the version:check event returned with error code 1
```

新規テスト `tests/Tools/ValidateVersionTest.php` が押さえている挙動:

| テスト | 内容 |
|---|---|
| `testPassesWhenReadmeClaimsTheCurrentVersion` | 一致していれば緑 |
| `testFailsWhenReadmeClaimsAnOlderVersion` | #1623 そのものの回帰（行番号・両方の版をメッセージで確認） |
| `testIgnoresHistoricalVersionReferencesWithoutACurrentClaim` | `v0.1.1` フォーク・"since v1.6.0" で誤検知しない |
| `testReportsEveryDriftedClaimOnALineAtOnce` | 1行に複数主張があれば全部報告 |
| `testPassesWhenTheProjectHasNoReadme` | README 不在で落ちない |
| `testStillFailsOnChangelogDriftWithACleanReadme` | README 検査が既存検査を覆い隠していない |
| `testRejectsUnknownArguments` | `--root` 追加で引数解析を壊していない（exit 2） |

## Self-review

`docs-policy`, `release-ci`

- `docs-policy`: 正本（`quality-tools.md`）を直し、`release-checklist.md` からはそこを参照する形にして規約本文の重複を避けた。英語ポリシー適用対象（`docs/development/`・README）はすべて英語。ADR は不要と判断（内部ツールの検査対象追加であって、アーキテクチャ・公開契約・依存の決定ではない）。`current.md` の状態更新は別レーンで実施する（本 PR のスコープ外・指揮と合意済み）。
- `release-ci`: ワークフローの変更なし。`composer check` に既に組み込まれている `version:check` の検査対象が増えるだけで、CI の必須化条件は変わらない。ローカル Docker での実行を先に確認してから push している。

## 残リスク

- 検出はヒューリスティック（`current`/`latest` を含む行）なので、README の書き方によっては見逃す。例えば表のセルで「| Version | v1.10.0 |」とだけ書いた場合は検出できない。現在の README にそのような書き方は無く、狭く外す方を選んだ（誤検知でリリースを止める方が害が大きい）。
- 逆方向の誤検知としては「latest Node.js 24.1.0」のような**版以外の**バージョン表記が `current`/`latest` を含む行に載った場合がありうる。現 README には該当箇所が無いが、将来出たら行の書き換えかスクリプト側の除外で対処する。
