### PR TITLE
chore(deps): root lockfile の postcss を修正版へ更新する (#1651)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2043,9 +2043,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2063,7 +2063,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## 目的

root の npm ツリー（docs ビルド専用）に出ていた **postcss の advisory 2件を lockfile のみで閉じる**。npm 依存監査ゲート（#1652）を入れる前段。

ゲートと同じ PR に混ぜると、赤が出たときに **bump 由来かゲート設計由来か切り分けられない**。NENE2 は配布元なので、切り分け不能な赤を上流で作らない形を優先した。

## 変更点

`package-lock.json`（root）のみ。`package.json` は変更なし＝既存の解決範囲内。

```
postcss 8.5.14 → 8.5.26
```

差分は 4 insertions / 4 deletions（postcss の `version` / `resolved` / `integrity` と、その `dependencies.nanoid` の範囲表記のみ）。

## 閉じた advisory

2026-08-22 に `gh api repos/hideyukiMORI/NENE2/dependabot/alerts` で実測：

| GHSA | severity | vulnerable range | first_patched |
|---|---|---|---|
| GHSA-r28c-9q8g-f849 | **high** | <= 8.5.17 | 8.5.18 |
| GHSA-fxqj-rqcc-2cmp | moderate | <= 8.5.22 | 8.5.23 |

## 検証結果

**1. `npm audit`（root）— 5件 → 3件**

```
3 vulnerabilities (2 moderate, 1 high)
```

残る **high は vite の1件のみ**。これは bump では閉じない — root の直接 devDependency は `vitepress: ^1.5.0` だけで、導入済み vitepress 1.6.4 が `dependencies.vite: ^5.4.14` を固定している。1.6.4 は最新公開版（`npm view vitepress version`）で 2.x 系は存在しない。⇒ **#1652 で期限つき allowlist として扱う**（GHSA-ID ＋依存関係条件つき）。

**2. lockfile の規模に変化なし** — `packages` 数は 174 のまま。意図しない解決の巻き込みは起きていない。

**3. `npm run docs:build` 成功**

CI と同条件（`NODE_OPTIONS=--max-old-space-size=12288`）で実行し **exit 0 / 456.08s**。

> ℹ️ 既定ヒープ（約4GB）では OOM する。これは `docs.yml` が 8GB swap ＋ 12GB ヒープを明示している**既存条件**（howto 1,581本 × 5ロケール）であって、本変更とは無関係。切り分けのため CI と同じ条件で測り直した。

## 残リスク

**なし**（このPRの射程内では）。root の npm 依存は配布物に載らない — NENE2 の配布形態は Composer パッケージ `hideyukimori/nene2`（`composer.json`: `type=library` / autoload psr-4 `Nene2\` → `src/`）で、consumer が入れるのは PHP ソース。

vite / esbuild の残 advisory は本 PR の射程外で、#1652 で明示的に扱う。**この PR がマージされても「root の npm ツリーが清浄になった」わけではない**点は明記しておく。

Self-review: release-ci

Closes #1651