### PR TITLE
docs(i18n): 陳腐化訳バッチ3（add-custom-route / add-jwt-authentication / use-transactions）を更新する (#1628)

### DIFF
--- a/docs/de/howto/add-custom-route.md
+++ b/docs/de/howto/add-custom-route.md
@@ -131,6 +131,77 @@ routeRegistrars: [
 
 Oder teilen Sie auf mehrere Registrar-Funktionen auf, wenn die Routenliste lang wird.
 
+> **Reihenfolge der Routenregistrierung**: Der Router matcht in der **Registrierungsreihenfolge**.
+> Registrieren Sie **statische Routen immer vor parametrisierten**, wenn beide dasselbe Präfix teilen.
+> Wenn Sie zuerst `GET /items/{id}` und danach `GET /items/summary` registrieren, matcht eine Anfrage
+> an `/items/summary` die `{id}`-Route mit `id = "summary"` — das ergibt einen verwirrenden
+> domänenspezifischen 404 statt eines Routing-Fehlers.
+>
+> ```php
+> // FALSCH — /items/summary matcht {id} mit id="summary"
+> $router->get('/items/{id}',    $this->show(...));
+> $router->get('/items/summary', $this->summary(...)); // wird nie erreicht
+>
+> // RICHTIG — statisches Segment zuerst gematcht
+> $router->get('/items/summary', $this->summary(...));
+> $router->get('/items/{id}',    $this->show(...));
+> ```
+
+---
+
+## Aktions-Endpunkte (Nicht-CRUD-Operationen)
+
+Manche Operationen passen nicht in die übliche CRUD-Form — archivieren, veröffentlichen, genehmigen,
+wiederherstellen. Verwenden Sie dafür `POST /resource/{id}/action`. Die Antwort ist `200 OK` mit der
+aktualisierten Ressource im Body.
+
+```php
+$router->post('/items/{id}/archive', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->archive($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+
+$router->post('/items/{id}/restore', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->restore($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+```
+
+> **Registrierungsreihenfolge**: Aktions-Routen (`/items/{id}/archive`) teilen das `{id}`-Segment mit
+> den Show-/Update-Routen — sie funktionieren dennoch korrekt, weil der Aktionspfad nach `{id}` ein
+> zusätzliches statisches Segment besitzt und damit unabhängig von der Registrierungsreihenfolge
+> eindeutig ist.
+
+### Aktions-Endpunkte mit optionalem Body
+
+Manche Aktionen akzeptieren einen optionalen JSON-Body (z. B. eine `reject`-Aktion mit optionalem
+`reason`). `JsonRequestBodyParser::parse()` wirft bei leerem Body einen 400 — prüfen Sie daher auf
+einen leeren Body, bevor Sie den Parser aufrufen:
+
+```php
+$router->post('/items/{id}/reject', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $raw    = (string) $req->getBody();
+    $reason = null;
+
+    if ($raw !== '') {
+        $body   = JsonRequestBodyParser::parse($req);
+        $reason = isset($body['reason']) && is_string($body['reason']) ? trim($body['reason']) : null;
+    }
+
+    $item = $repo->reject($id, $reason, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item));
+});
+```
+
 ---
 
 ## Verfügbare HTTP-Methoden
@@ -138,9 +209,49 @@ Oder teilen Sie auf mehrere Registrar-Funktionen auf, wenn die Routenliste lang 
 | Methode | Router-Methode | Typische Verwendung |
 |---|---|---|
 | GET | `$router->get()` | Eine Ressource lesen |
-| POST | `$router->post()` | Eine Ressource erstellen |
+| POST | `$router->post()` | Eine Ressource erstellen oder eine Aktion auslösen |
 | PUT | `$router->put()` | Eine Ressource ersetzen (vollständiges Update) |
+| PATCH | `$router->patch()` | Teilweises Update |
 | DELETE | `$router->delete()` | Eine Ressource entfernen |
+
+---
+
+## Reservierte Framework-Pfade
+
+Die folgenden Pfade werden von `RuntimeApplicationFactory` registriert, **bevor** Ihre
+Route-Registrars laufen. Von Nutzern registrierte Routen für diese Pfade matchen nie, weil die
+Routen des Frameworks zuerst geprüft werden.
+
+| Pfad | Methode | Beschreibung |
+|---|---|---|
+| `/` | GET | Smoke-Endpunkt des Frameworks (Name, Beschreibung, Status) |
+| `/health` | GET | Health-Check |
+| `/machine/health` | GET | Health-Check für Maschinen-Clients (erfordert API-Key) |
+| `/examples/ping` | GET | Beispiel-Ping |
+| `/examples/protected` | GET | Beispiel für einen geschützten Endpunkt (bei konfiguriertem JWT) |
+
+Wenn Ihre Anwendung eine Startseite benötigt, verwenden Sie einen anderen Pfad (z. B. `/welcome`,
+`/home`) oder liefern Sie das HTML über die Smoke-Antwort des Frameworks aus, indem Sie einen
+Health-Check registrieren.
+
+---
+
+## 204 No Content zurückgeben (DELETE-Endpunkte)
+
+Verwenden Sie `JsonResponseFactory::createEmpty()`, um eine 204-Antwort ohne Body zurückzugeben:
+
+```php
+private function delete(ServerRequestInterface $request): ResponseInterface
+{
+    $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $id     = (int) ($params['id'] ?? 0);
+    $this->repository->delete($id); // wirft NotFoundException, wenn nicht gefunden
+    return $this->json->createEmpty(204);
+}
+```
+
+> **Warum nicht `create([], 204)`?** Ein leeres Array erzeugt einen JSON-Body `{}`.
+> `createEmpty()` liefert eine wirklich body-lose Antwort, was für 204 No Content korrekt ist.
 
 ---
 

--- a/docs/de/howto/add-jwt-authentication.md
+++ b/docs/de/howto/add-jwt-authentication.md
@@ -129,6 +129,33 @@ $app = (new RuntimeApplicationFactory(
 
 ---
 
+### Optionen für den Pfad-Geltungsbereich
+
+`BearerTokenMiddleware` unterstützt drei sich gegenseitig ausschließende Strategien für den
+Pfad-Geltungsbereich. Wählen Sie die, die zu Ihrem Zugriffsmodell passt:
+
+| Strategie | Parameter | Einsatz, wenn |
+|---|---|---|
+| Blockliste (am häufigsten) | `$excludedPaths` | Alle Routen erfordern Auth **außer** einer kurzen Liste öffentlicher Routen |
+| Erlaubnisliste | `$protectedPaths` | Nur eine feste, bekannte Menge an Routen erfordert Auth |
+| Präfix-Erlaubnisliste | `$protectedPathPrefixes` | Ein ganzer Pfad-Teilbaum erfordert Auth (z. B. `/me/`, `/admin/`) |
+
+**Beispiel für die Präfix-Erlaubnisliste** — jeden Pfad unter `/me/` schützen, ohne ihn einzeln
+aufzuführen:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails:         $problems,
+    verifier:               $verifier,
+    protectedPathPrefixes:  ['/me/'],
+);
+```
+
+Eine Anfrage an `/me/favorites/42` trifft auf das Präfix zu und erfordert ein gültiges Bearer-Token.
+Eine Anfrage an `/products/1` trifft nicht zu und passiert ohne Authentifizierung.
+
+---
+
 ## Schritt 4 — Claims im Handler lesen
 
 ```php

--- a/docs/de/howto/use-transactions.md
+++ b/docs/de/howto/use-transactions.md
@@ -5,6 +5,20 @@ Diese Anleitung erklärt, wie atomare mehrstufige Operationen mit `DatabaseTrans
 **Voraussetzung**: Ein Repository, das auf `DatabaseQueryExecutorInterface` basiert.
 Falls nicht, mit [Datenbankgestützten Endpunkt hinzufügen](./add-database-endpoint.md) beginnen.
 
+> **🚫 SQLite `:memory:` ist mit `transactional()` nicht kompatibel.**
+>
+> `PdoDatabaseTransactionManager` öffnet pro Aufruf eine *neue* Verbindung. Jede
+> `:memory:`-Verbindung zeigt auf eine *andere* leere In-Memory-Datenbank, sodass Executor und
+> Transaktion unterschiedliche Daten sehen und Rollbacks keinerlei Wirkung auf die Sicht des
+> Executors haben. Das Symptom ist still: Abfragen liefern mitten im Callback `null`, oder
+> Rollbacks machen Schreibvorgänge nicht rückgängig, die der Test über einen separaten Executor
+> ausgeführt hat.
+>
+> Verwenden Sie in Tests eine **dateibasierte SQLite**-Datenbank (siehe „[Mit dateibasierter
+> SQLite-Datenbank testen](#mit-dateibasierter-sqlite-datenbank-testen)" unten).
+> `Nene2\Testing\DatabaseTestKit::sqlite(':memory:')` weist `:memory:` mit einer
+> `InvalidArgumentException` ab, damit dies fail-fast auffällt.
+
 ---
 
 ## Warum Transaktionen in NENE2
@@ -107,32 +121,25 @@ $createOrder = new CreateOrderUseCase($txManager);   // verwendet $tx intern
 
 In-Memory-SQLite (`sqlite::memory:`) erstellt eine **separate Datenbank pro Verbindung**, sodass `PdoDatabaseTransactionManager` (der pro `transactional()`-Aufruf eine neue Verbindung öffnet) keine vom `PdoDatabaseQueryExecutor` geschriebenen Zeilen sehen würde und umgekehrt.
 
-Stattdessen eine **temporäre Datei** verwenden:
+Stattdessen eine **temporäre Datei** verwenden. `Nene2\Testing\DatabaseTestKit` verdrahtet den
+Executor und den Transaction Manager in einer Zeile auf dieselbe Datei:
 
 ```php
+use Nene2\Testing\DatabaseTestKit;
+
 protected function setUp(): void
 {
-    $this->dbFile = sys_get_temp_dir() . '/test-' . bin2hex(random_bytes(8)) . '.sqlite';
+    $this->dbFile = sys_get_temp_dir() . '/' . uniqid('test-', true) . '.sqlite';
+
+    // Schema über eine Wegwerf-Verbindung einspielen und diese schließen, bevor das Kit seine eigene öffnet.
     $pdo = new \PDO('sqlite:' . $this->dbFile, options: [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
     $pdo->exec(file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
-    unset($pdo); // Init-Verbindung schließen, bevor die Factory ihre eigene öffnet
+    unset($pdo);
 
-    $dbConfig = new DatabaseConfig(
-        url:         null,
-        environment: 'test',
-        adapter:     'sqlite',
-        host:        '',      // für SQLite nicht verwendet
-        port:        1,       // für SQLite nicht verwendet
-        name:        $this->dbFile,
-        user:        '',      // für SQLite nicht verwendet
-        password:    '',      // für SQLite nicht verwendet
-        charset:     '',      // für SQLite nicht verwendet
-    );
-
-    $factory   = new PdoConnectionFactory($dbConfig);
-    $executor  = new PdoDatabaseQueryExecutor($factory);
-    $txManager = new PdoDatabaseTransactionManager($factory);
-    // ... Repositories und Use Cases verdrahten
+    $this->kit = DatabaseTestKit::sqlite($this->dbFile);
+    // $this->kit->queryExecutor       — für lesende Repositories
+    // $this->kit->transactionManager  — für Use Cases
+    // $this->kit->connectionFactory   — falls Sie weitere Executors bauen müssen
 }
 
 protected function tearDown(): void
@@ -143,17 +150,62 @@ protected function tearDown(): void
 }
 ```
 
-Jeder Test erhält eine frische Datei, sowohl `PdoDatabaseQueryExecutor` als auch `PdoDatabaseTransactionManager` verbinden sich mit derselben Datei, und `tearDown` löscht sie.
+Das Kit liegt unter `Nene2\Testing\DatabaseTestKit` (ADR 0012, öffentliche API). Es verdrahtet
+intern `PdoConnectionFactory` + `PdoDatabaseQueryExecutor` + `PdoDatabaseTransactionManager`,
+die sich alle dieselbe Datei teilen, sodass Tests keine `@internal`-Klasse namentlich referenzieren
+müssen. Sowohl `DatabaseTestKit::sqlite(':memory:')` als auch die zugrunde liegenden
+Konfigurationskombinationen werden bereits in der Factory blockiert.
 
-> **Hinweis zu SQLite `DatabaseConfig`-Feldern**: Für SQLite sind nur `adapter` und `name` erforderlich. Leere Strings für `host`, `user`, `password` und `charset` übergeben — sie werden nicht validiert, wenn `adapter` `'sqlite'` ist.
-
-> **Hinweis**: `PdoDatabaseQueryExecutor` akzeptiert kein rohes `PDO` als Konstruktorargument — es erfordert eine `DatabaseConnectionFactoryInterface`. `PdoConnectionFactory` (oben gezeigt) verwenden, um ein rohes `PDO`-Setup mit dem Executor zu verbinden.
+> **`DatabaseConfig::sqlite(string $path)`** ist die entsprechende Abkürzung, wenn Sie die
+> Verdrahtung explizit halten möchten (z. B. um eine eigene Unterklasse von
+> `PdoConnectionFactory` zu injizieren). Sie ersetzt die 9-Argument-Form
+> `new DatabaseConfig(...)` aus älteren Anleitungen.
 
 ---
 
 ## Rollback-Verhalten verifizieren
 
-Testen, dass ein Fehler mitten in einer Transaktion alle vorherigen Änderungen rückgängig macht:
+Ein Use Case, der mehrere Schreibvorgänge umschließt, ist nur dann korrekt, wenn der Rollback-Pfad
+vorherige Schreibvorgänge **tatsächlich rückgängig macht**. Ein Test, der nur den Erfolgsfall
+abdeckt, besteht auch dann, wenn der Use Case vergisst, `$tx` zu verwenden — `$this->products`
+läuft dann außerhalb der Transaktion und committet stillschweigend. Der Rollback-Test ist der,
+der den Fehler findet.
+
+### Rollback auf Unit-Ebene
+
+Den Use Case direkt mit `DatabaseTestKit` ansteuern und den Datenbankzustand nach der Exception
+prüfen:
+
+```php
+public function testRollbackUndoesStockDecrementWhenOrderInsertFails(): void
+{
+    $kit = DatabaseTestKit::sqlite($this->dbFile);
+    $kit->queryExecutor->execute(/* Seed: Produkt 1 mit stock=10 */);
+
+    $useCase = new CreateOrderUseCase($kit->transactionManager);
+
+    try {
+        // Eine Menge übergeben, die bei decrementStock erfolgreich ist, aber in orders.save
+        // eine Unique-Constraint-Verletzung auslöst (z. B. doppelter Idempotenzschlüssel).
+        $useCase->execute(productId: 1, qty: 3, idempotencyKey: $existingKey);
+        self::fail('Expected order creation to fail.');
+    } catch (DatabaseConstraintException) {
+        // erwartet
+    }
+
+    // Das decrementStock aus Schritt 1 muss zurückgerollt worden sein.
+    $row = $kit->queryExecutor->fetchOne('SELECT stock FROM products WHERE id = ?', [1]);
+    self::assertSame(10, $row['stock']);
+}
+```
+
+Dieser Test schlägt sofort fehl, wenn der Use Case `$this->products->decrementStock()` aufruft,
+statt ein Repository aus `$tx` zu bauen — die Bestandsminderung überlebt dann den Rollback und
+die Assertion fängt sie ab.
+
+### Rollback auf HTTP-Ebene
+
+Dieselbe Eigenschaft auf Integrationsebene:
 
 ```php
 public function testTransactionRollsBackOnDomainException(): void

--- a/docs/fr/howto/add-custom-route.md
+++ b/docs/fr/howto/add-custom-route.md
@@ -131,6 +131,77 @@ routeRegistrars: [
 
 Ou répartissez sur plusieurs fonctions registrar pour plus de clarté quand la liste de routes devient longue.
 
+> **Ordre d'enregistrement des routes** : le routeur effectue la correspondance dans l'**ordre
+> d'enregistrement**. Enregistrez **toujours les routes statiques avant les routes paramétrées**
+> lorsqu'elles partagent le même préfixe. Si vous enregistrez `GET /items/{id}` puis
+> `GET /items/summary`, une requête vers `/items/summary` correspondra à la route `{id}` avec
+> `id = "summary"` — produisant un 404 spécifique au domaine déroutant plutôt qu'une erreur de routage.
+>
+> ```php
+> // INCORRECT — /items/summary correspond à {id} avec id="summary"
+> $router->get('/items/{id}',    $this->show(...));
+> $router->get('/items/summary', $this->summary(...)); // jamais atteint
+>
+> // CORRECT — le segment statique est mis en correspondance en premier
+> $router->get('/items/summary', $this->summary(...));
+> $router->get('/items/{id}',    $this->show(...));
+> ```
+
+---
+
+## Endpoints d'action (opérations non-CRUD)
+
+Certaines opérations n'entrent pas dans la forme CRUD standard — archiver, publier, approuver,
+restaurer. Utilisez `POST /resource/{id}/action` pour celles-ci. La réponse est `200 OK` avec le
+corps de la ressource mise à jour.
+
+```php
+$router->post('/items/{id}/archive', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->archive($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+
+$router->post('/items/{id}/restore', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->restore($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+```
+
+> **Ordre d'enregistrement** : les routes d'action (`/items/{id}/archive`) partagent le segment
+> `{id}` avec les routes show/update — elles fonctionnent correctement car le chemin d'action
+> comporte un segment statique supplémentaire après `{id}`, ce qui les rend non ambiguës quel que
+> soit l'ordre d'enregistrement.
+
+### Endpoints d'action avec un corps optionnel
+
+Certaines actions acceptent un corps JSON optionnel (par exemple une action `reject` avec un
+`reason` optionnel). `JsonRequestBodyParser::parse()` lève une erreur 400 si le corps est vide —
+vérifiez donc que le corps n'est pas vide avant d'appeler le parseur :
+
+```php
+$router->post('/items/{id}/reject', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $raw    = (string) $req->getBody();
+    $reason = null;
+
+    if ($raw !== '') {
+        $body   = JsonRequestBodyParser::parse($req);
+        $reason = isset($body['reason']) && is_string($body['reason']) ? trim($body['reason']) : null;
+    }
+
+    $item = $repo->reject($id, $reason, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item));
+});
+```
+
 ---
 
 ## Méthodes HTTP disponibles
@@ -138,9 +209,49 @@ Ou répartissez sur plusieurs fonctions registrar pour plus de clarté quand la 
 | Méthode | Méthode Router | Usage typique |
 |---|---|---|
 | GET | `$router->get()` | Lire une ressource |
-| POST | `$router->post()` | Créer une ressource |
+| POST | `$router->post()` | Créer une ressource ou déclencher une action |
 | PUT | `$router->put()` | Remplacer une ressource (mise à jour complète) |
+| PATCH | `$router->patch()` | Mise à jour partielle |
 | DELETE | `$router->delete()` | Supprimer une ressource |
+
+---
+
+## Chemins réservés par le framework
+
+Les chemins suivants sont enregistrés par `RuntimeApplicationFactory` **avant** l'exécution de vos
+registrars de routes. Les routes enregistrées par l'utilisateur pour ces chemins ne correspondront
+jamais, car les routes du framework sont vérifiées en premier.
+
+| Chemin | Méthode | Description |
+|---|---|---|
+| `/` | GET | Endpoint de smoke du framework (nom, description, statut) |
+| `/health` | GET | Vérification de santé |
+| `/machine/health` | GET | Vérification de santé pour clients machine (clé API requise) |
+| `/examples/ping` | GET | Exemple de ping |
+| `/examples/protected` | GET | Exemple d'endpoint protégé (quand JWT est configuré) |
+
+Si votre application a besoin d'une page d'accueil, utilisez un chemin différent (par exemple
+`/welcome`, `/home`) ou servez le HTML via la réponse de smoke du framework en enregistrant une
+vérification de santé.
+
+---
+
+## Renvoyer 204 No Content (endpoints DELETE)
+
+Utilisez `JsonResponseFactory::createEmpty()` pour renvoyer une réponse 204 sans corps :
+
+```php
+private function delete(ServerRequestInterface $request): ResponseInterface
+{
+    $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $id     = (int) ($params['id'] ?? 0);
+    $this->repository->delete($id); // lève NotFoundException si introuvable
+    return $this->json->createEmpty(204);
+}
+```
+
+> **Pourquoi pas `create([], 204)` ?** Passer un tableau vide produit un corps JSON `{}`.
+> `createEmpty()` renvoie une réponse réellement sans corps, ce qui est correct pour 204 No Content.
 
 ---
 

--- a/docs/fr/howto/add-jwt-authentication.md
+++ b/docs/fr/howto/add-jwt-authentication.md
@@ -129,6 +129,33 @@ $app = (new RuntimeApplicationFactory(
 
 ---
 
+### Options de portée par chemin
+
+`BearerTokenMiddleware` prend en charge trois stratégies de portée par chemin mutuellement
+exclusives. Choisissez celle qui correspond à votre modèle d'accès :
+
+| Stratégie | Paramètre | À utiliser quand |
+|---|---|---|
+| Liste de blocage (la plus courante) | `$excludedPaths` | Toutes les routes exigent l'auth **sauf** une courte liste de routes publiques |
+| Liste d'autorisation | `$protectedPaths` | Seul un ensemble fixe et connu de routes exige l'auth |
+| Liste d'autorisation par préfixe | `$protectedPathPrefixes` | Tout un sous-arbre de chemins exige l'auth (p. ex. `/me/`, `/admin/`) |
+
+**Exemple de liste d'autorisation par préfixe** — protéger tous les chemins sous `/me/` sans les
+énumérer un par un :
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails:         $problems,
+    verifier:               $verifier,
+    protectedPathPrefixes:  ['/me/'],
+);
+```
+
+Une requête vers `/me/favorites/42` correspond au préfixe et exige un jeton Bearer valide.
+Une requête vers `/products/1` ne correspond pas et passe sans authentification.
+
+---
+
 ## Étape 4 — Lire les claims dans un handler
 
 ```php

--- a/docs/fr/howto/use-transactions.md
+++ b/docs/fr/howto/use-transactions.md
@@ -6,6 +6,19 @@ Ce guide explique comment effectuer des opérations atomiques multi-étapes en u
 **Prérequis** : Vous avez un repository soutenu par `DatabaseQueryExecutorInterface`.
 Si ce n'est pas le cas, commencez par [Ajouter un endpoint soutenu par une base de données](./add-database-endpoint.md).
 
+> **🚫 SQLite `:memory:` est incompatible avec `transactional()`.**
+>
+> `PdoDatabaseTransactionManager` ouvre une *nouvelle* connexion à chaque appel. Chaque connexion
+> `:memory:` pointe vers une base en mémoire vide *différente*, de sorte que l'exécuteur et la
+> transaction voient des données différentes et que les annulations n'ont aucun effet sur la vue de
+> l'exécuteur. Le symptôme est silencieux : les requêtes renvoient `null` au milieu du callback, ou
+> les annulations ne défont pas les écritures effectuées par le test via un exécuteur distinct.
+>
+> Utilisez une base SQLite **basée sur un fichier** dans les tests (voir « [Tester avec une base de
+> données SQLite basée sur des fichiers](#tester-avec-une-base-de-données-sqlite-basée-sur-des-fichiers) »
+> ci-dessous). `Nene2\Testing\DatabaseTestKit::sqlite(':memory:')` rejette `:memory:` avec une
+> `InvalidArgumentException` pour que l'échec soit immédiat.
+
 ---
 
 ## Pourquoi utiliser les transactions dans NENE2
@@ -124,32 +137,25 @@ Le SQLite en mémoire (`sqlite::memory:`) crée une **base de données séparée
 `PdoDatabaseTransactionManager` (qui ouvre une nouvelle connexion par appel `transactional()`)
 ne verrait pas les lignes écrites par `PdoDatabaseQueryExecutor` et vice-versa.
 
-Utiliser un **fichier temporaire** à la place :
+Utiliser un **fichier temporaire** à la place. `Nene2\Testing\DatabaseTestKit` câble l'exécuteur et
+le gestionnaire de transactions sur le même fichier en une ligne :
 
 ```php
+use Nene2\Testing\DatabaseTestKit;
+
 protected function setUp(): void
 {
-    $this->dbFile = sys_get_temp_dir() . '/test-' . bin2hex(random_bytes(8)) . '.sqlite';
+    $this->dbFile = sys_get_temp_dir() . '/' . uniqid('test-', true) . '.sqlite';
+
+    // Injecter le schéma via une connexion jetable, puis la fermer avant que le kit ouvre la sienne.
     $pdo = new \PDO('sqlite:' . $this->dbFile, options: [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
     $pdo->exec(file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
-    unset($pdo); // fermer la connexion d'initialisation avant que la factory ouvre la sienne
+    unset($pdo);
 
-    $dbConfig = new DatabaseConfig(
-        url:         null,
-        environment: 'test',
-        adapter:     'sqlite',
-        host:        '',      // inutilisé pour SQLite
-        port:        1,       // inutilisé pour SQLite
-        name:        $this->dbFile,
-        user:        '',      // inutilisé pour SQLite
-        password:    '',      // inutilisé pour SQLite
-        charset:     '',      // inutilisé pour SQLite
-    );
-
-    $factory   = new PdoConnectionFactory($dbConfig);
-    $executor  = new PdoDatabaseQueryExecutor($factory);
-    $txManager = new PdoDatabaseTransactionManager($factory);
-    // ... câbler les repositories et les use cases
+    $this->kit = DatabaseTestKit::sqlite($this->dbFile);
+    // $this->kit->queryExecutor       — pour les repositories en lecture
+    // $this->kit->transactionManager  — pour les use cases
+    // $this->kit->connectionFactory   — si vous devez construire d'autres exécuteurs
 }
 
 protected function tearDown(): void
@@ -160,22 +166,61 @@ protected function tearDown(): void
 }
 ```
 
-Chaque test obtient un fichier fraîchement créé, `PdoDatabaseQueryExecutor` et
-`PdoDatabaseTransactionManager` se connectent au même fichier, et `tearDown` le supprime.
+Le kit se trouve dans `Nene2\Testing\DatabaseTestKit` (ADR 0012, API publique). Il câble en interne
+`PdoConnectionFactory` + `PdoDatabaseQueryExecutor` + `PdoDatabaseTransactionManager`, tous
+partageant le même fichier, de sorte que les tests n'ont besoin de référencer aucune classe
+`@internal` par son nom. `DatabaseTestKit::sqlite(':memory:')` ainsi que les combinaisons de
+configuration sous-jacentes sont bloqués au niveau de la factory.
 
-> **Note sur les champs SQLite `DatabaseConfig`** : Pour SQLite, seuls `adapter` et `name`
-> sont requis. Passer des chaînes vides pour `host`, `user`, `password`, et `charset` — ils
-> ne sont pas validés quand `adapter` est `'sqlite'`.
-
-> **Note** : `PdoDatabaseQueryExecutor` n'accepte pas un `PDO` brut comme argument de constructeur
-> — il nécessite un `DatabaseConnectionFactoryInterface`. Utiliser `PdoConnectionFactory`
-> (montré ci-dessus) pour relier une configuration `PDO` brute à l'exécuteur.
+> **`DatabaseConfig::sqlite(string $path)`** est le raccourci équivalent lorsque vous voulez
+> garder un câblage explicite (par exemple pour injecter votre propre sous-classe de
+> `PdoConnectionFactory`). Il remplace la forme à 9 arguments `new DatabaseConfig(...)` montrée
+> dans les guides plus anciens.
 
 ---
 
 ## Vérifier le comportement d'annulation
 
-Tester qu'un échec au milieu d'une transaction défait toutes les modifications précédentes :
+Un use case qui englobe plusieurs écritures n'est correct que si le chemin d'annulation **défait
+réellement** les écritures précédentes. Un test qui ne couvre que le cas nominal passera même si le
+use case oublie d'utiliser `$tx` — `$this->products` s'exécutera alors hors de la transaction et
+sera validé silencieusement. C'est le test d'annulation qui attrape le bug.
+
+### Annulation au niveau unitaire
+
+Pilotez le use case directement avec `DatabaseTestKit` et vérifiez l'état de la base après
+l'exception :
+
+```php
+public function testRollbackUndoesStockDecrementWhenOrderInsertFails(): void
+{
+    $kit = DatabaseTestKit::sqlite($this->dbFile);
+    $kit->queryExecutor->execute(/* seed : produit 1 avec stock=10 */);
+
+    $useCase = new CreateOrderUseCase($kit->transactionManager);
+
+    try {
+        // Passer une quantité qui réussit à decrementStock mais déclenche une violation de
+        // contrainte d'unicité dans orders.save (p. ex. clé d'idempotence dupliquée).
+        $useCase->execute(productId: 1, qty: 3, idempotencyKey: $existingKey);
+        self::fail('Expected order creation to fail.');
+    } catch (DatabaseConstraintException) {
+        // attendu
+    }
+
+    // Le decrementStock de l'étape 1 doit avoir été annulé.
+    $row = $kit->queryExecutor->fetchOne('SELECT stock FROM products WHERE id = ?', [1]);
+    self::assertSame(10, $row['stock']);
+}
+```
+
+Ce test échoue immédiatement si le use case appelle `$this->products->decrementStock()` au lieu de
+construire un repository à partir de `$tx` — la décrémentation du stock survit à l'annulation et
+l'assertion la détecte.
+
+### Annulation au niveau HTTP
+
+La même propriété au niveau de l'intégration :
 
 ```php
 public function testTransactionRollsBackOnDomainException(): void

--- a/docs/ja/howto/add-custom-route.md
+++ b/docs/ja/howto/add-custom-route.md
@@ -132,6 +132,74 @@ routeRegistrars: [
 
 ルートリストが長くなったら、複数の registrar 関数に分割してください。
 
+> **ルート登録順**: ルーターは**登録順**にマッチします。同じプレフィックスを共有する場合は
+> **必ず静的ルートをパラメーター付きルートより先に登録してください**。`GET /items/{id}` を先に、
+> `GET /items/summary` を後に登録すると、`/items/summary` へのリクエストは `id = "summary"` として
+> `{id}` ルートにマッチします — ルーティングエラーではなく、分かりにくいドメイン固有の 404 が返ります。
+>
+> ```php
+> // 誤り — /items/summary が id="summary" として {id} にマッチする
+> $router->get('/items/{id}',    $this->show(...));
+> $router->get('/items/summary', $this->summary(...)); // 到達しない
+>
+> // 正しい — 静的セグメントを先にマッチさせる
+> $router->get('/items/summary', $this->summary(...));
+> $router->get('/items/{id}',    $this->show(...));
+> ```
+
+---
+
+## アクションエンドポイント（CRUD 以外の操作）
+
+アーカイブ・公開・承認・復元など、標準的な CRUD の形に収まらない操作があります。
+これらには `POST /resource/{id}/action` を使います。レスポンスは更新後のリソースを本文に持つ `200 OK` です。
+
+```php
+$router->post('/items/{id}/archive', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->archive($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+
+$router->post('/items/{id}/restore', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->restore($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+```
+
+> **登録順について**: アクションルート（`/items/{id}/archive`）は show/update ルートと `{id}`
+> セグメントを共有しますが、`{id}` の後に静的セグメントが追加されているため一意に定まります。
+> したがって登録順によらず正しく動作します。
+
+### 任意のボディを取るアクションエンドポイント
+
+アクションによっては任意の JSON ボディを受け取ります（例: 任意の `reason` を取る `reject`）。
+`JsonRequestBodyParser::parse()` はボディが空だと 400 を投げるため、パーサーを呼ぶ前に
+空ボディかどうかを確認してください:
+
+```php
+$router->post('/items/{id}/reject', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $raw    = (string) $req->getBody();
+    $reason = null;
+
+    if ($raw !== '') {
+        $body   = JsonRequestBodyParser::parse($req);
+        $reason = isset($body['reason']) && is_string($body['reason']) ? trim($body['reason']) : null;
+    }
+
+    $item = $repo->reject($id, $reason, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item));
+});
+```
+
 ---
 
 ## 使用可能な HTTP メソッド
@@ -139,9 +207,47 @@ routeRegistrars: [
 | メソッド | Router メソッド | 典型的な用途 |
 |---|---|---|
 | GET | `$router->get()` | リソースを読み取る |
-| POST | `$router->post()` | リソースを作成する |
+| POST | `$router->post()` | リソースを作成する、またはアクションを実行する |
 | PUT | `$router->put()` | リソースを置き換える（完全更新） |
+| PATCH | `$router->patch()` | 部分更新 |
 | DELETE | `$router->delete()` | リソースを削除する |
+
+---
+
+## フレームワークの予約パス
+
+以下のパスは、あなたの route registrar が動く**前**に `RuntimeApplicationFactory` が登録します。
+フレームワークのルートが先に評価されるため、これらのパスにユーザーが登録したルートは決してマッチしません。
+
+| パス | メソッド | 説明 |
+|---|---|---|
+| `/` | GET | フレームワークのスモークエンドポイント（name / description / status） |
+| `/health` | GET | ヘルスチェック |
+| `/machine/health` | GET | マシンクライアント向けヘルスチェック（API キー必須） |
+| `/examples/ping` | GET | サンプルの ping |
+| `/examples/protected` | GET | サンプルの保護エンドポイント（JWT 設定時） |
+
+アプリケーションにホームページが必要な場合は別のパス（`/welcome`・`/home` など）を使うか、
+ヘルスチェックを登録してフレームワークのスモークレスポンス経由で HTML を返してください。
+
+---
+
+## 204 No Content を返す（DELETE エンドポイント）
+
+本文なしの 204 レスポンスを返すには `JsonResponseFactory::createEmpty()` を使います:
+
+```php
+private function delete(ServerRequestInterface $request): ResponseInterface
+{
+    $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $id     = (int) ($params['id'] ?? 0);
+    $this->repository->delete($id); // 見つからなければ NotFoundException を投げる
+    return $this->json->createEmpty(204);
+}
+```
+
+> **なぜ `create([], 204)` ではないのか**: 空配列を渡すと `{}` という JSON 本文が生成されます。
+> `createEmpty()` は本当に本文を持たないレスポンスを返すため、204 No Content として正しい形です。
 
 ---
 

--- a/docs/ja/howto/add-jwt-authentication.md
+++ b/docs/ja/howto/add-jwt-authentication.md
@@ -264,6 +264,32 @@ $app = (new RuntimeApplicationFactory(
 
 ---
 
+### パススコープの指定方法
+
+`BearerTokenMiddleware` は互いに排他的な 3 つのパススコープ戦略をサポートします。
+アクセスモデルに合うものを選んでください:
+
+| 戦略 | パラメーター | 使いどころ |
+|---|---|---|
+| ブロックリスト（最も一般的） | `$excludedPaths` | 少数の公開ルート**以外**の全ルートに認証が必要 |
+| 許可リスト | `$protectedPaths` | 認証が必要なルートが固定・既知の集合である |
+| プレフィックス許可リスト | `$protectedPathPrefixes` | パスのサブツリー全体に認証が必要（例: `/me/`・`/admin/`） |
+
+**プレフィックス許可リストの例** — `/me/` 配下の全パスを、個別に列挙せずに保護する:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails:         $problems,
+    verifier:               $verifier,
+    protectedPathPrefixes:  ['/me/'],
+);
+```
+
+`/me/favorites/42` へのリクエストはプレフィックスにマッチするため有効な Bearer トークンが必要です。
+`/products/1` へのリクエストはマッチしないため、認証なしで通過します。
+
+---
+
 ## ステップ 5 — 保護されたハンドラーでクレームを読む
 
 `BearerTokenMiddleware` がトークンを検証すると、デコードされたクレームをリクエスト属性として保存します。

--- a/docs/ja/howto/use-transactions.md
+++ b/docs/ja/howto/use-transactions.md
@@ -5,6 +5,19 @@
 **前提条件**: `DatabaseQueryExecutorInterface` にバックされたリポジトリがあること。
 ない場合は [データベースバックエンドエンドポイントの追加](./add-database-endpoint.md) から始めてください。
 
+> **🚫 SQLite の `:memory:` は `transactional()` と併用できません。**
+>
+> `PdoDatabaseTransactionManager` は呼び出しごとに**新しい**接続を開きます。`:memory:` の接続は
+> それぞれ**別の空のインメモリデータベース**を指すため、エグゼキューターとトランザクションが
+> 別々のデータを見ることになり、ロールバックがエグゼキューター側の見え方に何の影響も与えません。
+> 症状は静かです — コールバックの途中でクエリが `null` を返す、あるいは別のエグゼキューター経由で
+> テストが書き込んだ内容をロールバックが取り消せない、といった形で現れます。
+>
+> テストでは**ファイルベースの SQLite** を使ってください（下の
+> 「[ファイルベースの SQLite データベースでのテスト](#ファイルベースの-sqlite-データベースでのテスト)」参照）。
+> `Nene2\Testing\DatabaseTestKit::sqlite(':memory:')` は `:memory:` を
+> `InvalidArgumentException` で弾き、この問題を fail-fast にします。
+
 ---
 
 ## NENE2 でトランザクションを使う理由
@@ -107,32 +120,25 @@ $createOrder = new CreateOrderUseCase($txManager);   // 内部で $tx を使用
 
 インメモリ SQLite（`sqlite::memory:`）は**接続ごとに別のデータベース**を作成するため、`PdoDatabaseTransactionManager`（`transactional()` 呼び出しごとに新しい接続を開く）は `PdoDatabaseQueryExecutor` が書き込んだ行を見えず、その逆も同様です。
 
-代わりに**テンポラリファイル**を使用してください:
+代わりに**テンポラリファイル**を使用してください。`Nene2\Testing\DatabaseTestKit` は
+エグゼキューターとトランザクションマネージャーを同じファイルに 1 行で配線します:
 
 ```php
+use Nene2\Testing\DatabaseTestKit;
+
 protected function setUp(): void
 {
-    $this->dbFile = sys_get_temp_dir() . '/test-' . bin2hex(random_bytes(8)) . '.sqlite';
+    $this->dbFile = sys_get_temp_dir() . '/' . uniqid('test-', true) . '.sqlite';
+
+    // 使い捨て接続でスキーマを投入し、kit が独自の接続を開く前に閉じる。
     $pdo = new \PDO('sqlite:' . $this->dbFile, options: [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
     $pdo->exec(file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
-    unset($pdo); // ファクトリーが独自の接続を開く前に初期化接続を閉じる
+    unset($pdo);
 
-    $dbConfig = new DatabaseConfig(
-        url:         null,
-        environment: 'test',
-        adapter:     'sqlite',
-        host:        '',      // SQLite では未使用
-        port:        1,       // SQLite では未使用
-        name:        $this->dbFile,
-        user:        '',      // SQLite では未使用
-        password:    '',      // SQLite では未使用
-        charset:     '',      // SQLite では未使用
-    );
-
-    $factory   = new PdoConnectionFactory($dbConfig);
-    $executor  = new PdoDatabaseQueryExecutor($factory);
-    $txManager = new PdoDatabaseTransactionManager($factory);
-    // ... リポジトリとユースケースを配線する
+    $this->kit = DatabaseTestKit::sqlite($this->dbFile);
+    // $this->kit->queryExecutor       — 読み取りリポジトリ用
+    // $this->kit->transactionManager  — ユースケース用
+    // $this->kit->connectionFactory   — 追加のエグゼキューターを組む必要がある場合
 }
 
 protected function tearDown(): void
@@ -143,17 +149,59 @@ protected function tearDown(): void
 }
 ```
 
-各テストは新鮮なファイルを取得し、`PdoDatabaseQueryExecutor` と `PdoDatabaseTransactionManager` の両方が同じファイルに接続し、`tearDown` がそれを削除します。
+この kit は `Nene2\Testing\DatabaseTestKit`（ADR 0012・公開 API）にあります。内部で
+`PdoConnectionFactory` + `PdoDatabaseQueryExecutor` + `PdoDatabaseTransactionManager` を
+同じファイルを共有する形で配線するため、テストが `@internal` なクラスを名指しする必要がありません。
+`DatabaseTestKit::sqlite(':memory:')` と、その裏にある設定の組み合わせは、いずれもファクトリーの
+段階で弾かれます。
 
-> **SQLite `DatabaseConfig` フィールドに関する注意**: SQLite の場合、`adapter` と `name` のみが必要です。`host`、`user`、`password`、`charset` には空文字列を渡してください — `adapter` が `'sqlite'` の場合、これらは検証されません。
-
-> **注意**: `PdoDatabaseQueryExecutor` はコンストラクター引数として生の `PDO` を受け入れません — `DatabaseConnectionFactoryInterface` が必要です。生の `PDO` セットアップをエグゼキューターにブリッジするには `PdoConnectionFactory`（上記参照）を使用してください。
+> **`DatabaseConfig::sqlite(string $path)`** は、配線を明示的に保ちたい場合（例えば
+> `PdoConnectionFactory` の独自サブクラスを注入したい場合）の同等のショートカットです。
+> 古いガイドに出てくる 9 引数の `new DatabaseConfig(...)` 形式を置き換えます。
 
 ---
 
 ## ロールバック動作の検証
 
-トランザクション中に失敗が発生すると、それ以前のすべての変更が元に戻ることをテストしてください:
+複数の書き込みをまとめるユースケースは、ロールバック経路が**実際に**それ以前の書き込みを
+取り消して初めて正しいと言えます。成功パスしか通らないテストは、ユースケースが `$tx` を
+使い忘れていても通ってしまいます — `$this->products` はトランザクションの外で実行され、
+黙ってコミットされるからです。バグを捕まえるのはロールバックのテストです。
+
+### ユニットレベルのロールバック
+
+`DatabaseTestKit` でユースケースを直接駆動し、例外の後にデータベースの状態を検証します:
+
+```php
+public function testRollbackUndoesStockDecrementWhenOrderInsertFails(): void
+{
+    $kit = DatabaseTestKit::sqlite($this->dbFile);
+    $kit->queryExecutor->execute(/* シード: 在庫 10 の製品 1 */);
+
+    $useCase = new CreateOrderUseCase($kit->transactionManager);
+
+    try {
+        // decrementStock は成功するが orders.save で一意制約違反になる数量を渡す
+        // （例: 冪等性キーの重複）。
+        $useCase->execute(productId: 1, qty: 3, idempotencyKey: $existingKey);
+        self::fail('Expected order creation to fail.');
+    } catch (DatabaseConstraintException) {
+        // 想定どおり
+    }
+
+    // ステップ 1 の decrementStock はロールバックされていなければならない。
+    $row = $kit->queryExecutor->fetchOne('SELECT stock FROM products WHERE id = ?', [1]);
+    self::assertSame(10, $row['stock']);
+}
+```
+
+ユースケースが `$tx` からリポジトリを組み立てず `$this->products->decrementStock()` を
+呼んでいると、このテストは即座に落ちます — 在庫の減算がロールバックをすり抜け、
+アサーションがそれを捕まえます。
+
+### HTTP レベルのロールバック
+
+同じ性質を統合レベルで確認します:
 
 ```php
 public function testTransactionRollsBackOnDomainException(): void

--- a/docs/pt-br/howto/add-custom-route.md
+++ b/docs/pt-br/howto/add-custom-route.md
@@ -131,6 +131,75 @@ routeRegistrars: [
 
 Ou divida em múltiplas funções registrar para clareza quando a lista de rotas crescer.
 
+> **Ordem de registro das rotas**: o roteador faz a correspondência na **ordem de registro**.
+> Registre **sempre as rotas estáticas antes das parametrizadas** quando ambas compartilham o mesmo
+> prefixo. Se você registrar `GET /items/{id}` primeiro e depois `GET /items/summary`, uma requisição
+> para `/items/summary` corresponderá à rota `{id}` com `id = "summary"` — produzindo um 404
+> específico do domínio confuso, em vez de um erro de roteamento.
+>
+> ```php
+> // ERRADO — /items/summary corresponde a {id} com id="summary"
+> $router->get('/items/{id}',    $this->show(...));
+> $router->get('/items/summary', $this->summary(...)); // nunca alcançado
+>
+> // CORRETO — o segmento estático é correspondido primeiro
+> $router->get('/items/summary', $this->summary(...));
+> $router->get('/items/{id}',    $this->show(...));
+> ```
+
+---
+
+## Endpoints de ação (operações não-CRUD)
+
+Algumas operações não se encaixam no formato CRUD padrão — arquivar, publicar, aprovar, restaurar.
+Use `POST /resource/{id}/action` para elas. A resposta é `200 OK` com o corpo do recurso atualizado.
+
+```php
+$router->post('/items/{id}/archive', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->archive($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+
+$router->post('/items/{id}/restore', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->restore($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+```
+
+> **Ordem de registro**: rotas de ação (`/items/{id}/archive`) compartilham o segmento `{id}` com as
+> rotas de show/update — elas funcionam corretamente porque o caminho da ação tem um segmento
+> estático adicional após `{id}`, tornando-as inequívocas independentemente da ordem de registro.
+
+### Endpoints de ação com corpo opcional
+
+Algumas ações aceitam um corpo JSON opcional (por exemplo, uma ação `reject` com um `reason`
+opcional). `JsonRequestBodyParser::parse()` lança um 400 se o corpo estiver vazio — verifique se o
+corpo está vazio antes de chamar o parser:
+
+```php
+$router->post('/items/{id}/reject', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $raw    = (string) $req->getBody();
+    $reason = null;
+
+    if ($raw !== '') {
+        $body   = JsonRequestBodyParser::parse($req);
+        $reason = isset($body['reason']) && is_string($body['reason']) ? trim($body['reason']) : null;
+    }
+
+    $item = $repo->reject($id, $reason, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item));
+});
+```
+
 ---
 
 ## Métodos HTTP disponíveis
@@ -138,9 +207,48 @@ Ou divida em múltiplas funções registrar para clareza quando a lista de rotas
 | Método | Método do Router | Uso típico |
 |---|---|---|
 | GET | `$router->get()` | Ler um recurso |
-| POST | `$router->post()` | Criar um recurso |
+| POST | `$router->post()` | Criar um recurso ou disparar uma ação |
 | PUT | `$router->put()` | Substituir um recurso (atualização completa) |
+| PATCH | `$router->patch()` | Atualização parcial |
 | DELETE | `$router->delete()` | Remover um recurso |
+
+---
+
+## Caminhos reservados pelo framework
+
+Os caminhos a seguir são registrados por `RuntimeApplicationFactory` **antes** que seus registrars de
+rota sejam executados. Rotas registradas pelo usuário para esses caminhos nunca corresponderão,
+porque as rotas do framework são verificadas primeiro.
+
+| Caminho | Método | Descrição |
+|---|---|---|
+| `/` | GET | Endpoint de smoke do framework (nome, descrição, status) |
+| `/health` | GET | Verificação de saúde |
+| `/machine/health` | GET | Verificação de saúde para clientes de máquina (requer chave de API) |
+| `/examples/ping` | GET | Exemplo de ping |
+| `/examples/protected` | GET | Exemplo de endpoint protegido (quando JWT está configurado) |
+
+Se sua aplicação precisar de uma página inicial, use um caminho diferente (por exemplo, `/welcome`,
+`/home`) ou sirva o HTML pela resposta de smoke do framework registrando uma verificação de saúde.
+
+---
+
+## Retornando 204 No Content (endpoints DELETE)
+
+Use `JsonResponseFactory::createEmpty()` para retornar uma resposta 204 sem corpo:
+
+```php
+private function delete(ServerRequestInterface $request): ResponseInterface
+{
+    $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $id     = (int) ($params['id'] ?? 0);
+    $this->repository->delete($id); // lança NotFoundException se não encontrado
+    return $this->json->createEmpty(204);
+}
+```
+
+> **Por que não `create([], 204)`?** Passar um array vazio produz um corpo JSON `{}`.
+> `createEmpty()` retorna uma resposta realmente sem corpo, o que é correto para 204 No Content.
 
 ---
 

--- a/docs/pt-br/howto/add-jwt-authentication.md
+++ b/docs/pt-br/howto/add-jwt-authentication.md
@@ -129,6 +129,33 @@ $app = (new RuntimeApplicationFactory(
 
 ---
 
+### Opções de escopo por caminho
+
+`BearerTokenMiddleware` suporta três estratégias mutuamente exclusivas de escopo por caminho.
+Escolha a que corresponde ao seu modelo de acesso:
+
+| Estratégia | Parâmetro | Use quando |
+|---|---|---|
+| Lista de bloqueio (mais comum) | `$excludedPaths` | Todas as rotas exigem auth **exceto** uma curta lista de rotas públicas |
+| Lista de permissão | `$protectedPaths` | Apenas um conjunto fixo e conhecido de rotas exige auth |
+| Lista de permissão por prefixo | `$protectedPathPrefixes` | Toda uma subárvore de caminhos exige auth (ex.: `/me/`, `/admin/`) |
+
+**Exemplo de lista de permissão por prefixo** — proteger todos os caminhos sob `/me/` sem listar
+cada um:
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails:         $problems,
+    verifier:               $verifier,
+    protectedPathPrefixes:  ['/me/'],
+);
+```
+
+Uma requisição para `/me/favorites/42` corresponde ao prefixo e exige um token Bearer válido.
+Uma requisição para `/products/1` não corresponde e passa sem autenticação.
+
+---
+
 ## Passo 4 — Ler as claims no handler
 
 ```php

--- a/docs/pt-br/howto/use-transactions.md
+++ b/docs/pt-br/howto/use-transactions.md
@@ -6,6 +6,19 @@ Este guia explica como realizar operações atômicas com múltiplos passos usan
 **Pré-requisito**: Você tem um repositório apoiado por `DatabaseQueryExecutorInterface`.
 Caso contrário, comece com [Adicionar um endpoint com banco de dados](./add-database-endpoint.md).
 
+> **🚫 O SQLite `:memory:` é incompatível com `transactional()`.**
+>
+> `PdoDatabaseTransactionManager` abre uma *nova* conexão a cada chamada. Cada conexão `:memory:`
+> aponta para um banco de dados em memória vazio *diferente*, de modo que o executor e a transação
+> veem dados distintos e os rollbacks não têm efeito algum sobre a visão do executor. O sintoma é
+> silencioso: consultas retornam `null` no meio do callback, ou rollbacks não desfazem escritas que
+> o teste realizou por meio de um executor separado.
+>
+> Use um banco SQLite **baseado em arquivo** nos testes (veja "[Testar com um banco de dados SQLite
+> baseado em arquivo](#testar-com-um-banco-de-dados-sqlite-baseado-em-arquivo)" abaixo).
+> `Nene2\Testing\DatabaseTestKit::sqlite(':memory:')` rejeita `:memory:` com
+> `InvalidArgumentException` para que a falha ocorra imediatamente.
+
 ---
 
 ## Por que usar transações no NENE2
@@ -122,32 +135,25 @@ SQLite em memória (`sqlite::memory:`) cria um **banco de dados separado por con
 `PdoDatabaseTransactionManager` (que abre uma nova conexão por chamada `transactional()`)
 não veria linhas escritas pelo `PdoDatabaseQueryExecutor` e vice-versa.
 
-Use um **arquivo temporário** em vez disso:
+Use um **arquivo temporário** em vez disso. `Nene2\Testing\DatabaseTestKit` conecta o executor e o
+gerenciador de transações ao mesmo arquivo em uma linha:
 
 ```php
+use Nene2\Testing\DatabaseTestKit;
+
 protected function setUp(): void
 {
-    $this->dbFile = sys_get_temp_dir() . '/test-' . bin2hex(random_bytes(8)) . '.sqlite';
+    $this->dbFile = sys_get_temp_dir() . '/' . uniqid('test-', true) . '.sqlite';
+
+    // Aplique o schema em uma conexão descartável e feche-a antes que o kit abra a sua.
     $pdo = new \PDO('sqlite:' . $this->dbFile, options: [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
     $pdo->exec(file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
-    unset($pdo); // fechar a conexão de inicialização antes da fábrica abrir a sua própria
+    unset($pdo);
 
-    $dbConfig = new DatabaseConfig(
-        url:         null,
-        environment: 'test',
-        adapter:     'sqlite',
-        host:        '',      // não usado para SQLite
-        port:        1,       // não usado para SQLite
-        name:        $this->dbFile,
-        user:        '',      // não usado para SQLite
-        password:    '',      // não usado para SQLite
-        charset:     '',      // não usado para SQLite
-    );
-
-    $factory   = new PdoConnectionFactory($dbConfig);
-    $executor  = new PdoDatabaseQueryExecutor($factory);
-    $txManager = new PdoDatabaseTransactionManager($factory);
-    // ... conectar repositórios e casos de uso
+    $this->kit = DatabaseTestKit::sqlite($this->dbFile);
+    // $this->kit->queryExecutor       — para repositórios de leitura
+    // $this->kit->transactionManager  — para casos de uso
+    // $this->kit->connectionFactory   — se precisar construir executores adicionais
 }
 
 protected function tearDown(): void
@@ -158,22 +164,60 @@ protected function tearDown(): void
 }
 ```
 
-Cada teste recebe um arquivo fresco, tanto `PdoDatabaseQueryExecutor` quanto
-`PdoDatabaseTransactionManager` conectam ao mesmo arquivo, e `tearDown` o deleta.
+O kit fica em `Nene2\Testing\DatabaseTestKit` (ADR 0012, API pública). Ele conecta internamente
+`PdoConnectionFactory` + `PdoDatabaseQueryExecutor` + `PdoDatabaseTransactionManager`, todos
+compartilhando o mesmo arquivo, de modo que os testes não precisam referenciar nenhuma classe
+`@internal` pelo nome. Tanto `DatabaseTestKit::sqlite(':memory:')` quanto as combinações de
+configuração subjacentes são bloqueadas na fábrica.
 
-> **Nota sobre campos `DatabaseConfig` para SQLite**: Para SQLite, apenas `adapter` e `name`
-> são obrigatórios. Passe strings vazias para `host`, `user`, `password` e `charset` — eles
-> não são validados quando `adapter` é `'sqlite'`.
-
-> **Nota**: `PdoDatabaseQueryExecutor` não aceita um `PDO` bruto como argumento do construtor
-> — ele requer um `DatabaseConnectionFactoryInterface`. Use `PdoConnectionFactory`
-> (mostrado acima) para conectar uma configuração `PDO` bruta ao executor.
+> **`DatabaseConfig::sqlite(string $path)`** é o atalho equivalente quando você quer manter a
+> conexão explícita (por exemplo, para injetar sua própria subclasse de `PdoConnectionFactory`).
+> Ele substitui a forma de 9 argumentos `new DatabaseConfig(...)` mostrada em guias mais antigos.
 
 ---
 
 ## Verificar comportamento de rollback
 
-Teste que uma falha no meio da transação desfaz todas as alterações anteriores:
+Um caso de uso que envolve múltiplas escritas só está correto se o caminho de rollback
+**realmente desfizer** as escritas anteriores. Um teste que cobre apenas o caminho feliz passará
+mesmo quando o caso de uso esquecer de usar `$tx` — `$this->products` será executado fora da
+transação e comitado silenciosamente. O teste de rollback é o que pega o bug.
+
+### Rollback em nível de unidade
+
+Conduza o caso de uso diretamente com `DatabaseTestKit` e verifique o estado do banco após a
+exceção:
+
+```php
+public function testRollbackUndoesStockDecrementWhenOrderInsertFails(): void
+{
+    $kit = DatabaseTestKit::sqlite($this->dbFile);
+    $kit->queryExecutor->execute(/* seed: produto 1 com stock=10 */);
+
+    $useCase = new CreateOrderUseCase($kit->transactionManager);
+
+    try {
+        // Passe uma quantidade que tenha sucesso em decrementStock mas dispare uma violação
+        // de restrição única em orders.save (ex.: chave de idempotência duplicada).
+        $useCase->execute(productId: 1, qty: 3, idempotencyKey: $existingKey);
+        self::fail('Expected order creation to fail.');
+    } catch (DatabaseConstraintException) {
+        // esperado
+    }
+
+    // O decrementStock do passo 1 precisa ter sido revertido.
+    $row = $kit->queryExecutor->fetchOne('SELECT stock FROM products WHERE id = ?', [1]);
+    self::assertSame(10, $row['stock']);
+}
+```
+
+Este teste falha imediatamente se o caso de uso chamar `$this->products->decrementStock()` em vez
+de construir um repositório a partir de `$tx` — a redução de estoque escapa do rollback e a
+asserção a detecta.
+
+### Rollback em nível HTTP
+
+A mesma propriedade no nível de integração:
 
 ```php
 public function testTransactionRollsBackOnDomainException(): void

--- a/docs/zh/howto/add-custom-route.md
+++ b/docs/zh/howto/add-custom-route.md
@@ -131,6 +131,72 @@ routeRegistrars: [
 
 当路由列表变长时，也可以拆分到多个 registrar 函数中以提高可读性。
 
+> **路由注册顺序**：路由器按**注册顺序**匹配。当静态路由与带参数的路由共享同一前缀时，
+> **务必先注册静态路由**。如果先注册 `GET /items/{id}` 再注册 `GET /items/summary`，
+> 那么对 `/items/summary` 的请求会以 `id = "summary"` 匹配到 `{id}` 路由 —
+> 返回的是令人困惑的领域相关 404，而不是路由错误。
+>
+> ```php
+> // 错误 —— /items/summary 会以 id="summary" 匹配 {id}
+> $router->get('/items/{id}',    $this->show(...));
+> $router->get('/items/summary', $this->summary(...)); // 永远不会到达
+>
+> // 正确 —— 先匹配静态段
+> $router->get('/items/summary', $this->summary(...));
+> $router->get('/items/{id}',    $this->show(...));
+> ```
+
+---
+
+## 动作端点（非 CRUD 操作）
+
+有些操作不符合标准 CRUD 形态 —— 归档、发布、审批、恢复。
+这类操作请使用 `POST /resource/{id}/action`，响应为 `200 OK`，正文是更新后的资源。
+
+```php
+$router->post('/items/{id}/archive', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->archive($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+
+$router->post('/items/{id}/restore', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $item   = $repo->restore($id, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item)); // 200 OK
+});
+```
+
+> **关于注册顺序**：动作路由（`/items/{id}/archive`）与 show/update 路由共享 `{id}` 段，
+> 但因为动作路径在 `{id}` 之后还有一个额外的静态段，所以无论注册顺序如何都不会产生歧义。
+
+### 带可选正文的动作端点
+
+有些动作接受可选的 JSON 正文（例如带可选 `reason` 的 `reject` 动作）。
+`JsonRequestBodyParser::parse()` 在正文为空时会抛出 400，因此调用解析器之前请先检查正文是否为空：
+
+```php
+$router->post('/items/{id}/reject', static function (ServerRequestInterface $req) use ($repo, $json): ResponseInterface {
+    $params = $req->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+    $id     = (int) ($params['id'] ?? 0);
+    $raw    = (string) $req->getBody();
+    $reason = null;
+
+    if ($raw !== '') {
+        $body   = JsonRequestBodyParser::parse($req);
+        $reason = isset($body['reason']) && is_string($body['reason']) ? trim($body['reason']) : null;
+    }
+
+    $item = $repo->reject($id, $reason, (new \DateTimeImmutable())->format('Y-m-d\TH:i:s\Z'));
+
+    return $json->create(self::serialize($item));
+});
+```
+
 ---
 
 ## 可用的 HTTP 方法
@@ -138,9 +204,47 @@ routeRegistrars: [
 | 方法 | Router 方法 | 典型用途 |
 |---|---|---|
 | GET | `$router->get()` | 读取资源 |
-| POST | `$router->post()` | 创建资源 |
+| POST | `$router->post()` | 创建资源或触发动作 |
 | PUT | `$router->put()` | 替换资源（完整更新） |
+| PATCH | `$router->patch()` | 部分更新 |
 | DELETE | `$router->delete()` | 删除资源 |
+
+---
+
+## 框架保留路径
+
+以下路径由 `RuntimeApplicationFactory` 在您的路由 registrar 运行**之前**注册。
+由于框架的路由会先被检查，用户为这些路径注册的路由永远不会匹配。
+
+| 路径 | 方法 | 说明 |
+|---|---|---|
+| `/` | GET | 框架冒烟端点（名称、描述、状态） |
+| `/health` | GET | 健康检查 |
+| `/machine/health` | GET | 机器客户端健康检查（需要 API 密钥） |
+| `/examples/ping` | GET | 示例 ping |
+| `/examples/protected` | GET | 示例受保护端点（配置 JWT 时） |
+
+如果您的应用需要首页，请使用其他路径（例如 `/welcome`、`/home`），
+或注册健康检查并通过框架的冒烟响应返回 HTML。
+
+---
+
+## 返回 204 No Content（DELETE 端点）
+
+使用 `JsonResponseFactory::createEmpty()` 返回无正文的 204 响应：
+
+```php
+private function delete(ServerRequestInterface $request): ResponseInterface
+{
+    $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE);
+    $id     = (int) ($params['id'] ?? 0);
+    $this->repository->delete($id); // 未找到时抛出 NotFoundException
+    return $this->json->createEmpty(204);
+}
+```
+
+> **为什么不用 `create([], 204)`？** 传入空数组会生成 `{}` 这样的 JSON 正文。
+> `createEmpty()` 返回真正没有正文的响应，这才符合 204 No Content 的语义。
 
 ---
 

--- a/docs/zh/howto/add-jwt-authentication.md
+++ b/docs/zh/howto/add-jwt-authentication.md
@@ -127,6 +127,31 @@ $app = (new RuntimeApplicationFactory(
 
 ---
 
+### 路径作用域选项
+
+`BearerTokenMiddleware` 支持三种互斥的路径作用域策略。请选择与您的访问模型相符的一种：
+
+| 策略 | 参数 | 适用场景 |
+|---|---|---|
+| 黑名单（最常用） | `$excludedPaths` | **除**少量公开路由外，所有路由都需要认证 |
+| 白名单 | `$protectedPaths` | 只有固定且已知的一组路由需要认证 |
+| 前缀白名单 | `$protectedPathPrefixes` | 整个路径子树都需要认证（例如 `/me/`、`/admin/`） |
+
+**前缀白名单示例** —— 保护 `/me/` 下的所有路径，无需逐一列举：
+
+```php
+$authMiddleware = new BearerTokenMiddleware(
+    problemDetails:         $problems,
+    verifier:               $verifier,
+    protectedPathPrefixes:  ['/me/'],
+);
+```
+
+对 `/me/favorites/42` 的请求匹配该前缀，需要有效的 Bearer 令牌。
+对 `/products/1` 的请求不匹配，将不经认证直接通过。
+
+---
+
 ## 第 4 步 — 在处理器中读取 Claims
 
 ```php

--- a/docs/zh/howto/use-transactions.md
+++ b/docs/zh/howto/use-transactions.md
@@ -5,6 +5,17 @@
 **前置条件**：你已有一个基于 `DatabaseQueryExecutorInterface` 的 repository。
 如果没有，请先阅读[添加数据库端点](./add-database-endpoint.md)。
 
+> **🚫 SQLite 的 `:memory:` 与 `transactional()` 不兼容。**
+>
+> `PdoDatabaseTransactionManager` 每次调用都会打开一个*新*连接。每个 `:memory:` 连接指向的是
+> *不同的*空内存数据库，因此 executor 与事务看到的是不同的数据，回滚对 executor 的视图没有任何影响。
+> 症状是静默的：回调执行到一半时查询返回 `null`，或者回滚无法撤销测试通过另一个 executor 写入的数据。
+>
+> 测试中请使用**基于文件的 SQLite** 数据库（参见下文
+> “[使用基于文件的 SQLite 数据库进行测试](#使用基于文件的-sqlite-数据库进行测试)”）。
+> `Nene2\Testing\DatabaseTestKit::sqlite(':memory:')` 会以 `InvalidArgumentException` 拒绝
+> `:memory:`，使该问题快速失败。
+
 ---
 
 ## 为什么在 NENE2 中使用事务
@@ -107,32 +118,25 @@ $createOrder = new CreateOrderUseCase($txManager);   // 内部使用 $tx
 
 内存 SQLite（`sqlite::memory:`）每个连接创建一个**独立的数据库**，因此 `PdoDatabaseTransactionManager`（每次 `transactional()` 调用都打开新连接）看不到 `PdoDatabaseQueryExecutor` 写入的行，反之亦然。
 
-应使用**临时文件**代替：
+应使用**临时文件**代替。`Nene2\Testing\DatabaseTestKit` 只需一行即可将 executor 与
+事务管理器接到同一个文件上：
 
 ```php
+use Nene2\Testing\DatabaseTestKit;
+
 protected function setUp(): void
 {
-    $this->dbFile = sys_get_temp_dir() . '/test-' . bin2hex(random_bytes(8)) . '.sqlite';
+    $this->dbFile = sys_get_temp_dir() . '/' . uniqid('test-', true) . '.sqlite';
+
+    // 用一次性连接写入 schema，并在 kit 打开自己的连接之前关闭它。
     $pdo = new \PDO('sqlite:' . $this->dbFile, options: [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
     $pdo->exec(file_get_contents(dirname(__DIR__) . '/database/schema.sql'));
-    unset($pdo); // 在工厂打开自己的连接之前关闭初始化连接
+    unset($pdo);
 
-    $dbConfig = new DatabaseConfig(
-        url:         null,
-        environment: 'test',
-        adapter:     'sqlite',
-        host:        '',      // SQLite 不使用
-        port:        1,       // SQLite 不使用
-        name:        $this->dbFile,
-        user:        '',      // SQLite 不使用
-        password:    '',      // SQLite 不使用
-        charset:     '',      // SQLite 不使用
-    );
-
-    $factory   = new PdoConnectionFactory($dbConfig);
-    $executor  = new PdoDatabaseQueryExecutor($factory);
-    $txManager = new PdoDatabaseTransactionManager($factory);
-    // ... 连接 repository 和 use case
+    $this->kit = DatabaseTestKit::sqlite($this->dbFile);
+    // $this->kit->queryExecutor       — 用于读取 repository
+    // $this->kit->transactionManager  — 用于 use case
+    // $this->kit->connectionFactory   — 需要构建额外 executor 时使用
 }
 
 protected function tearDown(): void
@@ -143,17 +147,56 @@ protected function tearDown(): void
 }
 ```
 
-每个测试都获得一个全新的文件，`PdoDatabaseQueryExecutor` 和 `PdoDatabaseTransactionManager` 都连接到同一个文件，`tearDown` 删除该文件。
+该 kit 位于 `Nene2\Testing\DatabaseTestKit`（ADR 0012，公开 API）。它在内部把
+`PdoConnectionFactory` + `PdoDatabaseQueryExecutor` + `PdoDatabaseTransactionManager` 接在
+同一个文件上，因此测试无需按名称引用任何 `@internal` 类。
+`DatabaseTestKit::sqlite(':memory:')` 及其底层的配置组合都会在工厂层被拦截。
 
-> **关于 SQLite `DatabaseConfig` 字段的说明**：对于 SQLite，只有 `adapter` 和 `name` 是必需的。`host`、`user`、`password`、`charset` 传空字符串——当 `adapter` 为 `'sqlite'` 时它们不会被验证。
-
-> **说明**：`PdoDatabaseQueryExecutor` 不接受原始 `PDO` 作为构造参数——它需要 `DatabaseConnectionFactoryInterface`。使用 `PdoConnectionFactory`（如上所示）将原始 `PDO` 设置桥接到 executor。
+> **`DatabaseConfig::sqlite(string $path)`** 是希望保持显式接线时（例如注入自定义的
+> `PdoConnectionFactory` 子类）的等价快捷方式。它取代了旧版指南中 9 个参数的
+> `new DatabaseConfig(...)` 写法。
 
 ---
 
 ## 验证回滚行为
 
-测试事务中途失败会撤销所有之前的变更：
+一个包裹多次写入的 use case，只有当回滚路径**确实撤销**了之前的写入时才是正确的。
+只覆盖成功路径的测试，即使 use case 忘记使用 `$tx` 也会通过——此时 `$this->products`
+会在事务之外执行并静默提交。真正能抓到这个 bug 的是回滚测试。
+
+### 单元级回滚
+
+用 `DatabaseTestKit` 直接驱动 use case，并在异常之后断言数据库状态：
+
+```php
+public function testRollbackUndoesStockDecrementWhenOrderInsertFails(): void
+{
+    $kit = DatabaseTestKit::sqlite($this->dbFile);
+    $kit->queryExecutor->execute(/* 种子数据：stock=10 的产品 1 */);
+
+    $useCase = new CreateOrderUseCase($kit->transactionManager);
+
+    try {
+        // 传入一个能通过 decrementStock、但会在 orders.save 触发唯一约束冲突的数量
+        //（例如重复的幂等键）。
+        $useCase->execute(productId: 1, qty: 3, idempotencyKey: $existingKey);
+        self::fail('Expected order creation to fail.');
+    } catch (DatabaseConstraintException) {
+        // 符合预期
+    }
+
+    // 第 1 步的 decrementStock 必须已被回滚。
+    $row = $kit->queryExecutor->fetchOne('SELECT stock FROM products WHERE id = ?', [1]);
+    self::assertSame(10, $row['stock']);
+}
+```
+
+如果 use case 调用的是 `$this->products->decrementStock()` 而不是从 `$tx` 构建 repository，
+这个测试会立刻失败——库存扣减会越过回滚，被断言抓住。
+
+### HTTP 级回滚
+
+在集成层面验证同一性质：
 
 ```php
 public function testTransactionRollsBackOnDomainException(): void

--- a/translations.baseline.json
+++ b/translations.baseline.json
@@ -197,24 +197,24 @@
         },
         "howto/add-custom-route.md": {
             "ja": {
-                "content": "b10f3ab19ff0a7fe",
-                "structure": "a2d2242ef42e0897"
+                "content": "62f9c2a1e2b06363",
+                "structure": "b5998ba60c01b4d0"
             },
             "de": {
-                "content": "b10f3ab19ff0a7fe",
-                "structure": "a2d2242ef42e0897"
+                "content": "62f9c2a1e2b06363",
+                "structure": "b5998ba60c01b4d0"
             },
             "fr": {
-                "content": "b10f3ab19ff0a7fe",
-                "structure": "a2d2242ef42e0897"
+                "content": "62f9c2a1e2b06363",
+                "structure": "b5998ba60c01b4d0"
             },
             "zh": {
-                "content": "b10f3ab19ff0a7fe",
-                "structure": "a2d2242ef42e0897"
+                "content": "62f9c2a1e2b06363",
+                "structure": "b5998ba60c01b4d0"
             },
             "pt-br": {
-                "content": "b10f3ab19ff0a7fe",
-                "structure": "a2d2242ef42e0897"
+                "content": "62f9c2a1e2b06363",
+                "structure": "b5998ba60c01b4d0"
             }
         },
         "howto/add-database-endpoint.md": {
@@ -329,24 +329,24 @@
         },
         "howto/add-jwt-authentication.md": {
             "ja": {
-                "content": "2ee22ce8dd752077",
-                "structure": "c1b17bda925d4867"
+                "content": "a28a7c84bc05bff2",
+                "structure": "b5df6a46bb82544e"
             },
             "de": {
-                "content": "45819fadbb7a5a78",
-                "structure": "ad7d8bbbc0a28832"
+                "content": "a28a7c84bc05bff2",
+                "structure": "b5df6a46bb82544e"
             },
             "fr": {
-                "content": "45819fadbb7a5a78",
-                "structure": "ad7d8bbbc0a28832"
+                "content": "a28a7c84bc05bff2",
+                "structure": "b5df6a46bb82544e"
             },
             "zh": {
-                "content": "45819fadbb7a5a78",
-                "structure": "ad7d8bbbc0a28832"
+                "content": "a28a7c84bc05bff2",
+                "structure": "b5df6a46bb82544e"
             },
             "pt-br": {
-                "content": "45819fadbb7a5a78",
-                "structure": "ad7d8bbbc0a28832"
+                "content": "a28a7c84bc05bff2",
+                "structure": "b5df6a46bb82544e"
             }
         },
         "howto/add-mcp-tools.md": {
@@ -5455,24 +5455,24 @@
         },
         "howto/use-transactions.md": {
             "ja": {
-                "content": "b8b1f80f810b25c4",
-                "structure": "feb230c20d62f738"
+                "content": "be4481cd46a254a9",
+                "structure": "025bb147d4a5aad5"
             },
             "de": {
-                "content": "b8b1f80f810b25c4",
-                "structure": "feb230c20d62f738"
+                "content": "be4481cd46a254a9",
+                "structure": "025bb147d4a5aad5"
             },
             "fr": {
-                "content": "b8b1f80f810b25c4",
-                "structure": "feb230c20d62f738"
+                "content": "be4481cd46a254a9",
+                "structure": "025bb147d4a5aad5"
             },
             "zh": {
-                "content": "b8b1f80f810b25c4",
-                "structure": "feb230c20d62f738"
+                "content": "be4481cd46a254a9",
+                "structure": "025bb147d4a5aad5"
             },
             "pt-br": {
-                "content": "b8b1f80f810b25c4",
-                "structure": "feb230c20d62f738"
+                "content": "be4481cd46a254a9",
+                "structure": "025bb147d4a5aad5"
             }
         },
         "howto/use-window-functions.md": {


### PR DESCRIPTION
## 目的

Issue #1628 の消し込み最終弾。英語原文に後から入った節を 5 ロケールへ反映し、
**#1628 の DoD（原文差分の反映）を充足する**。

## 変更点

対象 3 ドキュメント × 5 ロケール（ja/de/fr/zh/pt-br）= 15 ファイル。

| ドキュメント | 反映した原文の差分 |
|---|---|
| `add-custom-route` | ルート登録順の注意（静的ルートを先に登録する罠）／アクションエンドポイント（非 CRUD・任意ボディ版を含む）／フレームワーク予約パスの表／204 No Content の返し方／HTTP メソッド表に `PATCH` 追加・`POST` の説明更新 |
| `add-jwt-authentication` | `BearerTokenMiddleware` のパススコープ 3 戦略（blocklist / allowlist / prefix allowlist）の節 |
| `use-transactions` | SQLite `:memory:` が `transactional()` と非互換である警告／`setUp` を `DatabaseTestKit` ベースへ書き換え／`DatabaseConfig::sqlite()` の注記／ロールバック検証をユニットレベルと HTTP レベルの 2 節に分割 |

`use-transactions` は**訳が現に古い API 形（9 引数の `new DatabaseConfig(...)` 手組み）を提示していた**ため、
新規節の追加だけでなくコード例の是正を含む。

## 検証結果

```
composer i18n:check     →  1355 pairs checked — 7 error(s), 0 warning(s)   （変更前: 22 error）
composer howto:index    →  再生成しても差分なし（ドリフトなし）
composer howto:frontmatter --require-all →  262/262 annotated, Frontmatter validation passed
```

構造パリティ（見出し数／コードフェンス数）:

| ドキュメント | EN | ja | de | fr | zh | pt-br |
|---|---|---|---|---|---|---|
| add-custom-route | 13/18 | 13/18 | 13/18 | 13/18 | 13/18 | 13/18 |
| add-jwt-authentication | 19/42 | 19/42 | 14/18 | 14/18 | 14/18 | 14/18 |
| use-transactions | 10/12 | 10/12 | 10/12 | 10/12 | 10/12 | 10/12 |

`add-custom-route` は 5 ロケールとも要約版（9/12）から**完全パリティ**まで回復した。
`add-jwt-authentication` の de/fr/zh/pt-br が EN に届いていないのは**本 PR の対象外の既存の未完訳**で、#1640 の範囲。

PHP コードは変更していないため `composer test` / `analyse` は対象外。

## 残り 7 件について（#1628 のクローズ根拠）

`i18n:check` に残る 7 件は、いずれも**反映すべき原文差分が存在しない**もので、
指揮裁定により #1640（未完訳ペアの補完）へ移管済み:

| 残件 | 移管理由 |
|---|---|
| `add-database-endpoint` × 5 | 原文が +673 行成長した分がまるごと未反映。差分の反映ではなく実質的に未完訳の補完 |
| `quota-management` (de) | de だけが要約版。原文差分（`localhost:8080` → `8200`）に対応する記述を訳が持たない |
| `note-management-ownership` (ja) | 同上（ja だけが要約版） |

したがって #1628 の DoD は本 PR で充足する。

## baseline の扱い

`--only` で対象 3 ドキュメントに限定して再記録。差分が 3 エントリのみであることを確認済み。

Closes #1628

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)