### PR TITLE
docs(i18n): 陳腐化訳バッチ2（add-pagination / deploy-production / totp-authentication）を更新する (#1628)

### DIFF
--- a/docs/de/howto/add-pagination.md
+++ b/docs/de/howto/add-pagination.md
@@ -73,8 +73,6 @@ Im Handler ist keine zusätzliche Fehlerbehandlung erforderlich.
 
 `PaginationQueryParser::parse()` liest `getQueryParams()` aus der PSR-7-Anfrage, castet Werte zu `int`, validiert sie und gibt ein `PaginationQuery`-DTO zurück. Nicht-numerische Werte werden zu `0` gecastet (PHP-`(int)`-Cast-Verhalten) und dann durch die `limit < 1`-Prüfung abgefangen.
 
-## Siehe auch
-
 ## Schritt 4 — `PaginationResponse` zur Standardisierung des Envelopes verwenden
 
 `PaginationResponse` ist ein readonly DTO, das den Standard-Listenantwort-Envelope aufbaut:
@@ -108,8 +106,36 @@ Wenn `total` `null` ist, wird der Schlüssel weggelassen.
 > **Abwägung**: `COUNT(*)` kostet eine zusätzliche Abfrage pro Request. Lassen Sie `total` weg,
 > wenn der Overhead nicht akzeptabel ist.
 
+## Schritt 6 — Weitere Query-Parameter mit `QueryStringParser` parsen
+
+Verwenden Sie `QueryStringParser` für zusätzliche Filterparameter über `limit`/`offset` hinaus.
+
+```php
+use Nene2\Http\QueryStringParser;
+
+$search = QueryStringParser::string($request, 'search');   // ?string
+$page   = QueryStringParser::int($request, 'page');        // ?int
+$active = QueryStringParser::bool($request, 'is_active');  // ?bool
+
+// Kommagetrennte Mehrfachwerte: ?tags=php,lang → ['php', 'lang']
+$tags = QueryStringParser::commaSeparated($request, 'tags'); // list<string>|null
+
+// PHP-Stil wiederholter Schlüssel: ?tags[]=php&tags[]=api → ['php', 'api']
+$tags = QueryStringParser::array($request, 'tags'); // list<string>|null
+```
+
+`commaSeparated()` trennt an Kommas, entfernt Leerzeichen und leere Werte und gibt `null` zurück,
+wenn der Parameter fehlt oder nach dem Filtern eine leere Liste ergibt.
+
+`array()` verarbeitet wiederholte Schlüssel im PHP-Stil (`?key[]=v1&key[]=v2`). PSR-7-Implementierungen
+parsen diese in `getQueryParams()` zu `['key' => ['v1', 'v2']]`. Gibt `null` zurück, wenn der
+Schlüssel fehlt oder der Wert kein Array ist.
+
+## Siehe auch
+
 - `src/Example/Note/ListNotesHandler.php` — Referenzimplementierung mit `PaginationResponse`
 - `src/Example/Tag/ListTagsHandler.php` — zweites Beispiel
 - `Nene2\Http\PaginationQuery` — readonly DTO
 - `Nene2\Http\PaginationQueryParser` — die Parser-Klasse
 - `Nene2\Http\PaginationResponse` — das Listen-Envelope-DTO
+- `Nene2\Http\QueryStringParser` — typisierte Helfer für weitere Query-Parameter

--- a/docs/de/howto/deploy-production.md
+++ b/docs/de/howto/deploy-production.md
@@ -105,18 +105,42 @@ api.example.com {
 
 ---
 
-## 4. Produktions-Sicherheits-Checkliste
+## 4. JWT-Authentifizierung in Produktion
+
+> **Warnung**: `LocalBearerTokenVerifier` (die eingebaute HMAC-HS256-Implementierung) ist
+> **ausschließlich für lokale Entwicklung und Tests** gedacht. Sie verwendet keine externe
+> Bibliothek und besitzt nicht die für die produktive JWT-Validierung erforderliche
+> Sicherheitshärtung (Schlüsselrotation, asymmetrische RS256-Schlüssel, Widerruf, Toleranz
+> gegenüber Uhrenabweichungen über die einfachen `exp`/`nbf`-Prüfungen hinaus usw.).
+>
+> Bevor Sie eine Anwendung mit Bearer-JWT-Authentifizierung deployen:
+>
+> 1. Implementieren Sie `TokenVerifierInterface` und `TokenIssuerInterface` mit einer
+>    produktionstauglichen Bibliothek wie [`firebase/php-jwt`](https://github.com/firebase/php-jwt)
+>    oder [`lcobuzi/jwt`](https://github.com/lcobuzi/jwt).
+> 2. Verwenden Sie asymmetrische Schlüssel (RS256 oder ES256), damit die API Token verifizieren
+>    kann, ohne den Signaturschlüssel zu besitzen.
+> 3. Halten Sie `NENE2_LOCAL_JWT_SECRET` aus Ihrer Produktionsumgebung heraus — er gehört nur in
+>    `.env`-Dateien für die Entwicklung.
+>
+> Die vollständige Begründung finden Sie in [ADR 0008](../adr/0008-jwt-authentication.md).
+
+---
+
+## 5. Produktions-Sicherheits-Checkliste
 
 - [ ] `APP_ENV=production` — deaktiviert Entwicklungs-Fehlerdetails
 - [ ] `APP_DEBUG=false` — unterdrückt Stack-Traces in HTTP-Antworten
 - [ ] Datenbank-Zugangsdaten aus einem Secret Store
 - [ ] `NENE2_MACHINE_API_KEY` ist ein starker Zufallswert (≥ 32 Zeichen)
+- [ ] JWT: `LocalBearerTokenVerifier` durch eine Produktionsbibliothek ersetzt (siehe §4 oben)
+- [ ] `NENE2_LOCAL_JWT_SECRET` ist in Produktion **nicht** gesetzt
 - [ ] Container-Port nur an Loopback-Adresse gebunden
 - [ ] TLS am Reverse-Proxy terminiert
 
 ---
 
-## 5. Nach dem Deployment verifizieren
+## 6. Nach dem Deployment verifizieren
 
 ```bash
 curl -fsS https://api.example.com/health
@@ -125,7 +149,7 @@ curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
 
 ---
 
-## 6. Problem Details Typ-URIs
+## 7. Problem Details Typ-URIs
 
 NENE2 verwendet `https://nene2.dev/problems/...` als offizielle Framework-Domain. Die eingebauten Fehlertyp-Seiten werden dort automatisch aufgelöst — für den Standardfehlerumfang ist keine Konfiguration erforderlich.
 

--- a/docs/de/howto/totp-authentication.md
+++ b/docs/de/howto/totp-authentication.md
@@ -46,6 +46,47 @@ Die `used_totp_steps`-Tabelle ist der Kern der **Replay-Angriff-Prävention**. S
 
 ---
 
+## Eingebaute Framework-Primitive (empfohlen)
+
+Ab v1.5 können die sicherheitskritischen kryptografischen Teile direkt über die vom Framework
+bereitgestellten `Nene2\Auth\TotpAuthenticator` und `Nene2\Auth\RecoveryCodes` genutzt werden
+(stabile öffentliche API nach ADR 0009). Die RFC-6238-Berechnung, Base32 und der zeitkonstante
+Vergleich müssen nicht in jeder Anwendung neu implementiert werden.
+Wie bei `SecureTokenHelper` gilt die Aufteilung: Die riskante Kryptografie liefert das Framework in
+einer einzigen Implementierung, während der HTTP-Flow für Enroll/Challenge, die Enforce-Policy, die
+At-Rest-Verschlüsselung des Geheimnisses und die Persistenz zur Replay-Prävention in der
+Verantwortung der Anwendung liegen.
+
+```php
+use Nene2\Auth\TotpAuthenticator;
+use Nene2\Auth\RecoveryCodes;
+
+$totp = new TotpAuthenticator();          // digits=6 / period=30 / sha1 / window=1
+
+// Registrierung: Geheimnis erzeugen → otpauth-URI für den QR-Code
+$secret = $totp->generateSecret();
+$uri    = $totp->provisioningUri($secret, 'alice@example.com', 'NENE2');
+
+// Verifizierung: liefert den passenden time_step zurück (null = ungültig).
+// Für die Replay-Prävention wird der Step persistiert und geprüft.
+$step = $totp->verify($secret, $submittedCode);
+if ($step === null || $repo->isStepUsed($userId, $step)) {
+    // ungültig oder Replay
+} else {
+    $repo->markStepUsed($userId, $step);  // verbrauchten Step festhalten (nur einmal gültig)
+}
+
+// Recovery-Codes: erzeugen, genau einmal anzeigen, nur den Hash speichern,
+// beim Einlösen verifizieren → verbrauchen
+$codes = RecoveryCodes::generate();       // z. B. ["3f9ac-1b0e7-8d2f4-0a6c1", ...] (Standard 80 Bit)
+$repo->storeRecoveryHash($userId, RecoveryCodes::hash($codes[0]));
+```
+
+Die folgenden Abschnitte erläutern die Berechnung und das Sicherheitsdesign, die diese Primitive
+intern ausführen — als Referenz für eine eigene Implementierung oder zum Verständnis.
+
+---
+
 ## RFC 6238 TOTP-Implementierung
 
 ```php

--- a/docs/fr/howto/add-pagination.md
+++ b/docs/fr/howto/add-pagination.md
@@ -106,6 +106,31 @@ Quand `total` est `null` (défaut), la clé est omise de la réponse.
 > **Compromis** : `COUNT(*)` ajoute une requête par appel. Omettez `total` si l'overhead est
 > inacceptable et laissez les clients détecter la dernière page avec `items.length < limit`.
 
+## Étape 6 — Analyser d'autres paramètres de requête avec `QueryStringParser`
+
+Utilisez `QueryStringParser` pour les paramètres de filtrage autres que `limit`/`offset`.
+
+```php
+use Nene2\Http\QueryStringParser;
+
+$search = QueryStringParser::string($request, 'search');   // ?string
+$page   = QueryStringParser::int($request, 'page');        // ?int
+$active = QueryStringParser::bool($request, 'is_active');  // ?bool
+
+// Valeurs multiples séparées par des virgules : ?tags=php,lang → ['php', 'lang']
+$tags = QueryStringParser::commaSeparated($request, 'tags'); // list<string>|null
+
+// Clé répétée à la manière de PHP : ?tags[]=php&tags[]=api → ['php', 'api']
+$tags = QueryStringParser::array($request, 'tags'); // list<string>|null
+```
+
+`commaSeparated()` découpe sur les virgules, supprime les espaces et les valeurs vides, et renvoie
+`null` si le paramètre est absent ou si la liste est vide après filtrage.
+
+`array()` gère les clés répétées à la manière de PHP (`?key[]=v1&key[]=v2`). Les implémentations
+PSR-7 les analysent en `['key' => ['v1', 'v2']]` dans `getQueryParams()`. Renvoie `null` si la clé
+est absente ou si la valeur n'est pas un tableau.
+
 ## Voir aussi
 
 - `src/Example/Note/ListNotesHandler.php` — implémentation de référence avec `PaginationResponse`
@@ -113,3 +138,4 @@ Quand `total` est `null` (défaut), la clé est omise de la réponse.
 - `Nene2\Http\PaginationQuery` — DTO readonly
 - `Nene2\Http\PaginationQueryParser` — la classe parseur
 - `Nene2\Http\PaginationResponse` — le DTO envelope de liste
+- `Nene2\Http\QueryStringParser` — helpers typés pour les autres paramètres de requête

--- a/docs/fr/howto/deploy-production.md
+++ b/docs/fr/howto/deploy-production.md
@@ -105,18 +105,42 @@ api.example.com {
 
 ---
 
-## 4. Liste de contrôle de sécurité production
+## 4. Authentification JWT en production
+
+> **Avertissement** : `LocalBearerTokenVerifier` (l'implémentation HMAC-HS256 intégrée) est destiné
+> **au développement local et aux tests uniquement**. Il n'utilise aucune bibliothèque externe et
+> ne dispose pas du durcissement de sécurité requis pour la validation JWT en production (rotation
+> des clés, clés asymétriques RS256, révocation, tolérance au décalage d'horloge au-delà des
+> simples vérifications `exp`/`nbf`, etc.).
+>
+> Avant de déployer une application utilisant l'authentification Bearer JWT :
+>
+> 1. Implémentez `TokenVerifierInterface` et `TokenIssuerInterface` avec une bibliothèque de
+>    qualité production telle que [`firebase/php-jwt`](https://github.com/firebase/php-jwt) ou
+>    [`lcobuzi/jwt`](https://github.com/lcobuzi/jwt).
+> 2. Utilisez des clés asymétriques (RS256 ou ES256) pour que l'API puisse vérifier les jetons sans
+>    détenir la clé de signature.
+> 3. Gardez `NENE2_LOCAL_JWT_SECRET` hors de votre environnement de production — il ne doit
+>    apparaître que dans les fichiers `.env` de développement.
+>
+> Voir [ADR 0008](../adr/0008-jwt-authentication.md) pour la justification complète.
+
+---
+
+## 5. Liste de contrôle de sécurité production
 
 - [ ] `APP_ENV=production` — désactive les détails d'erreur de développement
 - [ ] `APP_DEBUG=false` — supprime les traces de pile dans les réponses HTTP
 - [ ] Identifiants de base de données depuis un gestionnaire de secrets
 - [ ] `NENE2_MACHINE_API_KEY` valeur aléatoire forte (≥ 32 caractères)
+- [ ] JWT : `LocalBearerTokenVerifier` remplacé par une bibliothèque de production (voir §4 ci-dessus)
+- [ ] `NENE2_LOCAL_JWT_SECRET` n'est **pas** défini en production
 - [ ] Port du conteneur lié à l'adresse de bouclage uniquement
 - [ ] TLS terminé au niveau du proxy inverse
 
 ---
 
-## 5. Vérifier après déploiement
+## 6. Vérifier après déploiement
 
 ```bash
 curl -fsS https://api.example.com/health
@@ -125,7 +149,7 @@ curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
 
 ---
 
-## 6. URIs de type Problem Details
+## 7. URIs de type Problem Details
 
 NENE2 utilise `https://nene2.dev/problems/...` comme domaine officiel du framework. Les pages des types d'erreurs intégrés se résolvent automatiquement sur ce domaine — aucune configuration requise pour l'ensemble d'erreurs standard.
 

--- a/docs/fr/howto/totp-authentication.md
+++ b/docs/fr/howto/totp-authentication.md
@@ -47,6 +47,47 @@ La table `used_totp_steps` est le cœur de la **prévention des attaques par rej
 
 ---
 
+## Primitives intégrées au framework (recommandé)
+
+Depuis la v1.5, les parties cryptographiques sensibles peuvent être utilisées directement via
+`Nene2\Auth\TotpAuthenticator` et `Nene2\Auth\RecoveryCodes` fournis par le framework (API publique
+stable au sens de l'ADR 0009). Il n'est pas nécessaire de réimplémenter le calcul RFC 6238, le
+Base32 et la comparaison à temps constant dans chaque application.
+Comme pour `SecureTokenHelper`, la répartition est la suivante : le framework fournit une
+implémentation unique de la cryptographie risquée, tandis que le flux HTTP d'enrôlement/challenge,
+la politique d'application, le chiffrement au repos du secret et la persistance de la prévention du
+rejeu relèvent de la responsabilité de l'application.
+
+```php
+use Nene2\Auth\TotpAuthenticator;
+use Nene2\Auth\RecoveryCodes;
+
+$totp = new TotpAuthenticator();          // digits=6 / period=30 / sha1 / window=1
+
+// Enrôlement : génération du secret → URI otpauth pour le QR code
+$secret = $totp->generateSecret();
+$uri    = $totp->provisioningUri($secret, 'alice@example.com', 'NENE2');
+
+// Vérification : renvoie le time_step correspondant (null si invalide).
+// Pour la prévention du rejeu, persistez le step et vérifiez-le.
+$step = $totp->verify($secret, $submittedCode);
+if ($step === null || $repo->isStepUsed($userId, $step)) {
+    // invalide ou rejeu
+} else {
+    $repo->markStepUsed($userId, $step);  // enregistre le step consommé (usage unique)
+}
+
+// Codes de récupération : générer, afficher une seule fois, ne stocker que le hash,
+// vérifier puis consommer lors de l'utilisation
+$codes = RecoveryCodes::generate();       // ex. ["3f9ac-1b0e7-8d2f4-0a6c1", ...] (80 bits par défaut)
+$repo->storeRecoveryHash($userId, RecoveryCodes::hash($codes[0]));
+```
+
+Les sections suivantes expliquent le calcul et la conception de sécurité que ces primitives
+réalisent en interne — à titre de référence pour une implémentation maison ou pour comprendre.
+
+---
+
 ## Implémentation de TOTP RFC 6238
 
 ```php

--- a/docs/ja/howto/add-pagination.md
+++ b/docs/ja/howto/add-pagination.md
@@ -105,6 +105,31 @@ return $this->response->create(
 > **トレードオフ**: `COUNT(*)` はリクエストごとにクエリが 1 件追加されます。オーバーヘッドが
 > 許容できない場合は `total` を省略し、クライアントに `items.length < limit` で最終ページを検出させてください。
 
+## ステップ 6 — `QueryStringParser` でその他のクエリパラメーターをパースする
+
+`limit`/`offset` 以外のフィルターパラメーターには `QueryStringParser` を使います。
+
+```php
+use Nene2\Http\QueryStringParser;
+
+$search = QueryStringParser::string($request, 'search');   // ?string
+$page   = QueryStringParser::int($request, 'page');        // ?int
+$active = QueryStringParser::bool($request, 'is_active');  // ?bool
+
+// カンマ区切りの複数値: ?tags=php,lang → ['php', 'lang']
+$tags = QueryStringParser::commaSeparated($request, 'tags'); // list<string>|null
+
+// PHP 形式の繰り返しキー: ?tags[]=php&tags[]=api → ['php', 'api']
+$tags = QueryStringParser::array($request, 'tags'); // list<string>|null
+```
+
+`commaSeparated()` はカンマで分割し、空白をトリムし、空の値を除去します。パラメーターが
+存在しない場合、またはフィルター後に空リストになった場合は `null` を返します。
+
+`array()` は PHP 形式の繰り返しキー（`?key[]=v1&key[]=v2`）を処理します。PSR-7 実装は
+これを `getQueryParams()` で `['key' => ['v1', 'v2']]` としてパースします。キーが存在しない
+場合、または値が配列でない場合は `null` を返します。
+
 ## 参考
 
 - `src/Example/Note/ListNotesHandler.php` — `PaginationResponse` を使ったリファレンス実装
@@ -112,3 +137,4 @@ return $this->response->create(
 - `Nene2\Http\PaginationQuery` — パース済みパラメーターの readonly DTO
 - `Nene2\Http\PaginationQueryParser` — パーサークラス
 - `Nene2\Http\PaginationResponse` — リストエンベロープ DTO
+- `Nene2\Http\QueryStringParser` — その他のクエリパラメーター用の型付きヘルパー

--- a/docs/ja/howto/deploy-production.md
+++ b/docs/ja/howto/deploy-production.md
@@ -147,7 +147,26 @@ Caddy は Let's Encrypt 経由で TLS 証明書を自動発行します。
 
 ---
 
-## 4. 本番セキュリティチェックリスト
+## 4. 本番環境での JWT 認証
+
+> **警告**: `LocalBearerTokenVerifier`（組み込みの HMAC-HS256 実装）は
+> **ローカル開発とテスト専用**です。外部ライブラリを使用しておらず、本番の JWT 検証に必要な
+> セキュリティ強化（鍵のローテーション、RS256 非対称鍵、失効、基本的な `exp`/`nbf` チェックを
+> 超えるクロックスキュー許容など）を備えていません。
+>
+> Bearer JWT 認証を使うアプリケーションをデプロイする前に:
+>
+> 1. [`firebase/php-jwt`](https://github.com/firebase/php-jwt) や
+>    [`lcobuzi/jwt`](https://github.com/lcobuzi/jwt) などの本番品質のライブラリを使って
+>    `TokenVerifierInterface` と `TokenIssuerInterface` を実装する。
+> 2. 非対称鍵（RS256 または ES256）を使い、API が署名鍵を保持せずにトークンを検証できるようにする。
+> 3. `NENE2_LOCAL_JWT_SECRET` を本番環境に置かない — 開発用の `.env` にのみ存在させる。
+>
+> 根拠の全文は [ADR 0008](../adr/0008-jwt-authentication.md) を参照してください。
+
+---
+
+## 5. 本番セキュリティチェックリスト
 
 トラフィックを受け入れる前に確認します。
 
@@ -155,6 +174,8 @@ Caddy は Let's Encrypt 経由で TLS 証明書を自動発行します。
 - [ ] `APP_DEBUG=false` — HTTP レスポンスのスタックトレースを抑制
 - [ ] データベース認証情報はシークレットストアから取得（イメージに含めない）
 - [ ] `NENE2_MACHINE_API_KEY` は強力なランダム値（32 文字以上）
+- [ ] JWT: `LocalBearerTokenVerifier` を本番用ライブラリに置き換え済み（上記 §4 参照）
+- [ ] `NENE2_LOCAL_JWT_SECRET` が本番環境に設定されて**いない**
 - [ ] コンテナポートはループバック（`127.0.0.1:8080`）または内部ネットワークにバインド（`0.0.0.0` ではない）
 - [ ] TLS はリバースプロキシで終端
 - [ ] `X-Forwarded-For` / `X-Real-IP` ヘッダーはプロキシのみが設定
@@ -162,7 +183,7 @@ Caddy は Let's Encrypt 経由で TLS 証明書を自動発行します。
 
 ---
 
-## 5. デプロイ後の確認
+## 6. デプロイ後の確認
 
 ```bash
 # ヘルスチェック
@@ -180,7 +201,7 @@ curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
 
 ---
 
-## 6. Problem Details の type URI について
+## 7. Problem Details の type URI について
 
 NENE2 のエラーレスポンスは次のような `type` URI を含みます。
 

--- a/docs/ja/howto/totp-authentication.md
+++ b/docs/ja/howto/totp-authentication.md
@@ -47,6 +47,43 @@ CREATE TABLE used_totp_steps (
 
 ---
 
+## フレームワーク組み込みプリミティブ（推奨）
+
+v1.5 以降、危険な暗号部分は framework が提供する `Nene2\Auth\TotpAuthenticator` と
+`Nene2\Auth\RecoveryCodes` をそのまま使える（ADR 0009 の安定 public API）。
+RFC 6238 の計算・Base32・定数時間比較を各アプリで再実装する必要はない。
+`SecureTokenHelper` と同じく「危険な暗号は framework の1実装、enroll/challenge の
+HTTP フロー・enforce ポリシー・シークレットの at-rest 暗号化・リプレイ防止の永続化は
+アプリの責務」という分担。
+
+```php
+use Nene2\Auth\TotpAuthenticator;
+use Nene2\Auth\RecoveryCodes;
+
+$totp = new TotpAuthenticator();          // digits=6 / period=30 / sha1 / window=1
+
+// 登録: シークレット生成 → QR 用 otpauth URI
+$secret = $totp->generateSecret();
+$uri    = $totp->provisioningUri($secret, 'alice@example.com', 'NENE2');
+
+// 検証: 一致した time_step が返る（null なら無効）。リプレイ防止は step を永続化して判定。
+$step = $totp->verify($secret, $submittedCode);
+if ($step === null || $repo->isStepUsed($userId, $step)) {
+    // 無効 or リプレイ
+} else {
+    $repo->markStepUsed($userId, $step);  // 使用済み step を記録（1回限り）
+}
+
+// リカバリコード: 生成して一度だけ表示、hash のみ保存、redeem 時に verify → consume
+$codes = RecoveryCodes::generate();       // 例: ["3f9ac-1b0e7-8d2f4-0a6c1", ...]（既定 80bit）
+$repo->storeRecoveryHash($userId, RecoveryCodes::hash($codes[0]));
+```
+
+次節以降は、このプリミティブが内部で行っている計算とセキュリティ設計の解説。
+自前実装や理解のための参考として残す。
+
+---
+
 ## RFC 6238 TOTP の実装
 
 ```php

--- a/docs/pt-br/howto/add-pagination.md
+++ b/docs/pt-br/howto/add-pagination.md
@@ -106,6 +106,31 @@ Quando `total` é `null` (padrão), a chave é omitida da resposta.
 > **Compromisso**: `COUNT(*)` adiciona uma consulta por chamada. Omita `total` se o overhead
 > for inaceitável e deixe os clientes detectar a última página com `items.length < limit`.
 
+## Passo 6 — Analisar outros parâmetros de query com `QueryStringParser`
+
+Use `QueryStringParser` para parâmetros de filtro além de `limit`/`offset`.
+
+```php
+use Nene2\Http\QueryStringParser;
+
+$search = QueryStringParser::string($request, 'search');   // ?string
+$page   = QueryStringParser::int($request, 'page');        // ?int
+$active = QueryStringParser::bool($request, 'is_active');  // ?bool
+
+// Múltiplos valores separados por vírgula: ?tags=php,lang → ['php', 'lang']
+$tags = QueryStringParser::commaSeparated($request, 'tags'); // list<string>|null
+
+// Chave repetida no estilo PHP: ?tags[]=php&tags[]=api → ['php', 'api']
+$tags = QueryStringParser::array($request, 'tags'); // list<string>|null
+```
+
+`commaSeparated()` divide nas vírgulas, remove espaços em branco e valores vazios, e retorna `null`
+quando o parâmetro está ausente ou resulta em uma lista vazia após a filtragem.
+
+`array()` trata chaves repetidas no estilo PHP (`?key[]=v1&key[]=v2`). Implementações PSR-7 as
+analisam como `['key' => ['v1', 'v2']]` em `getQueryParams()`. Retorna `null` quando a chave está
+ausente ou o valor não é um array.
+
 ## Veja também
 
 - `src/Example/Note/ListNotesHandler.php` — implementação de referência com `PaginationResponse`
@@ -113,3 +138,4 @@ Quando `total` é `null` (padrão), a chave é omitida da resposta.
 - `Nene2\Http\PaginationQuery` — DTO readonly para parâmetros analisados
 - `Nene2\Http\PaginationQueryParser` — a classe parser
 - `Nene2\Http\PaginationResponse` — o DTO de envelope de lista
+- `Nene2\Http\QueryStringParser` — helpers tipados para outros parâmetros de query

--- a/docs/pt-br/howto/deploy-production.md
+++ b/docs/pt-br/howto/deploy-production.md
@@ -105,18 +105,42 @@ api.example.com {
 
 ---
 
-## 4. Lista de verificação de segurança de produção
+## 4. Autenticação JWT em produção
+
+> **Aviso**: `LocalBearerTokenVerifier` (a implementação HMAC-HS256 embutida) destina-se
+> **apenas ao desenvolvimento local e a testes**. Ele não usa nenhuma biblioteca externa e não
+> possui o reforço de segurança exigido para a validação de JWT em produção (rotação de chaves,
+> chaves assimétricas RS256, revogação, tolerância a desvio de relógio além das verificações
+> básicas de `exp`/`nbf`, etc.).
+>
+> Antes de implantar uma aplicação que usa autenticação Bearer JWT:
+>
+> 1. Implemente `TokenVerifierInterface` e `TokenIssuerInterface` usando uma biblioteca de nível de
+>    produção como [`firebase/php-jwt`](https://github.com/firebase/php-jwt) ou
+>    [`lcobuzi/jwt`](https://github.com/lcobuzi/jwt).
+> 2. Use chaves assimétricas (RS256 ou ES256) para que a API possa verificar tokens sem manter a
+>    chave de assinatura.
+> 3. Mantenha `NENE2_LOCAL_JWT_SECRET` fora do seu ambiente de produção — ele deve aparecer apenas
+>    em arquivos `.env` de desenvolvimento.
+>
+> Consulte o [ADR 0008](../adr/0008-jwt-authentication.md) para a justificativa completa.
+
+---
+
+## 5. Lista de verificação de segurança de produção
 
 - [ ] `APP_ENV=production` — desabilita detalhes de erro de desenvolvimento
 - [ ] `APP_DEBUG=false` — suprime rastreamentos de pilha nas respostas HTTP
 - [ ] Credenciais do banco de dados vêm de um gerenciador de segredos
 - [ ] `NENE2_MACHINE_API_KEY` é um valor aleatório forte (≥ 32 caracteres)
+- [ ] JWT: `LocalBearerTokenVerifier` substituído por uma biblioteca de produção (veja §4 acima)
+- [ ] `NENE2_LOCAL_JWT_SECRET` **não** está definido em produção
 - [ ] Porta do contêiner vinculada apenas ao endereço de loopback
 - [ ] TLS terminado no proxy reverso
 
 ---
 
-## 5. Verificar após implantação
+## 6. Verificar após implantação
 
 ```bash
 curl -fsS https://api.example.com/health
@@ -125,7 +149,7 @@ curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
 
 ---
 
-## 6. URIs de tipo Problem Details
+## 7. URIs de tipo Problem Details
 
 NENE2 usa `https://nene2.dev/problems/...` como domínio oficial do framework. As páginas de tipos de erro integrados são resolvidas automaticamente nesse domínio — nenhuma configuração é necessária para o conjunto de erros padrão.
 

--- a/docs/pt-br/howto/totp-authentication.md
+++ b/docs/pt-br/howto/totp-authentication.md
@@ -47,6 +47,47 @@ A tabela `used_totp_steps` é o núcleo da **prevenção de ataques de replay**.
 
 ---
 
+## Primitivas embutidas no framework (recomendado)
+
+A partir da v1.5, as partes criptográficas sensíveis podem ser usadas diretamente por meio de
+`Nene2\Auth\TotpAuthenticator` e `Nene2\Auth\RecoveryCodes`, fornecidos pelo framework (API pública
+estável conforme o ADR 0009). Não é necessário reimplementar o cálculo RFC 6238, o Base32 e a
+comparação em tempo constante em cada aplicação.
+Assim como em `SecureTokenHelper`, a divisão é: o framework fornece uma única implementação da
+criptografia arriscada, enquanto o fluxo HTTP de registro/desafio, a política de aplicação, a
+criptografia em repouso do segredo e a persistência da prevenção de replay são responsabilidade da
+aplicação.
+
+```php
+use Nene2\Auth\TotpAuthenticator;
+use Nene2\Auth\RecoveryCodes;
+
+$totp = new TotpAuthenticator();          // digits=6 / period=30 / sha1 / window=1
+
+// Registro: gerar o segredo → URI otpauth para o QR code
+$secret = $totp->generateSecret();
+$uri    = $totp->provisioningUri($secret, 'alice@example.com', 'NENE2');
+
+// Verificação: retorna o time_step correspondente (null se inválido).
+// Para prevenção de replay, persista o step e verifique-o.
+$step = $totp->verify($secret, $submittedCode);
+if ($step === null || $repo->isStepUsed($userId, $step)) {
+    // inválido ou replay
+} else {
+    $repo->markStepUsed($userId, $step);  // registra o step consumido (uso único)
+}
+
+// Códigos de recuperação: gerar, exibir uma única vez, armazenar apenas o hash,
+// verificar e consumir no resgate
+$codes = RecoveryCodes::generate();       // ex.: ["3f9ac-1b0e7-8d2f4-0a6c1", ...] (80 bits por padrão)
+$repo->storeRecoveryHash($userId, RecoveryCodes::hash($codes[0]));
+```
+
+As seções seguintes explicam o cálculo e o design de segurança que essas primitivas executam
+internamente — como referência para uma implementação própria ou para entendimento.
+
+---
+
 ## Implementação RFC 6238 TOTP
 
 ```php

--- a/docs/zh/howto/add-pagination.md
+++ b/docs/zh/howto/add-pagination.md
@@ -105,6 +105,29 @@ return $this->response->create(
 > **权衡**：`COUNT(*)` 每次请求增加一个查询。若开销不可接受，可省略 `total`，
 > 让客户端通过 `items.length < limit` 判断是否为最后一页。
 
+## 步骤 6 — 使用 `QueryStringParser` 解析其他查询参数
+
+对于 `limit`/`offset` 之外的过滤参数，请使用 `QueryStringParser`。
+
+```php
+use Nene2\Http\QueryStringParser;
+
+$search = QueryStringParser::string($request, 'search');   // ?string
+$page   = QueryStringParser::int($request, 'page');        // ?int
+$active = QueryStringParser::bool($request, 'is_active');  // ?bool
+
+// 逗号分隔的多值：?tags=php,lang → ['php', 'lang']
+$tags = QueryStringParser::commaSeparated($request, 'tags'); // list<string>|null
+
+// PHP 风格的重复键：?tags[]=php&tags[]=api → ['php', 'api']
+$tags = QueryStringParser::array($request, 'tags'); // list<string>|null
+```
+
+`commaSeparated()` 按逗号拆分、去除空白并移除空值；当参数不存在或过滤后为空列表时返回 `null`。
+
+`array()` 处理 PHP 风格的重复键（`?key[]=v1&key[]=v2`）。PSR-7 实现会在 `getQueryParams()` 中
+将其解析为 `['key' => ['v1', 'v2']]`。当键不存在或值不是数组时返回 `null`。
+
 ## 另请参阅
 
 - `src/Example/Note/ListNotesHandler.php` — 使用 `PaginationResponse` 的参考实现
@@ -112,3 +135,4 @@ return $this->response->create(
 - `Nene2\Http\PaginationQuery` — 解析后参数的 readonly DTO
 - `Nene2\Http\PaginationQueryParser` — 解析器类
 - `Nene2\Http\PaginationResponse` — 列表结构 DTO
+- `Nene2\Http\QueryStringParser` — 其他查询参数的类型化辅助方法

--- a/docs/zh/howto/deploy-production.md
+++ b/docs/zh/howto/deploy-production.md
@@ -105,18 +105,38 @@ api.example.com {
 
 ---
 
-## 4. 生产安全检查清单
+## 4. 生产环境中的 JWT 认证
+
+> **警告**：`LocalBearerTokenVerifier`（内置的 HMAC-HS256 实现）**仅供本地开发和测试使用**。
+> 它不使用任何外部库，也不具备生产环境 JWT 校验所需的安全加固（密钥轮换、RS256 非对称密钥、
+> 吊销、超出基本 `exp`/`nbf` 检查的时钟偏移容忍等）。
+>
+> 在部署使用 Bearer JWT 认证的应用之前：
+>
+> 1. 使用生产级库（如 [`firebase/php-jwt`](https://github.com/firebase/php-jwt) 或
+>    [`lcobuzi/jwt`](https://github.com/lcobuzi/jwt)）实现 `TokenVerifierInterface` 和
+>    `TokenIssuerInterface`。
+> 2. 使用非对称密钥（RS256 或 ES256），使 API 无需持有签名密钥即可验证令牌。
+> 3. 不要在生产环境中设置 `NENE2_LOCAL_JWT_SECRET` — 它只应出现在开发用的 `.env` 文件中。
+>
+> 完整理由参见 [ADR 0008](../adr/0008-jwt-authentication.md)。
+
+---
+
+## 5. 生产安全检查清单
 
 - [ ] `APP_ENV=production` — 禁用开发错误详情
 - [ ] `APP_DEBUG=false` — 抑制 HTTP 响应中的堆栈跟踪
 - [ ] 数据库凭据来自密钥存储
 - [ ] `NENE2_MACHINE_API_KEY` 为强随机值（≥ 32 字符）
+- [ ] JWT：`LocalBearerTokenVerifier` 已替换为生产级库（参见上文 §4）
+- [ ] 生产环境**未**设置 `NENE2_LOCAL_JWT_SECRET`
 - [ ] 容器端口仅绑定到回环地址
 - [ ] TLS 在反向代理处终止
 
 ---
 
-## 5. 部署后验证
+## 6. 部署后验证
 
 ```bash
 curl -fsS https://api.example.com/health
@@ -125,7 +145,7 @@ curl -fsS -H 'X-NENE2-API-Key: <key>' https://api.example.com/machine/health
 
 ---
 
-## 6. Problem Details 类型 URI
+## 7. Problem Details 类型 URI
 
 NENE2 使用 `https://nene2.dev/problems/...` 作为框架官方域名。内置错误类型页面会自动解析到该域名，标准错误集无需任何配置。
 

--- a/docs/zh/howto/totp-authentication.md
+++ b/docs/zh/howto/totp-authentication.md
@@ -47,6 +47,41 @@ CREATE TABLE used_totp_steps (
 
 ---
 
+## 框架内置原语（推荐）
+
+自 v1.5 起，风险较高的加密部分可直接使用框架提供的 `Nene2\Auth\TotpAuthenticator` 和
+`Nene2\Auth\RecoveryCodes`（ADR 0009 的稳定公开 API）。无需在每个应用中重新实现
+RFC 6238 计算、Base32 和常量时间比较。
+与 `SecureTokenHelper` 相同的分工：风险较高的加密由框架提供唯一实现，而注册/挑战的 HTTP 流程、
+强制策略、密钥的静态加密以及重放防护的持久化则由应用负责。
+
+```php
+use Nene2\Auth\TotpAuthenticator;
+use Nene2\Auth\RecoveryCodes;
+
+$totp = new TotpAuthenticator();          // digits=6 / period=30 / sha1 / window=1
+
+// 注册：生成密钥 → 用于二维码的 otpauth URI
+$secret = $totp->generateSecret();
+$uri    = $totp->provisioningUri($secret, 'alice@example.com', 'NENE2');
+
+// 验证：返回匹配的 time_step（null 表示无效）。重放防护通过持久化 step 来判定。
+$step = $totp->verify($secret, $submittedCode);
+if ($step === null || $repo->isStepUsed($userId, $step)) {
+    // 无效或重放
+} else {
+    $repo->markStepUsed($userId, $step);  // 记录已使用的 step（仅一次有效）
+}
+
+// 恢复码：生成后仅显示一次，只保存 hash，兑换时先 verify 再 consume
+$codes = RecoveryCodes::generate();       // 例如 ["3f9ac-1b0e7-8d2f4-0a6c1", ...]（默认 80 位）
+$repo->storeRecoveryHash($userId, RecoveryCodes::hash($codes[0]));
+```
+
+以下各节讲解这些原语在内部执行的计算与安全设计，供自行实现或加深理解时参考。
+
+---
+
 ## RFC 6238 TOTP 实现
 
 ```php

--- a/translations.baseline.json
+++ b/translations.baseline.json
@@ -395,24 +395,24 @@
         },
         "howto/add-pagination.md": {
             "ja": {
-                "content": "bb3bf69da6c6f78e",
-                "structure": "9de97340f0a92402"
+                "content": "cf6268e92aceaf35",
+                "structure": "f28fc3ae7c54fcd5"
             },
             "de": {
-                "content": "bb3bf69da6c6f78e",
-                "structure": "9de97340f0a92402"
+                "content": "cf6268e92aceaf35",
+                "structure": "f28fc3ae7c54fcd5"
             },
             "fr": {
-                "content": "bb3bf69da6c6f78e",
-                "structure": "9de97340f0a92402"
+                "content": "cf6268e92aceaf35",
+                "structure": "f28fc3ae7c54fcd5"
             },
             "zh": {
-                "content": "bb3bf69da6c6f78e",
-                "structure": "9de97340f0a92402"
+                "content": "cf6268e92aceaf35",
+                "structure": "f28fc3ae7c54fcd5"
             },
             "pt-br": {
-                "content": "bb3bf69da6c6f78e",
-                "structure": "9de97340f0a92402"
+                "content": "cf6268e92aceaf35",
+                "structure": "f28fc3ae7c54fcd5"
             }
         },
         "howto/add-rate-limiting.md": {
@@ -1539,24 +1539,24 @@
         },
         "howto/deploy-production.md": {
             "ja": {
-                "content": "4e3db7cfd867813f",
-                "structure": "55b1cf9795aafd7d"
+                "content": "43a97d843c35baff",
+                "structure": "21598a740bde2c6e"
             },
             "de": {
-                "content": "4e3db7cfd867813f",
-                "structure": "55b1cf9795aafd7d"
+                "content": "43a97d843c35baff",
+                "structure": "21598a740bde2c6e"
             },
             "fr": {
-                "content": "4e3db7cfd867813f",
-                "structure": "55b1cf9795aafd7d"
+                "content": "43a97d843c35baff",
+                "structure": "21598a740bde2c6e"
             },
             "zh": {
-                "content": "4e3db7cfd867813f",
-                "structure": "55b1cf9795aafd7d"
+                "content": "43a97d843c35baff",
+                "structure": "21598a740bde2c6e"
             },
             "pt-br": {
-                "content": "4e3db7cfd867813f",
-                "structure": "55b1cf9795aafd7d"
+                "content": "43a97d843c35baff",
+                "structure": "21598a740bde2c6e"
             }
         },
         "howto/direct-messaging-system.md": {
@@ -5213,24 +5213,24 @@
         },
         "howto/totp-authentication.md": {
             "ja": {
-                "content": "043ddaad1a71fe92",
-                "structure": "5bde47433211cabf"
+                "content": "4f830c73f1098052",
+                "structure": "bdc229dd7a09fd5b"
             },
             "de": {
-                "content": "043ddaad1a71fe92",
-                "structure": "5bde47433211cabf"
+                "content": "4f830c73f1098052",
+                "structure": "bdc229dd7a09fd5b"
             },
             "fr": {
-                "content": "043ddaad1a71fe92",
-                "structure": "5bde47433211cabf"
+                "content": "4f830c73f1098052",
+                "structure": "bdc229dd7a09fd5b"
             },
             "zh": {
-                "content": "043ddaad1a71fe92",
-                "structure": "5bde47433211cabf"
+                "content": "4f830c73f1098052",
+                "structure": "bdc229dd7a09fd5b"
             },
             "pt-br": {
-                "content": "043ddaad1a71fe92",
-                "structure": "5bde47433211cabf"
+                "content": "4f830c73f1098052",
+                "structure": "bdc229dd7a09fd5b"
             }
         },
         "howto/transaction-scope-pattern.md": {


### PR DESCRIPTION
## 目的

Issue #1628 の消し込み第2弾。英語原文に後から入った節が 5 ロケールへ反映されておらず、
`composer i18n:check` が stale-structure を報告している状態を解消する。

## 変更点

対象 3 ドキュメント × 5 ロケール（ja/de/fr/zh/pt-br）= 15 ファイル。

| ドキュメント | 反映した原文の差分 |
|---|---|
| `add-pagination` | `QueryStringParser` を使うステップ6の新設 ＋ See also の項目1件 |
| `deploy-production` | 「本番環境での JWT 認証」節の新設、章番号 4/5/6 → 5/6/7 の繰り下げ、セキュリティチェックリストへ JWT 2 項目追加 |
| `totp-authentication` | framework 組み込みプリミティブ（`TotpAuthenticator` / `RecoveryCodes`）の節の新設 |

`deploy-production` は章番号の繰り下げを伴うため、翻訳側が**現に誤った番号を表示していた**
（原文 §5 の内容が訳では §4 と表示される状態）。ここは新規節の追加だけでなく既存記述の是正を含む。

### ついでに直したもの

- `docs/de/howto/add-pagination.md` の見出し順の誤り。`## Siehe auch` が Schritt 4/5 より**前**に
  置かれており、以降の節がすべて See also の配下にぶら下がって見えていた。正しい位置へ移動した。

### baseline の扱い

`--only` で対象 3 ドキュメントに限定して再記録した。未修正のドキュメントを巻き込んで
pass させない（ツールの doc-comment が警告している silent pass を避ける）ため。
`translations.baseline.json` の差分が 3 エントリのみであることを確認済み。

## 検証結果

```
composer i18n:check     →  1355 pairs checked — 22 error(s), 0 warning(s)   （変更前: 37 error）
composer howto:index    →  再生成しても差分なし（ドリフトなし）
composer howto:frontmatter --require-all →  262/262 annotated, Frontmatter validation passed
```

構造パリティの実測（見出し数／コードフェンス数）:

| ドキュメント | EN | ja | de | fr | zh | pt-br |
|---|---|---|---|---|---|---|
| add-pagination | 10/14 | 10/12 | 10/12 | 10/12 | 10/12 | 10/12 |
| deploy-production | 23/20 | 19/20 | 13/12 | 13/12 | 13/12 | 13/12 |
| totp-authentication | 16/16 | 16/16 | 16/16 | 16/16 | 16/16 | 16/16 |

PHP コードは変更していないため `composer test` / `analyse` は対象外。

## 残リスク・申し送り

**残 22 件は「陳腐化」ではなく「訳が原文より短い（未完訳）」が主因**で、性質が違う。実測:

| ドキュメント | 残ロケール | 訳 見出し/フェンス | EN |
|---|---|---|---|
| `add-custom-route` | 5 | 9/12 | 13/18 |
| `add-database-endpoint` | 5 | 15/26 | 41/94 |
| `add-jwt-authentication` | de/fr/zh/pt-br | 13/16 | 19/42 |
| `use-transactions` | 5 | 8/10 | 10/12 |
| `quota-management` | de のみ | 20/12 | 22/40 |
| `note-management-ownership` | ja のみ | 21/10 | 24/34 |

`quota-management`(de) と `note-management-ownership`(ja) は**そのロケールだけが要約版**で、
他4ロケールは完訳。原文側の差分（`localhost:8080` → `8200`）に対応する記述を訳が持っていないため、
差分を訳し戻すのではなく**未完訳部分の補完**が要る。`add-database-endpoint` は原文 +673 行と規模が大きい。

このため残りは「原文差分の反映」ではなく「翻訳の完成」レーンとして扱う必要がある。
バッチ3の切り方（完訳を追うのか、gate を通すことを優先するのか）は指揮の判断を仰ぎたい。

Closes なし（#1628 は残 22 件があるため未クローズ）

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)