### PR TITLE
ci: npm 依存監査ゲート・週次 schedule・失敗通知を追加する (#1652)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,10 +2,39 @@ name: Backend
 
 on:
   pull_request:
+
+  # Weekly re-run, so the `composer audit` step below is re-evaluated against
+  # newly published advisories even when nothing is pushed. This workflow does
+  # not run on `push: main` either, so before this schedule existed nothing
+  # re-checked the backend dependencies after a merge.
+  #
+  # Same cron as `frontend.yml` on purpose: the fleet allocation is one slot per
+  # repository (offset from the other repositories to avoid a same-minute
+  # stampede across them), and the two workflows in THIS repository are meant to
+  # report on the same weekly snapshot.
+  #
+  # KNOWN LIMITATION: GitHub auto-disables scheduled workflows after 60 days of
+  # repository inactivity -- silently, and precisely in the dormant repositories
+  # that need the check most. There is no in-repo fix; it needs an external
+  # poller at the fleet level. Do not delete this note as if it were resolved.
+  schedule:
+    - cron: '30 1 * * 1' # Monday 01:30 UTC = 10:30 JST
+
+  # See `frontend.yml` for the rationale: `notify-failure` only fires on a
+  # schedule run or on this input, so this switch is the only way to prove the
+  # notification path actually works rather than merely being configured.
   workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: 'Intentionally fail the job to verify the failure-notification path'
+        type: boolean
+        default: false
 
 concurrency:
-  group: backend-${{ github.head_ref || github.ref }}
+  # github.event_name is part of the group so a schedule/workflow_dispatch run is
+  # not cancelled by a push/PR run racing it on the same ref -- a cancelled run
+  # is indistinguishable from a check that never ran.
+  group: backend-${{ github.head_ref || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:
@@ -20,6 +49,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Placed after Checkout, not first: a step before checkout fails on a
+      # missing working tree, which rehearses a different failure than the one
+      # being tested. Still fails before any real work.
+      - name: Simulate failure (rehearsal only)
+        if: inputs.simulate_failure
+        run: exit 1
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -68,3 +104,33 @@ jobs:
 
       - name: Validate howto frontmatter
         run: composer howto:frontmatter -- --require-all
+
+  notify-failure:
+    name: Open an issue when the scheduled run fails
+    # Not `failure()` alone: a red check on a pull request already has someone
+    # looking at it. This job is for the runs nobody watches -- the weekly
+    # schedule -- plus the manual rehearsal that proves the path works.
+    if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
+    needs: [composer-check]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 NENE2: 週次 Backend CI（schedule）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      # Comment on the existing issue instead of opening a new one every week:
+      # duplicates are what make people stop reading the notifications.
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,10 +2,39 @@ name: Frontend
 
 on:
   pull_request:
+
+  # Weekly re-run of this same workflow (including the dependency audits in the
+  # `npm-audit` job). A newly published advisory lands against versions that are
+  # already locked, with no push to trigger anything -- and neither `backend.yml`
+  # nor this workflow runs on `push: main`, so without a schedule nothing is
+  # re-checked after a merge at all. The cron minute is offset from the other
+  # fleet repositories so the runs do not stampede on the same minute.
+  #
+  # KNOWN LIMITATION: GitHub auto-disables scheduled workflows after 60 days of
+  # repository inactivity. A dormant repository -- the one most in need of this
+  # check -- is exactly where it silently stops firing. There is no in-repo fix;
+  # detecting a stale last-run date needs an external poller at the fleet level.
+  # This comment is not a solved problem, and must not be deleted as if it were.
+  schedule:
+    - cron: '30 1 * * 1' # Monday 01:30 UTC = 10:30 JST
+
+  # Manual trigger, with an optional switch to rehearse the failure path (see the
+  # "Simulate failure" step below and the `notify-failure` job) without waiting
+  # for the next scheduled run. `notify-failure` only fires on `schedule` or this
+  # input, so this switch is the only way to prove the notification path works.
   workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: 'Intentionally fail the audit job to verify the failure-notification path'
+        type: boolean
+        default: false
 
 concurrency:
-  group: frontend-${{ github.head_ref || github.ref }}
+  # github.event_name is part of the group so a schedule/workflow_dispatch run is
+  # not cancelled by a push/PR run racing it on the same ref (observed during the
+  # fleet rollout of this harness: without it, dispatch and schedule runs get
+  # silently cancelled, which looks identical to "the check never ran").
+  group: frontend-${{ github.head_ref || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:
@@ -37,6 +66,61 @@ jobs:
       - name: Build frontend
         run: npm run build --prefix frontend
 
+  npm-audit:
+    name: npm Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Placed right after Checkout rather than literally first: a step before
+      # checkout would fail on a missing working tree instead of the intended
+      # `exit 1`, which rehearses the wrong failure. Still fails before any real
+      # work, so the rehearsal costs nothing.
+      - name: Simulate failure (rehearsal only)
+        if: inputs.simulate_failure
+        run: exit 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+          # Both lockfiles: this job installs both trees, so keying the cache on
+          # only one of them would reuse a cache that a change to the other had
+          # already invalidated.
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      # NENE2 has two independent npm trees and they are audited as two separate
+      # steps on purpose:
+      #
+      #   root/      vitepress -> vite 5.x, builds the documentation site. Every
+      #              open advisory on this repository lives here. This step makes
+      #              the existing hole visible.
+      #   frontend/  the SPA starter, already on vite 8.x. Reports nothing today;
+      #              this step is what stops that from regressing unnoticed.
+      #
+      # Folding them into one step (or into `npm run check`) would make the job
+      # log unable to show which tree was actually audited -- and a check that
+      # leaves no trace cannot be distinguished from a check that is missing.
+      # Each tree carries its own audit-ci.jsonc; the allowlist and the reasoning
+      # for an exception live next to the tree the exception applies to.
+      - name: Install root npm dependencies (docs toolchain)
+        run: npm ci
+
+      - name: Audit root tree (fail on high/critical)
+        run: npm run audit
+
+      - name: Install frontend npm dependencies
+        run: npm ci --prefix frontend
+
+      - name: Audit frontend tree (fail on high/critical)
+        run: npm run audit --prefix frontend
+
   e2e-smoke:
     name: Playwright Smoke
     runs-on: ubuntu-latest
@@ -64,3 +148,35 @@ jobs:
 
       - name: Run Playwright smoke
         run: npm run test:e2e --prefix frontend
+
+  notify-failure:
+    name: Open an issue when the scheduled run fails
+    # Deliberately not `failure()` alone: on a pull request the author is already
+    # looking at the red check, and filing an issue for it would be noise. This
+    # job exists for the runs nobody is watching -- the weekly schedule -- plus
+    # the manual rehearsal that proves the path works.
+    if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
+    needs: [npm-check, npm-audit, e2e-smoke]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 NENE2: 週次 Frontend CI（schedule）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      # Comment on the existing issue rather than opening a new one each week:
+      # a recurring failure otherwise buries the repository in duplicates, and
+      # the duplicates are what make people stop reading the notifications.
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,81 @@
+{
+  // Dependency-vulnerability gate for the ROOT npm tree (docs toolchain).
+  //
+  // NENE2 has two independent npm trees and this file governs only the first:
+  //
+  //   root/       vitepress -> vite 5.x. Builds the documentation site. NOT part of the
+  //               distributed artifact (see below). Every open advisory lives here.
+  //   frontend/   the SPA starter. Its own audit-ci.jsonc, with an empty allowlist.
+  //
+  // Keeping the two gates as separate CI steps is deliberate: the job log has to show which
+  // tree was audited. A check that leaves no trace cannot be distinguished from a check that
+  // is missing.
+  //
+  // What is actually shipped: NENE2 is distributed as the Composer package
+  // `hideyukimori/nene2` (composer.json: type=library, autoload psr-4 `Nene2\` -> src/).
+  // Consumers install PHP sources; no npm dependency from this tree reaches them. That does
+  // not make an advisory here harmless — it bounds who is exposed to the maintainers of this
+  // repository — but it is why an unfixable advisory here is allowlisted rather than treated
+  // as a release blocker.
+  //
+  // The gate stays sharp: anything high/critical NOT listed below fails the build.
+  // `allowlist` is per-advisory (GHSA id), never per-severity — we do not lower the level.
+  //
+  // Adding an entry requires, in this file: (1) the advisory id, (2) why it does not apply to
+  // THIS tree, measured — not assumed, (3) an expiry date, (4) what removes the need for it.
+  // An expired entry is a task, not a renewal: re-check it, do not extend it by reflex.
+  //
+  // Prefer the fix. postcss was taken rather than excepted (#1651, lockfile-only,
+  // 8.5.14 -> 8.5.26, closing GHSA-r28c-9q8g-f849 high and GHSA-fxqj-rqcc-2cmp moderate).
+  // What remains below could not be taken; the measurement of why is written out.
+  //
+  // 🔴 Re-read the advisories when you touch this file, not at expiry. An expiry date catches
+  // an entry that runs out; it does not catch an entry that stops being true. Measured in this
+  // fleet on 2026-08-22: the vite advisory's own numbers had moved since they were last
+  // recorded (first_patched 6.4.2 -> 6.4.3, range widened to <= 6.4.2) while the conclusion
+  // was unchanged — so a version number written as a removal condition would have gone stale
+  // silently. Removal conditions here are therefore written as *dependency facts*, not
+  // version numbers.
+  //
+  // Policy: docs/development/dependency-audit.md
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "moderate": false,
+  "high": true,
+  "critical": true,
+  "allowlist": [
+    // GHSA-fx2h-pf6j-xcff — vite "`server.fs.deny` bypass on Windows alternate paths" (high).
+    // Read from the primary source on 2026-08-22 (`gh api /advisories/GHSA-fx2h-pf6j-xcff`,
+    // advisory updated 2026-07-15):
+    //     vite  <= 6.4.2            first_patched 6.4.3
+    //     vite  >= 7.0.0, <= 7.3.4  first_patched 7.3.5
+    //     vite  >= 8.0.0, <= 8.0.15 first_patched 8.0.16
+    // This tree locks vite 5.4.21, which the `<= 6.4.2` range covers.
+    //
+    // Why it cannot be fixed here (measured 2026-08-22): vite is not a direct dependency of
+    // this tree. The only direct devDependency is `vitepress: ^1.5.0`, and the installed
+    // vitepress 1.6.4 declares `dependencies.vite: ^5.4.14` (node_modules/vitepress/package.json).
+    // 1.6.4 is also the latest published release (`npm view vitepress version`) — there is no
+    // 2.x line — so no vitepress upgrade reaches vite 6.4.3. Overriding vite past its caret
+    // would be forcing a major on a package that pins it.
+    //
+    // Why the exposure is bounded (measured, not assumed): the vulnerable surface is the vite
+    // **dev server**'s `server.fs.deny`, and the bypass is via Windows alternate path forms.
+    //   - CI never starts it: .github/workflows/docs.yml runs `npm run docs:build` only.
+    //   - Nothing here is served in production: the build output is static HTML for Pages.
+    //   - The dev server is reachable only through `npm run docs:dev` (port 5174), which binds
+    //     localhost and is a maintainer-local action.
+    // 🟡 Stated honestly, because this is the part that would rot quietly: a maintainer running
+    // `npm run docs:dev` **on a Windows host** is inside the advisory's scope for as long as
+    // that server is up. The repository's own development runtime is Docker/Linux, so this is
+    // an environment the project does not use, not an environment it forbids. If Windows-native
+    // docs work starts happening, this entry stops being adequate and must be re-argued.
+    //
+    // Expiry: 2026-11-22 (3 months).
+    // Removed by: vitepress publishing a release whose `dependencies.vite` resolves to a
+    // patched line (>= 6.4.3 / >= 7.3.5 / >= 8.0.16). Stated as a dependency fact on purpose —
+    // check `npm view vitepress dependencies.vite`, not a remembered version number.
+    // Scope: the root docs tree only. The `frontend/` tree is on vite 8.1.5, which is already
+    // past 8.0.16 and is NOT covered by this entry.
+    "GHSA-fx2h-pf6j-xcff",
+  ],
+}

--- a/docs/development/dependency-audit.md
+++ b/docs/development/dependency-audit.md
@@ -1,0 +1,143 @@
+# Dependency audit
+
+How NENE2 checks its dependencies for known vulnerabilities, and how an exception is written
+when a fix is genuinely unreachable.
+
+## Why this exists
+
+NENE2 is the framework the other products build on, so a hole here is not one project's hole.
+Until 2026-08, this repository had no npm dependency audit at all: no `audit-ci.jsonc`, no
+`npm audit` in any workflow, and no `audit` script. An empty allowlist looked like strictness;
+it was absence.
+
+Two properties of the setup make that easy to miss, and both are addressed here:
+
+- **No workflow ran on `push: main`, and none was scheduled.** Every check fired on pull
+  requests only, so after a merge nothing was ever re-evaluated. An advisory published against
+  an already-locked version would never surface from CI.
+- **There are two npm trees**, and auditing the wrong one reports nothing while looking green.
+
+## What runs
+
+| Command | Tree | Config |
+| --- | --- | --- |
+| `composer audit --no-interaction` | PHP | — |
+| `npm run audit` | root (docs toolchain) | `audit-ci.jsonc` |
+| `npm run audit --prefix frontend` | frontend (SPA starter) | `frontend/audit-ci.jsonc` |
+
+In CI: `composer audit` is its own step in `backend.yml`; the two npm audits are their own
+steps in the `npm-audit` job of `frontend.yml`.
+
+**Each audit is a separate step on purpose.** Folding them together — or into `npm run check` —
+would make the job log unable to show which one actually ran, and a check that leaves no trace
+cannot be distinguished from a check that is missing. For the same reason `audit` is not part
+of `check`: a developer running `npm run check` locally should not have a network-dependent
+advisory lookup silently attached to it.
+
+### The two npm trees
+
+|  | root | `frontend/` |
+| --- | --- | --- |
+| Purpose | builds the documentation site (`vitepress`) | the SPA starter |
+| Shipped to consumers? | no | no (it is a starter to copy, not a dependency) |
+| Open advisories (2026-08-22) | all of them | none |
+| Allowlist | one entry, expiring | empty |
+
+The root tree's gate makes an existing hole visible. The frontend tree's gate reports nothing
+today — **that is the intended state, not a reason to drop it.** It is what stops the frontend
+tree from falling behind unnoticed; a gate that only exists where problems are already known
+cannot catch the next one.
+
+### What is actually distributed
+
+NENE2 ships as the Composer package `hideyukimori/nene2` (`composer.json`: `type: library`,
+autoload `psr-4` `Nene2\` → `src/`). Consumers install PHP sources. No npm dependency from
+either tree reaches them.
+
+That bounds *who* is exposed by an npm advisory here — the maintainers of this repository — but
+it does not make one harmless, and it is not a reason to skip the audit. It is the reason an
+unreachable npm fix can be allowlisted with an argument instead of blocking a release.
+
+## Weekly re-run
+
+Both workflows run on `schedule: '30 1 * * 1'` (Monday 01:30 UTC / 10:30 JST). The minute is
+allocated per repository across the fleet so runs do not stampede on the same minute.
+
+The schedule re-runs the *existing* CI rather than a separate audit-only job, so the weekly
+signal covers the same checks a pull request gets.
+
+> **Known limitation, unsolved.** GitHub auto-disables scheduled workflows after 60 days of
+> repository inactivity. A dormant repository — the one most in need of this check — is exactly
+> where it stops firing, silently. There is no in-repo fix; detecting a stale last-run date
+> needs an external poller at the fleet level. The comments saying so in the workflows are not
+> stale notes to be tidied away.
+
+## Failure notification
+
+Each workflow has a `notify-failure` job that opens (or comments on) an issue when a **scheduled**
+run fails. It deliberately does not fire on pull requests: a red check on a PR already has
+someone looking at it, and filing an issue for it produces the duplicates that make people stop
+reading notifications.
+
+Because it only fires on `schedule`, a pull request cannot demonstrate that it works. Use the
+`simulate_failure` input on `workflow_dispatch` to rehearse the path and watch the issue appear.
+
+## 🔴 Verify the gate fails
+
+A gate that cannot fail is worse than no gate, because it is mistaken for protection.
+
+Adding or changing an audit gate is not finished until the failing path has been observed at
+least once:
+
+1. **The audit itself** — temporarily remove the allowlist entry, run the audit, and confirm it
+   exits non-zero and names the advisory. Restore the entry.
+2. **The notification** — dispatch the workflow with `simulate_failure: true` and confirm the
+   issue is created (and that a second run comments on the same issue rather than opening a
+   duplicate).
+
+"The step is present in the YAML" is not evidence that it runs, and "CI is green" is not
+evidence that it would go red.
+
+## Writing an exception
+
+`allowlist` is per advisory (GHSA id), never per severity — the level is not lowered. Anything
+high or critical that is not listed fails the build.
+
+**Prefer the fix.** Reach for an exception only when the fix is unreachable, and say why with a
+measurement rather than an assumption.
+
+An entry must carry, in the config file next to it:
+
+1. the advisory id;
+2. why it does not apply to **this** tree, measured — commands and outputs, not reasoning from
+   the package name;
+3. an expiry date;
+4. what removes the need for it.
+
+### Write removal conditions as dependency facts, not version numbers
+
+**Advisory ranges move.** Measured in this fleet on 2026-08-22: the vite advisory's own numbers
+had shifted since they were last written down (`first_patched` 6.4.2 → 6.4.3, the vulnerable
+range widened to `<= 6.4.2`) while the conclusion was unchanged. A removal condition phrased as
+"upgrade to 6.4.2" would have quietly become wrong without anything failing.
+
+So write the condition as the dependency fact that would actually change:
+
+```
+Removed by: vitepress publishing a release whose `dependencies.vite` resolves to a
+patched line. Check `npm view vitepress dependencies.vite`, not a remembered version.
+```
+
+Related failure modes seen in the fleet, all of the same shape — the entry was written well and
+stopped being true afterwards:
+
+- an exception whose stated remedy version was later pulled *into* the vulnerable range;
+- an exception arguing "there is no fix in the 7.x line" that a backport invalidated days later.
+
+**An expiry date catches an entry that runs out; it does not catch an entry that stops being
+true.** While an id sits in the allowlist the gate is silent about it, so *CI is green* and *we
+are not exposed* are different statements. **Re-read the advisory from the primary source
+(`gh api /advisories/<id>`) whenever you touch the file — not at expiry.**
+
+An expired entry is a task, not a renewal: re-check it, do not extend it by reflex. An entry
+that is no longer needed is deleted rather than carried.

--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -1,0 +1,35 @@
+{
+  // Dependency-vulnerability gate for the FRONTEND npm tree (the SPA starter).
+  //
+  // This is the second of NENE2's two independent npm trees; the root tree (documentation
+  // toolchain) has its own audit-ci.jsonc. They are audited as separate CI steps so the job
+  // log shows which tree ran — a check that leaves no trace cannot be distinguished from a
+  // check that is missing.
+  //
+  // 🔑 This gate currently reports nothing, and that is the intended state, not a reason to
+  // drop it. Measured 2026-08-22: all six open Dependabot alerts on this repository resolve to
+  // the ROOT lockfile; this tree has none, because it already runs vite 8.1.5 — past the
+  // 8.0.16 that patches the advisory the root tree is stuck below. A gate that is silent today
+  // is what stops that from regressing tomorrow. Deleting it because "it finds nothing" would
+  // mean nobody notices when this tree does fall behind.
+  //
+  // The gate stays sharp: anything high/critical that is not listed below fails the build.
+  // `allowlist` is per-advisory (GHSA id), never per-severity — we do not lower the level.
+  //
+  // The allowlist is deliberately EMPTY. It is not a template to fill in: an exception is
+  // written when one is actually needed, and it then requires, in this file: (1) the advisory
+  // id, (2) why it does not apply to THIS tree, measured — not assumed, (3) an expiry date,
+  // (4) what removes the need for it, written as a dependency fact rather than a version
+  // number (advisory ranges move; see the root tree's entry for a case measured in this fleet).
+  // An expired entry is a task, not a renewal.
+  //
+  // Prefer the fix. Reach for an exception only when the fix is genuinely unreachable, and say
+  // so with a measurement.
+  //
+  // Policy: docs/development/dependency-audit.md
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "moderate": false,
+  "high": true,
+  "critical": true,
+  "allowlist": [],
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.4",
+        "audit-ci": "^7.1.0",
         "eslint": "^10.6.0",
         "jsdom": "^29.1.1",
         "msw": "^2.12.4",
@@ -3824,6 +3825,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4710,6 +4735,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.393",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
@@ -5327,6 +5359,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -5655,6 +5703,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -6928,6 +6983,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -7115,6 +7177,33 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7585,6 +7674,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -8287,6 +8383,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8757,6 +8866,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/recast": {
@@ -9402,6 +9521,19 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stable-hash-x": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -9448,6 +9580,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "node_modules/strict-event-emitter": {
@@ -9950,6 +10093,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tiny-invariant": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "gen:page": "plop --plopfile plopfile.mjs page",
     "gen:api-schema": "openapi-typescript ../docs/openapi/openapi.yaml -o src/shared/api/schema.gen.ts",
     "conformance": "nene2-check conformance",
+    "audit": "audit-ci --config audit-ci.jsonc",
     "check": "npm run type-check && npm run lint && npm run lint:css && npm run check:themes && npm run format && npm run test"
   },
   "dependencies": {
@@ -49,6 +50,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.4",
+    "audit-ci": "^7.1.0",
     "eslint": "^10.6.0",
     "jsdom": "^29.1.1",
     "msw": "^2.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nene2-docs",
       "version": "0.0.1",
       "devDependencies": {
+        "audit-ci": "^7.1.0",
         "vitepress": "^1.5.0"
       },
       "engines": {
@@ -1589,6 +1590,56 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -1632,6 +1683,41 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -1657,6 +1743,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/csstype": {
@@ -1689,6 +1790,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex-xs": {
       "version": "1.0.0",
@@ -1749,12 +1864,51 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
     },
     "node_modules/focus-trap": {
       "version": "7.8.0",
@@ -1765,6 +1919,13 @@
       "dependencies": {
         "tabbable": "^6.4.0"
       }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1779,6 +1940,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/hast-util-to-html": {
@@ -1837,6 +2008,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-what": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
@@ -1850,6 +2038,47 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1859,6 +2088,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mark.js": {
       "version": "8.11.1",
@@ -2028,6 +2264,29 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -2093,6 +2352,31 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -2119,6 +2403,16 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
@@ -2172,6 +2466,27 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/search-insights": {
       "version": "2.17.3",
       "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
@@ -2179,6 +2494,42 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/shiki": {
       "version": "2.5.0",
@@ -2228,6 +2579,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -2241,6 +2641,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/superjson": {
@@ -2263,6 +2676,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -2273,6 +2703,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
@@ -2346,6 +2783,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -2499,6 +2943,79 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "docs:dev":     "vitepress dev --port 5174",
     "docs:build":   "vitepress build",
-    "docs:preview": "vitepress preview --port 5174"
+    "docs:preview": "vitepress preview --port 5174",
+    "audit":        "audit-ci --config audit-ci.jsonc"
   },
   "devDependencies": {
+    "audit-ci": "^7.1.0",
     "vitepress": "^1.5.0"
   },
   "engines": {


### PR DESCRIPTION
## 目的

NENE2 は**全製品の上流**でありながら、**npm 側の依存監査ゲートが1本も無かった**。`audit-ci.jsonc` は root にも `frontend/` にも不在、workflow に `npm audit` も `audit-ci` も登場せず、`frontend/package.json` に `audit` script も無い。**allowlist が空なのは厳格だったからではなく、検査していなかったから**。

あわせて、この repo は `backend.yml` / `frontend.yml` とも `pull_request` のみで **`push: main` も schedule も無く、マージ後は何も再実行されない**状態だった。2026-08-12 に nanoid（#1644）と js-yaml（#1645）を配布元で直したのに**それを検知する装置が自分に無い**のは、ここに起因する。

## 🔴 射程は root と frontend の2ツリー

| | root | `frontend/` |
|---|---|---|
| 中身 | `vitepress` → vite 5系（docs ビルド専用） | SPA スターター（vite 8.1.5） |
| open advisory | **全部ここ** | **ゼロ** |
| ゲートの意味 | **今ある穴を可視化する** | **将来の退行を止める**（今日は空振り＝それが正常） |
| allowlist | 1件（期限つき） | **空** |

`frontend.yml` は従来 `--prefix frontend` でしか動いておらず、素直にそちらへ足すと **advisory ゼロの側だけを検査する空振りゲート**になる。逆に root だけに足すと frontend の退行を誰も見なくなる。⇒ **両方に置き、それぞれが自分の `audit-ci.jsonc` を持つ**。

> 監査は**独立ステップ**にした。他コマンドや `npm run check` に畳み込むと、走ったかどうかがログから判別できない。**痕跡を残さないチェックは、無いチェックと区別がつかない**（`nene-serve/ci.yml` のコメントの趣旨をそのまま継いでいる）。

参照実装は `nene-serve/.github/workflows/ci.yml` ＋ `frontend/audit-ci.jsonc` ＋ `docs/development/dependency-audit.md`。**serve は単一ツリー前提**なので、2ツリー構成への読み替えだけ行い、理由コメントは写した。

## 変更点

- `audit-ci ^7.1.0` を root / frontend の devDependency へ追加
- `audit-ci.jsonc` を root / `frontend/` へ追加（`moderate:false` / `high:true` / `critical:true`）
- root の allowlist に **GHSA-fx2h-pf6j-xcff を期限つきで1件**
- `audit` script を両 `package.json` へ追加（**`check` には入れない**）
- `frontend.yml` に **`npm-audit` ジョブ**（root / frontend の独立2ステップ）
- 両 workflow に **`schedule: '30 1 * * 1'`**（フリート割当・他艦と分をずらす）
- 両 workflow に `workflow_dispatch` の `simulate_failure` input と **`notify-failure` ジョブ**
- `concurrency` group に `github.event_name` を追加 — schedule / dispatch 実行が push・PR 実行に巻き込まれて cancel されるのを防ぐ。**cancel された実行は「一度も走らなかった」と見分けがつかない**
- **`docs/development/dependency-audit.md`**（監査ポリシーの正本）

**60日非アクティブで scheduled workflow が自動無効化される既知の限界**は、両 workflow にコメントとして残した（「解決した」とは書いていない）。

## allowlist 1件の根拠

**GHSA-fx2h-pf6j-xcff**（vite・high・`server.fs.deny` bypass on Windows alternate paths）。一次情報を `gh api /advisories/GHSA-fx2h-pf6j-xcff` で直読み（advisory 更新 2026-07-15）：

```
vite  <= 6.4.2            first_patched 6.4.3
vite  >= 7.0.0, <= 7.3.4  first_patched 7.3.5
vite  >= 8.0.0, <= 8.0.15 first_patched 8.0.16
```

**bump では閉じない**（実測 2026-08-22）：root の直接 devDependency は `vitepress` のみ。導入済み vitepress 1.6.4 が `dependencies.vite: ^5.4.14` を固定し、1.6.4 は**最新公開版**（`npm view vitepress version`）で 2.x 系が存在しない。

**解除条件は版数ではなく依存関係の事実として書いた** — advisory のレンジ自体が動く実例をフリートで観測しており、本件も 08-19 → 08-22 で `first_patched` が **6.4.2 → 6.4.3** に移動している（結論は不変・**変わったのは目標値だけ**）。

🟡 **Windows ホストで `npm run docs:dev` を実行する場合は射程内**である点も、隠さず allowlist コメントに明記した。開発ランタイムが Docker/Linux なので**使っていない環境**であって、**禁じている環境ではない**ため。

## 🔴 検証結果 — 陽性対照を含む

**1. 監査ゲートの陽性対照（allowlist の存在理由を示す変異）**

| 条件 | 結果 |
|---|---|
| root・allowlist **あり** | `EXIT=0` — `Passed npm security audit.` |
| root・**allowlist を外す** | **`EXIT=1`** — `Failed security audit due to high vulnerabilities` |
| frontend・allowlist 空 | `EXIT=0` — `Passed npm security audit.` |

落ちたときの出力に依存経路まで出る：

```
Found vulnerable advisory paths:
GHSA-fx2h-pf6j-xcff|vitepress>vite
```

「vitepress が vite を引いている」という構造が**推論ではなく audit-ci の出力そのもの**で裏付けられている。**「ゲートが存在する」ではなく「allowlist が無ければ落ちていた」＝例外の存在理由**まで確認した。

**2. lockfile の巻き込みなし**

| | 既存パッケージの版変更 | 削除 | 追加 |
|---|---|---|---|
| root | **0** | **0** | 44（audit-ci とその依存） |
| frontend | **0** | **0** | 14（同上） |

**3. その他**

- `npm run check --prefix frontend`: 11 files / 33 tests 通過・prettier 通過
- audit-ci 導入で**新規 advisory は増えていない**（`npm audit` は 3件のまま）

## ⚠️ 残リスク・この PR で検証できていないこと

**`notify-failure` は未検証**。`if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)` なので、**PR では原理的に発火しない**。

⇒ **マージ後に `workflow_dispatch` の `simulate_failure: true` で発火・issue 起票・2回目が同一 issue へコメント追記されることまで確認する。** #1652 は**それを確認するまでクローズしない**。「入っている」で DoD を満たしたことにはしない。

**このゲートは root の advisory を消さない**。可視化して allowlist 1件に封じ込めただけで、vite の high は開いたまま（到達不能・配布物外）。`Passed npm security audit` と「露出していない」は別の主張である点は、`audit-ci.jsonc` とポリシー文書の両方に書いた。

Self-review: release-ci, docs-policy

Closes #1652