### PR TITLE
docs(i18n): 陳腐化訳バッチ1（15 pair）を更新し baseline の部分再記録を追加する (#1628)

### DIFF
--- a/docs/de/howto/add-health-check.md
+++ b/docs/de/howto/add-health-check.md
@@ -26,14 +26,21 @@ Wenn Sie `HealthCheckInterface`-Implementierungen registrieren, fügt der Endpun
 
 ```php
 use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 
 final class CacheHealthCheck implements HealthCheckInterface
 {
+    // Der Rückgabewert von name() wird zum Schlüssel in der "checks"-Map.
     public function name(): string { return 'cache'; }
-    public function check(): bool { return $this->ping(); }
-    private function ping(): bool { return true; }
+
+    public function check(): HealthStatus
+    {
+        return $this->ping() ? HealthStatus::Ok : HealthStatus::Error;
+    }
+
+    private function ping(): bool { /* ... */ return true; }
 }
 
 $psr17 = new Psr17Factory();
@@ -96,7 +103,7 @@ $app = (new RuntimeApplicationFactory(
 
 ## Ausnahmen in Checks behandeln
 
-Wenn `check()` eine Ausnahme wirft, behandelt das Framework sie als `false` — der Status wird zu `"degraded"`,
+Wenn `check()` eine Ausnahme wirft, behandelt das Framework sie wie die Rückgabe von `HealthStatus::Error` — der Status wird zu `"degraded"`,
 der Check zeigt `"error"`. Sie müssen keine Ausnahmen innerhalb von `check()` abfangen.
 
 ---

--- a/docs/de/howto/add-rate-limiting.md
+++ b/docs/de/howto/add-rate-limiting.md
@@ -7,10 +7,23 @@ indem Sie `ThrottleMiddleware` und `RateLimitStorageInterface` verwenden.
 
 ---
 
+## Produktionsanforderung — gemeinsamer Speicher
+
+> **Warnung**: `InMemoryRateLimitStorage` (unten im Schnellstart gezeigt) ist **nicht für den
+> Produktionsbetrieb geeignet**. PHP-FPM startet mehrere Worker-Prozesse, und jeder Prozess hat
+> seinen eigenen In-Memory-Speicher. Ein Client, der gleichzeitig 10 Worker trifft, wird pro
+> Worker nur einmal gezählt — das Limit wird damit faktisch umgangen. Verwenden Sie in jedem
+> Mehrprozess- oder Mehrserver-Deployment ein gemeinsames Speicher-Backend (Redis, Memcached
+> oder eine Datenbank).
+>
+> Eine Redis-Implementierung finden Sie unter [Speicher-Backend austauschen](#speicher-backend-austauschen).
+
+---
+
 ## Schnellstart
 
 Fügen Sie `ThrottleMiddleware` zu `RuntimeApplicationFactory` hinzu. Der eingebaute `InMemoryRateLimitStorage`
-ist für lokale Entwicklung und Einzelprozess-Deployments geeignet.
+ist nur für lokale Entwicklung und Einzelprozess-Tests geeignet.
 
 ```php
 use Nene2\Error\ProblemDetailsResponseFactory;

--- a/docs/de/reference/environment-variables.md
+++ b/docs/de/reference/environment-variables.md
@@ -17,7 +17,8 @@ Setzen Sie diese in `.env` (von phpdotenv geladen) oder exportieren Sie sie vor 
 | Variable | Typ | Standard | Beschreibung |
 |---|---|---|---|
 | `NENE2_MACHINE_API_KEY` | string | *(leer — deaktiviert)* | API-Schlüssel, der im `X-NENE2-API-Key`-Header für Machine-Client-Endpunkte erwartet wird. Leer lassen, um den Machine-Key-Pfad zu deaktivieren. |
-| `NENE2_LOCAL_JWT_SECRET` | string | *(leer — deaktiviert)* | HMAC-HS256-Geheimnis zum Schutz der Schreibwerkzeuge des lokalen MCP-Servers. Leer lassen für Lesezugriff ohne Authentifizierung. |
+| `NENE2_LOCAL_JWT_SECRET` | string | *(leer — deaktiviert)* | HMAC-HS256-Geheimnis, das `LocalBearerTokenVerifier` verwendet. Aktiviert die Bearer-JWT-Prüfung für `GET /examples/protected` und schützt die Schreibwerkzeuge des lokalen MCP-Servers. Leer lassen, um die JWT-Authentifizierung zu deaktivieren und nur lesenden MCP-Zugriff zuzulassen. Bei Auflösung über `Nene2\Auth\GuardedJwtSecretResolver` schlägt ein leerer Wert fail-closed fehl, sofern nicht der unten stehende Entwicklungs-Opt-in gesetzt ist (niemals in der Produktion). |
+| `NENE2_ALLOW_DEV_SECRET` | boolean (strikt) | `false` | Entwicklungs-Opt-in, das `Nene2\Auth\GuardedJwtSecretResolver` liest (verfügbar als `AppConfig::$allowDevSecret`). Akzeptiert **nur** `1`, `true` oder `yes` (Groß-/Kleinschreibung egal, getrimmt); jeder andere Wert — auch ein Tippfehler — bedeutet Opt-out. Wenn `NENE2_LOCAL_JWT_SECRET` in einer `local`/`test`-Umgebung nicht gesetzt ist, erlaubt dies das vom Produkt injizierte Entwicklungsgeheimnis. **In der Produktion ignoriert** — dort wird immer fail-closed abgebrochen. Siehe [ADR 0013](../adr/0013-guarded-jwt-secret-resolution.md). |
 
 ## Lokaler MCP-Server
 
@@ -30,13 +31,14 @@ Setzen Sie diese in `.env` (von phpdotenv geladen) oder exportieren Sie sie vor 
 | Variable | Typ | Standard | Beschreibung |
 |---|---|---|---|
 | `DATABASE_URL` | string | *(leer — verwendet `DB_*`)* | Vollständige Datenbankverbindungs-URL. Wenn nicht leer, überschreibt alle `DB_*`-Variablen. |
-| `DB_ADAPTER` | string | `mysql` | Datenbanktreiber. Gültig: `sqlite`, `mysql`. |
-| `DB_HOST` | string | `127.0.0.1` | Datenbankhost. **Nicht verwendet von SQLite.** |
+| `DB_ADAPTER` | string | `mysql` | Datenbanktreiber. Gültig: `sqlite`, `mysql`, `pgsql` (experimentell — siehe [PostgreSQL verwenden](../howto/use-postgresql.md)). |
+| `DB_HOST` | string | `127.0.0.1` | Datenbankhost. **Nicht verwendet von SQLite.** Innerhalb von Docker Compose überschreibt `compose.yaml` diesen Wert für den `app`-Dienst mit `mysql`. |
 | `DB_PORT` | integer | `3306` | Datenbankport (1–65535). **Nicht validiert für SQLite.** |
 | `DB_NAME` | string | `nene2` | Datenbankname. Bei SQLite: Dateipfad (z. B. `/tmp/myapp.sqlite`). |
 | `DB_USER` | string | `nene2` | Datenbankbenutzername. **Nicht verwendet von SQLite.** |
 | `DB_PASSWORD` | string | *(leer)* | Datenbankpasswort. |
 | `DB_CHARSET` | string | `utf8mb4` | Datenbankzeichensatz. **Nicht verwendet von SQLite.** |
+| `DB_ENV` | string | `local` | Name der Phinx-Migrationsumgebung (siehe `phinx.php`). |
 
 
 ### SQLite-Adapter

--- a/docs/development/quality-tools.md
+++ b/docs/development/quality-tools.md
@@ -135,9 +135,16 @@ Prose-only edits are a warning on purpose: making one typo fix in English block 
 
 After updating a translation, run `composer i18n:baseline` to re-record it. That rewrite is an explicit, reviewable diff — it cannot quietly erase a finding.
 
+A plain rewrite covers every pair, which is wrong while a burn-down is in progress: it would also bless the documents that PR never touched. Narrow it to what you actually updated:
+
+```bash
+php tools/i18n-freshness.php --write-baseline \
+  --only=howto/add-health-check.md --only=reference/environment-variables.md
+```
+
 Comparing commit dates instead of hashes does not work here. Measured on this repository it flagged 248 of 273 `ja` pairs, and 245 of those came from two bulk commits that added frontmatter to every guide without touching any prose.
 
-> **Current state: 52 of 1,355 pairs are `stale-structure`** across 12 documents (all five locales for ten of them). These are known and are being updated document by document; see issue #1628. `composer i18n:check` is therefore **not yet part of `composer check`** — it is wired into the standard check path only once that backlog is clear, so the gate starts from a green baseline rather than a permanently red one.
+> **Current state: 37 of 1,355 pairs are `stale-structure`** across 9 documents (started at 52 across 12). These are known and are being updated batch by batch; see issue #1628. `composer i18n:check` is therefore **not yet part of `composer check`** — it is wired into the standard check path only once that backlog is clear, so the gate starts from a green baseline rather than a permanently red one.
 
 `docs/development/` and `docs/integrations/` are English-only by policy (see `language-policy.md`) and are not in scope; walking every English file blindly would report 43 phantom omissions per locale. Scope, locales, and exclusions live in the baseline file as data so that changing them is a reviewable diff.
 

--- a/docs/fr/howto/add-health-check.md
+++ b/docs/fr/howto/add-health-check.md
@@ -26,14 +26,21 @@ Lorsque vous enregistrez des implémentations de `HealthCheckInterface`, l'endpo
 
 ```php
 use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 
 final class CacheHealthCheck implements HealthCheckInterface
 {
+    // La valeur retournée par name() devient la clé dans la map "checks".
     public function name(): string { return 'cache'; }
-    public function check(): bool { return $this->ping(); }
-    private function ping(): bool { return true; }
+
+    public function check(): HealthStatus
+    {
+        return $this->ping() ? HealthStatus::Ok : HealthStatus::Error;
+    }
+
+    private function ping(): bool { /* ... */ return true; }
 }
 
 $psr17 = new Psr17Factory();

--- a/docs/fr/howto/add-rate-limiting.md
+++ b/docs/fr/howto/add-rate-limiting.md
@@ -7,10 +7,23 @@ en utilisant `ThrottleMiddleware` et `RateLimitStorageInterface`.
 
 ---
 
+## Exigence de production — stockage partagé
+
+> **Avertissement** : `InMemoryRateLimitStorage` (utilisé dans le démarrage rapide ci-dessous)
+> **ne convient pas à la production**. PHP-FPM lance plusieurs processus worker, et chaque
+> processus possède son propre stockage en mémoire. Un client qui atteint 10 workers
+> simultanément ne sera compté qu'une fois par worker — contournant de fait la limite.
+> Utilisez un backend de stockage partagé (Redis, Memcached ou une base de données) dans
+> tout déploiement multi-processus ou multi-serveur.
+>
+> Voir [Remplacer le backend de stockage](#remplacer-le-backend-de-stockage) pour une implémentation Redis.
+
+---
+
 ## Démarrage rapide
 
 Ajoutez `ThrottleMiddleware` à `RuntimeApplicationFactory`. Le `InMemoryRateLimitStorage` intégré
-convient au développement local et aux déploiements mono-processus.
+convient uniquement au développement local et aux tests mono-processus.
 
 ```php
 use Nene2\Error\ProblemDetailsResponseFactory;

--- a/docs/fr/reference/environment-variables.md
+++ b/docs/fr/reference/environment-variables.md
@@ -17,7 +17,8 @@ Définissez-les dans `.env` (chargé par phpdotenv) ou exportez-les avant de dé
 | Variable | Type | Défaut | Description |
 |---|---|---|---|
 | `NENE2_MACHINE_API_KEY` | string | *(vide — désactivé)* | Clé API attendue dans l'en-tête `X-NENE2-API-Key` pour les endpoints machine. Laissez vide pour désactiver. |
-| `NENE2_LOCAL_JWT_SECRET` | string | *(vide — désactivé)* | Secret HMAC-HS256 pour protéger les outils d'écriture du serveur MCP local. Laissez vide pour un accès en lecture seule sans authentification. |
+| `NENE2_LOCAL_JWT_SECRET` | string | *(vide — désactivé)* | Secret HMAC-HS256 utilisé par `LocalBearerTokenVerifier`. Active la validation du JWT Bearer pour `GET /examples/protected` et protège les outils d'écriture du serveur MCP local. Laissez vide pour désactiver l'authentification JWT et n'autoriser que l'accès MCP en lecture seule. Lorsqu'il est résolu via `Nene2\Auth\GuardedJwtSecretResolver`, une valeur vide échoue en fail-closed sauf si l'opt-in de secret de développement ci-dessous est défini (jamais en production). |
+| `NENE2_ALLOW_DEV_SECRET` | boolean (strict) | `false` | Opt-in de secret de développement lu par `Nene2\Auth\GuardedJwtSecretResolver` (exposé via `AppConfig::$allowDevSecret`). Accepte **uniquement** `1`, `true` ou `yes` (insensible à la casse, espaces retirés) ; toute autre valeur — y compris une faute de frappe — vaut opt-out. Lorsque `NENE2_LOCAL_JWT_SECRET` n'est pas défini dans un environnement `local`/`test`, ceci autorise le secret de développement injecté par le produit. **Ignoré en production** — la production échoue toujours en fail-closed. Voir [ADR 0013](../adr/0013-guarded-jwt-secret-resolution.md). |
 
 ## Serveur MCP local
 
@@ -30,13 +31,14 @@ Définissez-les dans `.env` (chargé par phpdotenv) ou exportez-les avant de dé
 | Variable | Type | Défaut | Description |
 |---|---|---|---|
 | `DATABASE_URL` | string | *(vide — utilise `DB_*`)* | URL de connexion complète. Si non vide, remplace toutes les variables `DB_*` individuelles. |
-| `DB_ADAPTER` | string | `mysql` | Pilote de base de données. Accepté : `sqlite`, `mysql`. |
-| `DB_HOST` | string | `127.0.0.1` | Hôte de la base de données. **Non utilisé par SQLite.** |
+| `DB_ADAPTER` | string | `mysql` | Pilote de base de données. Accepté : `sqlite`, `mysql`, `pgsql` (expérimental — voir [Utiliser PostgreSQL](../howto/use-postgresql.md)). |
+| `DB_HOST` | string | `127.0.0.1` | Hôte de la base de données. **Non utilisé par SQLite.** Dans Docker Compose, `compose.yaml` remplace cette valeur par `mysql` pour le service `app`. |
 | `DB_PORT` | integer | `3306` | Port de la base de données (1–65535). **Non validé pour SQLite.** |
 | `DB_NAME` | string | `nene2` | Nom de la base de données. Pour SQLite : chemin du fichier (ex. `/tmp/myapp.sqlite`). |
 | `DB_USER` | string | `nene2` | Nom d'utilisateur de la base de données. **Non utilisé par SQLite.** |
 | `DB_PASSWORD` | string | *(vide)* | Mot de passe de la base de données. |
 | `DB_CHARSET` | string | `utf8mb4` | Jeu de caractères de la base de données. **Non utilisé par SQLite.** |
+| `DB_ENV` | string | `local` | Nom de l'environnement de migration Phinx (voir `phinx.php`). |
 
 
 ### Adaptateur SQLite

--- a/docs/howto/add-health-check.md
+++ b/docs/howto/add-health-check.md
@@ -144,8 +144,8 @@ Response when database is healthy but cache is degraded:
 ## Handle exceptions in checks
 
 If your `check()` method throws an exception, `RuntimeApplicationFactory` treats it the same
-as returning `false` — the status becomes `"degraded"` and the check shows `"error"`. You do
-not need to catch exceptions inside `check()`.
+as returning `HealthStatus::Error` — the status becomes `"degraded"` and the check shows
+`"error"`. You do not need to catch exceptions inside `check()`.
 
 ---
 

--- a/docs/ja/howto/add-health-check.md
+++ b/docs/ja/howto/add-health-check.md
@@ -27,17 +27,18 @@
 
 ```php
 use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 
 final class CacheHealthCheck implements HealthCheckInterface
 {
+    // name() の戻り値が "checks" マップのキーになります。
     public function name(): string { return 'cache'; }
 
-    public function check(): bool
+    public function check(): HealthStatus
     {
-        // true = 正常、false = 異常
-        return $this->ping();
+        return $this->ping() ? HealthStatus::Ok : HealthStatus::Error;
     }
 
     private function ping(): bool { /* ... */ return true; }
@@ -90,7 +91,7 @@ $app = (new RuntimeApplicationFactory(
 ))->create();
 ```
 
-このチェックは `SELECT 1` を実行し、成功すれば `true`、例外があれば `false` を返します。
+このチェックは `SELECT 1` を実行し、成功すれば `HealthStatus::Ok`、例外があれば `HealthStatus::Error` を返します。
 
 > **注意**: `DatabaseHealthCheck` は `src/Example/` にあり、参照実装です（安定 API 保証外）。
 > アプリケーションにコピーして用途に合わせて適応させてください。
@@ -132,7 +133,7 @@ $app = (new RuntimeApplicationFactory(
 
 ## チェック内の例外処理
 
-`check()` メソッドが例外をスローした場合、`RuntimeApplicationFactory` は `false` を返した場合と同様に扱います。ステータスは `"degraded"` になり、チェックは `"error"` を表示します。`check()` 内で例外をキャッチする必要はありません。
+`check()` メソッドが例外をスローした場合、`RuntimeApplicationFactory` は `HealthStatus::Error` を返した場合と同様に扱います。ステータスは `"degraded"` になり、チェックは `"error"` を表示します。`check()` 内で例外をキャッチする必要はありません。
 
 ---
 

--- a/docs/ja/howto/add-rate-limiting.md
+++ b/docs/ja/howto/add-rate-limiting.md
@@ -6,9 +6,21 @@
 
 ---
 
+## 本番環境の要件 — 共有ストレージ
+
+> **警告**: 以下のクイックスタートで使う `InMemoryRateLimitStorage` は**本番環境には適していません**。
+> PHP-FPM は複数のワーカープロセスを起動し、各プロセスが独自のインメモリストアを持ちます。
+> 10 個のワーカーに同時に到達したクライアントはワーカーごとに1回ずつしか数えられず、
+> 実質的に制限を回避できてしまいます。マルチプロセス／マルチサーバー構成では
+> 共有ストレージバックエンド（Redis・Memcached・データベース）を使ってください。
+>
+> Redis 実装は [ストレージバックエンドを交換する](#ストレージバックエンドを交換する) を参照してください。
+
+---
+
 ## クイックスタート
 
-`RuntimeApplicationFactory` に `ThrottleMiddleware` を追加します。組み込みの `InMemoryRateLimitStorage` はローカル開発とシングルプロセス環境に適しています。
+`RuntimeApplicationFactory` に `ThrottleMiddleware` を追加します。組み込みの `InMemoryRateLimitStorage` はローカル開発とシングルプロセスでの検証にのみ適しています。
 
 ```php
 use Nene2\Error\ProblemDetailsResponseFactory;

--- a/docs/ja/reference/environment-variables.md
+++ b/docs/ja/reference/environment-variables.md
@@ -17,7 +17,8 @@ NENE2 が認識するすべての環境変数です。
 | 変数 | 型 | デフォルト | 説明 |
 |---|---|---|---|
 | `NENE2_MACHINE_API_KEY` | string | *(空 — 無効)* | マシンクライアントエンドポイントの `X-NENE2-API-Key` ヘッダーに期待される API キー。空にするとマシンキーパスが無効になります。 |
-| `NENE2_LOCAL_JWT_SECRET` | string | *(空 — 無効)* | ローカル MCP サーバーの書き込みツールを保護する HMAC-HS256 シークレット。空にすると読み取り専用ツールは認証なしで利用可能です。 |
+| `NENE2_LOCAL_JWT_SECRET` | string | *(空 — 無効)* | `LocalBearerTokenVerifier` が使う HMAC-HS256 シークレット。`GET /examples/protected` の Bearer JWT 検証を有効にし、ローカル MCP サーバーの書き込みツールを保護します。空にすると JWT 認証は無効になり、読み取り専用の MCP アクセスのみになります。`Nene2\Auth\GuardedJwtSecretResolver` 経由で解決する場合、下記の開発用シークレット opt-in が設定されていない限り空値は fail closed になります（本番では決して許可されません）。 |
+| `NENE2_ALLOW_DEV_SECRET` | boolean（厳格） | `false` | `Nene2\Auth\GuardedJwtSecretResolver` が読む開発用シークレットの opt-in（`AppConfig::$allowDevSecret` として公開）。有効な値は `1` / `true` / `yes` **のみ**（大文字小文字は区別せず前後の空白は除去）。それ以外の値は — タイプミスを含めて — すべて opt-out として扱われます。`local` / `test` 環境で `NENE2_LOCAL_JWT_SECRET` が未設定のとき、製品側が注入した開発用シークレットの使用を許可します。**本番では無視され**、常に fail closed になります。[ADR 0013](../adr/0013-guarded-jwt-secret-resolution.md) を参照。 |
 
 ## ローカル MCP サーバー
 
@@ -30,13 +31,14 @@ NENE2 が認識するすべての環境変数です。
 | 変数 | 型 | デフォルト | 説明 |
 |---|---|---|---|
 | `DATABASE_URL` | string | *(空 — `DB_*` を使用)* | データベース接続 URL。空でない場合は個別の `DB_*` 変数をすべて上書きします。 |
-| `DB_ADAPTER` | string | `mysql` | データベースドライバー。使用可能な値: `sqlite`, `mysql`。 |
-| `DB_HOST` | string | `127.0.0.1` | データベースホスト名または IP アドレス。**SQLite では使用されません。** |
+| `DB_ADAPTER` | string | `mysql` | データベースドライバー。使用可能な値: `sqlite`, `mysql`, `pgsql`（実験的 — [PostgreSQL を使う](../howto/use-postgresql.md) を参照）。 |
+| `DB_HOST` | string | `127.0.0.1` | データベースホスト名または IP アドレス。**SQLite では使用されません。** Docker Compose 内では `compose.yaml` が `app` サービス向けに `mysql` へ上書きします。 |
 | `DB_PORT` | integer | `3306` | データベースポート番号（1〜65535）。**SQLite ではバリデーションされません。** |
 | `DB_NAME` | string | `nene2` | データベース名。SQLite の場合はファイルパス（例: `/tmp/myapp.sqlite`）を設定します。 |
 | `DB_USER` | string | `nene2` | データベースユーザー名。**SQLite では使用されません。** |
 | `DB_PASSWORD` | string | *(空)* | データベースパスワード。 |
 | `DB_CHARSET` | string | `utf8mb4` | データベース文字セット。**SQLite では使用されません。** |
+| `DB_ENV` | string | `local` | Phinx マイグレーションの環境名（`phinx.php` を参照）。 |
 
 
 ### SQLite アダプター

--- a/docs/pt-br/howto/add-health-check.md
+++ b/docs/pt-br/howto/add-health-check.md
@@ -26,14 +26,21 @@ Quando você registra implementações de `HealthCheckInterface`, o endpoint adi
 
 ```php
 use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 
 final class CacheHealthCheck implements HealthCheckInterface
 {
+    // O valor retornado por name() vira a chave no mapa "checks".
     public function name(): string { return 'cache'; }
-    public function check(): bool { return $this->ping(); }
-    private function ping(): bool { return true; }
+
+    public function check(): HealthStatus
+    {
+        return $this->ping() ? HealthStatus::Ok : HealthStatus::Error;
+    }
+
+    private function ping(): bool { /* ... */ return true; }
 }
 
 $psr17 = new Psr17Factory();

--- a/docs/pt-br/howto/add-rate-limiting.md
+++ b/docs/pt-br/howto/add-rate-limiting.md
@@ -7,10 +7,23 @@ Este guia mostra como proteger sua aplicação NENE2 com limitação de taxa de 
 
 ---
 
+## Requisito de produção — armazenamento compartilhado
+
+> **Aviso**: `InMemoryRateLimitStorage` (usado no início rápido abaixo) **não é adequado para
+> produção**. O PHP-FPM inicia vários processos worker, e cada processo tem seu próprio
+> armazenamento em memória. Um cliente que atinge 10 workers simultaneamente será contado
+> apenas uma vez por worker — contornando o limite na prática. Use um backend de
+> armazenamento compartilhado (Redis, Memcached ou um banco de dados) em qualquer
+> implantação multiprocesso ou multiservidor.
+>
+> Veja [Trocar o backend de armazenamento](#trocar-o-backend-de-armazenamento) para uma implementação com Redis.
+
+---
+
 ## Início rápido
 
 Adicione `ThrottleMiddleware` ao `RuntimeApplicationFactory`. O `InMemoryRateLimitStorage` embutido
-é adequado para desenvolvimento local e implantações de processo único.
+é adequado apenas para desenvolvimento local e testes de processo único.
 
 ```php
 use Nene2\Error\ProblemDetailsResponseFactory;

--- a/docs/pt-br/reference/environment-variables.md
+++ b/docs/pt-br/reference/environment-variables.md
@@ -17,7 +17,8 @@ Defina-as no arquivo `.env` (carregado pelo phpdotenv) ou exporte-as antes de in
 | Variável | Tipo | Padrão | Descrição |
 |---|---|---|---|
 | `NENE2_MACHINE_API_KEY` | string | *(vazio — desativado)* | Chave API esperada no cabeçalho `X-NENE2-API-Key` para endpoints de cliente máquina. Deixe vazio para desativar. |
-| `NENE2_LOCAL_JWT_SECRET` | string | *(vazio — desativado)* | Segredo HMAC-HS256 para proteger as ferramentas de escrita do servidor MCP local. Deixe vazio para acesso somente leitura sem autenticação. |
+| `NENE2_LOCAL_JWT_SECRET` | string | *(vazio — desativado)* | Segredo HMAC-HS256 usado por `LocalBearerTokenVerifier`. Habilita a validação de JWT Bearer para `GET /examples/protected` e protege as ferramentas de escrita do servidor MCP local. Deixe vazio para desabilitar a autenticação JWT e permitir apenas acesso MCP somente leitura. Quando resolvido por `Nene2\Auth\GuardedJwtSecretResolver`, um valor vazio falha em fail-closed a menos que o opt-in de segredo de desenvolvimento abaixo esteja definido (nunca em produção). |
+| `NENE2_ALLOW_DEV_SECRET` | boolean (estrito) | `false` | Opt-in de segredo de desenvolvimento lido por `Nene2\Auth\GuardedJwtSecretResolver` (exposto como `AppConfig::$allowDevSecret`). Aceita **apenas** `1`, `true` ou `yes` (sem distinção de maiúsculas, com espaços removidos); qualquer outro valor — inclusive um erro de digitação — significa desativado. Quando `NENE2_LOCAL_JWT_SECRET` não está definido em um ambiente `local`/`test`, isto permite o segredo de desenvolvimento injetado pelo produto. **Ignorado em produção** — produção sempre falha em fail-closed. Veja [ADR 0013](../adr/0013-guarded-jwt-secret-resolution.md). |
 
 ## Servidor MCP local
 
@@ -30,13 +31,14 @@ Defina-as no arquivo `.env` (carregado pelo phpdotenv) ou exporte-as antes de in
 | Variável | Tipo | Padrão | Descrição |
 |---|---|---|---|
 | `DATABASE_URL` | string | *(vazio — usa `DB_*`)* | URL completa de conexão. Quando não vazia, substitui todas as variáveis `DB_*`. |
-| `DB_ADAPTER` | string | `mysql` | Driver do banco de dados. Aceito: `sqlite`, `mysql`. |
-| `DB_HOST` | string | `127.0.0.1` | Host do banco de dados. **Não usado pelo SQLite.** |
+| `DB_ADAPTER` | string | `mysql` | Driver do banco de dados. Aceito: `sqlite`, `mysql`, `pgsql` (experimental — veja [Usar PostgreSQL](../howto/use-postgresql.md)). |
+| `DB_HOST` | string | `127.0.0.1` | Host do banco de dados. **Não usado pelo SQLite.** Dentro do Docker Compose, `compose.yaml` sobrescreve este valor para `mysql` no serviço `app`. |
 | `DB_PORT` | integer | `3306` | Porta do banco de dados (1–65535). **Não validado para SQLite.** |
 | `DB_NAME` | string | `nene2` | Nome do banco de dados. Para SQLite: caminho do arquivo (ex.: `/tmp/myapp.sqlite`). |
 | `DB_USER` | string | `nene2` | Usuário do banco de dados. **Não usado pelo SQLite.** |
 | `DB_PASSWORD` | string | *(vazio)* | Senha do banco de dados. |
 | `DB_CHARSET` | string | `utf8mb4` | Conjunto de caracteres do banco de dados. **Não usado pelo SQLite.** |
+| `DB_ENV` | string | `local` | Nome do ambiente de migração do Phinx (veja `phinx.php`). |
 
 
 ### Adaptador SQLite

--- a/docs/zh/howto/add-health-check.md
+++ b/docs/zh/howto/add-health-check.md
@@ -25,14 +25,21 @@
 
 ```php
 use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 
 final class CacheHealthCheck implements HealthCheckInterface
 {
+    // name() 的返回值将成为 "checks" 映射中的键。
     public function name(): string { return 'cache'; }
-    public function check(): bool { return $this->ping(); }
-    private function ping(): bool { return true; }
+
+    public function check(): HealthStatus
+    {
+        return $this->ping() ? HealthStatus::Ok : HealthStatus::Error;
+    }
+
+    private function ping(): bool { /* ... */ return true; }
 }
 
 $psr17 = new Psr17Factory();

--- a/docs/zh/howto/add-rate-limiting.md
+++ b/docs/zh/howto/add-rate-limiting.md
@@ -6,10 +6,21 @@
 
 ---
 
+## 生产环境要求 — 共享存储
+
+> **警告**：下面快速开始中使用的 `InMemoryRateLimitStorage` **不适用于生产环境**。
+> PHP-FPM 会启动多个 worker 进程，每个进程都有自己独立的内存存储。
+> 同时命中 10 个 worker 的客户端在每个 worker 中只会被计数一次——实际上绕过了限制。
+> 在任何多进程或多服务器部署中，请使用共享存储后端（Redis、Memcached 或数据库）。
+>
+> Redis 实现请参见[更换存储后端](#更换存储后端)。
+
+---
+
 ## 快速开始
 
 将 `ThrottleMiddleware` 添加到 `RuntimeApplicationFactory`。内置的 `InMemoryRateLimitStorage`
-适用于本地开发和单进程部署。
+仅适用于本地开发和单进程测试。
 
 ```php
 use Nene2\Error\ProblemDetailsResponseFactory;

--- a/docs/zh/reference/environment-variables.md
+++ b/docs/zh/reference/environment-variables.md
@@ -17,7 +17,8 @@ NENE2 识别的所有环境变量。
 | 变量 | 类型 | 默认值 | 说明 |
 |---|---|---|---|
 | `NENE2_MACHINE_API_KEY` | string | *(空 — 禁用)* | 机器客户端端点 `X-NENE2-API-Key` 请求头所需的 API 密钥。留空则禁用机器密钥路径。 |
-| `NENE2_LOCAL_JWT_SECRET` | string | *(空 — 禁用)* | 本地 MCP 服务器用于保护写工具的 HMAC-HS256 密钥。留空则只读工具无需认证。 |
+| `NENE2_LOCAL_JWT_SECRET` | string | *(空 — 禁用)* | `LocalBearerTokenVerifier` 使用的 HMAC-HS256 密钥。启用 `GET /examples/protected` 的 Bearer JWT 校验，并保护本地 MCP 服务器的写工具。留空则禁用 JWT 认证，仅允许只读 MCP 访问。通过 `Nene2\Auth\GuardedJwtSecretResolver` 解析时，除非设置了下面的开发密钥 opt-in，否则空值会 fail closed（生产环境绝不允许）。 |
+| `NENE2_ALLOW_DEV_SECRET` | boolean（严格） | `false` | `Nene2\Auth\GuardedJwtSecretResolver` 读取的开发密钥 opt-in（通过 `AppConfig::$allowDevSecret` 暴露）。**仅**接受 `1`、`true` 或 `yes`（不区分大小写、去除首尾空白）；任何其他值——包括拼写错误——都视为未启用。当 `local`/`test` 环境中未设置 `NENE2_LOCAL_JWT_SECRET` 时，此项允许使用产品注入的开发密钥。**在生产环境中被忽略**——生产环境始终 fail closed。参见 [ADR 0013](../adr/0013-guarded-jwt-secret-resolution.md)。 |
 
 ## 本地 MCP 服务器
 
@@ -30,13 +31,14 @@ NENE2 识别的所有环境变量。
 | 变量 | 类型 | 默认值 | 说明 |
 |---|---|---|---|
 | `DATABASE_URL` | string | *(空 — 使用 `DB_*`)* | 完整数据库连接 URL。非空时覆盖所有 `DB_*` 变量。 |
-| `DB_ADAPTER` | string | `mysql` | 数据库驱动。可选值：`sqlite`、`mysql`。 |
-| `DB_HOST` | string | `127.0.0.1` | 数据库主机名或 IP。**SQLite 不使用此字段。** |
+| `DB_ADAPTER` | string | `mysql` | 数据库驱动。可选值：`sqlite`、`mysql`、`pgsql`（实验性——参见[使用 PostgreSQL](../howto/use-postgresql.md)）。 |
+| `DB_HOST` | string | `127.0.0.1` | 数据库主机名或 IP。**SQLite 不使用此字段。** 在 Docker Compose 中，`compose.yaml` 会为 `app` 服务将其覆盖为 `mysql`。 |
 | `DB_PORT` | integer | `3306` | 数据库端口（1–65535）。**SQLite 不验证此字段。** |
 | `DB_NAME` | string | `nene2` | 数据库名称。SQLite 时填写文件路径（如 `/tmp/myapp.sqlite`）。 |
 | `DB_USER` | string | `nene2` | 数据库用户名。**SQLite 不使用此字段。** |
 | `DB_PASSWORD` | string | *(空)* | 数据库密码。 |
 | `DB_CHARSET` | string | `utf8mb4` | 数据库字符集。**SQLite 不使用此字段。** |
+| `DB_ENV` | string | `local` | Phinx 迁移环境名称（参见 `phinx.php`）。 |
 
 
 ### SQLite 适配器

--- a/tests/Tools/I18nFreshnessTest.php
+++ b/tests/Tools/I18nFreshnessTest.php
@@ -203,6 +203,38 @@ final class I18nFreshnessTest extends TestCase
         self::assertStringContainsString('needs a working git', $out);
     }
 
+    public function testOnlyRestrictsTheRewriteToTheNamedDocument(): void
+    {
+        // A staged burn-down updates one document at a time. Without --only the
+        // rewrite would bless the documents that PR never touched.
+        $this->writeGuide('howto/add-tag.md', "# Add a tag\n\n```php\nold();\n```\n");
+        $this->writeGuide('howto/add-note.md', "# Add a note\n\n```php\nold();\n```\n");
+        $this->writeTranslations('howto/add-tag.md', "# タグを追加する\n");
+        $this->writeTranslations('howto/add-note.md', "# ノートを追加する\n");
+        $this->seedBaseline();
+
+        $this->write('docs/howto/add-tag.md', "# Add a tag\n\n```php\nfixed();\n```\n");
+        $this->write('docs/howto/add-note.md', "# Add a note\n\n```php\nalsoChanged();\n```\n");
+
+        [$code, $out] = $this->runScript('--write-baseline', '--only=howto/add-tag.md');
+        self::assertSame(0, $code, $out);
+        self::assertStringContainsString('updated for 1 document(s)', $out);
+
+        [$code, $out] = $this->check();
+
+        self::assertSame(1, $code, $out);
+        self::assertStringNotContainsString('add-tag.md', $out);
+        self::assertStringContainsString('add-note.md', $out);
+    }
+
+    public function testOnlyWithoutWriteBaselineIsAUsageError(): void
+    {
+        [$code, $out] = $this->runScript('--only=howto/add-tag.md');
+
+        self::assertSame(2, $code, $out);
+        self::assertStringContainsString('--only only applies', $out);
+    }
+
     public function testRejectsUnknownArguments(): void
     {
         [$code, $out] = $this->runScript('--unknown');

--- a/tools/i18n-freshness.php
+++ b/tools/i18n-freshness.php
@@ -49,7 +49,12 @@ declare(strict_types=1);
  *
  * Usage:
  *   php tools/i18n-freshness.php [--root=PATH] [--format=text|json]
- *                                [--write-baseline] [--bootstrap]
+ *                                [--write-baseline] [--only=PATH]... [--bootstrap]
+ *
+ * `--only=howto/add-tag.md` (repeatable) narrows `--write-baseline` to the
+ * documents a burn-down PR actually updated. Without it the rewrite covers every
+ * pair, which during a staged burn-down would bless the documents that PR did not
+ * touch — the silent pass this checker exists to prevent.
  *
  * `--bootstrap` seeds the baseline from git history — for each translation it
  * records the English hashes as they were at that translation's last commit, so
@@ -99,6 +104,8 @@ $root = dirname(__DIR__);
 $format = 'text';
 $writeBaseline = false;
 $bootstrap = false;
+/** @var list<string> */
+$only = [];
 
 foreach ($argv as $index => $arg) {
     if ($index === 0) {
@@ -110,6 +117,8 @@ foreach ($argv as $index => $arg) {
         $root = realpath($explicit) ?: $explicit;
     } elseif (str_starts_with($arg, '--format=')) {
         $format = substr($arg, 9);
+    } elseif (str_starts_with($arg, '--only=')) {
+        $only[] = substr($arg, 7);
     } elseif ($arg === '--write-baseline') {
         $writeBaseline = true;
     } elseif ($arg === '--bootstrap') {
@@ -127,6 +136,11 @@ if (!in_array($format, ['text', 'json'], true)) {
 
 if ($writeBaseline && $bootstrap) {
     fwrite(STDERR, "--write-baseline and --bootstrap are mutually exclusive.\n");
+    exit(2);
+}
+
+if ($only !== [] && !$writeBaseline) {
+    fwrite(STDERR, "--only only applies to --write-baseline.\n");
     exit(2);
 }
 
@@ -463,6 +477,16 @@ foreach ($english as $relative) {
         }
 
         if ($writeBaseline) {
+            // With --only, everything outside the named documents keeps whatever
+            // was recorded before, so a burn-down PR cannot bless its neighbours.
+            $selected = $only === [] || in_array($relative, $only, true);
+            $previous = $baseline['entries'][$relative][$locale] ?? null;
+
+            if (!$selected && is_array($previous) && isset($previous['content'], $previous['structure'])) {
+                $entries[$relative][$locale] = ['content' => (string) $previous['content'], 'structure' => (string) $previous['structure']];
+                continue;
+            }
+
             $entries[$relative][$locale] = $current;
             continue;
         }
@@ -521,7 +545,11 @@ if ($writeBaseline || $bootstrap) {
     $baseline['entries'] = $entries;
     writeBaselineFile($root, $baseline);
 
-    $mode = $bootstrap ? 'bootstrapped from git history' : 'written from current sources';
+    $mode = $bootstrap
+        ? 'bootstrapped from git history'
+        : ($only === []
+            ? 'written from current sources'
+            : sprintf('updated for %d document(s), the rest untouched', count($only)));
     echo sprintf("%s %s: %d pairs across %d locales.\n", BASELINE_FILENAME, $mode, $pairs, count($baseline['locales']));
 
     if ($assumed > 0) {

--- a/translations.baseline.json
+++ b/translations.baseline.json
@@ -285,24 +285,24 @@
         },
         "howto/add-health-check.md": {
             "ja": {
-                "content": "0d3de332a83a0286",
-                "structure": "b7d80b65df412cf9"
+                "content": "dbbda1250cdf019e",
+                "structure": "81a1109d37995517"
             },
             "de": {
-                "content": "0d3de332a83a0286",
-                "structure": "b7d80b65df412cf9"
+                "content": "dbbda1250cdf019e",
+                "structure": "81a1109d37995517"
             },
             "fr": {
-                "content": "0d3de332a83a0286",
-                "structure": "b7d80b65df412cf9"
+                "content": "dbbda1250cdf019e",
+                "structure": "81a1109d37995517"
             },
             "zh": {
-                "content": "0d3de332a83a0286",
-                "structure": "b7d80b65df412cf9"
+                "content": "dbbda1250cdf019e",
+                "structure": "81a1109d37995517"
             },
             "pt-br": {
-                "content": "0d3de332a83a0286",
-                "structure": "b7d80b65df412cf9"
+                "content": "dbbda1250cdf019e",
+                "structure": "81a1109d37995517"
             }
         },
         "howto/add-html-view.md": {
@@ -417,24 +417,24 @@
         },
         "howto/add-rate-limiting.md": {
             "ja": {
-                "content": "04bd12fc785df4e3",
-                "structure": "673397be26a019d6"
+                "content": "f466ee1b5261cc77",
+                "structure": "2d2f43a22dd95e02"
             },
             "de": {
-                "content": "04bd12fc785df4e3",
-                "structure": "673397be26a019d6"
+                "content": "f466ee1b5261cc77",
+                "structure": "2d2f43a22dd95e02"
             },
             "fr": {
-                "content": "04bd12fc785df4e3",
-                "structure": "673397be26a019d6"
+                "content": "f466ee1b5261cc77",
+                "structure": "2d2f43a22dd95e02"
             },
             "zh": {
-                "content": "04bd12fc785df4e3",
-                "structure": "673397be26a019d6"
+                "content": "f466ee1b5261cc77",
+                "structure": "2d2f43a22dd95e02"
             },
             "pt-br": {
-                "content": "04bd12fc785df4e3",
-                "structure": "673397be26a019d6"
+                "content": "f466ee1b5261cc77",
+                "structure": "2d2f43a22dd95e02"
             }
         },
         "howto/add-second-entity.md": {
@@ -5873,24 +5873,24 @@
         },
         "reference/environment-variables.md": {
             "ja": {
-                "content": "85ff65630eab9777",
-                "structure": "39666264d1e94a2b"
+                "content": "c66efb5eca0f965b",
+                "structure": "777dd62b0ac5657f"
             },
             "de": {
-                "content": "85ff65630eab9777",
-                "structure": "39666264d1e94a2b"
+                "content": "c66efb5eca0f965b",
+                "structure": "777dd62b0ac5657f"
             },
             "fr": {
-                "content": "85ff65630eab9777",
-                "structure": "39666264d1e94a2b"
+                "content": "c66efb5eca0f965b",
+                "structure": "777dd62b0ac5657f"
             },
             "zh": {
-                "content": "85ff65630eab9777",
-                "structure": "39666264d1e94a2b"
+                "content": "c66efb5eca0f965b",
+                "structure": "777dd62b0ac5657f"
             },
             "pt-br": {
-                "content": "85ff65630eab9777",
-                "structure": "39666264d1e94a2b"
+                "content": "c66efb5eca0f965b",
+                "structure": "777dd62b0ac5657f"
             }
         },
         "reference/http-endpoints.md": {


### PR DESCRIPTION
## 目的

#1628 の消化レーン **バッチ1**（15 pair・目安 2026-07-31）。#1627 で入った `composer i18n:check` が検出した既知の陳腐化 52 pair のうち、小さい3ドキュメントを先に片付けて訳更新の手順を確立する。

Refs #1628

## 更新した内容

### `howto/add-health-check.md`（5ロケール）

英語側で `HealthCheckInterface::check()` の戻り値が **`bool` → `HealthStatus` enum** へ変わっていたのに、5ロケールの訳が古い `bool` の API を載せていた。

```diff
 use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;

-    public function check(): bool
-    {
-        // true = 正常、false = 異常
-        return $this->ping();
-    }
+    public function check(): HealthStatus
+    {
+        return $this->ping() ? HealthStatus::Ok : HealthStatus::Error;
+    }
```

散文側（`SELECT 1` の戻り値・例外時の扱い）も合わせた。

**英語側も1文直した**: 「例外は `false` を返した場合と同様に扱う」という bool 時代の記述が残っていた。同じ移行の取りこぼしで、放置すると**その誤りを5言語へ翻訳することになる**ため同時に修正した（スコープ外の変更ではなく、同一移行の完了）。

### `howto/add-rate-limiting.md`（5ロケール）

英語側に追加されていた「本番要件 — 共有ストレージ」の警告節が訳に無かった。内容は、`InMemoryRateLimitStorage` は PHP-FPM のワーカーごとに別のストアを持つため、10 ワーカーに同時到達したクライアントがワーカーごとに1回しか数えられず**実質的に制限を回避できる**、というもの。**本番の誤設定に直結する情報が5言語で欠落していた。**

クイックスタートの「シングルプロセス環境に適しています」→「シングルプロセスでの**検証にのみ**適しています」も合わせた。

節内のリンク先アンカーは、各ロケールの見出しから生成されるものを使っている（VitePress は描画後の見出しを slug 化するため、英語アンカーを流用すると全ロケールでリンク切れになる）。

### `reference/environment-variables.md`（5ロケール）

- **`NENE2_ALLOW_DEV_SECRET` の行を追加** — `1` / `true` / `yes` **のみ**有効でタイプミスは必ず opt-out、本番では無視して常に fail closed、という厳格パースの仕様。これが訳に無いのはセキュリティ上まずい
- **`DB_ENV` の行を追加**
- `NENE2_LOCAL_JWT_SECRET` の説明を `GuardedJwtSecretResolver`（ADR 0013）対応版へ
- `DB_ADAPTER` に `pgsql`（実験的）＋ howto へのリンク
- `DB_HOST` に Docker Compose が `app` サービス向けに `mysql` へ上書きする注記

## ツール側の修正 — `--only=PATH` を追加

**バッチ1を作業していて、道具の側に穴があることに気づいた。**

`composer i18n:baseline`（= `--write-baseline`）は**全 pair を書き直す**。段階的な消し込みの最中にこれを走らせると、その PR が触っていない残り 37 pair まで「新鮮」として記録され、**残りのバッチが静かに消える**。#1628 の手順にもそのまま `composer i18n:baseline` と書いてしまっていた。

例外も出ず、出力も成功で、ただ意味の違う結果が残る — この検査が防ぐために作られたのと同じ型なので、塞いだ:

```bash
php tools/i18n-freshness.php --write-baseline \
  --only=howto/add-health-check.md --only=reference/environment-variables.md
```

`--only` が指定された pair 以外は**以前の記録をそのまま保持**する。`--only` を `--write-baseline` 無しで渡すと usage error（exit 2）。

## 検証結果

```
docker compose run --rm app composer check
```

- **test**: `OK (896 tests, 2208 assertions)`（`--only` の回帰2件を追加）
- **analyse**: PHPStan level 8 `[OK] No errors`（336 files）
- **cs**: `Found 0 of 338 files that can be fixed`
- **openapi / mcp / conformance / version:check**: すべて OK
- `composer howto:index` を再生成しても差分ゼロ（索引ドリフト無し）
- `git diff --check` クリーン

**`composer i18n:check` の実測: 52 error → 37 error。** 消えたのはバッチ1の 15 pair だけで、残り 9 ドキュメントは変わらず検出されたままであることを確認した（`--only` が効いている証拠）。

```
1355 pairs checked — 37 error(s), 0 warning(s).
```

## 残り

| バッチ | 対象 | pair | 目安 |
|---|---|---|---|
| ~~1~~ | ~~add-rate-limiting + add-health-check + environment-variables~~ | ~~15~~ | ✅ 本 PR |
| 2 | deploy-production + add-jwt-authentication + add-pagination | 15 | 08-02 |
| 3 | note-management-ownership(ja) + quota-management(de) + totp-authentication | 7 | 08-04 |
| 4 | add-custom-route + use-transactions | 10 | 08-06 |
| 5 | add-database-endpoint（単独・実質新訳） | 5 | 08-08 |

## Self-review

`docs-policy`

- 訳の更新のみで、公開ライブラリ API・OpenAPI・設定の振る舞いは不変。ADR 不要。
- 英語ポリシー適用対象（`docs/development/quality-tools.md`）は英語で記述。
- `quality-tools.md` の「現在 stale な pair 数」を 52 → 37 に更新（数字を文書側にも置く方針の維持）。
- CHANGELOG は対象外（翻訳と内部ツールのみ・利用者向けの振る舞い変更なし）。
