### PR TITLE
chore(deps): bump nanoid to 3.3.18 in lockfile (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7760,9 +7760,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1998,9 +1998,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bumps `nanoid` to 3.3.18 in **both** lockfiles (`package-lock.json`: 3.3.12→3.3.18, `frontend/package-lock.json`: 3.3.16→3.3.18) to clear [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (HIGH — infinite loop on `size=0`, patch floor 3.3.17).
- Dev-only dependency path (`nene2-standards`→`postcss`→`nanoid`); not in the prod bundle.
- **Lockfile-only change** — `package.json` in both locations is untouched, verified via `git diff --stat`.
- Part of a fleet-wide nanoid cleanup ordered from the integration hub (2026-08-12). NENE2 is the distribution-source framework, so fixing it here keeps new installs clean.

## Test plan
- [x] Confirmed via `npm update nanoid --package-lock-only` in both `.` and `frontend/` that only the `nanoid` version/resolved/integrity fields changed.
- [x] Confirmed `package.json` has no diff in either location.
- [ ] CI green (auto-merge armed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)