### PR TITLE
chore(deps): bump js-yaml to 4.3.1 to clear GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6946,9 +6946,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- `frontend/package-lock.json` pinned js-yaml at 4.3.0, inside the vulnerable range (4.0.0–4.3.0) for [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (JS-YAML quadratic CPU consumption in `!!omap` resolution, CVE-2026-59870 fix not backported, high severity).
- Measured dependency path (`npm ls js-yaml`):
  - `openapi-typescript@7.13.0` → `@redocly/openapi-core@1.34.17` → `js-yaml` (overridden)
  - `stylelint@16.26.1` → `cosmiconfig@9.0.2` → `js-yaml` (deduped)
  - Both parents are devDependencies; the lockfile node has `"dev": true` — dev-only, not shipped in the prod bundle.
- `frontend/package.json` already declares `overrides: "js-yaml": "^4.3.0"`, which is compatible with 4.3.1, so `npm update js-yaml --package-lock-only` bumped the lockfile to 4.3.1 with **no package.json change** (lockfile-only).
- NENE2 is the fleet's distribution-origin framework, so this is high priority — an unpatched lockfile here seeds every new install downstream. Second wave of fleet-wide js-yaml GHSA-5p4m-2wfm-xmqj cleanup (six other ships already cleared same day).

## Test plan
- [x] `git diff --name-only` shows only `frontend/package-lock.json` changed
- [x] `npm ls js-yaml` / lockfile show js-yaml 4.3.1
- [x] `npm audit --package-lock-only --audit-level=high` in `frontend/` no longer lists GHSA-5p4m-2wfm-xmqj (5 unrelated advisories remain: brace-expansion, fast-uri, postcss, react-router, undici — out of scope)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)