### PR TITLE
chore(deps): frontend の既知脆弱性 5件を解消（lockfile のみ・7パッケージ更新／内訳を本文に開示） (#1646)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1226,9 +1226,9 @@
       "license": "MIT"
     },
     "node_modules/@hideyukimori/nene2-standards/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1892,9 +1892,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3927,16 +3927,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5426,9 +5426,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "devOptional": true,
       "funding": [
         {
@@ -8481,9 +8481,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -8501,7 +8501,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8717,9 +8717,9 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -10350,9 +10350,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## 目的

`frontend/package-lock.json` の既知脆弱性を解消する。起点は `brace-expansion`（GHSA-rgw5-rvv9-x895・high）だが、
**実際の変更はそれだけではない**ため、下に全数を開示する。

Closes #1646

## 🔴 変更内容の全数開示（当初の記述を訂正）

当初この PR を「brace-expansion のみ」と書いたが、**それは誤り**だった。
`npm audit fix --package-lock-only` の出力を採用したところ、**7 パッケージの版が動いている**。
lockfile を機械的に比較して数え直した結果：

| パッケージ | 変更前 | 変更後 | 位置づけ |
|---|---|---|---|
| `brace-expansion` | 5.0.7 | **5.0.9** | 本件の起点 |
| `@hideyukimori/nene2-standards/brace-expansion` | 1.1.16 | **1.1.18** | 同上（入れ子） |
| `@redocly/openapi-core/brace-expansion` | 2.1.2 | **2.1.4** | 同上（入れ子） |
| **`react-router`** | 7.18.1 | **7.18.2** | 🔴 **別 advisory（GHSA-qwww-vcr4-c8h2・high）の修正版** |
| `postcss` | 8.5.19 | **8.5.26** | advisory 由来 |
| `fast-uri` | 3.1.3 | 3.1.5 | 上記に伴う推移的更新 |
| `undici` | 7.28.0 | 7.29.0 | 同上 |

- **パッケージ総数は 761 → 761 で不変**（欠落・追加なし）。
- `package.json` は無変更（`diff` 差分なし）。
- **すべて前方向の更新**（降格なし）。

## 検証結果（実測）

- `npm audit`: **`{high: 4, moderate: 1, total: 5}` → 0 vulnerabilities**
- lockfile のパッケージ数: **761 → 761**（縮小していないことを機械で確認）
- `package.json`: 差分なし
- advisory の範囲は GitHub Advisory API の一次情報を読み直して使用

## 🔴 レビュー時に見てほしい点

`react-router` の 7.18.2 への更新が含まれる。これは `brace-expansion` とは別の advisory
（GHSA-qwww-vcr4-c8h2・2026-08-07 に脆弱範囲が 7.x / 8.x へ分割され、7.x 系の修正版として 7.18.2 が出たもの）の解消にあたる。
**このリポジトリでは 1 つの `npm audit fix` で同時に閉じた**が、
**別レーンで扱う予定の変更が混ざっていないか**という観点で確認してほしい。
分けるべきなら、`react-router` を戻した lockfile に作り直す。

## 残リスク

- `frontend` の依存ツリーが変わるため、ビルド・テストの再実行が要る（CI 緑を確認済み）。
- `nanoid` は 3.3.18 で floor（3.3.17）を満たしており対象外。


---

## ✅ 裁定（hub・2026-08-14 夕）— **受ける（作り直さない）**

上の「分けるべきなら作り直す」への回答が出た。**この PR はこのままマージしてよい。**

**理由**（hub 裁定）:

1. `react-router` の混入は **7.18.1 → 7.18.2 の昇格**であり、降格ではない。
2. **7.18.2 は、別レーンの玉（「react-router の allowlist 例外の根拠文が stale ＝ 例外を撤去できる」）の floor そのもの**。
   差し戻すと**同じ玉を二度撃つ**ことになる。
3. NENE2 は 7艦の allowlist 群に含まれないため、例外撤去の対象外。巻き添えを戻す作業自体が
   新しい lockfile 操作＝新しいリスク（判例44）。

### 独立再実測（fleet・2026-08-14 18:2x・`origin/main` と PR head の lockfile を機械比較）

| 指標 | 値 |
|---|---|
| パッケージ総数 | **761 → 761**（不変・縮小なし） |
| 版が動いたパッケージ | **5 名前 / 7 lockfile エントリ**（`brace-expansion` が3系列） |
| 向き | **7エントリすべて昇格・降格 0** |

```
brace-expansion : 1.1.16 / 2.1.2 / 5.0.7  ->  1.1.18 / 2.1.4 / 5.0.9   （↑）
fast-uri        : 3.1.3                   ->  3.1.5                    （↑）
postcss         : 8.5.19                  ->  8.5.26                   （↑）
react-router    : 7.18.1                  ->  7.18.2                   （↑）
undici          : 7.28.0                  ->  7.29.0                   （↑）
```

`GHSA-rgw5-rvv9-x895` の脆弱範囲も一次情報（GitHub Advisory GraphQL API）で読み直した〔実測 08-14 夕〕:
**`<1.1.18` / `>=2.0.0,<2.1.4` / `>=3.0.0,<3.0.6` / `>=4.0.0,<5.0.9`**（high・published 2026-08-03）。
本 PR 後の 3系列（1.1.18 / 2.1.4 / 5.0.9）は**すべて floor 丁度以上**。

### この PR が残す教訓（判例44②）

**「3件のつもりが7件動いていた」** — `npm audit fix` は起点にした advisory だけを直すのではなく、
**直せるものを全部直す**。PR 本文は起点の advisory 名だけでなく、**版が動いた全数と向き**を書く。
